### PR TITLE
[action] allow modify_services to enable data_protection 

### DIFF
--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -10,7 +10,7 @@ module Fastlane
           require 'produce/service'
           services = params[:services]
 
-          enabled_services = services.select { |_k, v| v == true || v.to_s == 'on' }.map { |k, v| [k, 'on'] }.to_h
+          enabled_services = services.select { |_k, v| v == true || v.to_s != 'off' }.map { |k, v| [k, v == true || v.to_s == 'on' ? 'on' : v] }.to_h
           disabled_services = services.reject { |_k, v| v == true || v.to_s == 'on' }.map { |k, v| [k, 'off'] }.to_h
 
           enabled_services_object = self.service_object

--- a/fastlane/spec/actions_specs/modify_services_spec.rb
+++ b/fastlane/spec/actions_specs/modify_services_spec.rb
@@ -8,7 +8,8 @@ describe Fastlane do
         expect(Produce::Service).to receive(:enable) do |options, args|
           expect(options.push_notification).to eq('on')
           expect(options.wallet).to eq('on')
-          expect(options.data_protection).to eq('on')
+          expect(options.hotspot).to eq('on')
+          expect(options.data_protection).to eq('complete')
         end
         expect(Produce::Service).to receive(:disable) do |options, args|
           expect(options.associated_domains).to eq('off')
@@ -24,7 +25,8 @@ describe Fastlane do
                 associated_domains: 'off',
                 wallet: :on,
                 apple_pay: :off,
-                data_protection: true,
+                data_protection: 'complete',
+                hotspot: true,
                 multipath: false
             })
         end").runner.execute(:test)


### PR DESCRIPTION
Fixes enabling of services with string values other than "on". Example:
```
    modify_services(
      app_identifier: MY_APP_ID,
      team_id: MY_TEAM,
      services: {
        data_protection: "complete"
      }
    )
```

Problem was that this lane disabled service instead of enable. This commit disables all services with value "off" or false and enables other ones.

fixes #14570