### PR TITLE
[download_dsyms] Fix wait for dSYM file to appear on App Store Connect

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -25,6 +25,7 @@ module Fastlane
         build_number = params[:build_number]
         platform = params[:platform]
         output_directory = params[:output_directory]
+        wait_for_dsym_processing = params[:wait_for_dsym_processing]
         min_version = Gem::Version.new(params[:min_version]) if params[:min_version]
 
         # Set version if it is latest
@@ -100,10 +101,10 @@ module Fastlane
               end
 
               unless download_url
-                UI.message("Waiting for dSYM file to appear...")
-                if (Time.now - start) > (60 * 5)
+                if !wait_for_dsym_processing || (Time.now - start) > (60 * 5)
                   UI.error("Could not find any dSYM for #{build.build_version} (#{train.version_string})")
                 else
+                  UI.message("Waiting for dSYM file to appear...")
                   sleep(30)
                   next
                 end
@@ -241,7 +242,14 @@ module Fastlane
                                        short_option: "-s",
                                        env_name: "DOWNLOAD_DSYMS_OUTPUT_DIRECTORY",
                                        description: "Where to save the download dSYMs, defaults to the current path",
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :wait_for_dsym_processing,
+                                       short_option: "-w",
+                                       env_name: "DOWNLOAD_DSYMS_WAIT_FOR_DSYM_PROCESSING",
+                                       description: "Wait for dSYMs to process",
+                                       optional: true,
+                                       default_value: false,
+                                       type: Boolean)
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When running action `download_dsyms` right after action `upload_to_testflight`, the dSYMs are not yet compiled and `download_dsyms` throws:
`No dSYM files found on App Store Connect - this usually happens when no recompiling has happened yet`

Full logs:
```
[09:52:32]: Successfully finished processing the build 1.0.0 - 2647 for IOS
[09:52:34]: Successfully set the changelog for build
[09:52:34]: Distributing new build to testers: 1.0.0 - 2647
[09:52:34]: Successfully distributed build to Internal testers 🚀
[09:52:34]: ----------------------------
[09:52:34]: --- Step: download_dsyms ---
[09:52:34]: ----------------------------
[09:52:34]: Login to App Store Connect (*******@*****.**)
[09:52:35]: Login successful
[09:52:35]: Looking for dSYM files for '***.****.*****.*****' on platform ios v1.0.0 (2647)
[09:52:42]: No dSYM URL for 2647 (1.0.0)
[09:52:42]: No dSYM files found on App Store Connect - this usually happens when no recompiling has happened yet
[09:52:42]: -------------------------------------------
[09:52:42]: --- Step: upload_symbols_to_crashlytics ---
[09:52:42]: -------------------------------------------
[09:52:42]: Error setting value 'build/***.****.*****.*****-1.0.0-2647.dSYM.zip' for option 'dsym_path'
[09:52:42]: You passed invalid parameters to 'upload_symbols_to_crashlytics'.
[09:52:42]: Check out the error below and available options by running `fastlane action upload_symbols_to_crashlytics`
```

Related PR: https://github.com/fastlane/fastlane/pull/14137
Related issue: https://github.com/fastlane/fastlane/issues/14393

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

Same logic as `wait_for_build`, simply sleep for 30 seconds and try again, with a timeout of 5 minutes.