### PR TITLE
[action] increment_version_number: Allow version without patch number

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -32,7 +32,7 @@ module Fastlane
         rescue
           current_version = ''
         end
-        
+
         if params[:version_number]
           UI.verbose(version_format_error(current_version)) unless current_version =~ version_regex
 
@@ -80,15 +80,15 @@ module Fastlane
         UI.error('Before being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html')
         raise ex
       end
-      
+
       def self.version_regex
         /^\d+(\.\d+){0,2}$/
       end
-      
+
       def self.version_format_error(version)
         "Your current version (#{version}) does not respect the format A or A.B or A.B.C"
       end
-      
+
       def self.version_token_error
         "Can't increment version"
       end

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -32,18 +32,14 @@ module Fastlane
         rescue
           current_version = ''
         end
-
-        version_regex = /^\d+(\.\d+){0,2}$/
-        version_format_error = "Your current version (#{current_version}) does not respect the format A or A.B or A.B.C"
-        version_token_error = "Can't increment version"
         
         if params[:version_number]
-          UI.verbose(version_format_error) unless current_version =~ version_regex
+          UI.verbose(version_format_error(current_version)) unless current_version =~ version_regex
 
           # Specific version
           next_version_number = params[:version_number]
         else
-          UI.user_error!(version_format_error) unless current_version =~ version_regex
+          UI.user_error!(version_format_error(current_version)) unless current_version =~ version_regex
           version_array = current_version.split(".").map(&:to_i)
 
           case params[:bump_type]
@@ -83,6 +79,18 @@ module Fastlane
       rescue => ex
         UI.error('Before being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html')
         raise ex
+      end
+      
+      def self.version_regex
+        /^\d+(\.\d+){0,2}$/
+      end
+      
+      def self.version_format_error(version)
+        "Your current version (#{version}) does not respect the format A or A.B or A.B.C"
+      end
+      
+      def self.version_token_error
+        "Can't increment version"
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -50,13 +50,13 @@ module Fastlane
           when "minor"
             UI.user_error!(version_token_error) if version_array.count < 2
             version_array[1] = version_array[1] + 1
-            version_array[2] = version_array[2] = 0
+            version_array[2] = 0 if version_array[2]
             next_version_number = version_array.join(".")
           when "major"
             UI.user_error!(version_token_error) if version_array.count == 0
             version_array[0] = version_array[0] + 1
-            version_array[1] = version_array[1] = 0
-            version_array[1] = version_array[2] = 0
+            version_array[1] = 0 if version_array[1]
+            version_array[2] = 0 if version_array[2]
             next_version_number = version_array.join(".")
           when "specific_version"
             next_version_number = specific_version_number

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -33,25 +33,31 @@ module Fastlane
           current_version = ''
         end
 
-        version_regex = /^\d+\.\d+\.\d+$/
+        version_regex = /^\d+(\.\d+){0,2}$/
+        version_format_error = "Your current version (#{current_version}) does not respect the format A or A.B or A.B.C"
+        version_token_error = "Can't increment version"
+        
         if params[:version_number]
-          UI.verbose("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ version_regex
+          UI.verbose(version_format_error) unless current_version =~ version_regex
 
           # Specific version
           next_version_number = params[:version_number]
         else
-          UI.user_error!("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ version_regex
+          UI.user_error!(version_format_error) unless current_version =~ version_regex
           version_array = current_version.split(".").map(&:to_i)
 
           case params[:bump_type]
           when "patch"
+            UI.user_error!(version_token_error) if version_array.count < 3
             version_array[2] = version_array[2] + 1
             next_version_number = version_array.join(".")
           when "minor"
+            UI.user_error!(version_token_error) if version_array.count < 2
             version_array[1] = version_array[1] + 1
             version_array[2] = version_array[2] = 0
             next_version_number = version_array.join(".")
           when "major"
+            UI.user_error!(version_token_error) if version_array.count == 0
             version_array[0] = version_array[0] + 1
             version_array[1] = version_array[1] = 0
             version_array[1] = version_array[2] = 0

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -32,7 +32,7 @@ describe Fastlane do
         "1.0.0" => "1.1.0",
         "10.13" => "10.14"
       }.each do |from_version, to_version|
-        it "increments all targets minor version number from #{from_version} to #{to_version}" do
+        it "increments all targets' minor version number from #{from_version} to #{to_version}" do
           expect(Fastlane::Actions).to receive(:sh)
             .with(/agvtool what-marketing-version/, any_args)
             .once

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -130,7 +130,7 @@ describe Fastlane do
         end.to raise_error("Please pass the path to the project, not the workspace")
       end
 
-      ["A", "1.2.3.4"].each do |version|
+      ["A", "1.2.3.4", "1.2.3-pre"].each do |version|
         it "raises an exception when unable to calculate new version for #{version} (which does not match any of the supported schemes)" do
           expect(Fastlane::Actions).to receive(:sh)
             .with(/agvtool what-marketing-version/, any_args)

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "Increment Version Number Integration" do
-      it "it increments all targets patch version number" do
+    describe "Increment Version Number Integration" do        
+      it "increments all targets' patch version number from 1.0.0 to 1.0.1" do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)
           .once
@@ -12,55 +12,96 @@ describe Fastlane do
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.0.1/)
       end
+      
+      ["1.0", "10"].each do |version|
+        it "raises an exception when trying to increment patch version number for #{version}" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool what-marketing-version/, any_args)
+            .once
+            .and_return(version)
 
-      it "it increments all targets minor version number" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              increment_version_number
+            end").runner.execute(:test)
+          end.to raise_error("Can't increment version")
+        end
+      end
+      
+      {
+        "1.0.0" => "1.1.0",
+        "10.13" => "10.14"
+      }.each do |from_version, to_version|
+        it "increments all targets minor version number from #{from_version} to #{to_version}" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool what-marketing-version/, any_args)
+            .once
+            .and_return(from_version)
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number(bump_type: 'minor')
+          end").runner.execute(:test)
+      
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version #{to_version}/)
+        end
+      end
+      
+      it "raises an exception when trying to increment minor version number for 12" do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)
           .once
-          .and_return("1.0.0")
-        Fastlane::FastFile.new.parse("lane :test do
-          increment_version_number(bump_type: 'minor')
-        end").runner.execute(:test)
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.1.0/)
+          .and_return("12")
+      
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number(bump_type: 'minor')
+          end").runner.execute(:test)
+        end.to raise_error("Can't increment version")
       end
-
-      it "it increments all targets minor version major" do
-        expect(Fastlane::Actions).to receive(:sh)
-          .with(/agvtool what-marketing-version/, any_args)
-          .once
-          .and_return("1.0.0")
-        Fastlane::FastFile.new.parse("lane :test do
-          increment_version_number(bump_type: 'major')
-        end").runner.execute(:test)
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 2.0.0/)
+      
+      {
+        "1.0.0" => "2.0.0",
+        "10.13" => "11.0",
+        "12" => "13"
+      }.each do |from_version, to_version|
+        it "it increments all targets major version number from #{from_version} to #{to_version}" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool what-marketing-version/, any_args)
+            .once
+            .and_return(from_version)
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number(bump_type: 'major')
+          end").runner.execute(:test)
+      
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version #{to_version}/)
+        end
       end
-
-      it "pass a custom version number" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          increment_version_number(version_number: '1.4.3')
-        end").runner.execute(:test)
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.4.3/)
+      
+      ["1.4.3", "1.0", "10"].each do |version|
+        it "pass a custom version number #{version}" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number(version_number: \"#{version}\")
+          end").runner.execute(:test)
+        
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version #{version}/)
+        end
       end
-
+      
       it "prefers a custom version number over a boring version bump" do
         Fastlane::FastFile.new.parse("lane :test do
           increment_version_number(version_number: '1.77.3', bump_type: 'major')
         end").runner.execute(:test)
-
+      
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.77.3/)
       end
-
+      
       it "automatically removes new lines from the version number" do
         Fastlane::FastFile.new.parse("lane :test do
           increment_version_number(version_number: '1.77.3\n', bump_type: 'major')
         end").runner.execute(:test)
-
+      
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to end_with("&& agvtool new-marketing-version 1.77.3")
       end
-
+      
       it "returns the new version as return value" do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)
@@ -69,10 +110,10 @@ describe Fastlane do
         result = Fastlane::FastFile.new.parse("lane :test do
           increment_version_number(bump_type: 'major')
         end").runner.execute(:test)
-
+      
         expect(result).to eq(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER])
       end
-
+      
       it "raises an exception when xcode project path wasn't found" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -80,7 +121,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Could not find Xcode project")
       end
-
+      
       it "raises an exception when user passes workspace" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -88,17 +129,19 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Please pass the path to the project, not the workspace")
       end
-
-      it "raises an exception when unable to calculate new version" do
-        expect(Fastlane::Actions).to receive(:sh)
-          .with(/agvtool what-marketing-version/, any_args)
-          .once
-          .and_return("00000")
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            increment_version_number
-          end").runner.execute(:test)
-        end.to raise_error("Your current version (00000) does not respect the format A.B.C")
+      
+      ["A", "1.2.3.4"].each do |version|
+        it "raises an exception when unable to calculate new version" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool what-marketing-version/, any_args)
+            .once
+            .and_return(version)
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              increment_version_number
+            end").runner.execute(:test)
+          end.to raise_error("Your current version (#{version}) does not respect the format A or A.B or A.B.C")
+        end
       end
     end
   end

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Increment Version Number Integration" do
-      it "increments all targets' patch version number from 1.0.0 to 1.0.1" do
+      it "increments all targets' patch version number (from 1.0.0 to 1.0.1)" do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)
           .once

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -131,7 +131,7 @@ describe Fastlane do
       end
       
       ["A", "1.2.3.4"].each do |version|
-        it "raises an exception when unable to calculate new version" do
+        it "raises an exception when unable to calculate new version for #{version}" do
           expect(Fastlane::Actions).to receive(:sh)
             .with(/agvtool what-marketing-version/, any_args)
             .once

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -63,7 +63,7 @@ describe Fastlane do
         "10.13" => "11.0",
         "12" => "13"
       }.each do |from_version, to_version|
-        it "it increments all targets major version number from #{from_version} to #{to_version}" do
+        it "it increments all targets' major version number from #{from_version} to #{to_version}" do
           expect(Fastlane::Actions).to receive(:sh)
             .with(/agvtool what-marketing-version/, any_args)
             .once

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -131,7 +131,7 @@ describe Fastlane do
       end
 
       ["A", "1.2.3.4"].each do |version|
-        it "raises an exception when unable to calculate new version for #{version}" do
+        it "raises an exception when unable to calculate new version for #{version} (which does not match any of the supported schemes)" do
           expect(Fastlane::Actions).to receive(:sh)
             .with(/agvtool what-marketing-version/, any_args)
             .once

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -45,7 +45,7 @@ describe Fastlane do
         end
       end
 
-      it "raises an exception when trying to increment minor version number for 12" do
+      it "raises an exception when trying to increment minor version number for 12 (which has no minor number)" do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)
           .once

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -1,6 +1,6 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "Increment Version Number Integration" do        
+    describe "Increment Version Number Integration" do
       it "increments all targets' patch version number from 1.0.0 to 1.0.1" do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)
@@ -12,7 +12,7 @@ describe Fastlane do
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.0.1/)
       end
-      
+
       ["1.0", "10"].each do |version|
         it "raises an exception when trying to increment patch version number for #{version}" do
           expect(Fastlane::Actions).to receive(:sh)
@@ -27,7 +27,7 @@ describe Fastlane do
           end.to raise_error("Can't increment version")
         end
       end
-      
+
       {
         "1.0.0" => "1.1.0",
         "10.13" => "10.14"
@@ -40,24 +40,24 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             increment_version_number(bump_type: 'minor')
           end").runner.execute(:test)
-      
+
           expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version #{to_version}/)
         end
       end
-      
+
       it "raises an exception when trying to increment minor version number for 12" do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)
           .once
           .and_return("12")
-      
+
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             increment_version_number(bump_type: 'minor')
           end").runner.execute(:test)
         end.to raise_error("Can't increment version")
       end
-      
+
       {
         "1.0.0" => "2.0.0",
         "10.13" => "11.0",
@@ -71,37 +71,37 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             increment_version_number(bump_type: 'major')
           end").runner.execute(:test)
-      
+
           expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version #{to_version}/)
         end
       end
-      
+
       ["1.4.3", "1.0", "10"].each do |version|
         it "pass a custom version number #{version}" do
           result = Fastlane::FastFile.new.parse("lane :test do
             increment_version_number(version_number: \"#{version}\")
           end").runner.execute(:test)
-        
+
           expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version #{version}/)
         end
       end
-      
+
       it "prefers a custom version number over a boring version bump" do
         Fastlane::FastFile.new.parse("lane :test do
           increment_version_number(version_number: '1.77.3', bump_type: 'major')
         end").runner.execute(:test)
-      
+
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.77.3/)
       end
-      
+
       it "automatically removes new lines from the version number" do
         Fastlane::FastFile.new.parse("lane :test do
           increment_version_number(version_number: '1.77.3\n', bump_type: 'major')
         end").runner.execute(:test)
-      
+
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to end_with("&& agvtool new-marketing-version 1.77.3")
       end
-      
+
       it "returns the new version as return value" do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)
@@ -110,10 +110,10 @@ describe Fastlane do
         result = Fastlane::FastFile.new.parse("lane :test do
           increment_version_number(bump_type: 'major')
         end").runner.execute(:test)
-      
+
         expect(result).to eq(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER])
       end
-      
+
       it "raises an exception when xcode project path wasn't found" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -121,7 +121,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Could not find Xcode project")
       end
-      
+
       it "raises an exception when user passes workspace" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
@@ -129,7 +129,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Please pass the path to the project, not the workspace")
       end
-      
+
       ["A", "1.2.3.4"].each do |version|
         it "raises an exception when unable to calculate new version for #{version}" do
           expect(Fastlane::Actions).to receive(:sh)

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -77,7 +77,7 @@ describe Fastlane do
       end
 
       ["1.4.3", "1.0", "10"].each do |version|
-        it "pass a custom version number #{version}" do
+        it "passes a custom version number #{version}" do
           result = Fastlane::FastFile.new.parse("lane :test do
             increment_version_number(version_number: \"#{version}\")
           end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
       end
 
       ["1.0", "10"].each do |version|
-        it "raises an exception when trying to increment patch version number for #{version}" do
+        it "raises an exception when trying to increment patch version number for #{version} (which has no patch number)" do
           expect(Fastlane::Actions).to receive(:sh)
             .with(/agvtool what-marketing-version/, any_args)
             .once


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
For our projects when have a major and a minor (without a patch number) however `increment_version_number` is expecting us to also have a patch (which is not required by `agvtool`)

### Description
I have modified the regex that checks for the format of the version string from `/^\d+\.\d+\.\d+$/` to `/^\d+(\.\d+){0,2}$/`

I also added some new tests for these cases and extended a couple of the old tests.
