### PR TITLE
[Fastlane.swift] Slather: Change binaryFile data type from Bool to String?

### DIFF
--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -3250,7 +3250,7 @@ func slather(buildDirectory: String? = nil,
              verbose: Bool? = nil,
              useBundleExec: Bool = false,
              binaryBasename: Bool = false,
-             binaryFile: Bool = false,
+             binaryFile: String?,
              arch: String? = nil,
              sourceFiles: Bool = false,
              decimals: Bool = false) {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Slather --binary-file takes a string parameter defining the binary file path to analyze per Slather's documentation here: https://github.com/SlatherOrg/slather/blob/master/lib/slather/command/coverage_command.rb

Fastlane.swift expects binaryFile to be a boolean, with the default value set to false.  Setting to true adds the Slather command line --binary-file but does not include a binary file as a parameter.  Instead, Slather will consume the next space delimited value as the --binary-file value.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Changes Fastlane.swift Slather `binaryFile` data type from `Bool` to `String?` allows the user to provide a binary file path and a working Slather command.

Fixes #14674 
