### PR TITLE
[fastlane] Improve Lane Variables documentation by detecting `SharedValues` key assignment in functions

### DIFF
--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -3,6 +3,7 @@ module Fastlane
     module SharedValues
       IPA_OUTPUT_PATH = :IPA_OUTPUT_PATH
       DSYM_OUTPUT_PATH = :DSYM_OUTPUT_PATH
+      XCODEBUILD_ARCHIVE ||= :XCODEBUILD_ARCHIVE
     end
 
     class BuildIosAppAction < Action
@@ -95,7 +96,8 @@ module Fastlane
       def self.output
         [
           ['IPA_OUTPUT_PATH', 'The path to the newly generated ipa file'],
-          ['DSYM_OUTPUT_PATH', 'The path to the dSYM files']
+          ['DSYM_OUTPUT_PATH', 'The path to the dSYM files'],
+          ['XCODEBUILD_ARCHIVE', 'The path to the xcodebuild archive']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -3,7 +3,7 @@ module Fastlane
     module SharedValues
       IPA_OUTPUT_PATH = :IPA_OUTPUT_PATH
       DSYM_OUTPUT_PATH = :DSYM_OUTPUT_PATH
-      XCODEBUILD_ARCHIVE ||= :XCODEBUILD_ARCHIVE
+      XCODEBUILD_ARCHIVE ||= :XCODEBUILD_ARCHIVE # originally defined in XcodebuildAction
     end
 
     class BuildIosAppAction < Action

--- a/fastlane/lib/fastlane/actions/get_build_number.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number.rb
@@ -1,5 +1,9 @@
 module Fastlane
   module Actions
+    module SharedValues
+      BUILD_NUMBER ||= :BUILD_NUMBER
+    end
+
     class GetBuildNumberAction < Action
       require 'shellwords'
 

--- a/fastlane/lib/fastlane/actions/get_build_number.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      BUILD_NUMBER ||= :BUILD_NUMBER
+      BUILD_NUMBER ||= :BUILD_NUMBER # originally defined in IncrementBuildNumberAction
     end
 
     class GetBuildNumberAction < Action

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      VERSION_NUMBER ||= :VERSION_NUMBER
+      VERSION_NUMBER ||= :VERSION_NUMBER # originally defined in IncrementVersionNumberAction
     end
 
     class GetVersionNumberAction < Action

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -1,5 +1,9 @@
 module Fastlane
   module Actions
+    module SharedValues
+      VERSION_NUMBER ||= :VERSION_NUMBER
+    end
+
     class GetVersionNumberAction < Action
       require 'shellwords'
 

--- a/fastlane/lib/fastlane/actions/ipa.rb
+++ b/fastlane/lib/fastlane/actions/ipa.rb
@@ -1,6 +1,11 @@
 # rubocop:disable Lint/AssignmentInCondition
 module Fastlane
   module Actions
+    module SharedValues
+      IPA_OUTPUT_PATH ||= :IPA_OUTPUT_PATH
+      DSYM_OUTPUT_PATH ||= :DSYM_OUTPUT_PATH
+    end
+
     ARGS_MAP = {
       workspace: '-w',
       project: '-p',

--- a/fastlane/lib/fastlane/actions/ipa.rb
+++ b/fastlane/lib/fastlane/actions/ipa.rb
@@ -2,8 +2,8 @@
 module Fastlane
   module Actions
     module SharedValues
-      IPA_OUTPUT_PATH ||= :IPA_OUTPUT_PATH
-      DSYM_OUTPUT_PATH ||= :DSYM_OUTPUT_PATH
+      IPA_OUTPUT_PATH ||= :IPA_OUTPUT_PATH # originally defined in BuildIosAppAction
+      DSYM_OUTPUT_PATH ||= :DSYM_OUTPUT_PATH # originally defined in BuildIosAppAction
     end
 
     ARGS_MAP = {

--- a/fastlane/lib/fastlane/actions/make_changelog_from_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/make_changelog_from_jenkins.rb
@@ -1,5 +1,9 @@
 module Fastlane
   module Actions
+    module SharedValues
+      FL_CHANGELOG ||= :FL_CHANGELOG
+    end
+
     class MakeChangelogFromJenkinsAction < Action
       def self.run(params)
         require 'json'

--- a/fastlane/lib/fastlane/actions/make_changelog_from_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/make_changelog_from_jenkins.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      FL_CHANGELOG ||= :FL_CHANGELOG
+      FL_CHANGELOG ||= :FL_CHANGELOG # originally defined in ChangelogFromGitCommitsAction
     end
 
     class MakeChangelogFromJenkinsAction < Action

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -2,6 +2,7 @@ module Fastlane
   module Actions
     module SharedValues
       MATCH_PROVISIONING_PROFILE_MAPPING = :MATCH_PROVISIONING_PROFILE_MAPPING
+      SIGH_PROFILE_TYPE ||= :SIGH_PROFILE_TYPE
     end
 
     class SyncCodeSigningAction < Action
@@ -69,7 +70,8 @@ module Fastlane
 
       def self.output
         [
-          ['MATCH_PROVISIONING_PROFILE_MAPPING', 'The match provisioning profile mapping']
+          ['MATCH_PROVISIONING_PROFILE_MAPPING', 'The match provisioning profile mapping'],
+          ['SIGH_PROFILE_TYPE', 'The profile type, can be appstore, adhoc, development, enterprise']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     module SharedValues
       MATCH_PROVISIONING_PROFILE_MAPPING = :MATCH_PROVISIONING_PROFILE_MAPPING
-      SIGH_PROFILE_TYPE ||= :SIGH_PROFILE_TYPE
+      SIGH_PROFILE_TYPE ||= :SIGH_PROFILE_TYPE # originally defined in GetProvisioningProfileAction
     end
 
     class SyncCodeSigningAction < Action

--- a/fastlane/lib/fastlane/actions/version_get_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_get_podspec.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      PODSPEC_VERSION_NUMBER ||= :PODSPEC_VERSION_NUMBER
+      PODSPEC_VERSION_NUMBER ||= :PODSPEC_VERSION_NUMBER # originally defined in VersionBumpPodspecAction
     end
 
     class VersionGetPodspecAction < Action

--- a/fastlane/lib/fastlane/actions/version_get_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_get_podspec.rb
@@ -1,5 +1,9 @@
 module Fastlane
   module Actions
+    module SharedValues
+      PODSPEC_VERSION_NUMBER ||= :PODSPEC_VERSION_NUMBER
+    end
+
     class VersionGetPodspecAction < Action
       def self.run(params)
         podspec_path = params[:path]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

The rubocop rule called `MissingKeysOnSharedArea` should be improved and check if there's `Actions.lane_context[SharedValues::KEY_NAME] = ...` assignment in a code but not declared in `SharedValues` module.

https://github.com/fastlane/fastlane/blob/457c5d647c77f0e078dafa5129da616914e002c5/fastlane/lib/fastlane/actions/sync_code_signing.rb#L1-L38

This PR is an attempt to fix it 💪 

<!-- If it fixes an open issue, please link to the issue here. -->

closes https://github.com/fastlane/fastlane/issues/14891

The whole thread: https://github.com/fastlane/fastlane/issues/14255. 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

Modified `MissingKeysOnSharedArea` rule, added missing `SharedValues` keys and `output` values. 

🙇 🙇 