### PR TITLE
[deliver] Fix builds whose versions have components with leading zeros infinitely wait for submission

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -74,18 +74,16 @@ module Deliver
         end
 
         latest_build = find_build(candidate_builds)
-        latest_build_matches = (latest_build&.train_version == app_version && latest_build&.build_version == build&.build_version)
+
+        # if the app version isn't present in the hash (could happen if we are waiting for submission, but didn't provide
+        # it explicitly and no ipa was passed to grab it from), then fall back to the best guess, which is the train_version
+        # of the most recently uploaded build
+        app_version = app_version || latest_build.train_version
+
         # Sometimes latest build will disappear and a different build would get selected
         # Only set build if no latest build found or if same build versions as previously fetched build
         # Issue: https://github.com/fastlane/fastlane/issues/10945
-        if build.nil? || latest_build_matches
-          # if the app version isn't present in the hash (could happen if we are waiting for submission, but didn't provide
-          # it explicitly and no ipa was passed to grab it from), then fall back to the best guess, which is the train_version
-          # of the most recently uploaded build
-          if app_version.nil?
-            app_version = latest_build.train_version
-          end
-
+        if build.nil? || (latest_build && latest_build.build_version == build.build_version && latest_build.train_version == app_version)
           build = latest_build
         end
 

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -74,10 +74,11 @@ module Deliver
         end
 
         latest_build = find_build(candidate_builds)
+        latest_build_matches = (latest_build && latest_build.train_version == app_version && latest_build.build_version == build.build_version)
         # Sometimes latest build will disappear and a different build would get selected
         # Only set build if no latest build found or if same build versions as previously fetched build
         # Issue: https://github.com/fastlane/fastlane/issues/10945
-        if build.nil? || (latest_build && latest_build.train_version == app_version && latest_build.build_version == build.build_version)
+        if build.nil? || latest_build_matches
           # if the app version isn't present in the hash (could happen if we are waiting for submission, but didn't provide
           # it explicitly and no ipa was passed to grab it from, then fall back to the best guess, which is the train_version
           # of the most recently uploaded build)

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -80,7 +80,7 @@ module Deliver
         # Issue: https://github.com/fastlane/fastlane/issues/10945
         if build.nil? || latest_build_matches
           # if the app version isn't present in the hash (could happen if we are waiting for submission, but didn't provide
-          # it explicitly and no ipa was passed to grab it from, then fall back to the best guess, which is the train_version
+          # it explicitly and no ipa was passed to grab it from), then fall back to the best guess, which is the train_version
           # of the most recently uploaded build)
           if app_version.nil?
             app_version = latest_build.train_version

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -29,7 +29,7 @@ module Deliver
       UI.success("Successfully submitted the app for review!")
     end
 
-    def select_build(options)
+    private def select_build(options)
       app = options[:app]
       app_version = options[:app_version]
       v = app.edit_version(platform: options[:platform])

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -74,7 +74,7 @@ module Deliver
         end
 
         latest_build = find_build(candidate_builds)
-        latest_build_matches = (latest_build && latest_build.train_version == app_version && latest_build.build_version == build.build_version)
+        latest_build_matches = (latest_build&.train_version == app_version && latest_build&.build_version == build&.build_version)
         # Sometimes latest build will disappear and a different build would get selected
         # Only set build if no latest build found or if same build versions as previously fetched build
         # Issue: https://github.com/fastlane/fastlane/issues/10945

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -31,6 +31,7 @@ module Deliver
 
     def select_build(options)
       app = options[:app]
+      app_version = options[:app_version]
       v = app.edit_version(platform: options[:platform])
 
       if options[:build_number] && options[:build_number] != "latest"
@@ -41,9 +42,9 @@ module Deliver
         end
       else
         UI.message("Selecting the latest build...")
-        build = wait_for_build(app)
+        build = wait_for_build(app, app_version)
       end
-      UI.message("Selecting build #{build.train_version} (#{build.build_version})...")
+      UI.message("Selecting build #{app_version} (#{build.build_version})...")
 
       v.select_build(build)
       v.save!
@@ -51,7 +52,7 @@ module Deliver
       UI.success("Successfully selected build")
     end
 
-    def wait_for_build(app)
+    def wait_for_build(app, app_version)
       UI.user_error!("Could not find app with app identifier") unless app
 
       start = Time.now
@@ -76,14 +77,21 @@ module Deliver
         # Sometimes latest build will disappear and a different build would get selected
         # Only set build if no latest build found or if same build versions as previously fetched build
         # Issue: https://github.com/fastlane/fastlane/issues/10945
-        if build.nil? || (latest_build && latest_build.train_version == build.train_version && latest_build.build_version == build.build_version)
+        if build.nil? || (latest_build && latest_build.train_version == app_version && latest_build.build_version == build.build_version)
+          # if the app version isn't present in the hash (could happen if we are waiting for submission, but didn't provide
+          # it explicitly and no ipa was passed to grab it from, then fall back to the best guess, which is the train_version
+          # of the most recently uploaded build)
+          if app_version.nil?
+            app_version = latest_build.train_version
+          end
+
           build = latest_build
         end
 
         return build if build && build.processing == false
 
         if build
-          UI.message("Waiting App Store Connect processing for build #{build.train_version} (#{build.build_version})... this might take a while...")
+          UI.message("Waiting App Store Connect processing for build #{app_version} (#{build.build_version})... this might take a while...")
         else
           UI.message("Waiting App Store Connect processing for build... this might take a while...")
         end

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -81,7 +81,7 @@ module Deliver
         if build.nil? || latest_build_matches
           # if the app version isn't present in the hash (could happen if we are waiting for submission, but didn't provide
           # it explicitly and no ipa was passed to grab it from), then fall back to the best guess, which is the train_version
-          # of the most recently uploaded build)
+          # of the most recently uploaded build
           if app_version.nil?
             app_version = latest_build.train_version
           end

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -78,7 +78,7 @@ module Deliver
         # if the app version isn't present in the hash (could happen if we are waiting for submission, but didn't provide
         # it explicitly and no ipa was passed to grab it from), then fall back to the best guess, which is the train_version
         # of the most recently uploaded build
-        app_version = app_version || latest_build.train_version
+        app_version ||= latest_build.train_version
 
         # Sometimes latest build will disappear and a different build would get selected
         # Only set build if no latest build found or if same build versions as previously fetched build

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -13,13 +13,13 @@ describe Deliver::SubmitForReview do
   end
 
   def make_fake_app
-    return OpenStruct.new({})
+    OpenStruct.new({})
   end
 
   def make_fake_version
     fake_version = double('fake_version')
     allow(fake_version).to receive(:[]).with(:app_version).and_return("1.2.3")
-    return fake_version
+    fake_version
   end
 
   describe :find_build do
@@ -86,7 +86,7 @@ describe Deliver::SubmitForReview do
           allow(build).to receive(:build_version).and_return(1)
           allow(build).to receive(:upload_date).and_return(1_554_754_590)
           expect(build).to receive(:processing).and_return(true)
-          return [build]
+          [build]
         end
         let(:fake_builds_with_processed_build) do
           build = double('fake_build')
@@ -94,12 +94,12 @@ describe Deliver::SubmitForReview do
           allow(build).to receive(:build_version).and_return(1)
           allow(build).to receive(:upload_date).and_return(1_554_754_590)
           expect(build).to receive(:processing).and_return(false)
-          return [build]
+          [build]
         end
         let(:fake_version) do
           fake_version = double('fake_version')
           allow(fake_version).to receive(:app_version).and_return(nil)
-          return fake_version
+          fake_version
         end
 
         it 'finds the one build when no app version is provided' do
@@ -119,7 +119,7 @@ describe Deliver::SubmitForReview do
           allow(build).to receive(:build_version).and_return(1)
           allow(build).to receive(:upload_date).and_return(1_554_754_590)
           allow(build).to receive(:processing).and_return(false)
-          return [build]
+          [build]
         end
         let(:fake_builds_with_trimmed_zero) do
           build = double('fake_build_with_trimmed_zero')
@@ -127,12 +127,12 @@ describe Deliver::SubmitForReview do
           allow(build).to receive(:build_version).and_return(1)
           allow(build).to receive(:upload_date).and_return(1_554_754_590)
           allow(build).to receive(:processing).and_return(true)
-          return [build]
+          [build]
         end
         let(:fake_version) do
           fake_version = double('fake_version')
           allow(fake_version).to receive(:[]).with(:app_version).and_return("1.02.3")
-          return fake_version
+          fake_version
         end
 
         it 'does not find the one build until the candidate is corrected' do

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -17,7 +17,11 @@ describe Deliver::SubmitForReview do
   end
 
   def make_fake_version
-    return OpenStruct.new({})
+    fake_version = OpenStruct.new({
+      app_version: "1.2.3"
+    })
+
+    return fake_version
   end
 
   describe :find_build do
@@ -49,11 +53,8 @@ describe Deliver::SubmitForReview do
     describe :wait_for_build do
       context 'no candidates' do
         let(:fake_app) { make_fake_app }
+        let(:fake_version) { make_fake_version }
         let(:time_now) { Time.now }
-        let(:fake_version) do
-          fake_version = make_fake_version
-          fake_version[:app_version] = "1.2.3"
-        end
 
         # Stub Time.now to return current time on first call and 6 minutes later on second
         before { allow(Time).to receive(:now).and_return(time_now, (time_now + 60 * 6)) }
@@ -68,11 +69,8 @@ describe Deliver::SubmitForReview do
 
       context 'has candidates and one build' do
         let(:fake_app) { make_fake_app }
+        let(:fake_version) { make_fake_version }
         let(:fake_builds) { make_fake_builds(1) }
-        let(:fake_version) do
-          fake_version = make_fake_version
-          fake_version[:app_version] = "1.2.3"
-        end
 
         it 'finds the one build' do
           allow(fake_app).to receive(:latest_version).and_return(fake_version)

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -84,7 +84,7 @@ describe Deliver::SubmitForReview do
           build = double('fake_build')
           allow(build).to receive(:train_version).and_return("1.2.3")
           allow(build).to receive(:build_version).and_return(1)
-          allow(build).to receive(:upload_date).and_return(1554754590)
+          allow(build).to receive(:upload_date).and_return(1_554_754_590)
           expect(build).to receive(:processing).and_return(true)
           return [build]
         end
@@ -92,7 +92,7 @@ describe Deliver::SubmitForReview do
           build = double('fake_build')
           allow(build).to receive(:train_version).and_return("1.2.3")
           allow(build).to receive(:build_version).and_return(1)
-          allow(build).to receive(:upload_date).and_return(1554754590)
+          allow(build).to receive(:upload_date).and_return(1_554_754_590)
           expect(build).to receive(:processing).and_return(false)
           return [build]
         end
@@ -117,7 +117,7 @@ describe Deliver::SubmitForReview do
           build = double('fake_build')
           expect(build).to receive(:train_version).and_return("1.02.3")
           allow(build).to receive(:build_version).and_return(1)
-          allow(build).to receive(:upload_date).and_return(1554754590)
+          allow(build).to receive(:upload_date).and_return(1_554_754_590)
           allow(build).to receive(:processing).and_return(false)
           return [build]
         end
@@ -125,7 +125,7 @@ describe Deliver::SubmitForReview do
           build = double('fake_build_with_trimmed_zero')
           expect(build).to receive(:train_version).and_return("1.2.3")
           allow(build).to receive(:build_version).and_return(1)
-          allow(build).to receive(:upload_date).and_return(1554754590)
+          allow(build).to receive(:upload_date).and_return(1_554_754_590)
           allow(build).to receive(:processing).and_return(true)
           return [build]
         end

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -113,7 +113,6 @@ describe Deliver::SubmitForReview do
         end
       end
 
-
       context 'has candidates and one build with a leading zero in the train version' do
         let(:fake_app) { make_fake_app }
         let(:fake_builds) do
@@ -144,7 +143,6 @@ describe Deliver::SubmitForReview do
           expect(review_submitter.wait_for_build(fake_app, "1.02.3")).to eq(only_build)
         end
       end
-
     end
   end
 end

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -49,28 +49,36 @@ describe Deliver::SubmitForReview do
     describe :wait_for_build do
       context 'no candidates' do
         let(:fake_app) { make_fake_app }
-        let(:fake_version) { make_fake_version }
         let(:time_now) { Time.now }
+        let(:fake_version) {
+          fake_version = make_fake_version
+          fake_version[:app_version] = "1.2.3"
+        }
+
         # Stub Time.now to return current time on first call and 6 minutes later on second
         before { allow(Time).to receive(:now).and_return(time_now, (time_now + 60 * 6)) }
         it 'throws a UI error' do
           allow(fake_app).to receive(:latest_version).and_return(fake_version)
           allow(fake_version).to receive(:candidate_builds).and_return([])
           expect do
-            review_submitter.wait_for_build(fake_app)
+            review_submitter.wait_for_build(fake_app, "1.2.3")
           end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not find any available candidate builds on App Store Connect to submit")
         end
       end
 
       context 'has candidates and one build' do
         let(:fake_app) { make_fake_app }
-        let(:fake_version) { make_fake_version }
         let(:fake_builds) { make_fake_builds(1) }
+        let(:fake_version) {
+          fake_version = make_fake_version
+          fake_version[:app_version] = "1.2.3"
+        }
+
         it 'finds the one build' do
           allow(fake_app).to receive(:latest_version).and_return(fake_version)
           allow(fake_version).to receive(:candidate_builds).and_return(fake_builds)
           only_build = fake_builds.first
-          expect(review_submitter.wait_for_build(fake_app)).to eq(only_build)
+          expect(review_submitter.wait_for_build(fake_app, "1.2.3")).to eq(only_build)
         end
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR fixes an issue in Deliver's `SubmitForReview` which causes builds containing zero-padding in their version components to fail to submit. It is caused by an Apple issue which causes the App Store Connect API to temporarily return a `train_version` whose components are stripped of their zero padding. For example, "2019.04.01" would be returned as "2019.4.1". During the processing, eventually the API starts returning the correct form of the version again, i.e. "2019.04.01". 

The above causes Deliver to infinitely wait for the build to be processed because it notes the most recently uploaded build as soon as Transporter finishes and uses it to compare the version of builds in future calls to `candidate_builds` to prevent accidentally selecting the wrong build for submission.

Below is some trimmed json demonstrating the relevant changes to the data throughout processing:

Immediately after upload:
```json
{
	"buildVersion": "82",
	"trainVersion": "2019.4.1",
	"uploadDate": 1554160879000,
	"processing": true,
	"processingState": "processing",
	"processingError": null,
}
```

After the first phase of processing; note the trainVersion format has changed:
```json
{
	"buildVersion": "82",
	"trainVersion": "2019.04.01",
	"uploadDate": 1554161105000,
	"processing": true,
	"processingState": "processing",
	"processingError": null,
}
```

Processing complete:
```json
{
	"buildVersion": "82",
	"trainVersion": "2019.04.01",
	"uploadDate": 1554161105000,
	"processing": false,
	"processingState": null,
	"processingError": null,
}
```

Should solve fastlane/fastlane#13372 and fastlane/fastlane#13577

### Solution

The solution is to use the `app_version` attached to the options hash for comparing to the `candidate_builds` instead of the `train_version` from the previously found build. This ensures that a correctly formatted version is always used for comparison. In cases where an `app_version` is not supplied in the options hash, such as when calling `SubmitForReview` without an ipa and also not providing an `app_version` explicitly, we fall back to the behavior of using the one on the first build we find and hoping for the best.

I added a test that confirms that `wait_for_build` properly returns a build with the supplied app version even when `candidate_builds` returns a build with the zeros stripped. I also added a test that confirms a build is returned when nil is passed as the app version to `wait_for_build`.
