### PR TITLE
[spaceship] migrate "olympus" authentication endpoint to appstoreconnect api

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -513,8 +513,9 @@ module Spaceship
     end
 
     # Get the `itctx` from the new (22nd May 2017) API endpoint "olympus"
+    # Update (29th March 2019) olympus migrates to new appstoreconnect API
     def fetch_olympus_session
-      response = request(:get, "https://olympus.itunes.apple.com/v1/session")
+      response = request(:get, "https://appstoreconnect.apple.com/olympus/v1/session")
       body = response.body
       if body
         body = JSON.parse(body) if body.kind_of?(String)
@@ -543,7 +544,7 @@ module Spaceship
       # Fixes issue https://github.com/fastlane/fastlane/issues/13281
       # Even though we are using https://appstoreconnect.apple.com, the service key needs to still use a
       # hostname through itunesconnect.apple.com
-      response = request(:get, "https://olympus.itunes.apple.com/v1/app/config?hostname=itunesconnect.apple.com")
+      response = request(:get, "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com")
       @service_key = response.body["authServiceKey"].to_s
 
       raise "Service key is empty" if @service_key.length == 0
@@ -599,7 +600,7 @@ module Spaceship
     def fetch_program_license_agreement_messages
       all_messages = []
 
-      messages_request = request(:get, "https://olympus.itunes.apple.com/v1/contractMessages")
+      messages_request = request(:get, "https://appstoreconnect.apple.com/olympus/v1/contractMessages")
       body = messages_request.body
       if body
         body = JSON.parse(body) if body.kind_of?(String)

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -321,7 +321,7 @@ describe Spaceship::Client do
         response = subject.fetch_program_license_agreement_messages
 
         # The method should make a GET request to this URL:
-        expect(a_request(:get, 'https://olympus.itunes.apple.com/v1/contractMessages')).to have_been_made
+        expect(a_request(:get, 'https://appstoreconnect.apple.com/olympus/v1/contractMessages')).to have_been_made
 
         # The method should just return the "message" key's value(s) in an array.
 

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -340,7 +340,7 @@ class PortalStubbing
     end
 
     def adp_stub_fetch_program_license_agreement_messages
-      stub_request(:get, 'https://olympus.itunes.apple.com/v1/contractMessages').
+      stub_request(:get, 'https://appstoreconnect.apple.com/olympus/v1/contractMessages').
         to_return(status: 200, body: adp_read_fixture_file('program_license_agreement_messages.json'), headers: { 'Content-Type' => 'application/json' })
     end
   end

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -21,9 +21,9 @@ class TunesStubbing
         to_return(status: 200, body: "")
       stub_request(:get, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/wa").
         to_return(status: 200, body: "")
-      stub_request(:get, "https://olympus.itunes.apple.com/v1/session").
+      stub_request(:get, "https://appstoreconnect.apple.com/olympus/v1/session").
         to_return(status: 200, body: itc_read_fixture_file('olympus_session.json'))
-      stub_request(:get, "https://olympus.itunes.apple.com/v1/app/config?hostname=itunesconnect.apple.com").
+      stub_request(:get, "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com").
         to_return(status: 200, body: { authServiceKey: 'e0abc' }.to_json, headers: { 'Content-Type' => 'application/json' })
 
       # Actual login


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The appstoreconnect API should be preferred over the older APIs. This PR is a work-in-progress to migrate the authentication to use the olympus endpoint under the appstoreconnect domain.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
