### PR TITLE
[action] Post line break characters as actual interpreted line break through slack integration

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -15,7 +15,9 @@ module Fastlane
         # We want the last 7000 characters, instead of the first 7000, as the error is at the bottom
         start_index = [message.length - 7000, 0].max
         message = message[start_index..-1]
-        message
+        # We want line breaks to be shown on slack output so we replace
+        # input non-interpreted line break with interpreted line break
+        message.gsub('\n', "\n")
       end
 
       def self.run(options)

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -26,7 +26,7 @@ module Fastlane
         options[:message] = self.trim_message(options[:message].to_s || '')
         options[:message] = Slack::Notifier::Util::LinkFormatter.format(options[:message])
 
-        options[:pretext] = (options[:pretext].gsub('\n', "\n")) unless options[:pretext].nil?
+        options[:pretext] = options[:pretext].gsub('\n', "\n") unless options[:pretext].nil?
 
         if options[:channel].to_s.length > 0
           channel = options[:channel]

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -26,6 +26,8 @@ module Fastlane
         options[:message] = self.trim_message(options[:message].to_s || '')
         options[:message] = Slack::Notifier::Util::LinkFormatter.format(options[:message])
 
+        options[:pretext] = (options[:pretext].gsub('\n', "\n")) unless options[:pretext].nil?
+
         if options[:channel].to_s.length > 0
           channel = options[:channel]
           channel = ('#' + options[:channel]) unless ['#', '@'].include?(channel[0]) # send message to channel by default

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -189,7 +189,6 @@ describe Fastlane do
 
         expect(notifier.config.defaults[:username]).to eq('fastlane')
         expect(notifier.config.defaults[:channel]).to eq(channel)
-        # binding.pry
 
         expect(attachments[:color]).to eq('danger')
         expect(attachments[:text]).to eq(expected_message)

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -165,6 +165,35 @@ describe Fastlane do
         expect(fields[0][:title]).to eq('Git Branch')
         expect(fields[1][:title]).to eq('Git Commit Hash')
       end
+
+      # https://github.com/fastlane/fastlane/issues/14141
+      it "prints line breaks on message parameter to slack" do
+        channel = "#myChannel"
+        # User is passing input_message through fastlane input parameter
+        input_message = 'Custom Message with\na line break'
+        # We expect the message to be escaped correctly after being processed by action
+        expected_message = "Custom Message with\na line break"
+        lane_name = "lane_name"
+
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+
+        require 'fastlane/actions/slack'
+        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          slack_url: 'https://127.0.0.1',
+          message: input_message,
+          success: false,
+          channel: channel
+        })
+
+        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+
+        expect(notifier.config.defaults[:username]).to eq('fastlane')
+        expect(notifier.config.defaults[:channel]).to eq(channel)
+        # binding.pry
+
+        expect(attachments[:color]).to eq('danger')
+        expect(attachments[:text]).to eq(expected_message)
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -193,6 +193,34 @@ describe Fastlane do
         expect(attachments[:color]).to eq('danger')
         expect(attachments[:text]).to eq(expected_message)
       end
+
+      # https://github.com/fastlane/fastlane/issues/14141
+      it "prints line breaks on pretext parameter to slack" do
+        channel = "#myChannel"
+        # User is passing input_message through fastlane input parameter
+        input_pretext = 'Custom Pretext with\na line break'
+        # We expect the message to be escaped correctly after being processed by action
+        expected_pretext = "Custom Pretext with\na line break"
+        lane_name = "lane_name"
+
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+
+        require 'fastlane/actions/slack'
+        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          slack_url: 'https://127.0.0.1',
+          pretext: input_pretext,
+          success: false,
+          channel: channel
+        })
+
+        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+
+        expect(notifier.config.defaults[:username]).to eq('fastlane')
+        expect(notifier.config.defaults[:channel]).to eq(channel)
+
+        expect(attachments[:color]).to eq('danger')
+        expect(attachments[:pretext]).to eq(expected_pretext)
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes open issue https://github.com/fastlane/fastlane/issues/14141
The issue is when posting to a slack channel with a line break in the message.

### Description
The problem seems to happen because when a message is sent to the slack action, the \n line break character is being parsed as two characters slash and n instead of a line break character. In ruby, this happens when \n is declared with single quotes. The fix simply uses gsub method to replace the '\n' from the input with the interpreted line break character \n, by using double quotes to declare it.

The test has an input with a message that contains a non-interpreted line break '\n' and checks that after the message is sent through the integration the line break is substituted by an interpreted one "\n".

