### PR TITLE
[action] Add optional argument to filter git commits for changelog

### DIFF
--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -37,9 +37,9 @@ module Fastlane
 
         Dir.chdir(params[:path]) do
           if params[:commits_count]
-            changelog = Actions.git_log_last_commits(params[:pretty], params[:commits_count], merge_commit_filtering, params[:date_format], params[:ancestry_path])
+            changelog = Actions.git_log_last_commits(params[:pretty], params[:commits_count], params[:matching_pattern], merge_commit_filtering, params[:date_format], params[:ancestry_path])
           else
-            changelog = Actions.git_log_between(params[:pretty], from, to, merge_commit_filtering, params[:date_format], params[:ancestry_path])
+            changelog = Actions.git_log_between(params[:pretty], from, to, params[:matching_pattern], merge_commit_filtering, params[:date_format], params[:ancestry_path])
           end
 
           changelog = changelog.gsub("\n\n", "\n") if changelog # as there are duplicate newlines
@@ -108,6 +108,11 @@ module Fastlane
                                        description: 'The format applied to each commit while generating the collected value',
                                        optional: true,
                                        default_value: '%B',
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :matching_pattern,
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_MATCHING_PATTERN',
+                                       description: 'A regexp pattern to filter only the commits matching the pattern',
+                                       optional: true,
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :date_format,
                                        env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_DATE_FORMAT',
@@ -182,6 +187,7 @@ module Fastlane
             pretty: "- (%ae) %s",                    # Optional, lets you provide a custom format to apply to each commit when generating the changelog text
             date_format: "short",                    # Optional, lets you provide an additional date format to dates within the pretty-formatted string
             match_lightweight_tag: false,            # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
+            matching_pattern: "[.*?].*",             # Optional, lets you filter out commits not matching the regex pattern
             merge_commit_filtering: "exclude_merges" # Optional, lets you filter out merge commits
           )'
         ]

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -2,9 +2,10 @@ module Fastlane
   module Actions
     GIT_MERGE_COMMIT_FILTERING_OPTIONS = [:include_merges, :exclude_merges, :only_include_merges].freeze
 
-    def self.git_log_between(pretty_format, from, to, merge_commit_filtering, date_format = nil, ancestry_path)
+    def self.git_log_between(pretty_format, from, to, matching_pattern, merge_commit_filtering, date_format = nil, ancestry_path)
       command = ['git log']
       command << "--pretty=\"#{pretty_format}\""
+      command << "--grep=\"#{matching_pattern}\"" if matching_pattern
       command << "--date=\"#{date_format}\"" if date_format
       command << '--ancestry-path' if ancestry_path
       command << "#{from.shellescape}...#{to.shellescape}"
@@ -14,9 +15,10 @@ module Fastlane
       nil
     end
 
-    def self.git_log_last_commits(pretty_format, commit_count, merge_commit_filtering, date_format = nil, ancestry_path)
+    def self.git_log_last_commits(pretty_format, commit_count, matching_pattern, merge_commit_filtering, date_format = nil, ancestry_path)
       command = ['git log']
       command << "--pretty=\"#{pretty_format}\""
+      command << "--grep=\"#{matching_pattern}\"" if matching_pattern
       command << "--date=\"#{date_format}\"" if date_format
       command << '--ancestry-path' if ancestry_path
       command << "-n #{commit_count}"


### PR DESCRIPTION
Added an optional argument `matching_pattern` to the `git_log_between` and `git_log_last_commits` actions. It injects the pattern to the `git log` command for the `grep` argument.

Added documentation and sample code.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
In some projects, might be needed to create release notes and Changelog entries from the commits, but only merge commits into a specific branch (e.g. `develop`). This feature will also  provide more flexibility to the users to choose their own commit naming schema to bypass or filter irrelevant commits for the release notes.

#14404 

### Description
The action `changelog_from_git_commits` provides some useful parameters already, but a `git log` parameter `--grep=""` is not implemented. Providing a parameter to pass to this function (e.g. `matching_pattern`) will allow the users to have more flexibility when generating their Changelogs.

Code examples:

In both functions `Actions.git_log_between` and `Actions.git_log_last_commits` an extra parameter will be added:

```ruby
def self.git_log_between(pretty_format, from, to, matching_pattern, merge_commit_filtering, date_format = nil, ancestry_path)
def self.git_log_last_commits(pretty_format, commit_count, matching_pattern, merge_commit_filtering, date_format = nil, ancestry_path)
```

In the function body, if the parameter exists, will be added as a `--grep=""` parameter to `git log`. Example:

```ruby
      command << "--grep=\"#{matching_pattern}\"" if matching_pattern
```

Since the parameter will be optional, if won't break the existing functionality.

I've been using the workaround for a while, and tested it on my local fork, from where I am creating this PR.