### PR TITLE
[cert] Prevent from crash when keychain_path param wasn't passed

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -94,7 +94,7 @@ module Cert
 
         # As keychain is specific to macOS, this will likely fail on non macOS systems.
         # See also: https://github.com/fastlane/fastlane/pull/14462
-        keychain = File.expand_path(Cert.config[:keychain_path])
+        keychain = File.expand_path(Cert.config[:keychain_path]) unless Cert.config[:keychain_path].nil?
         if FastlaneCore::CertChecker.installed?(path, in_keychain: keychain)
           # This certificate is installed on the local machine
           ENV["CER_CERTIFICATE_ID"] = certificate.id


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is probably a regression in `fastlane 2.120.0` that was added in #14462. On `2.119.0` everything works as expected.
When running `CertAction` fastlane was crashing with the next stacktrace:
```
02:01:14 [02:01:14]: An error has occured: no implicit conversion of nil into String
02:01:14 [02:01:14]: /.../fastlane-2.120.0/cert/lib/cert/runner.rb:97:in `expand_path'
02:01:14 [02:01:14]: /.../fastlane-2.120.0/cert/lib/cert/runner.rb:97:in `block in find_existing_cert'
02:01:14 [02:01:14]: /.../fastlane-2.120.0/cert/lib/cert/runner.rb:87:in `each'
02:01:14 [02:01:14]: /.../fastlane-2.120.0/cert/lib/cert/runner.rb:87:in `find_existing_cert'
02:01:14 [02:01:14]: /.../fastlane-2.120.0/cert/lib/cert/runner.rb:38:in `run'
02:01:14 [02:01:14]: /.../fastlane-2.120.0/cert/lib/cert/runner.rb:13:in `launch'
02:01:14 [02:01:14]: /.../fastlane-2.120.0/fastlane/lib/fastlane/actions/get_certificates.rb:17:in `run'
```
This is because we are setting the keychain path using an env var (`CERT_KEYCHAIN_PATH`) rather than passing it as a parameter (`keychain_path`), as it specified in `fastlane cert --help`.


### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
I just added a check it the param was passed before actually expending the path and passing it to the `CertChecker`.
@jcavar I'm not really sure about why this change was implemented in the first place, so it would be nice if you will also take a look at this PR. As another solution I can check the env var too, and if it was set, proceed with it.