### PR TITLE
[snapshot] Get rid of Xcode 10.2 / SwiftLint warnings

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -70,7 +70,7 @@ open class Snapshot: NSObject {
     }
 
     open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
-        
+
         Snapshot.app = app
         Snapshot.waitForAnimations = waitForAnimations
 
@@ -81,16 +81,16 @@ open class Snapshot: NSObject {
             setLocale(app)
             setLaunchArguments(app)
         } catch let error {
-            print(error)
+            NSLog(error.localizedDescription)
         }
     }
 
     class func setLanguage(_ app: XCUIApplication) {
         guard let cacheDirectory = self.cacheDirectory else {
-            print("CacheDirectory is not set - probably running on a physical device?")
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
             return
         }
-        
+
         let path = cacheDirectory.appendingPathComponent("language.txt")
 
         do {
@@ -98,29 +98,29 @@ open class Snapshot: NSObject {
             deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
             app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
         } catch {
-            print("Couldn't detect/set language...")
+            NSLog("Couldn't detect/set language...")
         }
     }
 
     class func setLocale(_ app: XCUIApplication) {
         guard let cacheDirectory = self.cacheDirectory else {
-            print("CacheDirectory is not set - probably running on a physical device?")
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
             return
         }
-        
+
         let path = cacheDirectory.appendingPathComponent("locale.txt")
 
         do {
             let trimCharacterSet = CharacterSet.whitespacesAndNewlines
             locale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
         } catch {
-            print("Couldn't detect/set locale...")
+            NSLog("Couldn't detect/set locale...")
         }
-        
+
         if locale.isEmpty && !deviceLanguage.isEmpty {
             locale = Locale(identifier: deviceLanguage).identifier
         }
-        
+
         if !locale.isEmpty {
             app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
         }
@@ -128,10 +128,10 @@ open class Snapshot: NSObject {
 
     class func setLaunchArguments(_ app: XCUIApplication) {
         guard let cacheDirectory = self.cacheDirectory else {
-            print("CacheDirectory is not set - probably running on a physical device?")
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
             return
         }
-        
+
         let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
         app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
 
@@ -144,7 +144,7 @@ open class Snapshot: NSObject {
             }
             app.launchArguments += results
         } catch {
-            print("Couldn't detect/set launch_arguments...")
+            NSLog("Couldn't detect/set launch_arguments...")
         }
     }
 
@@ -153,7 +153,7 @@ open class Snapshot: NSObject {
             waitForLoadingIndicatorToDisappear(within: timeout)
         }
 
-        print("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
+        NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
 
         if Snapshot.waitForAnimations {
             sleep(1) // Waiting for the animation to be finished (kind of)
@@ -161,18 +161,18 @@ open class Snapshot: NSObject {
 
         #if os(OSX)
             guard let app = self.app else {
-                print("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
                 return
             }
 
             app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
-            
+
             guard let app = self.app else {
-                print("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
                 return
             }
-            
+
             let window = app.windows.firstMatch
             let screenshot = window.screenshot()
             guard let simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
@@ -180,8 +180,8 @@ open class Snapshot: NSObject {
             do {
                 try screenshot.pngRepresentation.write(to: path)
             } catch let error {
-                print("Problem writing screenshot: \(name) to \(path)")
-                print(error)
+                NSLog("Problem writing screenshot: \(name) to \(path)")
+                NSLog(error.localizedDescription)
             }
         #endif
     }
@@ -192,7 +192,7 @@ open class Snapshot: NSObject {
         #endif
 
         guard let app = self.app else {
-            print("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
             return
         }
 
@@ -295,4 +295,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.15]
+// SnapshotHelperVersion [1.16]


### PR DESCRIPTION
Changed ‘print’ calls to call NSLog

Changed printouts of error to printing out error.localizedDescription

Upgraded SnashotHelper.swift file version number to 1.16

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass (See Note in Details Section)
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Generated SnapshotHelper.swift code file produces warnings when compiled under XCode 10.2 and SwiftLint. This pull request fixes all of those warnings.

### Description
The generated SnapshotHelper.swift has a compiler warning under XCode 10.2 (error verses error.localizeDescription).

These changes also address warnings output from SwiftLint about not using "print"


When Executing  `bundle exec rspec`, received 1 failure. BUT, this failure was NOT in a section of code that I touched.

```
Failures:

  1) Fastlane Fastlane::FastFile OCLint Integration works with both select and exclude regex
     Failure/Error: expect(result).not_to(include('Test'))
       expected "cd /Users/johnwolfe/Testing/fastlane && oclint -report-type=html -o=oclint_report.html -p ./fastlane...ane/spec/fixtures/oclint/src/DetailViewController.m\" \"fastlane/spec/fixtures/oclint/src/Model.m\"" not to include "Test"
     # ./fastlane/spec/actions_specs/oclint_spec.rb:127:in `block (4 levels) in <top (required)>'

Finished in 3 minutes 47.8 seconds (files took 3.86 seconds to load)
5785 examples, 1 failure

Failed examples:

rspec ./fastlane/spec/actions_specs/oclint_spec.rb:117 # Fastlane Fastlane::FastFile OCLint Integration works with both select and exclude regex
```