### PR TITLE
Add .body lookup to builds_resp in BuildTrains.all

### DIFF
--- a/spaceship/lib/spaceship/test_flight/build_trains.rb
+++ b/spaceship/lib/spaceship/test_flight/build_trains.rb
@@ -21,10 +21,10 @@ module Spaceship::TestFlight
 
       loop do
         builds_resp = client.get_builds(filter: { app: app_id, processingState: "VALID,PROCESSING,FAILED,INVALID" }, limit: 100, sort: "uploadedDate", includes: "preReleaseVersion,app", cursor: cursor)
-        builds += builds_resp["data"]
-        included += (builds_resp["included"] || [])
+        builds += builds_resp.body["data"]
+        included += (builds_resp.body["included"] || [])
 
-        next_page = builds_resp["links"]["next"]
+        next_page = builds_resp.body["links"]["next"]
         break if next_page.nil?
 
         uri = URI.parse(next_page)


### PR DESCRIPTION
Fix for:

/Library/Ruby/Gems/2.3.0/gems/fastlane-2.125.2/spaceship/lib/spaceship/test_flight/build_trains.rb:24:in `block in all': undefined method `[]' for #<Spaceship::ConnectAPI::Response:0x00007fd1466fadc8> (NoMethodError)
	from /Library/Ruby/Gems/2.3.0/gems/fastlane-2.125.2/spaceship/lib/spaceship/test_flight/build_trains.rb:22:in `loop'
	from /Library/Ruby/Gems/2.3.0/gems/fastlane-2.125.2/spaceship/lib/spaceship/test_flight/build_trains.rb:22:in `all'
	from /Library/Ruby/Gems/2.3.0/gems/fastlane-2.125.2/spaceship/lib/spaceship/tunes/application.rb:301:in `build_trains'

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
