### PR TITLE
[action] add :binary_files to slather action to handle multiple files

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -29,7 +29,9 @@ module Fastlane
           configuration: '--configuration',
           workspace: '--workspace',
           binary_file: '--binary-file',
+          binary_files: '--binary-file',
           binary_basename: '--binary-basename',
+          binary_basenames: '--binary-basename',
           arch: '--arch',
           source_files: '--source-files',
           decimals: '--decimals'
@@ -259,12 +261,44 @@ module Fastlane
                                        env_name: "FL_SLATHER_BINARY_BASENAME",
                                        description: "Basename of the binary file, this should match the name of your bundle excluding its extension (i.e. YourApp [for YourApp.app bundle])",
                                        is_string: false,
-                                       default_value: false),
+                                       optional: true,
+                                       conflicting_options: [:binary_basenames],
+                                       verify_block: proc do |value|
+                                         if value.kind_of?(Array)
+                                           UI.deprecated(":binary_basename will only accept a String in the future. Please migrate over to using :binary_basenames")
+                                         end
+                                       end,
+                                       conflict_block: proc do |value|
+                                         UI.user_error!("You can't use 'binary_basename' and 'binary_basenames' options in one run")
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :binary_basenames,
+                                       env_name: "FL_SLATHER_BINARY_BASENAMES",
+                                       description: "Basenames of the binary files, this should match the name of your bundle excluding its extension (i.e. YourApp [for YourApp.app bundle])",
+                                       optional: true,
+                                       type: Array,
+                                       conflicting_options: [:binary_basename],
+                                       conflict_block: proc do |value|
+                                         UI.user_error!("You can't use 'binary_basename' and 'binary_basenames' options in one run")
+                                       end),
           FastlaneCore::ConfigItem.new(key: :binary_file,
                                        env_name: "FL_SLATHER_BINARY_FILE",
-                                       description: "Binary file name to be used for code coverage",
+                                       description: "Binary file against the which the coverage will be run",
                                        skip_type_validation: true, # skipping validation for backwards compatibility with Boolean type
-                                       optional: true),
+                                       type: String,
+                                       optional: true,
+                                       conflicting_options: [:binary_files],
+                                       conflict_block: proc do |value|
+                                         UI.user_error!("You can't use 'binary_file' and 'binary_files' options in one run")
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :binary_files,
+                                       env_name: "FL_SLATHER_BINARY_FILES",
+                                       description: "Binary files against the which the coverage will be run",
+                                       optional: true,
+                                       type: Array,
+                                       conflicting_options: [:binary_file],
+                                       conflict_block: proc do |value|
+                                         UI.user_error!("You can't use 'binary_file' and 'binary_files' options in one run")
+                                       end),
           FastlaneCore::ConfigItem.new(key: :arch,
                                        env_name: "FL_SLATHER_ARCH",
                                        description: "Specify which architecture the binary file is in. Needed for universal binaries",


### PR DESCRIPTION
Fixes #14747

### Description
- `:binary_file` used to except any type (which is not great for doc and for Fastlane.swift)
  - A previous PR fixed this but introduced a regression (which was undocumented) but allowing only a `String`
- Introduced both a new `:binary_files` and `binary_basenames` which accepts arrays
- Put a deprecation notice in `binary_basename` when an `Array` is passed in to start migrating to `:binary_basenames`
