### PR TITLE
[pilot] add option for `uses_non_exempt_encryption` and wait for processing again when being set

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -50,6 +50,12 @@ module Pilot
       end
 
       UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+      latest_build = wait_for_build_processing_to_be_complete
+      distribute(options, build: latest_build)
+    end
+
+    def wait_for_build_processing_to_be_complete
+      platform = fetch_app_platform
       app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
       app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
       latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform, train_version: app_version, build_version: app_build, poll_interval: config[:wait_processing_interval], strict_build_watch: config[:wait_for_uploaded_build])
@@ -58,7 +64,7 @@ module Pilot
         UI.important("Uploaded app #{app_version} - #{app_build}, but received build #{latest_build.train_version} - #{latest_build.build_version}. If you want to wait for uploaded build to be finished processing, use the `wait_for_uploaded_build` option")
       end
 
-      distribute(options, build: latest_build)
+      return latest_build
     end
 
     def distribute(options, build: nil)
@@ -210,7 +216,7 @@ module Pilot
       UI.message("Distributing new build to testers: #{uploaded_build.train_version} - #{uploaded_build.build_version}")
 
       # This is where we could add a check to see if encryption is required and has been updated
-      check_export_compliance(uploaded_build)
+      set_export_compliance_if_needed(uploaded_build, options)
 
       if options[:groups] || options[:distribute_external]
         begin
@@ -241,32 +247,24 @@ module Pilot
         if external_group.nil? && options[:groups].nil?
           UI.user_error!("You must specify at least one group using the `:groups` option to distribute externally")
         end
-      else # distribute internally
-        # in case any changes to export_compliance are required
-        if uploaded_build.export_compliance_missing?
-          uploaded_build.save!
-        end
       end
 
       true
     end
 
-    def check_export_compliance(uploaded_build)
-      build = uploaded_build.get_app_store_connect_build
-      puts "cec: #{build}"
-      if build["usesNonExemptEncryption"].nil?
-        attributes = {usesNonExemptEncryption: false}
+    def set_export_compliance_if_needed(uploaded_build, options)
+      build = uploaded_build.find_app_store_connect_build
+      build_attributes = build["attributes"] || {}
+      if build_attributes["usesNonExemptEncryption"].nil?
+        uses_non_exempt_encryption = options[:uses_non_exempt_encryption]
+        attributes = { usesNonExemptEncryption: uses_non_exempt_encryption }
 
-        puts "about to send to patch build: #{attributes}"
         client = Spaceship::ConnectAPI::Base.client
-        resp = client.patch_builds(build_id: build["id"], attributes: attributes)
-        puts "resp: #{resp}"
+        client.patch_builds(build_id: build["id"], attributes: attributes)
 
-        UI.message("Waiting for this to process again")
-        platform = fetch_app_platform
-        app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
-        app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
-        latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform, train_version: app_version, build_version: app_build, poll_interval: config[:wait_processing_interval], strict_build_watch: config[:wait_for_uploaded_build])
+        UI.important("Export comlpiance has been set to '#{uses_non_exempt_encryption}'. Need to wait for build to finishing processing again...")
+        UI.important("Set 'ITSAppUsesNonExemptEncryption' in the 'Info.plist' to skip this step and speed up the submission")
+        wait_for_build_processing_to_be_complete
       end
     end
 

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -134,6 +134,12 @@ module Pilot
                                      default_value: false),
 
         # distribution
+        FastlaneCore::ConfigItem.new(key: :uses_non_exempt_encryption,
+                                     short_option: "-X",
+                                     env_name: "PILOT_USES_NON_EXEMPT_ENCRYPTION",
+                                     description: "Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist",
+                                     default_value: false,
+                                     type: Boolean),
         FastlaneCore::ConfigItem.new(key: :distribute_external,
                                      is_string: false,
                                      env_name: "PILOT_DISTRIBUTE_EXTERNAL",

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -230,6 +230,27 @@ module Spaceship
         handle_response(response)
       end
 
+      def patch_builds(build_id: nil, attributes: {})
+        # PATCH
+        # https://appstoreconnect.apple.com/iris/v1/builds/<build_id>
+        path = "builds/#{build_id}"
+
+        body = {
+          data: {
+            attributes: attributes,
+            id: build_id,
+            type: "builds"
+          }
+        }
+
+        response = request(:patch) do |req|
+          req.url(path)
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
       def post_beta_app_review_submissions(build_id: nil)
         # POST
         # https://appstoreconnect.apple.com/iris/v1/betaAppReviewSubmissions

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -217,9 +217,7 @@ module Spaceship
         return if ready_to_test?
         return if approved?
 
-        resp = Spaceship::ConnectAPI::Base.client.get_builds(filter: { expired: false, processingState: "PROCESSING,VALID", version: self.build_version })
-        build = resp.first
-
+        build = get_app_store_connect_build
         Spaceship::ConnectAPI::Base.client.post_beta_app_review_submissions(build_id: build["id"])
       end
 
@@ -229,6 +227,12 @@ module Spaceship
 
       def add_group!(group)
         client.add_group_to_build(app_id: app_id, group_id: group.id, build_id: id)
+      end
+
+      # Bridges the TestFlight::Build to the App Store Connect API build
+      def get_app_store_connect_build
+        resp = Spaceship::ConnectAPI::Base.client.get_builds(filter: { expired: false, processingState: "PROCESSING,VALID", version: self.build_version })
+        resp.first
       end
     end
   end

--- a/spaceship/lib/spaceship/test_flight/build.rb
+++ b/spaceship/lib/spaceship/test_flight/build.rb
@@ -217,7 +217,7 @@ module Spaceship
         return if ready_to_test?
         return if approved?
 
-        build = get_app_store_connect_build
+        build = find_app_store_connect_build
         Spaceship::ConnectAPI::Base.client.post_beta_app_review_submissions(build_id: build["id"])
       end
 
@@ -230,7 +230,7 @@ module Spaceship
       end
 
       # Bridges the TestFlight::Build to the App Store Connect API build
-      def get_app_store_connect_build
+      def find_app_store_connect_build
         resp = Spaceship::ConnectAPI::Base.client.get_builds(filter: { expired: false, processingState: "PROCESSING,VALID", version: self.build_version })
         resp.first
       end


### PR DESCRIPTION
Fixes #14033

### Motivation and Context
```sh
2019-03-05T01:14:00.4929920Z Spaceship::UnexpectedResponse: �[31m[!] The build is not in state for internal testing. - Build is not in internal testing state.�[0m
2019-03-05T01:14:00.4930960Z   /drop/vendor/bundle/ruby/2.3.0/gems/fastlane-2.117.1/spaceship/lib/spaceship/connect_api/client.rb:274:in `handle_response'
```
Taken from https://github.com/fastlane/fastlane/issues/14033#issuecomment-469615095

Soooo, the issue that caused the `The build is not in state for internal testing. - Build is not in internal testing state.` ended up being that if you **do not** provide the `ITSAppUsesNonExemptEncryption` key in your `Info.plist` and instead rely on `pilot` setting it for you, the build goes **back** into the `PROCESSING` state for about a minute or a few 😬

### Description
So the best solution is to add the `ITSAppUsesNonExemptEncryption` key to your `Info.plist` to make the _fastlane_ part take up less time so it only needs to process once but... I'm adding a fix where we will be waiting for the build to finish processing again between the setting of the export compliance and the actual submission.

I also added a new `uses_non_exempt_encryption` option since we shouldn't hardcode `false` for users and some users might need to set `true`

#### Output without `ITSAppUsesNonExemptEncryption`

<details>

```sh
[21:29:26]: -------------------
[21:29:26]: --- Step: pilot ---
[21:29:26]: -------------------
[21:29:26]: Login to App Store Connect (josh+fastlane@rokkincat.com)
[21:29:29]: Login successful
[21:29:30]: Ready to upload new build to TestFlight (App: 12341234)...
[21:29:31]: Going to upload updated app to App Store Connect
[21:29:31]: This might take a few minutes. Please don't interrupt the script.
[21:31:51]: iTunes Transporter successfully finished its job
[21:31:51]: ------------------------------------------------------------------------------------------------------------------
[21:31:51]: --- Successfully uploaded package to App Store Connect. It might take a few minutes until it's visible online. ---
[21:31:51]: ------------------------------------------------------------------------------------------------------------------
[21:31:51]: Successfully uploaded the new binary to App Store Connect
[21:31:51]: If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option
[21:31:55]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:32:29]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:33:03]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:33:37]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:34:11]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:34:44]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:35:17]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:35:50]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:36:23]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:36:57]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:37:30]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:38:05]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:38:38]: Waiting for App Store Connect to finish processing the new build (1.0 - 157)
[21:39:13]: Successfully finished processing the build 1.0 - 157
[21:39:19]: Successfully set the changelog for build
[21:39:21]: Distributing new build to testers: 1.0 - 157
[21:39:23]: Export comlpiance has been set to 'false'. Need to wait for build to finishing processing again....
[21:39:23]: Set 'ITSAppUsesNonExemptEncryption' in the 'Info.plist' to skip this step and speed up the submission
[21:39:27]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:40:01]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:40:35]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:41:08]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:41:56]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:42:31]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:43:05]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:43:38]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:44:12]: Successfully finished processing the build 1.0 - 157
[21:44:18]: Successfully distributed build to External testers 🚀
+------+------------------------+-------------+
|              fastlane summary               |
+------+------------------------+-------------+
| Step | Action                 | Time (in s) |
+------+------------------------+-------------+
| 1    | increment_build_number | 1           |
| 2    | gym                    | 52          |
| 3    | pilot                  | 891         |
+------+------------------------+-------------+
[21:44:18]: fastlane.tools just saved you 16 minutes! 🎉
```

</details>

#### Output with `ITSAppUsesNonExemptEncryption`

<details>

```sh
[21:14:50]: -------------------
[21:14:50]: --- Step: pilot ---
[21:14:50]: -------------------
[21:14:50]: Login to App Store Connect (josh+fastlane@rokkincat.com)
[21:14:52]: Login successful
[21:14:53]: Ready to upload new build to TestFlight (App: 12341234)...
[21:14:53]: Going to upload updated app to App Store Connect
[21:14:53]: This might take a few minutes. Please don't interrupt the script.
[21:16:44]: iTunes Transporter successfully finished its job
[21:16:44]: ------------------------------------------------------------------------------------------------------------------
[21:16:44]: --- Successfully uploaded package to App Store Connect. It might take a few minutes until it's visible online. ---
[21:16:44]: ------------------------------------------------------------------------------------------------------------------
[21:16:44]: Successfully uploaded the new binary to App Store Connect
[21:16:44]: If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option
[21:16:48]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:17:22]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:17:55]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:18:28]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:19:02]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:19:34]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:20:18]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:20:52]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:21:27]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:22:09]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:22:42]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:23:15]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:23:48]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:24:21]: Waiting for App Store Connect to finish processing the new build (1.0 - 156)
[21:24:55]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:25:28]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:26:02]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:26:36]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:27:09]: Build doesn't show up in the build list anymore, waiting for it to appear again (check your email for processing issues if this continues)
[21:27:43]: Successfully finished processing the build 1.0 - 156
[21:27:48]: Successfully set the changelog for build
[21:27:50]: Distributing new build to testers: 1.0 - 156
[21:27:57]: Successfully distributed build to External testers 🚀
+------+------------------------+-------------+
|              fastlane summary               |
+------+------------------------+-------------+
| Step | Action                 | Time (in s) |
+------+------------------------+-------------+
| 1    | increment_build_number | 1           |
| 2    | gym                    | 39          |
| 3    | pilot                  | 787         |
+------+------------------------+-------------+
[21:27:57]: fastlane.tools just saved you 14 minutes! 🎉
```

</details>