### PR TITLE
[frameit] Add double quotes to path in StringParser.encoding_type

### DIFF
--- a/frameit/lib/frameit/strings_parser.rb
+++ b/frameit/lib/frameit/strings_parser.rb
@@ -40,7 +40,7 @@ module Frameit
     end
 
     def self.encoding_type(path)
-      `file --mime-encoding "#{path}"`.downcase
+      Helper.backticks("file --mime-encoding #{path.shellescape}", print: false).downcase
     end
   end
 end

--- a/frameit/lib/frameit/strings_parser.rb
+++ b/frameit/lib/frameit/strings_parser.rb
@@ -40,7 +40,7 @@ module Frameit
     end
 
     def self.encoding_type(path)
-      `file --mime-encoding #{path}`.downcase
+      `file --mime-encoding "#{path}"`.downcase
     end
   end
 end

--- a/frameit/spec/fixtures/translations file.utf8.strings
+++ b/frameit/spec/fixtures/translations file.utf8.strings
@@ -1,0 +1,8 @@
+/* No comment provided by engineer. */
+"Cancel" = "Abbrechen";
+
+/* No comment provided by engineer. */
+"OK" = "OK";
+
+/* No comment provided by engineer. */
+"Multiple words working" = "einlangesdeutshceswort mit Abstand";

--- a/frameit/spec/strings_parser_spec.rb
+++ b/frameit/spec/strings_parser_spec.rb
@@ -53,5 +53,27 @@ describe Frameit do
         end
       end
     end
+
+    describe "encoding_type" do
+      let(:path) { "/Users/fastlane/directory/en-US/title.strings" }
+      let(:path_with_space) { "/Users/fastlane/directory name/en-US/title.strings" }
+
+      it "escapes path with no spaces" do
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("file --mime-encoding #{path}", print: false)
+          .and_return("").exactly(1).times
+
+        Frameit::StringsParser.encoding_type(path)
+      end
+
+      it "escapes path with spaces" do
+        escaped_path = path_with_space.shellescape
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("file --mime-encoding #{escaped_path}", print: false)
+          .and_return("").exactly(1).times
+
+        Frameit::StringsParser.encoding_type(path_with_space)
+      end
+    end
   end
 end

--- a/frameit/spec/strings_parser_spec.rb
+++ b/frameit/spec/strings_parser_spec.rb
@@ -33,6 +33,16 @@ describe Frameit do
             "Multiple words working" => "einlangesdeutshceswort mit Abstand"
           })
         end
+
+        it "parses a valid .strings file (utf8) with space in path" do
+          translations = Frameit::StringsParser.parse("./frameit/spec/fixtures/translations file.utf8.strings")
+
+          expect(translations).to eq({
+            "Cancel" => "Abbrechen",
+            "OK" => "OK",
+            "Multiple words working" => "einlangesdeutshceswort mit Abstand"
+          })
+        end
       end
 
       describe "failure parsing" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
It fixes #14451

### Description
I added double quotes in StringParser.encoding_type to enable proper encoding detection from files which contain spaces in their file paths.
