### PR TITLE
[Circle CI] Use Xcode 9.0.1 instead of 9.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   "Execute tests on macOS":
     macos:
-      xcode: "9.0.0"
+      xcode: "9.0.1"
     environment:
       CIRCLE_TEST_REPORTS: ~/test-reports
       LC_ALL: en_US.UTF-8


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation

The difference between Xcode 9.0.0 and 9.0.1 is minimal but 9.0.1 is a little more recent and has a tiny bit fewer bugs.

Here’s the complete list of software installed in the Xcode 9.0.1 image on CircleCI: [link](https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-282/index.html).