### PR TITLE
[action] Fix showing macOS notification via `notification` action

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
   spec.add_dependency('xcodeproj', '>= 1.8.1', '< 2.0.0') # Modify Xcode projects
   spec.add_dependency('xcpretty', '~> 0.3.0') # prettify xcodebuild output
-  spec.add_dependency('terminal-notifier', '>= 1.6.2', '< 2.0.0') # macOS notifications
+  spec.add_dependency('terminal-notifier', '>= 2.0.0', '< 3.0.0') # macOS notifications
   spec.add_dependency('terminal-table', '>= 1.4.5', '< 2.0.0') # Actions documentation
   spec.add_dependency('plist', '>= 3.1.0', '< 4.0.0') # Needed for set_build_number_repository and get_info_plist_value actions
   spec.add_dependency('CFPropertyList', '>= 2.3', '< 4.0.0') # Needed to be able to read binary plist format


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

`notification` action does not show an alert on macOS.

<!-- If it fixes an open issue, please link to the issue here. -->

closes https://github.com/fastlane/fastlane/issues/14402

### Description
<!-- Describe your changes in detail -->

To display macOS notification we are using [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) under the hood:

https://github.com/fastlane/fastlane/blob/cf52a29dc62e07c2b5a690b4b74e0b45c7754af8/fastlane/lib/fastlane/actions/notification.rb#L4-L18

Guys from `terminal-notifier` wrote: 

> alerter features were merged in terminal-notifier 1.7. This led to some issues and even more issues in the 1.8 release. We decided with Valère Jeantet to rollback this merge.

That ☝️ was a good reason to bump `terminal-notifier` version to `2.0.0` and get rid of the issue.

<!-- Please describe in detail how you tested your changes. -->

I analyzed the usage of `terminal-notifier` in `fastlane` and it seems that we do not use any of `alerter` functionalities.

I did manual testing and ran unit tests for `notification` action - all 💚💚💚

![image](https://user-images.githubusercontent.com/10795657/54472737-e9546200-47cd-11e9-9239-180c86633bbd.png)

macOS: 10.14.3