### PR TITLE
[docs] deliver: Remove duplicate language list

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -489,7 +489,7 @@ Key | Editable While Live | Directory | Filename
 ## Reference
 
 <details>
-<summary>View all available categories, languages, etc.</summary>
+<summary>View all available categories, etc.</summary>
 
 ### Available Categories
 
@@ -590,37 +590,6 @@ You can always prefix the category using `MZGenre.` (e.g. `MZGenre.Book`). _deli
 - `MZGenre.Apps.Stickers.People`
 - `MZGenre.Apps.Stickers.Places`
 - `MZGenre.Apps.Stickers.Sports`
-
-### Available Languages
-
-- `da`
-- `de-DE`
-- `el`
-- `en-AU`
-- `en-CA`
-- `en-GB`
-- `en-US`
-- `es-ES`
-- `es-MX`
-- `fi`
-- `fr-CA`
-- `fr-FR`
-- `id`
-- `it`
-- `ja`
-- `ko`
-- `ms`
-- `nl-NL`
-- `no`
-- `pt-BR`
-- `pt-PT`
-- `ru`
-- `sv`
-- `th`
-- `tr`
-- `vi`
-- `zh-Hans`
-- `zh-Hant`
 
 ### Available age rating groups
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There are two language lists on https://docs.fastlane.tools/actions/deliver/. One is hardcoded and out of date, and the other is generated by a script. This PR removes the hardcoded one.

Fixes fastlane/docs#828