### PR TITLE
[pilot] fix nil build metrics on pilot builds

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -157,7 +157,7 @@ module Pilot
         [
           build.app_version,
           build.version,
-          build.beta_build_metrics.map(&:install_count).reduce(:+)
+          (build.beta_build_metrics || []).map(&:install_count).reduce(:+)
         ]
       end
 


### PR DESCRIPTION
### Motivation and Context
Fixes #14856

### Description
`build.beta_build_metrics` can be `nil` if there aren't any
