### PR TITLE
[screengrab] Upgrade to AndroidX

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
@@ -26,10 +26,12 @@ sudo gem install fastlane
 
 ##### Gradle dependency
 ```java
-androidTestCompile('tools.fastlane:screengrab:x.x.x')
+androidTestImplementation 'tools.fastlane:screengrab:x.x.x'
 ```
 
 The latest version is [ ![Download](https://api.bintray.com/packages/fastlane/fastlane/screengrab/images/download.svg) ](https://bintray.com/fastlane/fastlane/screengrab/_latestVersion)
+
+As of Screengrab version 2.0.0, all Android test dependencies are AndroidX dependencies. This means a device with API 18+, Android 4.3 or greater is required. If you wish to capture screenshots with an older Android OS, then you must use a 1.x.x version.
 
 ##### Configuring your Manifest Permissions
 
@@ -82,10 +84,10 @@ As of _screengrab_ 0.5.0, you can specify different strategies to control the wa
 * Multi-window situations are correctly captured (dialogs, etc.)
 * Works on Android N
 
-However, UI Automator requires a device with **API level >= 18**, so it is not yet the default strategy. To enable it for all screenshots by default, make the following call before your tests run:
+UI Automator is the default strategy. However, UI Automator requires a device with **API level >= 18**. If you need to grab screenshots on an older Android version, use the latest 1.x.x version of this library and set the DecorView ScreenshotStrategy.
 
 ```java
-Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
+Screengrab.setDefaultScreenshotStrategy(new DecorViewScreenshotStrategy());
 ```
 
 ## Improved screenshot capture with Falcon

--- a/screengrab/build.gradle
+++ b/screengrab/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
     }
 }

--- a/screengrab/example/build.gradle
+++ b/screengrab/example/build.gradle
@@ -1,16 +1,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "tools.fastlane.localetester"
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 18
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -28,14 +28,14 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:28.0.0"
-    implementation "com.android.support:design:28.0.0"
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'com.google.android.material:material:1.0.0'
 
     testImplementation 'junit:junit:4.12'
 
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
     androidTestImplementation project(':screengrab-lib')
 }

--- a/screengrab/example/src/androidTest/java/tools/fastlane/localetester/FalconScreenshots.java
+++ b/screengrab/example/src/androidTest/java/tools/fastlane/localetester/FalconScreenshots.java
@@ -1,6 +1,6 @@
 package tools.fastlane.localetester;
 
-import android.support.test.rule.ActivityTestRule;
+import androidx.test.rule.ActivityTestRule;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -12,12 +12,12 @@ import tools.fastlane.screengrab.FalconScreenshotStrategy;
 import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.locale.LocaleTestRule;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(JUnit4.class)
 public class FalconScreenshots {

--- a/screengrab/example/src/androidTest/java/tools/fastlane/localetester/JUnit4StyleTests.java
+++ b/screengrab/example/src/androidTest/java/tools/fastlane/localetester/JUnit4StyleTests.java
@@ -1,6 +1,6 @@
 package tools.fastlane.localetester;
 
-import android.support.test.rule.ActivityTestRule;
+import androidx.test.rule.ActivityTestRule;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -13,12 +13,12 @@ import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
 import tools.fastlane.screengrab.locale.LocaleTestRule;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
 @RunWith(JUnit4.class)
 public class JUnit4StyleTests {

--- a/screengrab/example/src/main/java/tools/fastlane/localetester/AnotherActivity.java
+++ b/screengrab/example/src/main/java/tools/fastlane/localetester/AnotherActivity.java
@@ -2,8 +2,8 @@ package tools.fastlane.localetester;
 
 import android.content.DialogInterface;
 import android.os.Bundle;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
 

--- a/screengrab/example/src/main/java/tools/fastlane/localetester/MainActivity.java
+++ b/screengrab/example/src/main/java/tools/fastlane/localetester/MainActivity.java
@@ -2,10 +2,10 @@ package tools.fastlane.localetester;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.snackbar.Snackbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import android.text.format.DateFormat;
 import android.view.View;
 import android.view.Menu;

--- a/screengrab/example/src/main/res/layout/activity_main.xml
+++ b/screengrab/example/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -8,23 +8,23 @@
     android:fitsSystemWindows="true"
     tools:context="tools.fastlane.localetester.MainActivity">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/AppTheme.PopupOverlay"/>
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <include layout="@layout/content_main"/>
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -32,4 +32,4 @@
         android:layout_margin="@dimen/fab_margin"
         android:src="@android:drawable/ic_dialog_email"/>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/screengrab/gradle.properties
+++ b/screengrab/gradle.properties
@@ -19,3 +19,5 @@
 
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx2048M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/screengrab/gradle/wrapper/gradle-wrapper.properties
+++ b/screengrab/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Aug 22 16:28:53 CDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/screengrab/lib/screengrab/options.rb
+++ b/screengrab/lib/screengrab/options.rb
@@ -76,7 +76,7 @@ module Screengrab
         FastlaneCore::ConfigItem.new(key: :test_instrumentation_runner,
                                      env_name: 'SCREENGRAB_TEST_INSTRUMENTATION_RUNNER',
                                      optional: true,
-                                     default_value: 'android.support.test.runner.AndroidJUnitRunner',
+                                     default_value: 'androidx.test.runner.AndroidJUnitRunner',
                                      description: "The fully qualified class name of your test instrumentation runner"),
         FastlaneCore::ConfigItem.new(key: :ending_locale,
                                      env_name: 'SCREENGRAB_ENDING_LOCALE',

--- a/screengrab/screengrab-lib/build.gradle
+++ b/screengrab/screengrab-lib/build.gradle
@@ -18,10 +18,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 18
     }
 }
 
@@ -38,10 +38,10 @@ publish {
 }
 
 dependencies {
-    api "com.android.support:support-annotations:28.0.0"
-    api 'com.android.support.test:runner:1.0.2'
-    api 'com.android.support.test:rules:1.0.2'
-    api 'com.android.support.test.espresso:espresso-core:3.0.2'
-    api 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
-    api 'com.jraska:falcon:1.0.4'
+    api "androidx.annotation:annotation:1.1.0"
+    api 'androidx.test:runner:1.2.0'
+    api 'androidx.test:rules:1.2.0'
+    api 'androidx.test.espresso:espresso-core:3.2.0'
+    api 'androidx.test.uiautomator:uiautomator:2.2.0'
+    api 'com.jraska:falcon:2.1.1'
 }

--- a/screengrab/screengrab-lib/src/main/AndroidManifest.xml
+++ b/screengrab/screengrab-lib/src/main/AndroidManifest.xml
@@ -5,6 +5,6 @@
       We will manually check for API level >= 18 before using UiAutomator.
       We will manually check for API level >= 10 before using Falcon.
     -->
-    <uses-sdk tools:overrideLibrary="android.support.test.uiautomator.v18,com.jraska.falcon" />
+    <uses-sdk tools:overrideLibrary="androidx.test.uiautomator.v18,com.jraska.falcon" />
 
 </manifest>

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/DecorViewScreenshotStrategy.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/DecorViewScreenshotStrategy.java
@@ -6,10 +6,10 @@ import android.content.ContextWrapper;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.os.Looper;
-import android.support.test.espresso.Espresso;
-import android.support.test.espresso.UiController;
-import android.support.test.espresso.ViewAction;
-import android.support.test.espresso.matcher.ViewMatchers;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.matcher.ViewMatchers;
 import android.view.View;
 
 import org.hamcrest.Matcher;

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FalconScreenshotStrategy.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FalconScreenshotStrategy.java
@@ -1,8 +1,6 @@
 package tools.fastlane.screengrab;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
-import android.os.Build;
 
 import com.jraska.falcon.Falcon;
 
@@ -19,7 +17,6 @@ public class FalconScreenshotStrategy implements ScreenshotStrategy {
     }
 
     @Override
-    @TargetApi(Build.VERSION_CODES.GINGERBREAD_MR1)
     public void takeScreenshot(String screenshotName, ScreenshotCallback screenshotCallback) {
         screenshotCallback.screenshotCaptured(screenshotName, Falcon.takeScreenshotBitmap(activity));
     }

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/FileWritingScreenshotCallback.java
@@ -66,8 +66,8 @@ public class FileWritingScreenshotCallback implements ScreenshotCallback {
         File directory = null;
 
         if (Build.VERSION.SDK_INT >= 21) {
-            File externalDir = new File(Environment.getExternalStorageDirectory(), getDirectoryName(context, locale));
-            directory = initializeDirectory(externalDir);
+            File internalDir = new File(context.getFilesDir(), getDirectoryName(context, locale));
+            directory = initializeDirectory(internalDir);
         }
 
         // We can only try this fall-back before Android N, since N makes Context.MODE_WORLD_READABLE

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/Screengrab.java
@@ -22,15 +22,14 @@
 package tools.fastlane.screengrab;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 
-import java.util.HashMap;
 import java.util.regex.Pattern;
 
 public class Screengrab {
     private static final Pattern TAG_PATTERN = Pattern.compile("[a-zA-Z0-9_-]+");
 
-    private static ScreenshotStrategy defaultScreenshotStrategy = new DecorViewScreenshotStrategy();
+    private static ScreenshotStrategy defaultScreenshotStrategy = new UiAutomatorScreenshotStrategy();
 
     /**
      * @return The default {@link ScreenshotStrategy} used in {@link #screenshot(String)} invocations

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/UiAutomatorScreenshotStrategy.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/UiAutomatorScreenshotStrategy.java
@@ -1,9 +1,8 @@
 package tools.fastlane.screengrab;
 
-import android.annotation.TargetApi;
 import android.app.UiAutomation;
-import android.os.Build;
-import android.support.test.InstrumentationRegistry;
+
+import androidx.test.platform.app.InstrumentationRegistry;
 
 /**
  * <p>Screenshot strategy that delegates to UiAutomation for screenshot capture. <b>Requires
@@ -28,13 +27,9 @@ import android.support.test.InstrumentationRegistry;
  * </ul>
  */
 public class UiAutomatorScreenshotStrategy implements ScreenshotStrategy {
-    @Override
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
-    public void takeScreenshot(String screenshotName, ScreenshotCallback screenshotCallback) {
-        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            throw new RuntimeException("UiAutomatorScreenshotStrategy requires API level >= 18");
-        }
 
+    @Override
+    public void takeScreenshot(String screenshotName, ScreenshotCallback screenshotCallback) {
         UiAutomation uiAutomation = InstrumentationRegistry.getInstrumentation().getUiAutomation();
         screenshotCallback.screenshotCaptured(screenshotName, uiAutomation.takeScreenshot());
     }

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/file/Chmod.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/file/Chmod.java
@@ -28,11 +28,7 @@ public abstract class Chmod {
     private static final Chmod INSTANCE;
 
     static {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
-            INSTANCE = new Java6Chmod();
-        } else {
-            INSTANCE = new Java5Chmod();
-        }
+        INSTANCE = new Java6Chmod();
     }
 
     public static void chmodPlusR(File file) {

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/locale/LocaleUtil.java
@@ -2,8 +2,9 @@ package tools.fastlane.screengrab.locale;
 
 import android.content.res.Configuration;
 import android.os.Build;
-import android.support.test.InstrumentationRegistry;
 import android.util.Log;
+
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import java.lang.reflect.Method;
 import java.util.Locale;
@@ -37,9 +38,7 @@ public class LocaleUtil {
             config.getClass().getField("userSetLocale").setBoolean(config, true);
             config.locale = locale;
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                config.setLayoutDirection(locale);
-            }
+            config.setLayoutDirection(locale);
 
             Method updateConfigurationMethod = amnClass.getMethod("updateConfiguration", Configuration.class);
             updateConfigurationMethod.setAccessible(true);

--- a/screengrab/version.properties
+++ b/screengrab/version.properties
@@ -1,3 +1,3 @@
-major=1
-minor=2
+major=2
+minor=0
 patch=0


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Android Gradle Plugin 3.5.0 UI tests now require AndroidX dependencies. These conflict with the Screengrab uiautomator dependency in a way that makes it impossible for them to co-exist. See #14897.

Note that the minimum API level had to increase along with the minimum for AndroidX. Users of APIs 8 to 17 will need to stay on an older version of the library.

<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/14897

### Description
<!-- Describe your changes in detail. -->
I upgraded both the Screengrab library and the example to work with the latest Android APIs and AndroidX libraries. I updated to the latest Falcon library dependency.

<!-- Please describe in detail how you tested your changes. -->
I verified that the code builds and all tests work.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
