### PR TITLE
[action] add --set-upstream option to push_to_git_remote

### DIFF
--- a/fastlane/lib/fastlane/actions/push_to_git_remote.rb
+++ b/fastlane/lib/fastlane/actions/push_to_git_remote.rb
@@ -113,7 +113,7 @@ module Fastlane
             force: true,              # optional, default: false
             force_with_lease: true,   # optional, default: false
             tags: false,              # optional, default: true
-            no_verify: true           # optional, default: false
+            no_verify: true,           # optional, default: false
             set_upstream: true        # optional, default: false
           )'
         ]

--- a/fastlane/lib/fastlane/actions/push_to_git_remote.rb
+++ b/fastlane/lib/fastlane/actions/push_to_git_remote.rb
@@ -113,7 +113,7 @@ module Fastlane
             force: true,              # optional, default: false
             force_with_lease: true,   # optional, default: false
             tags: false,              # optional, default: true
-            no_verify: true,           # optional, default: false
+            no_verify: true,          # optional, default: false
             set_upstream: true        # optional, default: false
           )'
         ]

--- a/fastlane/lib/fastlane/actions/push_to_git_remote.rb
+++ b/fastlane/lib/fastlane/actions/push_to_git_remote.rb
@@ -29,6 +29,9 @@ module Fastlane
         # optionally add the no-verify component
         command << '--no-verify' if params[:no_verify]
 
+        # optionally add the no-verify component
+        command << '--set-upstream' if params[:set_upstream]
+
         # execute our command
         Actions.sh('pwd')
         return command.join(' ') if Helper.test?
@@ -76,6 +79,11 @@ module Fastlane
                                        env_name: "FL_GIT_PUSH_USE_NO_VERIFY",
                                        description: "Whether or not to use --no-verify",
                                        type: Boolean,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :set_upstream,
+                                       env_name: "FL_GIT_PUSH_USE_SET_UPSTREAM",
+                                       description: "Whether or not to use --set-upstream",
+                                       type: Boolean,
                                        default_value: false)
         ]
       end
@@ -85,7 +93,10 @@ module Fastlane
       end
 
       def self.details
-        "Lets you push your local commits to a remote git repo. Useful if you make local changes such as adding a version bump commit (using `commit_version_bump`) or a git tag (using 'add_git_tag') on a CI server, and you want to push those changes back to your canonical/main repo."
+        [
+          "Lets you push your local commits to a remote git repo. Useful if you make local changes such as adding a version bump commit (using `commit_version_bump`) or a git tag (using 'add_git_tag') on a CI server, and you want to push those changes back to your canonical/main repo.",
+          "If this is a new branch, use the `set_upstream` option to set the remote branch as upstream."
+        ].join("\n")
       end
 
       def self.is_supported?(platform)
@@ -103,6 +114,7 @@ module Fastlane
             force_with_lease: true,   # optional, default: false
             tags: false,              # optional, default: true
             no_verify: true           # optional, default: false
+            set_upstream: true        # optional, default: false
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/push_to_git_remote.rb
+++ b/fastlane/lib/fastlane/actions/push_to_git_remote.rb
@@ -29,7 +29,7 @@ module Fastlane
         # optionally add the no-verify component
         command << '--no-verify' if params[:no_verify]
 
-        # optionally add the no-verify component
+        # optionally add the set-upstream component
         command << '--set-upstream' if params[:set_upstream]
 
         # execute our command

--- a/fastlane/spec/actions_specs/push_to_git_remote_spec.rb
+++ b/fastlane/spec/actions_specs/push_to_git_remote_spec.rb
@@ -83,6 +83,16 @@ describe Fastlane do
 
         expect(result).to eq("git push origin master:master --tags --no-verify")
       end
+
+      it "runs git push with set_upstream:true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            push_to_git_remote(
+              set_upstream: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("git push origin master:master --tags --set-upstream")
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
As stated in issue #14491, I'm trying to automate my dev workflow as much as possible. So when designing it, I thought about adding a lane that bumps the version and build number, then creates a release/vVERSION branch, commits the bump, and finally pushes the new branch to the remote (which should trigger CI). Digging around the docs I saw that there's no option to set the `-u` flag for the `push_to_git_remote` action.

### Description
The request basically entails adding a single parameter to the command:

    # optionally add the set-upstream component
    command << '--set-upstream' if params[:upstream]

It also has a `FastlaneCore::ConfigItem` addition, and updates the example. Additionally, I added an extra sentence to the details, so as to inform the users what to do if the branch is new. A test has been added as well.