### PR TITLE
[actions] New action `validate_play_store_json_key`

### DIFF
--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -1,0 +1,104 @@
+require 'supply/client'
+
+module Fastlane
+  module Actions
+    class ValidatePlayStoreJsonKeyAction < Action
+      def self.run(params)
+        FastlaneCore::PrintTable.print_values(
+          config: params,
+          mask_keys: [:json_key_data],
+          title: "Summary for validate_play_store_json_key"
+        )
+
+        client = Supply::Client.make_from_config(params: params)
+
+        FastlaneCore::UI.success("Successfully established connection to Google Play.")
+        FastlaneCore::UI.verbose("client: " + client.inspect)
+      end
+
+      def self.description
+        "Validate that the Play Store `json_key` works"
+      end
+
+      def self.authors
+        ["janpio"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        "Use this action to test and validate your json key file used to connect and authenticate with the Google Play API"
+      end
+
+      def self.example_code
+        [
+          "validate_play_store_json_key(
+            json_key: 'path/to/you/json/key/file'
+          )"
+        ]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :json_key,
+            env_name: "SUPPLY_JSON_KEY",
+            short_option: "-j",
+            conflicting_options: [:json_key_data],
+            optional: true, # this shouldn't be optional but is until I find out how json_key OR json_key_data can be required
+            description: "The path to a file containing service account JSON, used to authenticate with Google",
+            code_gen_sensitive: true,
+            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
+            default_value_dynamic: true,
+            verify_block: proc do |value|
+              UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+              UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :json_key_data,
+            env_name: "SUPPLY_JSON_KEY_DATA",
+            short_option: "-c",
+            conflicting_options: [:json_key],
+            optional: true,
+            description: "The raw service account JSON data used to authenticate with Google",
+            code_gen_sensitive: true,
+            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
+            default_value_dynamic: true,
+            verify_block: proc do |value|
+              begin
+                JSON.parse(value)
+              rescue JSON::ParserError
+                UI.user_error!("Could not parse service account json: JSON::ParseError")
+              end
+            end
+          ),
+          # stuff
+          FastlaneCore::ConfigItem.new(key: :root_url,
+            env_name: "SUPPLY_ROOT_URL",
+            description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/",
+            optional: true,
+            verify_block: proc do |value|
+              UI.user_error!("Could not parse URL '#{value}'") unless value =~ URI.regexp
+            end),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+            env_name: "SUPPLY_TIMEOUT",
+            optional: true,
+            description: "Timeout for read, open, and send (in seconds)",
+            type: Integer,
+            default_value: 300)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        [:android].include?(platform)
+      end
+
+      def self.category
+        :misc
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -18,7 +18,7 @@ module Fastlane
           UI.error("Could not establish a connection to Google Play Store with this json key file.")
           UI.error("#{e.message}\n#{e.backtrace.join("\n")}") if FastlaneCore::Globals.verbose?
         end
-        
+
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -18,7 +18,6 @@ module Fastlane
           UI.error("Could not establish a connection to Google Play Store with this json key file.")
           UI.error("#{e.message}\n#{e.backtrace.join("\n")}") if FastlaneCore::Globals.verbose?
         end
-
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -10,14 +10,19 @@ module Fastlane
           title: "Summary for validate_play_store_json_key"
         )
 
-        client = Supply::Client.make_from_config(params: params)
-
-        FastlaneCore::UI.success("Successfully established connection to Google Play.")
-        FastlaneCore::UI.verbose("client: " + client.inspect)
+        begin
+          client = Supply::Client.make_from_config(params: params)
+          FastlaneCore::UI.success("Successfully established connection to Google Play Store.")
+          FastlaneCore::UI.verbose("client: " + client.inspect)
+        rescue => e
+          UI.error("Could not establish a connection to Google Play Store with this json key file.")
+          UI.error("#{e.message}\n#{e.backtrace.join("\n")}") if FastlaneCore::Globals.verbose?
+        end
+        
       end
 
       def self.description
-        "Validate that the Play Store `json_key` works"
+        "Validate that the Google Play Store `json_key` works"
       end
 
       def self.authors
@@ -29,7 +34,7 @@ module Fastlane
       end
 
       def self.details
-        "Use this action to test and validate your json key file used to connect and authenticate with the Google Play API"
+        "Use this action to test and validate your private key json key file used to connect and authenticate with the Google Play API"
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -28,10 +28,6 @@ module Fastlane
         ["janpio"]
       end
 
-      def self.return_value
-        # If your method provides a return value, you can describe here what it does
-      end
-
       def self.details
         "Use this action to test and validate your private key json key file used to connect and authenticate with the Google Play API"
       end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -65,6 +65,7 @@ describe Fastlane do
           xcov
           create_app_on_managed_play_store
           download_from_play_store
+          validate_play_store_json_key
         )
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Using _supply_/`upload_to_play_store` requires a [setup step](https://docs.fastlane.tools/actions/supply/#setup) which includes a json file for authentication with Google Play Store. This is error prone and difficult to test without 

### Description
Implements `validate_play_store_json_key` that uses `Supply::client` to check if `json_key` can be used to establish a working connection to the Google Play API.

![image](https://user-images.githubusercontent.com/183673/56612024-8eefc200-6613-11e9-81d4-c78bc0988ada.png)
![image](https://user-images.githubusercontent.com/183673/56612041-9616d000-6613-11e9-8957-60a205ef29c2.png)

---

Related docs PR: https://github.com/fastlane/docs/pull/821



