### PR TITLE
[deliver] upload_screenshots_spec to test screenshot collection

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -88,7 +88,7 @@ module Deliver
       screenshots = []
       extensions = '{png,jpg,jpeg}'
 
-      available_languages = Spaceship::Tunes.client.available_languages.each_with_object({}) do |lang, lang_hash|
+      available_languages = UploadScreenshots.available_languages.each_with_object({}) do |lang, lang_hash|
         lang_hash[lang.downcase] = lang
       end
 
@@ -145,6 +145,15 @@ module Deliver
       end
 
       return screenshots
+    end
+
+    # helper method so Spaceship::Tunes.client.available_languages is easier to test
+    def self.available_languages
+      if Helper.test?
+        FastlaneCore::Languages::ALL_LANGUAGES
+      else
+        Spaceship::Tunes.client.available_languages
+      end
     end
   end
 end

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -1,0 +1,93 @@
+require 'deliver/upload_screenshots'
+require 'fakefs/spec_helpers'
+
+describe Deliver::UploadScreenshots do
+  describe "#collect_screenshots_for_languages (screenshot collection)" do
+    include(FakeFS::SpecHelpers)
+
+    def add_screenshot(file)
+      FileUtils.mkdir_p(File.dirname(file))
+      File.open(file, 'w') { |f| f << 'touch' }
+    end
+
+    def collect_screenshots_from_dir(dir)
+      Deliver::UploadScreenshots.new.collect_screenshots_for_languages(dir, false)
+    end
+
+    before do
+      allow(FastImage).to receive(:size) do |path|
+        path.match(/{([0-9]+)x([0-9]+)}/).captures.map(&:to_i)
+      end
+    end
+
+    it "should not find any screenshots when the directory is empty" do
+      screenshots = collect_screenshots_from_dir("/")
+      expect(screenshots.count).to eq(0)
+    end
+
+    it "should find screenshot when present in the directory" do
+      add_screenshot("/en-GB/iPhone8-01First{750x1334}.jpg")
+      screenshots = collect_screenshots_from_dir("/")
+      expect(screenshots.count).to eq(1)
+      expect(screenshots.first.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_47)
+    end
+
+    it "should not collect iPhone XR screenshots" do
+      add_screenshot("/en-GB/iPhoneXR-01First{828x1792}.jpg")
+      screenshots = collect_screenshots_from_dir("/")
+      expect(screenshots.count).to eq(0)
+    end
+
+    it "should find different languages" do
+      add_screenshot("/en-GB/iPhone8-01First{750x1334}.jpg")
+      add_screenshot("/fr-FR/iPhone8-01First{750x1334}.jpg")
+      screenshots = collect_screenshots_from_dir("/")
+      expect(screenshots.count).to eq(2)
+      expect(screenshots.group_by(&:language).keys).to include("en-GB", "fr-FR")
+    end
+
+    it "should not collect regular screenshots if framed varieties exist" do
+      add_screenshot("/en-GB/iPhone8-01First{750x1334}.jpg")
+      add_screenshot("/en-GB/iPhone8-01First{750x1334}_framed.jpg")
+      screenshots = collect_screenshots_from_dir("/")
+      expect(screenshots.count).to eq(1)
+      expect(screenshots.first.path).to eq("/en-GB/iPhone8-01First{750x1334}_framed.jpg")
+    end
+
+    it "should collect Apple Watch screenshots" do
+      add_screenshot("/en-GB/AppleWatch-01First{368x448}.jpg")
+      screenshots = collect_screenshots_from_dir("/")
+      expect(screenshots.count).to eq(1)
+    end
+
+    it "should continue to collect Apple Watch screenshots even when framed iPhone screenshots exist" do
+      add_screenshot("/en-GB/AppleWatch-01First{368x448}.jpg")
+      add_screenshot("/en-GB/iPhone8-01First{750x1334}.jpg")
+      add_screenshot("/en-GB/iPhone8-01First{750x1334}_framed.jpg")
+      screenshots = collect_screenshots_from_dir("/")
+      expect(screenshots.count).to eq(2)
+      expect(screenshots.group_by(&:device_type).keys).to include("watchSeries4", "iphone6")
+    end
+
+    it "should support special appleTV directory" do
+      add_screenshot("/appleTV/en-GB/01First{3840x2160}.jpg")
+      screenshots = collect_screenshots_from_dir("/")
+      expect(screenshots.count).to eq(1)
+      expect(screenshots.first.device_type).to eq("appleTV")
+    end
+
+    it "should detect iMessage screenshots based on the directory they are contained within" do
+      add_screenshot("/iMessage/en-GB/iPhone8-01First{750x1334}.jpg")
+      screenshots = collect_screenshots_from_dir("/")
+      expect(screenshots.count).to eq(1)
+      expect(screenshots.first.is_messages?).to be_truthy
+    end
+
+    it "should raise an error if unsupported screenshot sizes are in iMessage directory" do
+      add_screenshot("/iMessage/en-GB/AppleTV-01First{3840x2160}.jpg")
+      expect do
+        collect_screenshots_from_dir("/")
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, "Unsupported screen size [3840, 2160] for path '/iMessage/en-GB/AppleTV-01First{3840x2160}.jpg'")
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The iPad Pro 12.9" (3rd Generation) has the same resolution as the 2nd and 1st Generation versions however in App Store Connect, they have different slots (and `device_type` values) for screenshots and this breaks a fundamental assumption that `deliver` has made when uploading screenshots.  

#14116 is tracking the actual issue itself and its pretty certain that `app_screenshot.rb` and `upload_screenshots.rb` will need to be updated to account for this however while I was investigating, I struggled undemanding all of the complicated things that these modules are handling so decided to try and write some tests for the existing behaviour.

### Description

These changes simply introduce an additional spec to test the collection of screenshots by `Deliver::UploadScreenshots`. The following cases are tested: 

- An empty directory (no screenshots)
- The most basic case of a screenshot
- Excluding device_type's unsupported by App Store Connect (the iPhone XR)
- Localisation
- Excluding original screenshots if _framed variants exist
  - But preserving Apple Watch screenshots without frames
- The magic appleTV directory
- iMessage screenshots

Since this module relies heavily on the file system, I copied the approach used in loader_spec.rb and used FakeFS to simulate things. Not sure if it's the best approach but it seems to have worked!