### PR TITLE
[match] fix match not making new profiles for force_for_new_devices

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -217,7 +217,7 @@ module Match
         end
       end
 
-      if profile.nil? || params[:force]
+      if profile.nil? || force
         if params[:readonly]
           UI.error("No matching provisioning profiles found for '#{profile_name}'")
           UI.error("A new one cannot be created because you enabled `readonly`")


### PR DESCRIPTION
Fixes #15118

### Motivation and Context
To force `match` to recreate new profiles (again) when a new device is added

### Description
Fixing a regression inserted with #15023. This PR introduced a new variable called `force` which replaced which `params[:force]` everywhere since there was some logic needed about when to use force. There was an instance of `params[:force]` that wasn't replaced which caused `force_for_new_devices` to never trigger generation of a new profile 😱

But we should be good now 🙃
