### PR TITLE
[action] build_and_upload_to_appetize: Added public key and note parameters

### DIFF
--- a/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
+++ b/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
@@ -19,7 +19,9 @@ module Fastlane
                                         output_path: File.join(tmp_path, "Result.zip"))
 
         other_action.appetize(path: zipped_bundle,
-                               api_token: params[:api_token])
+                              api_token: params[:api_token],
+                              public_key: params[:public_key],
+                              note: params[:note])
 
         public_key = Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY]
         UI.success("Generated Public Key: #{Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY]}")
@@ -61,7 +63,20 @@ module Fastlane
                                        env_name: "APPETIZE_API_TOKEN",
                                        description: "Appetize.io API Token",
                                        sensitive: true,
-                                       is_string: true)
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :public_key,
+                                       description: "If not provided, a new app will be created. If provided, the existing build will be overwritten",
+                                       is_string: true,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         if value.start_with?("private_")
+                                           UI.user_error!("You provided a private key to appetize, please provide the public key")
+                                         end
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :note,
+                                       description: "Notes you wish to add to the uploaded app",
+                                       is_string: true,
+                                       optional: true)
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fix #14630 
