### PR TITLE
[screengrab] LocaleUtil set default locale

### DIFF
--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
@@ -8,7 +8,7 @@ import android.util.Log;
 import java.lang.reflect.Method;
 import java.util.Locale;
 
-public class LocaleUtil {
+public final class LocaleUtil {
 
     private static final String TAG =  LocaleUtil.class.getSimpleName();
 
@@ -17,6 +17,8 @@ public class LocaleUtil {
             Log.w(TAG, "Skipping setting device locale to null");
             return;
         }
+
+        Locale.setDefault(locale);
 
         try {
             Class amnClass = Class.forName("android.app.ActivityManagerNative");


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Some of my code does depend on the default locale which wasn't set via the rule.

cc @janpio since you seem to be the person reviewing the related screengrab changes