### PR TITLE
[action] Fix increment_build_number precondition issue

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -31,7 +31,7 @@ module Fastlane
         # Attention: This is NOT the version number - but the build number
 
         agv_enabled = system([command_prefix, 'agvtool what-version', command_suffix].join(' '))
-        raise "Apple Generic Versioning is not enabled." unless agv_enabled
+        raise "Apple Generic Versioning is not enabled." unless agv_enabled || params[:build_number]
 
         command = [
           command_prefix,
@@ -47,7 +47,7 @@ module Fastlane
         end
 
         # Store the new number in the shared hash
-        build_number = Actions.sh("#{command_prefix} agvtool what-version", log: false).split("\n").last.strip
+        build_number = params[:build_number] ? params[:build_number].to_s.strip : Actions.sh("#{command_prefix} agvtool what-version", log: false).split("\n").last.strip
 
         return Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
       rescue
@@ -62,7 +62,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :build_number,
                                        env_name: "FL_BUILD_NUMBER_BUILD_NUMBER",
-                                       description: "Change to a specific version",
+                                       description: "Change to a specific version. When you provide this parameter, enabled Apple Generic Versioning is not required",
                                        optional: true,
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :xcodeproj,

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -62,7 +62,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :build_number,
                                        env_name: "FL_BUILD_NUMBER_BUILD_NUMBER",
-                                       description: "Change to a specific version. When you provide this parameter, enabled Apple Generic Versioning is not required",
+                                       description: "Change to a specific version. When you provide this parameter, Apple Generic Versioning does not have to be enabled",
                                        optional: true,
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :xcodeproj,

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -30,8 +30,8 @@ module Fastlane
         # https://developer.apple.com/library/ios/qa/qa1827/_index.html
         # Attention: This is NOT the version number - but the build number
 
-        agv_enabled = system([command_prefix, 'agvtool what-version', command_suffix].join(' '))
-        raise "Apple Generic Versioning is not enabled." unless agv_enabled || params[:build_number]
+        agv_disabled = !system([command_prefix, 'agvtool what-version', command_suffix].join(' '))
+        raise "Apple Generic Versioning is not enabled." if agv_disabled && params[:build_number].nil?
 
         command = [
           command_prefix,
@@ -47,7 +47,8 @@ module Fastlane
         end
 
         # Store the new number in the shared hash
-        build_number = params[:build_number] ? params[:build_number].to_s.strip : Actions.sh("#{command_prefix} agvtool what-version", log: false).split("\n").last.strip
+        build_number = params[:build_number].to_s.strip
+        build_number = Actions.sh("#{command_prefix} agvtool what-version", log: false).split("\n").last.strip if build_number.to_s == ""
 
         return Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
       rescue

--- a/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
@@ -32,11 +32,6 @@ describe Fastlane do
             .once
             .and_return("")
 
-          expect(Fastlane::Actions).to receive(:sh)
-            .with(/agvtool what[-]version/, log: false)
-            .once
-            .and_return("Current version of project Test is:\n24")
-
           result = Fastlane::FastFile.new.parse("lane :test do
             increment_build_number(build_number: 24, xcodeproj: '.xcproject')
           end").runner.execute(:test)
@@ -48,11 +43,6 @@ describe Fastlane do
           expect(Fastlane::Actions).to receive(:sh)
             .with(/agvtool new[-]version [-]all 24 && cd [-]/)
             .and_return("Something\n$(SRCROOT)/Test/Info.plist")
-
-          expect(Fastlane::Actions).to receive(:sh)
-            .with(/agvtool what[-]version/, log: false)
-            .once
-            .and_return("Current version of project Test is:\n24")
 
           expect(UI).to receive(:error).with('Cannot set build number with plist path containing $(SRCROOT)')
           expect(UI).to receive(:error).with('Please remove $(SRCROOT) in your Xcode target build settings')
@@ -78,11 +68,6 @@ describe Fastlane do
             .once
             .and_return("")
 
-          expect(Fastlane::Actions).to receive(:sh)
-            .with(/agvtool what[-]version/, log: false)
-            .once
-            .and_return("Current version of project Test is:\n24")
-
           result = Fastlane::FastFile.new.parse("lane :test do
             increment_build_number(build_number: '24\n', xcodeproj: '.xcproject')
           end").runner.execute(:test)
@@ -102,6 +87,20 @@ describe Fastlane do
               increment_build_number(xcodeproj: '.xcproject')
             end").runner.execute(:test)
           end.to raise_error(/Apple Generic Versioning is not enabled./)
+        end
+
+        it "pass a custom build number to the tool" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool new[-]version [-]all 21 && cd [-]/)
+            .once
+            .and_return("")
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            increment_build_number(build_number: 21, xcodeproj: '.xcproject')
+          end").runner.execute(:test)
+
+          expect(result).to eq('21')
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('21')
         end
       end
     end

--- a/fastlane/spec/actions_specs/set_build_number_repository_spec.rb
+++ b/fastlane/spec/actions_specs/set_build_number_repository_spec.rb
@@ -11,10 +11,6 @@ describe Fastlane do
           .with(/agvtool new[-]version [-]all asd123 && cd [-]/)
           .and_return("")
 
-        expect(Fastlane::Actions).to receive(:sh)
-          .with(/agvtool what[-]version/, log: false)
-          .and_return("Current version of project Test is:\nasd123")
-
         result = Fastlane::FastFile.new.parse("lane :test do
             set_build_number_repository
         end").runner.execute(:test)
@@ -26,10 +22,6 @@ describe Fastlane do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool new[-]version [-]all asd123 && cd [-]/)
           .and_return("")
-
-        expect(Fastlane::Actions).to receive(:sh)
-          .with(/agvtool what[-]version/, log: false)
-          .and_return("Current version of project Test is:\nasd123")
 
         result = Fastlane::FastFile.new.parse("lane :test do
             set_build_number_repository(
@@ -44,10 +36,6 @@ describe Fastlane do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool new[-]version [-]all asd123 && cd [-]/)
           .and_return("")
-
-        expect(Fastlane::Actions).to receive(:sh)
-          .with(/agvtool what[-]version/, log: false)
-          .and_return("Current version of project Test is:\nasd123")
 
         result = Fastlane::FastFile.new.parse("lane :test do
             set_build_number_repository(


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

> increment_build_number can be called with and without build_number parameter.  In [increment_build_number.rb:33](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/increment_build_number.rb#L33) there's a check if Apple Generic Versioning is enabled, but this is only relevant if no build number is provided, as only in this case Apple Generic Versioning is being used.

<!-- If it fixes an open issue, please link to the issue here. -->

closes https://github.com/fastlane/fastlane/issues/14357

### Description
<!-- Describe your changes in detail -->

* Fixed precondition when `build_number` parameter is set and Apple Generic Versioning  is disabled.
* Added new unit test: pass a custom build number to the tool when Apple Generic Versioning  is disabled. 
* Modified existing unit tests: there's no need to call `agvtool what-version` anymore when `build_number` is passed as parameter (Apple Generic Versioning can be disabled anyway). 
* Updated `build_number` parameter documentation. 

<!-- Please describe in detail how you tested your changes. -->

Unit tests + manual testing. Below the results for the project with disabled Apple Generic Versioning 👇 

<img width="988" alt="Screenshot 2019-03-16 at 12 44 40" src="https://user-images.githubusercontent.com/10795657/54479184-a076ca80-481a-11e9-8518-52d77f39aea6.png">

🙇 🙇 