### PR TITLE
[action] create_pull_request: add assignees option

### DIFF
--- a/fastlane/lib/fastlane/actions/create_pull_request.rb
+++ b/fastlane/lib/fastlane/actions/create_pull_request.rb
@@ -36,6 +36,9 @@ module Fastlane
           # Add labels to pull request
           add_labels(params, number) if params[:labels]
 
+          # Add assignees to pull request
+          add_assignees(params, number) if params[:assignees]
+
           Actions.lane_context[SharedValues::CREATE_PULL_REQUEST_HTML_URL] = html_url
           return html_url
         end
@@ -50,6 +53,25 @@ module Fastlane
           api_token: params[:api_token],
           http_method: 'PATCH',
           path: "repos/#{params[:repo]}/issues/#{number}",
+          body: payload,
+          error_handlers: {
+            '*' => proc do |result|
+              UI.error("GitHub responded with #{result[:status]}: #{result[:body]}")
+              return nil
+            end
+          }
+        )
+      end
+
+      def self.add_assignees(params, number)
+        payload = {
+          'assignees' => params[:assignees]
+        }
+        GithubApiAction.run(
+          server_url: params[:api_url],
+          api_token: params[:api_token],
+          http_method: 'POST',
+          path: "repos/#{params[:repo]}/issues/#{number}/assignees",
           body: payload,
           error_handlers: {
             '*' => proc do |result|
@@ -119,12 +141,17 @@ module Fastlane
                                        is_string: true,
                                        code_gen_default_value: 'https://api.github.com',
                                        default_value: 'https://api.github.com',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :assignees,
+                                       env_name: "GITHUB_PULL_REQUEST_ASSIGNEES",
+                                       description: "The assignees for the pull request",
+                                       type: Array,
                                        optional: true)
         ]
       end
 
       def self.author
-        ["seei", "tommeier"]
+        ["seei", "tommeier", "marumemomo"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/spec/actions_specs/create_pull_request_spec.rb
+++ b/fastlane/spec/actions_specs/create_pull_request_spec.rb
@@ -25,6 +25,16 @@ describe Fastlane do
                 'User-Agent' => 'fastlane-github_api'
               }
             ).to_return(status: 200, body: "", headers: {})
+
+          stub_request(:post, "https://api.github.com/repos/fastlane/fastlane/issues/#{number}/assignees").
+            with(
+              body: '{"assignees":["octocat","hubot","other_user"]}',
+              headers: {
+                'Authorization' => 'Basic MTIzNDU2Nzg5',
+                'Host' => 'api.github.com:443',
+                'User-Agent' => 'fastlane-github_api'
+              }
+            ).to_return(status: 201, body: "", headers: {})
         end
 
         it 'correctly submits to github' do
@@ -49,6 +59,21 @@ describe Fastlane do
                 title: 'test PR',
                 repo: 'fastlane/fastlane',
                 labels: ['fastlane', 'is', 'awesome']
+              )
+            end
+          ").runner.execute(:test)
+
+          expect(result).to eq('https://github.com/fastlane/fastlane/pull/1347')
+        end
+
+        it 'correctly submits to github with assignees' do
+          result = Fastlane::FastFile.new.parse("
+            lane :test do
+              create_pull_request(
+                api_token: '123456789',
+                title: 'test PR',
+                repo: 'fastlane/fastlane',
+                assignees: ['octocat','hubot','other_user']
               )
             end
           ").runner.execute(:test)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In our project, we should add assignee to pull request but we have to use `github_api` action after `create_pull_request` action.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

Call [Add assignees to an issue API](https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue) after created a pull_request (like add_labels)
