### PR TITLE
[action] app_store_build_number (and latest_testflight_build_number) don't raise error if using :initial_build_number

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -41,32 +41,32 @@ module Fastlane
           # Get version number from latest pre-release if no version number given
           client = Spaceship::ConnectAPI::Base.client
           version = client.get_pre_release_versions(filter: filter, sort: "-version", limit: 1).first
-          unless version
-            UI.user_error!("Could not find a build number for version #{version_number}")
-          end
+          if version
+            # Need pre_release_version_id for filtering build numbers
+            pre_release_version_id = version["id"]
+            version_number = version["attributes"]["version"]
 
-          # Need pre_release_version_id for filtering build numbers
-          pre_release_version_id = version["id"]
-          version_number = version["attributes"]["version"]
+            UI.message("Fetching the latest build number for version #{version_number}")
 
-          UI.message("Fetching the latest build number for version #{version_number}")
-
-          # Get latest build for version number
-          build = client.get_builds(filter: { app: app.apple_id, "preReleaseVersion" => pre_release_version_id }, sort: "-uploadedDate", limit: 1).first
-          if build
-            build_nr = build["attributes"]["version"]
-            build_nr
-          else
-            UI.important("Could not find a build number for version #{version_number} on App Store Connect")
+            # Get latest build for version number
+            build = client.get_builds(filter: { app: app.apple_id, "preReleaseVersion" => pre_release_version_id }, sort: "-uploadedDate", limit: 1).first
+            if build
+              build_nr = build["attributes"]["version"]
+              build_nr
+            else
+              UI.important("Could not find a build number for version #{version_number} on App Store Connect")
+            end
           end
 
           # Show error and set initial build number
-          unless build_nr
+          if build_nr
+            UI.message("Latest upload for version #{version_number} is build: #{build_nr}")
+          else
             UI.user_error!("Could not find a build on App Store Connect - and 'initial_build_number' option is not set") unless params[:initial_build_number]
             build_nr = params[:initial_build_number]
+            UI.message("Using initial build number of #{build_nr} for version #{version_number}")
           end
 
-          UI.message("Latest upload for version #{version_number} is build: #{build_nr}")
         end
 
         build_nr

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -61,8 +61,9 @@ module Fastlane
           # Show error and set initial build number
           if build_nr
             UI.message("Latest upload for version #{version_number} is build: #{build_nr}")
+          elsif params[:initial_build_number].nil?
+            UI.user_error!("Could not find a build on App Store Connect - and 'initial_build_number' option is not set")
           else
-            UI.user_error!("Could not find a build on App Store Connect - and 'initial_build_number' option is not set") unless params[:initial_build_number]
             build_nr = params[:initial_build_number]
             UI.message("Using initial build number of #{build_nr} for version #{version_number}")
           end


### PR DESCRIPTION
Fixes #14649
Fixes #14650

### Description
`app_store_build_number` now only fails if no version found **and** and not using `:initial_build_number`