### PR TITLE
[actions] reset simulator content tvOS & watchOS

### DIFF
--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -2,12 +2,12 @@ module Fastlane
   module Actions
     class ResetSimulatorContentsAction < Action
       def self.run(params)
-        ios_versions = params[:ios]
+        os_versions = params[:version]
 
         if Helper.xcode_at_least?("9")
-          reset_xcode9_and_higher(ios_versions)
+          reset_xcode9_and_higher(os_versions)
         else
-          reset_up_to_xcode8(ios_versions)
+          reset_up_to_xcode8(os_versions)
         end
       end
 

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -14,7 +14,7 @@ module Fastlane
           os_versions.each do |os_version|
             reset_all_by_version(os_version)
           end
-        else 
+        else
           reset_all
         end
 

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -46,9 +46,7 @@ module Fastlane
                                        description: "Which OS versions of Simulators you want to reset content and settings, this does not remove/recreate the simulators",
                                        is_string: false,
                                        optional: true,
-                                       type: Array,
-                                       default_value: ENV["FASTLANE_RESET_SIMULATOR_OS_VERSIONS"],
-                                       default_value_dynamic: true),
+                                       type: Array),
           FastlaneCore::ConfigItem.new(key: :os_versions,
                                        short_option: "-v",
                                        env_name: "FASTLANE_RESET_SIMULATOR_OS_VERSIONS",
@@ -81,7 +79,8 @@ module Fastlane
 
       def self.example_code
         [
-          'reset_simulator_contents'
+          'reset_simulator_contents',
+          'reset_simulator_contents(os_versions: ["10.3.1","12.2"])'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -41,10 +41,10 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :ios,
-                                       short_option: "-i",
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       short_option: "-v",
                                        env_name: "FASTLANE_RESET_SIMULATOR_VERSIONS",
-                                       description: "Which versions of Simulators you want to reset content and settings, this does not remove/recreate the simulators",
+                                       description: "Which OS versions of Simulators you want to reset content and settings, this does not remove/recreate the simulators",
                                        is_string: false,
                                        optional: true,
                                        type: Array)

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class ResetSimulatorContentsAction < Action
       def self.run(params)
-        os_versions = params[:os_versions]
+        os_versions = params[:os_versions] || params[:ios]
 
         reset_simulators(os_versions)
       end
@@ -39,9 +39,19 @@ module Fastlane
 
       def self.available_options
         [
+          FastlaneCore::ConfigItem.new(key: :ios,
+                                       deprecated: "Use `:os_versions` instead",
+                                       short_option: "-i",
+                                       env_name: "FASTLANE_RESET_SIMULATOR_VERSIONS",
+                                       description: "Which OS versions of Simulators you want to reset content and settings, this does not remove/recreate the simulators",
+                                       is_string: false,
+                                       optional: true,
+                                       type: Array,
+                                       default_value: ENV["FASTLANE_RESET_SIMULATOR_OS_VERSIONS"],
+                                       default_value_dynamic: true),
           FastlaneCore::ConfigItem.new(key: :os_versions,
                                        short_option: "-v",
-                                       env_name: "FASTLANE_RESET_SIMULATOR_VERSIONS",
+                                       env_name: "FASTLANE_RESET_SIMULATOR_OS_VERSIONS",
                                        description: "Which OS versions of Simulators you want to reset content and settings, this does not remove/recreate the simulators",
                                        is_string: false,
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -68,7 +68,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :tvos, :watchos].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -4,35 +4,33 @@ module Fastlane
       def self.run(params)
         os_versions = params[:version]
 
-        if Helper.xcode_at_least?("9")
-          reset_xcode9_and_higher(os_versions)
-        else
-          reset_up_to_xcode8(os_versions)
-        end
+        reset_simulators(os_versions)
       end
 
-      def self.reset_xcode9_and_higher(ios_versions)
-        UI.verbose("Resetting simulator contents for Xcode 9 and later")
-        simulators = FastlaneCore::DeviceManager.simulators('iOS')
-        if ios_versions
-          simulators.select! { |s| ios_versions.include?(s.os_version) }
-        end
-        simulators.each do |simulator|
-          FastlaneCore::Simulator.reset(udid: simulator.udid)
-        end
-        UI.success('Simulators reset')
-      end
+      def self.reset_simulators(os_versions)
+        UI.verbose("Resetting simulator contents")
 
-      def self.reset_up_to_xcode8(ios_versions)
-        UI.verbose("Resetting simulator contents for Xcode 8 and earlier")
-        if ios_versions
-          ios_versions.each do |os_version|
-            FastlaneCore::Simulator.reset_all_by_version(os_version: os_version)
+        if os_versions
+          os_versions.each do |os_version|
+            reset_all_by_version(os_version)
           end
-        else
-          FastlaneCore::Simulator.reset_all
+        else 
+          reset_all
         end
-        UI.success('Simulators reset')
+
+        UI.success('Simulators reset done')
+      end
+
+      def self.reset_all_by_version(os_version)
+        FastlaneCore::Simulator.reset_all_by_version(os_version: os_version)
+        FastlaneCore::SimulatorTV.reset_all_by_version(os_version: os_version)
+        FastlaneCore::SimulatorWatch.reset_all_by_version(os_version: os_version)
+      end
+
+      def self.reset_all
+        FastlaneCore::Simulator.reset_all
+        FastlaneCore::SimulatorTV.reset_all
+        FastlaneCore::SimulatorWatch.reset_all
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class ResetSimulatorContentsAction < Action
       def self.run(params)
-        os_versions = params[:version]
+        os_versions = params[:os_versions]
 
         reset_simulators(os_versions)
       end
@@ -39,7 +39,7 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :version,
+          FastlaneCore::ConfigItem.new(key: :os_versions,
                                        short_option: "-v",
                                        env_name: "FASTLANE_RESET_SIMULATOR_VERSIONS",
                                        description: "Which OS versions of Simulators you want to reset content and settings, this does not remove/recreate the simulators",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
We need to be able to reset the simulator content for both tvOS and watchOS simulators. Currently only iOS simulators are supported.

### Description
I've renamed the current iOS parameter to os_versions, also modified the supported_platform method.
I've created a couple of example apps, installed them on a couple of simulators. Afterwards i cleared the content with the `reset_simulator_contents` action.