### PR TITLE
[spaceship] Fix typo in `ready_for_beta_submission?` error message

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -79,7 +79,7 @@ module Spaceship
       end
 
       def ready_for_beta_submission?
-        raise "No build_beat_detail included" unless build_beta_detail
+        raise "No build_beta_detail included" unless build_beta_detail
         return build_beta_detail.ready_for_beta_submission?
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
It addresses the typo in the `ready_for_beta_submission?` error message. 
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
I swapped the placement of the 'a' and 't' to change the word from 'beat' to 'beta'.
<!-- Please describe in detail how you tested your changes. -->
I thought writing an automated test (or performing a manual one for that matter) would be a little overkill for checking the spelling of an error message 😅.