### PR TITLE
update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-present the fastlane authors
+Copyright (c) 2015-2019 The Fastlane Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR was requested by Google's Open Source License reviewers.

While the _fastlane_ brand name is stylized as all lower-case, in this case, it was requested be titlized as such.