### PR TITLE
[action] fix app_store_build_number and latest_testflight_build_number when no version given

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -32,36 +32,42 @@ module Fastlane
           build_nr = app.live_version.current_build_number
 
           UI.message("Latest upload for live-version #{app.live_version.version} is build: #{build_nr}")
+
+          return build_nr
         else
           version_number = params[:version]
 
-          # Get version number from latest pre-release if no version number given
-          if version_number
-            UI.message("Fetching the latest build number for version #{version_number}")
+          # Used for determining how to display the optional version number
+          version_number_message = version_number.nil? ? "any version" : "version #{version_number}"
 
-            # Get latest build for version number
-            client = Spaceship::ConnectAPI::Base.client
-            build = client.get_builds(filter: { app: app.apple_id, "preReleaseVersion.version" => version_number }, sort: "-version", limit: 1).first
-            if build
-              build_nr = build.version
-            else
-              UI.important("Could not find a build number for version #{version_number} on App Store Connect")
-            end
+          # Create filter for get_builds with optional version number
+          filter = { app: app.apple_id }
+          if version_number
+            filter["preReleaseVersion.version"] = version_number
           end
 
-          # Show error and set initial build number
-          if build_nr
-            UI.message("Latest upload for version #{version_number} is build: #{build_nr}")
-          elsif params[:initial_build_number].nil?
+          UI.message("Fetching the latest build number for #{version_number_message}")
+
+          # Get latest build for optional version number and return build number if found
+          client = Spaceship::ConnectAPI::Base.client
+          build = client.get_builds(filter: filter, sort: "-version", includes: "preReleaseVersion", limit: 1).first
+          if build
+            build_nr = build.version
+            UI.message("Latest upload for version #{build.app_version} is build: #{build_nr}")
+            return build_nr
+          end
+
+          # Let user know that build couldn't be found
+          UI.important("Could not find a build for #{version_number_message} on App Store Connect")
+
+          if params[:initial_build_number].nil?
             UI.user_error!("Could not find a build on App Store Connect - and 'initial_build_number' option is not set")
           else
             build_nr = params[:initial_build_number]
-            UI.message("Using initial build number of #{build_nr} for version #{version_number}")
+            UI.message("Using initial build number of #{build_nr}")
+            return build_nr
           end
-
         end
-
-        build_nr
       end
 
       def self.order_versions(versions)

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -37,13 +37,13 @@ module Fastlane
         else
           version_number = params[:version]
 
-          # Used for determining how to display the optional version number
-          version_number_message = version_number.nil? ? "any version" : "version #{version_number}"
-
           # Create filter for get_builds with optional version number
           filter = { app: app.apple_id }
           if version_number
             filter["preReleaseVersion.version"] = version_number
+            version_number_message = "version #{version_number}"
+          else
+            version_number_message = "any version"
           end
 
           UI.message("Fetching the latest build number for #{version_number_message}")


### PR DESCRIPTION
### Motivation and Context
Fixes #14845 on more time 😊

### Description
- Need to support when `live:false` and `version: nil`
- Cleaned code up a bit to make it easier to follow with early and explicit returns
- Clearer `UI` messages when version is specified and when nil

#### Example
```
[15:18:39]: --------------------------------------------
[15:18:39]: --- Step: latest_testflight_build_number ---
[15:18:39]: --------------------------------------------
[15:18:40]: Login to App Store Connect (me@joshholtz.com)
[15:18:47]: Login successful
[15:18:48]: Fetching the latest build number for any version
[15:18:49]: Latest upload for version 1.1 is build: 259
[15:18:49]: any version value: 259
[15:18:49]: --------------------------------------------
[15:18:49]: --- Step: latest_testflight_build_number ---
[15:18:49]: --------------------------------------------
[15:18:49]: Login to App Store Connect (me@joshholtz.com)
[15:18:51]: Login successful
[15:18:52]: Fetching the latest build number for version 1.1
[15:18:52]: Latest upload for version 1.1 is build: 259
[15:18:52]: version 1.1 value: 259
[15:18:52]: --------------------------------------------
[15:18:52]: --- Step: latest_testflight_build_number ---
[15:18:52]: --------------------------------------------
[15:18:52]: Login to App Store Connect (me@joshholtz.com)
[15:18:54]: Login successful
[15:18:55]: Fetching the latest build number for version 1.4
[15:18:55]: Latest upload for version 1.4 is build: 230
[15:18:55]: version 1.4 value: 230
```
