### PR TITLE
[action] prioritize GSP path over fabric token

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -87,8 +87,11 @@ module Fastlane
         UI.message("Uploading '#{path}'...")
         command = []
         command << File.expand_path(params[:binary_path]).shellescape
-        command << "-gsp #{params[:gsp_path].shellescape}" if params[:gsp_path]
-        command << "-a #{params[:api_token]}" if params[:api_token] && !params[:gsp_path]
+        if params[:gsp_path]
+          command << "-gsp #{params[:gsp_path].shellescape}"
+        elsif params[:api_token]
+          command << "-a #{params[:api_token]}"
+        end
         command << "-p #{params[:platform] == 'appletvos' ? 'tvos' : params[:platform]}"
         command << File.expand_path(path).shellescape
         begin

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -9,7 +9,7 @@ module Fastlane
         find_binary_path(params)
         find_gsp_path(params)
         find_api_token(params)
-        
+
         if !params[:api_token] && !params[:gsp_path]
           UI.user_error!('Either Fabric API key or path to Firebase Crashlytics GoogleService-Info.plist must be given.')
         end

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -7,9 +7,9 @@ module Fastlane
         require 'tmpdir'
 
         find_binary_path(params)
-        find_api_token(params)
         find_gsp_path(params)
-
+        find_api_token(params)
+        
         if !params[:api_token] && !params[:gsp_path]
           UI.user_error!('Either Fabric API key or path to Firebase Crashlytics GoogleService-Info.plist must be given.')
         end
@@ -87,8 +87,8 @@ module Fastlane
         UI.message("Uploading '#{path}'...")
         command = []
         command << File.expand_path(params[:binary_path]).shellescape
-        command << "-a #{params[:api_token]}" if params[:api_token]
         command << "-gsp #{params[:gsp_path].shellescape}" if params[:gsp_path]
+        command << "-a #{params[:api_token]}" if params[:api_token] && !params[:gsp_path]
         command << "-p #{params[:platform] == 'appletvos' ? 'tvos' : params[:platform]}"
         command << File.expand_path(path).shellescape
         begin


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
GSP path should be prioritized over the Fabric token.  It is required because users who migrated from Fabric to Firebase Crashlytics will still have the Fabric token setup as well as the GSP path, and currently it will not upload to Firebase Crashlytics if Fabric is also setup.  Should prioritize Firebase for smoother transition for when Fabric is fully shut down in a few months for users with dual configs atm. TL;DR: if both are setup, dSYMS get sent to deprecated service. 
<!-- If it fixes an open issue, please link to the issue here. -->
Not and open issue, but one that was mistakenly closed and there have been active conversation on: https://github.com/fastlane/fastlane/issues/13096 ... the issue under discussion, despite it being closed last year was only resolved 11 days ago, but not entirely.
### Description
<!-- Describe your changes in detail -->
Search for the gsp path _first_ before fabric token.  Also, don't set the `-a` flag if gsp is already set.  
<!-- Please describe in detail how you tested your changes. -->
I have a product with both a gsp path and fabric token.  Tested on latest Fastlane first to show that the `-a` flag was being used for the `upload-symbols` binary, despite the existence of a GoogleService-Info.plist in my project.  With the changes, the -gsp flag was successfully used instead.