### PR TITLE
[action] pod_lib_lint: Add support for use_module_headers and subspecs

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -5,30 +5,16 @@ module Fastlane
         command = []
 
         command << "bundle exec" if params[:use_bundle_exec] && shell_out_should_use_bundle_exec?
-
         command << "pod lib lint"
 
-        if params[:verbose]
-          command << "--verbose"
-        end
-
         command << params[:podspec] if params[:podspec]
-
-        if params[:sources]
-          sources = params[:sources].join(",")
-          command << "--sources='#{sources}'"
-        end
-
-        if params[:swift_version]
-          swift_version = params[:swift_version]
-          command << "--swift-version=#{swift_version}"
-        end
-
-        if params[:allow_warnings]
-          command << "--allow-warnings"
-        end
-
+        command << "--verbose" if params[:verbose]
+        command << "--allow-warnings" if params[:allow_warnings]
+        command << "--sources='#{params[:sources].join(',')}'" if params[:sources]
+        command << "--subspec='#{params[:subspec]}'" if params[:subspec]
+        command << "--swift-version=#{params[:swift_version]}" if params[:swift_version]
         command << "--use-libraries" if params[:use_libraries]
+        command << "--use-modular-headers" if params[:use_modular_headers]
         command << "--fail-fast" if params[:fail_fast]
         command << "--private" if params[:private]
         command << "--quick" if params[:quick]
@@ -54,48 +40,78 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :use_bundle_exec,
                                        description: "Use bundle exec when there is a Gemfile presented",
-                                       is_string: false,
-                                       default_value: true),
+                                       type: Boolean,
+                                       default_value: true,
+                                       env_name: "FL_POD_LIB_LINT_USE_BUNDLE" 
+                                      ),
           FastlaneCore::ConfigItem.new(key: :podspec,
                                        description: "Path of spec to lint",
+                                       type: String,
                                        optional: true,
-                                       is_string: true),
+                                       env_name: "FL_POD_LIB_LINT_PODSPEC"
+                                      ),
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        description: "Allow output detail in console",
+                                       type: Boolean,
                                        optional: true,
-                                       is_string: false),
+                                       env_name: "FL_POD_LIB_LINT_VERBOSE"
+                                      ),
           FastlaneCore::ConfigItem.new(key: :allow_warnings,
                                        description: "Allow warnings during pod lint",
+                                       type: Boolean,
                                        optional: true,
-                                       is_string: false),
+                                       env_name: "FL_POD_LIB_LINT_ALLOW_WARNINGS"
+                                      ),
           FastlaneCore::ConfigItem.new(key: :sources,
                                        description: "The sources of repos you want the pod spec to lint with, separated by commas",
-                                       optional: true,
-                                       is_string: false,
                                        type: Array,
+                                       optional: true,
+                                       env_name: "FL_POD_LIB_LINT_SOURCES",
                                        verify_block: proc do |value|
                                          UI.user_error!("Sources must be an array.") unless value.kind_of?(Array)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :subspec,
+                                       description: "A specific subspec to lint instead of the entire spec",
+                                       type: String,
+                                       optional: true,
+                                       env_name: "FL_POD_LIB_LINT_SUBSPEC"
+                                      ),
           FastlaneCore::ConfigItem.new(key: :swift_version,
                                        description: "The SWIFT_VERSION that should be used to lint the spec. This takes precedence over a .swift-version file",
+                                       type: String,
                                        optional: true,
-                                       is_string: true),
+                                       env_name: "FL_POD_LIB_LINT_SWIFT_VERSION"
+                                      ),
           FastlaneCore::ConfigItem.new(key: :use_libraries,
                                        description: "Lint uses static libraries to install the spec",
-                                       is_string: false,
-                                       default_value: false),
+                                       type: Boolean,
+                                       default_value: false,
+                                       env_name: "FL_POD_LIB_LINT_USE_LIBRARIES"
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :use_modular_headers,
+                                       description: "Lint using modular libraries",
+                                       type: Boolean,
+                                       default_value: false,
+                                       env_name: "FL_POD_LIB_LINT_USE_MODULAR_HEADERS"
+                                      ),
           FastlaneCore::ConfigItem.new(key: :fail_fast,
                                        description: "Lint stops on the first failing platform or subspec",
-                                       is_string: false,
-                                       default_value: false),
+                                       type: Boolean,
+                                       default_value: false,
+                                       env_name: "FL_POD_LIB_LINT_FAIL_FAST"
+                                      ),
           FastlaneCore::ConfigItem.new(key: :private,
                                        description: "Lint skips checks that apply only to public specs",
-                                       is_string: false,
-                                       default_value: false),
+                                       type: Boolean,
+                                       default_value: false,
+                                       env_name: "FL_POD_LIB_LINT_PRIVATE"
+                                      ),
           FastlaneCore::ConfigItem.new(key: :quick,
                                        description: "Lint skips checks that would require to download and build the spec",
-                                       is_string: false,
-                                       default_value: false)
+                                       type: Boolean,
+                                       default_value: false,
+                                       env_name: "FL_POD_LIB_LINT_QUICK"
+                                      )
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -100,7 +100,7 @@ module Fastlane
                                        description: "Lint skips checks that would require to download and build the spec",
                                        type: Boolean,
                                        default_value: false,
-                                       env_name: "FL_POD_LIB_LINT_QUICK"),
+                                       env_name: "FL_POD_LIB_LINT_QUICK")
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -42,26 +42,22 @@ module Fastlane
                                        description: "Use bundle exec when there is a Gemfile presented",
                                        type: Boolean,
                                        default_value: true,
-                                       env_name: "FL_POD_LIB_LINT_USE_BUNDLE" 
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_USE_BUNDLE"),
           FastlaneCore::ConfigItem.new(key: :podspec,
                                        description: "Path of spec to lint",
                                        type: String,
                                        optional: true,
-                                       env_name: "FL_POD_LIB_LINT_PODSPEC"
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_PODSPEC"),
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        description: "Allow output detail in console",
                                        type: Boolean,
                                        optional: true,
-                                       env_name: "FL_POD_LIB_LINT_VERBOSE"
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_VERBOSE"),
           FastlaneCore::ConfigItem.new(key: :allow_warnings,
                                        description: "Allow warnings during pod lint",
                                        type: Boolean,
                                        optional: true,
-                                       env_name: "FL_POD_LIB_LINT_ALLOW_WARNINGS"
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_ALLOW_WARNINGS"),
           FastlaneCore::ConfigItem.new(key: :sources,
                                        description: "The sources of repos you want the pod spec to lint with, separated by commas",
                                        type: Array,
@@ -74,44 +70,37 @@ module Fastlane
                                        description: "A specific subspec to lint instead of the entire spec",
                                        type: String,
                                        optional: true,
-                                       env_name: "FL_POD_LIB_LINT_SUBSPEC"
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_SUBSPEC"),
           FastlaneCore::ConfigItem.new(key: :swift_version,
                                        description: "The SWIFT_VERSION that should be used to lint the spec. This takes precedence over a .swift-version file",
                                        type: String,
                                        optional: true,
-                                       env_name: "FL_POD_LIB_LINT_SWIFT_VERSION"
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_SWIFT_VERSION"),
           FastlaneCore::ConfigItem.new(key: :use_libraries,
                                        description: "Lint uses static libraries to install the spec",
                                        type: Boolean,
                                        default_value: false,
-                                       env_name: "FL_POD_LIB_LINT_USE_LIBRARIES"
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_USE_LIBRARIES"),
           FastlaneCore::ConfigItem.new(key: :use_modular_headers,
                                        description: "Lint using modular libraries",
                                        type: Boolean,
                                        default_value: false,
-                                       env_name: "FL_POD_LIB_LINT_USE_MODULAR_HEADERS"
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_USE_MODULAR_HEADERS"),
           FastlaneCore::ConfigItem.new(key: :fail_fast,
                                        description: "Lint stops on the first failing platform or subspec",
                                        type: Boolean,
                                        default_value: false,
-                                       env_name: "FL_POD_LIB_LINT_FAIL_FAST"
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_FAIL_FAST"),
           FastlaneCore::ConfigItem.new(key: :private,
                                        description: "Lint skips checks that apply only to public specs",
                                        type: Boolean,
                                        default_value: false,
-                                       env_name: "FL_POD_LIB_LINT_PRIVATE"
-                                      ),
+                                       env_name: "FL_POD_LIB_LINT_PRIVATE"),
           FastlaneCore::ConfigItem.new(key: :quick,
                                        description: "Lint skips checks that would require to download and build the spec",
                                        type: Boolean,
                                        default_value: false,
-                                       env_name: "FL_POD_LIB_LINT_QUICK"
-                                      )
+                                       env_name: "FL_POD_LIB_LINT_QUICK"),
         ]
       end
 

--- a/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
+++ b/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
@@ -76,6 +76,22 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec pod lib lint fastlane")
       end
+
+      it "generates the correct pod lib lint command with subspec parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(subspec: 'test-subspec')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --subspec='test-subspec'")
+      end
+
+      it "generates the correct pod lib lint command with use_modular_headers parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(use_modular_headers: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --use-modular-headers")
+      end
     end
   end
 end


### PR DESCRIPTION
Adds parameters to support subspecs and using module headers.  Also adds environment variables for each of the parameters.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adds additional parameters to support underlying options of the lint command.  Namely, it adds support for the [--use-module-headers](https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/command/lib/lint.rb#L24) and [--subspsec](https://github.com/CocoaPods/CocoaPods/blob/master/lib/cocoapods/command/lib/lint.rb#L19) options.

Additionally, it adds environment variables for each of the supported parameters for convenience.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->