### PR TITLE
[spaceship] class to handle JWT token generation for AppStore connect

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -91,6 +91,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('faraday', '~> 0.9') # Used for deploygate, hockey and testfairy actions
   spec.add_dependency('faraday_middleware', '~> 0.9') # same as faraday
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
+  spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.

--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -1,5 +1,6 @@
 require 'spaceship/connect_api/client'
 require 'spaceship/connect_api/base'
+require 'spaceship/connect_api/token'
 
 require 'spaceship/connect_api/models/model'
 require 'spaceship/connect_api/models/app'

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -1,0 +1,44 @@
+require 'jwt'
+require 'openssl'
+
+# extract pem from .p8
+# openssl pkcs8 -topk8 -outform PEM -in AuthKey.p8 -out key.pem -nocrypt
+
+# compute public key
+# openssl ec -in key.pem -pubout -out public_key.pem -aes256
+
+module Spaceship
+  module ConnectAPI
+    class Token
+      # maximum expiration supported by AppStore (20 minutes)
+      MAX_TOKEN_DURATION = 1200
+
+      attr_reader :key_id
+      attr_reader :issuer_id
+      attr_reader :text
+
+      def initialize(key_id: nil, issuer_id: nil, key: nil)
+        @expiration = Time.now + MAX_TOKEN_DURATION
+        @key_id = key_id
+        @key = key
+        @issuer_id = issuer_id
+
+        header = {
+          kid: key_id
+        }
+
+        payload = {
+          iss: issuer_id,
+          exp: @expiration.to_i,
+          aud: 'appstoreconnect-v1'
+        }
+
+        @text = JWT.encode(payload, key, 'ES256', header)
+      end
+
+      def expired?
+        @expiration < Time.now
+      end
+    end
+  end
+end

--- a/spaceship/spec/connect/token_spec.rb
+++ b/spaceship/spec/connect/token_spec.rb
@@ -1,0 +1,31 @@
+describe Spaceship::ConnectAPI::Token do
+  let(:key_id) { 'BA5176BF04' }
+  let(:issuer_id) { '693fbb20-54a0-4d94-88ce-8a6caf875439' }
+
+  context 'init' do
+    let(:private_key) do
+      key = OpenSSL::PKey::EC.new('prime256v1')
+      key.generate_key
+      key
+    end
+    let(:public_key) do
+      key = OpenSSL::PKey::EC.new(private_key)
+      key.private_key = nil
+      key
+    end
+
+    it 'generates proper token' do
+      token = Spaceship::ConnectAPI::Token.new(key_id: key_id, issuer_id: issuer_id, key: private_key)
+      expect(token.key_id).to eq(key_id)
+      expect(token.issuer_id).to eq(issuer_id)
+
+      payload, header = JWT.decode(token.text, public_key, true, { algorithm: 'ES256' })
+
+      expect(payload['iss']).to eq(issuer_id)
+      expect(payload['aud']).to eq('appstoreconnect-v1')
+      expect(payload['exp']).to be > Time.now.to_i
+
+      expect(header['kid']).to eq(key_id)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Adds support for JWT authentication required by AppStore Connect API
It will help addressing #12713

### Description
Created a `ConnectAPI::Token` class that manages generation of an JWT access token to authenticate with AppStore Connect API

I've validated it by using the class to generate a token using our combination of Private Key, Issuer ID, and Key ID, then run the curl command described at: https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests. The request succeeded.

One way I image the token could be used is that `ConnectAPI::Client` could have a `token` method that looks somewhat like this:
```ruby
def token
  if @token.nil? || @token.expired? 
    @token = Token.new(
      key_id: 'some-key-id-provided-by-user',
      issuer_id: 'some-issuer-id-provided-by-user',
      key: OpenSSL::PKey::EC.new(File.read('private-key-file-provided-by-user.pem'))
    ))
  end

  @token
end
```