### PR TITLE
[spaceship] require pathname needed when not using bundler and requiring spaceship directly

### DIFF
--- a/spaceship/lib/spaceship/module.rb
+++ b/spaceship/lib/spaceship/module.rb
@@ -1,4 +1,8 @@
 module Spaceship
+  # Requiring pathname is required here if not using bundler and requiring spaceship directly
+  # https://github.com/fastlane/fastlane/issues/14661
+  require 'pathname'
+
   ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
   DESCRIPTION = "Ruby library to access the Apple Dev Center and App Store Connect".freeze
 end


### PR DESCRIPTION
Fixes #14661

### Description

### Fails when
- _fastlane_ gem install directly without bundler
- requiring only `spaceship`
```
require 'spaceship'
puts "hey"
```

### Reason
This works if requiring `fastlane` or using `bundler` because `pathname` will end up getting required through `fastlane_core/helper` - https://github.com/fastlane/fastlane/blob/master/fastlane_core/lib/fastlane_core/helper.rb#L4 
