### PR TITLE
[frameit] Add ability to resume frameit with --resume flag

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -237,7 +237,7 @@ frameit(
   path: "./fastlane/screenshots",
   force_orientation_block: proc do |filename|
     case filename
-      when "iPad Pro (12.9-inch)-01LoginScreen" 
+      when "iPad Pro (12.9-inch)-01LoginScreen"
         :landscape_right
       when "iPhone 6 Plus-01LoginScreen"
         :portrait
@@ -301,6 +301,10 @@ Check out the [MindNode example project](https://github.com/fastlane/examples/tr
 ## Generate localized screenshots
 
 Check out [_snapshot_](https://docs.fastlane.tools/actions/snapshot/) to automatically generate screenshots using ```UI Automation```.
+
+## Resume framing
+
+Framing screenshots is a slow operation. In case you need to resume framing, or just frame a couple updated screenshots again, you can rely on the `--resume` flag. Only screenshots which have not been framed yet – or for which there isn't an up-to-date framed image – will be framed. This feature uses the file modification dates and will reframe screenshots if the screenshot is newer than the framed file.
 
 ## Upload screenshots
 

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -72,7 +72,7 @@ module Frameit
     private
 
     def store_result
-      output_path = screenshot.path.gsub('.png', '_framed.png').gsub('.PNG', '_framed.png')
+      output_path = screenshot.output_path
       image.format("png")
       image.write(output_path)
       Helper.hide_loading_indicator

--- a/frameit/lib/frameit/options.rb
+++ b/frameit/lib/frameit/options.rb
@@ -70,6 +70,11 @@ module Frameit
                                      env_name: "FRAMEIT_DEBUG_MODE",
                                      description: "Output debug information in framed screenshots",
                                      default_value: false,
+                                     type: Boolean),
+        FastlaneCore::ConfigItem.new(key: :resume,
+                                     env_name: "FRAMEIT_RESUME",
+                                     description: "Resume frameit instead of reprocessing all screenshots",
+                                     default_value: false,
                                      type: Boolean)
       ]
     end

--- a/frameit/lib/frameit/runner.rb
+++ b/frameit/lib/frameit/runner.rb
@@ -26,28 +26,15 @@ module Frameit
 
       if screenshots.count > 0
         screenshots.each do |full_path|
-          next if full_path.include?("_framed.png")
-          next if full_path.include?(".itmsp/") # a package file, we don't want to modify that
-          next if full_path.include?("device_frames/") # these are the device frames the user is using
-          device = full_path.rpartition('/').last.partition('-').first # extract device name
-          if device.downcase.include?("watch")
-            UI.error("Apple Watch screenshots are not framed: '#{full_path}'")
-            next # we don't care about watches right now
-          end
+          next if skip_path?(full_path)
 
           begin
             screenshot = Screenshot.new(full_path, color)
 
-            if !screenshot.outdated? && Frameit.config[:resume]
-              UI.message("Skipping framing of screenshot #{screenshot.path} because its framed file seems up-to-date.")
-              next
-            end
+            next if skip_up_to_date?(screenshot)
 
-            if screenshot.mac?
-              editor = MacEditor.new(screenshot)
-            else
-              editor = Editor.new(screenshot, Frameit.config[:debug_mode])
-            end
+            editor = editor(screenshot)
+
             if editor.should_skip?
               UI.message("Skipping framing of screenshot #{screenshot.path}.  No title provided in your Framefile.json or title.strings.")
             else
@@ -61,6 +48,34 @@ module Frameit
         end
       else
         UI.error("Could not find screenshots in current directory: '#{File.expand_path(path)}'")
+      end
+    end
+
+    def skip_path?(path)
+      return true if path.include?("_framed.png")
+      return true if path.include?(".itmsp/") # a package file, we don't want to modify that
+      return true if path.include?("device_frames/") # these are the device frames the user is using
+      device = path.rpartition('/').last.partition('-').first # extract device name
+      if device.downcase.include?("watch")
+        UI.error("Apple Watch screenshots are not framed: '#{path}'")
+        return true # we don't care about watches right now
+      end
+      false
+    end
+
+    def skip_up_to_date?(screenshot)
+      if !screenshot.outdated? && Frameit.config[:resume]
+        UI.message("Skipping framing of screenshot #{screenshot.path} because its framed file seems up-to-date.")
+        return true
+      end
+      false
+    end
+
+    def editor(screenshot)
+      if screenshot.mac?
+        return MacEditor.new(screenshot)
+      else
+        return Editor.new(screenshot, Frameit.config[:debug_mode])
       end
     end
   end

--- a/frameit/lib/frameit/runner.rb
+++ b/frameit/lib/frameit/runner.rb
@@ -37,6 +37,12 @@ module Frameit
 
           begin
             screenshot = Screenshot.new(full_path, color)
+
+            if !screenshot.outdated? && Frameit.config[:resume]
+              UI.message("Skipping framing of screenshot #{screenshot.path} because its framed file seems up-to-date.")
+              next
+            end
+
             if screenshot.mac?
               editor = MacEditor.new(screenshot)
             else

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -119,6 +119,17 @@ module Frameit
       return self.landscape_left? || self.landscape_right
     end
 
+    def output_path
+      path.gsub('.png', '_framed.png').gsub('.PNG', '_framed.png')
+    end
+
+    # If the framed screenshot was generated *before* the screenshot file,
+    # then we must be outdated.
+    def outdated?
+      return true unless File.exist?(output_path)
+      return File.mtime(path) > File.mtime(output_path)
+    end
+
     def to_s
       self.path
     end


### PR DESCRIPTION
:key:

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`frameit` can be quite slow (#14626), taking around 10-20 seconds per screenshot sometimes. Sometimes, we just want to re-frame only a subset of the screenshots.

### Description

This PR adds a `--resume` flag to Frameit. When this flag is turned on, screenshots will be reframed only if the framed file doesn't exist yet _or_ if the framed file exists and is older than the screenshot.

This change is backward compatible because the `--resume` flag is false by default.