### PR TITLE
[action] Add support for analyzer mode in SwiftLint

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -19,6 +19,7 @@ module Fastlane
         command << " --reporter #{params[:reporter]}" if params[:reporter]
         command << supported_option_switch(params, :quiet, "0.9.0", true)
         command << supported_option_switch(params, :format, "0.11.0", true) if params[:mode] == :autocorrect
+        command << " --compiler-log-path #{params[:compiler_log_path].shellescape}" if params[:compiler_log_path]
 
         if params[:files]
           if version < Gem::Version.new('0.5.1')
@@ -71,7 +72,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :mode,
-                                       description: "SwiftLint mode: :lint or :autocorrect",
+                                       description: "SwiftLint mode: :lint, :autocorrect or :analyze",
                                        is_string: false,
                                        default_value: :lint,
                                        optional: true),
@@ -124,7 +125,14 @@ module Fastlane
                                        default_value: false,
                                        is_string: false,
                                        type: Boolean,
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :compiler_log_path,
+                                       description: "Compiler log path when mode is :analyze",
+                                       is_string: true,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find compiler_log_path '#{File.expand_path(value)}'") unless File.exist?(value)
+                                       end)
         ]
       end
 

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -352,6 +352,33 @@ describe Fastlane do
           expect(result).to eq("swiftlint autocorrect")
         end
       end
+
+      context "when using analyzer mode" do
+        it "adds compiler-log-path option" do
+          path = "./spec/fixtures"
+          result = Fastlane::FastFile.new.parse("
+            lane :test do
+              swiftlint(
+                compiler_log_path: '#{path}',
+                mode: :analyze
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint analyze --compiler-log-path #{path}")
+        end
+
+        it "adds invalid path option" do
+          path = "./non/existent/path"
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              swiftlint(
+                compiler_log_path: '#{path}',
+                mode: :analyze
+              )
+            end").runner.execute(:test)
+          end.to raise_error(/Couldn't find compiler_log_path '.*#{path}'/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This adds support for the [analyze mode in SwiftLint](https://github.com/realm/SwiftLint#analyze-experimental).

### Description

Tested via unit tests.