### PR TITLE
[screengrab] add `adb_host` option

### DIFF
--- a/screengrab/lib/screengrab/options.rb
+++ b/screengrab/lib/screengrab/options.rb
@@ -137,7 +137,11 @@ module Screengrab
                                      env_name: 'SCREENGRAB_USE_TIMESTAMP_SUFFIX',
                                      description: "Add timestamp suffix to screenshot filename",
                                      default_value: true,
-                                     type: Boolean)
+                                     type: Boolean),
+        FastlaneCore::ConfigItem.new(key: :adb_host,
+                                     env_name: 'SCREENGRAB_ADB_HOST',
+                                     description: "Configure the host used by adb to connect, allows running on remote devices farm",
+                                     default_value: "localhost")
       ]
     end
   end

--- a/screengrab/lib/screengrab/options.rb
+++ b/screengrab/lib/screengrab/options.rb
@@ -141,7 +141,7 @@ module Screengrab
         FastlaneCore::ConfigItem.new(key: :adb_host,
                                      env_name: 'SCREENGRAB_ADB_HOST',
                                      description: "Configure the host used by adb to connect, allows running on remote devices farm",
-                                     default_value: "localhost")
+                                     optional: true)
       ]
     end
   end

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -62,7 +62,7 @@ module Screengrab
 
       # Root is needed to access device paths at /data
       if @config[:use_adb_root]
-        run_adb_command("adb root", print_all: false, print_command: true)
+        run_adb_command("root", print_all: false, print_command: true)
       end
 
       clear_device_previous_screenshots(device_serial, device_screenshots_paths)

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -82,7 +82,7 @@ module Screengrab
     end
 
     def select_device
-      devices = run_adb_command("adb devices -l", print_all: true, print_command: true).split("\n")
+      devices = run_adb_command("devices -l", print_all: true, print_command: true).split("\n")
       # the first output by adb devices is "List of devices attached" so remove that and any adb startup output
       devices.reject! do |device|
         [
@@ -144,7 +144,7 @@ module Screengrab
       # macOS evaluates $foo in `echo $foo` before executing the command,
       # Windows doesn't - hence the double backslash vs. single backslash
       command = Helper.windows? ? "shell echo \$EXTERNAL_STORAGE " : "shell echo \\$EXTERNAL_STORAGE"
-      device_ext_storage = run_adb_command("adb -s #{device_serial} #{command}",
+      device_ext_storage = run_adb_command("-s #{device_serial} #{command}",
                                            print_all: true,
                                            print_command: true)
       device_ext_storage = device_ext_storage.strip
@@ -164,7 +164,7 @@ module Screengrab
 
       device_screenshots_paths.each do |device_path|
         if_device_path_exists(device_serial, device_path) do |path|
-          run_adb_command("adb -s #{device_serial} shell rm -rf #{path}",
+          run_adb_command("-s #{device_serial} shell rm -rf #{path}",
                           print_all: true,
                           print_command: true)
         end
@@ -191,13 +191,13 @@ module Screengrab
 
     def install_apks(device_serial, app_apk_path, tests_apk_path)
       UI.message('Installing app APK')
-      apk_install_output = run_adb_command("adb -s #{device_serial} install -t -r #{app_apk_path.shellescape}",
+      apk_install_output = run_adb_command("-s #{device_serial} install -t -r #{app_apk_path.shellescape}",
                                            print_all: true,
                                            print_command: true)
       UI.user_error!("App APK could not be installed") if apk_install_output.include?("Failure [")
 
       UI.message('Installing tests APK')
-      apk_install_output = run_adb_command("adb -s #{device_serial} install -t -r #{tests_apk_path.shellescape}",
+      apk_install_output = run_adb_command("-s #{device_serial} install -t -r #{tests_apk_path.shellescape}",
                                            print_all: true,
                                            print_command: true)
       UI.user_error!("Tests APK could not be installed") if apk_install_output.include?("Failure [")
@@ -208,14 +208,14 @@ module Screengrab
 
       if packages.include?(app_package_name.to_s)
         UI.message('Uninstalling app APK')
-        run_adb_command("adb -s #{device_serial} uninstall #{app_package_name}",
+        run_adb_command("-s #{device_serial} uninstall #{app_package_name}",
                         print_all: true,
                         print_command: true)
       end
 
       if packages.include?(tests_package_name.to_s)
         UI.message('Uninstalling tests APK')
-        run_adb_command("adb -s #{device_serial} uninstall #{tests_package_name}",
+        run_adb_command("-s #{device_serial} uninstall #{tests_package_name}",
                         print_all: true,
                         print_command: true)
       end
@@ -223,20 +223,20 @@ module Screengrab
 
     def grant_permissions(device_serial)
       UI.message('Granting the permission necessary to change locales on the device')
-      run_adb_command("adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.CHANGE_CONFIGURATION",
+      run_adb_command("-s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.CHANGE_CONFIGURATION",
                       print_all: true,
                       print_command: true)
 
-      device_api_version = run_adb_command("adb -s #{device_serial} shell getprop ro.build.version.sdk",
+      device_api_version = run_adb_command("-s #{device_serial} shell getprop ro.build.version.sdk",
                                            print_all: true,
                                            print_command: true).to_i
 
       if device_api_version >= 23
         UI.message('Granting the permissions necessary to access device external storage')
-        run_adb_command("adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.WRITE_EXTERNAL_STORAGE",
+        run_adb_command("-s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.WRITE_EXTERNAL_STORAGE",
                         print_all: true,
                         print_command: true)
-        run_adb_command("adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.READ_EXTERNAL_STORAGE",
+        run_adb_command("-s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.READ_EXTERNAL_STORAGE",
                         print_all: true,
                         print_command: true)
       end
@@ -261,7 +261,7 @@ module Screengrab
     def run_tests_for_locale(locale, device_serial, test_classes_to_use, test_packages_to_use, launch_arguments)
       UI.message("Running tests for locale: #{locale}")
 
-      instrument_command = ["adb -s #{device_serial} shell am instrument --no-window-animation -w",
+      instrument_command = ["-s #{device_serial} shell am instrument --no-window-animation -w",
                             "-e testLocale #{locale.tr('-', '_')}",
                             "-e endingLocale #{@config[:ending_locale].tr('-', '_')}"]
       instrument_command << "-e appendTimestamp #{@config[:use_timestamp_suffix]}"
@@ -295,7 +295,7 @@ module Screengrab
       Dir.mktmpdir do |tempdir|
         device_screenshots_paths.each do |device_path|
           if_device_path_exists(device_serial, device_path) do |path|
-            run_adb_command("adb -s #{device_serial} pull #{path} #{tempdir}",
+            run_adb_command("-s #{device_serial} pull #{path} #{tempdir}",
                             print_all: false,
                             print_command: true)
           end
@@ -358,7 +358,7 @@ module Screengrab
     # Some device commands fail if executed against a device path that does not exist, so this helper method
     # provides a way to conditionally execute a block only if the provided path exists on the device.
     def if_device_path_exists(device_serial, device_path)
-      return if run_adb_command("adb -s #{device_serial} shell ls #{device_path}",
+      return if run_adb_command("-s #{device_serial} shell ls #{device_path}",
                                 print_all: false,
                                 print_command: false).include?('No such file')
 
@@ -370,7 +370,7 @@ module Screengrab
 
     # Return an array of packages that are installed on the device
     def installed_packages(device_serial)
-      packages = run_adb_command("adb -s #{device_serial} shell pm list packages",
+      packages = run_adb_command("-s #{device_serial} shell pm list packages",
                                  print_all: true,
                                  print_command: true)
       packages.split("\n").map { |package| package.gsub("package:", "") }
@@ -378,7 +378,9 @@ module Screengrab
 
     def run_adb_command(command, print_all: false, print_command: false)
       adb_path = @android_env.adb_path.chomp("adb")
-      output = @executor.execute(command: adb_path + command,
+      adb_host = @config[:adb_host]
+      host = adb_host.nil? ? '' : "-H #{adb_host} "
+      output = @executor.execute(command: adb_path + "adb " + host + command,
                                  print_all: print_all,
                                  print_command: print_command) || ''
       output.lines.reject do |line|

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -303,9 +303,22 @@ describe Screengrab::Runner do
 
           ADB_OUTPUT
 
-      mock_adb_response_for_command("test", adb_response)
+      mock_adb_response_for_command("adb test", adb_response)
 
       expect(@runner.run_adb_command("test").lines.any? { |line| line.start_with?('adb: ') }).to eq(false)
+    end
+
+    it 'connects to host if specified' do
+      config[:adb_host] = "device_farm"
+      adb_response = strip_heredoc(<<-ADB_OUTPUT)
+            List of devices attached
+            e1dbf228               device usb:1-1.2 product:a33gdd model:SM_A300H device:a33g
+
+          ADB_OUTPUT
+
+      mock_adb_response_for_command("adb -H device_farm devices -l", adb_response)
+
+      expect(@runner.select_device).to eq('e1dbf228')
     end
   end
 end


### PR DESCRIPTION
Allow to specify the host to use when invoking `screengrab` :

 * either through CLI `adb_host`
 * environment variable: `SCREENGRAB_ADB_HOST`
 * configuration parameter: `:adb_host`

This allows to use a device farm to run screen grabs instead of having
an attached device to the build machine.

It is useful in the context of CI

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When using CI, it is cumbersome and slow to provision emulators (and we can't always as KVM is not always available). To solve this we can use a remote adb daemon and issue commands to it, but there is not any environment variables available to do this easily in adb.

This way I can run a CI build step on the proper network that can talk to remote adb to take screengrabs of app. 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

Added an option to `screengrab` to allow specifying the adb host to use, if one is provided, adb command is updated to include the `-H $adb_host`elements.
Added a unit test to cover the case where `adb_host` is set and updated the method `run_adb_command` to remove the need for passing "adb" but focus on the command to be run: 

 * this way it is easier  to add the required `-H ...` flag
 * it makes no sense to repeat "adb" in the `run_adb_command` method call.