### PR TITLE
[deliver] Test Deliver::AppScreenshot methods and fix uncovered bugs

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -178,24 +178,30 @@ module Deliver
     def self.device_messages
       return {
         ScreenSize::IOS_65_MESSAGES => [
-          [1242, 2688]
+          [1242, 2688],
+          [2688, 1242]
         ],
         ScreenSize::IOS_61_MESSAGES => [
-          [828, 1792]
+          [828, 1792],
+          [1792, 828]
         ],
         ScreenSize::IOS_58_MESSAGES => [
-          [1125, 2436]
+          [1125, 2436],
+          [2436, 1125]
         ],
         ScreenSize::IOS_55_MESSAGES => [
-          [1242, 2208]
+          [1242, 2208],
+          [2208, 1242]
         ],
         ScreenSize::IOS_47_MESSAGES => [
-          [750, 1334]
+          [750, 1334],
+          [1334, 750]
         ],
         ScreenSize::IOS_40_MESSAGES => [
-          [640, 1136],
           [640, 1096],
-          [1136, 600] # landscape status bar is smaller
+          [640, 1136],
+          [1136, 600],
+          [1136, 640]
         ],
         ScreenSize::IOS_IPAD_MESSAGES => [
           [1024, 748],
@@ -226,29 +232,36 @@ module Deliver
     def self.devices
       return {
         ScreenSize::IOS_65 => [
-          [1242, 2688]
+          [1242, 2688],
+          [2688, 1242]
         ],
         ScreenSize::IOS_61 => [
-          [828, 1792]
+          [828, 1792],
+          [1792, 828]
         ],
         ScreenSize::IOS_58 => [
-          [1125, 2436]
+          [1125, 2436],
+          [2436, 1125]
         ],
         ScreenSize::IOS_55 => [
-          [1242, 2208]
+          [1242, 2208],
+          [2208, 1242]
         ],
         ScreenSize::IOS_47 => [
-          [750, 1334]
+          [750, 1334],
+          [1334, 750]
         ],
         ScreenSize::IOS_40 => [
-          [640, 1136],
           [640, 1096],
-          [1136, 600] # landscape without status bar
+          [640, 1136],
+          [1136, 600],
+          [1136, 640]
         ],
         ScreenSize::IOS_35 => [
-          [640, 960],
           [640, 920],
-          [960, 600] # landscape without status bar
+          [640, 960],
+          [960, 600],
+          [960, 640]
         ],
         ScreenSize::IOS_IPAD => [ # 9.7 inch
           [1024, 748],
@@ -296,26 +309,14 @@ module Deliver
 
       UI.user_error!("Could not find or parse file at path '#{path}'") if size.nil? || size.count == 0
 
-      # Walk up two directories and test if we need to handle a platform that doesn't support landscape
-      path_component = Pathname.new(path).each_filename.to_a[-3]
-      if path_component.eql?("appleTV")
-        skip_landscape = true
-      end
-
       # iMessage screenshots have same resolution as app screenshots so we need to distinguish them
+      path_component = Pathname.new(path).each_filename.to_a[-3]
       devices = path_component.eql?("iMessage") ? self.device_messages : self.devices
 
       devices.each do |device_type, array|
         array.each do |resolution|
-          if skip_landscape
-            if size[0] == (resolution[0]) && size[1] == (resolution[1]) # portrait
-              return device_type
-            end
-          else
-            if (size[0] == (resolution[0]) && size[1] == (resolution[1])) || # portrait
-               (size[1] == (resolution[0]) && size[0] == (resolution[1])) # landscape
-              return device_type
-            end
+          if size[0] == (resolution[0]) && size[1] == (resolution[1])
+            return device_type
           end
         end
       end

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -313,12 +313,8 @@ module Deliver
       path_component = Pathname.new(path).each_filename.to_a[-3]
       devices = path_component.eql?("iMessage") ? self.device_messages : self.devices
 
-      devices.each do |device_type, array|
-        array.each do |resolution|
-          if size[0] == (resolution[0]) && size[1] == (resolution[1])
-            return device_type
-          end
-        end
+      devices.each do |screen_size, resolutions|
+        return screen_size if resolutions.include?(size)
       end
 
       UI.user_error!("Unsupported screen size #{size} for path '#{path}'")

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -212,7 +212,7 @@ module Deliver
           [1668, 2224],
           [2224, 1668]
         ],
-        ScreenSize::IOS_IPAD_11 => [
+        ScreenSize::IOS_IPAD_11_MESSAGES => [
           [1668, 2388],
           [2388, 1668]
         ],

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -187,7 +187,6 @@ module Deliver
           [1125, 2436]
         ],
         ScreenSize::IOS_55_MESSAGES => [
-          [1080, 1920],
           [1242, 2208]
         ],
         ScreenSize::IOS_47_MESSAGES => [
@@ -236,7 +235,6 @@ module Deliver
           [1125, 2436]
         ],
         ScreenSize::IOS_55 => [
-          [1080, 1920],
           [1242, 2208]
         ],
         ScreenSize::IOS_47 => [

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -230,4 +230,74 @@ describe Deliver::AppScreenshot do
       end
     end
   end
+
+  describe "#device_type" do
+    before do
+      allow_any_instance_of(Deliver::AppScreenshot).to receive(:is_valid?).and_return(true)
+    end
+
+    it "should return iphone35 for 3.5 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_35).device_type).to eq("iphone35")
+    end
+
+    it "should return iphone4 for 4 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_40).device_type).to eq("iphone4")
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_40_MESSAGES).device_type).to eq("iphone4")
+    end
+
+    it "should return iphone6 for 4.7 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_47).device_type).to eq("iphone6")
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_47_MESSAGES).device_type).to eq("iphone6")
+    end
+
+    it "should return iphone6Plus for 5.5 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_55).device_type).to eq("iphone6Plus")
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_55_MESSAGES).device_type).to eq("iphone6Plus")
+    end
+
+    it "should return nil for 6.1 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_61).device_type).to be_nil
+    end
+
+    it "should return iphone65 for 6.5 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_65).device_type).to eq("iphone65")
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_65_MESSAGES).device_type).to eq("iphone65")
+    end
+
+    it "should return ipad for 9.7 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD).device_type).to eq("ipad")
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_MESSAGES).device_type).to eq("ipad")
+    end
+
+    it "should return ipad105 for 10.5 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_10_5).device_type).to eq("ipad105")
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_10_5_MESSAGES).device_type).to eq("ipad105")
+    end
+
+    it "should return ipadPro11 for 11 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_11).device_type).to eq("ipadPro11")
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_11_MESSAGES).device_type).to eq("ipadPro11")
+    end
+
+    it "should return ipadPro for 12.9 inch displays" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_PRO).device_type).to eq("ipadPro")
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_PRO_MESSAGES).device_type).to eq("ipadPro")
+    end
+
+    it "should return watch for original Apple Watch" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_APPLE_WATCH).device_type).to eq("watch")
+    end
+
+    it "should return watchSeries4 for Apple Watch Series 4" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_APPLE_WATCH_SERIES4).device_type).to eq("watchSeries4")
+    end
+
+    it "should return appleTV for Apple TV" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::APPLE_TV).device_type).to eq("appleTV")
+    end
+
+    it "should return desktop for Mac" do
+      expect(Deliver::AppScreenshot.new("", "", ScreenSize::MAC).device_type).to eq("desktop")
+    end
+  end
 end

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -1,0 +1,231 @@
+require 'deliver/app_screenshot'
+
+# Ensure that screenshots correctly map to the following:
+# https://help.apple.com/app-store-connect/#/devd274dd925
+describe Deliver::AppScreenshot do
+  def screen_size_from(path)
+    path.match(/{([0-9]+)x([0-9]+)}/).captures.map(&:to_i)
+  end
+
+  before do
+    allow(FastImage).to receive(:size) do |path|
+      screen_size_from(path)
+    end
+  end
+
+  describe "#calculate_screen_size" do
+    def expect_screen_size_from_file(file)
+      expect(Deliver::AppScreenshot.calculate_screen_size(file))
+    end
+
+    describe "valid screen sizes" do
+      it "should calculate all 6.5 inch iPhone resolutions" do
+        expect_screen_size_from_file("iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65)
+        expect_screen_size_from_file("iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65)
+      end
+
+      it "should calculate all 5.8 inch iPhone resolutions" do
+        expect_screen_size_from_file("iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58)
+        expect_screen_size_from_file("iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58)
+      end
+
+      it "should calculate all 5.5 inch iPhone resolutions" do
+        expect_screen_size_from_file("iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55)
+        expect_screen_size_from_file("iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55)
+      end
+
+      it "should calculate all 4.7 inch iPhone resolutions" do
+        expect_screen_size_from_file("iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47)
+        expect_screen_size_from_file("iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47)
+      end
+
+      it "should calculate all 4 inch iPhone resolutions" do
+        expect_screen_size_from_file("iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
+        expect_screen_size_from_file("iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
+        expect_screen_size_from_file("iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
+        expect_screen_size_from_file("iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
+      end
+
+      it "should calculate all 3.5 inch iPhone resolutions" do
+        expect_screen_size_from_file("iPhone4S-Portrait{640x960}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
+        expect_screen_size_from_file("iPhone4S-Landscape{960x640}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
+        expect_screen_size_from_file("iPhone4S-Portrait-NoStatusBar{640x920}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
+        expect_screen_size_from_file("iPhone4S-Landscape-NoStatusBar{960x600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
+      end
+
+      it "should calculate all 12.9 inch iPad resolutions" do
+        expect_screen_size_from_file("iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
+        expect_screen_size_from_file("iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
+      end
+
+      it "should calculate all 11 inch iPad resolutions" do
+        expect_screen_size_from_file("iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11)
+        expect_screen_size_from_file("iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11)
+      end
+
+      it "should calculate all 10.5 inch iPad resolutions" do
+        expect_screen_size_from_file("iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5)
+        expect_screen_size_from_file("iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5)
+      end
+
+      it "should calculate all 9.7 inch iPad resolutions" do
+        expect_screen_size_from_file("iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+      end
+
+      it "should calculate all supported Mac resolutions" do
+        expect_screen_size_from_file("Mac{1280x800}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
+        expect_screen_size_from_file("Mac{1440x900}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
+        expect_screen_size_from_file("Mac{2560x1600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
+        expect_screen_size_from_file("Mac{2880x1800}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
+      end
+
+      it "should calculate all supported Apple TV resolutions" do
+        expect_screen_size_from_file("AppleTV{1920x1080}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::APPLE_TV)
+        expect_screen_size_from_file("AppleTV-4K{3840x2160}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::APPLE_TV)
+      end
+
+      it "should calculate all supported Apple Watch resolutions" do
+        expect_screen_size_from_file("AppleWatch-Series3{312x390}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH)
+        expect_screen_size_from_file("AppleWatch-Series4{368x448}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES4)
+      end
+    end
+
+    describe "valid iMessage app screen sizes" do
+      it "should calculate all 6.5 inch iPhone resolutions" do
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65_MESSAGES)
+      end
+
+      it "should calculate all 5.8 inch iPhone resolutions" do
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58_MESSAGES)
+      end
+
+      it "should calculate all 5.5 inch iPhone resolutions" do
+        expect_screen_size_from_file("iMessage/en-GB/iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55_MESSAGES)
+      end
+
+      it "should calculate all 4.7 inch iPhone resolutions" do
+        expect_screen_size_from_file("iMessage/en-GB/iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47_MESSAGES)
+      end
+
+      it "should calculate all 4 inch iPhone resolutions" do
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
+      end
+
+      it "should calculate all 12.9 inch iPad resolutions" do
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_MESSAGES)
+      end
+
+      it "should calculate all 11 inch iPad resolutions" do
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11_MESSAGES)
+      end
+
+      it "should calculate all 10.5 inch iPad resolutions" do
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5_MESSAGES)
+      end
+
+      it "should calculate all 9.7 inch iPad resolutions" do
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+      end
+    end
+
+    describe "invalid screen sizes" do
+      def expect_invalid_screen_size_from_file(file)
+        expect do
+          Deliver::AppScreenshot.calculate_screen_size(file)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, "Unsupported screen size #{screen_size_from(file)} for path '#{file}'")
+      end
+
+      it "shouldn't allow native resolution 5.5 inch iPhone screenshots" do
+        expect_invalid_screen_size_from_file("iPhone8Plus-NativeResolution{1080x1920}.jpg")
+        expect_invalid_screen_size_from_file("iMessage/en-GB/iPhone8Plus-NativeResolution{1080x1920}.jpg")
+      end
+
+      it "shouldn't calculate portrait Apple TV resolutions" do
+        expect_invalid_screen_size_from_file("appleTV/en-GB/AppleTV-Portrait{1080x1920}.jpg")
+        expect_invalid_screen_size_from_file("appleTV/en-GB/AppleTV-Portrait{2160x3840}.jpg")
+      end
+
+      it "shouldn't calculate modern devices excluding status bars" do
+        expect_invalid_screen_size_from_file("iPhoneXSMax-Portrait-NoStatusBar{1242x2556}.jpg")
+        expect_invalid_screen_size_from_file("iPhoneXS-Portrait-NoStatusBar{1125x2304}.jpg")
+        expect_invalid_screen_size_from_file("iPhone8Plus-Portrait-NoStatusBar{1242x2148}.jpg")
+        expect_invalid_screen_size_from_file("iPhone8-Portrait-NoStatusBar{750x1294}.jpg")
+        expect_invalid_screen_size_from_file("iPad-Portrait-12_9Inch-NoStatusBar{2048x2692}.jpg")
+        expect_invalid_screen_size_from_file("iPad-Portrait-11Inch{1668x2348}.jpg")
+        expect_invalid_screen_size_from_file("iPad-Portrait-10_5Inch{1668x2184}.jpg")
+      end
+
+      it "shouldn't allow non 16:10 resolutions for Mac" do
+        expect_invalid_screen_size_from_file("Mac-Portrait{800x1280}.jpg")
+        expect_invalid_screen_size_from_file("Mac-Portrait{900x1440}.jpg")
+        expect_invalid_screen_size_from_file("Mac-Portrait{1600x2560}.jpg")
+        expect_invalid_screen_size_from_file("Mac-Portrait{1800x2880}.jpg")
+      end
+    end
+  end
+
+  describe "#is_messages?" do
+    it "should return true when contained in the iMessage directory" do
+      files = [
+        "screenshots/iMessage/en-GB/iPhoneXSMax-Potrait{1242x2688}.png",
+        "screenshots/iMessage/en-GB/iPhoneXS-Potrait{1125x2436}.png",
+        "screenshots/iMessage/en-GB/iPhone8Plus-Landscape{2208x1242}.png",
+        "screenshots/iMessage/en-GB/iPhone8-Landscape{1334x750}.png",
+        "screenshots/iMessage/en-GB/iPhoneSE-Portrait-NoStatusBar{640x1096}.png",
+        "screenshots/iMessage/en-GB/iPad-Portrait-12_9Inch{2048x2732}.png",
+        "screenshots/iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.png",
+        "screenshots/iMessage/en-GB/iPad-Landscape-10_5Inch{2224x1668}.png",
+        "screenshots/iMessage/en-GB/iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.png"
+      ]
+      files.each do |file|
+        screenshot = Deliver::AppScreenshot.new(file, 'en-GB')
+        expect({ file: file, result: screenshot.is_messages? }).to eq({ file: file, result: true })
+      end
+    end
+
+    it "should return false when not contained in the iMessage directory" do
+      files = [
+        "screenshots/en-GB/iPhoneXSMax-Potrait{1242x2688}.png",
+        "screenshots/en-GB/iPhoneXS-Potrait{1125x2436}.png",
+        "screenshots/en-GB/iPhone8Plus-Landscape{2208x1242}.png",
+        "screenshots/en-GB/iPhone8-Landscape{1334x750}.png",
+        "screenshots/en-GB/iPhoneSE-Portrait-NoStatusBar{640x1096}.png",
+        "screenshots/en-GB/iPad-Portrait-12_9Inch{2048x2732}.png",
+        "screenshots/en-GB/iPad-Portrait-11Inch{1668x2388}.png",
+        "screenshots/en-GB/iPad-Landscape-10_5Inch{2224x1668}.png",
+        "screenshots/en-GB/iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.png",
+        "screenshots/en-GB/Mac{1440x900}.png",
+        "screenshots/en-GB/AppleWatch-Series4{368x448}.png",
+        "screenshots/appleTV/en-GB/AppleTV-4K{3840x2160}.png"
+      ]
+      files.each do |file|
+        screenshot = Deliver::AppScreenshot.new(file, 'en-GB')
+        expect({ file: file, result: screenshot.is_messages? }).to eq({ file: file, result: false })
+      end
+    end
+  end
+end

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -13,6 +13,8 @@ describe Deliver::AppScreenshot do
     end
   end
 
+  ScreenSize = Deliver::AppScreenshot::ScreenSize
+
   describe "#calculate_screen_size" do
     def expect_screen_size_from_file(file)
       expect(Deliver::AppScreenshot.calculate_screen_size(file))
@@ -20,135 +22,135 @@ describe Deliver::AppScreenshot do
 
     describe "valid screen sizes" do
       it "should calculate all 6.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65)
-        expect_screen_size_from_file("iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65)
+        expect_screen_size_from_file("iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(ScreenSize::IOS_65)
+        expect_screen_size_from_file("iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(ScreenSize::IOS_65)
       end
 
       it "should calculate all 5.8 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58)
-        expect_screen_size_from_file("iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58)
+        expect_screen_size_from_file("iPhoneXS-Portrait{1125x2436}.jpg").to eq(ScreenSize::IOS_58)
+        expect_screen_size_from_file("iPhoneXS-Landscape{2436x1125}.jpg").to eq(ScreenSize::IOS_58)
       end
 
       it "should calculate all 5.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55)
-        expect_screen_size_from_file("iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55)
+        expect_screen_size_from_file("iPhone8Plus-Portrait{1242x2208}.jpg").to eq(ScreenSize::IOS_55)
+        expect_screen_size_from_file("iPhone8Plus-Landscape{2208x1242}.jpg").to eq(ScreenSize::IOS_55)
       end
 
       it "should calculate all 4.7 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47)
-        expect_screen_size_from_file("iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47)
+        expect_screen_size_from_file("iPhone8-Portrait{750x1334}.jpg").to eq(ScreenSize::IOS_47)
+        expect_screen_size_from_file("iPhone8-Landscape{1334x750}.jpg").to eq(ScreenSize::IOS_47)
       end
 
       it "should calculate all 4 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
-        expect_screen_size_from_file("iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
-        expect_screen_size_from_file("iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
-        expect_screen_size_from_file("iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
+        expect_screen_size_from_file("iPhoneSE-Portrait{640x1136}.jpg").to eq(ScreenSize::IOS_40)
+        expect_screen_size_from_file("iPhoneSE-Landscape{1136x640}.jpg").to eq(ScreenSize::IOS_40)
+        expect_screen_size_from_file("iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(ScreenSize::IOS_40)
+        expect_screen_size_from_file("iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(ScreenSize::IOS_40)
       end
 
       it "should calculate all 3.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhone4S-Portrait{640x960}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
-        expect_screen_size_from_file("iPhone4S-Landscape{960x640}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
-        expect_screen_size_from_file("iPhone4S-Portrait-NoStatusBar{640x920}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
-        expect_screen_size_from_file("iPhone4S-Landscape-NoStatusBar{960x600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
+        expect_screen_size_from_file("iPhone4S-Portrait{640x960}.jpg").to eq(ScreenSize::IOS_35)
+        expect_screen_size_from_file("iPhone4S-Landscape{960x640}.jpg").to eq(ScreenSize::IOS_35)
+        expect_screen_size_from_file("iPhone4S-Portrait-NoStatusBar{640x920}.jpg").to eq(ScreenSize::IOS_35)
+        expect_screen_size_from_file("iPhone4S-Landscape-NoStatusBar{960x600}.jpg").to eq(ScreenSize::IOS_35)
       end
 
       it "should calculate all 12.9 inch iPad resolutions" do
-        expect_screen_size_from_file("iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
-        expect_screen_size_from_file("iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
+        expect_screen_size_from_file("iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(ScreenSize::IOS_IPAD_PRO)
+        expect_screen_size_from_file("iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(ScreenSize::IOS_IPAD_PRO)
       end
 
       it "should calculate all 11 inch iPad resolutions" do
-        expect_screen_size_from_file("iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11)
-        expect_screen_size_from_file("iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11)
+        expect_screen_size_from_file("iPad-Portrait-11Inch{1668x2388}.jpg").to eq(ScreenSize::IOS_IPAD_11)
+        expect_screen_size_from_file("iPad-Landscape-11Inch{2388x1668}.jpg").to eq(ScreenSize::IOS_IPAD_11)
       end
 
       it "should calculate all 10.5 inch iPad resolutions" do
-        expect_screen_size_from_file("iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5)
-        expect_screen_size_from_file("iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5)
+        expect_screen_size_from_file("iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(ScreenSize::IOS_IPAD_10_5)
+        expect_screen_size_from_file("iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(ScreenSize::IOS_IPAD_10_5)
       end
 
       it "should calculate all 9.7 inch iPad resolutions" do
-        expect_screen_size_from_file("iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(ScreenSize::IOS_IPAD)
+        expect_screen_size_from_file("iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(ScreenSize::IOS_IPAD)
       end
 
       it "should calculate all supported Mac resolutions" do
-        expect_screen_size_from_file("Mac{1280x800}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
-        expect_screen_size_from_file("Mac{1440x900}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
-        expect_screen_size_from_file("Mac{2560x1600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
-        expect_screen_size_from_file("Mac{2880x1800}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
+        expect_screen_size_from_file("Mac{1280x800}.jpg").to eq(ScreenSize::MAC)
+        expect_screen_size_from_file("Mac{1440x900}.jpg").to eq(ScreenSize::MAC)
+        expect_screen_size_from_file("Mac{2560x1600}.jpg").to eq(ScreenSize::MAC)
+        expect_screen_size_from_file("Mac{2880x1800}.jpg").to eq(ScreenSize::MAC)
       end
 
       it "should calculate all supported Apple TV resolutions" do
-        expect_screen_size_from_file("AppleTV{1920x1080}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::APPLE_TV)
-        expect_screen_size_from_file("AppleTV-4K{3840x2160}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::APPLE_TV)
+        expect_screen_size_from_file("AppleTV{1920x1080}.jpg").to eq(ScreenSize::APPLE_TV)
+        expect_screen_size_from_file("AppleTV-4K{3840x2160}.jpg").to eq(ScreenSize::APPLE_TV)
       end
 
       it "should calculate all supported Apple Watch resolutions" do
-        expect_screen_size_from_file("AppleWatch-Series3{312x390}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH)
-        expect_screen_size_from_file("AppleWatch-Series4{368x448}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES4)
+        expect_screen_size_from_file("AppleWatch-Series3{312x390}.jpg").to eq(ScreenSize::IOS_APPLE_WATCH)
+        expect_screen_size_from_file("AppleWatch-Series4{368x448}.jpg").to eq(ScreenSize::IOS_APPLE_WATCH_SERIES4)
       end
     end
 
     describe "valid iMessage app screen sizes" do
       it "should calculate all 6.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(ScreenSize::IOS_65_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(ScreenSize::IOS_65_MESSAGES)
       end
 
       it "should calculate all 5.8 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneXS-Portrait{1125x2436}.jpg").to eq(ScreenSize::IOS_58_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneXS-Landscape{2436x1125}.jpg").to eq(ScreenSize::IOS_58_MESSAGES)
       end
 
       it "should calculate all 5.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhone8Plus-Portrait{1242x2208}.jpg").to eq(ScreenSize::IOS_55_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhone8Plus-Landscape{2208x1242}.jpg").to eq(ScreenSize::IOS_55_MESSAGES)
       end
 
       it "should calculate all 4.7 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhone8-Portrait{750x1334}.jpg").to eq(ScreenSize::IOS_47_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhone8-Landscape{1334x750}.jpg").to eq(ScreenSize::IOS_47_MESSAGES)
       end
 
       it "should calculate all 4 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Portrait{640x1136}.jpg").to eq(ScreenSize::IOS_40_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Landscape{1136x640}.jpg").to eq(ScreenSize::IOS_40_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(ScreenSize::IOS_40_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(ScreenSize::IOS_40_MESSAGES)
       end
 
       it "should calculate all 12.9 inch iPad resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(ScreenSize::IOS_IPAD_PRO_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(ScreenSize::IOS_IPAD_PRO_MESSAGES)
       end
 
       it "should calculate all 11 inch iPad resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.jpg").to eq(ScreenSize::IOS_IPAD_11_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-11Inch{2388x1668}.jpg").to eq(ScreenSize::IOS_IPAD_11_MESSAGES)
       end
 
       it "should calculate all 10.5 inch iPad resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(ScreenSize::IOS_IPAD_10_5_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(ScreenSize::IOS_IPAD_10_5_MESSAGES)
       end
 
       it "should calculate all 9.7 inch iPad resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(ScreenSize::IOS_IPAD_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(ScreenSize::IOS_IPAD_MESSAGES)
       end
     end
 

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -1,7 +1,5 @@
 require 'deliver/app_screenshot'
 
-# Ensure that screenshots correctly map to the following:
-# https://help.apple.com/app-store-connect/#/devd274dd925
 describe Deliver::AppScreenshot do
   def screen_size_from(path)
     path.match(/{([0-9]+)x([0-9]+)}/).captures.map(&:to_i)
@@ -15,6 +13,8 @@ describe Deliver::AppScreenshot do
 
   ScreenSize = Deliver::AppScreenshot::ScreenSize
 
+  # Ensure that screenshots correctly map based on the following:
+  # https://help.apple.com/app-store-connect/#/devd274dd925
   describe "#calculate_screen_size" do
     def expect_screen_size_from_file(file)
       expect(Deliver::AppScreenshot.calculate_screen_size(file))
@@ -255,7 +255,7 @@ describe Deliver::AppScreenshot do
       expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_55_MESSAGES).device_type).to eq("iphone6Plus")
     end
 
-    it "should return nil for 6.1 inch displays" do
+    it "should return nil for 6.1 inch displays (iPhone XR)" do
       expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_61).device_type).to be_nil
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I'm attempting to add some extra test coverage around the uploading and detection of screenshots however ran into a few bugs along the way. This PR introduces the tests and addresses the bugs that the tests spotted.

Each bug was raised individually below:

- [x] 11 inch iPad Pro iMessage screenshots are uploaded to regular app screenshots #14586
- [x] Incorrectly allows 5.5 inch screenshots @ native device resolution #14585
- [x] Invalid screen resolution images can be uploaded as Apple TV and Mac screenshots #14587

### Description

The first commit in this change introduces the relevant tests, you can see the failures that led to the bug reports below: 

<details>

```
➜  fastlane git:(add-app-screenshot-tests) bundle exec rspec deliver/spec/app_screenshot_spec.rb
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Changing stdout to /var/folders/tc/81bst8bs0qx2qzkd_rl45hl00000gn/T/fastlane_tests, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)

Deliver::AppScreenshot
  #calculate_screen_size
    valid screen sizes
      should calculate all 6.5 inch iPhone resolutions
      should calculate all 5.8 inch iPhone resolutions
      should calculate all 5.5 inch iPhone resolutions
      should calculate all 4.7 inch iPhone resolutions
      should calculate all 4 inch iPhone resolutions
      should calculate all 3.5 inch iPhone resolutions
      should calculate all 12.9 inch iPad resolutions
      should calculate all 11 inch iPad resolutions
      should calculate all 10.5 inch iPad resolutions
      should calculate all 9.7 inch iPad resolutions
      should calculate all supported Mac resolutions
      should calculate all supported Apple TV resolutions (FAILED - 1)
      should calculate all supported Apple Watch resolutions
    valid iMessage app screen sizes
      should calculate all 6.5 inch iPhone resolutions
      should calculate all 5.8 inch iPhone resolutions
      should calculate all 5.5 inch iPhone resolutions
      should calculate all 4.7 inch iPhone resolutions
      should calculate all 4 inch iPhone resolutions
      should calculate all 12.9 inch iPad resolutions
      should calculate all 11 inch iPad resolutions (FAILED - 2)
      should calculate all 10.5 inch iPad resolutions
      should calculate all 9.7 inch iPad resolutions
    invalid screen sizes
      shouldn't allow native resolution 5.5 inch iPhone screenshots (FAILED - 3)
      shouldn't calculate portrait Apple TV resolutions (FAILED - 4)
      shouldn't calculate modern devices excluding status bars
      shouldn't allow non 16:10 resolutions for Mac (FAILED - 5)
  #is_messages?
    should return true when contained in the iMessage directory (FAILED - 6)
    should return false when not contained in the iMessage directory

Failures:

  1) Deliver::AppScreenshot#calculate_screen_size valid screen sizes should calculate all supported Apple TV resolutions
     Failure/Error: expect_screen_size_from_file("AppleTV{1920x1080}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::APPLE_TV)

       expected: "Apple-TV"
            got: "iOS-5.5-in"

       (compared using ==)
     # ./deliver/spec/app_screenshot_spec.rb:90:in `block (4 levels) in <top (required)>'

  2) Deliver::AppScreenshot#calculate_screen_size valid iMessage app screen sizes should calculate all 11 inch iPad resolutions
     Failure/Error: expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11_MESSAGES)

       expected: "iOS-11-messages"
            got: "iOS-iPad-11"

       (compared using ==)
     # ./deliver/spec/app_screenshot_spec.rb:134:in `block (4 levels) in <top (required)>'

  3) Deliver::AppScreenshot#calculate_screen_size invalid screen sizes shouldn't allow native resolution 5.5 inch iPhone screenshots
     Failure/Error:
       expect do
         Deliver::AppScreenshot.calculate_screen_size(file)
       end.to raise_error(FastlaneCore::Interface::FastlaneError, "Unsupported screen size #{screen_size_from(file)} for path '#{file}'")

       expected FastlaneCore::Interface::FastlaneError with "Unsupported screen size [1080, 1920] for path 'iPhone8Plus-NativeResolution{1080x1920}.jpg'" but nothing was raised
     # ./deliver/spec/app_screenshot_spec.rb:157:in `expect_invalid_screen_size_from_file'
     # ./deliver/spec/app_screenshot_spec.rb:163:in `block (4 levels) in <top (required)>'

  4) Deliver::AppScreenshot#calculate_screen_size invalid screen sizes shouldn't calculate portrait Apple TV resolutions
     Failure/Error:
       expect do
         Deliver::AppScreenshot.calculate_screen_size(file)
       end.to raise_error(FastlaneCore::Interface::FastlaneError, "Unsupported screen size #{screen_size_from(file)} for path '#{file}'")

       expected FastlaneCore::Interface::FastlaneError with "Unsupported screen size [1080, 1920] for path 'appleTV/en-GB/AppleTV-Portrait{1080x1920}.jpg'" but nothing was raised
     # ./deliver/spec/app_screenshot_spec.rb:157:in `expect_invalid_screen_size_from_file'
     # ./deliver/spec/app_screenshot_spec.rb:168:in `block (4 levels) in <top (required)>'

  5) Deliver::AppScreenshot#calculate_screen_size invalid screen sizes shouldn't allow non 16:10 resolutions for Mac
     Failure/Error:
       expect do
         Deliver::AppScreenshot.calculate_screen_size(file)
       end.to raise_error(FastlaneCore::Interface::FastlaneError, "Unsupported screen size #{screen_size_from(file)} for path '#{file}'")

       expected FastlaneCore::Interface::FastlaneError with "Unsupported screen size [800, 1280] for path 'Mac-Portrait{800x1280}.jpg'" but nothing was raised
     # ./deliver/spec/app_screenshot_spec.rb:157:in `expect_invalid_screen_size_from_file'
     # ./deliver/spec/app_screenshot_spec.rb:183:in `block (4 levels) in <top (required)>'

  6) Deliver::AppScreenshot#is_messages? should return true when contained in the iMessage directory
     Failure/Error: expect({ file: file, result: screenshot.is_messages? }).to eq({ file: file, result: true })

       expected: {:file=>"screenshots/iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.png", :result=>true}
            got: {:file=>"screenshots/iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.png", :result=>false}

       (compared using ==)

       Diff:
       @@ -1,3 +1,3 @@
        :file => "screenshots/iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.png",
       -:result => true,
       +:result => false,

     # ./deliver/spec/app_screenshot_spec.rb:206:in `block (4 levels) in <top (required)>'
     # ./deliver/spec/app_screenshot_spec.rb:204:in `each'
     # ./deliver/spec/app_screenshot_spec.rb:204:in `block (3 levels) in <top (required)>'

Finished in 0.05015 seconds (files took 1.64 seconds to load)
28 examples, 6 failures

Failed examples:

rspec ./deliver/spec/app_screenshot_spec.rb:89 # Deliver::AppScreenshot#calculate_screen_size valid screen sizes should calculate all supported Apple TV resolutions
rspec ./deliver/spec/app_screenshot_spec.rb:133 # Deliver::AppScreenshot#calculate_screen_size valid iMessage app screen sizes should calculate all 11 inch iPad resolutions
rspec ./deliver/spec/app_screenshot_spec.rb:162 # Deliver::AppScreenshot#calculate_screen_size invalid screen sizes shouldn't allow native resolution 5.5 inch iPhone screenshots
rspec ./deliver/spec/app_screenshot_spec.rb:167 # Deliver::AppScreenshot#calculate_screen_size invalid screen sizes shouldn't calculate portrait Apple TV resolutions
rspec ./deliver/spec/app_screenshot_spec.rb:182 # Deliver::AppScreenshot#calculate_screen_size invalid screen sizes shouldn't allow non 16:10 resolutions for Mac
rspec ./deliver/spec/app_screenshot_spec.rb:192 # Deliver::AppScreenshot#is_messages? should return true when contained in the iMessage directory
```

</details>

There were three reasons for the bugs:
1. Misconfiguration with the `device_messages` map that returned the non-messages screen size constant
2. Outdated screen resolutions
3. Portrait checks only applied to the special appleTV directory and not others

I want to use `DisplayFamily` (#14574) and replace the hardcoded resolutions in app_screenshot.md so hopefully I can update this PR once that class is available. To prepare for future refactors, I've also introduced tests for the device_type return value 