### PR TITLE
Version bump to 2.126.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
 <td id='fumiya-nakamura'>
 <a href='https://github.com/nafu'>
@@ -58,31 +46,107 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
-</tr>
-<tr>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
 <img src='https://github.com/joshdholtz.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+</tr>
+<tr>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+</tr>
+<tr>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+</tr>
+<tr>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 <td id='jimmy-dee'>
 <a href='https://github.com/jdee'>
@@ -95,70 +159,6 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <img src='https://github.com/lacostej.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-</tr>
-<tr>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-</tr>
-<tr>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,26 +15,26 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Joshua Liebowitz",
-                        "Stefan Natchev",
-                        "Andrew McBurney",
+  spec.authors       = ["Matthew Ellis",
+                        "Helmut Januschka",
+                        "Jérôme Lacoste",
                         "Felix Krause",
                         "Jorge Revuelta H",
-                        "Manu Wallner",
-                        "Josh Holtz",
-                        "Matthew Ellis",
-                        "Luka Mirosevic",
-                        "Iulian Onofrei",
-                        "Jimmy Dee",
-                        "Danielle Tomlinson",
                         "Kohki Miki",
+                        "Iulian Onofrei",
+                        "Olivier Halligon",
+                        "Stefan Natchev",
+                        "Joshua Liebowitz",
+                        "Andrew McBurney",
                         "Maksym Grebenets",
-                        "Jan Piotrowski",
-                        "Aaron Brager",
+                        "Danielle Tomlinson",
+                        "Manu Wallner",
                         "Fumiya Nakamura",
-                        "Jérôme Lacoste",
-                        "Helmut Januschka",
-                        "Olivier Halligon"]
+                        "Jan Piotrowski",
+                        "Jimmy Dee",
+                        "Josh Holtz",
+                        "Aaron Brager",
+                        "Luka Mirosevic"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.125.2'.freeze
+  VERSION = '2.126.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.125.2
+// Generated with fastlane 2.126.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -44,6 +44,7 @@ protocol DeliverfileProtocol: class {
   var secondarySecondSubCategory: String? { get }
   var tradeRepresentativeContactInformation: [String : Any]? { get }
   var appReviewInformation: [String : Any]? { get }
+  var appReviewAttachmentFile: String? { get }
   var description: String? { get }
   var name: String? { get }
   var subtitle: [String : Any]? { get }
@@ -106,6 +107,7 @@ extension DeliverfileProtocol {
   var secondarySecondSubCategory: String? { return nil }
   var tradeRepresentativeContactInformation: [String : Any]? { return nil }
   var appReviewInformation: [String : Any]? { return nil }
+  var appReviewAttachmentFile: String? { return nil }
   var description: String? { return nil }
   var name: String? { return nil }
   var subtitle: [String : Any]? { return nil }
@@ -124,4 +126,4 @@ extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.7]
+// FastlaneRunnerAPIVersion [0.9.8]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -268,6 +268,7 @@ func appstore(username: String,
               secondarySecondSubCategory: String? = nil,
               tradeRepresentativeContactInformation: [String : Any]? = nil,
               appReviewInformation: [String : Any]? = nil,
+              appReviewAttachmentFile: String? = nil,
               description: String? = nil,
               name: String? = nil,
               subtitle: [String : Any]? = nil,
@@ -327,6 +328,7 @@ func appstore(username: String,
                                                                                           RubyCommand.Argument(name: "secondary_second_sub_category", value: secondarySecondSubCategory),
                                                                                           RubyCommand.Argument(name: "trade_representative_contact_information", value: tradeRepresentativeContactInformation),
                                                                                           RubyCommand.Argument(name: "app_review_information", value: appReviewInformation),
+                                                                                          RubyCommand.Argument(name: "app_review_attachment_file", value: appReviewAttachmentFile),
                                                                                           RubyCommand.Argument(name: "description", value: description),
                                                                                           RubyCommand.Argument(name: "name", value: name),
                                                                                           RubyCommand.Argument(name: "subtitle", value: subtitle),
@@ -1278,6 +1280,7 @@ func deliver(username: String = deliverfile.username,
              secondarySecondSubCategory: String? = deliverfile.secondarySecondSubCategory,
              tradeRepresentativeContactInformation: [String : Any]? = deliverfile.tradeRepresentativeContactInformation,
              appReviewInformation: [String : Any]? = deliverfile.appReviewInformation,
+             appReviewAttachmentFile: String? = deliverfile.appReviewAttachmentFile,
              description: String? = deliverfile.description,
              name: String? = deliverfile.name,
              subtitle: [String : Any]? = deliverfile.subtitle,
@@ -1337,6 +1340,7 @@ func deliver(username: String = deliverfile.username,
                                                                                          RubyCommand.Argument(name: "secondary_second_sub_category", value: secondarySecondSubCategory),
                                                                                          RubyCommand.Argument(name: "trade_representative_contact_information", value: tradeRepresentativeContactInformation),
                                                                                          RubyCommand.Argument(name: "app_review_information", value: appReviewInformation),
+                                                                                         RubyCommand.Argument(name: "app_review_attachment_file", value: appReviewAttachmentFile),
                                                                                          RubyCommand.Argument(name: "description", value: description),
                                                                                          RubyCommand.Argument(name: "name", value: name),
                                                                                          RubyCommand.Argument(name: "subtitle", value: subtitle),
@@ -2330,7 +2334,8 @@ func oclint(oclintPath: String = "oclint",
             maxPriority3: String? = nil,
             enableClangStaticAnalyzer: Bool = false,
             enableGlobalAnalysis: Bool = false,
-            allowDuplicatedViolations: Bool = false) {
+            allowDuplicatedViolations: Bool = false,
+            extraArg: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "oclint", className: nil, args: [RubyCommand.Argument(name: "oclint_path", value: oclintPath),
                                                                                         RubyCommand.Argument(name: "compile_commands", value: compileCommands),
                                                                                         RubyCommand.Argument(name: "select_reqex", value: selectReqex),
@@ -2348,7 +2353,8 @@ func oclint(oclintPath: String = "oclint",
                                                                                         RubyCommand.Argument(name: "max_priority_3", value: maxPriority3),
                                                                                         RubyCommand.Argument(name: "enable_clang_static_analyzer", value: enableClangStaticAnalyzer),
                                                                                         RubyCommand.Argument(name: "enable_global_analysis", value: enableGlobalAnalysis),
-                                                                                        RubyCommand.Argument(name: "allow_duplicated_violations", value: allowDuplicatedViolations)])
+                                                                                        RubyCommand.Argument(name: "allow_duplicated_violations", value: allowDuplicatedViolations),
+                                                                                        RubyCommand.Argument(name: "extra_arg", value: extraArg)])
   _ = runner.executeCommand(command)
 }
 func onesignal(authToken: String,
@@ -2699,8 +2705,10 @@ func resetGitRepo(files: String? = nil,
                                                                                                 RubyCommand.Argument(name: "exclude", value: exclude)])
   _ = runner.executeCommand(command)
 }
-func resetSimulatorContents(ios: [String]? = nil) {
-  let command = RubyCommand(commandID: "", methodName: "reset_simulator_contents", className: nil, args: [RubyCommand.Argument(name: "ios", value: ios)])
+func resetSimulatorContents(ios: [String]? = nil,
+                            osVersions: [String]? = nil) {
+  let command = RubyCommand(commandID: "", methodName: "reset_simulator_contents", className: nil, args: [RubyCommand.Argument(name: "ios", value: ios),
+                                                                                                          RubyCommand.Argument(name: "os_versions", value: osVersions)])
   _ = runner.executeCommand(command)
 }
 func resign(ipa: String,
@@ -2807,6 +2815,7 @@ func runTests(workspace: String? = nil,
               slackOnlyOnFailure: Bool = false,
               destination: String? = nil,
               customReportFileName: String? = nil,
+              xcodebuildCommand: String = "env NSUnbufferedIO=YES xcodebuild",
               failBuild: Bool = true) {
   let command = RubyCommand(commandID: "", methodName: "run_tests", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                            RubyCommand.Argument(name: "project", value: project),
@@ -2860,6 +2869,7 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "slack_only_on_failure", value: slackOnlyOnFailure),
                                                                                            RubyCommand.Argument(name: "destination", value: destination),
                                                                                            RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
+                                                                                           RubyCommand.Argument(name: "xcodebuild_command", value: xcodebuildCommand),
                                                                                            RubyCommand.Argument(name: "fail_build", value: failBuild)])
   _ = runner.executeCommand(command)
 }
@@ -2955,6 +2965,7 @@ func scan(workspace: String? = scanfile.workspace,
           slackOnlyOnFailure: Bool = scanfile.slackOnlyOnFailure,
           destination: String? = scanfile.destination,
           customReportFileName: String? = scanfile.customReportFileName,
+          xcodebuildCommand: String = scanfile.xcodebuildCommand,
           failBuild: Bool = scanfile.failBuild) {
   let command = RubyCommand(commandID: "", methodName: "scan", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -3008,6 +3019,7 @@ func scan(workspace: String? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "slack_only_on_failure", value: slackOnlyOnFailure),
                                                                                       RubyCommand.Argument(name: "destination", value: destination),
                                                                                       RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
+                                                                                      RubyCommand.Argument(name: "xcodebuild_command", value: xcodebuildCommand),
                                                                                       RubyCommand.Argument(name: "fail_build", value: failBuild)])
   _ = runner.executeCommand(command)
 }
@@ -3940,6 +3952,7 @@ func uploadToAppStore(username: String,
                       secondarySecondSubCategory: String? = nil,
                       tradeRepresentativeContactInformation: [String : Any]? = nil,
                       appReviewInformation: [String : Any]? = nil,
+                      appReviewAttachmentFile: String? = nil,
                       description: String? = nil,
                       name: String? = nil,
                       subtitle: [String : Any]? = nil,
@@ -3999,6 +4012,7 @@ func uploadToAppStore(username: String,
                                                                                                      RubyCommand.Argument(name: "secondary_second_sub_category", value: secondarySecondSubCategory),
                                                                                                      RubyCommand.Argument(name: "trade_representative_contact_information", value: tradeRepresentativeContactInformation),
                                                                                                      RubyCommand.Argument(name: "app_review_information", value: appReviewInformation),
+                                                                                                     RubyCommand.Argument(name: "app_review_attachment_file", value: appReviewAttachmentFile),
                                                                                                      RubyCommand.Argument(name: "description", value: description),
                                                                                                      RubyCommand.Argument(name: "name", value: name),
                                                                                                      RubyCommand.Argument(name: "subtitle", value: subtitle),
@@ -4379,4 +4393,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.50]
+// FastlaneRunnerAPIVersion [0.9.51]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.125.2
+// Generated with fastlane 2.126.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.125.2
+// Generated with fastlane 2.126.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.125.2
+// Generated with fastlane 2.126.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.125.2
+// Generated with fastlane 2.126.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -51,6 +51,7 @@ protocol ScanfileProtocol: class {
   var slackOnlyOnFailure: Bool { get }
   var destination: String? { get }
   var customReportFileName: String? { get }
+  var xcodebuildCommand: String { get }
   var failBuild: Bool { get }
 }
 
@@ -107,9 +108,10 @@ extension ScanfileProtocol {
   var slackOnlyOnFailure: Bool { return false }
   var destination: String? { return nil }
   var customReportFileName: String? { return nil }
+  var xcodebuildCommand: String { return "env NSUnbufferedIO=YES xcodebuild" }
   var failBuild: Bool { return true }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.10]
+// FastlaneRunnerAPIVersion [0.9.11]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.125.2
+// Generated with fastlane 2.126.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.125.2
+// Generated with fastlane 2.126.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.125.2':**

* [spaceship] App Store Connect - add support for JWT token, add provisioning API, unify calls under Spaceship::ConnectAPI class (#14888) via Josh Holtz
* [action] Add xcodebuild_command option to scan action (#14874) via Daniel Jankowski
* [action] Add extra_arg parameter to oclint action (#14877) via Mourad
* [fastlane] handle empty exception backtrace (#14939) via Raymond Hoagland
* [action] reset simulator content tvOS & watchOS (#14911) via Dylan Gyesbreghs
* [snpshot] Remove "Clone X of " in simulator name (#14895) via Jean Mainguy
* [deliver, spaceship] Allow developers to upload files as review attachments while submitting app to AppStore (#14412) via Krish
* [spaceship] moved Spaceship::ConnectAPI into Spaceship::ConnectAPI::TestFlight (#14873) via Josh Holtz
* [spaceship,produce,fastlane_core] Add support for Arabic and Hebrew (#14864) via Max Ott
