### PR TITLE
[core] chomp, not strip output in CommandExecutor

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -51,7 +51,7 @@ module FastlaneCore
         begin
           status = FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
             command_stdout.each do |l|
-              line = l.strip # strip so that \n gets removed
+              line = l.chomp
               output << line
 
               next unless print_all


### PR DESCRIPTION
### Checklist
- [x] #15131 is merged
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Current output from CommandExecutor is hard to parse for a human eye when indentation is important.

### Description

[`String#strip`](https://ruby-doc.org/core-2.6/String.html#method-i-strip) removes whitespaces (and CR/LF) *around* the line, while [`String#chomp`](https://ruby-doc.org/core-2.6/String.html#method-i-chomp) removes only record separator (CR/LF) at the end of the line.