### PR TITLE
[screengrab] Add config to allow disabling timestamp suffix to filename 

### DIFF
--- a/screengrab/lib/screengrab/module.rb
+++ b/screengrab/lib/screengrab/module.rb
@@ -23,4 +23,5 @@ module Screengrab
   Boolean = Fastlane::Boolean
   ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
   DESCRIPTION = "Automated localized screenshots of your Android app on every device".freeze
+  Boolean = Fastlane::Boolean
 end

--- a/screengrab/lib/screengrab/module.rb
+++ b/screengrab/lib/screengrab/module.rb
@@ -23,5 +23,4 @@ module Screengrab
   Boolean = Fastlane::Boolean
   ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
   DESCRIPTION = "Automated localized screenshots of your Android app on every device".freeze
-  Boolean = Fastlane::Boolean
 end

--- a/screengrab/lib/screengrab/options.rb
+++ b/screengrab/lib/screengrab/options.rb
@@ -132,6 +132,11 @@ module Screengrab
                                      env_name: 'SCREENGRAB_REINSTALL_APP',
                                      description: "Enabling this option will automatically uninstall the application before running it",
                                      default_value: false,
+                                     type: Boolean),
+        FastlaneCore::ConfigItem.new(key: :use_timestamp_suffix,
+                                     env_name: 'SCREENGRAB_USE_TIMESTAMP_SUFFIX',
+                                     description: "Add timestamp suffix to screenshot filename",
+                                     default_value: true,
                                      type: Boolean)
       ]
     end

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -264,6 +264,7 @@ module Screengrab
       instrument_command = ["adb -s #{device_serial} shell am instrument --no-window-animation -w",
                             "-e testLocale #{locale.tr('-', '_')}",
                             "-e endingLocale #{@config[:ending_locale].tr('-', '_')}"]
+      instrument_command << "-e appendTimestamp #{@config[:use_timestamp_suffix]}"
       instrument_command << "-e class #{test_classes_to_use.join(',')}" if test_classes_to_use
       instrument_command << "-e package #{test_packages_to_use.join(',')}" if test_packages_to_use
       instrument_command << launch_arguments.map { |item| '-e ' + item }.join(' ') if launch_arguments

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -264,7 +264,7 @@ module Screengrab
       instrument_command = ["adb -s #{device_serial} shell am instrument --no-window-animation -w",
                             "-e testLocale #{locale.tr('-', '_')}",
                             "-e endingLocale #{@config[:ending_locale].tr('-', '_')}"]
-      instrument_command << "-e appendTimestamp #{@config[:use_timestamp_suffix] == true}"
+      instrument_command << "-e appendTimestamp #{@config[:use_timestamp_suffix]}"
       instrument_command << "-e class #{test_classes_to_use.join(',')}" if test_classes_to_use
       instrument_command << "-e package #{test_packages_to_use.join(',')}" if test_packages_to_use
       instrument_command << launch_arguments.map { |item| '-e ' + item }.join(' ') if launch_arguments

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -264,7 +264,7 @@ module Screengrab
       instrument_command = ["adb -s #{device_serial} shell am instrument --no-window-animation -w",
                             "-e testLocale #{locale.tr('-', '_')}",
                             "-e endingLocale #{@config[:ending_locale].tr('-', '_')}"]
-      instrument_command << "-e appendTimestamp #{@config[:use_timestamp_suffix]}"
+      instrument_command << "-e appendTimestamp #{@config[:use_timestamp_suffix] == true}"
       instrument_command << "-e class #{test_classes_to_use.join(',')}" if test_classes_to_use
       instrument_command << "-e package #{test_packages_to_use.join(',')}" if test_packages_to_use
       instrument_command << launch_arguments.map { |item| '-e ' + item }.join(' ') if launch_arguments

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
@@ -3,8 +3,7 @@ package tools.fastlane.screengrab;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Build;
-import android.os.Environment;
-import android.support.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import android.util.Log;
 
 import java.io.BufferedOutputStream;

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.Environment;
+import android.support.test.InstrumentationRegistry;
 import android.util.Log;
 
 import java.io.BufferedOutputStream;
@@ -26,6 +27,7 @@ public class FileWritingScreenshotCallback implements ScreenshotCallback {
     protected static final String EXTENSION = ".png";
     private static final int FULL_QUALITY = 100;
     private static final String SCREENGRAB_DIR_NAME = "screengrab";
+    private static final String APPEND_TIMESTAMP_CONFIG_KEY = "appendTimestamp";
 
     private final Context appContext;
 
@@ -58,7 +60,9 @@ public class FileWritingScreenshotCallback implements ScreenshotCallback {
     }
 
     protected File getScreenshotFile(File screenshotDirectory, String screenshotName) {
-        String screenshotFileName = screenshotName + NAME_SEPARATOR + System.currentTimeMillis() + EXTENSION;
+        String screenshotFileName = screenshotName
+                + (shouldAppendTimestamp() ? (NAME_SEPARATOR + System.currentTimeMillis()) : "")
+                + EXTENSION;
         return new File(screenshotDirectory, screenshotFileName);
     }
 
@@ -123,5 +127,9 @@ public class FileWritingScreenshotCallback implements ScreenshotCallback {
             throw new IOException("Unable to create output dir: " + dir.getAbsolutePath());
         }
         Chmod.chmodPlusRWX(dir);
+    }
+
+    private static boolean shouldAppendTimestamp() {
+        return Boolean.parseBoolean(InstrumentationRegistry.getArguments().getString(APPEND_TIMESTAMP_CONFIG_KEY));
     }
 }

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -36,7 +36,7 @@ describe Screengrab::Runner do
       end
       it 'sets custom launch_arguments' do
         expect(mock_executor).to receive(:execute)
-          .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e username hjanuschka -e build_type x500 \\\n/"))
+          .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp false \\\n-e username hjanuschka -e build_type x500 \\\n/"))
         @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, config[:launch_arguments])
       end
     end

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -33,10 +33,11 @@ describe Screengrab::Runner do
         config[:launch_arguments] = ["username hjanuschka", "build_type x500"]
         config[:locales] = %w(en-US)
         config[:ending_locale] = 'en-US'
+        config[:use_timestamp_suffix] = true
       end
       it 'sets custom launch_arguments' do
         expect(mock_executor).to receive(:execute)
-          .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp false \\\n-e username hjanuschka -e build_type x500 \\\n/"))
+          .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp true \\\n-e username hjanuschka -e build_type x500 \\\n/"))
         @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, config[:launch_arguments])
       end
     end
@@ -74,6 +75,38 @@ describe Screengrab::Runner do
 
             @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
           end
+        end
+      end
+    end
+
+    context 'when using use_timestamp_suffix' do
+      context 'when set to false' do
+        before do
+          @runner = Screengrab::Runner.new(
+            mock_executor,
+            FastlaneCore::Configuration.create(Screengrab::Options.available_options, { use_timestamp_suffix: false }),
+            mock_android_environment
+          )
+        end
+        it 'sets appendTimestamp as false' do
+          expect(mock_executor).to receive(:execute)
+            .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp false \\\n/android.support.test.runner.AndroidJUnitRunner"))
+          @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
+        end
+      end
+
+      context 'use_timestamp_suffix is not specified' do
+        before do
+          @runner = Screengrab::Runner.new(
+            mock_executor,
+            FastlaneCore::Configuration.create(Screengrab::Options.available_options, {}),
+            mock_android_environment
+          )
+        end
+        it 'should set appendTimestamp by default' do
+          expect(mock_executor).to receive(:execute)
+            .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp true \\\n/android.support.test.runner.AndroidJUnitRunner"))
+          @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
         end
       end
     end

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -90,7 +90,7 @@ describe Screengrab::Runner do
         end
         it 'sets appendTimestamp as false' do
           expect(mock_executor).to receive(:execute)
-            .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp false \\\n/android.support.test.runner.AndroidJUnitRunner"))
+            .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp false \\\n/androidx.test.runner.AndroidJUnitRunner"))
           @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
         end
       end
@@ -105,7 +105,7 @@ describe Screengrab::Runner do
         end
         it 'should set appendTimestamp by default' do
           expect(mock_executor).to receive(:execute)
-            .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp true \\\n/android.support.test.runner.AndroidJUnitRunner"))
+            .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp true \\\n/androidx.test.runner.AndroidJUnitRunner"))
           @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
         end
       end


### PR DESCRIPTION
Implementing feature request in issue #14309

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See linked issue above - Adding a configuration so that user can opt out of appending timestamp to sceenshots produced by screengrab
### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Tested on example project in screengrab codebase by running bundle exec fastlane screengrab with appropriate parameters.