### PR TITLE
[action] Fix variable usage in increment_build_number call

### DIFF
--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -63,7 +63,7 @@ module Fastlane
         [
           'increment_build_number(build_number: number_of_commits)',
           'build_number = number_of_commits(all: true)
-          increment_build_number(build_number: number_of_commits)'
+          increment_build_number(build_number: build_number)'
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Fix variable usage in the docs
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
The example provides a way to captures commit count from all branches but in the subsequent call does not use this variable. This changes fixes that so that others reading this code can just copy paste this example code and have it work without any changes.
<!-- Please describe in detail how you tested your changes. -->
