### PR TITLE
[action] create_keychain: do not add keychain to list-keychains if it is already present

### DIFF
--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -52,20 +52,37 @@ module Fastlane
         commands << Fastlane::Actions.sh(command, log: false)
 
         if params[:add_to_search_list]
-          keychains = Action.sh("security list-keychains -d user").shellsplit
-          keychains << File.expand_path(keychain_path)
-          commands << Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)
+          keychains = list_keychains
+          expanded_path = resolved_keychain_path(keychain_path)
+          if keychains.include?(expanded_path)
+            UI.important("Found keychain '#{expanded_path}' in list-keychains, adding to search list skipped")
+          else
+            keychains << expanded_path
+            commands << Fastlane::Actions.sh("security list-keychains -s #{keychains.shelljoin}", log: false)
+          end
         end
 
         commands
       end
 
+      def self.list_keychains
+        Action.sh("security list-keychains -d user").shellsplit
+      end
+
       def self.exists?(keychain_path)
+        !resolved_keychain_path(keychain_path).nil?
+      end
+
+      # returns the expanded and resolved path for the keychain, or nil if not found
+      def self.resolved_keychain_path(keychain_path)
         keychain_path = File.expand_path(keychain_path)
 
         # Creating Keychains using the security
         # CLI appends `-db` to the file name.
-        File.exist?("#{keychain_path}-db") || File.exist?(keychain_path)
+        ["#{keychain_path}-db", keychain_path].each do |path|
+          return path if File.exist?(path)
+        end
+        nil
       end
 
       def self.description


### PR DESCRIPTION
Also improve the tests to return the proper executed commands

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
running create_keychain multiple times in a row adds the keychain multiple times to the user's keychain list.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
Test whether the keychain expanded path is in the list of the list-keychains output.
I had to add code for mocking the functions that run the commands to simulate the system state.
<!-- Please describe in detail how you tested your changes. -->
I ran `bundle exec fastlane run create_keychain name:test password:toto` several times in a row.

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/24282/55879592-4bbb3b00-5b9f-11e9-8c73-b24078d2fd16.png">
