### PR TITLE
[fastlane] git: more responsible, Windows-compatible shellout

### DIFF
--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -3,36 +3,38 @@ module Fastlane
     GIT_MERGE_COMMIT_FILTERING_OPTIONS = [:include_merges, :exclude_merges, :only_include_merges].freeze
 
     def self.git_log_between(pretty_format, from, to, merge_commit_filtering, date_format = nil, ancestry_path)
-      command = ['git log']
-      command << "--pretty=\"#{pretty_format}\""
-      command << "--date=\"#{date_format}\"" if date_format
+      command = %w(git log)
+      command << "--pretty=#{pretty_format}"
+      command << "--date=#{date_format}" if date_format
       command << '--ancestry-path' if ancestry_path
-      command << "#{from.shellescape}...#{to.shellescape}"
+      command << "#{from}...#{to}"
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
-      Actions.sh(command.compact.join(' '), log: false).chomp
+      Actions.sh(*command.compact, log: false).chomp
     rescue
       nil
     end
 
     def self.git_log_last_commits(pretty_format, commit_count, merge_commit_filtering, date_format = nil, ancestry_path)
-      command = ['git log']
-      command << "--pretty=\"#{pretty_format}\""
-      command << "--date=\"#{date_format}\"" if date_format
+      command = %w(git log)
+      command << "--pretty=#{pretty_format}"
+      command << "--date=#{date_format}" if date_format
       command << '--ancestry-path' if ancestry_path
-      command << "-n #{commit_count}"
+      command << '-n' << commit_count.to_s
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
-      Actions.sh(command.compact.join(' '), log: false).chomp
+      Actions.sh(*command.compact, log: false).chomp
     rescue
       nil
     end
 
     def self.last_git_tag_name(match_lightweight = true, tag_match_pattern = nil)
-      tag_pattern_param = tag_match_pattern ? "=#{tag_match_pattern.shellescape}" : ''
+      tag_pattern_param = tag_match_pattern ? "=#{tag_match_pattern}" : ''
+      tag_name = Actions.sh('git', 'rev-list', "--tags#{tag_pattern_param}",
+                            '--max-count=1').chomp
 
-      command = ['git describe']
+      command = %w(git describe)
       command << '--tags' if match_lightweight
-      command << "`git rev-list --tags#{tag_pattern_param} --max-count=1`"
-      Actions.sh(command.compact.join(' '), log: false).chomp
+      command << tag_name
+      Actions.sh(*command.compact, log: false).chomp
     rescue
       nil
     end
@@ -52,10 +54,10 @@ module Fastlane
     # Gets the last git commit information formatted into a String by the provided
     # pretty format String. See the git-log documentation for valid format placeholders
     def self.last_git_commit_formatted_with(pretty_format, date_format = nil)
-      command = ['git log -1']
-      command << "--pretty=\"#{pretty_format}\""
-      command << "--date=\"#{date_format}\"" if date_format
-      Actions.sh(command.compact.join(' '), log: false).chomp
+      command = %w(git log -1)
+      command << "--pretty=#{pretty_format}"
+      command << "--date=#{date_format}" if date_format
+      Actions.sh(*command.compact, log: false).chomp
     rescue
       nil
     end

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -9,6 +9,8 @@ module Fastlane
       command << '--ancestry-path' if ancestry_path
       command << "#{from}...#{to}"
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
+      # "*command" syntax expands "command" array into variable arguments, which
+      # will then be individually shell-escaped by Actions.sh.
       Actions.sh(*command.compact, log: false).chomp
     rescue
       nil

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -26,14 +26,23 @@ module Fastlane
       nil
     end
 
-    def self.last_git_tag_name(match_lightweight = true, tag_match_pattern = nil)
+    def self.last_git_tag_hash(tag_match_pattern = nil)
       tag_pattern_param = tag_match_pattern ? "=#{tag_match_pattern}" : ''
-      tag_name = Actions.sh('git', 'rev-list', "--tags#{tag_pattern_param}",
-                            '--max-count=1').chomp
+      Actions.sh('git', 'rev-list', "--tags#{tag_pattern_param}", '--max-count=1').chomp
+    rescue
+      nil
+    end
+
+    def self.last_git_tag_name(match_lightweight = true, tag_match_pattern = nil)
+      hash = last_git_tag_hash(tag_match_pattern)
+      # If hash is nil (command fails), "git describe" command below will still
+      # run and provide some output, although it's definitely not going to be
+      # anything reasonably expected. Bail out early.
+      return unless hash
 
       command = %w(git describe)
       command << '--tags' if match_lightweight
-      command << tag_name
+      command << hash
       Actions.sh(*command.compact, log: false).chomp
     rescue
       nil

--- a/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -6,10 +6,12 @@ describe Fastlane do
           changelog_from_git_commits
         end").runner.execute(:test)
 
-        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
-        # this is not really the command that would have been executed, but a "fabricated" representation for tests (by Actions.sh) that includes both command that would have been run
-        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
-        expect(result).to eq(pseudocommand)
+        # In test mode, Actions.sh returns command to be executed rather than
+        # actual command output.
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%B #{describe}...HEAD).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Uses the provided pretty format to collect log messages" do
@@ -17,9 +19,10 @@ describe Fastlane do
           changelog_from_git_commits(pretty: '%s%n%b')
         end").runner.execute(:test)
 
-        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
-        pseudocommand = "git log --pretty=\"%s%n%b\" #{inner_command.shellescape}...HEAD"
-        expect(result).to eq(pseudocommand)
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%s%n%b #{describe}...HEAD).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Uses the provided date format to collect log messages if specified" do
@@ -27,9 +30,10 @@ describe Fastlane do
           changelog_from_git_commits(pretty: '%s%n%b', date_format: 'short')
         end").runner.execute(:test)
 
-        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
-        pseudocommand = "git log --pretty=\"%s%n%b\" --date=\"short\" #{inner_command.shellescape}...HEAD"
-        expect(result).to eq(pseudocommand)
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%s%n%b --date=short #{describe}...HEAD).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Does not match lightweight tags when searching for the last one if so requested" do
@@ -37,9 +41,10 @@ describe Fastlane do
           changelog_from_git_commits(match_lightweight_tag: false)
         end").runner.execute(:test)
 
-        inner_command = "git describe `git rev-list --tags --max-count=1`"
-        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
-        expect(result).to eq(pseudocommand)
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%B #{describe}...HEAD).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Collects logs in the specified revision range if specified" do
@@ -47,7 +52,7 @@ describe Fastlane do
           changelog_from_git_commits(between: ['abcd', '1234'])
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" abcd...1234")
+        expect(result).to eq(%w(git log --pretty=%B abcd...1234).shelljoin)
       end
 
       it "Handles tag names with characters that need shell escaping" do
@@ -56,7 +61,7 @@ describe Fastlane do
           changelog_from_git_commits(between: ['#{tag}', 'HEAD'])
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" #{tag.shellescape}...HEAD")
+        expect(result).to eq(%W(git log --pretty=%B #{tag}...HEAD).shelljoin)
       end
 
       it "Does not accept a :between array of size 1" do
@@ -80,7 +85,7 @@ describe Fastlane do
           changelog_from_git_commits(commits_count: '10')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" -n 10")
+        expect(result).to eq(%w(git log --pretty=%B -n 10).shelljoin)
       end
 
       it "Does not accept a :commits_count and :between at the same time" do
@@ -104,7 +109,7 @@ describe Fastlane do
           changelog_from_git_commits(commits_count: 10)
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" -n 10")
+        expect(result).to eq(%w(git log --pretty=%B -n 10).shelljoin)
       end
 
       it "Does not accept an invalid value for :merge_commit_filtering" do
@@ -123,9 +128,10 @@ describe Fastlane do
           changelog_from_git_commits(include_merges: false)
         end").runner.execute(:test)
 
-        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
-        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD --no-merges"
-        expect(result).to eq(pseudocommand)
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%B #{describe}...HEAD --no-merges).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Only include merge commits if merge_commit_filtering is only_include_merges" do
@@ -133,9 +139,10 @@ describe Fastlane do
           changelog_from_git_commits(merge_commit_filtering: 'only_include_merges')
         end").runner.execute(:test)
 
-        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
-        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD --merges"
-        expect(result).to eq(pseudocommand)
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%B #{describe}...HEAD --merges).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Include merge commits if merge_commit_filtering is include_merges" do
@@ -143,9 +150,10 @@ describe Fastlane do
           changelog_from_git_commits(merge_commit_filtering: 'include_merges')
         end").runner.execute(:test)
 
-        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
-        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
-        expect(result).to eq(pseudocommand)
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%B #{describe}...HEAD).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Does not include merge commits if merge_commit_filtering is exclude_merges" do
@@ -153,9 +161,10 @@ describe Fastlane do
           changelog_from_git_commits(merge_commit_filtering: 'exclude_merges')
         end").runner.execute(:test)
 
-        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
-        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD --no-merges"
-        expect(result).to eq(pseudocommand)
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%B #{describe}...HEAD --no-merges).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Uses pattern matching for tag name if requested" do
@@ -164,9 +173,10 @@ describe Fastlane do
           changelog_from_git_commits(tag_match_pattern: '#{tag_match_pattern}')
         end").runner.execute(:test)
 
-        inner_command = "git describe --tags `git rev-list --tags=#{tag_match_pattern.shellescape} --max-count=1`"
-        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
-        expect(result).to eq(pseudocommand)
+        tag_name = %W(git rev-list --tags=#{tag_match_pattern} --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%B #{describe}...HEAD).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Does not use pattern matching for tag name if so requested" do
@@ -174,9 +184,10 @@ describe Fastlane do
           changelog_from_git_commits()
         end").runner.execute(:test)
 
-        inner_command = "git describe --tags `git rev-list --tags --max-count=1`"
-        pseudocommand = "git log --pretty=\"%B\" #{inner_command.shellescape}...HEAD"
-        expect(result).to eq(pseudocommand)
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%B #{describe}...HEAD).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Runs between option from command line" do
@@ -188,7 +199,7 @@ describe Fastlane do
           changelog_from_git_commits(between: 'abcd,1234')
         end").runner.execute(:test)
 
-        expect(result).to eq("git log --pretty=\"%B\" abcd...1234")
+        expect(result).to eq(%w(git log --pretty=%B abcd...1234).shelljoin)
       end
 
       it "Does not accept string if it does not contain comma" do

--- a/fastlane/spec/actions_specs/last_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/last_git_tag_spec.rb
@@ -6,7 +6,9 @@ describe Fastlane do
           last_git_tag
         end").runner.execute(:test)
 
-        expect(result).to eq("git describe --tags `git rev-list --tags --max-count=1`")
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        expect(result).to eq(describe)
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Some git actions (ex.: `changelog_from_git_commits`) were not working on Windows. This have been noticed when our projects got student contributors with Windows workstations. While fixing that, I also fixed shell escaping in `git_helper.rb`.

### Description

* some things are `#shellescape`'d, the others aren't. Make it uniform and let `Actions.sh` handle escaping properly;
* additionally, do not use bquot (`` ` ``). It is not compatible with Windows cmd.exe;
* tested on a real project by running on Windows in AppVeyor with `changelog_from_git_commits`, `number_of_commits` and `last_git_tag`.