### PR TITLE
[snapshot] Fix warning about unused variable in SnapshotHelper.swift

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -168,7 +168,7 @@ open class Snapshot: NSObject {
             app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
         #else
 
-            guard let app = self.app else {
+            guard self.app != nil else {
                 NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
                 return
             }

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -300,4 +300,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.19]
+// SnapshotHelperVersion [1.20]


### PR DESCRIPTION
### Checklist
(The first two is intentionally kept unchecked as this change has nothing to do with Ruby)
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Xcode will throw a warning when running a target containing the current version of `SnapshotHelper.swift`. The `app` variable isn't used after the guard block.

### Description
This fix will remove the warning in Xcode when running/debugging a UI test for Snapshot.