### PR TITLE
Update gradle docs with example for task "bundle" (Resolves #15053)

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -102,7 +102,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :task,
                                        env_name: 'FL_GRADLE_TASK',
-                                       description: 'The gradle task you want to execute, e.g. `assemble` or `test`. For tasks such as `assembleMyFlavorRelease` you should use gradle(task: \'assemble\', flavor: \'Myflavor\', build_type: \'Release\')',
+                                       description: 'The gradle task you want to execute, e.g. `assemble`, `bundle` or `test`. For tasks such as `assembleMyFlavorRelease` you should use gradle(task: \'assemble\', flavor: \'Myflavor\', build_type: \'Release\')',
                                        optional: false,
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :flavor,
@@ -183,12 +183,27 @@ module Fastlane
 
       def self.example_code
         [
-          'gradle(
+          'To build an .apk file use:
+          ```ruby
+          gradle(
             task: "assemble",
             flavor: "WorldDomination",
             build_type: "Release"
-          )',
-          'gradle(
+          )
+          ```
+
+          To build an .aab file use:
+          ```ruby
+          gradle(
+            task: "bundle",
+            flavor: "WorldDomination",
+            build_type: "Release"
+          )
+          ```
+
+          You can pass properties to gradle:
+          ```ruby
+          gradle(
             # ...
 
             properties: {
@@ -211,8 +226,11 @@ module Fastlane
               "android.injected.signing.key.alias" => "key_alias",
               "android.injected.signing.key.password" => "key_password",
             }
-          )',
-          '# If you need to pass sensitive information through the `gradle` action, and don\'t want the generated command to be printed before it is run, you can suppress that:
+          )
+          ```
+          
+          If you need to pass sensitive information through the `gradle` action, and don\'t want the generated command to be printed before it is run, you can suppress that:
+          ```ruby
           gradle(
             # ...
             print_command: false
@@ -233,8 +251,11 @@ module Fastlane
             # ...
 
             flags: "--exitcode --xml file.xml"
-          )',
-          '# Delete the build directory and generated APKs
+          )
+          ```
+
+          Delete the build directory and generated APKs:
+          ```ruby
           gradle(
             task: "clean"
           )'

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -228,7 +228,7 @@ module Fastlane
             }
           )
           ```
-          
+
           If you need to pass sensitive information through the `gradle` action, and don\'t want the generated command to be printed before it is run, you can suppress that:
           ```ruby
           gradle(


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves issue #15053 by adding missing documentation to gradle action. It specifically adds an example for building an .aab file (Android Application Bundle) and clarifies that the existing example builds an .apk file.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
No code changes were made, only comments and documentation was updated.
All tests were run successfully afterwards.
