### PR TITLE
Adds FASTLANE_SKIP_ACTION_SUMMARY variable to skip table output

### DIFF
--- a/fastlane/lib/fastlane/lane_manager_base.rb
+++ b/fastlane/lib/fastlane/lane_manager_base.rb
@@ -32,6 +32,7 @@ module Fastlane
     # Print a table as summary of the executed actions
     def self.print_table(actions)
       return if actions.count == 0
+      return if FastlaneCore::Env.truthy?('FASTLANE_SKIP_ACTION_SUMMARY') # User disabled table output
 
       require 'terminal-table'
 

--- a/fastlane/spec/lane_manager_spec.rb
+++ b/fastlane/spec/lane_manager_spec.rb
@@ -108,6 +108,19 @@ describe Fastlane do
           expect(lanes[:ios][:apple].description).to eq([])
           expect(lanes[:android][:robot].description).to eq([])
         end
+
+        it "Does output a summary table when FASTLANE_SKIP_ACTION_SUMMARY ENV variable is not set" do
+          ENV["FASTLANE_SKIP_ACTION_SUMMARY"] = nil
+          expect(Terminal::Table).to(receive(:new).with(title: "fastlane summary".green, headings: anything, rows: anything))
+          ff = Fastlane::LaneManager.cruise_lane(nil, 'test')
+        end
+
+        it "Does not output summary table when FASTLANE_SKIP_ACTION_SUMMARY ENV variable is set" do
+          ENV["FASTLANE_SKIP_ACTION_SUMMARY"] = "true"
+          expect(Terminal::Table).to_not(receive(:new).with(title: "fastlane summary".green, headings: anything, rows: anything))
+          ff = Fastlane::LaneManager.cruise_lane(nil, 'test')
+          ENV["FASTLANE_SKIP_ACTION_SUMMARY"] = nil
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #14430 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #14430

### Description
When the `FASTLANE_SKIP_ACTION_SUMMARY` environment variable is set, suppress output of the action summary table.
