### PR TITLE
[action] update_app_identifier fails to search for curly brace variables in Info.plist

### DIFF
--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -14,14 +14,16 @@ module Fastlane
         plist = Plist.parse_xml(info_plist_path)
 
         # Check if current app identifier product bundle identifier
-        if plist['CFBundleIdentifier'] == "$(#{identifier_key})"
+        app_id_equals_bundle_id = plist['CFBundleIdentifier'] == "$(#{identifier_key})"
+        app_id_equals_bundle_id ||= plist['CFBundleIdentifier'] == "${#{identifier_key}}"
+        if app_id_equals_bundle_id
           # Load .xcodeproj
           project_path = params[:xcodeproj]
           project = Xcodeproj::Project.open(project_path)
 
           # Fetch the build configuration objects
           configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
-          UI.user_error!("Info plist uses $(#{identifier_key}), but xcodeproj does not") unless configs.count > 0
+          UI.user_error!("Info plist uses #{identifier_key}, but xcodeproj does not") unless configs.count > 0
 
           configs = configs.select { |obj| resolve_path(obj.build_settings[info_plist_key], params[:xcodeproj]) == info_plist_path }
           UI.user_error!("Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.") unless configs.count > 0

--- a/fastlane/lib/fastlane/actions/update_app_identifier.rb
+++ b/fastlane/lib/fastlane/actions/update_app_identifier.rb
@@ -14,8 +14,7 @@ module Fastlane
         plist = Plist.parse_xml(info_plist_path)
 
         # Check if current app identifier product bundle identifier
-        app_id_equals_bundle_id = plist['CFBundleIdentifier'] == "$(#{identifier_key})"
-        app_id_equals_bundle_id ||= plist['CFBundleIdentifier'] == "${#{identifier_key}}"
+        app_id_equals_bundle_id = %W($(#{identifier_key}) ${#{identifier_key}}).include?(plist['CFBundleIdentifier'])
         if app_id_equals_bundle_id
           # Load .xcodeproj
           project_path = params[:xcodeproj]
@@ -23,10 +22,10 @@ module Fastlane
 
           # Fetch the build configuration objects
           configs = project.objects.select { |obj| obj.isa == 'XCBuildConfiguration' && !obj.build_settings[identifier_key].nil? }
-          UI.user_error!("Info plist uses #{identifier_key}, but xcodeproj does not") unless configs.count > 0
+          UI.user_error!("Info plist uses #{identifier_key}, but xcodeproj does not") if configs.empty?
 
           configs = configs.select { |obj| resolve_path(obj.build_settings[info_plist_key], params[:xcodeproj]) == info_plist_path }
-          UI.user_error!("Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.") unless configs.count > 0
+          UI.user_error!("Xcodeproj doesn't have configuration with info plist #{params[:plist_path]}.") if configs.empty?
 
           # For each of the build configurations, set app identifier
           configs.each do |c|

--- a/fastlane/spec/actions_specs/update_app_identifier_spec.rb
+++ b/fastlane/spec/actions_specs/update_app_identifier_spec.rb
@@ -78,6 +78,36 @@ describe Fastlane do
           expect(stub_settings_2['PRODUCT_BUNDLE_IDENTIFIER']).to_not(eq('com.test.plist'))
         end
 
+        it "updates the xcode project when product bundle identifier in use and it uses curly brackets notation" do
+          stub_project = 'stub project'
+          stub_configuration_1 = 'stub config 1'
+          stub_configuration_2 = 'stub config 2'
+          stub_object = ['object']
+          stub_settings_1 = Hash['PRODUCT_BUNDLE_IDENTIFIER', 'com.something.else']
+          stub_settings_1['INFOPLIST_FILE'] = plist_path
+          stub_settings_2 = Hash['PRODUCT_BUNDLE_IDENTIFIER', 'com.something.entirely.else']
+          stub_settings_2['INFOPLIST_FILE'] = "Other-Info.plist"
+
+          expect(Xcodeproj::Project).to receive(:open).with('/tmp/fastlane/tests/fastlane/bundle.xcodeproj').and_return(stub_project)
+          expect(stub_project).to receive(:objects).and_return(stub_object)
+          expect(stub_object).to receive(:select).and_return([stub_configuration_1, stub_configuration_2])
+          expect(stub_configuration_1).to receive(:build_settings).twice.and_return(stub_settings_1)
+          expect(stub_configuration_2).to receive(:build_settings).and_return(stub_settings_2)
+          expect(stub_project).to receive(:save)
+
+          create_plist_with_identifier("${#{identifier_key}}")
+          Fastlane::FastFile.new.parse("lane :test do
+            update_app_identifier({
+              xcodeproj: '#{xcodeproj}',
+              plist_path: '#{plist_path}',
+              app_identifier: '#{app_identifier}'
+            })
+          end").runner.execute(:test)
+
+          expect(stub_settings_1['PRODUCT_BUNDLE_IDENTIFIER']).to eq('com.test.plist')
+          expect(stub_settings_2['PRODUCT_BUNDLE_IDENTIFIER']).to_not(eq('com.test.plist'))
+        end
+
         it "updates the xcode project when info plist path contains $(SRCROOT)" do
           stub_project = 'stub project'
           stub_configuration_1 = 'stub config 1'
@@ -179,7 +209,7 @@ describe Fastlane do
               app_identifier: '#{app_identifier}'
             })
             end").runner.execute(:test)
-          end.to raise_error("Info plist uses $(#{identifier_key}), but xcodeproj does not")
+          end.to raise_error("Info plist uses #{identifier_key}, but xcodeproj does not")
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

> The update_app_identifier action does not properly detect all uses of PRODUCT_BUNDLE_IDENTIFIER in the Info.plist file. Older Xcode projects and many examples show curly braces being used for variables inside the Info.plist file like ${PRODUCT_BUNDLE_IDENTIFIER}. update_app_identifier only searches very specifically for parenthesis like $(PRODUCT_BUNDLE_IDENTIFIER) and fails to find the curly brace instance of this variable.

closes https://github.com/fastlane/fastlane/issues/14672

### Description
<!-- Describe your changes in detail -->

Added the support for curly brackets for product bundle identifier in `update_app_identifier` action. 

<img width="553" alt="Screen Shot 2019-04-26 at 16 01 47" src="https://user-images.githubusercontent.com/10795657/56813480-4e738c80-683d-11e9-9cbb-4e2d225e7163.png">

<!-- Please describe in detail how you tested your changes. -->

I added the new unit tests and did manual testing. 

<img width="595" alt="Screen Shot 2019-04-26 at 16 01 29" src="https://user-images.githubusercontent.com/10795657/56813506-5c291200-683d-11e9-9e86-a05bc1c81826.png">

I also performed regression tests and all seems to be good 👍 

💪 