### PR TITLE
[WIP] [spaceship] Methods for TestFlight tester management via Connect API

### DIFF
--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -335,6 +335,35 @@ module Spaceship
         handle_response(response)
       end
 
+      def post_create_beta_tester(attributes: {})
+        # POST
+        # https://api.appstoreconnect.apple.com/v1/betaTesters
+        path = "betaTesters"
+
+        body = {
+          data: {
+            attributes: attributes,
+            type: "betaTesters"
+          }
+        }
+
+        response = request(:post) do |req|
+          req.url(path)
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
+      def delete_beta_tester(tester_id: nil)
+        # DELETE
+        # https://api.appstoreconnect.apple.com/v1/betaTesters/<tester_id>
+        path = "betaTesters/#{tester_id}"
+
+        response = request(:delete, path)
+        handle_response(response)
+      end
+
       protected
 
       def handle_response(response, only_data: true)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

- Adds support for the Connect APIs for managing beta testers (https://developer.apple.com/documentation/appstoreconnectapi/testflight/beta_testers)
- The currently used APIs may not be documented and are at risk of breaking without prior notice (or already have)

### Description
It seems like the Connect API uses different parameters than fastlane users are used to providing. For this reason (and also because I'm new to the fastlane codebase) fastlane users won't immediately notice the changes in this PR until the fastlane modules are updated accordingly, which may be a breaking change.


<!-- Please describe in detail how you tested your changes. -->
