### PR TITLE
[action] artifactory: Add a read timeout option

### DIFF
--- a/fastlane/lib/fastlane/actions/artifactory.rb
+++ b/fastlane/lib/fastlane/actions/artifactory.rb
@@ -148,7 +148,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :read_timeout,
                                        env_name: "FL_ARTIFACTORY_READ_TIMEOUT",
                                        description: "Read timeout",
-                                       default_value: 120,
+                                       default_value: nil,
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/actions/artifactory.rb
+++ b/fastlane/lib/fastlane/actions/artifactory.rb
@@ -37,7 +37,7 @@ module Fastlane
       end
 
       def self.connect_to_artifactory(params)
-        config_keys = [:endpoint, :username, :password, :ssl_pem_file, :ssl_verify, :proxy_username, :proxy_password, :proxy_address, :proxy_port]
+        config_keys = [:endpoint, :username, :password, :ssl_pem_file, :ssl_verify, :proxy_username, :proxy_password, :proxy_address, :proxy_port, :read_timeout]
         config = params.values.select do |key|
           config_keys.include?(key)
         end
@@ -144,6 +144,11 @@ module Fastlane
                                        env_name: "FL_ARTIFACTORY_PROXY_PORT",
                                        description: "Proxy port",
                                        default_value: nil,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :read_timeout,
+                                       env_name: "FL_ARTIFACTORY_READ_TIMEOUT",
+                                       description: "Read timeout",
+                                       default_value: 120,
                                        optional: true)
         ]
       end


### PR DESCRIPTION
The Artifactory gem supports a configurable option for the read timeout.  The Fastlane action can be extended to pass the argument through to the client.

The [default](https://github.com/chef/artifactory-client/blob/master/lib/artifactory/defaults.rb#L149) read timeout for the client is 120 so I see no reason to set a different default.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Allow configuration of a timeout in case there is a slow connection or other blocker.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
This change just adds a new option to set the read timeout for the Artifactory client.  This is already a configurable in the underlying gem and will just be passed when initializing the client.
<!-- Please describe in detail how you tested your changes. -->
