### PR TITLE
[CI] Run tests with Xcode 11 (and ruby 2.5) on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
+            echo "2.5" > .ruby-version
             gem update --system
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,8 @@ jobs:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
-"Execute tests on macOS (Xcode 11.0.0)":
+
+  "Execute tests on macOS (Xcode 11.0.0)":
     macos:
       xcode: "11.0.0"
     environment:
@@ -117,6 +118,7 @@ jobs:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
+
   "Execute tests on Ubuntu":
     environment:
       CIRCLE_TEST_REPORTS: ~/test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            echo "2.3" > .ruby-version
+            echo "2.3.7" > .ruby-version
             gem update --system
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,6 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            echo "2.3.7" > .ruby-version
             gem update --system
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  "Execute tests on macOS (Xcode 9.0.1)":
+  "Execute tests on macOS (Xcode 9.0.1, Ruby 2.3)":
     macos:
       xcode: "9.0.1"
     environment:
@@ -60,7 +60,7 @@ jobs:
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
 
-  "Execute tests on macOS (Xcode 11.0.0)":
+  "Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)":
     macos:
       xcode: "11.0.0"
     environment:
@@ -226,8 +226,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - "Execute tests on macOS (Xcode 9.0.1)"
-      - "Execute tests on macOS (Xcode 11.0.0)"
+      - "Execute tests on macOS (Xcode 9.0.1, Ruby 2.3)"
+      - "Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)"
       - "Execute tests on Ubuntu"
       - "Validate Documentation"
       - "Lint Source Code"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - "Execute tests on macOS"
+      - "Execute tests on macOS (Xcode 9.0.1)"
+      - "Execute tests on macOS (Xcode 11.0.0)"
       - "Execute tests on Ubuntu"
       - "Validate Documentation"
       - "Lint Source Code"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,67 @@
 version: 2
 
 jobs:
-  "Execute tests on macOS":
+  "Execute tests on macOS (Xcode 9.0.1)":
     macos:
       xcode: "9.0.1"
+    environment:
+      CIRCLE_TEST_REPORTS: ~/test-reports
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+    shell: /bin/bash --login -eo pipefail
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+      - restore_cache:
+          keys:
+            - v3-homebrew-{{ epoch }}
+            - v3-homebrew
+      - run:
+          name: Setup Build
+          command: |
+            mkdir -p ~/test-reports
+            echo "2.3" > .ruby-version
+            gem update --system
+            brew install shellcheck
+            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
+
+      - save_cache:
+          key: v3-homebrew-{{ epoch }}
+          paths:
+            - /usr/local/Homebrew
+      - save_cache:
+          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+          paths:
+            - .bundle
+
+      - run:
+          name: Check PR Metadata
+          command: bundle exec danger || echo "danger failed"
+
+      - restore_cache:
+          key: v1-{{ arch }}-rubocop
+
+      - run: bundle exec fastlane execute_tests
+
+      - save_cache:
+          key: v1-{{ arch }}-rubocop
+          paths:
+            - ~/.cache/rubocop_cache
+      - store_test_results:
+          path: ~/test-reports
+      - store_artifacts:
+          path: ~/test-reports/rspec
+          destination: test-reports
+
+      - run:
+          name: Post Test Results to GitHub
+          command: bundle exec danger || echo "danger failed"
+          when: always # Run this even when tests fail
+"Execute tests on macOS (Xcode 11.0.0)":
+    macos:
+      xcode: "11.0.0"
     environment:
       CIRCLE_TEST_REPORTS: ~/test-reports
       LC_ALL: en_US.UTF-8

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -105,7 +105,7 @@ describe FastlaneCore do
       end
 
       it "#transporter_path", requires_xcode: true do
-        expect(FastlaneCore::Helper.transporter_path).to match(%r{/Applications/Xcode.*.app/Contents/Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter})
+        expect(FastlaneCore::Helper.transporter_path).to match(%r{/Applications/Xcode.*.app/Contents/Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter|/Applications/Xcode.*.app/Contents/SharedFrameworks/ContentDeliveryServices.framework/Versions/A/itms/bin/iTMSTransporter})
       end
 
       it "#xcode_version", requires_xcode: true do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Xcode 11 changes some bits around, so it makes sense to run CI with it as well.

### Description
This duplicates our macOS build job with Xcode 11 and Ruby 2.5 (as 2.3 is not available on that image any more). One test had to be adapted to the new paths of Xcode 11 as well.
