### PR TITLE
[Fastlane.swift] options of `is_string: false` should be Any and not String

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_api_generator.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_api_generator.rb
@@ -337,6 +337,7 @@ func parseInt(fromString: String, function: String = #function) -> Int {
       key_default_values = []
       key_optionality_values = []
       key_type_overrides = []
+      key_is_strings = []
 
       if options.kind_of?(Array)
         options.each do |current|
@@ -350,6 +351,7 @@ func parseInt(fromString: String, function: String = #function) -> Int {
           key_default_values << current.code_gen_default_value
           key_optionality_values << current.optional
           key_type_overrides << current.data_type
+          key_is_strings << current.is_string
         end
       end
       action_return_type = action.return_type
@@ -362,6 +364,7 @@ func parseInt(fromString: String, function: String = #function) -> Int {
           key_default_values: key_default_values,
           key_optionality_values: key_optionality_values,
           key_type_overrides: key_type_overrides,
+          key_is_strings: key_is_strings,
           return_type: action_return_type
         )
         generated_protocol_file_path = generate_tool_protocol(tool_swift_function: tool_swift_function)
@@ -375,6 +378,7 @@ func parseInt(fromString: String, function: String = #function) -> Int {
           key_default_values: key_default_values,
           key_optionality_values: key_optionality_values,
           key_type_overrides: key_type_overrides,
+          key_is_strings: key_is_strings,
           return_type: action_return_type
         )
       end

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -7,15 +7,17 @@ module Fastlane
     attr_accessor :param_default_values
     attr_accessor :param_optionality_values
     attr_accessor :param_type_overrides
+    attr_accessor :param_is_strings
     attr_accessor :reserved_words
     attr_accessor :default_values_to_ignore
 
-    def initialize(action_name: nil, keys: nil, key_descriptions: nil, key_default_values: nil, key_optionality_values: nil, key_type_overrides: nil, return_type: nil)
+    def initialize(action_name: nil, keys: nil, key_descriptions: nil, key_default_values: nil, key_optionality_values: nil, key_type_overrides: nil, key_is_strings: nil, return_type: nil)
       @function_name = action_name
       @param_names = keys
       @param_descriptions = key_descriptions
       @param_default_values = key_default_values
       @param_optionality_values = key_optionality_values
+      @param_is_strings = key_is_strings
       @return_type = return_type
       @param_type_overrides = key_type_overrides
 
@@ -91,11 +93,13 @@ module Fastlane
       return default_value
     end
 
-    def get_type(param: nil, default_value: nil, optional: nil, param_type_override: nil)
+    def get_type(param: nil, default_value: nil, optional: nil, param_type_override: nil, is_string: true)
       unless param_type_override.nil?
         type = determine_type_from_override(type_override: param_type_override)
       end
-      type ||= "String"
+
+      # defaulting type to Any if is_string is false so users area llowed to input all allowed types
+      type ||= is_string ? "String" : "Any"
 
       optional_specifier = ""
       # if we are optional and don't have a default value, we'll need to use ?
@@ -121,8 +125,8 @@ module Fastlane
         return ""
       end
 
-      param_names_and_types = @param_names.zip(param_default_values, param_optionality_values, param_type_overrides).map do |param, default_value, optional, param_type_override|
-        type = get_type(param: param, default_value: default_value, optional: optional, param_type_override: param_type_override)
+      param_names_and_types = @param_names.zip(param_default_values, param_optionality_values, param_type_overrides, param_is_strings).map do |param, default_value, optional, param_type_override, is_string|
+        type = get_type(param: param, default_value: default_value, optional: optional, param_type_override: param_type_override, is_string: is_string)
 
         unless default_value.nil?
           if type == "[String : Any]"
@@ -304,8 +308,8 @@ module Fastlane
         return ""
       end
 
-      param_names_and_types = @param_names.zip(param_default_values, param_optionality_values, param_type_overrides).map do |param, default_value, optional, param_type_override|
-        type = get_type(param: param, default_value: default_value, optional: optional, param_type_override: param_type_override)
+      param_names_and_types = @param_names.zip(param_default_values, param_optionality_values, param_type_overrides).map do |param, default_value, optional, param_type_override, is_string|
+        type = get_type(param: param, default_value: default_value, optional: optional, param_type_override: param_type_override, is_string: is_string)
 
         param = camel_case_lower(string: param)
         param = sanitize_reserved_word(word: param)

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -98,7 +98,7 @@ module Fastlane
         type = determine_type_from_override(type_override: param_type_override)
       end
 
-      # defaulting type to Any if is_string is false so users area llowed to input all allowed types
+      # defaulting type to Any if is_string is false so users are allowed to input all allowed types
       type ||= is_string ? "String" : "Any"
 
       optional_specifier = ""


### PR DESCRIPTION
### Motivation and Context
Inspired by #15105

### Description
Parameters in `Fastlane.swift` functions were being set to `String` (or `String?`) if there was not `type` associated with it. This is acceptable except for when `is_string` is set to to `false` on the option. If `is_string` is set to `false` and not `type` is given or can be inferred, then the parameter type should be set as `Any` (or `Any?`).

This will change the generated Swift API a significant amount. In the near future, we should be removing `is_string` completely and start using `type` everywhere as this provides better type checking and documentation.

### Example of a change
This diff shows that more values types will be allowed for this option
![Screen Shot 2019-08-12 at 7 05 51 AM](https://user-images.githubusercontent.com/401294/62863856-abe9f700-bccf-11e9-85ea-77fa73aee81b.png)
![Screen Shot 2019-08-12 at 7 05 29 AM](https://user-images.githubusercontent.com/401294/62863857-abe9f700-bccf-11e9-9160-9dcaaf329315.png)
