### PR TITLE
[action] add SonarQube pull request parameters to sonar

### DIFF
--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -21,6 +21,9 @@ module Fastlane
         sonar_scanner_args << "-Dsonar.login=\"#{params[:sonar_login]}\"" if params[:sonar_login]
         sonar_scanner_args << "-Dsonar.host.url=\"#{params[:sonar_url]}\"" if params[:sonar_url]
         sonar_scanner_args << "-Dsonar.branch.name=\"#{params[:branch_name]}\"" if params[:branch_name]
+        sonar_scanner_args << "-Dsonar.pullrequest.branch=\"#{params[:pull_request_branch]}\"" if params[:pull_request_branch]
+        sonar_scanner_args << "-Dsonar.pullrequest.base=\"#{params[:pull_request_base]}\"" if params[:pull_request_base]
+        sonar_scanner_args << "-Dsonar.pullrequest.key=\"#{params[:pull_request_key]}\"" if params[:pull_request_key]
         sonar_scanner_args << params[:sonar_runner_args] if params[:sonar_runner_args]
 
         command = [
@@ -102,6 +105,21 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :branch_name,
                                        env_name: "FL_SONAR_RUNNER_BRANCH_NAME",
                                        description: "Pass the branch name which is getting scanned",
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :pull_request_branch,
+                                       env_name: "FL_SONAR_RUNNER_PULL_REQUEST_BRANCH",
+                                       description: "The name of the branch that contains the changes to be merged",
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :pull_request_base,
+                                       env_name: "FL_SONAR_RUNNER_PULL_REQUEST_BASE",
+                                       description: "The long-lived branch into which the PR will be merged",
+                                       optional: true,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :pull_request_key,
+                                       env_name: "FL_SONAR_RUNNER_PULL_REQUEST_KEY",
+                                       description: "Unique identifier of your PR. Must correspond to the key of the PR in GitHub or TFS",
                                        optional: true,
                                        is_string: true)
         ]

--- a/fastlane/spec/actions_specs/sonar_spec.rb
+++ b/fastlane/spec/actions_specs/sonar_spec.rb
@@ -1,6 +1,19 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Sonar Integration" do
+      let(:test_path) { "/tmp/fastlane/tests/fastlane" }
+      let(:sonar_project_path) { "sonar-project.properties" }
+
+      before do
+        # Set up example sonar-project.properties file
+        FileUtils.mkdir_p(test_path)
+        File.write(File.join(test_path, sonar_project_path), '')
+      end
+
+      after(:each) do
+        File.delete(File.join(test_path, sonar_project_path)) if File.exist?(File.join(test_path, sonar_project_path))
+      end
+
       it "Should not print sonar command" do
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
         expected_command = "cd #{File.expand_path('.').shellescape} && sonar-scanner -Dsonar.login=\"asdf\""
@@ -9,6 +22,45 @@ describe Fastlane do
         Fastlane::FastFile.new.parse("lane :sonar_test do
           sonar(sonar_login: 'asdf')
         end").runner.execute(:sonar_test)
+      end
+
+      it "works with all parameters" do
+        expect(Fastlane::Actions::SonarAction).to receive(:verify_sonar_scanner_binary).and_return(true)
+        allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          sonar({
+            project_configuration_path: '#{test_path}/#{sonar_project_path}',
+            project_key: 'project-key',
+            project_name: 'project-name',
+            project_version: '1.0.0',
+            sources_path: '/Sources',
+            project_language: 'ruby',
+            source_encoding: 'utf-8',
+            sonar_login: 'sonar-login',
+            sonar_url: 'http://www.sonarqube.com',
+            branch_name: 'branch-name',
+            pull_request_branch: 'pull-request-branch-name',
+            pull_request_base: 'pull-request-base',
+            pull_request_key: 'pull-request-key'
+          })
+        end").runner.execute(:test)
+
+        expected = "cd #{File.expand_path('.').shellescape} && sonar-scanner
+                    -Dproject.settings=\"#{test_path}/#{sonar_project_path}\"
+                    -Dsonar.projectKey=\"project-key\"
+                    -Dsonar.projectName=\"project-name\"
+                    -Dsonar.projectVersion=\"1.0.0\"
+                    -Dsonar.sources=\"/Sources\"
+                    -Dsonar.language=\"ruby\"
+                    -Dsonar.sourceEncoding=\"utf-8\"
+                    -Dsonar.login=\"sonar-login\"
+                    -Dsonar.host.url=\"http://www.sonarqube.com\"
+                    -Dsonar.branch.name=\"branch-name\"
+                    -Dsonar.pullrequest.branch=\"pull-request-branch-name\"
+                    -Dsonar.pullrequest.base=\"pull-request-base\"
+                    -Dsonar.pullrequest.key=\"pull-request-key\"".gsub(/\s+/, ' ')
+        expect(result).to eq(expected)
       end
     end
   end

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -3419,10 +3419,7 @@ func sonar(projectConfigurationPath: String? = nil,
            sonarRunnerArgs: String? = nil,
            sonarLogin: String? = nil,
            sonarUrl: String? = nil,
-           branchName: String? = nil,
-           pullRequestBranchName: String? = nil,
-           pullRequestBase: String? = nil,
-           pullRequestKey: String? = nil) {
+           branchName: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "sonar", className: nil, args: [RubyCommand.Argument(name: "project_configuration_path", value: projectConfigurationPath),
                                                                                        RubyCommand.Argument(name: "project_key", value: projectKey),
                                                                                        RubyCommand.Argument(name: "project_name", value: projectName),
@@ -3433,10 +3430,7 @@ func sonar(projectConfigurationPath: String? = nil,
                                                                                        RubyCommand.Argument(name: "sonar_runner_args", value: sonarRunnerArgs),
                                                                                        RubyCommand.Argument(name: "sonar_login", value: sonarLogin),
                                                                                        RubyCommand.Argument(name: "sonar_url", value: sonarUrl),
-                                                                                       RubyCommand.Argument(name: "branch_name", value: branchName),
-                                                                                       RubyCommand.Argument(name: "pull_request_branch", value: pullRequestBranchName),
-                                                                                       RubyCommand.Argument(name: "pull_request_base", value: pullRequestBase),
-                                                                                       RubyCommand.Argument(name: "pull_request_key", value: pullRequestKey)])
+                                                                                       RubyCommand.Argument(name: "branch_name", value: branchName)])
   _ = runner.executeCommand(command)
 }
 func spaceshipLogs(latest: Bool = true,
@@ -4401,4 +4395,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.52]
+// FastlaneRunnerAPIVersion [0.9.54]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -3419,7 +3419,10 @@ func sonar(projectConfigurationPath: String? = nil,
            sonarRunnerArgs: String? = nil,
            sonarLogin: String? = nil,
            sonarUrl: String? = nil,
-           branchName: String? = nil) {
+           branchName: String? = nil,
+           pullRequestBranchName: String? = nil,
+           pullRequestBase: String? = nil,
+           pullRequestKey: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "sonar", className: nil, args: [RubyCommand.Argument(name: "project_configuration_path", value: projectConfigurationPath),
                                                                                        RubyCommand.Argument(name: "project_key", value: projectKey),
                                                                                        RubyCommand.Argument(name: "project_name", value: projectName),
@@ -3430,7 +3433,10 @@ func sonar(projectConfigurationPath: String? = nil,
                                                                                        RubyCommand.Argument(name: "sonar_runner_args", value: sonarRunnerArgs),
                                                                                        RubyCommand.Argument(name: "sonar_login", value: sonarLogin),
                                                                                        RubyCommand.Argument(name: "sonar_url", value: sonarUrl),
-                                                                                       RubyCommand.Argument(name: "branch_name", value: branchName)])
+                                                                                       RubyCommand.Argument(name: "branch_name", value: branchName),
+                                                                                       RubyCommand.Argument(name: "pull_request_branch", value: pullRequestBranchName),
+                                                                                       RubyCommand.Argument(name: "pull_request_base", value: pullRequestBase),
+                                                                                       RubyCommand.Argument(name: "pull_request_key", value: pullRequestKey)])
   _ = runner.executeCommand(command)
 }
 func spaceshipLogs(latest: Bool = true,

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -4395,4 +4395,4 @@ let screengrabfile: Screengrabfile = Screengrabfile()
 let snapshotfile: Snapshotfile = Snapshotfile()
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.54]
+// FastlaneRunnerAPIVersion [0.9.52]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR implements and closes #15068.

As explained in the linked issue, using the currently available parameters of the `sonar` action is limited in term of PR management from **SonarQube**.

This PR goal is to add the missing parameters that would allow for relevant code coverage comparison between branches.

### Description
This PR add three new parameters to the `sonar` action.

Those parameters can be used to allow **SonarQube** to perform code coverage differentiation between the base branch and the targeted branch.
