### PR TITLE
[fastlane_core] Verify environment variable values for options

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -219,7 +219,8 @@ module FastlaneCore
       value = if @values.key?(key) && !@values[key].nil?
                 @values[key]
               elsif option.env_name && !ENV[option.env_name].nil?
-                ENV[option.env_name].dup
+                # Convert and verify! before using it (https://github.com/fastlane/fastlane/issues/14449)
+                ENV[option.env_name].dup if option.verify!(option.auto_convert_value(ENV[option.env_name]))
               elsif self.config_file_options.key?(key)
                 self.config_file_options[key]
               else

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -219,7 +219,7 @@ module FastlaneCore
       value = if @values.key?(key) && !@values[key].nil?
                 @values[key]
               elsif option.env_name && !ENV[option.env_name].nil?
-                # Convert and verify! before using it (https://github.com/fastlane/fastlane/issues/14449)
+                # verify! before using (see https://github.com/fastlane/fastlane/issues/14449)
                 ENV[option.env_name].dup if option.verify!(option.auto_convert_value(ENV[option.env_name]))
               elsif self.config_file_options.key?(key)
                 self.config_file_options[key]

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -438,8 +438,33 @@ describe FastlaneCore do
                                           type: Float,
                           skip_type_validation: true,
                                    description: "Description")
-
           expect(c.valid?('a string')).to eq(true)
+        end
+
+        it "fails verification for a improper value set as an environment variable" do
+          c = FastlaneCore::ConfigItem.new(key: :test_key,
+                                    env_name: "TEST_KEY",
+                                 description: "A test key",
+                                verify_block: proc do |value|
+                                  UI.user_error!("Invalid value") unless value.start_with?('a')
+                                end)
+          expect do
+            @config = FastlaneCore::Configuration.create([c], {})
+            ENV["TEST_KEY"] = "does_not_start_with_a"
+            @config[:test_key]
+          end.to raise_error("Invalid value")
+        end
+
+        it "passes verification for a proper value set as an environment variable" do
+          c = FastlaneCore::ConfigItem.new(key: :test_key,
+                                    env_name: "TEST_KEY",
+                                 description: "A test key",
+                                verify_block: proc do |value|
+                                  UI.user_error!("Invalid value") unless value.start_with?('a')
+                                end)
+          @config = FastlaneCore::Configuration.create([c], {})
+          ENV["TEST_KEY"] = "a_good_value"
+          expect(@config[:test_key]).to eq('a_good_value')
         end
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The change ensures that value for configuration options are validated by the verify_block of the option as expected. #14449  

### Description
Convert and verify the value from the environment before allowing it to be fetched.

Tested using the sample project from the issue as well as running all the rspec tests.
