### PR TITLE
[action] plugin_scores: Add support for rendering multiline description of plugin actions on docs

### DIFF
--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -294,6 +294,7 @@ module Fastlane
         end
 
         # Parses the file to find all included actions
+        # rubocop:disable PerceivedComplexity
         def parse_file(file, debug_state: false)
           lines = File.read(file).lines
           actions = []
@@ -327,8 +328,9 @@ module Fastlane
               if (string_statement = string_statement_from_line(line))
                 # Multiline support for `description` method
                 if last_method_name == 'description'
+                  # rubocop:disable BlockNesting
                   last_string_statement.concat(string_statement) unless last_string_statement.nil?
-                else 
+                else
                   last_string_statement = string_statement
                 end
               end

--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -325,7 +325,12 @@ module Fastlane
               end
             when :in_method
               if (string_statement = string_statement_from_line(line))
-                last_string_statement = string_statement
+                # Multiline support for `description` method
+                if last_method_name == 'description'
+                  last_string_statement.concat(string_statement) unless last_string_statement.nil?
+                else 
+                  last_string_statement = string_statement
+                end
               end
               if is_block?(line)
                 self.state << :in_block


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

> On docs.fastlane.tools, action description is only the last line when multi-line Ruby string is used:
> 
> https://github.com/fastlane/docs/blob/93169702a4f3c090824c08747f3b7050f3094ee1/plugin_scores_cache.yml#L4560
> 
> vs
>
>https://github.com/dotdoom/fastlane-plugin-flutter/blob/23d517049d11da95563d35f76bfd44a64eb54eeb/lib/fastlane/plugin/flutter/actions/flutter_generate_action.rb#L36-L39

<!-- If it fixes an open issue, please link to the issue here. -->

closes https://github.com/fastlane/fastlane/issues/15201

### Description
<!-- Describe your changes in detail. -->
When a method called `description` is detected, we basically concat description lines till the end of the block. 

<!-- Please describe in detail how you tested your changes. -->

I generated the docs locally and multiline descriptions look good 👍 

**Important note** ⚠️ 

The following description won't be rendered correctly on the docs site due to breaking markdown `${...}`

https://github.com/dotdoom/fastlane-plugin-flutter/blob/23d517049d11da95563d35f76bfd44a64eb54eeb/lib/fastlane/plugin/flutter/actions/flutter_generate_action.rb#L35-L40

I modified the description locally:

```
<details>
<summary class="plugin-actions">Provided actions</summary>

 Name | Category | Description
------|----------|------------
  **flutter_bootstrap** | - | Flutter SDK installation, upgrade and application bootstrap
  **flutter** | - | Run "flutter" binary with the specified arguments
  **flutter_build** | building | Run "flutter build" to build a Flutter application
  **flutter_generate** | - | According to package:intl, take `$strings_file` and generate `${strings_file.dirname}/arb/intl_messages.arb`, then take all files matching `${strings_file.dirname}/intl_*.arb`, fix them and generate .dart files from them

</details>
```

 and got:

<img width="1039" alt="Screen Shot 2019-08-21 at 09 38 05" src="https://user-images.githubusercontent.com/10795657/63414512-506ce700-c3fc-11e9-9100-3709ab6d445b.png">

### Testing steps

To test these changes, please point a `fastlane` version in your `Gemfile` to my branch and follow the instructions from [docs repository](https://github.com/fastlane/docs) 🙇 