### PR TITLE
[spaceship] Clean up README

### DIFF
--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -97,11 +97,11 @@ This requires you to install `pry` using `sudo gem install pry`. `pry` is not in
 
 ## Apple Developer Portal API
 
-##### Open [DeveloperPortal.md](docs/DeveloperPortal.md) for code samples
+Open [DeveloperPortal.md](docs/DeveloperPortal.md) for code samples
 
 ## App Store Connect API
 
-##### Open [AppStoreConnect.md](docs/AppStoreConnect.md) for code samples
+Open [AppStoreConnect.md](docs/AppStoreConnect.md) for code samples
 
 ## 2 Step Verification
 
@@ -125,13 +125,7 @@ export FASTLANE_SESSION='---\n- !ruby/object:HTTP::Cookie\n  name: DES5c148586df
 
 #### Transporter
 
-If you want to upload builds to TestFlight/App Store Connect from your CI, you have to generate and use an application specific password:
-
-1. Visit [appleid.apple.com/account/manage](https://appleid.apple.com/account/manage)
-1. Generate a new application specific password
-1. Provide the application specific password using an environment variable `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`.
-
-Alternatively you can enter the application specific password when you're asked the first time _fastlane_ uploads a build.
+See [Continuous Integration > Authentication with Apple services > Application specific passwords](https://docs.fastlane.tools/best-practices/continuous-integration/#application-specific-passwords)
 
 ## _spaceship_ in use
 

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -137,7 +137,8 @@ All [fastlane tools](https://fastlane.tools) that communicate with Apple's web s
 
 Overview of the used API endpoints
 
-- `https://idmsa.apple.com`: Used to authenticate to get a valid session
+- `https://idmsa.apple.com`: 
+  - Used to authenticate to get a valid session
 - `https://developerservices2.apple.com`:
   - Get a list of all available provisioning profiles
   - Register new devices

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -123,15 +123,6 @@ This will authenticate you and provide a string that can be transferred to your 
 export FASTLANE_SESSION='---\n- !ruby/object:HTTP::Cookie\n  name: DES5c148586dfd451e55afbaaa5f62418f91\n  value: HSARMTKNSRVTWFla1+yO4gVPowH17VaaaxPFnUdMUegQZxqy1Ie1c2v6bM1vSOzIbuOmrl/FNenlScsd/NbF7/Lw4cpnL15jsyg0TOJwP32tC/NguPiyOaaaU+jrj4tf4uKdIywVaaaFSRVT\n  domain: idmsa.apple.com\n  for_domain: true\n  path: "/"\n  secure: true\n  httponly: true\n  expires: 2016-04-27 23:55:56.000000000 Z\n  max_age: \n  created_at: 2016-03-28 16:55:57.032086000 -07:00\n  accessed_at: 2016-03-28 19:11:17.828141000 -07:00\n'
 ```
 
-#### Bypass trusted device and use SMS for verification
-
-If you have a trusted device configured, Apple will not send a SMS code to your phone for your Apple account when you try to generate a web session with _fastlane_. Instead, a code will be displayed on one of your account's trusted devices. This can be problematic if you are trying to authenticate but don't have access to a trusted device. Take the following steps to circumvent the device and use SMS instead:
-
-- Attempt to generate a web session with `fastlane spaceauth -u [email]` and wait for security code prompt to appear
-- Open a browser to [appleid.apple.com](https://appleid.apple.com) or an address that requires you to login with your Apple ID, and logout of any previous session
-- Login with your Apple ID and request a code be sent to the desired phone when prompted for a security code
-- Use the code sent to phone with _fastlane_ instead of with the browser
-
 #### Transporter
 
 If you want to upload builds to TestFlight/App Store Connect from your CI, you have to generate and use an application specific password:


### PR DESCRIPTION
Remove outdated information:

- "Bypass trusted device and use SMS for verification" is not needed any more with `sms` escape implemented
- "transporter" section is not related to spaceship and better described in real docs