### PR TITLE
[CI] Download libiconv.exe to a temporary directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,10 @@ install:
   - set PATH=C:\Ruby24-x64\bin;%PATH%
   - bundle install
   # iconv
-  - appveyor DownloadFile https://downloads.sourceforge.net/project/gnuwin32/libiconv/1.9.2-1/libiconv-1.9.2-1.exe?download
-  - libiconv-1.9.2-1.exe /SILENT /SUPPRESSMSGBOXES
+  - appveyor DownloadFile
+    https://downloads.sourceforge.net/project/gnuwin32/libiconv/1.9.2-1/libiconv-1.9.2-1.exe?download
+    -FileName %TEMP%\libiconv.exe
+  - "%TEMP%\\libiconv.exe /SILENT /SUPPRESSMSGBOXES"
 
 environment:
   LC_ALL: en_US.UTF-8


### PR DESCRIPTION
Keep source tree clean.

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

During the build on AppVeyor, a file is downloaded into source code directory. This makes the directory unclean, and may interfere with tests.

### Description

Download libiconv to a temporary directory.

Documentation:
https://www.appveyor.com/docs/how-to/download-file/#appveyor-command-line-utility