### PR TITLE
[deliver] `download_screenshots`: write screenshots as binary

### DIFF
--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -41,7 +41,7 @@ module Deliver
             # if it's already there
           end
           path = File.join(containing_folder, file_name)
-          File.write(path, open(screenshot.url).read)
+          File.binwrite(path, open(screenshot.url).read)
         end
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`fastlane deliver download_screenshots` did not work on Windows.

### Description
Now it does by writing them as binary.
