### PR TITLE
[action] fix for Xcode 11 when using `$(MARKETING_VERSION)` in `get_version_number`

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -18,6 +18,7 @@ module Fastlane
         plist_file = get_plist!(folder, target, configuration)
         version_number = get_version_number_from_plist!(plist_file)
 
+        # Get from build settings if needed (ex: $(MARKETING_VERSION) is default in Xcode 11)
         if version_number =~ /\$\(([\w\-]+)\)/
           version_number = get_version_number_from_build_settings!(target, $1, configuration)
         end
@@ -70,19 +71,14 @@ module Fastlane
       end
 
       def self.get_version_number_from_build_settings!(target, variable, configuration = nil)
-        value = nil
-
         target.build_configurations.each do |config|
           if configuration.nil? || config.name == configuration
             value = config.build_settings[variable]
+            return value if value
           end
         end
 
-        if value
-          return value
-        else
-          UI.user_error!("Unable to find Xcode build setting: #{variable}")
-        end
+        UI.user_error!("Unable to find Xcode build setting: #{variable}")
       end
 
       def self.get_plist!(folder, target, configuration = nil)

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -17,7 +17,7 @@ module Fastlane
         target = get_target!(project, target_name)
         plist_file = get_plist!(folder, target, configuration)
         version_number = get_version_number_from_plist!(plist_file)
-        
+
         if version_number =~ /\$\(([\w\-]+)\)/
           version_number = get_version_number_from_build_settings!(target, $1, configuration)
         end
@@ -68,16 +68,16 @@ module Fastlane
 
         target
       end
-      
+
       def self.get_version_number_from_build_settings!(target, variable, configuration = nil)
         value = nil
-        
+
         target.build_configurations.each do |config|
-          if configuration.nil? or config.name == configuration
+          if configuration.nil? || config.name == configuration
             value = config.build_settings[variable]
           end
         end
-        
+
         if value
           return value
         else

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -12,6 +12,13 @@ describe Fastlane do
         expect(result).to eq("4.3.2")
       end
 
+      it "gets the correct version number for 'TargetVariableAsBundleVersion'", requires_xcodeproj: true do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '#{path}', target: 'TargetVariableAsBundleVersion')
+        end").runner.execute(:test)
+        expect(result).to eq("4.3.2")
+      end
+
       it "gets the correct version number for 'TargetATests'", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetATests')

--- a/fastlane/spec/fixtures/actions/get_version_number/TargetVariableAsBundleVersion-Info.plist
+++ b/fastlane/spec/fixtures/actions/get_version_number/TargetVariableAsBundleVersion-Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
@@ -91,6 +91,21 @@
 		03CFC576206409ED00CD6CB1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82EB2056A51B00BAAFD1 /* Assets.xcassets */; };
 		03CFC577206409ED00CD6CB1 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83062056A5D600BAAFD1 /* Info.plist */; };
 		03CFC578206409ED00CD6CB1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82E82056A51B00BAAFD1 /* Main.storyboard */; };
+		4AA286EA2300242500067244 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E62056A51B00BAAFD1 /* ViewController.swift */; };
+		4AA286EB2300242500067244 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E42056A51B00BAAFD1 /* AppDelegate.swift */; };
+		4AA286EE2300242500067244 /* TargetDifferentConfigurations-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83AD2057215F00BAAFD1 /* TargetDifferentConfigurations-Debug.plist */; };
+		4AA286EF2300242500067244 /* TargetC_production-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83482056AEC500BAAFD1 /* TargetC_production-Info.plist */; };
+		4AA286F02300242500067244 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82ED2056A51B00BAAFD1 /* LaunchScreen.storyboard */; };
+		4AA286F12300242500067244 /* TargetA-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83042056A5D000BAAFD1 /* TargetA-Info.plist */; };
+		4AA286F22300242500067244 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82EB2056A51B00BAAFD1 /* Assets.xcassets */; };
+		4AA286F32300242500067244 /* Plist-For-D-Target.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83992056B2CD00BAAFD1 /* Plist-For-D-Target.plist */; };
+		4AA286F42300242500067244 /* SampleProject-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83972056B29A00BAAFD1 /* SampleProject-Info.plist */; };
+		4AA286F52300242500067244 /* TargetDifferentConfigurations-Release.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83AE2057215F00BAAFD1 /* TargetDifferentConfigurations-Release.plist */; };
+		4AA286F62300242500067244 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83062056A5D600BAAFD1 /* Info.plist */; };
+		4AA286F72300242500067244 /* TargetB-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83242056AAD200BAAFD1 /* TargetB-Info.plist */; };
+		4AA286F82300242500067244 /* TargetC_internal-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83492056AEC500BAAFD1 /* TargetC_internal-Info.plist */; };
+		4AA286F92300242500067244 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82E82056A51B00BAAFD1 /* Main.storyboard */; };
+		4AA286FA2300242500067244 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83262056AADB00BAAFD1 /* Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -146,6 +161,8 @@
 		03AB83AE2057215F00BAAFD1 /* TargetDifferentConfigurations-Release.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetDifferentConfigurations-Release.plist"; sourceTree = "<group>"; };
 		03CFC57C206409ED00CD6CB1 /* TargetSRC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetSRC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		03CFC57D206409ED00CD6CB1 /* TargetSRC.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = TargetSRC.plist; path = /Users/josh/Projects/fastlane/fastlane/fastlane/spec/fixtures/actions/get_version_number/TargetSRC.plist; sourceTree = "<absolute>"; };
+		4AA286FE2300242500067244 /* TargetVariableAsBundleVersion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetVariableAsBundleVersion.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AA286FF2300242600067244 /* TargetVariableAsBundleVersion-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "TargetVariableAsBundleVersion-Info.plist"; path = "/Users/florent/ruby_projects/fastlane/fastlane/spec/fixtures/actions/get_version_number/TargetVariableAsBundleVersion-Info.plist"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -226,6 +243,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4AA286EC2300242500067244 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -241,6 +265,7 @@
 				03AB83482056AEC500BAAFD1 /* TargetC_production-Info.plist */,
 				03AB83262056AADB00BAAFD1 /* Info.plist */,
 				03AB83242056AAD200BAAFD1 /* TargetB-Info.plist */,
+				4AA286FF2300242600067244 /* TargetVariableAsBundleVersion-Info.plist */,
 				03AB82E32056A51B00BAAFD1 /* get_version_number */,
 				03AB82F82056A51B00BAAFD1 /* get_version_numberTests */,
 				03AB82E22056A51B00BAAFD1 /* Products */,
@@ -261,6 +286,7 @@
 				03AB83952056B27800BAAFD1 /* SampleProject.app */,
 				03AB83AB2057212800BAAFD1 /* TargetDifferentConfigurations.app */,
 				03CFC57C206409ED00CD6CB1 /* TargetSRC.app */,
+				4AA286FE2300242500067244 /* TargetVariableAsBundleVersion.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -480,6 +506,23 @@
 			productReference = 03CFC57C206409ED00CD6CB1 /* TargetSRC.app */;
 			productType = "com.apple.product-type.application";
 		};
+		4AA286E82300242500067244 /* TargetVariableAsBundleVersion */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4AA286FB2300242500067244 /* Build configuration list for PBXNativeTarget "TargetVariableAsBundleVersion" */;
+			buildPhases = (
+				4AA286E92300242500067244 /* Sources */,
+				4AA286EC2300242500067244 /* Frameworks */,
+				4AA286ED2300242500067244 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TargetVariableAsBundleVersion;
+			productName = get_version_number;
+			productReference = 4AA286FE2300242500067244 /* TargetVariableAsBundleVersion.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -530,6 +573,9 @@
 					03CFC56E206409ED00CD6CB1 = {
 						ProvisioningStyle = Automatic;
 					};
+					4AA286E82300242500067244 = {
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 03AB82DC2056A51B00BAAFD1 /* Build configuration list for PBXProject "get_version_number" */;
@@ -557,6 +603,7 @@
 				03AB839D2057212800BAAFD1 /* TargetDifferentConfigurations */,
 				03CFC56E206409ED00CD6CB1 /* TargetSRC */,
 				03B8E43E20729336001D1742 /* AggTarget */,
+				4AA286E82300242500067244 /* TargetVariableAsBundleVersion */,
 			);
 		};
 /* End PBXProject section */
@@ -691,6 +738,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4AA286ED2300242500067244 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4AA286EE2300242500067244 /* TargetDifferentConfigurations-Debug.plist in Resources */,
+				4AA286EF2300242500067244 /* TargetC_production-Info.plist in Resources */,
+				4AA286F02300242500067244 /* LaunchScreen.storyboard in Resources */,
+				4AA286F12300242500067244 /* TargetA-Info.plist in Resources */,
+				4AA286F22300242500067244 /* Assets.xcassets in Resources */,
+				4AA286F32300242500067244 /* Plist-For-D-Target.plist in Resources */,
+				4AA286F42300242500067244 /* SampleProject-Info.plist in Resources */,
+				4AA286F52300242500067244 /* TargetDifferentConfigurations-Release.plist in Resources */,
+				4AA286F62300242500067244 /* Info.plist in Resources */,
+				4AA286F72300242500067244 /* TargetB-Info.plist in Resources */,
+				4AA286F82300242500067244 /* TargetC_internal-Info.plist in Resources */,
+				4AA286F92300242500067244 /* Main.storyboard in Resources */,
+				4AA286FA2300242500067244 /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -787,6 +854,15 @@
 			files = (
 				03CFC570206409ED00CD6CB1 /* ViewController.swift in Sources */,
 				03CFC571206409ED00CD6CB1 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4AA286E92300242500067244 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4AA286EA2300242500067244 /* ViewController.swift in Sources */,
+				4AA286EB2300242500067244 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1319,6 +1395,40 @@
 			};
 			name = Release;
 		};
+		4AA286FC2300242500067244 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 4.3.2;
+				INFOPLIST_FILE = "$(SRCROOT)/TargetVariableAsBundleVersion-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 4.3.2;
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		4AA286FD2300242500067244 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 4.3.2;
+				INFOPLIST_FILE = "$(SRCROOT)/TargetVariableAsBundleVersion-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 4.3.2;
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1435,6 +1545,15 @@
 			buildConfigurations = (
 				03CFC57A206409ED00CD6CB1 /* Debug */,
 				03CFC57B206409ED00CD6CB1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4AA286FB2300242500067244 /* Build configuration list for PBXNativeTarget "TargetVariableAsBundleVersion" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4AA286FC2300242500067244 /* Debug */,
+				4AA286FD2300242500067244 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When using Xcode 11, `CFBundleShortVersionString` use `$(MARKETING_VERSION)` instead of version number like `xxx.yyy.zzz` in `Info.plist`. So, `get_version_number` returns `$(MARKETING_VERSION)`.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

`$(MARKETING_VERSION)` comes from Build settings of Xcode project.

So, if version number from `Info.plist` looks like a build setting, the good value is extracted from build settings and returned by `get_version_number`.