### PR TITLE
[Snapshot] Fix "Clone of" regex

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -178,7 +178,7 @@ open class Snapshot: NSObject {
             
             do {
                 // The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
-                let regex = try NSRegularExpression(pattern: "Clone [0-1]+ of ")
+                let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
                 let range = NSMakeRange(0, simulator.count)
                 simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
 
@@ -300,4 +300,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.18]
+// SnapshotHelperVersion [1.19]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In my last PR https://github.com/fastlane/fastlane/pull/14895, I made a mistake in the regex.
The current regex `"Clone [0-1]+ of "` should be `"Clone [0-9]+ of "`.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

This PR fixes the described above issue.
