### PR TITLE
[spaceship] add invited state for TestFlight beta testers.

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/beta_tester_metric.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_tester_metric.rb
@@ -24,6 +24,7 @@ module Spaceship
 
       module BetaTesterState
         INSTALLED = "INSTALLED"
+        INVITED = "INVITED"
         NO_BUILDS = "NO_BUILDS"
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I recently pushed a [PR](https://github.com/KrauseFx/fastlane-plugin-clean_testflight_testers/pull/11) to add `ConnectAPI` support to Krause's awesome `clean_testflight_testers` plugin, and while doing so realized _Spaceship_ doesn't include a state for when a tester has been invited, but not yet accepted the invitation.

### Description
This PR adds the `INVITED` state, as returned by the App Store Connect API.
