### PR TITLE
[spaceship] Add app screenshot download endpoint to README.md

### DIFF
--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -137,7 +137,7 @@ All [fastlane tools](https://fastlane.tools) that communicate with Apple's web s
 
 Overview of the used API endpoints
 
-- `https://idmsa.apple.com`: 
+- `https://idmsa.apple.com`:
   - Used to authenticate to get a valid session
 - `https://developerservices2.apple.com`:
   - Get a list of all available provisioning profiles
@@ -157,6 +157,8 @@ Overview of the used API endpoints
   - Managing app metadata
 - `https://du-itc.appstoreconnect.apple.com`:
   - Upload icons, screenshots, trailers ...
+- `https://is[1-9]-ssl.mzstatic.com`:
+  - Download app screenshots from App Store Connect
 
 _spaceship_ uses all those API points to offer this seamless experience.
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While URLs for app screenshots are not exactly _API_ endpoints, those are still used to download app screenshots from App Store Connect, i.e. as part of `deliver download_screenshots` action.
It is very useful for those who have to configure their enterprise firewall to be able to use fastlane in tight enterprise setup.

### Description
Add links to where Apple stores app screenshots.
