### PR TITLE
[deliver] iPad Pro (12.9-inch) (3rd generation) ambiguity resolution

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -32,7 +32,7 @@ module Deliver
       # iPad Pro
       IOS_IPAD_PRO = "iOS-iPad-Pro"
       # iPad Pro (12.9-inch) (3rd generation)
-      IOS_IPAD_PRO129_3RD = "iOS-iPad-Pro-12.9-3rd-gen"
+      IOS_IPAD_PRO_12_9 = "iOS-iPad-Pro-12.9-3rd-gen"
 
       # iPhone 5 iMessage
       IOS_40_MESSAGES = "iOS-4-in-messages"
@@ -56,7 +56,7 @@ module Deliver
       # iPad Pro iMessage
       IOS_IPAD_PRO_MESSAGES = "iOS-iPad-Pro-messages"
       # iPad Pro (12.9-inch) (3rd generation) iMessage
-      IOS_IPAD_PRO129_3RD_MESSAGES = "iOS-iPad-Pro-12.9-3rd-gen-messages"
+      IOS_IPAD_PRO_12_9_MESSAGES = "iOS-iPad-Pro-12.9-3rd-gen-messages"
 
       # Apple Watch
       IOS_APPLE_WATCH = "iOS-Apple-Watch"
@@ -105,7 +105,7 @@ module Deliver
         ScreenSize::IOS_IPAD_10_5 => "ipad105",
         ScreenSize::IOS_IPAD_11 => "ipadPro11",
         ScreenSize::IOS_IPAD_PRO => "ipadPro",
-        ScreenSize::IOS_IPAD_PRO129_3RD => "ipadPro129",
+        ScreenSize::IOS_IPAD_PRO_12_9 => "ipadPro129",
         ScreenSize::IOS_40_MESSAGES => "iphone4",
         ScreenSize::IOS_47_MESSAGES => "iphone6", # also 7 & 8
         ScreenSize::IOS_55_MESSAGES => "iphone6Plus", # also 7 Plus & 8 Plus
@@ -113,7 +113,7 @@ module Deliver
         ScreenSize::IOS_65_MESSAGES => "iphone65",
         ScreenSize::IOS_IPAD_MESSAGES => "ipad",
         ScreenSize::IOS_IPAD_PRO_MESSAGES => "ipadPro",
-        ScreenSize::IOS_IPAD_PRO129_3RD_MESSAGES => "ipadPro129",
+        ScreenSize::IOS_IPAD_PRO_12_9_MESSAGES => "ipadPro129",
         ScreenSize::IOS_IPAD_10_5_MESSAGES => "ipad105",
         ScreenSize::IOS_IPAD_11_MESSAGES => "ipadPro11",
         ScreenSize::MAC => "desktop",
@@ -138,7 +138,7 @@ module Deliver
         ScreenSize::IOS_IPAD_10_5 => "iPad 10.5",
         ScreenSize::IOS_IPAD_11 => "iPad 11",
         ScreenSize::IOS_IPAD_PRO => "iPad Pro",
-        ScreenSize::IOS_IPAD_PRO129_3RD => "iPad Pro (12.9-inch) (3rd generation)",
+        ScreenSize::IOS_IPAD_PRO_12_9 => "iPad Pro (12.9-inch) (3rd generation)",
         ScreenSize::IOS_40_MESSAGES => "iPhone 5 (iMessage)",
         ScreenSize::IOS_47_MESSAGES => "iPhone 6 (iMessage)", # also 7 & 8
         ScreenSize::IOS_55_MESSAGES => "iPhone 6 Plus (iMessage)", # also 7 Plus & 8 Plus
@@ -147,7 +147,7 @@ module Deliver
         ScreenSize::IOS_65_MESSAGES => "iPhone XS Max (iMessage)",
         ScreenSize::IOS_IPAD_MESSAGES => "iPad (iMessage)",
         ScreenSize::IOS_IPAD_PRO_MESSAGES => "iPad Pro (iMessage)",
-        ScreenSize::IOS_IPAD_PRO129_3RD_MESSAGES => "iPad Pro (12.9-inch) (3rd generation) (iMessage)",
+        ScreenSize::IOS_IPAD_PRO_12_9_MESSAGES => "iPad Pro (12.9-inch) (3rd generation) (iMessage)",
         ScreenSize::IOS_IPAD_10_5_MESSAGES => "iPad 10.5 (iMessage)",
         ScreenSize::IOS_IPAD_11_MESSAGES => "iPad 11 (iMessage)",
         ScreenSize::MAC => "Mac",
@@ -174,7 +174,7 @@ module Deliver
         ScreenSize::IOS_65_MESSAGES,
         ScreenSize::IOS_IPAD_MESSAGES,
         ScreenSize::IOS_IPAD_PRO_MESSAGES,
-        ScreenSize::IOS_IPAD_PRO129_3RD_MESSAGES,
+        ScreenSize::IOS_IPAD_PRO_12_9_MESSAGES,
         ScreenSize::IOS_IPAD_10_5_MESSAGES,
         ScreenSize::IOS_IPAD_11_MESSAGES
       ].include?(self.screen_size)
@@ -306,9 +306,9 @@ module Deliver
       is_3rd_gen = filename.include?("(3rd generation)")
       if is_3rd_gen
         if device_type == ScreenSize::IOS_IPAD_PRO
-          return ScreenSize::IOS_IPAD_PRO129_3RD
+          return ScreenSize::IOS_IPAD_PRO_12_9
         elsif device_type == ScreenSize::IOS_IPAD_PRO_MESSAGES
-          return ScreenSize::IOS_IPAD_PRO129_3RD_MESSAGES
+          return ScreenSize::IOS_IPAD_PRO_12_9_MESSAGES
         end
       end
       device_type

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -302,8 +302,8 @@ module Deliver
       }
     end
 
-    def self.resolve_ipadpro_conflict_if_needed(device_type, file_name)
-      is_3rd_gen = file_name.include?("(3rd generation)")
+    def self.resolve_ipadpro_conflict_if_needed(device_type, filename)
+      is_3rd_gen = filename.include?("(3rd generation)")
       if is_3rd_gen
         if device_type == ScreenSize::IOS_IPAD_PRO
           return ScreenSize::IOS_IPAD_PRO129_3RD
@@ -311,7 +311,7 @@ module Deliver
           return ScreenSize::IOS_IPAD_PRO129_3RD_MESSAGES
         end
       end
-      return device_type
+      device_type
     end
 
     def self.calculate_screen_size(path)
@@ -322,7 +322,7 @@ module Deliver
       # Walk up two directories and test if we need to handle a platform that doesn't support landscape
       path_filenames = Pathname.new(path).each_filename.to_a
       path_component = path_filenames[-3]
-      file_name = path_filenames.to_a[-1]
+      filename = path_filenames.to_a[-1]
       if path_component.eql?("appleTV")
         skip_landscape = true
       end
@@ -334,12 +334,12 @@ module Deliver
         array.each do |resolution|
           if skip_landscape
             if size[0] == (resolution[0]) && size[1] == (resolution[1]) # portrait
-              return resolve_ipadpro_conflict_if_needed(device_type, file_name)
+              return resolve_ipadpro_conflict_if_needed(device_type, filename)
             end
           else
             if (size[0] == (resolution[0]) && size[1] == (resolution[1])) || # portrait
                (size[1] == (resolution[0]) && size[0] == (resolution[1])) # landscape
-              return resolve_ipadpro_conflict_if_needed(device_type, file_name)
+              return resolve_ipadpro_conflict_if_needed(device_type, filename)
             end
           end
         end

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -303,7 +303,7 @@ module Deliver
     end
 
     def self.resolve_ipadpro_conflict_if_needed(device_type, file_name)
-      is_3rd_gen = file_name.include? "(3rd generation)"
+      is_3rd_gen = file_name.include?("(3rd generation)")
       if is_3rd_gen
         if device_type == ScreenSize::IOS_IPAD_PRO
           return ScreenSize::IOS_IPAD_PRO129_3RD

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -314,7 +314,10 @@ module Deliver
     end
 
     def self.resolve_ipadpro_conflict_if_needed(screen_size, filename)
-      is_3rd_gen = filename.include?("(3rd generation)")
+      is_3rd_gen = [
+        "(3rd generation)", # default simulator name has this
+        "ipadPro129" # downloaded screenshots name has this
+      ].any? { |key| filename.include?(key) }
       if is_3rd_gen
         if screen_size == ScreenSize::IOS_IPAD_PRO
           return ScreenSize::IOS_IPAD_PRO_12_9
@@ -331,14 +334,13 @@ module Deliver
       UI.user_error!("Could not find or parse file at path '#{path}'") if size.nil? || size.count == 0
 
       # iMessage screenshots have same resolution as app screenshots so we need to distinguish them
-      path_filenames = Pathname.new(path).each_filename.to_a
-      path_component = path_filenames[-3]
-      filename = path_filenames.to_a[-1]
+      path_component = Pathname.new(path).each_filename.to_a[-3]
       devices = path_component.eql?("iMessage") ? self.device_messages : self.devices
 
       devices.each do |screen_size, resolutions|
         if resolutions.include?(size)
-          return resolve_ipadpro_conflict_if_needed(screen_size, filename) 
+          filename = Pathname.new(path).basename.to_s
+          return resolve_ipadpro_conflict_if_needed(screen_size, filename)
         end
       end
 

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -22,9 +22,16 @@ describe Deliver::AppScreenshot do
       end
     end
 
-    context "when filename contains '(3rd generation)" do
+    context "when filename contains '(3rd generation)'" do
       it "returns iPad Pro(12.9-inch) 3rd generation" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (3rd generation){2732x2048}.png", "de-DE")
+        expect(screenshot.screen_size).to eq(ScreenSize::IOS_IPAD_PRO_12_9)
+      end
+    end
+
+    context "when filename contains 'ipadPro129'" do
+      it "returns iPad Pro(12.9-inch) 3rd generation" do
+        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/ipadPro129-AAABBBCCCDDD{2732x2048}.png", "de-DE")
         expect(screenshot.screen_size).to eq(ScreenSize::IOS_IPAD_PRO_12_9)
       end
     end

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -17,7 +17,7 @@ describe Deliver::AppScreenshot do
     context "when filename contains '(3rd generation)" do
       it "returns iPad Pro(12.9-inch) 3rd generation" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (3rd generation).png", "de-DE")
-        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO129_3RD)
+        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_12_9)
       end
     end
   end

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -1,0 +1,20 @@
+require 'deliver/app_screenshot'
+require 'deliver/setup'
+
+describe Deliver::AppScreenshot do
+  before do
+    allow(FastImage).to receive(:size).and_return([2732, 2048])
+  end
+
+  describe "should resolve iPad Pro (12.9-inch) ambiguity if" do
+    it "has path not including distinction" do
+      screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch).png", "de-DE")
+      expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
+    end
+
+    it "has path including distinction" do
+      screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (3rd generation).png", "de-DE")
+      expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO129_3RD)
+    end
+  end
+end

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -6,15 +6,19 @@ describe Deliver::AppScreenshot do
     allow(FastImage).to receive(:size).and_return([2732, 2048])
   end
 
-  describe "should resolve iPad Pro (12.9-inch) ambiguity if" do
-    it "has path not including distinction" do
-      screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch).png", "de-DE")
-      expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
+  describe "#initialize" do
+    context "when filename doesn't contain '(3rd generation)'" do
+      it "returns iPad Pro(12.9-inch)" do
+        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch).png", "de-DE")
+        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
+      end
     end
 
-    it "has path including distinction" do
-      screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (3rd generation).png", "de-DE")
-      expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO129_3RD)
+    context "when filename contains '(3rd generation)" do
+      it "returns iPad Pro(12.9-inch) 3rd generation" do
+        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (3rd generation).png", "de-DE")
+        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO129_3RD)
+      end
     end
   end
 end

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -704,7 +704,11 @@ You can do the same with folders
 
 In this case, default values for keywords, urls, name and release notes are used in all localizations, but each language has a fully localized description
 
+## iPad Pro 12.9-inch 2nd and 3rd generation ambiguity resolution
 
+From March 20, 2019 Apple App Store [requires](https://developer.apple.com/news/?id=03202019a) 2nd and 3rd generation iPad [screenshots](https://help.apple.com/app-store-connect/#/devd274dd925).
+
+Ambiguity arise as Fastlane checks for screenshot size to identify the device. To solve this issue 3rd generation screenshots must contain `(3rd generation)` part in the name of screenshot.
 
 ## Automatically create screenshots
 

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -704,11 +704,11 @@ You can do the same with folders
 
 In this case, default values for keywords, urls, name and release notes are used in all localizations, but each language has a fully localized description
 
-## iPad Pro 12.9-inch 2nd and 3rd generation ambiguity resolution
+## Uploading screenshots for "iPad Pro (12.9-inch) (3rd generation)"
 
-From March 20, 2019 Apple App Store [requires](https://developer.apple.com/news/?id=03202019a) 2nd and 3rd generation iPad [screenshots](https://help.apple.com/app-store-connect/#/devd274dd925).
+[Starting March 20, 2019 Apple's App Store](https://developer.apple.com/news/?id=03202019a) requires 12.9-inch iPad Pro (3rd generation) screenshots additionally to the iPad Pro 2nd generation [screenshots](https://help.apple.com/app-store-connect/#/devd274dd925). As fastlane historically uses the screenshot dimensions to determine the "display family" of a screenshot, this poses a problem as both use the same dimensions and are recognized as the same device family.
 
-Ambiguity arise as Fastlane checks for screenshot size to identify the device. To solve this issue 3rd generation screenshots must contain `(3rd generation)` part in the name of screenshot.
+To solve this a screenshot of a 12.9-inch iPad Pro (3rd generation) must contain either the string `(3rd generation)` or `ipadPro129` (Apple's internal naming of the display family for the 3rd generation iPad Pro) in its filename to be assigned the correct display family and to be uploaded to the correct screenshot slot in your app's metadata.
 
 ## Automatically create screenshots
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
As iTC now requires iPad Pro 12.9" 3rd generation screenshots (https://help.apple.com/app-store-connect/#/devd274dd925) deliver's inability to upload them has become quite a blocker.
It solves #14474 & #14116.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
Approach is quite simple: if screenshot size matches iPad Pro's then ambiguity is resolved taking into account screenshot name: 3rd gen screenshots has to have `(3rd generation)` part in the name (naming is taken from default simulator names).
Changes have been tested in production, successfully uploaded them! 🚀 Furthermore, HTML preview is generated correctly out-of-the-box. Hopefully solution approach is good enough 🙏 

If changes are approved please describe where ambiguity resolution should be documented 🙇 
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
