### PR TITLE
[scan] reorganize order of operations for simulator management in scan action.

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -75,20 +75,12 @@ module Scan
                                      env_name: 'SCAN_FORCE_QUIT_SIMULATOR',
                                      description: "Enabling this option will automatically killall Simulator processes before the run",
                                      default_value: false,
-                                     type: Boolean,
-                                     conflicting_options: [:reinstall_app],
-                                     conflict_block: proc do |value|
-                                       UI.user_error!("You can't use 'force_quit_simulator' and 'reinstall_app' options in one run, the simulator will not be running to uninstall the app")
-                                     end),
+                                     type: Boolean),
         FastlaneCore::ConfigItem.new(key: :reset_simulator,
                                      env_name: 'SCAN_RESET_SIMULATOR',
                                      description: "Enabling this option will automatically erase the simulator before running the application",
                                      default_value: false,
-                                     type: Boolean,
-                                     conflicting_options: [:reinstall_app],
-                                     conflict_block: proc do |value|
-                                       UI.user_error!("You can't use 'reinstall_app' and 'reset_simulator' options in one run, the reset will uninstall the app too")
-                                     end),
+                                     type: Boolean),
         FastlaneCore::ConfigItem.new(key: :prelaunch_simulator,
                                      env_name: 'SCAN_PRELAUNCH_SIMULATOR',
                                      description: "Enabling this option will launch the first simulator prior to calling any xcodebuild command",
@@ -99,11 +91,7 @@ module Scan
                                      env_name: 'SCAN_REINSTALL_APP',
                                      description: "Enabling this option will automatically uninstall the application before running it",
                                      default_value: false,
-                                     type: Boolean,
-                                     conflicting_options: [:reset_simulator],
-                                     conflict_block: proc do |value|
-                                       UI.user_error!("You can't use 'reinstall_app' and 'reset_simulator' options in one run, the reset will uninstall the app too")
-                                     end),
+                                     type: Boolean),
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      env_name: 'SCAN_APP_IDENTIFIER',
                                      optional: true,

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -2,8 +2,8 @@ require 'fastlane_core/configuration/config_item'
 require 'credentials_manager/appfile_config'
 require_relative 'module'
 
+# rubocop:disable Metrics/ClassLength
 module Scan
-  # rubocop:disable Metrics/ClassLength
   class Options
     def self.verify_type(item_name, acceptable_types, value)
       type_ok = [Array, String].any? { |type| value.kind_of?(type) }
@@ -70,19 +70,40 @@ module Scan
                                      type: Boolean,
                                      optional: true),
 
-        # reset simulator
+        # simulator management
+        FastlaneCore::ConfigItem.new(key: :force_quit_simulator,
+                                     env_name: 'SCAN_FORCE_QUIT_SIMULATOR',
+                                     description: "Enabling this option will automatically killall Simulator processes before the run",
+                                     default_value: false,
+                                     type: Boolean,
+                                     conflicting_options: [:reinstall_app],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'force_quit_simulator' and 'reinstall_app' options in one run, the simulator will not be running to uninstall the app")
+                                     end),
         FastlaneCore::ConfigItem.new(key: :reset_simulator,
                                      env_name: 'SCAN_RESET_SIMULATOR',
                                      description: "Enabling this option will automatically erase the simulator before running the application",
                                      default_value: false,
+                                     type: Boolean,
+                                     conflicting_options: [:reinstall_app],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'reinstall_app' and 'reset_simulator' options in one run, the reset will uninstall the app too")
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :prelaunch_simulator,
+                                     env_name: 'SCAN_PRELAUNCH_SIMULATOR',
+                                     description: "Enabling this option will launch the first simulator prior to calling any xcodebuild command",
+                                     default_value: ENV['FASTLANE_EXPLICIT_OPEN_SIMULATOR'],
+                                     optional: true,
                                      type: Boolean),
-
-        # reinstall app
         FastlaneCore::ConfigItem.new(key: :reinstall_app,
                                      env_name: 'SCAN_REINSTALL_APP',
                                      description: "Enabling this option will automatically uninstall the application before running it",
                                      default_value: false,
-                                     is_string: false),
+                                     type: Boolean,
+                                     conflicting_options: [:reset_simulator],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'reinstall_app' and 'reset_simulator' options in one run, the reset will uninstall the app too")
+                                     end),
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      env_name: 'SCAN_APP_IDENTIFIER',
                                      optional: true,

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -23,12 +23,30 @@ module Scan
     end
 
     def test_app
+      force_quit_simulator_processes if Scan.config[:force_quit_simulator]
+
+      if Scan.config[:reset_simulator]
+        Scan.devices.each do |device|
+          FastlaneCore::Simulator.reset(udid: device.udid)
+        end
+      end
+
       # We call this method, to be sure that all other simulators are killed
       # And a correct one is freshly launched. Switching between multiple simulator
       # in case the user specified multiple targets works with no issues
       # This way it's okay to just call it for the first simulator we're using for
       # the first test run
-      open_simulator_for_device(Scan.devices.first) if Scan.devices
+      FastlaneCore::Simulator.launch(Scan.devices.first) if Scan.devices && Scan.config[:prelaunch_simulator]
+
+      if Scan.config[:reinstall_app]
+        app_identifier = Scan.config[:app_identifier]
+        app_identifier ||= UI.input("App Identifier: ")
+
+        Scan.devices.each do |device|
+          FastlaneCore::Simulator.uninstall_app(app_identifier, device.name, device.udid)
+        end
+      end
+
       command = @test_command_generator.generate
       prefix_hash = [
         {
@@ -39,19 +57,6 @@ module Scan
         }
       ]
       exit_status = 0
-
-      if Scan.config[:reset_simulator]
-        Scan.devices.each do |device|
-          FastlaneCore::Simulator.reset(udid: device.udid)
-        end
-      elsif Scan.config[:reinstall_app]
-        app_identifier = Scan.config[:app_identifier]
-        app_identifier ||= UI.input("App Identifier: ")
-
-        Scan.devices.each do |device|
-          FastlaneCore::Simulator.uninstall_app(app_identifier, device.name, device.udid)
-        end
-      end
 
       FastlaneCore::CommandExecutor.execute(command: command,
                                           print_all: true,
@@ -160,13 +165,9 @@ module Scan
       end
     end
 
-    def open_simulator_for_device(device)
-      return unless FastlaneCore::Env.truthy?('FASTLANE_EXPLICIT_OPEN_SIMULATOR')
-
-      UI.message("Killing all running simulators")
-      `killall Simulator &> /dev/null`
-
-      FastlaneCore::Simulator.launch(device)
+    def force_quit_simulator_processes
+      # Silently execute and kill, verbose flags will show this command occurring
+      Fastlane::Actions.sh("killall Simulator &> /dev/null || true", log: false)
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Makes simulator management options behave as expected when used together. Suggested fix for: #14717 

### Description
- Move all simulator management operations to the start. 
- Add option and method to force quit simulators
- Add option conflicts so they reflect the `elsif` usage

Ran all automated tests. validated manually that the messaging from the issue did not occur.
