### PR TITLE
[spaceship] Include 'DES' cookie into FASTLANE_SESSION

### DIFF
--- a/spaceship/lib/spaceship.rb
+++ b/spaceship/lib/spaceship.rb
@@ -13,6 +13,7 @@ require_relative 'spaceship/tunes/tunes'
 require_relative 'spaceship/tunes/spaceship'
 require_relative 'spaceship/test_flight'
 require_relative 'spaceship/connect_api'
+require_relative 'spaceship/spaceauth_runner'
 
 require_relative 'spaceship/module'
 

--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -44,7 +44,7 @@ module Spaceship
 
       # We remove all the un-needed cookies
       cookies.select! do |cookie|
-        cookie.name.start_with?("myacinfo") || cookie.name == 'dqsid'
+        cookie.name.start_with?("myacinfo") || cookie.name == "dqsid" || cookie.name.start_with?("DES")
       end
 
       yaml = cookies.to_yaml.gsub("\n", "\\n")

--- a/spaceship/spec/spaceauth_spec.rb
+++ b/spaceship/spec/spaceauth_spec.rb
@@ -1,0 +1,16 @@
+require_relative 'tunes/tunes_stubbing'
+
+describe Spaceship::SpaceauthRunner do
+  let(:user_cookie) { TunesStubbing.itc_read_fixture_file('spaceauth_cookie.yml') }
+
+  it 'uses all required cookies for fastlane session' do
+    if FastlaneCore::Helper.mac?
+      expect(Spaceship::Client::UserInterface).to receive(:interactive?).and_return(false)
+    end
+    expect_any_instance_of(Spaceship::Client).to receive(:store_cookie).exactly(2).times.and_return(user_cookie)
+
+    expect do
+      Spaceship::SpaceauthRunner.new.run
+    end.to output(/export FASTLANE_SESSION=.*name: DES.*name: myacinfo.*name: dqsid.*/).to_stdout
+  end
+end

--- a/spaceship/spec/tunes/fixtures/spaceauth_cookie.yml
+++ b/spaceship/spec/tunes/fixtures/spaceauth_cookie.yml
@@ -1,0 +1,121 @@
+---
+- !ruby/object:HTTP::Cookie
+  name: dc
+  value: "-1"
+  domain: itunes.apple.com
+  for_domain: true
+  path: "/"
+  secure: false
+  httponly: false
+  expires:
+  max_age: 3600
+  created_at: &1 2019-04-02 09:10:30.550571000 +11:00
+  accessed_at: *1
+- !ruby/object:HTTP::Cookie
+  name: aa
+  value: aa_value
+  domain: idmsa.apple.com
+  for_domain: true
+  path: "/"
+  secure: true
+  httponly: true
+  expires:
+  max_age:
+  created_at: &2 2019-04-02 09:10:29.241247000 +11:00
+  accessed_at: *2
+- !ruby/object:HTTP::Cookie
+  name: DES123456789012345678901234567890123
+  value: DES_value
+  domain: idmsa.apple.com
+  for_domain: true
+  path: "/"
+  secure: true
+  httponly: true
+  expires:
+  max_age: 2592000
+  created_at: 2019-03-26 12:14:50.450738000 +11:00
+  accessed_at: 2019-04-02 09:10:27.988931000 +11:00
+- !ruby/object:HTTP::Cookie
+  name: dslang
+  value: US-EN
+  domain: apple.com
+  for_domain: true
+  path: "/"
+  secure: true
+  httponly: true
+  expires:
+  max_age:
+  created_at: 2019-04-02 09:10:29.241376000 +11:00
+  accessed_at: &3 2019-04-02 09:10:29.242939000 +11:00
+- !ruby/object:HTTP::Cookie
+  name: site
+  value: USA
+  domain: apple.com
+  for_domain: true
+  path: "/"
+  secure: true
+  httponly: true
+  expires:
+  max_age:
+  created_at: 2019-04-02 09:10:29.241531000 +11:00
+  accessed_at: *3
+- !ruby/object:HTTP::Cookie
+  name: acn01
+  value: acn01_value
+  domain: apple.com
+  for_domain: true
+  path: "/"
+  secure: true
+  httponly: true
+  expires:
+  max_age: 31536000
+  created_at: 2019-04-02 09:10:29.241770000 +11:00
+  accessed_at: *3
+- !ruby/object:HTTP::Cookie
+  name: myacinfo
+  value: myacinfo_value
+  domain: apple.com
+  for_domain: true
+  path: "/"
+  secure: true
+  httponly: true
+  expires:
+  max_age:
+  created_at: 2019-04-02 09:10:29.242011000 +11:00
+  accessed_at: *3
+- !ruby/object:HTTP::Cookie
+  name: itctx
+  value: itctx_value
+  domain: apple.com
+  for_domain: true
+  path: "/"
+  secure: true
+  httponly: true
+  expires:
+  max_age:
+  created_at: &4 2019-04-02 09:10:30.550735000 +11:00
+  accessed_at: *4
+- !ruby/object:HTTP::Cookie
+  name: itcdq
+  value: '0'
+  domain: apple.com
+  for_domain: true
+  path: "/"
+  secure: true
+  httponly: false
+  expires:
+  max_age:
+  created_at: &5 2019-04-02 09:10:30.550837000 +11:00
+  accessed_at: *5
+- !ruby/object:HTTP::Cookie
+  name: dqsid
+  value: dqsid_value
+  domain: olympus.itunes.apple.com
+  for_domain: false
+  path: "/"
+  secure: true
+  httponly: true
+  expires:
+  max_age: 1800
+  created_at: &6 2019-04-02 09:10:30.550448000 +11:00
+  accessed_at: *6


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Improve contents of fastlane session to include long-living cookie for `idmsa.apple.com` domain.

### Description
The "DES*" cookie is the cookie that expires in 30 days and enables longer Fastlane authentication sessions.
It has been filtered out from `FASTLANE_SESSION` variable, however.
The resulting session's longest living cookie only lasts for 30 minutes, which is not ideal for CI setup.
The original code had an intention to keep "DES*" cookie, see this comment:

```ruby
      # The only value we actually need is the "DES5c148586daa451e55afb017aa62418f91" cookie
      # We're not sure if the key changes
      #
      # Example:
      # name: DES5c148586daa451e55afb017aa62418f91
      # value: HSARMTKNSRVTWFlaF/ek8asaa9lymMA0dN8JQ6pY7B3F5kdqTxJvMT19EVEFX8EQudB/uNwBHOHzaa30KYTU/eCP/UF7vGTgxs6PAnlVWKscWssOVHfP2IKWUPaa4Dn+I6ilA7eAFQsiaaVT

```

See #14301 for more details.
Note, this PR does **not** fix #14301, just relates to it.

This PR is WIP, trying to find time to add some tests.
