### PR TITLE
[snapshot] Make the `sleep` waiting for animations optional

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
@@ -349,6 +349,12 @@ if ProcessInfo().arguments.contains("SKIP_ANIMATIONS") {
 }
 ```
 
+This requires you to pass the launch argument like so:
+
+```ruby
+snapshot(launch_arguments: ["SKIP_ANIMATIONS"])
+```
+
 By default, _snapshot_ will wait for a short time for the animations to finish.
 If you're skipping the animations, this is wait time is unnecessary and can be skipped:
 

--- a/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
@@ -336,3 +336,22 @@ When the app dies directly after the application is launched there might be 2 pr
 ## Determine language
 
 To detect the currently used localization in your tests, access the `deviceLanguage` variable from `SnapshotHelper.swift`.
+
+## Speed up snapshots
+
+A lot of time in UI tests is spent waiting for animations.
+
+You can disable `UIView` animations in your app to make the tests faster:
+
+```swift
+if ProcessInfo().arguments.contains("SKIP_ANIMATIONS") {
+    UIView.setAnimationsEnabled(false)
+}
+```
+
+By default, `snapshot` will wait for a short time for the animations to finish.
+If you're skipping the animations, this is wait time is unnecessary and can be skipped:
+
+```swift
+setupSnapshot(app, waitForAnimations: false)
+```

--- a/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
@@ -349,7 +349,7 @@ if ProcessInfo().arguments.contains("SKIP_ANIMATIONS") {
 }
 ```
 
-By default, `snapshot` will wait for a short time for the animations to finish.
+By default, _snapshot_ will wait for a short time for the animations to finish.
 If you're skipping the animations, this is wait time is unnecessary and can be skipped:
 
 ```swift

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -18,8 +18,8 @@ import XCTest
 var deviceLanguage = ""
 var locale = ""
 
-func setupSnapshot(_ app: XCUIApplication) {
-    Snapshot.setupSnapshot(app)
+func setupSnapshot(_ app: XCUIApplication, animationsEnabled: Bool = true) {
+    Snapshot.setupSnapshot(app, animationsEnabled: animationsEnabled)
 }
 
 func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
@@ -63,14 +63,16 @@ enum SnapshotError: Error, CustomDebugStringConvertible {
 @objcMembers
 open class Snapshot: NSObject {
     static var app: XCUIApplication?
+    static var animationsEnabled = true
     static var cacheDirectory: URL?
     static var screenshotsDirectory: URL? {
         return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
     }
 
-    open class func setupSnapshot(_ app: XCUIApplication) {
+    open class func setupSnapshot(_ app: XCUIApplication, animationsEnabled: Bool = true) {
         
         Snapshot.app = app
+        Snapshot.animationsEnabled = animationsEnabled
 
         do {
             let cacheDir = try pathPrefix()
@@ -153,7 +155,9 @@ open class Snapshot: NSObject {
 
         print("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
 
-        sleep(1) // Waiting for the animation to be finished (kind of)
+        if Snapshot.animationsEnabled {
+            sleep(1) // Waiting for the animation to be finished (kind of)
+        }
 
         #if os(OSX)
             guard let app = self.app else {
@@ -291,4 +295,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.14]
+// SnapshotHelperVersion [1.15]

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -18,8 +18,8 @@ import XCTest
 var deviceLanguage = ""
 var locale = ""
 
-func setupSnapshot(_ app: XCUIApplication, animationsEnabled: Bool = true) {
-    Snapshot.setupSnapshot(app, animationsEnabled: animationsEnabled)
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+    Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
 }
 
 func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
@@ -63,16 +63,16 @@ enum SnapshotError: Error, CustomDebugStringConvertible {
 @objcMembers
 open class Snapshot: NSObject {
     static var app: XCUIApplication?
-    static var animationsEnabled = true
+    static var waitForAnimations = true
     static var cacheDirectory: URL?
     static var screenshotsDirectory: URL? {
         return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
     }
 
-    open class func setupSnapshot(_ app: XCUIApplication, animationsEnabled: Bool = true) {
+    open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
         
         Snapshot.app = app
-        Snapshot.animationsEnabled = animationsEnabled
+        Snapshot.waitForAnimations = waitForAnimations
 
         do {
             let cacheDir = try pathPrefix()
@@ -155,7 +155,7 @@ open class Snapshot: NSObject {
 
         print("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
 
-        if Snapshot.animationsEnabled {
+        if Snapshot.waitForAnimations {
             sleep(1) // Waiting for the animation to be finished (kind of)
         }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context

We recently started running our snapshot tests without animations (`UIView.setAnimationsEnabled(false)`).

In the `SnapshotHelper` there is a `sleep` that waits for animations:

```swift
sleep(1) // Waiting for the animation to be finished (kind of)
```

When we remove this line, our screenshot UI tests speed up by **75%**

### Description

This request adds the option `animationsEnabled` to the `setupSnapshot` function.
If set to `false`, the snapshot helper will not sleep.

Since it has a default argument that make the helper behave as before, this is not a breaking change.


### Open Questions

- [ ] Should I document this new option somewhere?
- [ ] Is there a way to derive this value from `UIView.areAnimationsEnabled` automatically?