### PR TITLE
[action] `sh` does not remove whitespace around output any more

### DIFF
--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -54,7 +54,7 @@ module Fastlane
         Open3.popen2e(*command) do |stdin, io, thread|
           io.sync = true
           io.each do |line|
-            UI.command_output(line.strip) if print_command_output
+            UI.command_output(line) if print_command_output
             result << line
           end
           exit_status = thread.value

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -68,8 +68,7 @@ module FastlaneCore
     end
 
     def command_output(message)
-      actual = (message.split("\r").last || "") # as clearing the line will remove the `>` and the time stamp
-      actual.split("\n").each do |msg|
+      message.lines.map(&:chomp).each do |msg|
         if FastlaneCore::Env.truthy?("FASTLANE_DISABLE_OUTPUT_FORMAT")
           log.info(msg)
         else


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently `sh` looses both whitespace and empty lines in output.

### Description

- Remove `strip` that removed whitespace at beginning and end of output lines
- fix and simplify code that should split string into lines so that it doesn't lose empty lines (via @joshdholtz at https://github.com/fastlane/fastlane/issues/15021#issuecomment-513754165)

closes #15021

