### PR TITLE
[action] Fix latest testflight build number problems / expired build scenario

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -25,7 +25,7 @@ module Fastlane
         UI.message("Login successful")
 
         app = Spaceship::Tunes::Application.find(params[:app_identifier])
-        UI.user_error!("Could not find the app : #{params[:app_identifier]} on iTC") unless app
+        UI.user_error!("Could not find an app on App Store Connect with app_identifier: #{params[:app_identifier]}") unless app
         if params[:live]
           UI.message("Fetching the latest build number for live-version")
           UI.user_error!("Could not find a live-version of #{params[:app_identifier]} on iTC") unless app.live_version

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -48,14 +48,14 @@ module Fastlane
 
             UI.message("Fetching the latest build number for version #{version_number}")
 
-            # Get latest build for version number
-            build = client.get_builds(filter: { app: app.apple_id, "preReleaseVersion" => pre_release_version_id }, sort: "-uploadedDate", limit: 1).first
-            if build
-              build_nr = build["attributes"]["version"]
-              build_nr
-            else
-              UI.important("Could not find a build number for version #{version_number} on App Store Connect")
+            # Get latest build number for version number
+
+            builds = client.get_builds(filter: { "preReleaseVersion" => pre_release_version_id, expired: false, processingState: "PROCESSING,VALID" }, limit: 200, includes: "preReleaseVersion")
+            if builds.count == 0
+              builds = client.get_builds(filter: { "preReleaseVersion" => pre_release_version_id, expired: true, processingState: "PROCESSING,VALID" }, limit: 200, includes: "preReleaseVersion")
             end
+            build_nr = (builds.max_by { |k| k["attributes"]["version"].to_i }["attributes"]["version"]).to_i
+            UI.important("Could not find a build number for version #{version_number} on App Store Connect") unless build_nr
           end
 
           # Show error and set initial build number

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -49,7 +49,7 @@ module Fastlane
             UI.message("Fetching the latest build number for version #{version_number}")
 
             # Get latest build number for version number
-
+            # Check all non-expired builds, if none exists, then check expired builds
             builds = client.get_builds(filter: { "preReleaseVersion" => pre_release_version_id, expired: false, processingState: "PROCESSING,VALID" }, limit: 200, includes: "preReleaseVersion")
             if builds.count == 0
               builds = client.get_builds(filter: { "preReleaseVersion" => pre_release_version_id, expired: true, processingState: "PROCESSING,VALID" }, limit: 200, includes: "preReleaseVersion")

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -25,6 +25,7 @@ module Fastlane
         UI.message("Login successful")
 
         app = Spaceship::Tunes::Application.find(params[:app_identifier])
+        UI.user_error!("Could not find the app : #{params[:app_identifier]} on iTC") unless app
         if params[:live]
           UI.message("Fetching the latest build number for live-version")
           UI.user_error!("Could not find a live-version of #{params[:app_identifier]} on iTC") unless app.live_version

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -49,14 +49,14 @@ module Fastlane
 
             UI.message("Fetching the latest build number for version #{version_number}")
 
-            # Get latest build number for version number
-            # Check all non-expired builds, if none exists, then check expired builds
-            builds = client.get_builds(filter: { "preReleaseVersion" => pre_release_version_id, expired: false, processingState: "PROCESSING,VALID" }, limit: 200, includes: "preReleaseVersion")
-            if builds.count == 0
-              builds = client.get_builds(filter: { "preReleaseVersion" => pre_release_version_id, expired: true, processingState: "PROCESSING,VALID" }, limit: 200, includes: "preReleaseVersion")
+            # Get latest build for version number
+            build = client.get_builds(filter: { app: app.apple_id, "preReleaseVersion" => pre_release_version_id }, sort: "-version", limit: 1).first
+            if build
+              build_nr = build["attributes"]["version"]
+              build_nr
+            else
+              UI.important("Could not find a build number for version #{version_number} on App Store Connect")
             end
-            build_nr = (builds.max_by { |k| k["attributes"]["version"].to_i }["attributes"]["version"]).to_i
-            UI.important("Could not find a build number for version #{version_number} on App Store Connect") unless build_nr
           end
 
           # Show error and set initial build number


### PR DESCRIPTION
Fixed everything in this change. Also handled the expired build scenario too.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change is required to solve the latest testflight build number issue. There could be many issues related to this item. I am referring only one here.
 https://github.com/fastlane/fastlane/issues/14606

### Description
Instead of sorting it by uploaddate - as it wont work anymore, I am fetching all the builds response from Appstoreconnect API and fetching the max across the responses - to always get the latest testflight build number. First doing it with non-expired builds and then doing it with expired builds if there is no non-expired builds. This will solve all edge cases too.

 I tested it with my own account with an existing app - new version, existing version, by passing without any version. same test case repeated for the new app.
