### PR TITLE
Fix slack message newline escape

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -18,11 +18,19 @@ module Fastlane
         message
       end
 
+      def self.unescape_newline(text)
+        text = text.gsub('\n', "\n")
+        text
+      end
+
       def self.run(options)
         require 'slack-notifier'
 
         options[:message] = self.trim_message(options[:message].to_s || '')
+        options[:message] = self.unescape_newline(options[:message])
         options[:message] = Slack::Notifier::Util::LinkFormatter.format(options[:message])
+
+        options[:pretext] = self.unescape_newline(options[:pretext]) unless options[:pretext].nil?
 
         if options[:channel].to_s.length > 0
           channel = options[:channel]

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -10,6 +10,27 @@ describe Fastlane do
         expect(Fastlane::Actions::SlackAction.trim_message(long_text).length).to eq(7000)
       end
 
+      it "unescapes newlines on message and pretext arguments" do
+        escaped_message = 'Custom\nMessage'
+        escaped_pretext = 'this\nis\na\npretext'
+        unescaped_message = "Custom\nMessage"
+        unescaped_pretext = "this\nis\na\npretext"
+        lane_name = "lane_name"
+
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+
+        require 'fastlane/actions/slack'
+        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          message: escaped_message,
+          pretext: escaped_pretext
+        })
+
+        _, attachments = Fastlane::Actions::SlackAction.run(arguments)
+
+        expect(attachments[:text]).to eq(unescaped_message)
+        expect(attachments[:pretext]).to eq(unescaped_pretext)
+      end
+
       it "works so perfect, like Slack does" do
         channel = "#myChannel"
         message = "Custom Message"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR solves the issue #14141 about newline beign escaped on `message` and `pretext` arguments, for the Slack action.
 
### Description
I've added a helper method on the Slack action and applied to the `message` and `pretext` arguments.

To test it, I've write a test case that reproduced the issue. And after fix it I've modified the Gemfile on our project to use the Fastlane fork with the changes.

Then run the action from the terminal as follows:
```shell
bundle exec fastlane run slack \
  slack_url:YOUR_SLACK_WEBHOOK_URL \
  username=Adam \
  use_webhook_configured_username_and_icon:true \
  message:"this\nis\na\nmessage" \
  pretext:"This\nis\na\npretext" default_payloads:""
```

 Before the changes 😢:

> <img width="266" alt="Screenshot 2019-03-29 at 15 58 26" src="https://user-images.githubusercontent.com/1521546/55244006-9c966f80-5240-11e9-9ed2-d968e9bcf4b1.png">

After the changes 😄:

> <img width="208" alt="Screenshot 2019-03-29 at 16 00 04" src="https://user-images.githubusercontent.com/1521546/55244017-a0c28d00-5240-11e9-8da8-cada0df5fd33.png">
