### PR TITLE
[spaceship] Automate phone number selection for "request code via SMS" in 2FA with `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` env var

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -153,7 +153,7 @@ module Cert
       # Create a new certificate signing request
       csr, pkey = Spaceship.certificate.create_certificate_signing_request
 
-      # Use the signing request to create a new distribution certificate
+      # Use the signing request to create a new (development|distribution) certificate
       begin
         certificate = certificate_type.create!(csr: csr)
       rescue => ex

--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -18,13 +18,15 @@ module Spaceship
         Spaceship::Tunes.login(@username)
         puts("Successfully logged in to App Store Connect".green)
         puts("")
-      rescue
+      rescue => ex
         puts("Could not login to App Store Connect".red)
         puts("Please check your credentials and try again.".yellow)
         puts("This could be an issue with App Store Connect,".yellow)
         puts("Please try unsetting the FASTLANE_SESSION environment variable".yellow)
         puts("(if it is set) and re-run `fastlane spaceauth`".yellow)
-        raise "Problem connecting to App Store Connect"
+        puts("")
+        puts("Execption type: #{ex.class}")
+        raise ex
       end
 
       itc_cookie_content = Spaceship::Tunes.client.store_cookie

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -206,7 +206,7 @@ module Spaceship
         number_with_dialcode_regex = /^#{number_with_dialcode_regex_part}$/
         # => /^\+49([0-9]{8})85$/ or /^\+1([0-9]{7,8})66$/
 
-        return phone['id'] if phone_number.match?(number_with_dialcode_regex)
+        return phone['id'] if phone_number =~ number_with_dialcode_regex
         # +491621234585 matches /^\+49([0-9]{8})85$/
       end
 

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -184,7 +184,7 @@ module Spaceship
     end
 
     def phone_id_from_number(phone_numbers, phone_number)
-      characters_to_remove_from_phone_numbers = ' \-()'
+      characters_to_remove_from_phone_numbers = ' \-()"'
 
       # start with e.g. +49 162 1234585 or +1-123-456-7866
       phone_number = phone_number.tr(characters_to_remove_from_phone_numbers, '')

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -128,6 +128,7 @@ module Spaceship
         puts("SPACESHIP_2FA_DEFAULT_PHONE_NUMBER = #{ENV['SPACESHIP_2FA_DEFAULT_PHONE_NUMBER']}")
         phone_number = ENV["SPACESHIP_2FA_DEFAULT_PHONE_NUMBER"]
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
+        code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length)
       else
         puts("(Input `sms` to escape this prompt and select a trusted phone number to send the code as a text message)")

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -124,9 +124,9 @@ module Spaceship
 
       puts("")
       if ENV["SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER"]
-        puts("Environment variable `SPACESHIP_2FA_DEFAULT_PHONE_NUMBER` is set, automatically requesting 2FA token via SMS to that number")
-        puts("SPACESHIP_2FA_DEFAULT_PHONE_NUMBER = #{ENV['SPACESHIP_2FA_DEFAULT_PHONE_NUMBER']}")
-        phone_number = ENV["SPACESHIP_2FA_DEFAULT_PHONE_NUMBER"]
+        puts("Environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` is set, automatically requesting 2FA token via SMS to that number")
+        puts("SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER = #{ENV['SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER']}")
+        phone_number = ENV["SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER"]
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
         code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length)

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -134,7 +134,7 @@ module Spaceship
         puts("(Input `sms` to escape this prompt and select a trusted phone number to send the code as a text message)")
         puts("(You can also set the environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` to automate this)")
         code_type = 'trusteddevice'
-        code = ask("Please enter the #{code_length} digit code:")
+        code = ask_for_2fa_code("Please enter the #{code_length} digit code:")
         body = { "securityCode" => { "code" => code.to_s } }.to_json
 
         # User exited by entering `sms` and wants to choose phone number for SMS
@@ -181,6 +181,11 @@ module Spaceship
       store_session
 
       return true
+    end
+
+    # extracted into its own method for testing
+    def ask_for_2fa_code(text)
+      ask(text)
     end
 
     def phone_id_from_number(phone_numbers, phone_number)
@@ -254,7 +259,7 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
 
       puts("Successfully requested text message to #{phone_number}")
 
-      code = ask("Please enter the #{code_length} digit code you received at #{phone_number}:")
+      code = ask_for_2fa_code("Please enter the #{code_length} digit code you received at #{phone_number}:")
 
       return { "securityCode" => { "code" => code.to_s }, "phoneNumber" => { "id" => phone_id }, "mode" => "sms" }.to_json
     end

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -196,7 +196,7 @@ module Spaceship
         # rubocop:enable Style/AsciiComments
 
         maskings_count = number_with_dialcode_masked.count('•') # => 9 or 8
-        pattern = /^([0-9+]{2,3})([•]{#{maskings_count}})([0-9]{2})$/
+        pattern = /^([0-9+]{2,4})([•]{#{maskings_count}})([0-9]{2})$/
         replacement = "\\1([0-9]{#{maskings_count - 1},#{maskings_count}})\\3"
         number_with_dialcode_regex_part = number_with_dialcode_masked.gsub(pattern, replacement)
         # => +49([0-9]{8,9})85 or +1([0-9]{7,8})66

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -131,6 +131,7 @@ module Spaceship
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length)
       else
         puts("(Input `sms` to escape this prompt and select a trusted phone number to send the code as a text message)")
+        puts("(You can also set the environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` to automate this)")
         code_type = 'trusteddevice'
         code = ask("Please enter the #{code_length} digit code:")
         body = { "securityCode" => { "code" => code.to_s } }.to_json

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -130,13 +130,17 @@ module Spaceship
 
         puts("Environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` is set, automatically requesting 2FA token via SMS to that number")
         puts("SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER = #{env_2fa_sms_default_phone_number}")
+        puts("")
         phone_number = env_2fa_sms_default_phone_number
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
         code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length)
       else
         puts("(Input `sms` to escape this prompt and select a trusted phone number to send the code as a text message)")
+        puts("")
         puts("(You can also set the environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` to automate this)")
+        puts("(Read more at: https://github.com/fastlane/fastlane/blob/master/spaceship/docs/Authentication.md#auto-select-sms-via-spaceship-2fa-sms-default-phone-number)")
+        puts("")
         code_type = 'trusteddevice'
         code = ask_for_2fa_code("Please enter the #{code_length} digit code:")
         body = { "securityCode" => { "code" => code.to_s } }.to_json

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -123,10 +123,13 @@ module Spaceship
       code_length = security_code["length"]
 
       puts("")
-      if ENV["SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER"]
+      2fa_sms_default_phone_number = ENV["SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER"]
+      if 2fa_sms_default_phone_number
+        raise Tunes::Error.new, "Environment variable SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER is set, but empty." if 2fa_sms_default_phone_number.empty?
+
         puts("Environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` is set, automatically requesting 2FA token via SMS to that number")
-        puts("SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER = #{ENV['SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER']}")
-        phone_number = ENV["SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER"]
+        puts("SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER = #{2fa_sms_default_phone_number}")
+        phone_number = 2fa_sms_default_phone_number
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
         code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length)

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -123,13 +123,14 @@ module Spaceship
       code_length = security_code["length"]
 
       puts("")
-      2fa_sms_default_phone_number = ENV["SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER"]
-      if 2fa_sms_default_phone_number
-        raise Tunes::Error.new, "Environment variable SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER is set, but empty." if 2fa_sms_default_phone_number.empty?
+      env_2fa_sms_default_phone_number = ENV["SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER"]
+
+      if env_2fa_sms_default_phone_number
+        raise Tunes::Error.new, "Environment variable SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER is set, but empty." if env_2fa_sms_default_phone_number.empty?
 
         puts("Environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` is set, automatically requesting 2FA token via SMS to that number")
-        puts("SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER = #{2fa_sms_default_phone_number}")
-        phone_number = 2fa_sms_default_phone_number
+        puts("SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER = #{env_2fa_sms_default_phone_number}")
+        phone_number = env_2fa_sms_default_phone_number
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
         code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length)

--- a/spaceship/spec/fixtures/client_appleauth_auth_2fa_response.json
+++ b/spaceship/spec/fixtures/client_appleauth_auth_2fa_response.json
@@ -1,0 +1,37 @@
+{
+	"trustedPhoneNumbers": [{
+		"numberWithDialCode": "+49 •••• •••••85",
+		"pushMode": "sms",
+		"obfuscatedNumber": "•••• •••••85",
+		"id": 1
+	}, {
+		"numberWithDialCode": "+49 ••••• •••••81",
+		"pushMode": "sms",
+		"obfuscatedNumber": "••••• •••••81",
+		"id": 2
+	}],
+	"securityCode": {
+		"length": 6,
+		"tooManyCodesSent": false,
+		"tooManyCodesValidated": false,
+		"securityCodeLocked": false
+	},
+	"authenticationType": "hsa2",
+	"recoveryUrl": "https://iforgot.apple.com/phone/add?prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+	"cantUsePhoneNumberUrl": "https://iforgot.apple.com/iforgot/phone/add?context=cantuse&prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+	"recoveryWebUrl": "https://iforgot.apple.com/password/verify/appleid?prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+	"repairPhoneNumberUrl": "https://gsa.apple.com/appleid/account/manage/repair/verify/phone",
+	"repairPhoneNumberWebUrl": "https://appleid.apple.com/widget/account/repair?#!repair",
+	"aboutTwoFactorAuthenticationUrl": "https://support.apple.com/kb/HT204921",
+	"autoVerified": false,
+	"showAutoVerificationUI": false,
+	"managedAccount": false,
+	"trustedPhoneNumber": {
+		"numberWithDialCode": "+49 •••• •••••85",
+		"pushMode": "sms",
+		"obfuscatedNumber": "•••• •••••85",
+		"id": 1
+	},
+	"hsa2Account": true,
+	"supportsRecovery": true
+}

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -40,6 +40,20 @@ class TunesStubbing
         with(body: "{\"contentProviderId\":\"5678\",\"dsId\":null}",
               headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type' => 'application/json' }).
         to_return(status: 200, body: "", headers: {})
+
+      # 2FA: Request security code to trusted phone
+      stub_request(:put, "https://idmsa.apple.com/appleauth/auth/verify/phone").
+        with(body: "{\"phoneNumber\":{\"id\":1},\"mode\":\"sms\"}").
+        to_return(status: 200, body: "", headers: {})
+
+      # 2FA: Submit security code from trusted phone for verification
+      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode").
+        with(body: "{\"securityCode\":{\"code\":\"123\"},\"phoneNumber\":{\"id\":1},\"mode\":\"sms\"}").
+        to_return(status: 200, body: "", headers: {})
+
+      # 2FA: Trust computer
+      stub_request(:get, "https://idmsa.apple.com/appleauth/auth/2sv/trust").
+        to_return(status: 200, body: "", headers: {})
     end
 
     def itc_stub_applications

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -65,11 +65,11 @@ describe Spaceship::Client do
       response.body = JSON.parse(response_fixture)
     end
 
-    after do
-      ENV.delete('SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER')
-    end
-
     describe 'with SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER set' do
+      after do
+        ENV.delete('SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER')
+      end
+
       it 'to a known phone number returns true (and sends the correct requests)' do
         phone_number = '+49 123 4567885'
         ENV['SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER'] = phone_number
@@ -94,6 +94,11 @@ describe Spaceship::Client do
           bool = subject.handle_two_factor(response)
         end.to raise_error(Spaceship::Tunes::Error)
       end
+    end
+
+    describe 'with SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER not set' do
+      # 1. input of pushed code
+      # 2. input of `sms`, then selection of phone, then input of sms-ed code
     end
   end
 end

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -13,6 +13,10 @@ describe Spaceship::Client do
     def store_cookie(path: nil)
       true
     end
+
+    def update_request_headers(req)
+      req
+    end
   end
 
   let(:subject) { TwoStepOrFactorClient.new }

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -20,7 +20,8 @@ describe Spaceship::Client do
         { "id" : 1, "numberWithDialCode" : "+49 •••• •••••85", "obfuscatedNumber" : "•••• •••••85", "pushMode" : "sms" },
         { "id" : 2, "numberWithDialCode" : "+49 ••••• •••••81", "obfuscatedNumber" : "••••• •••••81", "pushMode" : "sms" },
         { "id" : 3, "numberWithDialCode" : "+1 (•••) •••-••66", "obfuscatedNumber" : "(•••) •••-••66", "pushMode" : "sms" },
-        { "id" : 4, "numberWithDialCode" : "+39 ••• ••• ••71", "obfuscatedNumber" : "••• ••• ••71", "pushMode" : "sms" }
+        { "id" : 4, "numberWithDialCode" : "+39 ••• ••• ••71", "obfuscatedNumber" : "••• ••• ••71", "pushMode" : "sms" },
+        { "id" : 5, "numberWithDialCode" : "+353 •• ••• ••43", "obfuscatedNumber" : "••• ••• •43", "pushMode" : "sms" }
       ]
     '
   end
@@ -31,7 +32,8 @@ describe Spaceship::Client do
       "+49 123 4567885" => 1,
       "+4912341234581" => 2,
       "+1-123-456-7866" => 3,
-      "+39 123 456 7871" => 4
+      "+39 123 456 7871" => 4,
+      "+353123456743" => 5
     }.each do |number_to_test, expected_phone_id|
       it "selects correct phone id #{expected_phone_id} for provided phone number #{number_to_test}" do
         phone_id = subject.phone_id_from_number(phone_numbers, number_to_test)

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -1,0 +1,51 @@
+describe Spaceship::Client do
+  class TestClient < Spaceship::Client
+    def self.hostname
+      "http://example.com"
+    end
+
+    def req_home
+      request(:get, TestClient.hostname)
+    end
+
+    def send_login_request(_user, _password)
+      true
+    end
+  end
+
+  let(:subject) { TestClient.new }
+  let(:phone_numbers_json_string) { 
+    %q(
+      [ 
+        { "id" : 1, "numberWithDialCode" : "+49 •••• •••••85", "obfuscatedNumber" : "•••• •••••85", "pushMode" : "sms" }, 
+        { "id" : 2, "numberWithDialCode" : "+49 ••••• •••••81", "obfuscatedNumber" : "••••• •••••81", "pushMode" : "sms" },
+        { "id" : 3, "numberWithDialCode" : "+1 (•••) •••-••66", "obfuscatedNumber" : "(•••) •••-••66", "pushMode" : "sms" },
+        { "id" : 4, "numberWithDialCode" : "+39 ••• ••• ••71", "obfuscatedNumber" : "••• ••• ••71", "pushMode" : "sms" }
+      ] 
+    )
+  }
+  let(:phone_numbers) { JSON.parse(phone_numbers_json_string) }
+
+  describe 'phone_id_from_number' do
+
+    {
+      "+49 123 4567885" => 1,
+      "+4912341234581" => 2,
+      "+1-123-456-7866" => 3,
+      "+39 123 456 7871" => 4
+    }.each do |number_to_test, expected_phone_id| 
+      it "selects correct phone id #{expected_phone_id} for provided phone number #{number_to_test}" do
+        phone_id = subject.phone_id_from_number(phone_numbers, number_to_test)
+        expect(phone_id).to eq(expected_phone_id)
+      end
+    end
+
+    it "raises an error with unknown phone number" do
+      phone_number = 'la le lu'
+      expect do
+        phone_id =  subject.phone_id_from_number(phone_numbers, phone_number)
+      end.to raise_error(Spaceship::Tunes::Error)
+    end
+
+  end  
+end

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -14,6 +14,8 @@ describe Spaceship::Client do
       true
     end
 
+    # these tests actually "send requests" - and `update_request_headers` would otherwise 
+    # add data to the headers that does not exist / is empty which will crash faraday later
     def update_request_headers(req)
       req
     end
@@ -87,7 +89,7 @@ describe Spaceship::Client do
       it 'to a unknown phone number throws an exception' do
         phone_number = '+49 123 4567800'
         ENV['SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER'] = phone_number
-        
+
         expect do
           bool = subject.handle_two_factor(response)
         end.to raise_error(Spaceship::Tunes::Error)

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -14,26 +14,25 @@ describe Spaceship::Client do
   end
 
   let(:subject) { TestClient.new }
-  let(:phone_numbers_json_string) { 
-    %q(
-      [ 
-        { "id" : 1, "numberWithDialCode" : "+49 •••• •••••85", "obfuscatedNumber" : "•••• •••••85", "pushMode" : "sms" }, 
+  let(:phone_numbers_json_string) do
+    '
+      [
+        { "id" : 1, "numberWithDialCode" : "+49 •••• •••••85", "obfuscatedNumber" : "•••• •••••85", "pushMode" : "sms" },
         { "id" : 2, "numberWithDialCode" : "+49 ••••• •••••81", "obfuscatedNumber" : "••••• •••••81", "pushMode" : "sms" },
         { "id" : 3, "numberWithDialCode" : "+1 (•••) •••-••66", "obfuscatedNumber" : "(•••) •••-••66", "pushMode" : "sms" },
         { "id" : 4, "numberWithDialCode" : "+39 ••• ••• ••71", "obfuscatedNumber" : "••• ••• ••71", "pushMode" : "sms" }
-      ] 
-    )
-  }
+      ]
+    '
+  end
   let(:phone_numbers) { JSON.parse(phone_numbers_json_string) }
 
   describe 'phone_id_from_number' do
-
     {
       "+49 123 4567885" => 1,
       "+4912341234581" => 2,
       "+1-123-456-7866" => 3,
       "+39 123 456 7871" => 4
-    }.each do |number_to_test, expected_phone_id| 
+    }.each do |number_to_test, expected_phone_id|
       it "selects correct phone id #{expected_phone_id} for provided phone number #{number_to_test}" do
         phone_id = subject.phone_id_from_number(phone_numbers, number_to_test)
         expect(phone_id).to eq(expected_phone_id)
@@ -43,9 +42,8 @@ describe Spaceship::Client do
     it "raises an error with unknown phone number" do
       phone_number = 'la le lu'
       expect do
-        phone_id =  subject.phone_id_from_number(phone_numbers, phone_number)
+        phone_id = subject.phone_id_from_number(phone_numbers, phone_number)
       end.to raise_error(Spaceship::Tunes::Error)
     end
-
-  end  
+  end
 end

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -1,3 +1,5 @@
+require_relative 'mock_servers'
+
 describe Spaceship::Client do
   class TestClient < Spaceship::Client
     def self.hostname
@@ -11,9 +13,22 @@ describe Spaceship::Client do
     def send_login_request(_user, _password)
       true
     end
+
+    def self.user
+      "foouser"
+    end
+
+    def ask_for_2fa_code(text)
+      '123'
+    end
+
+    def persistent_cookie_path
+      'foo' # TODO creates file in current directory with useless content
+    end
   end
 
   let(:subject) { TestClient.new }
+
   let(:phone_numbers_json_string) do
     '
       [
@@ -46,6 +61,48 @@ describe Spaceship::Client do
       expect do
         phone_id = subject.phone_id_from_number(phone_numbers, phone_number)
       end.to raise_error(Spaceship::Tunes::Error)
+    end
+  end
+
+  describe 'handle_two_factor' do
+    let(:response_fixture) { File.read(File.join('spaceship', 'spec', 'fixtures', 'client_appleauth_auth_2fa_response.json'), encoding: 'utf-8') }
+
+    it 'successfully requests a session with SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER set to a known phone number and the correct security code being entered' do
+      # call 1
+      MockAPI::DeveloperPortalServer.put('https://idmsa.apple.com/appleauth/auth/verify/phone') do
+        {}
+      end
+
+      # call 2
+      MockAPI::DeveloperPortalServer.post('https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode') do
+        {}
+      end
+
+      # call 3
+      MockAPI::DeveloperPortalServer.get('https://idmsa.apple.com/appleauth/auth/2sv/trust') do
+        {}
+      end
+
+      ENV['SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER'] = '+491622850885'
+
+      response = OpenStruct.new
+      response.body = JSON.parse(response_fixture)
+      bool = subject.handle_two_factor(response)
+
+      ENV.delete('SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER')
+
+      expect(bool).to eq(true)
+
+      # call 1
+      expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone')
+        .with(body: { phoneNumber: { id: 1 }, mode: "sms" })
+
+      # call 2
+      expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode')
+        .with(body: { securityCode: { code: "123" }, phoneNumber: { id: 1 }, mode: "sms" })
+
+      # call 3
+      expect(WebMock).to have_requested(:get, 'https://idmsa.apple.com/appleauth/auth/2sv/trust')
     end
   end
 end

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -14,7 +14,7 @@ describe Spaceship::Client do
       true
     end
 
-    # these tests actually "send requests" - and `update_request_headers` would otherwise 
+    # these tests actually "send requests" - and `update_request_headers` would otherwise
     # add data to the headers that does not exist / is empty which will crash faraday later
     def update_request_headers(req)
       req


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context

2FA with token entry is a hassle to fastlane users. Some use cases also force people to use trusted phone numbers instead of the usual pushed tokens, so we can streamline their workflow by allowing them to skip the pushed token and remove the necessary interaction to get a token sent to a specific phone number.

### Description

The new environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` allows you to set a phone number, that is automatically used as the recipient of the 2FA token. You do not have to "escape" the normal input via inputting `sms` and then selecting your phone number from a dropdown any more.

#### Testing

I wrote a few tests for the specific methods I introduced that helped me to make sure they actually do what I expected them to do. Then I manually tested via `bundle exec fastlane spaceauth` as it basically just does the spaceship login - which is what this code impacts.

#### Unrelated changes 

This PR also includes a little comment in the cert runner and changes the way `fastlane spaceauth` handles exceptions - before they were just swallowed, but as my new code raises one if it can't find the correct phone number, that was not very good for testing. Now they are bubbled up to the user.

closes #13980

---

### Review Notes

- I am not really happy with the code of `phone_id_from_number`, the way I find the `phone_id` for the value of the ENV variable via the regex pattern, and especially the way I build it looks really crap and complicated. Is there a better way to do this?
- Does my spec file make sense? It worked for me when writing the initial code, but are those actually good tests? Should I do more here? The whole file was completely untested before. Now at least those two methods I touched are tested a tiny bit.