### PR TITLE
[action] Continue git_commit action execution if there is nothing to commit

### DIFF
--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -10,17 +10,15 @@ module Fastlane
 
         skip_git_hooks = params[:skip_git_hooks] ? '--no-verify' : ''
 
-        command = "git commit -m #{params[:message].shellescape} #{paths} #{skip_git_hooks}".strip
-        nothing_to_commit = false
-
         if params[:allow_nothing_to_commit]
           repo_clean = Actions.sh("git status --porcelain").empty?
           UI.success("Nothing to commit, working tree clean ✅.") if repo_clean
           return if repo_clean
         end
 
+        command = "git commit -m #{params[:message].shellescape} #{paths} #{skip_git_hooks}".strip
         result = Actions.sh(command)
-        UI.success("Successfully committed \"#{params[:path]}\" 💾.") unless nothing_to_commit
+        UI.success("Successfully committed \"#{params[:path]}\" 💾.")
         return result
       end
 

--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -14,18 +14,12 @@ module Fastlane
         nothing_to_commit = false
 
         if params[:allow_nothing_to_commit]
-          result = Actions.sh(
-            command,
-            log: FastlaneCore::Globals.verbose?,
-            error_callback: lambda { |_|
-              nothing_to_commit = true
-              UI.success("Nothing to commit, working tree clean ✅.")
-            }
-          )
-        else
-          result = Actions.sh(command)
+          repo_clean = Actions.sh("git status --porcelain").empty?
+          UI.success("Nothing to commit, working tree clean ✅.") if repo_clean
+          return if repo_clean
         end
 
+        result = Actions.sh(command)
         UI.success("Successfully committed \"#{params[:path]}\" 💾.") unless nothing_to_commit
         return result
       end

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -52,6 +52,14 @@ describe Fastlane do
 
         expect(result).to eq("git commit -m message ./fastlane/README.md --no-verify")
       end
+
+      it "generates the correct git command when configured to allow nothing to commit" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          git_commit(path: './fastlane/README.md', message: 'message', allow_nothing_to_commit: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("git commit -m message ./fastlane/README.md")
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -53,12 +53,23 @@ describe Fastlane do
         expect(result).to eq("git commit -m message ./fastlane/README.md --no-verify")
       end
 
-      it "generates the correct git command when configured to allow nothing to commit" do
+      it "generates the correct git command when configured to allow nothing to commit and there are changes to commit" do
         result = Fastlane::FastFile.new.parse("lane :test do
           git_commit(path: './fastlane/README.md', message: 'message', allow_nothing_to_commit: true)
         end").runner.execute(:test)
 
         expect(result).to eq("git commit -m message ./fastlane/README.md")
+      end
+
+      it "does not generate the git command when configured to allow nothing to commit and there are no changes to commit" do
+        allow(Fastlane::Actions).to receive(:sh)
+          .with("git status --porcelain")
+          .and_return("")
+        result = Fastlane::FastFile.new.parse("lane :test do
+          git_commit(path: './fastlane/README.md', message: 'message', allow_nothing_to_commit: true)
+        end").runner.execute(:test)
+
+        expect(result).to be_nil
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
[`git_commit`](https://docs.fastlane.tools/actions/git_commit/) action fails if there's nothing to commit. 

<img width="589" alt="git_commit_nothing_to_commit" src="https://user-images.githubusercontent.com/10795657/55280686-39ccd300-5329-11e9-96f3-cf301792ae7c.png">

<!-- If it fixes an open issue, please link to the issue here. -->
closes https://github.com/fastlane/fastlane/issues/14437

### Description
<!-- Describe your changes in detail -->

Added a new parameter `allow_nothing_to_commit`. 

<!-- Please describe in detail how you tested your changes. -->

Tested the changes by adding a new unit test and doing manual testing. 

<img width="455" alt="Screenshot 2019-03-30 at 19 27 40" src="https://user-images.githubusercontent.com/10795657/55280688-481aef00-5329-11e9-9754-1ce21026b713.png">

<img width="511" alt="Screenshot 2019-03-30 at 19 27 03" src="https://user-images.githubusercontent.com/10795657/55280692-51a45700-5329-11e9-8dee-71f017679269.png">