### PR TITLE
[scan] Skip unavailable os_versions from simclt output

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -40,12 +40,12 @@ module FastlaneCore
         end
 
         output.split(/\n/).each do |line|
-          break if line =~ /^-- Unavailable/
           next if line =~ /unavailable/
           next if line =~ /^== /
           if line =~ /^-- /
             (os_type, os_version) = line.gsub(/-- (.*) --/, '\1').split
           else
+            next if os_type =~ /^Unavailable/
 
             # "    iPad (5th generation) (852A5796-63C3-4641-9825-65EBDC5C4259) (Shutdown)"
             # This line will turn the above string into

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -40,6 +40,7 @@ module FastlaneCore
         end
 
         output.split(/\n/).each do |line|
+          break if line =~ /^-- Unavailable/
           next if line =~ /unavailable/
           next if line =~ /^== /
           if line =~ /^-- /

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -248,7 +248,7 @@ describe FastlaneCore do
       allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
 
       devices = FastlaneCore::DeviceManager.simulators
-      expect(devices.count).to eq(2)
+      expect(devices.count).to eq(3)
 
       expect(devices[0]).to have_attributes(
         name: "iPhone 5s", os_type: "iOS", os_version: "12.0",
@@ -259,6 +259,12 @@ describe FastlaneCore do
       expect(devices[1]).to have_attributes(
         name: "iPhone 6", os_type: "iOS", os_version: "12.0",
         udid: "C68031AE-E525-4065-9DB6-0D4450326BDA",
+        state: "Shutdown",
+        is_simulator: true
+      )
+      expect(devices[2]).to have_attributes(
+        name: "Apple Watch Series 2 - 38mm", os_type: "watchOS", os_version: "5.0",
+        udid: "34144812-F701-4A49-9210-4A226FE5E0A9",
         state: "Shutdown",
         is_simulator: true
       )

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -238,6 +238,32 @@ describe FastlaneCore do
       )
     end
 
+    it "properly parses the simctl output with unavailable devices and generates Device objects for all simulators" do
+      response = "response"
+      simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode10BootedUnavailable')
+      expect(response).to receive(:read).and_return(simctl_output)
+      expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+      thing = {}
+      expect(thing).to receive(:read).and_return("line\n")
+      allow(Open3).to receive(:popen3).with("xcrun simctl list runtimes").and_yield(nil, thing, nil, nil)
+
+      devices = FastlaneCore::DeviceManager.simulators
+      expect(devices.count).to eq(2)
+
+      expect(devices[0]).to have_attributes(
+        name: "iPhone 5s", os_type: "iOS", os_version: "12.0",
+        udid: "238C6D64-8720-4BFF-9DE9-FFBB9A1375D4",
+        state: "Shutdown",
+        is_simulator: true
+      )
+      expect(devices[1]).to have_attributes(
+        name: "iPhone 6", os_type: "iOS", os_version: "12.0",
+        udid: "C68031AE-E525-4065-9DB6-0D4450326BDA",
+        state: "Shutdown",
+        is_simulator: true
+      )
+    end
+
     it "properly parses system_profiler and instruments output and generates Device objects for iOS" do
       response = "response"
       expect(response).to receive(:read).and_return(@system_profiler_output)

--- a/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode10BootedUnavailable
+++ b/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode10BootedUnavailable
@@ -1,0 +1,7 @@
+== Devices ==
+-- iOS 12.0 --
+    iPhone 5s (238C6D64-8720-4BFF-9DE9-FFBB9A1375D4) (Shutdown) 
+    iPhone 6 (C68031AE-E525-4065-9DB6-0D4450326BDA) (Shutdown) 
+-- Unavailable: com.apple.CoreSimulator.SimRuntime.iOS-12-1 --
+    iPhone XR (8350A403-0E68-4F48-8ABA-C392F9CB8D7C) (Booted) 
+    iPhone 5s (2721F3DC-A96B-4CA4-A9BD-B7CE3595BC82) (Shutdown) (unavailable, runtime profile not found)

--- a/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode10BootedUnavailable
+++ b/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode10BootedUnavailable
@@ -5,3 +5,6 @@
 -- Unavailable: com.apple.CoreSimulator.SimRuntime.iOS-12-1 --
     iPhone XR (8350A403-0E68-4F48-8ABA-C392F9CB8D7C) (Booted) 
     iPhone 5s (2721F3DC-A96B-4CA4-A9BD-B7CE3595BC82) (Shutdown) (unavailable, runtime profile not found)
+-- watchOS 5.0 --
+    Apple Watch - 42mm (3BE7BCB8-BCDB-45A2-8569-48B657BDD44E) (Shutdown) (unavailable, device type not supported by runtime)
+    Apple Watch Series 2 - 38mm (34144812-F701-4A49-9210-4A226FE5E0A9) (Shutdown) 


### PR DESCRIPTION
* Stop processing simctl output immediately after first "Unavailable" OS as simctl aggregates them at the end of the output


### Checklist 🔑
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
If your machine had already booted simulators that are not available in current's Xcode toolchain, these booted simulators get parsed as usually, but with some invalid os_version (like `com.apple.CoreSimulator.SimRuntime.iOS-12-1`). This breaks `scan` command which tries to transform "com.apple.CoreSimulator.SimRuntime.iOS-12-0" into `Gem::Version`. 

Fixes:
* https://github.com/fastlane/fastlane/issues/12734

### Description
Since `simctl` always returns all the unavailable OSes below available ones, once we recognize first unavailable OS (using `^-- Unavailable` regexp) we don't have to parse `simctl` output anymore.

Test spec adds a custom `simctl` output with already booted unavailable device that previously was considered as a valid simulator even it should not.
I was also to reproduce #12734 by given configuration which now succeeds:

```
xcversion(version: "10.1")
run_tests(device: "iPhone XR")
xcversion(version: "10.0")
run_tests(device: "iPhone XR")
```