### PR TITLE
[action] Added `format` option to `swiftlint` action

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -92,6 +92,7 @@ module Fastlane
                                        description: 'Fail on warnings? (true/false)',
                                        default_value: false,
                                        is_string: false,
+                                       type: Boolean,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :files,
                                        description: 'List of files to process',
@@ -102,6 +103,7 @@ module Fastlane
                                                     don't fail the build (true/false)",
                                        default_value: false,
                                        is_string: false,
+                                       type: Boolean,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :reporter,
                                        description: 'Choose output reporter',
@@ -111,16 +113,18 @@ module Fastlane
                                        description: "Don't print status logs like 'Linting <file>' & 'Done linting'",
                                        default_value: false,
                                        is_string: false,
+                                       type: Boolean,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :executable,
                                        description: "Path to the `swiftlint` executable on your machine",
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :format,
-                                        description: "Format code when mode is :autocorrect",
-                                        default_value: false,
-                                        is_string: false,
-                                        optional: true)
+                                       description: "Format code when mode is :autocorrect",
+                                       default_value: false,
+                                       is_string: false,
+                                       type: Boolean,
+                                       optional: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -18,6 +18,7 @@ module Fastlane
         command << " --config #{params[:config_file].shellescape}" if params[:config_file]
         command << " --reporter #{params[:reporter]}" if params[:reporter]
         command << supported_option_switch(params, :quiet, "0.9.0", true)
+        command << supported_option_switch(params, :format, "0.11.0", true) if params[:mode] == :autocorrect
 
         if params[:files]
           if version < Gem::Version.new('0.5.1')
@@ -114,7 +115,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :executable,
                                        description: "Path to the `swiftlint` executable on your machine",
                                        is_string: true,
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :format,
+                                        description: "Format code when mode is :autocorrect",
+                                        default_value: false,
+                                        is_string: false,
+                                        optional: true)
         ]
       end
 

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -1,7 +1,7 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "SwiftLint" do
-      let(:swiftlint_gem_version) { Gem::Version.new('0.9.2') }
+      let(:swiftlint_gem_version) { Gem::Version.new('0.11.0') }
       let(:output_file) { "swiftlint.result.json" }
       let(:config_file) { ".swiftlint-ci.yml" }
 
@@ -295,7 +295,31 @@ describe Fastlane do
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
               mode: :autocorrect,
-              format: false
+              format: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint autocorrect --format")
+        end
+
+        it "omits the switch if mode is :lint" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :lint,
+              format: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint")
+        end
+
+        it "omits the switch if swiftlint version is too low" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.10.0'))
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :autocorrect,
+              format: true
             )
           end").runner.execute(:test)
 
@@ -308,11 +332,11 @@ describe Fastlane do
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
               mode: :autocorrect,
-              format: true
+              format: false
             )
           end").runner.execute(:test)
 
-          expect(result).to eq("swiftlint autocorrect --format")
+          expect(result).to eq("swiftlint autocorrect")
         end
       end
     end

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -289,6 +289,32 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint")
         end
       end
+
+      context "when specify format option" do
+        it "adds format option" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :autocorrect,
+              format: false
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint autocorrect")
+        end
+      end
+
+      context "when specify false for format option" do
+        it "doesn't add format option" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :autocorrect,
+              format: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint autocorrect --format")
+        end
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -327,6 +327,7 @@ describe Fastlane do
 
         it "omits format option if swiftlint does not support it" do
           allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.10.0'))
+          expect(FastlaneCore::UI).to receive(:important).with(/Your version of swiftlint \(0.10.0\) does not support/)
 
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -30,6 +30,18 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint --strict")
         end
 
+        it "omits strict option if swiftlint does not support it" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.9.1'))
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              strict: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint")
+        end
+
         it "adds strict option for custom executable" do
           CUSTOM_EXECUTABLE_NAME = "custom_executable"
 
@@ -265,7 +277,7 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint --quiet")
         end
 
-        it "omits the switch if swiftlint version is too low" do
+        it "omits quiet option if swiftlint does not support it" do
           allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.8.0'))
 
           result = Fastlane::FastFile.new.parse("lane :test do
@@ -302,7 +314,7 @@ describe Fastlane do
           expect(result).to eq("swiftlint autocorrect --format")
         end
 
-        it "omits the switch if mode is :lint" do
+        it "omits format option if mode is :lint" do
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
               mode: :lint,
@@ -313,7 +325,7 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint")
         end
 
-        it "omits the switch if swiftlint version is too low" do
+        it "omits format option if swiftlint does not support it" do
           allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.10.0'))
 
           result = Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR adds the option `format` to `swiftlint` action.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
The option is only available for mode `autocorrect`, it formats the code besides the changes regarding the rules. If the mode is set to `lint`, then the option has no effect.
