### PR TITLE
[pilot] Trim leading zeros in app_version in wait_for_build_processing_to_be_complete

### DIFF
--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -120,6 +120,16 @@ describe FastlaneCore::BuildWatcher do
       expect(found_build).to eq(ready_build)
     end
 
+    it 'returns a ready to submit build with train_version and build_version truncated' do
+      expect(mock_base_api_client).to receive(:get_build_deliveries).and_return([])
+      expect(Spaceship::TestFlight::Build).to receive(:all).and_return([ready_build])
+
+      expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.train_version} - #{ready_build.build_version}")
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '01.00', build_version: '01')
+
+      expect(found_build).to eq(ready_build)
+    end
+
     #    it 'returns a export-compliance-missing build' do
     #      expect(Spaceship::TestFlight::Build).to receive(:all_processing_builds).and_return([])
     #      expect(Spaceship::TestFlight::Build).to receive(:latest).and_return(export_compliance_required_build)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Testflight truncates leading zeros in CFBundleShortVersionString and after wait_for_uploaded_build was deprecated, we can no longer get the original CFBundleShortVersionString.
To solve https://github.com/fastlane/fastlane/issues/13372#issuecomment-486729226

### Description
Compare app_version with leading zeros trimmed