### PR TITLE
Version bump to 2.122.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
 <td id='aaron-brager'>
 <a href='https://github.com/getaaron'>
@@ -51,31 +51,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-</tr>
-<tr>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
 <td id='matthew-ellis'>
 <a href='https://github.com/matthewellis'>
@@ -83,11 +63,19 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
+</tr>
+<tr>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 <td id='jan-piotrowski'>
 <a href='https://github.com/janpio'>
@@ -95,51 +83,25 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
-</tr>
-<tr>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
 <img src='https://github.com/milch.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/DanToml'>
-<img src='https://github.com/DanToml.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
 </tr>
 <tr>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
@@ -147,17 +109,55 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+</tr>
+<tr>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/DanToml'>
+<img src='https://github.com/DanToml.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/DanToml'>Danielle Tomlinson</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
 <td id='iulian-onofrei'>
 <a href='https://github.com/revolter'>
 <img src='https://github.com/revolter.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -16,25 +16,25 @@ Gem::Specification.new do |spec|
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
   spec.authors       = ["Jimmy Dee",
+                        "Kohki Miki",
                         "Iulian Onofrei",
                         "Matthew Ellis",
-                        "Stefan Natchev",
-                        "Kohki Miki",
-                        "Olivier Halligon",
-                        "Maksym Grebenets",
+                        "Luka Mirosevic",
                         "Fumiya Nakamura",
+                        "Felix Krause",
+                        "Stefan Natchev",
                         "Aaron Brager",
+                        "Olivier Halligon",
+                        "Joshua Liebowitz",
                         "Josh Holtz",
+                        "Helmut Januschka",
+                        "Andrew McBurney",
+                        "Maksym Grebenets",
+                        "Manu Wallner",
                         "Danielle Tomlinson",
                         "Jan Piotrowski",
-                        "Helmut Januschka",
-                        "Jérôme Lacoste",
-                        "Luka Mirosevic",
-                        "Felix Krause",
-                        "Joshua Liebowitz",
                         "Jorge Revuelta H",
-                        "Manu Wallner",
-                        "Andrew McBurney"]
+                        "Jérôme Lacoste"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.121.1'.freeze
+  VERSION = '2.122.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.121.1
+// Generated with fastlane 2.122.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -441,10 +441,14 @@ func badge(dark: String? = nil,
 }
 func buildAndUploadToAppetize(xcodebuild: [String : Any] = [:],
                               scheme: String? = nil,
-                              apiToken: String) {
+                              apiToken: String,
+                              publicKey: String? = nil,
+                              note: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "build_and_upload_to_appetize", className: nil, args: [RubyCommand.Argument(name: "xcodebuild", value: xcodebuild),
                                                                                                               RubyCommand.Argument(name: "scheme", value: scheme),
-                                                                                                              RubyCommand.Argument(name: "api_token", value: apiToken)])
+                                                                                                              RubyCommand.Argument(name: "api_token", value: apiToken),
+                                                                                                              RubyCommand.Argument(name: "public_key", value: publicKey),
+                                                                                                              RubyCommand.Argument(name: "note", value: note)])
   _ = runner.executeCommand(command)
 }
 func buildAndroidApp(task: String,
@@ -1176,7 +1180,8 @@ func createPullRequest(apiToken: String,
                        labels: [String]? = nil,
                        head: String? = nil,
                        base: String = "master",
-                       apiUrl: String = "https://api.github.com") {
+                       apiUrl: String = "https://api.github.com",
+                       assignees: [String]? = nil) {
   let command = RubyCommand(commandID: "", methodName: "create_pull_request", className: nil, args: [RubyCommand.Argument(name: "api_token", value: apiToken),
                                                                                                      RubyCommand.Argument(name: "repo", value: repo),
                                                                                                      RubyCommand.Argument(name: "title", value: title),
@@ -1184,7 +1189,8 @@ func createPullRequest(apiToken: String,
                                                                                                      RubyCommand.Argument(name: "labels", value: labels),
                                                                                                      RubyCommand.Argument(name: "head", value: head),
                                                                                                      RubyCommand.Argument(name: "base", value: base),
-                                                                                                     RubyCommand.Argument(name: "api_url", value: apiUrl)])
+                                                                                                     RubyCommand.Argument(name: "api_url", value: apiUrl),
+                                                                                                     RubyCommand.Argument(name: "assignees", value: assignees)])
   _ = runner.executeCommand(command)
 }
 func danger(useBundleExec: Bool = true,
@@ -3093,6 +3099,12 @@ func setPodKey(useBundleExec: Bool = true,
                                                                                              RubyCommand.Argument(name: "project", value: project)])
   _ = runner.executeCommand(command)
 }
+func setupCi(force: Bool = false,
+             provider: Bool = false) {
+  let command = RubyCommand(commandID: "", methodName: "setup_ci", className: nil, args: [RubyCommand.Argument(name: "force", value: force),
+                                                                                          RubyCommand.Argument(name: "provider", value: provider)])
+  _ = runner.executeCommand(command)
+}
 func setupCircleCi(force: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "setup_circle_ci", className: nil, args: [RubyCommand.Argument(name: "force", value: force)])
   _ = runner.executeCommand(command)
@@ -3250,7 +3262,7 @@ func slather(buildDirectory: String? = nil,
              verbose: Bool? = nil,
              useBundleExec: Bool = false,
              binaryBasename: Bool = false,
-             binaryFile: Bool = false,
+             binaryFile: String? = nil,
              arch: String? = nil,
              sourceFiles: Bool = false,
              decimals: Bool = false) {
@@ -3510,7 +3522,8 @@ func swiftlint(mode: String = "lint",
                ignoreExitStatus: Bool = false,
                reporter: String? = nil,
                quiet: Bool = false,
-               executable: String? = nil) {
+               executable: String? = nil,
+               format: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "swiftlint", className: nil, args: [RubyCommand.Argument(name: "mode", value: mode),
                                                                                            RubyCommand.Argument(name: "path", value: path),
                                                                                            RubyCommand.Argument(name: "output_file", value: outputFile),
@@ -3520,7 +3533,8 @@ func swiftlint(mode: String = "lint",
                                                                                            RubyCommand.Argument(name: "ignore_exit_status", value: ignoreExitStatus),
                                                                                            RubyCommand.Argument(name: "reporter", value: reporter),
                                                                                            RubyCommand.Argument(name: "quiet", value: quiet),
-                                                                                           RubyCommand.Argument(name: "executable", value: executable)])
+                                                                                           RubyCommand.Argument(name: "executable", value: executable),
+                                                                                           RubyCommand.Argument(name: "format", value: format)])
   _ = runner.executeCommand(command)
 }
 func syncCodeSigning(type: String = "development",
@@ -4093,6 +4107,16 @@ func uploadToTestflight(username: String,
                                                                                                       RubyCommand.Argument(name: "reject_build_waiting_for_review", value: rejectBuildWaitingForReview)])
   _ = runner.executeCommand(command)
 }
+func validatePlayStoreJsonKey(jsonKey: String? = nil,
+                              jsonKeyData: String? = nil,
+                              rootUrl: String? = nil,
+                              timeout: Int = 300) {
+  let command = RubyCommand(commandID: "", methodName: "validate_play_store_json_key", className: nil, args: [RubyCommand.Argument(name: "json_key", value: jsonKey),
+                                                                                                              RubyCommand.Argument(name: "json_key_data", value: jsonKeyData),
+                                                                                                              RubyCommand.Argument(name: "root_url", value: rootUrl),
+                                                                                                              RubyCommand.Argument(name: "timeout", value: timeout)])
+  _ = runner.executeCommand(command)
+}
 func verifyBuild(provisioningType: String? = nil,
                  provisioningUuid: String? = nil,
                  teamIdentifier: String? = nil,
@@ -4323,4 +4347,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.47]
+// FastlaneRunnerAPIVersion [0.9.48]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.121.1
+// Generated with fastlane 2.122.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.121.1
+// Generated with fastlane 2.122.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.121.1
+// Generated with fastlane 2.122.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.121.1
+// Generated with fastlane 2.122.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.121.1
+// Generated with fastlane 2.122.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.121.1
+// Generated with fastlane 2.122.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.121.1':**

* [action] Added `format` option to `swiftlint` action (#14643) via Bruno Guidolim
* [action] create_pull_request add assignees option (#14637) via Kaito Watanabe
* [action] increment_version_number: Allow version without patch number (#14615) via Dunya Kirkali
* [pilot] Trim leading zeros in app_version in wait_for_build_processing_to_be_complete (#14691) via Edward Lai
* [supply] add API error logging and spec for supply (#14695) via Stefan Natchev
* [action] slather: Change binaryFile data type from Bool to optional String (#14677) via Robert Bauer
* [tests] fix failing tests (#14702) via Josh Holtz
* [scan] spec_helper refactoring and fixing Scan tests (#14503) via Artem Sheremet
* [tests/ci] Test module import (#14668) via Viktoras Laukevičius
* [ci] Use Xcode 9.0.1 instead of 9.0.0 (#14679) via Alexey
* [actions] New action `validate_play_store_json_key` (#14659) via Jan Piotrowski
* [action] Fix latest testflight build number problems / expired build scenario (#14683) via Ram
* [action] dded public key and note parameters to BuildAndUploadToAppetize. (#14631) via DanAtApex
* [action] update_app_identifier fails to search for curly brace variables in Info.plist (#14687) via Daniel Jankowski
* [spaceship] Feature to troubleshoot to_json issues, related to #13608 (#14682) via Jerome Lacoste
* [rubocop] Add a new rule to prevent missing keys on the shared area provided by an action (#14610) via Daniel Jankowski
* [actions] extract shared code from setup_travis and setup_circle_ci actions (#14346) via Daniel Jankowski
* [action] Fix increment_build_number precondition issue (#14409) via Daniel Jankowski
* [spaceship] require pathname needed when not using bundler and requiring spaceship directly (#14667) via Josh Holtz
