### PR TITLE
[action] added new spaceship_logs action

### DIFF
--- a/fastlane/lib/fastlane/actions/clipboard.rb
+++ b/fastlane/lib/fastlane/actions/clipboard.rb
@@ -2,9 +2,15 @@ module Fastlane
   module Actions
     class ClipboardAction < Action
       def self.run(params)
-        UI.message("Storing '#{params[:value]}' in the clipboard 🎨")
+        value = params[:value]
 
-        `echo "#{params[:value]}" | tr -d '\n' | pbcopy` # we don't use `sh`, as the command looks ugly
+        truncated_value = value[0..800].gsub(/\s\w+\s*$/, '...')
+        UI.message("Storing '#{truncated_value}' in the clipboard 🎨")
+
+        if FastlaneCore::Helper.mac?
+          require 'open3'
+          Open3.popen3('pbcopy') { |input, _, _| input << value }
+        end
       end
 
       #####################################################
@@ -24,7 +30,7 @@ module Fastlane
       end
 
       def self.authors
-        ["KrauseFx"]
+        ["KrauseFx", "joshdholtz"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/lib/fastlane/actions/spaceship_logs.rb
+++ b/fastlane/lib/fastlane/actions/spaceship_logs.rb
@@ -1,0 +1,132 @@
+module Fastlane
+  module Actions
+    class SpaceshipLogsAction < Action
+      def self.run(params)
+        latest = params[:latest]
+        print_contents = params[:print_contents]
+        print_paths = params[:print_paths]
+        copy_to_path = params[:copy_to_path]
+        copy_to_clipboard = params[:copy_to_clipboard]
+
+        # Get log files
+        files = Dir.glob("/tmp/spaceship*.log").sort_by { |f| File.mtime(f) }.reverse
+
+        # Filter to latest
+        if latest
+          files = [files.first]
+        end
+
+        # Print contents
+        if print_contents
+          files.each do |file|
+            data = File.read(file)
+            puts("-----------------------------------------------------------------------------------")
+            puts(" Spaceship Log Content - #{file}")
+            puts("-----------------------------------------------------------------------------------")
+            puts(data)
+            puts("\n")
+          end
+        end
+
+        # Print paths
+        if print_paths
+          puts("-----------------------------------------------------------------------------------")
+          puts(" Spaceship Log Paths")
+          puts("-----------------------------------------------------------------------------------")
+          files.each do |file|
+            puts(file)
+          end
+          puts("\n")
+        end
+
+        # Copy to a directory
+        if copy_to_path
+          require 'fileutils'
+          FileUtils.mkdir_p(copy_to_path)
+          files.each do |file|
+            FileUtils.cp(file, copy_to_path)
+          end
+        end
+
+        # Copy contents to clipboard
+        if copy_to_clipboard
+          string = files.map { |file| File.read(file) }.join("\n")
+          require 'open3'
+          Open3.popen3('pbcopy') { |input, _, _| input << string }
+          UI.message("📎 Copied to clipboard!")
+        end
+
+        return files
+      end
+
+      def self.description
+        "Find, print, and copy Spaceship logs"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :latest,
+                                       description: "Finds only the latest Spaceshop log file if set to true, otherwise returns all",
+                                       default_value: true,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :print_contents,
+                                       description: "Prints the contents of the found Spaceship log file(s)",
+                                       default_value: false,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :print_paths,
+                                       description: "Prints the paths of the found Spaceship log file(s)",
+                                       default_value: false,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :copy_to_path,
+                                       description: "Copies the found Spaceship log file(s) to a directory",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :copy_to_clipboard,
+                                       description: "Copies the contents of the found Spaceship log file(s) to the clipboard",
+                                       default_value: false,
+                                       type: Boolean)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.example_code
+        [
+          'spaceship_logs',
+          'spaceship_logs(
+            copy_to_path: "/tmp/artifacts"
+          )',
+          'spaceship_logs(
+            copy_to_clipboard: true
+          )',
+          'spaceship_logs(
+            print_contents: true,
+            print_paths: true
+          )',
+          'spaceship_logs(
+            latest: false,
+            print_contents: true,
+            print_paths: true
+          )'
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+
+      def self.return_value
+        "The array of Spaceship logs"
+      end
+
+      def self.return_type
+        :array
+      end
+
+      def self.author
+        "joshdholtz"
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/spaceship_logs.rb
+++ b/fastlane/lib/fastlane/actions/spaceship_logs.rb
@@ -11,6 +11,11 @@ module Fastlane
         # Get log files
         files = Dir.glob("/tmp/spaceship*.log").sort_by { |f| File.mtime(f) }.reverse
 
+        if files.size == 0
+          UI.message("No Spaceship log files found")
+          return []
+        end
+
         # Filter to latest
         if latest
           files = [files.first]
@@ -51,9 +56,7 @@ module Fastlane
         # Copy contents to clipboard
         if copy_to_clipboard
           string = files.map { |file| File.read(file) }.join("\n")
-          require 'open3'
-          Open3.popen3('pbcopy') { |input, _, _| input << string }
-          UI.message("📎 Copied to clipboard!")
+          ClipboardAction.run(value: string)
         end
 
         return files


### PR DESCRIPTION
## Motivation and Context
We have been asking users more often lately to send us their Spaceship logs and its not always the easiest thing to find since there are a lot of them. This new action should make this easier 🤞

## Description
This new action allows the follow types of abilities:
- returning log files in array from action
- printing of contents
- printing of paths
- copying files to a directory
- copying contents to clipboard

### Return path and copy to clipboard

#### Command
```sh
fastlane run spaceship_logs copy_to_clipboard:true
```
#### Output
```sh
[06:13:54]: ----------------------------
[06:13:54]: --- Step: spaceship_logs ---
[06:13:54]: ----------------------------
[06:13:54]: 📎 Copied to clipboard!
[06:13:54]: Result: ["/tmp/spaceship1552529905_30791_70100288018780.log"]
```

### Return path

#### Command
```sh
fastlane run spaceship_logs latest:false
```
#### Output
```sh
[06:11:29]: ----------------------------
[06:11:29]: --- Step: spaceship_logs ---
[06:11:29]: ----------------------------
[06:11:29]: Result: ["/tmp/spaceship1552529905_30791_70100288018780.log", "/tmp/spaceship1552529903_30791_70100288018780.log", "/tmp/spaceship1552529879_30762_70260007098700.log", "/tmp/spaceship1552529877_30762_70260007098700.log", "/tmp/spaceship1552529825_30736_70309583788380.log", "/tmp/spaceship1552529822_30736_70309583788380.log", "/tmp/spaceship1552529698_30690_70278302669100.log", "/tmp/spaceship1552529695_30690_70278302669100.log", "/tmp/spaceship1552529673_30671_70310317783340.log", "/tmp/spaceship1552529671_30671_70310317783340.log", "/tmp/spaceship1552529647_30649_70315535440220.log", "/tmp/spaceship1552529645_30649_70315535440220.log", "/tmp/spaceship1552529625_30630_70264050424140.log", "/tmp/spaceship1552529621_30630_70264050424140.log", "/tmp/spaceship1552529489_30576_70170517371180.log", "/tmp/spaceship1552529486_30576_70170517371180.log", "/tmp/spaceship1552529308_30511_70204403169580.log", "/tmp/spaceship1552529305_30511_70204403169580.log", "/tmp/spaceship1552529131_30448_70094315256140.log", "/tmp/spaceship1552529126_30448_70094315256140.log", "/tmp/spaceship1552528961_30373_70103236565340.log", "/tmp/spaceship1552528958_30373_70103236565340.log", "/tmp/spaceship1552528749_30299_70122643650900.log", "/tmp/spaceship1552528746_30299_70122643650900.log", "/tmp/spaceship1552528726_30270_70241224898880.log", "/tmp/spaceship1552528720_30270_70241224898880.log", "/tmp/spaceship1552527525_28843_70198380149060.log", "/tmp/spaceship1552528126_28843_70198380149060.log", "/tmp/spaceship1552527160_28843_70198380149060.log", "/tmp/spaceship1552486410_13551_70352101366060.log", "/tmp/spaceship1552486856_13551_70352101366060.log", "/tmp/spaceship1552485926_13551_70352101366060.log", "/tmp/spaceship1552485167_12352_70152054110540.log", "/tmp/spaceship1552485550_12352_70152054110540.log", "/tmp/spaceship1552484940_12352_70152054110540.log", "/tmp/spaceship1552484590_11869_70165215836460.log", "/tmp/spaceship1552484528_11869_70165215836460.log", "/tmp/spaceship1552484422_11393_70133230074180.log"
```

### Print contents and print paths

#### Command
```sh
fastlane run spaceship_logs print_contents:true print_paths:true
```
#### Output
```sh
[06:12:44]: ----------------------------
[06:12:44]: --- Step: spaceship_logs ---
[06:12:44]: ----------------------------
-----------------------------------------------------------------------------------
 Spaceship Log Content - /tmp/spaceship1552529905_30791_70100288018780.log
-----------------------------------------------------------------------------------
# Logfile created on 2019-03-13 21:18:25 -0500 by logger.rb/56438
INFO  [21:18:25]: >> PATCH betaAppReviewDetails/1358899889: {"data":{"attributes":{"contactEmail":"josh+connectapi@rokkincat.com","contactFirstName":"Connect","contactLastName":"API","contactPhone":"2622514802","demoAccountName":"josh+connectdemo@rokkincat.com","demoAccountPassword":"testapi0101","demoAccountRequired":true,"notes":"This are api fastlane connect notes"},"id":"1358899889","type":"betaAppReviewDetails"}}
DEBUG [21:18:26]: << PATCH betaAppReviewDetails/1358899889: 200 {"data"=>{"type"=>"betaAppReviewDetails", "id"=>"1358899889", "attributes"=>{"contactFirstName"=>"Connect", "contactLastName"=>"API", "contactPhone"=>"2622514802", "contactEmail"=>"josh+connectapi@rokkincat.com", "demoAccountName"=>"josh+connectdemo@rokkincat.com", "demoAccountPassword"=>"testapi0101", "demoAccountRequired"=>true, "notes"=>"This are api fastlane connect notes"}, "relationships"=>{"app"=>{"links"=>{"self"=>"https://appstoreconnect.apple.com/iris/v1/betaAppReviewDetails/1358899889/relationships/app", "related"=>"https://appstoreconnect.apple.com/iris/v1/betaAppReviewDetails/1358899889/app"}}}, "links"=>{"self"=>"https://appstoreconnect.apple.com/iris/v1/betaAppReviewDetails/1358899889"}}, "links"=>{"self"=>"https://appstoreconnect.apple.com/iris/v1/betaAppReviewDetails/1358899889"}}
-----------------------------------------------------------------------------------
 Spaceship Log Paths
-----------------------------------------------------------------------------------
/tmp/spaceship1552529905_30791_70100288018780.log
[06:12:44]: Result: ["/tmp/spaceship1552529905_30791_70100288018780.log"]
```

### Copy to directory
Probably best used in a CI

#### Command
```sh
fastlane run spaceship_logs copy_to_dir:"/tmp/artifacts"
```

#### Fastfile
```rb
spaceship_logs(copy_to_dir:"/tmp/artifacts")
```