### PR TITLE
Integrated new AppStore APIs to create beta groups and add testers to…

### DIFF
--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -314,6 +314,69 @@ module Spaceship
         handle_response(response)
       end
 
+      def create_beta_group(app_id: nil, group_name: nil)
+        # POST
+        # https://appstoreconnect.apple.com/iris/v1/betaGroups
+        body = {
+                data: { 
+                type: "betaGroups",
+                attributes: {
+                  name: group_name
+                },
+                relationships:{
+                  app:{
+                    data:{
+                      type:"apps",
+                      id: app_id
+                    }
+                  }
+                }
+              }
+            }
+
+        response = request(:post, "betaGroups") do |req|
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
+      def add_testers_to_group(tester_emails: nil, group_id: nil)
+        # POST
+        # https://appstoreconnect.apple.com/iris/v1/bulkBetaTesterAssignments
+        body = {
+          data: {
+            type: "bulkBetaTesterAssignments",
+            attributes: {
+              betaTesters: tester_emails.map do |email|
+                {
+                  id: nil,
+                  email: email,
+                  firstName: "",
+                  lastName: "",
+                  assignmentResult: nil,
+                  errors: []
+                }
+              end
+            },
+            relationships: {
+              betaGroup: {
+                data: {
+                  type: "betaGroups",
+                  id: group_id
+                }
+              }
+            }
+          }
+        }
+
+        response = request(:post, "bulkBetaTesterAssignments") do |req|
+          req.body = body.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        handle_response(response)
+      end
+
       def add_beta_groups_to_build(build_id: nil, beta_group_ids: [])
         # POST
         # https://appstoreconnect.apple.com/iris/v1/builds/<build_id>/relationships/betaGroups


### PR DESCRIPTION
… the group

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Implementing missing AppStore Connect APIs is Spaceship::ConnectAPI. Following are the list of APIs added.
* Create beta groups API
* Add Testers to Group API

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Create beta groups API will take app_id and group_name are params and create Tester Group for the App.
Add Testers to Group API will add testers to the existing group using tester email.