### PR TITLE
[sigh] Allow download_all to support the platform option

### DIFF
--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -12,7 +12,42 @@ module Sigh
       Spaceship.select_team
       UI.message("Successfully logged in")
 
-      Spaceship.provisioning_profile.all(xcode: download_xcode_profiles).each do |profile|
+      case Sigh.config[:platform].to_s
+      when 'ios'
+        download_profiles(Spaceship.provisioning_profile.all(xcode: download_xcode_profiles))
+        xcode_profiles_downloaded?(xcode: download_xcode_profiles, supported: true)
+      when 'macos'
+        download_profiles(Spaceship.provisioning_profile.all(mac: true, xcode: download_xcode_profiles))
+        xcode_profiles_downloaded?(xcode: download_xcode_profiles, supported: true)
+      when 'tvos'
+        download_profiles(Spaceship.provisioning_profile.all_tvos)
+        xcode_profiles_downloaded?(xcode: download_xcode_profiles, supported: false)
+      end
+    end
+
+    # @param xcode [Bool] Whether or not the user passed the download_xcode_profiles flag
+    # @param supported [Bool] Whether or not this platform supports downloading xcode profiles at all
+    def xcode_profiles_downloaded?(xcode: false, supported: false)
+      if supported
+        if xcode
+          UI.message("This run also included all Xcode managed provisioning profiles, as you used the `--download_xcode_profiles` flag")
+        elsif !xcode
+          UI.message("All Xcode managed provisioning profiles were ignored on this, to include them use the `--download_xcode_profiles` flag")
+        end
+
+      elsif !supported
+        if xcode
+          UI.important("Downloading Xcode managed profiles is not supported for platform #{Sigh.config[:platform]}")
+          return
+        end
+      end
+    end
+
+    # @param profiles [Array] Array of all the provisioning profiles we want to download
+    def download_profiles(profiles)
+      UI.important("No profiles available for download") if profiles.empty?
+
+      profiles.each do |profile|
         if profile.valid?
           UI.message("Downloading profile '#{profile.name}'...")
           download_profile(profile)
@@ -20,19 +55,24 @@ module Sigh
           UI.important("Skipping invalid/expired profile '#{profile.name}'")
         end
       end
-
-      if download_xcode_profiles
-        UI.message("This run also included all Xcode managed provisioning profiles, as you used the `--download_xcode_profiles` flag")
-      else
-        UI.message("All Xcode managed provisioning profiles were ignored on this, to include them use the `--download_xcode_profiles` flag")
-      end
     end
 
+    # @param profile [ProvisioningProfile] A profile we plan to download and store
     def download_profile(profile)
       FileUtils.mkdir_p(Sigh.config[:output_path])
 
       type_name = profile.class.pretty_type
-      profile_name = "#{type_name}_#{profile.uuid}_#{profile.app.bundle_id}.mobileprovision" # default name
+      profile_name = "#{type_name}_#{profile.uuid}_#{profile.app.bundle_id}"
+
+      if Sigh.config[:platform].to_s == 'tvos'
+        profile_name += "_tvos"
+      end
+
+      if Sigh.config[:platform].to_s == 'macos'
+        profile_name += '.provisionprofile'
+      else
+        profile_name += '.mobileprovision'
+      end
 
       output_path = File.join(Sigh.config[:output_path], profile_name)
       File.open(output_path, "wb") do |f|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When I saw the "download_all" option I assumed this meant all profiles -- including the macos ones. After seeing that some of our machines were missing some profiles, I dug deeper and saw the only profiles missing were out mac ones. As a sanity check I looked at the documentation, assumed I could probably just pass the "platform" flag but multiple attempts showed me this was not the case. Looking at the source code it became apparent that this functionality was missing! And just calling sigh with the platform flag is forcing me to specify a bundle identifier but I want all of the mac profiles!

Resolves https://github.com/fastlane/fastlane/issues/15084

### Description
I have added support for the platform flag when we are using `download_all`

### Testing Steps
I made sure I was running my local version by running
`bundle show fastlane`
Then ran the `download_all` command in a few different ways, to check with my real Portal if the correct profiles were being downloaded
```
bundle exec fastlane sigh download_all --skip_install --output_path /tmp/profiles/

bundle exec fastlane sigh download_all --download_xcode_profiles --skip_install --output_path /tmp/profiles/

bundle exec fastlane sigh download_all --platform macos --skip_install --output_path /tmp/profiles/

bundle exec fastlane sigh download_all --platform macos --download_xcode_profiles --skip_install --output_path /tmp/profiles/

bundle exec fastlane sigh download_all --platform tvos --skip_install --output_path /tmp/profiles/

bundle exec fastlane sigh download_all --platform tvos --download_xcode_profiles --skip_install --output_path /tmp/profiles/
```
However, we don't have any TvOS profiles to really check and make sure those were downlaoded