### PR TITLE
[supply] Also upload changelog when uploading bundle

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -162,7 +162,7 @@ module Supply
 
       aab_paths.each do |aab_path|
         UI.message("Preparing aab at path '#{aab_path}' for upload...")
-        bundle_version_code = client.upload_bundle(aab_path) 
+        bundle_version_code = client.upload_bundle(aab_path)
 
         if metadata_path
           all_languages.each do |language|

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -162,7 +162,16 @@ module Supply
 
       aab_paths.each do |aab_path|
         UI.message("Preparing aab at path '#{aab_path}' for upload...")
-        aab_version_codes.push(client.upload_bundle(aab_path))
+        bundle_version_code = client.upload_bundle(aab_path) 
+
+        if metadata_path
+          all_languages.each do |language|
+            next if language.start_with?('.') # e.g. . or .. or hidden folders
+            upload_changelog(language, bundle_version_code)
+          end
+        end
+
+        aab_version_codes.push(bundle_version_code)
       end
 
       return aab_version_codes


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR addresses the issue documented at https://github.com/fastlane/fastlane/issues/13616

New android bundle updates would not upload the changenotes for the new version.


### Description
After uploading an apk, the existing code checks for new changenote metadata from the uploaded version and immediately uploads it. This was not occurring when uploading app bundles. This fix does the same thing for bundles, as it is doing for apks in the upload_binary_data(apk_path) function.

changes have been tested on our android code base, by utilising my local modified version of fastlane as documented at https://github.com/fastlane/fastlane/blob/master/Testing.md#test-your-local-fastlane-code-base-with-your-setup
