### PR TITLE
Drop MultiJson in favor of stdlib JSON

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -81,7 +81,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('highline', '>= 1.7.2', '< 2.0.0') # user inputs (e.g. passwords)
   spec.add_dependency('json', '< 3.0.0') # Because sometimes it's just not installed
   spec.add_dependency('mini_magick', '~> 4.5.1') # To open, edit and export PSD files
-  spec.add_dependency('multi_json') # Because sometimes it's just not installed
   spec.add_dependency('multi_xml', '~> 0.5')
   spec.add_dependency('rubyzip', '>= 1.2.2', '< 2.0.0') # fix swift/ipa in gym
   spec.add_dependency('security', '= 0.1.3') # macOS Keychain manager, a dead project, no updates expected

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -120,7 +120,7 @@ module Supply
           private_key: key.to_s,
           client_email: params[:issuer]
         }
-        service_account_json = StringIO.new(MultiJson.dump(cred_json))
+        service_account_json = StringIO.new(JSON.dump(cred_json))
         service_account_json
       else
         UI.user_error!("No authentication parameters were specified. These must be provided in order to authenticate with Google")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

JSON is part of the Ruby stdlib since 1.9.3 and fastlane uses `JSON` directly in many other places already.

JSON, on `master`:
```console
$ rg 'JSON\.' --stats --quiet

121 matches
120 matched lines
64 files contained matches
2227 files searched
```

`MultiJson` on `master` branch:
```console
$ rg 'multi.?json' --stats --quiet

2 matches
2 matched lines
2 files contained matches
2227 files searched
```

`MultiJson` on `ar/remove_multi_json` branch:
```console
$ rg 'multi.?json' --stats --quiet

0 matches
0 matched lines
0 files contained matches
2227 files searched
```

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

Simply removed the `multi_json` dependency and replaced a single `MultiJson` occurrence with `JSON`.
