### PR TITLE
Just the tests from #14456

### DIFF
--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -240,4 +240,65 @@ describe "Build Manager" do
       end
     end
   end
+
+  describe "#upload" do
+    describe "uses Manager.login (which does spaceship login)" do
+      let(:fake_build_manager) { Pilot::BuildManager.new }
+      let(:upload_options) do
+        {
+          apple_id: 'mock_apple_id',
+          skip_waiting_for_build_processing: true,
+          ipa: 'foo'
+        }
+      end
+
+      before(:each) do
+        allow(fake_build_manager).to receive(:fetch_app_platform).and_return('ios')
+
+        fake_ipauploadpackagebuilder = double
+        allow(fake_ipauploadpackagebuilder).to receive(:generate).and_return(true)
+        allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
+
+        fake_itunestransporter = double
+        allow(fake_itunestransporter).to receive(:upload).and_return(true)
+        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+      end
+
+      it "NOT when skip_waiting_for_build_processing and apple_id are set" do
+        fake_build_manager.upload(upload_options)
+
+        # should not execute Manager.login (which does spaceship login)
+        expect(fake_build_manager).not_to receive(:login)
+      end
+
+      it "when skip_waiting_for_build_processing and apple_id are not set" do
+        # remove options that make login unnecessary
+        upload_options.delete(:apple_id)
+        upload_options.delete(:skip_waiting_for_build_processing)
+
+        # allow Manager.login method this time
+        expect(fake_build_manager).to receive(:login).at_least(:once)
+
+        # other stuff required to let `upload` work:
+
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_identifier).and_return("com.fastlane")
+        allow(fake_build_manager).to receive(:fetch_apple_id).and_return(123)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
+        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
+
+        fake_app = double
+        allow(fake_app).to receive(:apple_id).and_return(123)
+        allow(fake_build_manager).to receive(:app).and_return(fake_app)
+
+        fake_build = double
+        allow(fake_build).to receive(:train_version)
+        allow(fake_build).to receive(:build_version)
+        allow(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+        allow(fake_build_manager).to receive(:distribute)
+
+        fake_build_manager.upload(upload_options)
+      end
+    end
+  end
 end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -265,10 +265,10 @@ describe "Build Manager" do
       end
 
       it "NOT when skip_waiting_for_build_processing and apple_id are set" do
-        fake_build_manager.upload(upload_options)
-
         # should not execute Manager.login (which does spaceship login)
         expect(fake_build_manager).not_to(receive(:login))
+
+        fake_build_manager.upload(upload_options)
       end
 
       it "when skip_waiting_for_build_processing and apple_id are not set" do

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -268,7 +268,7 @@ describe "Build Manager" do
         fake_build_manager.upload(upload_options)
 
         # should not execute Manager.login (which does spaceship login)
-        expect(fake_build_manager).not_to receive(:login)
+        expect(fake_build_manager).not_to(receive(:login))
       end
 
       it "when skip_waiting_for_build_processing and apple_id are not set" do


### PR DESCRIPTION
This PR adds just the tests from #14456 to show that they would fail with the current implementation.

```
1) Build Manager #upload uses Manager.login (which does spaceship login) NOT when skip_waiting_for_build_processing and apple_id are set
     Failure/Error: fake_build_manager.upload(upload_options)

       (#<Pilot::BuildManager:0x00000009747968 @config={:apple_id=>"mock_apple_id", :skip_waiting_for_build_processing=>true, :ipa=>"foo"}>).login(no args)
           expected: 0 times with any arguments
           received: 1 time
     # ./pilot/lib/pilot/manager.rb:16:in `start'
     # ./pilot/lib/pilot/build_manager.rb:13:in `upload'
     # ./pilot/spec/build_manager_spec.rb:271:in `block (4 levels) in <top (required)>'
```

This test failure shows that currently `Manager.login` is always calles, not matter which options are set.