### PR TITLE
[rubocop] Add a new rule to prevent missing keys on the shared area provided by an action

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop/require_tools
   - ./rubocop/fork_usage.rb
+  - ./rubocop/missing_keys_on_shared_area.rb
 
 Style/MultipleComparison:
   Enabled: false

--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -95,7 +95,7 @@ module Fastlane
       def self.output
         [
           ['IPA_OUTPUT_PATH', 'The path to the newly generated ipa file'],
-          ['DSYM_OUTPUT_PATH', 'Te path to the dSYM files']
+          ['DSYM_OUTPUT_PATH', 'The path to the dSYM files']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -92,6 +92,13 @@ module Fastlane
         "More information: https://fastlane.tools/gym"
       end
 
+      def self.output
+        [
+          ['IPA_OUTPUT_PATH', 'The path to the newly generated ipa file'],
+          ['DSYM_OUTPUT_PATH', 'Te path to the dSYM files']
+        ]
+      end
+
       def self.return_value
         "The absolute path to the generated ipa file"
       end

--- a/fastlane/lib/fastlane/actions/capture_android_screenshots.rb
+++ b/fastlane/lib/fastlane/actions/capture_android_screenshots.rb
@@ -28,6 +28,12 @@ module Fastlane
         Screengrab::Options.available_options
       end
 
+      def self.output
+        [
+          ['SCREENGRAB_OUTPUT_DIRECTORY', 'The path to the output directory']
+        ]
+      end
+
       def self.author
         ['asfalcone', 'i2amsam', 'mfurtak']
       end

--- a/fastlane/lib/fastlane/actions/capture_ios_screenshots.rb
+++ b/fastlane/lib/fastlane/actions/capture_ios_screenshots.rb
@@ -28,6 +28,12 @@ module Fastlane
         Snapshot::Options.available_options
       end
 
+      def self.output
+        [
+          ['SNAPSHOT_SCREENSHOTS_PATH', 'The path to the screenshots']
+        ]
+      end
+
       def self.author
         "KrauseFx"
       end

--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -69,7 +69,7 @@ module Fastlane
 
       def self.output
         [
-          ['FL_CHANGELOG', 'The changelog String generated from the collected Git commit messages']
+          ['FL_CHANGELOG', 'The changelog string generated from the collected git commit messages']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -68,7 +68,9 @@ module Fastlane
       end
 
       def self.output
-        ['FL_CHANGELOG', 'The changelog String generated from the collected Git commit messages']
+        [
+          ['FL_CHANGELOG', 'The changelog String generated from the collected Git commit messages']
+        ]
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -141,6 +141,12 @@ module Fastlane
         "Creates a 'Version Bump' commit. Run after `increment_build_number`"
       end
 
+      def self.output
+        [
+          ['MODIFIED_FILES', 'The list of paths of modified files']
+        ]
+      end
+
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :message,

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -74,7 +74,7 @@ module Fastlane
 
       def self.output
         [
-          ['ORIGINAL_DEFAULT_KEYCHAIN', 'The path to the new system default keychain']
+          ['ORIGINAL_DEFAULT_KEYCHAIN', 'The path to the default keychain']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -72,6 +72,12 @@ module Fastlane
         "Create a new Keychain"
       end
 
+      def self.output
+        [
+          ['ORIGINAL_DEFAULT_KEYCHAIN', 'The path to the new system default keychain']
+        ]
+      end
+
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :name,

--- a/fastlane/lib/fastlane/actions/create_pull_request.rb
+++ b/fastlane/lib/fastlane/actions/create_pull_request.rb
@@ -68,6 +68,12 @@ module Fastlane
         "This will create a new pull request on GitHub"
       end
 
+      def self.output
+        [
+          ['CREATE_PULL_REQUEST_HTML_URL', 'The HTML URL to the created pull request']
+        ]
+      end
+
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :api_token,

--- a/fastlane/lib/fastlane/actions/default_platform.rb
+++ b/fastlane/lib/fastlane/actions/default_platform.rb
@@ -19,6 +19,12 @@ module Fastlane
         "Defines a default platform to not have to specify the platform"
       end
 
+      def self.output
+        [
+          ['DEFAULT_PLATFORM', 'The default platform']
+        ]
+      end
+
       def self.example_code
         [
           'default_platform(:android)'

--- a/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
@@ -1,9 +1,5 @@
 module Fastlane
   module Actions
-    module SharedValues
-      ENSURE_XCODE_VERSION_CUSTOM_VALUE = :ENSURE_XCODE_VERSION_CUSTOM_VALUE
-    end
-
     class EnsureXcodeVersionAction < Action
       def self.run(params)
         Actions.verify_gem!('xcode-install')

--- a/fastlane/lib/fastlane/actions/get_certificates.rb
+++ b/fastlane/lib/fastlane/actions/get_certificates.rb
@@ -42,6 +42,13 @@ module Fastlane
         Cert::Options.available_options
       end
 
+      def self.output
+        [
+          ['CERT_FILE_PATH', 'The path to the certificate'],
+          ['CERT_CERTIFICATE_ID', 'The id of the certificate']
+        ]
+      end
+
       def self.author
         "KrauseFx"
       end

--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -3,6 +3,7 @@ module Fastlane
     module SharedValues
       SIGH_PROFILE_PATH = :SIGH_PROFILE_PATH
       SIGH_PROFILE_PATHS = :SIGH_PROFILE_PATHS
+      SIGH_UDID = :SIGH_UDID # deprecated
       SIGH_UUID = :SIGH_UUID
       SIGH_NAME = :SIGH_NAME
       SIGH_PROFILE_TYPE = :SIGH_PROFILE_TYPE
@@ -21,7 +22,6 @@ module Fastlane
         Actions.lane_context[SharedValues::SIGH_PROFILE_PATHS] ||= []
         Actions.lane_context[SharedValues::SIGH_PROFILE_PATHS] << path
 
-        # SharedValues::SIGH_UDID is deprecated
         uuid = ENV["SIGH_UUID"] || ENV["SIGH_UDID"] # the UUID of the profile
         name = ENV["SIGH_NAME"] # the name of the profile
         Actions.lane_context[SharedValues::SIGH_UUID] = Actions.lane_context[SharedValues::SIGH_UDID] = uuid if uuid
@@ -52,6 +52,7 @@ module Fastlane
         "KrauseFx"
       end
 
+      # rubocop:disable Lint/MissingKeysOnSharedArea
       def self.output
         [
           ['SIGH_PROFILE_PATH', 'A path in which export certificates, key and profile'],

--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -57,7 +57,7 @@ module Fastlane
         [
           ['SIGH_PROFILE_PATH', 'A path in which certificates, key and profile are exported'],
           ['SIGH_PROFILE_PATHS', 'Paths in which certificates, key and profile are exported'],
-          ['SIGH_UUID', 'UUID (Universally Unique IDentifier) of an application on a device'],
+          ['SIGH_UUID', 'UUID (Universally Unique IDentifier) of a provisioning profile'],
           ['SIGH_NAME', 'The name of the profile'],
           ['SIGH_PROFILE_TYPE', 'The profile type, can be appstore, adhoc, development, enterprise']
         ]

--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -55,9 +55,9 @@ module Fastlane
       # rubocop:disable Lint/MissingKeysOnSharedArea
       def self.output
         [
-          ['SIGH_PROFILE_PATH', 'A path in which export certificates, key and profile'],
-          ['SIGH_PROFILE_PATHS', 'Paths in which export certificates, key and profile'],
-          ['SIGH_UUID', 'UUID (Universally Unique IDentifier)'],
+          ['SIGH_PROFILE_PATH', 'A path in which certificates, key and profile are exported'],
+          ['SIGH_PROFILE_PATHS', 'Paths in which certificates, key and profile are exported'],
+          ['SIGH_UUID', 'UUID (Universally Unique IDentifier) of an application on a device'],
           ['SIGH_NAME', 'The name of the profile'],
           ['SIGH_PROFILE_TYPE', 'The profile type, can be appstore, adhoc, development, enterprise']
         ]

--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -3,7 +3,6 @@ module Fastlane
     module SharedValues
       SIGH_PROFILE_PATH = :SIGH_PROFILE_PATH
       SIGH_PROFILE_PATHS = :SIGH_PROFILE_PATHS
-      SIGH_UDID = :SIGH_UDID # deprecated
       SIGH_UUID = :SIGH_UUID
       SIGH_NAME = :SIGH_NAME
       SIGH_PROFILE_TYPE = :SIGH_PROFILE_TYPE
@@ -22,6 +21,7 @@ module Fastlane
         Actions.lane_context[SharedValues::SIGH_PROFILE_PATHS] ||= []
         Actions.lane_context[SharedValues::SIGH_PROFILE_PATHS] << path
 
+        # SharedValues::SIGH_UDID is deprecated
         uuid = ENV["SIGH_UUID"] || ENV["SIGH_UDID"] # the UUID of the profile
         name = ENV["SIGH_NAME"] # the name of the profile
         Actions.lane_context[SharedValues::SIGH_UUID] = Actions.lane_context[SharedValues::SIGH_UDID] = uuid if uuid
@@ -50,6 +50,16 @@ module Fastlane
 
       def self.author
         "KrauseFx"
+      end
+
+      def self.output
+        [
+          ['SIGH_PROFILE_PATH', 'A path in which export certificates, key and profile'],
+          ['SIGH_PROFILE_PATHS', 'Paths in which export certificates, key and profile'],
+          ['SIGH_UUID', 'UUID (Universally Unique IDentifier)'],
+          ['SIGH_NAME', 'The name of the profile'],
+          ['SIGH_PROFILE_TYPE', 'The profile type, can be appstore, adhoc, development, enterprise']
+        ]
       end
 
       def self.return_value

--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -26,7 +26,6 @@ module Fastlane
         []
       end
 
-      # rubocop:disable Lint/MissingKeysOnSharedArea
       def self.output
         [
           ['GIT_BRANCH_ENV_VARS', 'The git branch environment variables']

--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -26,8 +26,11 @@ module Fastlane
         []
       end
 
+      # rubocop:disable Lint/MissingKeysOnSharedArea
       def self.output
-        []
+        [
+          ['GIT_BRANCH_ENV_VARS', 'The git branch environment variables']
+        ]
       end
 
       def self.authors

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -163,7 +163,9 @@ module Fastlane
           ['GRADLE_APK_OUTPUT_PATH', 'The path to the newly generated apk file. Undefined in a multi-variant assemble scenario'],
           ['GRADLE_ALL_APK_OUTPUT_PATHS', 'When running a multi-variant `assemble`, the array of signed apk\'s that were generated'],
           ['GRADLE_FLAVOR', 'The flavor, e.g. `MyFlavor`'],
-          ['GRADLE_BUILD_TYPE', 'The build type, e.g. `Release`']
+          ['GRADLE_BUILD_TYPE', 'The build type, e.g. `Release`'],
+          ['GRADLE_AAB_OUTPUT_PATH', 'The path to the most recent Android app bundle'],
+          ['GRADLE_ALL_AAB_OUTPUT_PATHS', 'The paths to the most recent Android app bundles']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -70,6 +70,15 @@ module Fastlane
         ]
       end
 
+      def self.output
+        [
+          ['SCAN_DERIVED_DATA_PATH', 'The path to the derived data'],
+          ['SCAN_GENERATED_PLIST_FILE', 'The generated plist file'],
+          ['SCAN_GENERATED_PLIST_FILES', 'The generated plist files'],
+          ['SCAN_ZIP_BUILD_PRODUCTS_PATH', 'The path to the zipped build products']
+        ]
+      end
+
       def self.is_supported?(platform)
         [:ios, :mac].include?(platform)
       end

--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -1,9 +1,5 @@
 module Fastlane
   module Actions
-    module SharedValues
-      SLATHER_CUSTOM_VALUE = :SLATHER_CUSTOM_VALUE
-    end
-
     class SlatherAction < Action
       # https://github.com/SlatherOrg/slather/blob/v2.4.2/lib/slather/command/coverage_command.rb
       ARGS_MAP = {

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -68,7 +68,9 @@ module Fastlane
       end
 
       def self.output
-        []
+        [
+          ['MATCH_PROVISIONING_PROFILE_MAPPING', 'The match provisioning profile mapping']
+        ]
       end
 
       def self.return_value

--- a/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
@@ -61,7 +61,9 @@ module Fastlane
       end
 
       def self.output
-        ['APP_GROUP_IDENTIFIERS', 'The new App Group Identifiers']
+        [
+          ['APP_GROUP_IDENTIFIERS', 'The new App Group Identifiers']
+        ]
       end
 
       def self.authors

--- a/fastlane/lib/fastlane/actions/update_icloud_container_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_icloud_container_identifiers.rb
@@ -69,7 +69,9 @@ module Fastlane
       end
 
       def self.output
-        ['UPDATE_ICLOUD_CONTAINER_IDENTIFIERS', 'The new iCloud Container Identifiers']
+        [
+          ['UPDATE_ICLOUD_CONTAINER_IDENTIFIERS', 'The new iCloud Container Identifiers']
+        ]
       end
 
       def self.authors

--- a/fastlane/lib/fastlane/actions/verify_build.rb
+++ b/fastlane/lib/fastlane/actions/verify_build.rb
@@ -2,9 +2,6 @@ require 'plist'
 
 module Fastlane
   module Actions
-    module SharedValues
-      VERIFY_BUILD_CUSTOM_VALUE = :VERIFY_BUILD_CUSTOM_VALUE
-    end
     class VerifyBuildAction < Action
       def self.run(params)
         Dir.mktmpdir do |dir|

--- a/fastlane/lib/fastlane/actions/xcode_install.rb
+++ b/fastlane/lib/fastlane/actions/xcode_install.rb
@@ -71,7 +71,7 @@ module Fastlane
 
       def self.output
         [
-          ['XCODE_INSTALL_CUSTOM_VALUE', 'A description of what this value contains']
+          ['XCODE_INSTALL_XCODE_PATH', 'The path to the installed Xcode']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/xcode_install.rb
+++ b/fastlane/lib/fastlane/actions/xcode_install.rb
@@ -71,7 +71,7 @@ module Fastlane
 
       def self.output
         [
-          ['XCODE_INSTALL_XCODE_PATH', 'The path to the installed Xcode']
+          ['XCODE_INSTALL_XCODE_PATH', 'The path to the newly installed Xcode']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
+++ b/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
@@ -1,6 +1,5 @@
 module Fastlane
   module Actions
-    # rubocop:disable Lint/MissingKeysOnSharedArea
     module SharedValues
       XCODE_SERVER_GET_ASSETS_PATH = :XCODE_SERVER_GET_ASSETS_PATH
       XCODE_SERVER_GET_ASSETS_ARCHIVE_PATH = :XCODE_SERVER_GET_ASSETS_ARCHIVE_PATH

--- a/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
+++ b/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
@@ -1,5 +1,6 @@
 module Fastlane
   module Actions
+    # rubocop:disable Lint/MissingKeysOnSharedArea
     module SharedValues
       XCODE_SERVER_GET_ASSETS_PATH = :XCODE_SERVER_GET_ASSETS_PATH
       XCODE_SERVER_GET_ASSETS_ARCHIVE_PATH = :XCODE_SERVER_GET_ASSETS_ARCHIVE_PATH

--- a/fastlane/spec/fixtures/actions/archive.rb
+++ b/fastlane/spec/fixtures/actions/archive.rb
@@ -1,9 +1,5 @@
 module Fastlane
   module Actions
-    module SharedValues
-      ARCHIVE = :ARCHIVE
-    end
-
     class ArchiveAction < Action
       def self.run(params)
         puts('yes')

--- a/fastlane/spec/fixtures/actions/example_action_second.rb
+++ b/fastlane/spec/fixtures/actions/example_action_second.rb
@@ -1,9 +1,5 @@
 module Fastlane
   module Actions
-    module SharedValues
-      ARCHIVE_DIR = :ARCHIVE_DIR
-    end
-
     class ExampleActionSecondAction
       def self.run(params)
         puts('running')

--- a/rubocop/missing_keys_on_shared_area.rb
+++ b/rubocop/missing_keys_on_shared_area.rb
@@ -42,29 +42,29 @@ module RuboCop
       end
 
       def on_class(node)
-        name, superclass, body = *node
+        _name, superclass, body = *node
         return unless superclass
         return unless superclass.loc.name.source == 'Action'
 
         add_offense(node, :expression, MISSING_OUTPUT_METHOD_MSG) if body.nil? && self.shared_values_constants.any?
         return if body.nil?
 
-        check(name, body)
+        has_output_method?(body)
       end
 
-      def check(_name, node)
+      def has_output_method?(node)
         return if node.nil?
         return if self.shared_values_constants.empty?
 
         if node.defs_type? # A single method
-          add_offense(node, :expression, MISSING_OUTPUT_METHOD_MSG) unless contains_output?(node)
+          add_offense(node, :expression, MISSING_OUTPUT_METHOD_MSG) unless output_method?(node)
         elsif node.begin_type? # Multiple methods
-          outputs = node.each_child_node(:defs).select { |n| contains_output?(n) }
+          outputs = node.each_child_node(:defs).select { |n| output_method?(n) }
           add_offense(node, :expression, MISSING_OUTPUT_METHOD_MSG) if outputs.empty?
         end
       end
 
-      def contains_output?(node)
+      def output_method?(node)
         _definee, method_name, _args, _body = *node
         method_name.to_s == 'output'
       end

--- a/rubocop/missing_keys_on_shared_area.rb
+++ b/rubocop/missing_keys_on_shared_area.rb
@@ -1,0 +1,82 @@
+require 'rubocop'
+
+module RuboCop
+  module Lint
+    class MissingKeysOnSharedArea < RuboCop::Cop::Cop
+      MISSING_KEYS_MSG = "There are missing keys on the shared area. Check constants provided in 'SharedValues' or keys provided in 'output' method in the action's code".freeze
+      MISSING_OUTPUT_METHOD_MSG = "There are declared keys on the shared area 'SharedValues', but 'output' method has not been found".freeze
+
+      attr_writer :shared_values_constants
+      def shared_values_constants
+        @shared_values_constants ||= []
+      end
+
+      def on_module(node)
+        name, body = *node
+        return unless name.source == 'SharedValues'
+        return if body.nil?
+
+        body.children.compact.each do |child|
+          next unless child.respond_to?('casgn_type?')
+
+          if child.or_asgn_type? # Multiple constant values
+            lhs, _value = *child
+            _scope, const_name = *lhs
+          else # Single constant value
+            _scope, const_name, _value = *child
+            self.shared_values_constants << const_name.to_s if const_name
+          end
+
+          _scope, const_name, _value = *body unless const_name
+          self.shared_values_constants << const_name.to_s if const_name
+        end
+      end
+
+      def on_defs(node)
+        return if self.shared_values_constants.empty?
+
+        _definee, method_name, _args, body = *node
+        return unless method_name.to_s == 'output'
+
+        if body.nil?
+          add_offense(node, :expression, MISSING_KEYS_MSG)
+          return
+        end
+
+        unless body.array_type?
+          add_offense(node, :expression, MISSING_KEYS_MSG)
+          return
+        end
+
+        children = body.children.select(&:array_type?)
+        keys = children.map { |child| child.children.first.source.to_s.gsub(/\s|"|'/, '') }
+        add_offense(node, :expression, MISSING_KEYS_MSG) unless self.shared_values_constants.to_set == keys.to_set
+      end
+
+      def on_class(node)
+        name, _superclass, body = *node
+        add_offense(node, :expression, MISSING_OUTPUT_METHOD_MSG) if body.nil? && self.shared_values_constants.any?
+        return if body.nil?
+
+        check(name, body)
+      end
+
+      def check(_name, node)
+        return if node.nil?
+        return if self.shared_values_constants.empty?
+
+        if node.defs_type? # A single method
+          add_offense(node, :expression, MISSING_OUTPUT_METHOD_MSG) unless contains_output?(node)
+        elsif node.begin_type? # Multiple methods
+          outputs = node.each_child_node(:defs).select { |n| contains_output?(n) }
+          add_offense(node, :expression, MISSING_OUTPUT_METHOD_MSG) if outputs.empty?
+        end
+      end
+
+      def contains_output?(node)
+        _definee, method_name, _args, _body = *node
+        method_name.to_s == 'output'
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

> It's confusing to figure out what are `SharedValues` keys stored in [`lane_context`](https://docs.fastlane.tools/advanced/lanes/#lane-context) when given fastlane action completes. To get more details about this issue, please have a look at [this thread](https://github.com/fastlane/fastlane/issues/14255). 

> fastlane action action_name prints SharedValues declared in output action's method, however not every action declares SharedValues in its output scope.

<!-- If it fixes an open issue, please link to the issue here. -->
closes https://github.com/fastlane/fastlane/issues/14517

### Description
<!-- Describe your changes in detail -->

Added a new `rubocop` rule called `missing_keys_on_shared_area`. 

<!-- Please describe in detail how you tested your changes. -->

I wish I could add unit tests according to the [`rubocop` documentation](https://github.com/rubocop-hq/rubocop-rspec), however couldn't get that working. 

```bash
rspec NameError: uninitialized constant ...
```

Would be great, if someone could help me on that ☝️🙏 I really would like to add unit tests.

With the new `missing_keys_on_shared_area` rule, we detected `26 offenses` (fixed in this PR).

```bash
$ 1053 files inspected, 26 offenses detected
```

**Ignored files**

We do ignore the rule for two actions: 
* ~`git_branch` due to array const assignment~ 
* ~`xcode_server_get_assets` due to multiple classes~
* `get_provisioning_profile` due to deprecated `SIGH_UDID`

**Manual testing**

I performed a couple of manual testing: 

✅- the rule **does not** trigger a warning 
🥊- the rules triggers a warning 

+ No `SharedValues` module && no `output` method ✅
+ Empty `SharedValues` module  && no `output` method ✅
+ Single const defined in `SharedValues` && no `output` method 🥊
+ Single const defined in `SharedValues` && empty `output` method 🥊
+ Single const defined in `SharedValues` && non-array content in `output` method 🥊
+ Single const defined in `SharedValues` && empty array in `output` method 🥊
+ Single const defined in `SharedValues` && incorrect key in array in `output` method 🥊
+ Single const defined in `SharedValues` && correct key in array in `output` method ✅
+ Two consts defined in `SharedValues` && one correct key in array in `output` method 🥊
+ Two consts defined in `SharedValues` && two correct keys in array in `output` method ✅
+ Missing consts defined in `SharedValues` && one key in array in `output` method 🥊
+ Missing consts defined in `SharedValues` && two keys in array in `output` method 🥊
+ Missing `SharedValues` module && one key in array in `output` method 🥊

🙇 🙇 