### PR TITLE
Avoid Search for the Crashlytics API token if parameter gsp_path is set

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -101,6 +101,7 @@ module Fastlane
       end
 
       def self.find_api_token(params)
+        return if params[:gsp_path]
         unless params[:api_token].to_s.length > 0
           Dir["./**/Info.plist"].each do |current|
             result = Actions::GetInfoPlistValueAction.run(path: current, key: "Fabric")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change reduces the confusion mentionend in [Issue 14176](https://github.com/fastlane/fastlane/issues/14176), tho make clear, the missing symbols in Firebase after an upload are not related to the errors in the log, created, when searching for the API token


### Description
When the parameter gsp_path is set, there is no need to search for the API token
and we can skip the search, like it is already done in function find_gsp_path
if parameter api_token is set.
