### PR TITLE
Fix create keychain creates keychain file in wrong keychain directory

### DIFF
--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -11,7 +11,7 @@ module Fastlane
         escaped_password = params[:password].shellescape
 
         if params[:name]
-          keychain_path = "~/Library/Keychains/#{params[:name]}"
+          keychain_path = "#{ENV['HOME']}/Library/Keychains/#{params[:name]}"
         else
           keychain_path = params[:path]
         end

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -10,7 +10,6 @@ module Fastlane
       def self.run(params)
         escaped_password = params[:password].shellescape
 
-
         if params[:name]
           keychain_path = "#{ENV['HOME']}/Library/Keychains/#{params[:name]}"
         else

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -10,6 +10,7 @@ module Fastlane
       def self.run(params)
         escaped_password = params[:password].shellescape
 
+
         if params[:name]
           keychain_path = "#{ENV['HOME']}/Library/Keychains/#{params[:name]}"
         else


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The recent fix for ShellEscaping in create_keychain created this issue
https://github.com/fastlane/fastlane/pull/14311

The HOME directory should be referenced via $HOME Env Variable and not via **~**
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/14418
### Description
<!-- Describe your changes in detail -->
Changed the **~** to #{ENV['HOME']} 
<!-- Please describe in detail how you tested your changes. -->
Tested this by running the earlier regression on my Environment.