### PR TITLE
[actions] Fix `SharedValues` warnings when executing `fastlane` commands

### DIFF
--- a/fastlane/lib/fastlane/actions/build_ios_app.rb
+++ b/fastlane/lib/fastlane/actions/build_ios_app.rb
@@ -1,8 +1,8 @@
 module Fastlane
   module Actions
     module SharedValues
-      IPA_OUTPUT_PATH = :IPA_OUTPUT_PATH
-      DSYM_OUTPUT_PATH = :DSYM_OUTPUT_PATH
+      IPA_OUTPUT_PATH ||= :IPA_OUTPUT_PATH
+      DSYM_OUTPUT_PATH ||= :DSYM_OUTPUT_PATH
       XCODEBUILD_ARCHIVE ||= :XCODEBUILD_ARCHIVE # originally defined in XcodebuildAction
     end
 

--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      FL_CHANGELOG = :FL_CHANGELOG
+      FL_CHANGELOG ||= :FL_CHANGELOG
     end
 
     class ChangelogFromGitCommitsAction < Action

--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -6,7 +6,7 @@ module Fastlane
       SIGH_UDID = :SIGH_UDID # deprecated
       SIGH_UUID = :SIGH_UUID
       SIGH_NAME = :SIGH_NAME
-      SIGH_PROFILE_TYPE = :SIGH_PROFILE_TYPE
+      SIGH_PROFILE_TYPE ||= :SIGH_PROFILE_TYPE
     end
 
     class GetProvisioningProfileAction < Action

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      BUILD_NUMBER = :BUILD_NUMBER
+      BUILD_NUMBER ||= :BUILD_NUMBER
     end
 
     class IncrementBuildNumberAction < Action

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      VERSION_NUMBER = :VERSION_NUMBER
+      VERSION_NUMBER ||= :VERSION_NUMBER
     end
 
     class IncrementVersionNumberAction < Action

--- a/fastlane/lib/fastlane/actions/version_bump_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_bump_podspec.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      PODSPEC_VERSION_NUMBER = :PODSPEC_VERSION_NUMBER
+      PODSPEC_VERSION_NUMBER ||= :PODSPEC_VERSION_NUMBER
     end
 
     class VersionBumpPodspecAction < Action

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -2,7 +2,7 @@
 module Fastlane
   module Actions
     module SharedValues
-      XCODEBUILD_ARCHIVE = :XCODEBUILD_ARCHIVE
+      XCODEBUILD_ARCHIVE ||= :XCODEBUILD_ARCHIVE
       XCODEBUILD_DERIVED_DATA_PATH = :XCODEBUILD_DERIVED_DATA_PATH
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

When I execute `fastlane` commands like `fastlane init`, I get a bunch of warnings. These warnings were introduce by #14892.

<!-- If it fixes an open issue, please link to the issue here. -->

closes https://github.com/fastlane/fastlane/issues/15012

### Description
<!-- Describe your changes in detail -->

I took a look at the changes in #14892 and got rid of warnings by declaring a consts **only** if it weren't declared before. Made this change for each action which defines a const in `SharedValues` module. 

<!-- Please describe in detail how you tested your changes. -->

Before

<img width="1472" alt="Screen Shot 2019-07-11 at 13 36 15" src="https://user-images.githubusercontent.com/10795657/61048769-17942800-a3e3-11e9-8a05-2e727c53702e.png">

After

<img width="640" alt="Screen Shot 2019-07-11 at 13 36 03" src="https://user-images.githubusercontent.com/10795657/61048775-1f53cc80-a3e3-11e9-8f00-a1bbe9b5f447.png">

