### PR TITLE
[fastlane_core] added deliver/pilot support for Xcode 11 - new search path for itms_path

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -202,6 +202,11 @@ module FastlaneCore
       return ENV["FASTLANE_ITUNES_TRANSPORTER_PATH"] if FastlaneCore::Env.truthy?("FASTLANE_ITUNES_TRANSPORTER_PATH")
 
       if self.mac?
+        # First check for manually install iTMSTransporter
+        user_local_itms_path = "/usr/local/itms"
+        return user_local_itms_path if File.exist?(user_local_itms_path)
+
+        # Then check for iTMSTransporter in the Xcode path
         [
           "../Applications/Application Loader.app/Contents/MacOS/itms",
           "../Applications/Application Loader.app/Contents/itms",

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -204,7 +204,8 @@ module FastlaneCore
       if self.mac?
         [
           "../Applications/Application Loader.app/Contents/MacOS/itms",
-          "../Applications/Application Loader.app/Contents/itms"
+          "../Applications/Application Loader.app/Contents/itms",
+          "../SharedFrameworks/ContentDeliveryServices.framework/Versions/A/itms" # For Xcode 11
         ].each do |path|
           result = File.expand_path(File.join(self.xcode_path, path))
           return result if File.exist?(result)


### PR DESCRIPTION
Fixes #14955

## Motivation
Couldn't find `itms_path` when using Xcode 11 Beta 2 💥 

## Description
Adds new `itms_path` to search 👀 