### PR TITLE
add --no-verify option to commit_version_bump

### DIFF
--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -130,7 +130,16 @@ module Fastlane
 
           params[:message] ||= (build_number ? "Version Bump to #{build_number}" : "Version Bump")
 
-          Actions.sh("git commit -m '#{params[:message]}'")
+          command = [
+            'git',
+            'commit',
+            '-m',
+            "'#{params[:message]}'"
+          ]
+
+          command << '--no-verify' if params[:no_verify]
+
+          Actions.sh(command.join(' '))
 
           UI.success("Committed \"#{params[:message]}\" 💾.")
         rescue => ex
@@ -178,7 +187,12 @@ module Fastlane
                                        description: "A list of extra files to be included in the version bump (string array or comma-separated string)",
                                        optional: true,
                                        default_value: [],
-                                       type: Array)
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :no_verify,
+                                      env_name: "FL_GIT_PUSH_USE_NO_VERIFY",
+                                      description: "Whether or not to use --no-verify",
+                                      type: Boolean,
+                                      default_value: false)
         ]
       end
 
@@ -227,6 +241,9 @@ module Fastlane
           )',
           'commit_version_bump(
             ignore: /OtherProject/ # ignore files matching a regular expression
+          )',
+          'commit_version_bump(
+            no_verify: true           # optional, default: false
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -130,16 +130,9 @@ module Fastlane
 
           params[:message] ||= (build_number ? "Version Bump to #{build_number}" : "Version Bump")
 
-          command = [
-            'git',
-            'commit',
-            '-m',
-            "'#{params[:message]}'"
-          ]
+          command = build_git_command(params)
 
-          command << '--no-verify' if params[:no_verify]
-
-          Actions.sh(command.join(' '))
+          Actions.sh(command)
 
           UI.success("Committed \"#{params[:message]}\" 💾.")
         rescue => ex
@@ -282,6 +275,19 @@ module Fastlane
             Pathname.new(path).relative_path_from(root_pathname).to_s
           end
           return all_modified_files.uniq
+        end
+
+        def build_git_command(params)
+          command = [
+            'git',
+            'commit',
+            '-m',
+            "'#{params[:message]}'"
+          ]
+
+          command << '--no-verify' if params[:no_verify]
+
+          return command.join(' ')
         end
       end
     end

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -126,7 +126,6 @@ module Fastlane
         Actions.sh("git add #{git_add_paths.map(&:shellescape).join(' ')}")
 
         begin
-
           command = build_git_command(params)
 
           Actions.sh(command)

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -126,9 +126,6 @@ module Fastlane
         Actions.sh("git add #{git_add_paths.map(&:shellescape).join(' ')}")
 
         begin
-          build_number = Actions.lane_context[Actions::SharedValues::BUILD_NUMBER]
-
-          params[:message] ||= (build_number ? "Version Bump to #{build_number}" : "Version Bump")
 
           command = build_git_command(params)
 
@@ -278,6 +275,10 @@ module Fastlane
         end
 
         def build_git_command(params)
+          build_number = Actions.lane_context[Actions::SharedValues::BUILD_NUMBER]
+
+          params[:message] ||= (build_number ? "Version Bump to #{build_number}" : "Version Bump")
+
           command = [
             'git',
             'commit',

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -73,4 +73,18 @@ describe Fastlane::Actions::CommitVersionBumpAction do
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::MODIFIED_FILES]).to eq(expected)
     end
   end
+
+  describe 'build_git_command' do
+    it 'creates a git commit with the provided message' do
+      command = action.build_git_command(message: "my commit message")
+
+      expect(command).to eq "git commit -m 'my commit message'"
+    end
+
+    it 'appends the --no-verify if required' do
+      command = action.build_git_command(message: "my commit message", no_verify: true)
+
+      expect(command).to eq "git commit -m 'my commit message' --no-verify"
+    end
+  end
 end

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -78,26 +78,26 @@ describe Fastlane::Actions::CommitVersionBumpAction do
     it 'creates a git commit with the provided message' do
       command = action.build_git_command(message: "my commit message")
 
-      expect(command).to eq "git commit -m 'my commit message'"
+      expect(command).to eq("git commit -m 'my commit message'")
     end
 
     it 'creates a commit message containing the build number if no message is provided' do
       Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER] = "123"
       command = action.build_git_command(no_verify: false)
 
-      expect(command).to eq "git commit -m 'Version Bump to 123'"
+      expect(command).to eq("git commit -m 'Version Bump to 123'")
     end
 
     it 'creates a default commit message if no message or build number is provided' do
       command = action.build_git_command(no_verify: false)
 
-      expect(command).to eq "git commit -m 'Version Bump'"
+      expect(command).to eq("git commit -m 'Version Bump'")
     end
 
     it 'appends the --no-verify if required' do
       command = action.build_git_command(message: "my commit message", no_verify: true)
 
-      expect(command).to eq "git commit -m 'my commit message' --no-verify"
+      expect(command).to eq("git commit -m 'my commit message' --no-verify")
     end
   end
 end

--- a/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
+++ b/fastlane/spec/actions_specs/commit_version_bump_action_spec.rb
@@ -81,6 +81,19 @@ describe Fastlane::Actions::CommitVersionBumpAction do
       expect(command).to eq "git commit -m 'my commit message'"
     end
 
+    it 'creates a commit message containing the build number if no message is provided' do
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER] = "123"
+      command = action.build_git_command(no_verify: false)
+
+      expect(command).to eq "git commit -m 'Version Bump to 123'"
+    end
+
+    it 'creates a default commit message if no message or build number is provided' do
+      command = action.build_git_command(no_verify: false)
+
+      expect(command).to eq "git commit -m 'Version Bump'"
+    end
+
     it 'appends the --no-verify if required' do
       command = action.build_git_command(message: "my commit message", no_verify: true)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adding this feature as per the request in https://github.com/fastlane/fastlane/pull/14288#issuecomment-474971322

### Description
adds the `--no-verify` flag to the `commit_version_bump` action
