### PR TITLE
Add the ability to specify Step Name for all actions

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,7 @@ lane :lint_source do
   ensure_no_debug_code(text: " UI\\.", path: "spaceship/lib", extension: ".rb", exclude_dirs: ["\.bundle"])
   ensure_no_debug_code(text: " UI\\.", path: "credentials_manager/lib", extension: ".rb", exclude_dirs: ["\.bundle"])
 
-  rubocop
+  rubocop(step_name: 'policekeeping_the_code_with_rubocop')
 
   Dir.chdir("..") do
     # Verify shell code style

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -228,7 +228,11 @@ module Fastlane
           # If another action is calling this action, we shouldn't show it in the summary
           # (see https://github.com/fastlane/fastlane/issues/4546)
 
-          action_name = from_action ? nil : class_ref.step_text
+          if arguments.kind_of? Array and arguments.first.is_a?(Hash)
+            step_name_override = arguments.first[:step_name]
+            arguments.first.delete(:step_name)
+          end
+          action_name = from_action ? nil : (step_name_override || class_ref.step_text)
           Actions.execute_action(action_name) do
             # arguments is an array by default, containing an hash with the actual parameters
             # Since we usually just need the passed hash, we'll just use the first object if there is only one

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -228,11 +228,11 @@ module Fastlane
           # If another action is calling this action, we shouldn't show it in the summary
           # (see https://github.com/fastlane/fastlane/issues/4546)
 
-          if arguments.kind_of?(Array) && arguments.first.kind_of?(Hash)
-            step_name_override = arguments.first[:step_name]
-            arguments.first.delete(:step_name)
+          unless from_action # see https://github.com/fastlane/fastlane/issues/4546
+            args = arguments.kind_of?(Array) && arguments.first.kind_of?(Hash) ? arguments.first : {}
+            action_name = args[:step_name] || class_ref.step_text
+            args.delete(:step_name)
           end
-          action_name = from_action ? nil : (step_name_override || class_ref.step_text)
           Actions.execute_action(action_name) do
             # arguments is an array by default, containing an hash with the actual parameters
             # Since we usually just need the passed hash, we'll just use the first object if there is only one

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -226,9 +226,8 @@ module Fastlane
       begin
         Dir.chdir(custom_dir) do # go up from the fastlane folder, to the project folder
           # If another action is calling this action, we shouldn't show it in the summary
-          # (see https://github.com/fastlane/fastlane/issues/4546)
 
-          unless from_action # see https://github.com/fastlane/fastlane/issues/4546
+          unless from_action
             args = arguments.kind_of?(Array) && arguments.first.kind_of?(Hash) ? arguments.first : {}
             action_name = args[:step_name] || class_ref.step_text
             args.delete(:step_name)

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -228,7 +228,7 @@ module Fastlane
           # If another action is calling this action, we shouldn't show it in the summary
           # (see https://github.com/fastlane/fastlane/issues/4546)
 
-          if arguments.kind_of? Array and arguments.first.is_a?(Hash)
+          if arguments.kind_of?(Array) && arguments.first.kind_of?(Hash)
             step_name_override = arguments.first[:step_name]
             arguments.first.delete(:step_name)
           end

--- a/fastlane/spec/runner_spec.rb
+++ b/fastlane/spec/runner_spec.rb
@@ -20,6 +20,17 @@ describe Fastlane do
       it "doesn't show private lanes" do
         expect(@ff.runner.available_lanes).to_not(include('android such_private'))
       end
+      describe "step_name override" do
+        it "handle overriding of step_name" do
+          allow(Fastlane::Actions).to receive(:execute_action).with('Let it Frame')
+          @ff.runner.execute_action(:frameit, Fastlane::Actions::FrameitAction, [{ step_name: "Let it Frame" }])
+        end
+        it "rely on step_text when no step_name given" do
+          allow(Fastlane::Actions).to receive(:execute_action).with('frameit')
+
+          @ff.runner.execute_action(:frameit, Fastlane::Actions::FrameitAction, [{}])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary. (🚧  _incoming_ )

### Motivation and Context
Some actions are meant to be runned several time with different configuration.

One of this exemple is  the [yarn plugin](https://github.com/joshrlesch/fastlane-plugin-yarn) that you may invoke different time with different script. Each of this invocation will appear with the same step_name, as `self.step_text` does not allow override on a per invocation basis.

**This PR tries to add a way to customize this (_each step name_)**

### Description

This PR add a mecanism so that the `step_name` of each action can be customized.
This is done by a facultative `:step_name` param that gets them removed from the properties passed to `action.run(params)`

#### Usage Example: 
```ruby
  rubocop(step_name: 'policekeeping_the_code_with_rubocop')
  yarn(command: 'fetch:version', step_name: 'fetch_version_code')
  yarn(command: 'pull:certificate', step_name: 'pull_certificates')
```
