### PR TITLE
[supply] Allow track rollout value to be 1.0

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -311,15 +311,12 @@ module Supply
       ensure_active_edit!
 
       track_version_codes = apk_version_code.kind_of?(Array) ? apk_version_code : [apk_version_code]
-
-      # This change happend on 2018-04-24
-      # rollout cannot be sent on any other track besides "rollout"
-      # https://github.com/fastlane/fastlane/issues/12372
-      rollout = nil unless track == "rollout"
+      staged_release = (track == "rollout" && rollout < 1.0)
 
       track_body = Androidpublisher::Track.new({
         track: track,
-        user_fraction: rollout,
+        user_fraction: staged_release ? rollout : nil,
+        status: staged_release ? "inProgress" : "completed",
         version_codes: track_version_codes
       })
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -64,10 +64,8 @@ module Supply
 
     def promote_track
       version_codes = client.track_version_codes(Supply.config[:track])
-      # the actual value passed for the rollout argument does not matter because it will be ignored by the Google Play API
-      # but it has to be between 0.0 and 1.0 to pass the validity check. So we are passing the default value 0.1
-      client.update_track(Supply.config[:track], 0.1, nil) if Supply.config[:deactivate_on_promote]
-      client.update_track(Supply.config[:track_promote_to], Supply.config[:rollout] || 0.1, version_codes)
+      client.update_track(Supply.config[:track], 1.0, nil) if Supply.config[:deactivate_on_promote]
+      client.update_track(Supply.config[:track_promote_to], Supply.config[:rollout] || 1.0, version_codes)
     end
 
     def upload_changelogs(language)

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -174,16 +174,16 @@ describe Supply do
         Supply.config = config
         allow(Supply::Client).to receive(:make_from_config).and_return(client)
         allow(client).to receive(:track_version_codes).and_return(version_codes)
-        allow(client).to receive(:update_track).with(config[:track], 0.1, nil)
-        allow(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes)
+        allow(client).to receive(:update_track).with(config[:track], 1.0, nil)
+        allow(client).to receive(:update_track).with(config[:track_promote_to], 1.0, version_codes)
       end
 
       context 'when deactivate_on_promote is true' do
         it 'should update track multiple times' do
           Supply.config[:deactivate_on_promote] = true
 
-          expect(client).to receive(:update_track).with(config[:track], 0.1, nil).once
-          expect(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes).once
+          expect(client).to receive(:update_track).with(config[:track], 1.0, nil).once
+          expect(client).to receive(:update_track).with(config[:track_promote_to], 1.0, version_codes).once
           subject
         end
       end
@@ -192,8 +192,8 @@ describe Supply do
         it 'should only update track once' do
           Supply.config[:deactivate_on_promote] = false
 
-          expect(client).not_to(receive(:update_track).with(config[:track], 0.1, nil))
-          expect(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes).once
+          expect(client).not_to(receive(:update_track).with(config[:track], 1.0, nil))
+          expect(client).to receive(:update_track).with(config[:track_promote_to], 1.0, version_codes).once
           subject
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

The default rollout value when updating a track via supply is 0.1 instead of 1.0. This was done because the value 1.0 was being rejected by the Google API. However, it is being rejected because the track's `status` property was not properly set to "completed". 

<!-- If it fixes an open issue, please link to the issue here. -->

This is the correct fix for [this issue](https://github.com/fastlane/fastlane/issues/6501).

### Description
<!-- Describe your changes in detail -->
* Sets the track status to "completed" if rollout value is 1.0.
* Restores the default rollout value to 1.0 since it will not work as expected.

<!-- Please describe in detail how you tested your changes. -->
In order to test these changes, we need to promote a build from a non-production track to the "rollout" track with a rollout value of 1.0. So either we get someone to try this change who needs to roll out an app soon, or the next time I roll out my app to production (likely within next 1-2 weeks) I can test this change myself.