### PR TITLE
[spaceship] add a check in app_version.setup_screenshots to also check if there is an app_preview already uploaded

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -708,7 +708,7 @@ module Spaceship
       end
 
       def setup_screenshots
-        # Enable Scaling for all screen sizes that don't have at least one screenshot
+        # Enable Scaling for all screen sizes that don't have at least one screenshot or at least one trailer (app_preview)
         # We automatically disable scaling once we upload at least one screenshot
         language_details = raw_data_details.each do |current_language|
           language_details = (current_language["displayFamilies"] || {})["value"]

--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -713,8 +713,13 @@ module Spaceship
         language_details = raw_data_details.each do |current_language|
           language_details = (current_language["displayFamilies"] || {})["value"]
           (language_details || []).each do |device_language_details|
+            # Do not enable scaling if a screenshot already exists
             next if device_language_details["screenshots"].nil?
             next if device_language_details["screenshots"]["value"].count > 0
+
+            # Do not enable scaling if a trailer already exists
+            next if device_language_details["trailers"].nil?
+            next if device_language_details["trailers"]["value"].count > 0
 
             # The current row includes screenshots for all device types
             # so we need to enable scaling for both iOS and watchOS apps


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When trying to do any update, fastlane will first update the `scaled` flags of the display_families to `true` **unless** they have a screenshot. This doesn't take in account that a trailer (app preview) might be present instead. As a result, the `scaled` flag is set to `true` for said display_family and upon saving, the server complains that *Your app preview can't be uploaded because you have selected to use an app preview from a larger display size*.

This happens when a user tries to do a deliver, even with the `skip_screenshots` flags set to `true`. And that is because Fastlane will send the whole configuration again in order to update any part of it. The prerequisites are that there should be **only video previews** in a display_family that can be set as scalable. It might also happen if the `overwrite_screenshots` flag is also set to `true`.

### Description
There is one more check added to check if the `trailers` key is present and the `value` key of it has contents.
