### PR TITLE
[download_dsyms] show platform name during download

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -53,7 +53,7 @@ module Fastlane
 
         # Write a nice message
         message = []
-        message << "Looking for dSYM files for #{platform} #{params[:app_identifier]}"
+        message << "Looking for dSYM files for `#{params[:app_identifier]}` (platform: #{platform})"
         message << "v#{version}" if version
         message << "(#{build_number})" if build_number
         UI.message(message.join(" "))

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -53,7 +53,7 @@ module Fastlane
 
         # Write a nice message
         message = []
-        message << "Looking for dSYM files for `#{params[:app_identifier]}` (platform: #{platform})"
+        message << "Looking for dSYM files for '#{params[:app_identifier]}' on platform #{platform}"
         message << "v#{version}" if version
         message << "(#{build_number})" if build_number
         UI.message(message.join(" "))

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -53,7 +53,7 @@ module Fastlane
 
         # Write a nice message
         message = []
-        message << "Looking for dSYM files for #{params[:app_identifier]}"
+        message << "Looking for dSYM files for #{platform} #{params[:app_identifier]}"
         message << "v#{version}" if version
         message << "(#{build_number})" if build_number
         UI.message(message.join(" "))


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Easier debugging when looking at the logs. I have apps with the same bundle id, same version, same build number but one is ios and the other is appletvos.