### PR TITLE
[sign] fix sigh not using custom keychain path

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -12,7 +12,7 @@ module Cert
     def launch
       run
 
-      installed = FastlaneCore::CertChecker.installed?(ENV["CER_FILE_PATH"])
+      installed = FastlaneCore::CertChecker.installed?(ENV["CER_FILE_PATH"], in_keychain: ENV["CER_KEYCHAIN_PATH"])
       UI.message("Verifying the certificate is properly installed locally...")
       UI.user_error!("Could not find the newly generated certificate installed", show_github_issues: true) unless installed
       UI.success("Successfully installed certificate #{ENV['CER_CERTIFICATE_ID']}")
@@ -92,22 +92,24 @@ module Cert
         path = store_certificate(certificate, Cert.config[:filename])
         private_key_path = File.expand_path(File.join(Cert.config[:output_path], "#{certificate.id}.p12"))
 
-        if FastlaneCore::CertChecker.installed?(path)
+        keychain = File.expand_path(Cert.config[:keychain_path])
+        if FastlaneCore::CertChecker.installed?(path, in_keychain: keychain)
           # This certificate is installed on the local machine
           ENV["CER_CERTIFICATE_ID"] = certificate.id
           ENV["CER_FILE_PATH"] = path
+          ENV["CER_KEYCHAIN_PATH"] = keychain
 
           UI.success("Found the certificate #{certificate.id} (#{certificate.name}) which is installed on the local machine. Using this one.")
 
           return path
         elsif File.exist?(private_key_path)
-          keychain = File.expand_path(Cert.config[:keychain_path])
           password = Cert.config[:keychain_password]
           FastlaneCore::KeychainImporter.import_file(private_key_path, keychain, keychain_password: password)
           FastlaneCore::KeychainImporter.import_file(path, keychain, keychain_password: password)
 
           ENV["CER_CERTIFICATE_ID"] = certificate.id
           ENV["CER_FILE_PATH"] = path
+          ENV["CER_KEYCHAIN_PATH"] = keychain
 
           UI.success("Found the cached certificate #{certificate.id} (#{certificate.name}). Using this one.")
 

--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -92,6 +92,8 @@ module Cert
         path = store_certificate(certificate, Cert.config[:filename])
         private_key_path = File.expand_path(File.join(Cert.config[:output_path], "#{certificate.id}.p12"))
 
+        # As keychain is specific to macOS, this will likely fail on non macOS systems.
+        # See also: https://github.com/fastlane/fastlane/pull/14462
         keychain = File.expand_path(Cert.config[:keychain_path])
         if FastlaneCore::CertChecker.installed?(path, in_keychain: keychain)
           # This certificate is installed on the local machine

--- a/cert/spec/runner_spec.rb
+++ b/cert/spec/runner_spec.rb
@@ -16,14 +16,20 @@ describe Cert do
       allow(Spaceship.client).to receive(:in_house?).and_return(false)
       allow(Spaceship.certificate.production).to receive(:all).and_return([certificate])
 
-      allow(FastlaneCore::CertChecker).to receive(:installed?).and_return(true)
+      certificate_path = "#{Dir.pwd}/cert_id.cer"
+      keychain_path = Dir.pwd.to_s
+      expect(FastlaneCore::CertChecker).to receive(:installed?)
+        .with(certificate_path, in_keychain: keychain_path)
+        .twice
+        .and_return(true)
 
       options = { keychain_path: "." }
       Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, options)
 
       Cert::Runner.new.launch
       expect(ENV["CER_CERTIFICATE_ID"]).to eq("cert_id")
-      expect(ENV["CER_FILE_PATH"]).to eq("#{Dir.pwd}/cert_id.cer")
+      expect(ENV["CER_FILE_PATH"]).to eq(certificate_path)
+      expect(ENV["CER_KEYCHAIN_PATH"]).to eq(keychain_path)
       File.delete(ENV["CER_FILE_PATH"])
     end
 

--- a/cert/spec/runner_spec.rb
+++ b/cert/spec/runner_spec.rb
@@ -101,7 +101,7 @@ describe Cert do
       end
 
       let(:generate) do
-        options = { output_path: temp, filename: filename }
+        options = { output_path: temp, filename: filename, keychain_path: "." }
         Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, options)
         Cert::Runner.new.launch
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This fixes https://github.com/fastlane/fastlane/issues/14453