### PR TITLE
[frameit] Add missing case for iPad Pro 12.9 (3rd Generation)

### DIFF
--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -47,6 +47,8 @@ module Frameit
         return 'iPad Air 2'
       when sizes::IOS_IPAD_PRO
         return 'iPad Pro'
+      when sizes::IOS_IPAD_PRO_12_9
+        return 'iPad Pro 3rd Generation'
       when sizes::MAC
         return 'MacBook'
       else

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -48,7 +48,7 @@ module Frameit
       when sizes::IOS_IPAD_PRO
         return 'iPad Pro'
       when sizes::IOS_IPAD_PRO_12_9
-        return 'iPad Pro 3rd Generation'
+        return 'iPad Pro (12.9-inch) (3rd generation)'
       when sizes::MAC
         return 'MacBook'
       else


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`fastlane` cannot frame screenshots with an asset named for the iPad Pro 3rd Generation.
Although some great ground work has already been completed in #14653 and  #14576, the `frameit` action was not able to use the disambiguation code to determine the device type. Instead I saw the error output:
`[12:42:35]: Unknown device type for size iOS-iPad-Pro-12.9 for path './en-US/iPad Pro (12.9-inch) (3rd generation)-2Deals.png'`

There is a related issue open #14713 

### Description
<!-- Describe your changes in detail -->
Adds the missing case for the newly added IOS_IPAD_PRO_12_9
<!-- Please describe in detail how you tested your changes. -->

After implementing the change, I ran the test suite.
After the test suit passed, I pointed our project to my local `fastlane` instance with the changes and ran our `fastlane` lane which generates the screen shots for our four selected devices and subsequently frames the screenshots and places them in our background. This completed the lane with the desired results including two iPad framed assets, one with the 2nd generation frame and the other with the 3rd generation frame which I have added to my `~/.fastlane/frameit/` 

Available from https://github.com/mikelrob/frameit-frames