### PR TITLE
[core] Less hacks in command_executor_spec

### DIFF
--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -12,23 +12,21 @@ describe FastlaneCore do
       end
 
       it 'handles reading which throws a EIO exception', requires_pty: true do
-        explodes_on_strip = 'danger! lasers!'
-        fake_std_in = ['a_filename', explodes_on_strip]
-
-        # In reality the exception is raised by the `each` call, but for easier mocking
-        # we manually raise the exception when the line is cleaned up with `strip` afterward
-        expect(explodes_on_strip).to receive(:strip).and_raise(Errno::EIO)
-
-        child_process_id = 1
-        expect(Process).to receive(:wait).with(child_process_id)
-
-        # Hacky approach because $? is not be defined since we skip the actual spawn
-        allow_message_expectations_on_nil
-        expect($?).to receive(:exitstatus).and_return(0)
+        fake_std_in = [
+          "a_filename\n"
+        ]
+        expect(fake_std_in).to receive(:each).and_yield(*fake_std_in).and_raise(Errno::EIO)
 
         # Make a fake child process so we have a valid PID and $? is set correctly
         expect(PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('ls')
+
+          # PTY uses "$?" to get exitcode, which is filled in by Process.wait(),
+          # so we have to spawn a real process unless we want to mock methods
+          # on nil.
+          child_process_id = Process.spawn('echo foo', out: File::NULL)
+          expect(Process).to receive(:wait).with(child_process_id)
+
           block.yield(fake_std_in, 'not_really_std_out', child_process_id)
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Improving spec to be less of a change trigger, and having less hacks.

### Description

- get rid of `allow_message_expectations_on_nil`
- set mocks on the right call (not implementation detail of calling `String#strip`, but rather yielding from `each`)
