### PR TITLE
[spaceship] relax SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER matching regex

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -214,7 +214,7 @@ module Spaceship
         pattern = /^([0-9+]{2,4})([•]{#{maskings_count}})([0-9]{2})$/
         # following regex: range from maskings_count-2 because sometimes the masked number has 1 or 2 dots more than the actual number
         # e.g. https://github.com/fastlane/fastlane/issues/14969
-        replacement = "\\1([0-9]{#{maskings_count - 2},#{maskings_count}})\\3" 
+        replacement = "\\1([0-9]{#{maskings_count - 2},#{maskings_count}})\\3"
         number_with_dialcode_regex_part = number_with_dialcode_masked.gsub(pattern, replacement)
         # => +49([0-9]{8,9})85 or +1([0-9]{7,8})66
 

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -212,7 +212,7 @@ module Spaceship
 
         maskings_count = number_with_dialcode_masked.count('•') # => 9 or 8
         pattern = /^([0-9+]{2,4})([•]{#{maskings_count}})([0-9]{2})$/
-        # following regex: range from maskings_count-2 because sometimes the masked number has 1 or 2 `•` more than the actual number
+        # following regex: range from maskings_count-2 because sometimes the masked number has 1 or 2 dots more than the actual number
         # e.g. https://github.com/fastlane/fastlane/issues/14969
         replacement = "\\1([0-9]{#{maskings_count - 2},#{maskings_count}})\\3" 
         number_with_dialcode_regex_part = number_with_dialcode_masked.gsub(pattern, replacement)

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -212,7 +212,9 @@ module Spaceship
 
         maskings_count = number_with_dialcode_masked.count('•') # => 9 or 8
         pattern = /^([0-9+]{2,4})([•]{#{maskings_count}})([0-9]{2})$/
-        replacement = "\\1([0-9]{#{maskings_count - 1},#{maskings_count}})\\3"
+        # following regex: range from maskings_count-2 because sometimes the masked number has 1 or 2 `•` more than the actual number
+        # e.g. https://github.com/fastlane/fastlane/issues/14969
+        replacement = "\\1([0-9]{#{maskings_count - 2},#{maskings_count}})\\3" 
         number_with_dialcode_regex_part = number_with_dialcode_masked.gsub(pattern, replacement)
         # => +49([0-9]{8,9})85 or +1([0-9]{7,8})66
 

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -44,7 +44,7 @@ describe Spaceship::Client do
       "+4912341234581" => 2,
       "+1-123-456-7866" => 3,
       "+39 123 456 7871" => 4,
-      "+353123456743" => 5.
+      "+353123456743" => 5,
       "+375 00 000-00-59" => 6
     }.each do |number_to_test, expected_phone_id|
       it "selects correct phone id #{expected_phone_id} for provided phone number #{number_to_test}" do

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -44,7 +44,7 @@ describe Spaceship::Client do
       "+4912341234581" => 2,
       "+1-123-456-7866" => 3,
       "+39 123 456 7871" => 4,
-      "+353123456743" => 5
+      "+353123456743" => 5.
       "+375 00 000-00-59" => 6
     }.each do |number_to_test, expected_phone_id|
       it "selects correct phone id #{expected_phone_id} for provided phone number #{number_to_test}" do

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -30,7 +30,9 @@ describe Spaceship::Client do
         { "id" : 2, "numberWithDialCode" : "+49 ••••• •••••81", "obfuscatedNumber" : "••••• •••••81", "pushMode" : "sms" },
         { "id" : 3, "numberWithDialCode" : "+1 (•••) •••-••66", "obfuscatedNumber" : "(•••) •••-••66", "pushMode" : "sms" },
         { "id" : 4, "numberWithDialCode" : "+39 ••• ••• ••71", "obfuscatedNumber" : "••• ••• ••71", "pushMode" : "sms" },
+        { "id" : 5, "numberWithDialCode" : "+353 •• ••• ••43", "obfuscatedNumber" : "••• ••• •43", "pushMode" : "sms" },
         { "id" : 5, "numberWithDialCode" : "+353 •• ••• ••43", "obfuscatedNumber" : "••• ••• •43", "pushMode" : "sms" }
+        { "id" : 6, "numberWithDialCode" : "+375 • ••• •••-••-59", "obfuscatedNumber" : "• ••• •••-••-59", "pushMode" : "sms" }
       ]
     '
   end
@@ -43,6 +45,7 @@ describe Spaceship::Client do
       "+1-123-456-7866" => 3,
       "+39 123 456 7871" => 4,
       "+353123456743" => 5
+      "+375 00 000-00-59" => 6
     }.each do |number_to_test, expected_phone_id|
       it "selects correct phone id #{expected_phone_id} for provided phone number #{number_to_test}" do
         phone_id = subject.phone_id_from_number(phone_numbers, number_to_test)

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -31,7 +31,6 @@ describe Spaceship::Client do
         { "id" : 3, "numberWithDialCode" : "+1 (•••) •••-••66", "obfuscatedNumber" : "(•••) •••-••66", "pushMode" : "sms" },
         { "id" : 4, "numberWithDialCode" : "+39 ••• ••• ••71", "obfuscatedNumber" : "••• ••• ••71", "pushMode" : "sms" },
         { "id" : 5, "numberWithDialCode" : "+353 •• ••• ••43", "obfuscatedNumber" : "••• ••• •43", "pushMode" : "sms" },
-        { "id" : 5, "numberWithDialCode" : "+353 •• ••• ••43", "obfuscatedNumber" : "••• ••• •43", "pushMode" : "sms" },
         { "id" : 6, "numberWithDialCode" : "+375 • ••• •••-••-59", "obfuscatedNumber" : "• ••• •••-••-59", "pushMode" : "sms" }
       ]
     '

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -31,7 +31,7 @@ describe Spaceship::Client do
         { "id" : 3, "numberWithDialCode" : "+1 (•••) •••-••66", "obfuscatedNumber" : "(•••) •••-••66", "pushMode" : "sms" },
         { "id" : 4, "numberWithDialCode" : "+39 ••• ••• ••71", "obfuscatedNumber" : "••• ••• ••71", "pushMode" : "sms" },
         { "id" : 5, "numberWithDialCode" : "+353 •• ••• ••43", "obfuscatedNumber" : "••• ••• •43", "pushMode" : "sms" },
-        { "id" : 5, "numberWithDialCode" : "+353 •• ••• ••43", "obfuscatedNumber" : "••• ••• •43", "pushMode" : "sms" }
+        { "id" : 5, "numberWithDialCode" : "+353 •• ••• ••43", "obfuscatedNumber" : "••• ••• •43", "pushMode" : "sms" },
         { "id" : 6, "numberWithDialCode" : "+375 • ••• •••-••-59", "obfuscatedNumber" : "• ••• •••-••-59", "pushMode" : "sms" }
       ]
     '


### PR DESCRIPTION
... by 1 more character so it also matches numbers from Belarus

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Numbers from Belarus failed.

### Description

Relax the regex, so the number matcher works for Belarus numbers.

closes #14969