### PR TITLE
[action] app_store_build_number: Pass teamID when selecting itunes team

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -21,7 +21,7 @@ module Fastlane
       def self.get_build_number(params)
         UI.message("Login to App Store Connect (#{params[:username]})")
         Spaceship::Tunes.login(params[:username])
-        Spaceship::Tunes.select_team(team_id: params[:team_id])
+        Spaceship::Tunes.select_team(team_id: params[:team_id], team_name: params[:team_name])
         UI.message("Login successful")
 
         app = Spaceship::Tunes::Application.find(params[:app_identifier])

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -21,7 +21,7 @@ module Fastlane
       def self.get_build_number(params)
         UI.message("Login to App Store Connect (#{params[:username]})")
         Spaceship::Tunes.login(params[:username])
-        Spaceship::Tunes.select_team
+        Spaceship::Tunes.select_team(team_id: params[:team_id])
         UI.message("Login successful")
 
         app = Spaceship::Tunes::Application.find(params[:app_identifier])

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -79,10 +79,7 @@ module Fastlane
                                        is_string: false, # as we also allow integers, which we convert to strings anyway
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:itc_team_id),
-                                       default_value_dynamic: true,
-                                       verify_block: proc do |value|
-                                         ENV["FASTLANE_ITC_TEAM_ID"] = value.to_s
-                                       end),
+                                       default_value_dynamic: true),
           FastlaneCore::ConfigItem.new(key: :team_name,
                                        short_option: "-e",
                                        env_name: "LATEST_TESTFLIGHT_BUILD_NUMBER_TEAM_NAME",
@@ -90,10 +87,7 @@ module Fastlane
                                        optional: true,
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:itc_team_name),
-                                       default_value_dynamic: true,
-                                       verify_block: proc do |value|
-                                         ENV["FASTLANE_ITC_TEAM_NAME"] = value.to_s
-                                       end)
+                                       default_value_dynamic: true)
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We are using the `LatestTestflightBuildNumberAction` for incrementing our project build number. We are providing all the necessary params and credentials for signing and it was working smooth. Lately, I guess after unification of AppStoreConnect and DeveloperPortal teams, fastlane is asking to specify the team id even if we are passing it within the params.
```
Multiple App Store Connect teams found, please enter the number of the team you want to use:
Note: to automatically choose the team, provide either the App Store Connect Team ID, or the Team Name in your fastlane/Appfile:
Alternatively you can pass the team name or team ID using the `FASTLANE_ITC_TEAM_ID` or `FASTLANE_ITC_TEAM_NAME` environment variable
{...}
```
If we pass the environment variable before launching this fastlane action, everything works. But we are passing it through the parameters, and it should also work. I started looking where the problem is and found that when `AppStoreBuildNumberAction` is preparing `Spaceship::Tunes`, it was not passing the specified `team_id`.
```ruby
Spaceship::Tunes.login(params[:username])
Spaceship::Tunes.select_team #no team_id passed
```
Adding the `team_id` parameter solved the issue.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
There is a pretty small change and it is described above in detail. About how did I test it, I tested within our own project, the next use cases:
1. faslane is automatically `Login to App Store Connect` when a `FASTLANE_ITC_TEAM_ID` env var is set
2. faslane is automatically `Login to App Store Connect` when `team_id` argument is passed to the  
`LatestTestflightBuildNumberAction`
3. If neither of above is done, fastlane is asking for the teamID within the dialog.