### PR TITLE
[match] Broken link to register_devices in docs

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -310,7 +310,7 @@ gym
 
 ##### Registering new devices
 
-By using _match_, you'll save a lot of time every time you add new device to your Ad Hoc or Development profiles. Use _match_ in combination with the [`register_devices`](https://docs.fastlane.tools/actions#register_devices) action.
+By using _match_, you'll save a lot of time every time you add new device to your Ad Hoc or Development profiles. Use _match_ in combination with the [`register_devices`](https://docs.fastlane.tools/actions/register_devices/) action.
 
 ```ruby
 lane :beta do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The documentation for `match` links to `/action#register_devices` instead of `/action/register_devices/`

This [issue](https://github.com/fastlane/docs/issues/810) somewhat captures it but mentions pages that does not seem to contain the link.

### Description
Simply changed the link to `register_devices` from `/action#register_devices` to `/action/register_devices/`.
