### PR TITLE
[update_project_provisioning] Show default xcodeproj in success output

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -79,7 +79,7 @@ module Fastlane
         project.save
 
         # complete
-        UI.success("Successfully updated project settings in '#{params[:xcodeproj]}'")
+        UI.success("Successfully updated project settings in '#{folder}'")
       end
 
       def self.description


### PR DESCRIPTION
If you run `update_project_provisioning` and don't provide the `xcodeproj` param, the project is automatically located but the successful output prints:

> Successfully updated project settings in ''

This change uses the existing `folder` variable to show the actual location of the project that was used