### PR TITLE
[action] Add xcodebuild_command option to scan action

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -376,14 +376,9 @@ module Scan
                                      conflicting_options: [:output_files],
                                      optional: true,
                                      is_string: true),
-        FastlaneCore::ConfigItem.new(key: :sonar_build_wrapper,
-                                      env_name: "GYM_SONAR_BUILD_WRAPPER",
-                                       description: "The path to the SonarQube build-wrapper executable",
-                                       type: String,
-                                       optional: true),
-        FastlaneCore::ConfigItem.new(key: :sonar_build_wrapper_output,
-                                    env_name: "GYM_SONAR_BUILD_WRAPPER_OUTPUT",
-                                    description: "The path to place the output from SonarQube's build-wrapper, requires a sonar build wrapper",
+        FastlaneCore::ConfigItem.new(key: :xcodebuild_command,
+                                    env_name: "GYM_XCODE_BUILD_COMMAND",
+                                    description: "Allows for override of the default `xcodebuild` command",
                                     type: String,
                                     optional: true)
 

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -375,7 +375,17 @@ module Scan
                                      deprecated: "Use `--output_files` instead",
                                      conflicting_options: [:output_files],
                                      optional: true,
-                                     is_string: true)
+                                     is_string: true),
+        FastlaneCore::ConfigItem.new(key: :sonar_build_wrapper,
+                                      env_name: "GYM_SONAR_BUILD_WRAPPER",
+                                       description: "The path to the SonarQube build-wrapper executable",
+                                       type: String,
+                                       optional: true),
+        FastlaneCore::ConfigItem.new(key: :sonar_build_wrapper_output,
+                                    env_name: "GYM_SONAR_BUILD_WRAPPER_OUTPUT",
+                                    description: "The path to place the output from SonarQube's build-wrapper, requires a sonar build wrapper",
+                                    type: String,
+                                    optional: true)
 
       ]
     end

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -380,7 +380,8 @@ module Scan
                                     env_name: "GYM_XCODE_BUILD_COMMAND",
                                     description: "Allows for override of the default `xcodebuild` command",
                                     type: String,
-                                    optional: true)
+                                    optional: true,
+                                    default_value: "env NSUnbufferedIO=YES xcodebuild")
 
       ]
     end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -4,8 +4,10 @@ module Scan
   # Responsible for building the fully working xcodebuild command
   class TestCommandGenerator
     def generate
+      Scan.config[:xcodebuild_command] ||= "env NSUnbufferedIO=YES xcodebuild"
+
       parts = prefix
-      parts << "xcodebuild"
+      parts << Scan.config[:xcodebuild_command]
       parts += options
       parts += actions
       parts += suffix
@@ -15,22 +17,7 @@ module Scan
     end
 
     def prefix
-      config = Scan.config
-
-      if config[:sonar_build_wrapper].to_s.length > 0 && config[:sonar_build_wrapper_output].to_s.length == 0
-        UI.user_error!("Cannot use sonar_build_wrapper option without a sonar_build_wrapper_output.")
-      end
-
-      if config[:sonar_build_wrapper_output].to_s.length > 0 && config[:sonar_build_wrapper].to_s.length == 0
-        UI.user_error!("Cannot use sonar_build_wrapper_output option without a sonar_build_wrapper.")
-      end
-
-      options = []
-      options << "set -o pipefail && env NSUnbufferedIO=YES"
-      options << config[:sonar_build_wrapper].shellescape.to_s if config[:sonar_build_wrapper]
-      options << "--out-dir #{config[:sonar_build_wrapper_output].shellescape}" if config[:sonar_build_wrapper_output]
-
-      options
+      ["set -o pipefail &&"]
     end
 
     # Path to the project or workspace as parameter

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -5,7 +5,7 @@ module Scan
   class TestCommandGenerator
     def generate
       parts = prefix
-      parts << "env NSUnbufferedIO=YES xcodebuild"
+      parts << "xcodebuild"
       parts += options
       parts += actions
       parts += suffix
@@ -26,9 +26,9 @@ module Scan
       end
 
       options = []
+      options << "set -o pipefail && env NSUnbufferedIO=YES"
       options << config[:sonar_build_wrapper].shellescape.to_s if config[:sonar_build_wrapper]
       options << "--out-dir #{config[:sonar_build_wrapper_output].shellescape}" if config[:sonar_build_wrapper_output]
-      options << "set -o pipefail &&"
 
       options
     end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -15,7 +15,22 @@ module Scan
     end
 
     def prefix
-      ["set -o pipefail &&"]
+      config = Scan.config
+
+      if config[:sonar_build_wrapper].to_s.length > 0 && config[:sonar_build_wrapper_output].to_s.length == 0
+        UI.user_error!("Cannot use sonar_build_wrapper option without a sonar_build_wrapper_output.")
+      end
+
+      if config[:sonar_build_wrapper_output].to_s.length > 0 && config[:sonar_build_wrapper].to_s.length == 0
+        UI.user_error!("Cannot use sonar_build_wrapper_output option without a sonar_build_wrapper.")
+      end
+
+      options = []
+      options << config[:sonar_build_wrapper].shellescape.to_s if config[:sonar_build_wrapper]
+      options << "--out-dir #{config[:sonar_build_wrapper_output].shellescape}" if config[:sonar_build_wrapper_output]
+      options << "set -o pipefail &&"
+
+      options
     end
 
     # Path to the project or workspace as parameter

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -4,8 +4,6 @@ module Scan
   # Responsible for building the fully working xcodebuild command
   class TestCommandGenerator
     def generate
-      Scan.config[:xcodebuild_command] ||= "env NSUnbufferedIO=YES xcodebuild"
-
       parts = prefix
       parts << Scan.config[:xcodebuild_command]
       parts += options

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -582,32 +582,26 @@ describe Scan do
     end
 
     describe "sonar_build_wrapper and sonar_build_wrapper-output" do
-      before do
-        options = { project: "./scan/examples/standard/app.xcodeproj" }
-        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-      end
-
       it "raises an error if `sonar_build_wrapper` was given but `sonar_build_wrapper_output` was missing" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(".")
         expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            scan(
-              project: './scan/examples/standard/app.xcodeproj',
-              sonar_build_wrapper: 'build-wrapper-macosx-x86-64',
-            )
-          end").runner.execute(:test)
+          options = {
+            project: "./scan/examples/standard/app.xcodeproj",
+            sonar_build_wrapper: "build-wrapper-macosx-x86-64"
+          }
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+          @test_command_generator.generate
         end.to raise_error("Cannot use sonar_build_wrapper option without a sonar_build_wrapper_output.")
       end
 
       it "raises an error if `sonar_build_wrapper_output` was given but `sonar_build_wrapper` was missing" do
-        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(".")
         expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            scan(
-              project: './scan/examples/standard/app.xcodeproj',
-              sonar_build_wrapper_output: 'bw_output',
-            )
-          end").runner.execute(:test)
+          options = {
+            project: "./scan/examples/standard/app.xcodeproj",
+            sonar_build_wrapper_output: "bw_output"
+          }
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+          @test_command_generator.generate
         end.to raise_error("Cannot use sonar_build_wrapper_output option without a sonar_build_wrapper.")
       end
 

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -106,8 +106,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-sdk '9.0'",
@@ -129,8 +129,8 @@ describe Scan do
 
       result = @test_command_generator.generate
       expect(result).to start_with([
-                                     "set -o pipefail &&",
-                                     "env NSUnbufferedIO=YES xcodebuild",
+                                     "set -o pipefail && env NSUnbufferedIO=YES",
+                                     "xcodebuild",
                                      "-scheme app",
                                      "-project ./scan/examples/standard/app.xcodeproj",
                                      "-sdk '9.0'",
@@ -169,8 +169,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -215,8 +215,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -300,8 +300,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -324,8 +324,8 @@ describe Scan do
         result = @test_command_generator.generate
 
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -347,8 +347,8 @@ describe Scan do
         result = @test_command_generator.generate
 
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -369,8 +369,8 @@ describe Scan do
         result = @test_command_generator.generate
 
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -392,8 +392,8 @@ describe Scan do
         result = @test_command_generator.generate
 
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -411,8 +411,8 @@ describe Scan do
 
       result = @test_command_generator.generate
       expect(result).to start_with([
-                                     "set -o pipefail &&",
-                                     "env NSUnbufferedIO=YES xcodebuild",
+                                     "set -o pipefail && env NSUnbufferedIO=YES",
+                                     "xcodebuild",
                                      "-scheme app",
                                      "-project ./scan/examples/standard/app.xcodeproj",
                                      # expect the single highest versioned iOS simulator device available with matching name
@@ -444,8 +444,8 @@ describe Scan do
         Scan.config[:build_for_testing] = true
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
@@ -458,8 +458,8 @@ describe Scan do
         Scan.config[:test_without_building] = true
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
@@ -485,8 +485,8 @@ describe Scan do
         Scan.config[:xctestrun] = "/folder/mytests.xctestrun"
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
@@ -506,8 +506,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
@@ -527,8 +527,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=70E1E92F-A292-4980-BC3C-7770C5EEFCFD' " \
@@ -548,8 +548,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail &&",
-                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "set -o pipefail && env NSUnbufferedIO=YES",
+                                       "xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=9905A018-9DC9-4DD8-BA14-B0B000CC8622'",
@@ -622,10 +622,10 @@ describe Scan do
 
           result = @test_command_generator.generate
           expect(result).to start_with([
+                                         "set -o pipefail && env NSUnbufferedIO=YES",
                                          "build-wrapper-macosx-x86-64",
                                          "--out-dir bw_output",
-                                         "set -o pipefail &&",
-                                         "env NSUnbufferedIO=YES xcodebuild",
+                                         "xcodebuild",
                                          "-scheme app",
                                          "-project ./scan/examples/standard/app.xcodeproj"
                                        ])

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -106,8 +106,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-sdk '9.0'",
@@ -129,8 +129,8 @@ describe Scan do
 
       result = @test_command_generator.generate
       expect(result).to start_with([
-                                     "set -o pipefail && env NSUnbufferedIO=YES",
-                                     "xcodebuild",
+                                     "set -o pipefail &&",
+                                     "env NSUnbufferedIO=YES xcodebuild",
                                      "-scheme app",
                                      "-project ./scan/examples/standard/app.xcodeproj",
                                      "-sdk '9.0'",
@@ -169,8 +169,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -215,8 +215,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -300,8 +300,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -324,8 +324,8 @@ describe Scan do
         result = @test_command_generator.generate
 
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -347,8 +347,8 @@ describe Scan do
         result = @test_command_generator.generate
 
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -369,8 +369,8 @@ describe Scan do
         result = @test_command_generator.generate
 
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -392,8 +392,8 @@ describe Scan do
         result = @test_command_generator.generate
 
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
@@ -411,8 +411,8 @@ describe Scan do
 
       result = @test_command_generator.generate
       expect(result).to start_with([
-                                     "set -o pipefail && env NSUnbufferedIO=YES",
-                                     "xcodebuild",
+                                     "set -o pipefail &&",
+                                     "env NSUnbufferedIO=YES xcodebuild",
                                      "-scheme app",
                                      "-project ./scan/examples/standard/app.xcodeproj",
                                      # expect the single highest versioned iOS simulator device available with matching name
@@ -444,8 +444,8 @@ describe Scan do
         Scan.config[:build_for_testing] = true
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
@@ -458,8 +458,8 @@ describe Scan do
         Scan.config[:test_without_building] = true
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
@@ -485,8 +485,8 @@ describe Scan do
         Scan.config[:xctestrun] = "/folder/mytests.xctestrun"
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
@@ -506,8 +506,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
@@ -527,8 +527,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=70E1E92F-A292-4980-BC3C-7770C5EEFCFD' " \
@@ -548,8 +548,8 @@ describe Scan do
 
         result = @test_command_generator.generate
         expect(result).to start_with([
-                                       "set -o pipefail && env NSUnbufferedIO=YES",
-                                       "xcodebuild",
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=9905A018-9DC9-4DD8-BA14-B0B000CC8622'",
@@ -581,49 +581,21 @@ describe Scan do
       end
     end
 
-    describe "sonar_build_wrapper and sonar_build_wrapper-output" do
-      it "raises an error if `sonar_build_wrapper` was given but `sonar_build_wrapper_output` was missing" do
-        expect do
-          options = {
-            project: "./scan/examples/standard/app.xcodeproj",
-            sonar_build_wrapper: "build-wrapper-macosx-x86-64"
-          }
-          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+    describe "Custom xcodebuild_command example" do
+      it "uses xcodebuild_command" do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          xcodebuild_command: "env NSUnbufferedIO=YES /usr/local/bin/build-wrapper-macosx-x86 --out-dir ./build/bw_output xcodebuild"
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
 
-          @test_command_generator.generate
-        end.to raise_error("Cannot use sonar_build_wrapper option without a sonar_build_wrapper_output.")
-      end
-
-      it "raises an error if `sonar_build_wrapper_output` was given but `sonar_build_wrapper` was missing" do
-        expect do
-          options = {
-            project: "./scan/examples/standard/app.xcodeproj",
-            sonar_build_wrapper_output: "bw_output"
-          }
-          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-          @test_command_generator.generate
-        end.to raise_error("Cannot use sonar_build_wrapper_output option without a sonar_build_wrapper.")
-      end
-
-      it "uses SonarCFamily for Objective-C wrapper" do
-        expect do
-          options = {
-            project: "./scan/examples/standard/app.xcodeproj",
-            sonar_build_wrapper: "build-wrapper-macosx-x86-64",
-            sonar_build_wrapper_output: "bw_output"
-          }
-          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-
-          result = @test_command_generator.generate
-          expect(result).to start_with([
-                                         "set -o pipefail && env NSUnbufferedIO=YES",
-                                         "build-wrapper-macosx-x86-64",
-                                         "--out-dir bw_output",
-                                         "xcodebuild",
-                                         "-scheme app",
-                                         "-project ./scan/examples/standard/app.xcodeproj"
-                                       ])
-        end
+        result = @test_command_generator.generate
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES /usr/local/bin/build-wrapper-macosx-x86 --out-dir ./build/bw_output xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj"
+                                     ])
       end
     end
   end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -582,7 +582,7 @@ describe Scan do
     end
 
     describe "Custom xcodebuild_command example" do
-      it "uses xcodebuild_command" do
+      it "uses xcodebuild_command", requires_xcodebuild: true do
         options = {
           project: "./scan/examples/standard/app.xcodeproj",
           xcodebuild_command: "env NSUnbufferedIO=YES /usr/local/bin/build-wrapper-macosx-x86 --out-dir ./build/bw_output xcodebuild"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

> As an app developer, I want to have my older C/C++/Objective-C code analyzed by Sonar. In order for the C code to be analyzed properly, SonarQube created a build wrapper executable that starts up the xcodebuild command. For Swift code this build wrapper is not needed.

[SonarCFamily for Objective-C](https://docs.sonarqube.org/display/PLUG/SonarCFamily+for+Objective-C)

Example command line 👇 

```bash
build-wrapper-macosx-x86-64 --out-dir bw_output xcodebuild clean build
sonar-scanner
```

<!-- If it fixes an open issue, please link to the issue here. -->

closes https://github.com/fastlane/fastlane/issues/14861.

### Description
<!-- Describe your changes in detail -->

Added new options to scan action: 
* ~sonar_build_wrapper~
* ~sonar_build_wrapper_output~
* xcodebuild_command

<!-- Please describe in detail how you tested your changes. -->

Added unit test. 

🙇 🙇 