### PR TITLE
[fastlane] use IO.popen instead of sh for release because input needed for 2FA

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -264,8 +264,14 @@ lane :release do
     )
 
     # Actual release of the gem
+    # Using IO.popen because `gem push` will prompt for 2FA if enabled
     #
-    sh("gem push ../pkg/fastlane-#{version}.gem")
+    command = "gem push ../pkg/fastlane-#{version}.gem"
+    IO.popen(command) do |io|
+      io.each do |line|
+        puts(line)
+      end
+    end
 
     release_url = github_release['html_url']
 


### PR DESCRIPTION
### Motivation and Context
Enabling 2FA on a rubygems account requires entering of otp when pushing

### Description
`sh` does not allow for inputting of executed commands. Needed to switch to using `IO.popen`