### PR TITLE
[fastlane] fix FastlaneCore::BuildWatcher from erroring on multiple builds found

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -102,9 +102,9 @@ module Spaceship
       # API
       #
 
-      def self.all(app_id: nil, version: nil, build_number: nil, platform: nil, includes: ESSENTIAL_INCLUDES, sort: "-uploadedDate", limit: 30)
+      def self.all(app_id: nil, version: nil, build_number: nil, platform: nil, processing_states: "PROCESSING,FAILED,INVALID,VALID", includes: ESSENTIAL_INCLUDES, sort: "-uploadedDate", limit: 30)
         resps = Spaceship::ConnectAPI.get_builds(
-          filter: { app: app_id, "preReleaseVersion.version" => version, version: build_number, processingState: "PROCESSING,FAILED,INVALID,VALID" },
+          filter: { app: app_id, "preReleaseVersion.version" => version, version: build_number, processingState: processing_states },
           includes: includes,
           sort: sort,
           limit: limit


### PR DESCRIPTION
Fixes #15007

### Motivation and Context
Prevent `FastlaneCore::BuildWatcher` from raising error that there were multiple builds being watched

### Description
1. Turns out this issue was from `app_version = train_version` being set in the wrong place so `app_version` was getting nil-ed 🙄 
2. Made a more descriptive error if (for some reason) the fetching of builds does return more than 1 build
3. Added output to show what build watcher is watching
