### PR TITLE
[spaceship] fix crash deleting testers

### DIFF
--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -228,7 +228,7 @@ module Spaceship
           end
         }
 
-        delete("betaTesters/#{beta_tester_id}/relationships/apps", nil, body)
+        Client.instance.delete("betaTesters/#{beta_tester_id}/relationships/apps", nil, body)
       end
 
       def delete_beta_tester_from_beta_groups(beta_tester_id: nil, beta_group_ids: [])
@@ -241,7 +241,7 @@ module Spaceship
           end
         }
 
-        delete("betaTesters/#{beta_tester_id}/relationships/betaGroups", nil, body)
+        Client.instance.delete("betaTesters/#{beta_tester_id}/relationships/betaGroups", nil, body)
       end
 
       #

--- a/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
@@ -11,15 +11,6 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
   context 'sends api request' do
     before(:each) do
       allow(client).to receive(:handle_response)
-      module Spaceship
-        class ConnectAPI
-          module Provisioning
-            class Client
-              include Spaceship::ConnectAPI::Provisioning
-            end
-          end
-        end
-      end
     end
 
     def test_request_params(url, params)
@@ -62,7 +53,7 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
           params = {}
           req_mock = test_request_body(path, params)
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.get_bundle_ids
+          Spaceship::ConnectAPI.get_bundle_ids
         end
       end
     end
@@ -75,7 +66,7 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
           params = {}
           req_mock = test_request_body(path, params)
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.get_certificates
+          Spaceship::ConnectAPI.get_certificates
         end
       end
     end
@@ -88,7 +79,7 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
           params = {}
           req_mock = test_request_body(path, params)
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.get_devices
+          Spaceship::ConnectAPI.get_devices
         end
       end
     end
@@ -101,7 +92,7 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
           params = {}
           req_mock = test_request_body(path, params)
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.get_profiles
+          Spaceship::ConnectAPI.get_profiles
         end
       end
     end

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -11,15 +11,6 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
   context 'sends api request' do
     before(:each) do
       allow(client).to receive(:handle_response)
-      module Spaceship
-        class ConnectAPI
-          module TestFlight
-            class Client
-              include Spaceship::ConnectAPI::TestFlight
-            end
-          end
-        end
-      end
     end
 
     def test_request_params(url, params)
@@ -56,14 +47,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_apps
+          Spaceship::ConnectAPI.get_apps
         end
 
         it 'succeeds with filter' do
           params = { filter: { bundleId: bundle_id } }
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_apps(filter: { bundleId: bundle_id })
+          Spaceship::ConnectAPI.get_apps(filter: { bundleId: bundle_id })
         end
       end
 
@@ -75,7 +66,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_app(app_id: app_id)
+          Spaceship::ConnectAPI.get_app(app_id: app_id)
         end
       end
     end
@@ -89,14 +80,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_app_localizations
+          Spaceship::ConnectAPI.get_beta_app_localizations
         end
 
         it 'succeeds with filter' do
           params = { filter: { app: app_id } }
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_app_localizations(params)
+          Spaceship::ConnectAPI.get_beta_app_localizations(params)
         end
       end
 
@@ -126,7 +117,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.post_beta_app_localizations(app_id: app_id, attributes: attributes)
+          Spaceship::ConnectAPI.post_beta_app_localizations(app_id: app_id, attributes: attributes)
         end
       end
 
@@ -149,7 +140,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:patch).and_yield(req_mock)
-          client.patch_beta_app_localizations(localization_id: localization_id, attributes: attributes)
+          Spaceship::ConnectAPI.patch_beta_app_localizations(localization_id: localization_id, attributes: attributes)
         end
       end
     end
@@ -163,14 +154,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_app_review_detail
+          Spaceship::ConnectAPI.get_beta_app_review_detail
         end
 
         it 'succeeds with filter' do
           params = { filter: { app: app_id } }
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_app_review_detail(filter: { app: app_id })
+          Spaceship::ConnectAPI.get_beta_app_review_detail(filter: { app: app_id })
         end
       end
 
@@ -192,7 +183,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           url = "#{path}/#{app_id}"
           req_mock = test_request_body(url, body)
           expect(client).to receive(:request).with(:patch).and_yield(req_mock)
-          client.patch_beta_app_review_detail(app_id: app_id, attributes: attributes)
+          Spaceship::ConnectAPI.patch_beta_app_review_detail(app_id: app_id, attributes: attributes)
         end
       end
     end
@@ -206,14 +197,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_app_review_submissions
+          Spaceship::ConnectAPI.get_beta_app_review_submissions
         end
 
         it 'succeeds with filter' do
           params = { filter: { app: app_id } }
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_app_review_submissions(filter: { app: app_id })
+          Spaceship::ConnectAPI.get_beta_app_review_submissions(filter: { app: app_id })
         end
       end
 
@@ -241,7 +232,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.post_beta_app_review_submissions(build_id: build_id)
+          Spaceship::ConnectAPI.post_beta_app_review_submissions(build_id: build_id)
         end
       end
 
@@ -253,7 +244,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:delete).and_yield(req_mock)
-          client.delete_beta_app_review_submission(beta_app_review_submission_id: beta_app_review_submission_id)
+          Spaceship::ConnectAPI.delete_beta_app_review_submission(beta_app_review_submission_id: beta_app_review_submission_id)
         end
       end
     end
@@ -267,14 +258,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_build_localizations
+          Spaceship::ConnectAPI.get_beta_build_localizations
         end
 
         it 'succeeds with filter' do
           params = { filter: { build: build_id } }
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_build_localizations(params)
+          Spaceship::ConnectAPI.get_beta_build_localizations(params)
         end
       end
 
@@ -304,7 +295,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.post_beta_build_localizations(build_id: build_id, attributes: attributes)
+          Spaceship::ConnectAPI.post_beta_build_localizations(build_id: build_id, attributes: attributes)
         end
       end
 
@@ -327,7 +318,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:patch).and_yield(req_mock)
-          client.patch_beta_build_localizations(localization_id: localization_id, attributes: attributes)
+          Spaceship::ConnectAPI.patch_beta_build_localizations(localization_id: localization_id, attributes: attributes)
         end
       end
     end
@@ -342,14 +333,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_groups
+          Spaceship::ConnectAPI.get_beta_groups
         end
 
         it 'succeeds with filter' do
           params = { filter: { name: name } }
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_groups(params)
+          Spaceship::ConnectAPI.get_beta_groups(params)
         end
       end
 
@@ -373,7 +364,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.add_beta_groups_to_build(build_id: build_id, beta_group_ids: beta_group_ids)
+          Spaceship::ConnectAPI.add_beta_groups_to_build(build_id: build_id, beta_group_ids: beta_group_ids)
         end
       end
     end
@@ -387,14 +378,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_testers
+          Spaceship::ConnectAPI.get_beta_testers
         end
 
         it 'succeeds with filter' do
           params = { filter: { app: app_id } }
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_beta_testers(params)
+          Spaceship::ConnectAPI.get_beta_testers(params)
         end
       end
 
@@ -431,7 +422,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.post_bulk_beta_tester_assignments(beta_group_id: beta_group_id, beta_testers: beta_testers)
+          Spaceship::ConnectAPI.post_bulk_beta_tester_assignments(beta_group_id: beta_group_id, beta_testers: beta_testers)
         end
       end
 
@@ -455,7 +446,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:delete).and_yield(req_mock)
-          client.delete_beta_tester_from_apps(beta_tester_id: beta_tester_id, app_ids: app_ids)
+          Spaceship::ConnectAPI.delete_beta_tester_from_apps(beta_tester_id: beta_tester_id, app_ids: app_ids)
         end
       end
 
@@ -479,7 +470,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:delete).and_yield(req_mock)
-          client.delete_beta_tester_from_beta_groups(beta_tester_id: beta_tester_id, beta_group_ids: beta_group_ids)
+          Spaceship::ConnectAPI.delete_beta_tester_from_beta_groups(beta_tester_id: beta_tester_id, beta_group_ids: beta_group_ids)
         end
       end
     end
@@ -494,14 +485,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_builds
+          Spaceship::ConnectAPI.get_builds
         end
 
         it 'succeeds with filter' do
           params = { filter: { expired: false, processingState: "PROCESSING,VALID", version: "123" } }
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_builds(params)
+          Spaceship::ConnectAPI.get_builds(params)
         end
       end
 
@@ -513,7 +504,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_build(build_id: build_id)
+          Spaceship::ConnectAPI.get_build(build_id: build_id)
         end
       end
 
@@ -536,7 +527,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:patch).and_yield(req_mock)
-          client.patch_builds(build_id: build_id, attributes: attributes)
+          Spaceship::ConnectAPI.patch_builds(build_id: build_id, attributes: attributes)
         end
       end
     end
@@ -550,14 +541,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_build_beta_details
+          Spaceship::ConnectAPI.get_build_beta_details
         end
 
         it 'succeeds with filter' do
           params = { filter: { build: build_id } }
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_build_beta_details(params)
+          Spaceship::ConnectAPI.get_build_beta_details(params)
         end
       end
 
@@ -580,7 +571,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           req_mock = test_request_body(url, body)
 
           expect(client).to receive(:request).with(:patch).and_yield(req_mock)
-          client.patch_build_beta_details(build_beta_details_id: build_beta_details_id, attributes: attributes)
+          Spaceship::ConnectAPI.patch_build_beta_details(build_beta_details_id: build_beta_details_id, attributes: attributes)
         end
       end
     end
@@ -595,14 +586,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_build_deliveries
+          Spaceship::ConnectAPI.get_build_deliveries
         end
 
         it 'succeeds with filter' do
           params = { filter: { version: version } }
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_build_deliveries(params)
+          Spaceship::ConnectAPI.get_build_deliveries(params)
         end
       end
     end
@@ -617,14 +608,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_pre_release_versions
+          Spaceship::ConnectAPI.get_pre_release_versions
         end
 
         it 'succeeds with filter' do
           params = { filter: { version: version } }
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_pre_release_versions(params)
+          Spaceship::ConnectAPI.get_pre_release_versions(params)
         end
       end
     end

--- a/spaceship/spec/connect_api/users/user_client_spec.rb
+++ b/spaceship/spec/connect_api/users/user_client_spec.rb
@@ -11,15 +11,6 @@ describe Spaceship::ConnectAPI::Users::Client do
   context 'sends api request' do
     before(:each) do
       allow(client).to receive(:handle_response)
-      module Spaceship
-        class ConnectAPI
-          module Users
-            class Client
-              include Spaceship::ConnectAPI::Users
-            end
-          end
-        end
-      end
     end
 
     def test_request_params(url, params)
@@ -55,7 +46,7 @@ describe Spaceship::ConnectAPI::Users::Client do
           params = {}
           req_mock = test_request_params(path, params)
           expect(client).to receive(:request).with(:get).and_yield(req_mock)
-          client.get_users
+          Spaceship::ConnectAPI.get_users
         end
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes a crash that happens when calling `tester.delete_from_apps(apps: [app])`

### Description