### PR TITLE
[deliver] fix ipad 3rd gen naming to prevent future collisions

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -32,7 +32,7 @@ module Deliver
       # iPad Pro
       IOS_IPAD_PRO = "iOS-iPad-Pro"
       # iPad Pro (12.9-inch) (3rd generation)
-      IOS_IPAD_PRO_12_9 = "iOS-iPad-Pro-12.9-3rd-gen"
+      IOS_IPAD_PRO_12_9 = "iOS-iPad-Pro-12.9"
 
       # iPhone 5 iMessage
       IOS_40_MESSAGES = "iOS-4-in-messages"
@@ -315,7 +315,7 @@ module Deliver
 
     def self.resolve_ipadpro_conflict_if_needed(screen_size, filename)
       is_3rd_gen = [
-        "(3rd generation)", # default simulator name has this
+        "iPad Pro (12.9-inch) (3rd generation)", # default simulator name has this
         "ipadPro129" # downloaded screenshots name has this
       ].any? { |key| filename.include?(key) }
       if is_3rd_gen

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -56,7 +56,7 @@ module Deliver
       # iPad Pro iMessage
       IOS_IPAD_PRO_MESSAGES = "iOS-iPad-Pro-messages"
       # iPad Pro (12.9-inch) (3rd generation) iMessage
-      IOS_IPAD_PRO_12_9_MESSAGES = "iOS-iPad-Pro-12.9-3rd-gen-messages"
+      IOS_IPAD_PRO_12_9_MESSAGES = "iOS-iPad-Pro-12.9-messages"
 
       # Apple Watch
       IOS_APPLE_WATCH = "iOS-Apple-Watch"

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -708,15 +708,11 @@ In this case, default values for keywords, urls, name and release notes are used
 
 [Starting March 20, 2019 Apple's App Store](https://developer.apple.com/news/?id=03202019a) requires 12.9-inch iPad Pro (3rd generation) screenshots additionally to the iPad Pro 2nd generation [screenshots](https://help.apple.com/app-store-connect/#/devd274dd925). As fastlane historically uses the screenshot dimensions to determine the "display family" of a screenshot, this poses a problem as both use the same dimensions and are recognized as the same device family.
 
-To solve this a screenshot of a 12.9-inch iPad Pro (3rd generation) must contain either the string `(3rd generation)` or `ipadPro129` (Apple's internal naming of the display family for the 3rd generation iPad Pro) in its filename to be assigned the correct display family and to be uploaded to the correct screenshot slot in your app's metadata.
+To solve this a screenshot of a 12.9-inch iPad Pro (3rd generation) must contain either the string `iPad Pro (12.9-inch) (3rd generation)` or `ipadPro129` (Apple's internal naming of the display family for the 3rd generation iPad Pro) in its filename to be assigned the correct display family and to be uploaded to the correct screenshot slot in your app's metadata.
 
 ## Automatically create screenshots
 
 If you want to integrate _deliver_ with [_snapshot_](https://docs.fastlane.tools/actions/snapshot/), check out [_fastlane_](https://fastlane.tools)!
-
-## Screenshot naming
-
-App Store Connect requires "iPad Pro (3rd Gen)" screenshots before submitting an app for review. For _deliver_ to know which screenshots to upload as "iPad Pro (3rd Gen)", the image must contain "iPad Pro (12.9-inch) (3rd generation)" in the name.
 
 ## Jenkins integration
 Detailed instructions about how to set up _deliver_ and _fastlane_ in `Jenkins` can be found in the [fastlane README](https://docs.fastlane.tools/best-practices/continuous-integration/#jenkins-integration).

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -714,6 +714,10 @@ To solve this a screenshot of a 12.9-inch iPad Pro (3rd generation) must contain
 
 If you want to integrate _deliver_ with [_snapshot_](https://docs.fastlane.tools/actions/snapshot/), check out [_fastlane_](https://fastlane.tools)!
 
+## Screenshot naming
+
+App Store Connect requires "iPad Pro (3rd Gen)" screenshots before submitting an app for review. For _deliver_ to know which screenshots to upload as "iPad Pro (3rd Gen)", the image must contain "iPad Pro (12.9-inch) (3rd generation)" in the name.
+
 ## Jenkins integration
 Detailed instructions about how to set up _deliver_ and _fastlane_ in `Jenkins` can be found in the [fastlane README](https://docs.fastlane.tools/best-practices/continuous-integration/#jenkins-integration).
 


### PR DESCRIPTION
### Description
- Finishes up some changes needed from https://github.com/fastlane/fastlane/pull/14576
- Removed `-3rd-gen` from the name
- More exact match on simulator name
