### PR TITLE
[sigh] Make download_all include mac profiles

### DIFF
--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -12,7 +12,9 @@ module Sigh
       Spaceship.select_team
       UI.message("Successfully logged in")
 
-      Spaceship.provisioning_profile.all(xcode: download_xcode_profiles).each do |profile|
+      # all ios profiles (including or excluding Xcode Managed Profiles) and mac profiles
+      profiles = Spaceship.provisioning_profile.all(xcode: download_xcode_profiles) + Spaceship.provisioning_profile.all(mac: true)
+      profiles.each do |profile|
         if profile.valid?
           UI.message("Downloading profile '#{profile.name}'...")
           download_profile(profile)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
When I saw the "download_all" option I assumed this meant all profiles -- including the macos ones. After seeing that some of our machines were missing some profiles, I dug deeper and saw the only profiles missing were out mac ones. As a sanity check I looked at the documentation, assumed I could probably just pass the "platform" flag but multiple attempts showed me this was not the case. Looking at the source code it became apparent that this functionality was missing! And just calling sigh with the platform flag is forcing me to specify a bundle identifier but I want all of the mac profiles!

<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/15084

### Description
<!-- Describe your changes in detail -->
All I did was combine the collection of ios profiles (with or without the xcode managed ones) as well as the mac profiles.

<!-- Please describe in detail how you tested your changes. -->
First, I checked via spaceship if what I did is syntactically and logically correct.
Then, I executed rspec.
Finally, I used my fastlane clone to test and see if the behavior is as expected. At the very bottom of the output I saw all of the mac profiles that weren't being downloaded before!

I made sure I was running my local version by running
`bundle show fastlane`
Then ran the same exact command as before
`bundle exec fastlane sigh download_all --readonly --skip_install --output_path /tmp/profiles/`
