### PR TITLE
[pilot] Add verification to apple_id parameter

### DIFF
--- a/fastlane/spec/actions_specs/pilot_spec.rb
+++ b/fastlane/spec/actions_specs/pilot_spec.rb
@@ -29,56 +29,26 @@ describe Fastlane do
               apple_id: "username@example.com"
             }
             pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
-          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
+          end.to raise_error("`apple_id` value is incorrect. The correct value should be taken from Apple ID property in the App Information section in App Store Connect.")
         end
 
-        it "raises an error if `apple_id` contains team id with invalid characters" do
+        it "raises an error if `apple_id` is set to bundle identifier" do
           expect do
             options = {
               username: "username@example.com",
-              apple_id: "A!C@0ABC1.com.bundle.identifier"
+              apple_id: "com.bundle.identifier"
             }
             pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
-          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
-        end
-
-        it "raises an error if `apple_id` contains team id with invalid characters count" do
-          expect do
-            options = {
-              username: "username@example.com",
-              apple_id: "ABC101.com.bundle.identifier"
-            }
-            pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
-          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
-        end
-
-        it "raises an error if `apple_id` contains only team id" do
-          expect do
-            options = {
-              username: "username@example.com",
-              apple_id: "ABC101ABC1"
-            }
-            pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
-          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
-        end
-
-        it "raises an error if `apple_id` contains correct team id and bundle id with invalid characters" do
-          expect do
-            options = {
-              username: "username@example.com",
-              apple_id: "ABC1234567.com.bundle.id@ent!fier?"
-            }
-            pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
-          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
+          end.to raise_error("`apple_id` value is incorrect. The correct value should be taken from Apple ID property in the App Information section in App Store Connect.")
         end
 
         it "passes when `apple_id` is correct" do
           options = {
             username: "username@example.com",
-            apple_id: "ABCD9089AC.com.bundle.identifier"
+            apple_id: "123456789"
           }
           pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
-          expect(pilot_config[:apple_id]).to eq('ABCD9089AC.com.bundle.identifier')
+          expect(pilot_config[:apple_id]).to eq('123456789')
         end
       end
     end

--- a/fastlane/spec/actions_specs/pilot_spec.rb
+++ b/fastlane/spec/actions_specs/pilot_spec.rb
@@ -20,6 +20,67 @@ describe Fastlane do
 
         expect(values[:changelog]).to eq('custom changelog')
       end
+
+      describe "Test `apple_id` parameter" do
+        it "raises an error if `apple_id` is set to email address" do
+          expect do
+            options = {
+              username: "username@example.com",
+              apple_id: "username@example.com"
+            }
+            pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
+        end
+
+        it "raises an error if `apple_id` contains team id with invalid characters" do
+          expect do
+            options = {
+              username: "username@example.com",
+              apple_id: "A!C@0ABC1.com.bundle.identifier"
+            }
+            pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
+        end
+
+        it "raises an error if `apple_id` contains team id with invalid characters count" do
+          expect do
+            options = {
+              username: "username@example.com",
+              apple_id: "ABC101.com.bundle.identifier"
+            }
+            pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
+        end
+
+        it "raises an error if `apple_id` contains only team id" do
+          expect do
+            options = {
+              username: "username@example.com",
+              apple_id: "ABC101ABC1"
+            }
+            pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
+        end
+
+        it "raises an error if `apple_id` contains correct team id and bundle id with invalid characters" do
+          expect do
+            options = {
+              username: "username@example.com",
+              apple_id: "ABC1234567.com.bundle.id@ent!fier?"
+            }
+            pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+          end.to raise_error("`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings.")
+        end
+
+        it "passes when `apple_id` is correct" do
+          options = {
+            username: "username@example.com",
+            apple_id: "ABCD9089AC.com.bundle.identifier"
+          }
+          pilot_config = FastlaneCore::Configuration.create(Pilot::Options.available_options, options)
+          expect(pilot_config[:apple_id]).to eq('ABCD9089AC.com.bundle.identifier')
+        end
+      end
     end
   end
 end

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -42,7 +42,23 @@ module Pilot
                                      optional: true,
                                      code_gen_sensitive: true,
                                      default_value: ENV["TESTFLIGHT_APPLE_ID"],
-                                     default_value_dynamic: true),
+                                     default_value_dynamic: true,
+                                     type: String,
+                                     verify_block: proc do |value|
+                                       error_message = "`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings."
+
+                                       # App ID = TeamID.bundleID
+                                       values = value.split('.')
+                                       UI.user_error!(error_message) if values.size < 2
+
+                                       # Team ID validation
+                                       team_id = values[0]
+                                       UI.user_error!(error_message) unless team_id =~ /[A-Z0-9]{10}/
+
+                                       # Bundle ID validation
+                                       bundle_id = values.drop(1).join('.')
+                                       UI.user_error!(error_message) unless bundle_id =~ /^[a-zA-Z0-9\-.]+$/
+                                     end),
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",
                                      optional: true,

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -45,19 +45,13 @@ module Pilot
                                      default_value_dynamic: true,
                                      type: String,
                                      verify_block: proc do |value|
-                                       error_message = "`apple_id` value is incorrect. App ID consists of a Team ID and a bundle ID search string, with a period (.) separating the two parts. You can find your Team ID here: https://developer.apple.com/account/#/membership and your bundle ID in Xcode settings."
+                                       error_message = "`apple_id` value is incorrect. The correct value should be taken from Apple ID property in the App Information section in App Store Connect."
 
-                                       # App ID = TeamID.bundleID
-                                       values = value.split('.')
-                                       UI.user_error!(error_message) if values.size < 2
+                                       # Validate if the value is not an email address
+                                       UI.user_error!(error_message) if value =~ /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
 
-                                       # Team ID validation
-                                       team_id = values[0]
-                                       UI.user_error!(error_message) unless team_id =~ /[A-Z0-9]{10}/
-
-                                       # Bundle ID validation
-                                       bundle_id = values.drop(1).join('.')
-                                       UI.user_error!(error_message) unless bundle_id =~ /^[a-zA-Z0-9\-.]+$/
+                                       # Validate if the value is not a bundle identifier
+                                       UI.user_error!(error_message) if value =~ /^[A-Za-x]{2,6}((?!-)\.[A-Za-z0-9-]{1,63}(?<!-))+$/i
                                      end),
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -38,7 +38,7 @@ module Pilot
         FastlaneCore::ConfigItem.new(key: :apple_id,
                                      short_option: "-p",
                                      env_name: "PILOT_APPLE_ID",
-                                     description: "The unique App ID provided by App Store Connect",
+                                     description: "Apple ID property in the App Information section in App Store Connect",
                                      optional: true,
                                      code_gen_sensitive: true,
                                      default_value: ENV["TESTFLIGHT_APPLE_ID"],

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -43,7 +43,7 @@ describe Pilot::TesterManager do
 
     let(:default_add_tester_options) do
       FastlaneCore::Configuration.create(Pilot::Options.available_options, {
-        apple_id: '123456789',
+        apple_id: 'ABCD9089AC.com.bundle.identifier',
         email: fake_tester.email,
         first_name: fake_tester.first_name,
         last_name: fake_tester.last_name
@@ -52,7 +52,7 @@ describe Pilot::TesterManager do
 
     let(:remove_tester_options) do
       FastlaneCore::Configuration.create(Pilot::Options.available_options, {
-        apple_id: '123456789',
+        apple_id: 'ABCD9089AC.com.bundle.identifier',
         email: fake_tester.email,
         first_name: fake_tester.first_name,
         last_name: fake_tester.last_name
@@ -61,7 +61,7 @@ describe Pilot::TesterManager do
 
     let(:default_add_tester_options_with_group) do
       FastlaneCore::Configuration.create(Pilot::Options.available_options, {
-        apple_id: 'com.whatever',
+        apple_id: 'ABCD9089AC.com.bundle.identifier',
         email: fake_tester.email,
         first_name: fake_tester.first_name,
         last_name: fake_tester.last_name,
@@ -75,7 +75,7 @@ describe Pilot::TesterManager do
     let(:fake_client) { "fake client" }
 
     before(:each) do
-      allow(fake_app).to receive(:apple_id).and_return("com.whatever")
+      allow(fake_app).to receive(:apple_id).and_return("ABCD9089AC.com.bundle.identifier")
       allow(fake_app).to receive(:name).and_return(fake_app_name)
       allow(Spaceship::ConnectAPI::TestFlight::App).to receive(:get).and_return(fake_app)
       allow(Spaceship::ConnectAPI::TestFlight::App).to receive(:find).and_return(fake_app)

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -43,7 +43,7 @@ describe Pilot::TesterManager do
 
     let(:default_add_tester_options) do
       FastlaneCore::Configuration.create(Pilot::Options.available_options, {
-        apple_id: 'ABCD9089AC.com.bundle.identifier',
+        apple_id: '123456789',
         email: fake_tester.email,
         first_name: fake_tester.first_name,
         last_name: fake_tester.last_name
@@ -52,7 +52,7 @@ describe Pilot::TesterManager do
 
     let(:remove_tester_options) do
       FastlaneCore::Configuration.create(Pilot::Options.available_options, {
-        apple_id: 'ABCD9089AC.com.bundle.identifier',
+        apple_id: '123456789',
         email: fake_tester.email,
         first_name: fake_tester.first_name,
         last_name: fake_tester.last_name
@@ -61,7 +61,7 @@ describe Pilot::TesterManager do
 
     let(:default_add_tester_options_with_group) do
       FastlaneCore::Configuration.create(Pilot::Options.available_options, {
-        apple_id: 'ABCD9089AC.com.bundle.identifier',
+        apple_id: '123456789',
         email: fake_tester.email,
         first_name: fake_tester.first_name,
         last_name: fake_tester.last_name,
@@ -75,7 +75,7 @@ describe Pilot::TesterManager do
     let(:fake_client) { "fake client" }
 
     before(:each) do
-      allow(fake_app).to receive(:apple_id).and_return("ABCD9089AC.com.bundle.identifier")
+      allow(fake_app).to receive(:apple_id).and_return("123456789")
       allow(fake_app).to receive(:name).and_return(fake_app_name)
       allow(Spaceship::ConnectAPI::TestFlight::App).to receive(:get).and_return(fake_app)
       allow(Spaceship::ConnectAPI::TestFlight::App).to receive(:find).and_return(fake_app)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

According to [Apple's documentation](https://help.apple.com/app-store-connect/#/dev219b53a88) `Apple ID`:

> A unique identifier automatically generated for your app when you add the app to your account. You can view this property in the App Information section in App Store Connect. This identifier is also used in the URL for the App Store on desktop computers. You can’t edit this property.
>
> Note: This identifier is not the same as your Apple ID that you use to sign in to App Store Connect and your developer account.
however [sometimes it is mistaken](https://github.com/fastlane/fastlane/issues/14834) with user's Apple ID. 

There is [on-going discussion](https://github.com/fastlane/fastlane/issues/14788) about parameter renaming, but as a quick win, this PR is introducing a parameter validation. 

<!-- If it fixes an open issue, please link to the issue here. -->

closes https://github.com/fastlane/fastlane/issues/14834

### Description
<!-- Describe your changes in detail -->

`apple_id` parameter validation was added:

* check if `apple_id` parameter is not an email address
* check if `apple_id` parameter is not a bundle identifier 

According to [the documentation](https://help.apple.com/xcode/mac/current/#/dev9b66ae7df) `bundle ID`:

> The bundle ID string must be a uniform type identifier (UTI) that contains only alphanumeric characters (A-Z, a-z, 0-9), hyphen (-), and period (.). The string should be in reverse-DNS format. Bundle IDs are case sensitive.

<!-- Please describe in detail how you tested your changes. -->

I implemented unit tests. 

🙇 