### PR TITLE
[action] New action to install provisioning profile from file

### DIFF
--- a/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
@@ -4,16 +4,16 @@ module Fastlane
   module Actions
     class InstallProvisioningProfileAction < Action
       def self.run(params)
-        absolute_path = File.expand_path(params[:provisioning_profile_path])
+        absolute_path = File.expand_path(params[:path])
         FastlaneCore::ProvisioningProfile.install(absolute_path)
       end
 
       def self.description
-        "Install provisioning profile from inputfile"
+        "Install provisioning profile from path"
       end
 
       def self.details
-        "Install provisioning profile from inputfile for current user"
+        "Install provisioning profile from path for current user"
       end
 
       def self.authors
@@ -30,7 +30,7 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :provisioning_profile_path,
+          FastlaneCore::ConfigItem.new(key: :path,
                                   env_name: "FL_INSTALL_PROVISIONING_PROFILE_PATH",
                                description: "Path to provisioning profile",
                                   optional: false,
@@ -50,7 +50,7 @@ module Fastlane
 
       def self.example_code
         [
-          'install_provisioning_profile(provisioning_profile_path: "profiles/profile.mobileprovision")'
+          'install_provisioning_profile(path: "profiles/profile.mobileprovision")'
         ]
       end
     end

--- a/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
@@ -1,0 +1,52 @@
+require 'shellwords'
+
+module Fastlane
+  module Actions
+    class InstallProvisioningProfileAction < Action
+      def self.run(params)
+        provisioning_profile_path = params[:provisioning_profile_path]
+        FastlaneCore::ProvisioningProfile.install(provisioning_profile_path)
+      end
+
+      def self.description
+        "Install provisioning profile from inputfile"
+      end
+
+      def self.details
+        "Install provisioning profile from inputfile for current user"
+      end
+
+      def self.authors
+        ["SofteqDG"]
+      end
+
+      def self.category
+        :code_signing
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :provisioning_profile_path,
+                                  env_name: "FL_INSTALL_PROVISIONING_PROFILE_PATH",
+                               description: "Path to provisioning profile",
+                                  optional: false,
+                                      type: String)
+        ]
+      end
+
+      def self.return_value
+        "The absolute path to the installed provisioning profile"
+      end
+
+      def self.example_code
+        [
+          'install_provisioning_profile(provisioning_profile_path: "profiles/profile.mobileprovision")'
+        ]
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
@@ -4,8 +4,13 @@ module Fastlane
   module Actions
     class InstallProvisioningProfileAction < Action
       def self.run(params)
-        provisioning_profile_path = params[:provisioning_profile_path]
-        FastlaneCore::ProvisioningProfile.install(provisioning_profile_path)
+        profile_path = params[:provisioning_profile_path]
+        absolute_profile_path = File.expand_path(profile_path)
+        if File.exist?(absolute_profile_path)
+          FastlaneCore::ProvisioningProfile.install(absolute_profile_path)
+        else
+          UI.user_error!("Failed installation of provisioning profile from file at path: '#{profile_path}'")
+        end
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
@@ -4,13 +4,8 @@ module Fastlane
   module Actions
     class InstallProvisioningProfileAction < Action
       def self.run(params)
-        profile_path = params[:provisioning_profile_path]
-        absolute_profile_path = File.expand_path(profile_path)
-        if File.exist?(absolute_profile_path)
-          FastlaneCore::ProvisioningProfile.install(absolute_profile_path)
-        else
-          UI.user_error!("Failed installation of provisioning profile from file at path: '#{profile_path}'")
-        end
+        absolute_path = File.expand_path(params[:provisioning_profile_path])
+        FastlaneCore::ProvisioningProfile.install(absolute_path)
       end
 
       def self.description
@@ -39,7 +34,13 @@ module Fastlane
                                   env_name: "FL_INSTALL_PROVISIONING_PROFILE_PATH",
                                description: "Path to provisioning profile",
                                   optional: false,
-                                      type: String)
+                                      type: String,
+                              verify_block: proc do |value|
+                                absolute_path = File.expand_path(value)
+                                unless File.exist?(absolute_path)
+                                  UI.user_error!("Failed installation of provisioning profile from file at path: '#{value}'")
+                                end
+                              end)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
@@ -38,7 +38,7 @@ module Fastlane
                               verify_block: proc do |value|
                                 absolute_path = File.expand_path(value)
                                 unless File.exist?(absolute_path)
-                                  UI.user_error!("Failed installation of provisioning profile from file at path: '#{value}'")
+                                  UI.user_error!("Could not find provisioning profile at path: '#{value}'")
                                 end
                               end)
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This action can be very useful if user doesn't use `match` action for automatic provisioning profiles management. It can be used inside of Fastfile and also can be run from shell.
This PR also fixes open issue #11788 

### Description
This action allow user to install provisioning profile from local file. This is just a wrapper around the `FastlaneCore::ProvisioningProfile` class and doesn't provide any additional functionality.