### PR TITLE
Changed the sort value for when returning the list of builds from the …

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -50,7 +50,7 @@ module Fastlane
 
           # Get latest build for optional version number and return build number if found
           client = Spaceship::ConnectAPI::Base.client
-          build = client.get_builds(filter: filter, sort: "-version", includes: "preReleaseVersion", limit: 1).first
+          build = client.get_builds(filter: filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1).first
           if build
             build_nr = build.version
             UI.message("Latest upload for version #{build.app_version} is build: #{build_nr}")


### PR DESCRIPTION
…Connect API for TestFlight builds

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The ordering of the build was not valid when using a specific build number schema
Fixes: https://github.com/fastlane/fastlane/issues/14867

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
The initial flag '-version' works only if you use integer values for sorting the list of builds and their version numbers.
Seeing that my is not the standard integer but rather a string in a specific format, for some reason the -version flag was not working, so with changing the flag to '-uploadedDate' it will reorder the build list based on the data of upload which should be the same as the one before function wise, or in other words, it will always fetch the news/last/uploaded version from TestFlight.
