### PR TITLE
[action] pod_lib_lint: Add new cocoapods 1.7 parameters of the lint command

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -19,6 +19,14 @@ module Fastlane
           command << "--sources='#{sources}'"
         end
 
+        if params[:include_podspecs]
+          command << "--include-podspecs='#{params[:include_podspecs]}'"
+        end
+
+        if params[:external_podspecs]
+          command << "--external-podspecs='#{params[:external_podspecs]}'"
+        end
+
         if params[:swift_version]
           swift_version = params[:swift_version]
           command << "--swift-version=#{swift_version}"
@@ -76,6 +84,15 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :include_podspecs,
+                                       description: "A Glob of additional ancillary podspecs which are used for linting via :path",
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :external_podspecs,
+                                       description: "A Glob of additional ancillary podspecs which are used for linting via :podspec. If there"\
+                                         " are --include-podspecs, then these are removed from them",
+                                       optional: true,
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :swift_version,
                                        description: "The SWIFT_VERSION that should be used to lint the spec. This takes precedence over a .swift-version file",
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -85,12 +85,12 @@ module Fastlane
                                          UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
                                        end),
           FastlaneCore::ConfigItem.new(key: :include_podspecs,
-                                       description: "A Glob of additional ancillary podspecs which are used for linting via :path",
+                                       description: "A Glob of additional ancillary podspecs which are used for linting via :path (available since cocoapods >= 1.7)",
                                        optional: true,
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :external_podspecs,
                                        description: "A Glob of additional ancillary podspecs which are used for linting via :podspec. If there"\
-                                         " are --include-podspecs, then these are removed from them",
+                                         " are --include-podspecs, then these are removed from them (available since cocoapods >= 1.7)",
                                        optional: true,
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :swift_version,

--- a/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
+++ b/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
@@ -76,6 +76,22 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec pod lib lint fastlane")
       end
+
+      it "generates the correct pod lib lint command with include_podspecs parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(include_podspecs: '**/*.podspec')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --include-podspecs='**/*.podspec'")
+      end
+
+      it "generates the correct pod lib lint command with external_podspecs parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(external_podspecs: '**/*.podspec')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --external-podspecs='**/*.podspec'")
+      end
     end
   end
 end


### PR DESCRIPTION
Source [PR 8536](https://github.com/CocoaPods/CocoaPods/pull/8536)

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Cocoapods 1.7 introduces new command line arguments for the `pod lib lint` action named `--include-podspecs` and `--external-podspecs` (https://github.com/CocoaPods/CocoaPods/pull/8536).

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->


### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

This PR extends the `pod_lib_lint` action to reflect the new parameters of `pod lib lint`. As CocoaPods 1.7 has not been release yet, I'm not sure if this PR should wait for the release.

The change does not validate the used cocoapods version in any way. Is there any need to do so? If, how could I achieve that?
