### PR TITLE
[frameit] Fix iPhone XR black color (instead of Space Gray)

### DIFF
--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -59,8 +59,6 @@ module Frameit
       if !Frameit.config[:use_legacy_iphone6s] && @color == Frameit::Color::BLACK
         if @screen_size == Deliver::AppScreenshot::ScreenSize::IOS_55 || @screen_size == Deliver::AppScreenshot::ScreenSize::IOS_47
           return "Matte Black" # RIP space gray
-        elsif @screen_size == Deliver::AppScreenshot::ScreenSize::IOS_61
-          return "Black"
         end
       end
       return @color


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It fixes the problem with iPhone XR black edition and _frameit_ where it failed because the frame used was `Apple iPhone XR Black.png` instead `Apple iPhone XR Space Gray.png`.

It fixes #14590.

### Description
<!-- Describe your changes in detail -->
I removed the `elsif` condition that [shouldn't](https://github.com/fastlane/fastlane/pull/13774/files#r238531607) be here (introduced by #13774).

> I don't know how to add a test (don't know ruby), I'll need some help with it 😄 