### PR TITLE
[pilot] Do not use spaceship if both skip_waiting_for_build_processing and apple_id are set 

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
@@ -225,3 +225,7 @@ _pilot_ uses the [CredentialsManager](https://github.com/fastlane/fastlane/tree/
 
 ## Provider Short Name
 If you are on multiple App Store Connect teams, iTunes Transporter may need a provider short name to know where to upload your binary. _pilot_ will try to use the long name of the selected team to detect the provider short name. To override the detected value with an explicit one, use the `itc_provider` option.
+
+## Use an Application Specific Password to upload
+
+_pilot_/`upload_to_testflight` can use an [Application Specific Password via the `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` envirionment variable](https://docs.fastlane.tools/best-practices/continuous-integration/#application-specific-passwords) to upload a binary if both the `skip_waiting_for_build_processing` and `apple_id` options are set. (If any of those are not set, it will use the normal Apple login process that might require 2FA authentication.)

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -51,7 +51,7 @@ module Pilot
       end
 
       UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-      latest_build = wait_for_build_processing_to_be_complete
+      latest_build = wait_for_build_processing_to_be_complete(options)
       distribute(options, build: latest_build)
     end
 

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -10,12 +10,13 @@ require_relative 'manager'
 module Pilot
   class BuildManager < Manager
     def upload(options)
-      start(options) unless options[:skip_waiting_for_build_processing] && options[:apple_id]
-      @config = options if options[:skip_waiting_for_build_processing] && options[:apple_id] # ugly as hell, we want to do that differently
+      # Only need to login before upload if no apple_id was given
+      should_login = options[:apple_id].nil?
+      start(options, should_login: should_login)
 
       options[:changelog] = self.class.sanitize_changelog(options[:changelog]) if options[:changelog]
 
-      UI.user_error!("No ipa file given") unless options[:ipa]
+      UI.user_error!("No ipa file given") unless config[:ipa]
 
       if options[:changelog].nil? && options[:distribute_external] == true
         if UI.interactive?
@@ -25,18 +26,18 @@ module Pilot
         end
       end
 
-      UI.success("Ready to upload new build to TestFlight (App: #{fetch_only_apple_id})...")
+      UI.success("Ready to upload new build to TestFlight (App: #{fetch_apple_id})...")
 
       dir = Dir.mktmpdir
 
       platform = fetch_app_platform
-      package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(app_id: fetch_only_apple_id,
+      package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(app_id: fetch_apple_id,
                                                                       ipa_path: options[:ipa],
                                                                   package_path: dir,
                                                                       platform: platform)
 
       transporter = transporter_for_selected_team(options)
-      result = transporter.upload(fetch_only_apple_id, package_path)
+      result = transporter.upload(fetch_apple_id, package_path)
 
       unless result
         UI.user_error!("Error uploading ipa file, for more information see above")
@@ -50,12 +51,14 @@ module Pilot
         return
       end
 
+      login_if_not_logged_in
+
       UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-      latest_build = wait_for_build_processing_to_be_complete(options)
+      latest_build = wait_for_build_processing_to_be_complete
       distribute(options, build: latest_build)
     end
 
-    def wait_for_build_processing_to_be_complete(options)
+    def wait_for_build_processing_to_be_complete
       platform = fetch_app_platform
       app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
       app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
@@ -188,6 +191,10 @@ module Pilot
 
     private
 
+    def login_if_not_logged_in
+      login unless Spaceship::Tunes.client
+    end
+
     def describe_build(build)
       row = [build.train_version,
              build.build_version,
@@ -221,7 +228,8 @@ module Pilot
     # If there are fewer than two teams, don't infer the provider.
     def transporter_for_selected_team(options)
       generic_transporter = FastlaneCore::ItunesTransporter.new(options[:username], nil, false, options[:itc_provider])
-      return generic_transporter unless options[:itc_provider].nil? && Spaceship::Tunes.client.teams.count > 1
+      return generic_transporter if options[:itc_provider] || Spaceship::Tunes.client.nil?
+      return generic_transporter unless Spaceship::Tunes.client.teams.count > 1
 
       begin
         team = Spaceship::Tunes.client.teams.find { |t| t['contentProvider']['contentProviderId'].to_s == Spaceship::Tunes.client.team_id }

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -55,7 +55,7 @@ module Pilot
       distribute(options, build: latest_build)
     end
 
-    def wait_for_build_processing_to_be_complete
+    def wait_for_build_processing_to_be_complete(options)
       platform = fetch_app_platform
       app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
       app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -11,6 +11,7 @@ module Pilot
   class BuildManager < Manager
     def upload(options)
       start(options) unless options[:skip_waiting_for_build_processing] && options[:apple_id]
+      @config = options if options[:skip_waiting_for_build_processing] && options[:apple_id] # ugly as hell, we want to do that differently
 
       options[:changelog] = self.class.sanitize_changelog(options[:changelog]) if options[:changelog]
 

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -10,7 +10,7 @@ require_relative 'manager'
 module Pilot
   class BuildManager < Manager
     def upload(options)
-      start(options)
+      start(options) unless config[:skip_waiting_for_build_processing] && config[:apple_id]
 
       options[:changelog] = self.class.sanitize_changelog(options[:changelog]) if options[:changelog]
 
@@ -24,18 +24,18 @@ module Pilot
         end
       end
 
-      UI.success("Ready to upload new build to TestFlight (App: #{app.apple_id})...")
+      UI.success("Ready to upload new build to TestFlight (App: #{fetch_only_apple_id})...")
 
       dir = Dir.mktmpdir
 
       platform = fetch_app_platform
-      package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(app_id: app.apple_id,
+      package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(app_id: fetch_only_apple_id,
                                                                       ipa_path: config[:ipa],
                                                                   package_path: dir,
                                                                       platform: platform)
 
       transporter = transporter_for_selected_team(options)
-      result = transporter.upload(app.apple_id, package_path)
+      result = transporter.upload(fetch_only_apple_id, package_path)
 
       unless result
         UI.user_error!("Error uploading ipa file, for more information see above")

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -10,11 +10,11 @@ require_relative 'manager'
 module Pilot
   class BuildManager < Manager
     def upload(options)
-      start(options) unless config[:skip_waiting_for_build_processing] && config[:apple_id]
+      start(options) unless options[:skip_waiting_for_build_processing] && options[:apple_id]
 
       options[:changelog] = self.class.sanitize_changelog(options[:changelog]) if options[:changelog]
 
-      UI.user_error!("No ipa file given") unless config[:ipa]
+      UI.user_error!("No ipa file given") unless options[:ipa]
 
       if options[:changelog].nil? && options[:distribute_external] == true
         if UI.interactive?
@@ -30,7 +30,7 @@ module Pilot
 
       platform = fetch_app_platform
       package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(app_id: fetch_only_apple_id,
-                                                                      ipa_path: config[:ipa],
+                                                                      ipa_path: options[:ipa],
                                                                   package_path: dir,
                                                                       platform: platform)
 
@@ -58,7 +58,7 @@ module Pilot
       platform = fetch_app_platform
       app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
       app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
-      latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform, train_version: app_version, build_version: app_build, poll_interval: config[:wait_processing_interval])
+      latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: app.apple_id, platform: platform, train_version: app_version, build_version: app_build, poll_interval: config[:wait_processing_interval], strict_build_watch: config[:wait_for_uploaded_build])
 
       unless latest_build.train_version == app_version && latest_build.build_version == app_build
         UI.important("Uploaded app #{app_version} - #{app_build}, but received build #{latest_build.train_version} - #{latest_build.build_version}.")

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -10,10 +10,10 @@ require_relative 'module'
 
 module Pilot
   class Manager
-    def start(options)
+    def start(options, should_login: true)
       return if @config # to not login multiple times
       @config = options
-      login
+      login if should_login
     end
 
     def login
@@ -42,14 +42,8 @@ module Pilot
     # Config Related
     ################
 
-    # this exists so there is a way to get the apple_id without using spaceship if the config value exists
-    def fetch_only_apple_id
-      apple_id = config[:apple_id]
-      apple_id ||= app.apple_id
-      return apple_id
-    end
-
     def fetch_apple_id
+      @apple_id ||= config[:apple_id]
       return @apple_id if @apple_id
       config[:app_identifier] = fetch_app_identifier
 

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -43,9 +43,10 @@ module Pilot
     ################
 
     # this exists so there is a way to get the apple_id without using spaceship if the config value exists
-    def fetch_only_apple_id 
+    def fetch_only_apple_id
       apple_id = config[:apple_id]
       apple_id ||= app.apple_id
+      return apple_id
     end
 
     def fetch_apple_id

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -27,7 +27,7 @@ module Pilot
 
     # The app object we're currently using
     def app
-      @apple_id ||= fetch_app_id
+      @apple_id ||= fetch_apple_id
 
       @app ||= Spaceship::Tunes::Application.find(@apple_id)
       unless @app
@@ -42,19 +42,25 @@ module Pilot
     # Config Related
     ################
 
-    def fetch_app_id
+    # this exists so there is a way to get the apple_id without using spaceship if the config value exists
+    def fetch_only_apple_id 
+      apple_id = config[:apple_id]
+      apple_id ||= app.apple_id
+    end
+
+    def fetch_apple_id
       return @apple_id if @apple_id
       config[:app_identifier] = fetch_app_identifier
 
       if config[:app_identifier]
         @app ||= Spaceship::Tunes::Application.find(config[:app_identifier])
         UI.user_error!("Couldn't find app '#{config[:app_identifier]}' on the account of '#{config[:username]}' on App Store Connect") unless @app
-        app_id ||= @app.apple_id
+        apple_id ||= @app.apple_id
       end
 
-      app_id ||= UI.input("Could not automatically find the app ID, please enter it here (e.g. 956814360): ")
+      apple_id ||= UI.input("Could not automatically find the app ID, please enter it here (e.g. 956814360): ")
 
-      return app_id
+      return apple_id
     end
 
     def fetch_app_identifier

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -282,6 +282,9 @@ describe "Build Manager" do
         allow(fake_app).to receive(:apple_id).and_return(123)
         allow(fake_build_manager).to receive(:app).and_return(fake_app)
 
+        allow(Spaceship::Tunes::Application).to receive(:find).and_return(fake_app)
+
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_identifier).and_return("com.fastlane")
         allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
         allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
 

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -267,10 +267,10 @@ describe "Build Manager" do
       end
 
       it "NOT when skip_waiting_for_build_processing and apple_id are set" do
-        fake_build_manager.upload(upload_options)
-
         # should not execute Manager.login (which does spaceship login)
         expect(fake_build_manager).not_to(receive(:login))
+
+        fake_build_manager.upload(upload_options)
       end
 
       it "when skip_waiting_for_build_processing and apple_id are not set" do

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -270,7 +270,7 @@ describe "Build Manager" do
         fake_build_manager.upload(upload_options)
 
         # should not execute Manager.login (which does spaceship login)
-        expect(fake_build_manager).not_to receive(:login)
+        expect(fake_build_manager).not_to(receive(:login))
       end
 
       it "when skip_waiting_for_build_processing and apple_id are not set" do

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -11,6 +11,7 @@ describe "Build Manager" do
       expect(changelog).to eq("1234")
     end
   end
+
   describe ".sanitize_changelog" do
     it "removes emoji" do
       changelog = "I'm 🦇B🏧an!"
@@ -24,7 +25,8 @@ describe "Build Manager" do
       expect(changelog).to eq(File.read("./pilot/spec/fixtures/build_manager/changelog_long_truncated"))
     end
   end
-  describe "distribute submits the build for review" do
+
+  describe "#distribute submits the build for review" do
     let(:mock_base_client) { "fake testflight base client" }
     let(:mock_base_api_client) { "fake api base client" }
     let(:fake_build_manager) { Pilot::BuildManager.new }

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -268,6 +268,9 @@ describe "Build Manager" do
 
       it "NOT when skip_waiting_for_build_processing and apple_id are set" do
         fake_build_manager.upload(upload_options)
+
+        # should not execute Manager.login (which does spaceship login)
+        expect(fake_build_manager).not_to receive(:login)
       end
 
       it "when skip_waiting_for_build_processing and apple_id are not set" do
@@ -275,18 +278,19 @@ describe "Build Manager" do
         upload_options.delete(:apple_id)
         upload_options.delete(:skip_waiting_for_build_processing)
 
-        # allow the spaceship login method this time
-        allow(fake_build_manager).to receive(:login)
+        # allow Manager.login method this time
+        expect(fake_build_manager).to receive(:login).at_least(:once)
+
+        # other stuff required to let `upload` work:
+
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_identifier).and_return("com.fastlane")
+        allow(fake_build_manager).to receive(:fetch_apple_id).and_return(123)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
 
         fake_app = double
         allow(fake_app).to receive(:apple_id).and_return(123)
         allow(fake_build_manager).to receive(:app).and_return(fake_app)
-
-        allow(Spaceship::Tunes::Application).to receive(:find).and_return(fake_app)
-
-        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_identifier).and_return("com.fastlane")
-        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
-        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
 
         fake_build = double
         allow(fake_build).to receive(:train_version)

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -245,9 +245,8 @@ describe "Build Manager" do
 
   describe "#upload" do
     describe "spaceship login (via Manager.login)" do
-
       let(:fake_build_manager) { Pilot::BuildManager.new }
-      let(:upload_options) do 
+      let(:upload_options) do
         {
           apple_id: 'mock_apple_id',
           skip_waiting_for_build_processing: true,
@@ -257,12 +256,12 @@ describe "Build Manager" do
 
       before(:each) do
         allow(fake_build_manager).to receive(:fetch_app_platform).and_return('ios')
-        
-        fake_ipauploadpackagebuilder = double()
+
+        fake_ipauploadpackagebuilder = double
         allow(fake_ipauploadpackagebuilder).to receive(:generate).and_return(true)
         allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
-        
-        fake_itunestransporter = double()
+
+        fake_itunestransporter = double
         allow(fake_itunestransporter).to receive(:upload).and_return(true)
         allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
       end
@@ -275,18 +274,18 @@ describe "Build Manager" do
         # clean options
         upload_options.delete(:apple_id)
         upload_options.delete(:skip_waiting_for_build_processing)
-        
+
         # allow the spaceship login method this time
         allow(fake_build_manager).to receive(:login)
-        
-        fake_app = double()
+
+        fake_app = double
         allow(fake_app).to receive(:apple_id).and_return(123)
         allow(fake_build_manager).to receive(:app).and_return(fake_app)
-        
+
         allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
         allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
-        
-        fake_build = double()
+
+        fake_build = double
         allow(fake_build).to receive(:train_version)
         allow(fake_build).to receive(:build_version)
         allow(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
@@ -295,8 +294,6 @@ describe "Build Manager" do
 
         fake_build_manager.upload(upload_options)
       end
-
     end
   end
-
 end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -244,7 +244,7 @@ describe "Build Manager" do
   end
 
   describe "#upload" do
-    describe "spaceship login (via Manager.login)" do
+    describe "uses Manager.login (which does spaceship login)" do
       let(:fake_build_manager) { Pilot::BuildManager.new }
       let(:upload_options) do
         {
@@ -266,12 +266,12 @@ describe "Build Manager" do
         allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
       end
 
-      it "is not executed when skip_waiting_for_build_processing and apple_id are set" do
+      it "NOT when skip_waiting_for_build_processing and apple_id are set" do
         fake_build_manager.upload(upload_options)
       end
 
-      it "is executed when skip_waiting_for_build_processing and apple_id are not set" do
-        # clean options
+      it "when skip_waiting_for_build_processing and apple_id are not set" do
+        # remove options that make login unnecessary
         upload_options.delete(:apple_id)
         upload_options.delete(:skip_waiting_for_build_processing)
 

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -242,4 +242,61 @@ describe "Build Manager" do
       end
     end
   end
+
+  describe "#upload" do
+    describe "spaceship login (via Manager.login)" do
+
+      let(:fake_build_manager) { Pilot::BuildManager.new }
+      let(:upload_options) do 
+        {
+          apple_id: 'mock_apple_id',
+          skip_waiting_for_build_processing: true,
+          ipa: 'foo'
+        }
+      end
+
+      before(:each) do
+        allow(fake_build_manager).to receive(:fetch_app_platform).and_return('ios')
+        
+        fake_ipauploadpackagebuilder = double()
+        allow(fake_ipauploadpackagebuilder).to receive(:generate).and_return(true)
+        allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
+        
+        fake_itunestransporter = double()
+        allow(fake_itunestransporter).to receive(:upload).and_return(true)
+        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+      end
+
+      it "is not executed when skip_waiting_for_build_processing and apple_id are set" do
+        fake_build_manager.upload(upload_options)
+      end
+
+      it "is executed when skip_waiting_for_build_processing and apple_id are not set" do
+        # clean options
+        upload_options.delete(:apple_id)
+        upload_options.delete(:skip_waiting_for_build_processing)
+        
+        # allow the spaceship login method this time
+        allow(fake_build_manager).to receive(:login)
+        
+        fake_app = double()
+        allow(fake_app).to receive(:apple_id).and_return(123)
+        allow(fake_build_manager).to receive(:app).and_return(fake_app)
+        
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
+        
+        fake_build = double()
+        allow(fake_build).to receive(:train_version)
+        allow(fake_build).to receive(:build_version)
+        allow(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+        allow(fake_build_manager).to receive(:distribute)
+
+        fake_build_manager.upload(upload_options)
+      end
+
+    end
+  end
+
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
With the new 2FA rules by Apple, more and more users are looking for a way to use app specific passwords to upload to the App Store. 

### Description
As iTunes Transporter does accept app specific passwords, and is used by `pilot` to upload the binary, we can achieve this with a few tiny changes in the program logic (do not log in via Spaceship if there is no reason to. This is the case if both `skip_waiting_for_build_processing` and `apple_id` are set).

closes #14258
closes #14723