### PR TITLE
[snapshot] Replace Objective-C-style NSMakeRange with Swift-style NSRange.init

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -300,4 +300,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.20]
+// SnapshotHelperVersion [1.21]

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -175,11 +175,11 @@ open class Snapshot: NSObject {
 
             let screenshot = XCUIScreen.main.screenshot()
             guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
-            
+
             do {
                 // The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
                 let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
-                let range = NSMakeRange(0, simulator.count)
+                let range = NSRange(location: 0, length: simulator.count)
                 simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
 
                 let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### 🔑 Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Get the following message in SnapshotHelper.swift line 182 when running _swiftlint_: **Swift constructors are preferred over legacy convenience functions**. I think it would be great to use modern Swift API in _fastlane_.
This is a very small improvement, but I think all users will enjoy it.

### Description
Replace Objective-C-style `NSMakeRange(0, simulator.count)` with Swift-style `NSRange(location: 0, length: simulator.count)` (suggested by _swiftlint_ https://github.com/realm/SwiftLint). Delete empty line.
To test my changes I replaced **SnapshotHelper.swift** from the tag fastlane/2.128.1 with my version of **SnapshotHelper.swift** and run `capture_screenshots`. _Fastlane_ generated the same screenshots successfully.