### PR TITLE
[spaceship] Spaceship::Portal raising UnexpectedResponse instead of ProgramLicenseAgreementUpdated

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -738,7 +738,7 @@ module Spaceship
         raise InternalServerError, "Received an internal server error from App Store Connect / Developer Portal, please try again later"
       elsif body.to_s.include?("Gateway Timeout - In read")
         raise GatewayTimeoutError, "Received a gateway timeout error from App Store Connect / Developer Portal, please try again later"
-      elsif (body["resultString"] || "").include?("Program License Agreement")
+      elsif (body["userString"] || "").include?("Program License Agreement")
         raise ProgramLicenseAgreementUpdated, "#{body['userString']} Please manually log into your Apple Developer account to review and accept the updated agreement."
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
When we execute `Spaceship::Portal.client.apps.find(<apple_id>)` (for a pre-selected team) and there are pending terms of service contracts which need to be accepted by the team agent, Fastlane raises an `UncaughtException` error instead of the expected `ProgramLicenseAgreementUpdated`

<!-- If it fixes an open issue, please link to the issue here. -->
Fixes Open Issue: https://github.com/fastlane/fastlane/issues/14973

### Description
<!-- Describe your changes in detail. -->
The code was previously checking for the presence of the phrase `"Program License Agreement"` in the `resultString` field, whereas the error message to check if it is included is in `userString`.

<!-- Please describe in detail how you tested your changes. -->
I used the steps provided by the reporter in the open issue and used multiple teams which have pending Apple Terms of Service agreements, I ran the following commands to verify that the change raises the expected exception:
```
bundle console
require 'spaceship'
Spaceship.login
Spaceship::Portal.client.team_id = team_id
Spaceship::Portal.app.find('com.company.appid')
```