### PR TITLE
[action] Only add derived data parameter if it's set, and command is update, build…

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -14,7 +14,7 @@ module Fastlane
         # "update", "build" and "bootstrap" are the only commands that support "--derived-data" parameter
         elsif ["update", "build", "bootstrap"].include?(command_name)
           if params[:dependencies].count > 0
-            cmd.concat(params[:dependencies])
+            cmd.concat(params[:dependencies]) if params[:dependencies].count > 0
           end
           if params[:derived_data]
             cmd << "--derived-data #{params[:derived_data].shellescape}"

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -13,12 +13,8 @@ module Fastlane
           cmd.concat(params[:frameworks])
         # "update", "build" and "bootstrap" are the only commands that support "--derived-data" parameter
         elsif ["update", "build", "bootstrap"].include?(command_name)
-          if params[:dependencies].count > 0
-            cmd.concat(params[:dependencies]) if params[:dependencies].count > 0
-          end
-          if params[:derived_data]
-            cmd << "--derived-data #{params[:derived_data].shellescape}" if params[:derived_data]
-          end
+          cmd.concat(params[:dependencies]) if params[:dependencies].count > 0
+          cmd << "--derived-data #{params[:derived_data].shellescape}" if params[:derived_data]
         end
 
         cmd << "--output #{params[:output]}" if params[:output]

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -11,8 +11,13 @@ module Fastlane
 
         if command_name == "archive" && params[:frameworks].count > 0
           cmd.concat(params[:frameworks])
-        elsif ["update", "build", "bootstrap"].include?(command_name) && params[:dependencies].count > 0
-          cmd.concat(params[:dependencies])
+        elsif ["update", "build", "bootstrap"].include?(command_name)
+          if params[:dependencies].count > 0
+             cmd.concat(params[:dependencies])
+          end
+          if params[:derived_data]
+            cmd << "--derived-data #{params[:derived_data].shellescape}"
+          end
         end
 
         cmd << "--output #{params[:output]}" if params[:output]
@@ -24,7 +29,6 @@ module Fastlane
         cmd << "--verbose" if params[:verbose] == true
         cmd << "--platform #{params[:platform]}" if params[:platform]
         cmd << "--configuration #{params[:configuration]}" if params[:configuration]
-        cmd << "--derived-data #{params[:derived_data].shellescape}" if params[:derived_data]
         cmd << "--toolchain #{params[:toolchain]}" if params[:toolchain]
         cmd << "--project-directory #{params[:project_directory]}" if params[:project_directory]
         cmd << "--cache-builds" if params[:cache_builds]

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -11,6 +11,7 @@ module Fastlane
 
         if command_name == "archive" && params[:frameworks].count > 0
           cmd.concat(params[:frameworks])
+        # "update", "build" and "bootstrap" are the only commands that support "--derived-data" parameter
         elsif ["update", "build", "bootstrap"].include?(command_name)
           if params[:dependencies].count > 0
             cmd.concat(params[:dependencies])

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -17,7 +17,7 @@ module Fastlane
             cmd.concat(params[:dependencies]) if params[:dependencies].count > 0
           end
           if params[:derived_data]
-            cmd << "--derived-data #{params[:derived_data].shellescape}"
+            cmd << "--derived-data #{params[:derived_data].shellescape}" if params[:derived_data]
           end
         end
 

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -13,7 +13,7 @@ module Fastlane
           cmd.concat(params[:frameworks])
         elsif ["update", "build", "bootstrap"].include?(command_name)
           if params[:dependencies].count > 0
-             cmd.concat(params[:dependencies])
+            cmd.concat(params[:dependencies])
           end
           if params[:derived_data]
             cmd << "--derived-data #{params[:derived_data].shellescape}"

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -621,6 +621,20 @@ describe Fastlane do
             expect(result).to eq("carthage bootstrap --log-path bla.log")
           end
         end
+
+        context "when specify derived_data" do
+          context "when command is archive" do
+              let(:command) { 'archive' }
+              it "--derived-data option should not be present, even if ENV is set" do
+                # Stub the environment variable specifying the derived data path
+                stub_const('ENV', {'FL_CARTHAGE_DERIVED_DATA' => './derived_data'})
+                result = Fastlane::FastFile.new.parse("lane :test do
+                  carthage(command: '#{command}')
+                end").runner.execute(:test)
+                expect(result).to eq("carthage archive")
+              end
+          end
+        end
       end
     end
   end

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -624,15 +624,15 @@ describe Fastlane do
 
         context "when specify derived_data" do
           context "when command is archive" do
-              let(:command) { 'archive' }
-              it "--derived-data option should not be present, even if ENV is set" do
-                # Stub the environment variable specifying the derived data path
-                stub_const('ENV', {'FL_CARTHAGE_DERIVED_DATA' => './derived_data'})
-                result = Fastlane::FastFile.new.parse("lane :test do
-                  carthage(command: '#{command}')
-                end").runner.execute(:test)
-                expect(result).to eq("carthage archive")
-              end
+            let(:command) { 'archive' }
+            it "--derived-data option should not be present, even if ENV is set" do
+              # Stub the environment variable specifying the derived data path
+              stub_const('ENV', { 'FL_CARTHAGE_DERIVED_DATA' => './derived_data' })
+              result = Fastlane::FastFile.new.parse("lane :test do
+                carthage(command: '#{command}')
+              end").runner.execute(:test)
+              expect(result).to eq("carthage archive")
+            end
           end
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This pull request fixes #15145 

### Description
Changed the parameter checking in the carthage action, to only add `derived_data` parameter if it is set, and the command isn't `archive`.
