### PR TITLE
[snapshot] Added --force option to fastlane snapshot update

### DIFF
--- a/snapshot/lib/snapshot/commands_generator.rb
+++ b/snapshot/lib/snapshot/commands_generator.rb
@@ -59,7 +59,7 @@ module Snapshot
         c.option('--force', 'Disables confirmation prompts')
         c.action do |args, options|
           require 'snapshot/update'
-          Snapshot::Update.new.update(options.force)
+          Snapshot::Update.new.update(force: options.force)
         end
       end
 

--- a/snapshot/lib/snapshot/commands_generator.rb
+++ b/snapshot/lib/snapshot/commands_generator.rb
@@ -56,10 +56,10 @@ module Snapshot
       command :update do |c|
         c.syntax = 'fastlane snapshot update'
         c.description = "Updates your SnapshotHelper.swift to the latest version"
-
+        c.option('--force', 'Disables confirmation prompts')
         c.action do |args, options|
           require 'snapshot/update'
-          Snapshot::Update.new.update
+          Snapshot::Update.new.update(options.force)
         end
       end
 

--- a/snapshot/lib/snapshot/update.rb
+++ b/snapshot/lib/snapshot/update.rb
@@ -11,7 +11,7 @@ module Snapshot
       paths.reject { |p| p.include?("snapshot/lib/assets/") }
     end
 
-    def update(force = false)
+    def update(force: false)
       paths = self.class.find_helper
       UI.user_error!("Couldn't find any SnapshotHelper files in current directory") if paths.count == 0
 
@@ -22,8 +22,8 @@ module Snapshot
       UI.message("The underlying API will not change. You can always migrate manually by looking at")
       UI.message("https://github.com/fastlane/fastlane/blob/master/snapshot/lib/assets/SnapshotHelper.swift")
 
-      unless force
-        return 1 unless UI.confirm("Overwrite configuration files?")
+      if !force && !UI.confirm("Overwrite configuration files?")
+        return 1
       end
 
       paths.each do |path|

--- a/snapshot/lib/snapshot/update.rb
+++ b/snapshot/lib/snapshot/update.rb
@@ -11,7 +11,7 @@ module Snapshot
       paths.reject { |p| p.include?("snapshot/lib/assets/") }
     end
 
-    def update
+    def update(force = false)
       paths = self.class.find_helper
       UI.user_error!("Couldn't find any SnapshotHelper files in current directory") if paths.count == 0
 
@@ -22,7 +22,9 @@ module Snapshot
       UI.message("The underlying API will not change. You can always migrate manually by looking at")
       UI.message("https://github.com/fastlane/fastlane/blob/master/snapshot/lib/assets/SnapshotHelper.swift")
 
-      return 1 unless UI.confirm("Overwrite configuration files?")
+      unless force
+        return 1 unless UI.confirm("Overwrite configuration files?")
+      end
 
       paths.each do |path|
         UI.message("Updating '#{path}'...")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This enables fastlane snapshot update to be run in headless mode, i.e. from a Jenkins shell script. 
<!-- If it fixes an open issue, please link to the issue here. -->
close #15019

### Description
<!-- Describe your changes in detail. -->
Added a "--force" option to fastlane snapshot update. If the option is present, update will skip the UI confirmation and behave as if a "y" was entered.

<!-- Please describe in detail how you tested your changes. -->
In my project, I updated the gemfile gemspec path to point to the path of my local fastlane clone & ran "bundle update". I verified the correct path with "bundle show fastlane"

I then ran "bundle exec fastlane update" both with the --force option and without it. I was shown the confirmation step without --force, and with --force it skipped past the prompt. 

Regarding documentation - please let me know if there are changes required other than including a description for the new --force option. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
Run "fastlane snapshot update" with and without the --force option
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
