### PR TITLE
[deliver] Do not set ratings_resets to null if not specified

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -130,7 +130,7 @@ module Deliver
       set_trade_representative_contact_information(v, options)
       set_review_information(v, options)
       set_app_rating(v, options)
-      v.ratings_reset = options[:reset_ratings]
+      v.ratings_reset = options[:reset_ratings] unless options[:reset_ratings].nil?
 
       Helper.show_loading_indicator("Uploading metadata to App Store Connect")
       v.save!


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context and Description
I use Deliver as a library and, if I don't specify `options[:reset_ratings] = true|false` when running `Deliver::UploadMetadata.new.upload(options)`, it changes the value to `null` and then fails to upload because `null` is not valid.
Most parameters in the `upload` method are only set if they exist in the `options` hash, but this one missed the check and it kept breaking my stuff.