### PR TITLE
[spaceship] Adding support for DEP_ID

### DIFF
--- a/spaceship/lib/spaceship/tunes/b2b_organization.rb
+++ b/spaceship/lib/spaceship/tunes/b2b_organization.rb
@@ -1,0 +1,50 @@
+require_relative 'tunes_base'
+module Spaceship
+  module Tunes
+    class B2bOrganization < TunesBase
+      # @return (String) add or remove
+      attr_accessor :type
+
+      # @return (String) customer id
+      attr_accessor :dep_customer_id
+
+      # @return (String) organization id
+      attr_accessor :dep_organization_id
+
+      # @return (String) organization name
+      attr_accessor :name
+
+      # enum for types
+      class TYPE
+        ADD = "ADD"
+        REMOVE = "REMOVE"
+        NO_CHANGE = "NO_CHANGE"
+      end
+
+      attr_mapping(
+        'value.type' => :type,
+        'value.depCustomerId' => :dep_customer_id,
+        'value.organizationId' => :dep_organization_id,
+        'value.name' => :name
+      )
+
+      def self.from_id_info(dep_id: nil, dep_org_id: nil, dep_name: nil, type: TYPE::NO_CHANGE)
+        self.new({ "value" => { "type" => type, "depCustomerId" => dep_id, "organizationId" => dep_org_id, "name" => dep_name } })
+      end
+
+      def ==(other)
+        other.class == self.class && other.state == self.state
+      end
+
+      def state
+        return [type, dep_customer_id, name]
+      end
+
+      alias eql? ==
+
+      def hash
+        state.hash
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -718,7 +718,7 @@ module Spaceship
       data["preOrder"]["clearedForPreOrder"] = { "value" => cleared_for_preorder, "isEditable" => true, "isRequired" => true, "errorKeys" => nil }
       data["preOrder"]["appAvailableDate"] = { "value" => app_available_date, "isEditable" => true, "isRequired" => true, "errorKeys" => nil }
       data["b2bUsers"] = availability.b2b_app_enabled ? availability.b2b_users.map { |user| { "value" => { "add" => user.add, "delete" => user.delete, "dsUsername" => user.ds_username } } } : []
-
+      data["b2bOrganizations"] = availability.b2b_app_enabled ? availability.b2b_organizations.map { |org| { "value" => { "type" => org.type, "depCustomerId" => org.dep_customer_id, "organizationId" => org.dep_organization_id, "name" => org.name } } } : []
       # send the changes back to Apple
       r = request(:post) do |req|
         req.url("ra/apps/#{app_id}/pricing/intervals")

--- a/spaceship/spec/tunes/availability_spec.rb
+++ b/spaceship/spec/tunes/availability_spec.rb
@@ -54,6 +54,15 @@ describe Spaceship::Tunes::Availability do
     end
   end
 
+  it "correctly parses b2b organizations" do
+    TunesStubbing.itc_stub_app_pricing_intervals_vpp
+    availability = client.availability(app.apple_id)
+    expect(availability.b2b_organizations.length).to eq(1)
+    b2b_org_0 = availability.b2b_organizations[0]
+    expect(b2b_org_0).not_to(be_nil)
+    expect(b2b_org_0.name).to eq('the best company')
+  end
+
   describe "update_availability!" do
     it "inspect works" do
       TunesStubbing.itc_stub_app_remove_territory

--- a/spaceship/spec/tunes/b2b_organization_spec.rb
+++ b/spaceship/spec/tunes/b2b_organization_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+# require_relative '../../../spaceship/lib/spaceship/tunes/b2b_organization'
+class B2bOrganizationSpec
+  describe Spaceship::Tunes::B2bOrganization do
+    before { Spaceship::Tunes.login }
+    before { TunesStubbing.itc_stub_app_pricing_intervals }
+
+    let(:client) { Spaceship::AppVersion.client }
+    let(:app) { Spaceship::Application.all.first }
+    let(:mock_client) { double('MockClient') }
+    let(:b2b_organization) do
+      Spaceship::Tunes::B2bOrganization.new(
+        'value' => {
+            'type' => "DELETE",
+            'depCustomerId' => 'abcdefgh',
+            'organizationId' => '1234567890',
+            'name' => 'My awesome company'
+        }
+      )
+    end
+    before do
+      allow(Spaceship::Tunes::TunesBase).to receive(:client).and_return(mock_client)
+      allow(mock_client).to receive(:team_id).and_return('')
+    end
+
+    describe 'b2b_organization' do
+      it 'parses the data correctly' do
+        expect(b2b_organization).to be_instance_of(Spaceship::Tunes::B2bOrganization)
+        expect(b2b_organization.type).to eq("DELETE")
+        expect(b2b_organization.dep_customer_id).to eq("abcdefgh")
+        expect(b2b_organization.dep_organization_id).to eq('1234567890')
+        expect(b2b_organization.name).to eq('My awesome company')
+      end
+    end
+
+    describe 'from_id_info' do
+      it 'creates correct object' do
+        b2b_org_created = Spaceship::Tunes::B2bOrganization.from_id_info(dep_id: 'jklmnopqr',
+                                                                         dep_name: 'Another awesome company',
+                                                                         type: Spaceship::Tunes::B2bOrganization::TYPE::ADD)
+        expect(b2b_org_created.type).to eq("ADD")
+        expect(b2b_org_created.dep_customer_id).to eq('jklmnopqr')
+        expect(b2b_org_created.name).to eq('Another awesome company')
+      end
+    end
+
+    describe '==' do
+      it 'works correctly' do
+        org1 = Spaceship::Tunes::B2bOrganization.new(
+          'value' => {
+              'type' => "DELETE",
+              'depCustomerId' => 'abcdefgh',
+              'organizationId' => '1234567890',
+              'name' => 'My awesome company'
+          }
+        )
+        org2 = Spaceship::Tunes::B2bOrganization.new(
+          'value' => {
+              'type' => "DELETE",
+              'depCustomerId' => 'abcdefgh',
+              'organizationId' => nil,
+              'name' => 'My awesome company'
+          }
+        )
+        org3 = Spaceship::Tunes::B2bOrganization.new(
+          'value' => {
+              'type' => "NO_CHANGE",
+              'depCustomerId' => 'abcdefgh',
+              'organizationId' => '1234567890',
+              'name' => 'My awesome company'
+          }
+        )
+
+        expect(org1 == org2).to eq(true)
+        expect(org1 != org2).to eq(false)
+        expect(org1 == org3).to eq(false)
+      end
+    end
+  end
+end

--- a/spaceship/spec/tunes/fixtures/app_pricing_intervals.json
+++ b/spaceship/spec/tunes/fixtures/app_pricing_intervals.json
@@ -72,6 +72,9 @@
     },
     "b2bUsers": [
 
+    ],
+    "b2bOrganizations": [
+
     ]
   },
   "messages": {

--- a/spaceship/spec/tunes/fixtures/app_pricing_intervals_b2b_flag_disabled.json
+++ b/spaceship/spec/tunes/fixtures/app_pricing_intervals_b2b_flag_disabled.json
@@ -72,6 +72,9 @@
     },
     "b2bUsers": [
 
+    ],
+    "b2bOrganizations": [
+
     ]
   },
   "messages": {

--- a/spaceship/spec/tunes/fixtures/app_pricing_intervals_b2b_included.json
+++ b/spaceship/spec/tunes/fixtures/app_pricing_intervals_b2b_included.json
@@ -1,13 +1,10 @@
 {
   "data": {
     "sectionErrorKeys": [
-
     ],
     "sectionInfoKeys": [
-
     ],
     "sectionWarningKeys": [
-
     ],
     "countriesChanged": false,
     "countries": [
@@ -50,46 +47,57 @@
     "unavailableDate": -2,
     "creatingApp": false,
     "hasApprovedVersion": false,
-    "preOrder":{  
-      "clearedForPreOrder":{  
-        "value":false,
-        "isEditable":true,
-        "isRequired":true,
-        "errorKeys":null
+    "preOrder": {
+      "clearedForPreOrder": {
+        "value": false,
+        "isEditable": true,
+        "isRequired": true,
+        "errorKeys": null
       },
-      "appAvailableDate":{  
-        "value":null,
-        "isEditable":true,
-        "isRequired":true,
-        "errorKeys":null
+      "appAvailableDate": {
+        "value": null,
+        "isEditable": true,
+        "isRequired": true,
+        "errorKeys": null
       },
-      "preOrderAvailableDate":null
+      "preOrderAvailableDate": null
     },
     "appVersionsForOTAByPlatforms": {
       "iOS": [
-
       ]
     },
     "b2bUsers": [
       {
         "value": {
-          "dsUsername":"b2b1@abc.com",
-          "delete":false,"add":false,
-          "company":"b2b1"
+          "dsUsername": "b2b1@abc.com",
+          "delete": false,
+          "add": false,
+          "company": "b2b1"
         },
-        "isEditable":true,
-        "isRequired":false,
-        "errorKeys":null
+        "isEditable": true,
+        "isRequired": false,
+        "errorKeys": null
       },
       {
         "value": {
-          "dsUsername":"b2b2@def.com",
-          "delete":false,"add":false,
-          "company":"b2b2"
+          "dsUsername": "b2b2@def.com",
+          "delete": false,
+          "add": false,
+          "company": "b2b2"
         },
-        "isEditable":true,
-        "isRequired":false,
-        "errorKeys":null
+        "isEditable": true,
+        "isRequired": false,
+        "errorKeys": null
+      }
+    ],
+    "b2bOrganizations": [
+      {
+        "value": {
+          "type": "ADD",
+          "depCustomerId": "123456",
+          "organizationId": null,
+          "name": "the best company"
+        }
       }
     ]
   },

--- a/spaceship/spec/tunes/fixtures/availability/add_request.json
+++ b/spaceship/spec/tunes/fixtures/availability/add_request.json
@@ -66,5 +66,8 @@
   },
   "b2bUsers": [
 
+  ],
+  "b2bOrganizations":[
+
   ]
 }

--- a/spaceship/spec/tunes/fixtures/availability/add_response.json
+++ b/spaceship/spec/tunes/fixtures/availability/add_response.json
@@ -79,6 +79,9 @@
     },
     "b2bUsers": [
 
+    ],
+    "b2bOrganizations": [
+
     ]
   },
   "messages": {

--- a/spaceship/spec/tunes/fixtures/availability/remove_request.json
+++ b/spaceship/spec/tunes/fixtures/availability/remove_request.json
@@ -60,5 +60,8 @@
   },
   "b2bUsers": [
 
+  ],
+  "b2bOrganizations": [
+
   ]
 }

--- a/spaceship/spec/tunes/fixtures/availability/remove_response.json
+++ b/spaceship/spec/tunes/fixtures/availability/remove_response.json
@@ -65,6 +65,9 @@
     },
     "b2bUsers": [
 
+    ],
+    "b2bOrganizations":[
+
     ]
   },
   "messages": {

--- a/spaceship/spec/tunes/fixtures/availability/set_preorder_cleared_request.json
+++ b/spaceship/spec/tunes/fixtures/availability/set_preorder_cleared_request.json
@@ -60,5 +60,8 @@
   },
   "b2bUsers": [
 
+  ],
+  "b2bOrganizations": [
+
   ]
 }

--- a/spaceship/spec/tunes/fixtures/availability/set_preorder_cleared_response.json
+++ b/spaceship/spec/tunes/fixtures/availability/set_preorder_cleared_response.json
@@ -65,6 +65,9 @@
     },
     "b2bUsers": [
 
+    ],
+    "b2bOrganizations" : [
+      
     ]
   },
   "messages": {

--- a/spaceship/spec/tunes/fixtures/availability/set_preorder_cleared_with_date_request.json
+++ b/spaceship/spec/tunes/fixtures/availability/set_preorder_cleared_with_date_request.json
@@ -60,5 +60,8 @@
   },
   "b2bUsers": [
 
+  ],
+  "b2bOrganizations":[
+
   ]
 }

--- a/spaceship/spec/tunes/fixtures/availability/set_preorder_cleared_with_date_response.json
+++ b/spaceship/spec/tunes/fixtures/availability/set_preorder_cleared_with_date_response.json
@@ -65,6 +65,9 @@
     },
     "b2bUsers": [
 
+    ],
+    "b2bOrganizations":[
+
     ]
   },
   "messages": {

--- a/spaceship/spec/tunes/fixtures/availability/uninclude_all_future_territories_request.json
+++ b/spaceship/spec/tunes/fixtures/availability/uninclude_all_future_territories_request.json
@@ -63,5 +63,8 @@
   },
   "b2bUsers": [
 
+  ],
+  "b2bOrganizations":[
+
   ]
 }

--- a/spaceship/spec/tunes/fixtures/availability/uninclude_all_future_territories_response.json
+++ b/spaceship/spec/tunes/fixtures/availability/uninclude_all_future_territories_response.json
@@ -79,6 +79,9 @@
     },
     "b2bUsers": [
 
+    ],
+    "b2bOrganizations":[
+
     ]
   },
   "messages": {

--- a/spaceship/spec/tunes/fixtures/update_price_tier/update_price_tier_request.json
+++ b/spaceship/spec/tunes/fixtures/update_price_tier/update_price_tier_request.json
@@ -56,5 +56,8 @@
   },
   "b2bUsers": [
 
+  ],
+  "b2bOrganizations":[
+
   ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change allows the DEP id to be updated in avaliability - this will be default in coming times instead of VPP id. 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
- Added the class `B2bOrganization` and added related parsing for it in `Availability` and `TunesClient`
- Added tests
- Updated test fixtures to work with the tests  