### PR TITLE
[match] fix for match username not found if readonly

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -43,7 +43,7 @@ module Match
         google_cloud_keys_file: params[:google_cloud_keys_file].to_s,
         google_cloud_project_id: params[:google_cloud_project_id].to_s,
         readonly: params[:readonly],
-        username: params[:username],
+        username: params[:readonly] ? nil : params[:username], # only pass username if not readonly
         team_id: params[:team_id],
         team_name: params[:team_name]
       })


### PR DESCRIPTION
Fixes #15072

^ https://github.com/fastlane/fastlane/pull/15023#issuecomment-514211867

### Motivation and Context
Don't read username if not needed

### Description
`username` is a required option for _match_. This means that once that `params[:username]` is read that it will force the user to enter (or error if in CI mode).

1. This line was added in `2.128.0` as a way to move logic into the storage providers. - https://github.com/fastlane/fastlane/blob/master/match/lib/match/runner.rb#L46 
2. There was an oversight where `params[:username]` should only get read if `readonly` is `false` (see following examples)
  - https://github.com/fastlane/fastlane/blob/master/match/lib/match/runner.rb#L60
  - https://github.com/fastlane/fastlane/blob/master/match/lib/match/runner.rb#L79
  - https://github.com/fastlane/fastlane/blob/master/match/lib/match/runner.rb#L85
3. The above examples were not implemented in a way that made this super apparent
4. Additionally, `:username` most likely won't be `nil` a lot of a dev machine because the following dynamic default happening in the match options
  - https://github.com/fastlane/fastlane/blob/master/match/lib/match/options.rb#L14-L15
  - https://github.com/fastlane/fastlane/blob/master/match/lib/match/options.rb#L51

So the reason this happened in a CI was because of `readonly: true` and the dynamic default being `nil`.

So... this fix will only set call and pass the `:username` if `reaonly: false` because that is the only time that `:username` is needed