### PR TITLE
[supply] Change default track from production to internal

### DIFF
--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -18,7 +18,7 @@ module Supply
                                      short_option: "-a",
                                      env_name: "SUPPLY_TRACK",
                                      description: "The track of the application to use. The default available tracks are: #{default_tracks.join(', ')}",
-                                     default_value: 'production'),
+                                     default_value: 'internal'),
         FastlaneCore::ConfigItem.new(key: :rollout,
                                      short_option: "-r",
                                      description: "The percentage of the user fraction when uploading to the rollout track",


### PR DESCRIPTION
Change default track value to `internal` to mitigate accidentally releasing an APK to production.

Google presently doesn't allow the cancellation of a `Full Rollout` meaning that the default track `production` can not be cancelled, if the script was run in error.

I believe it would be best to require the developer to force the track to production, therefore explicating giving acknowledgement that this behaviour will occur.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
While trying to debug a problem with Supply, I accidentally released an app to production. I think it would be better to mitigating this problem by setting the default value to `internal`
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
I've changed the default from `Production` to `Internal`
<!-- Please describe in detail how you tested your changes. -->