### PR TITLE
[action] slather: Add :binary_file support for handling multiple input files

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -263,6 +263,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :binary_file,
                                        env_name: "FL_SLATHER_BINARY_FILE",
                                        description: "Binary file name to be used for code coverage",
+                                       type: Array,
                                        skip_type_validation: true, # skipping validation for backwards compatibility with Boolean type
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :arch,

--- a/fastlane/spec/actions_specs/slather_spec.rb
+++ b/fastlane/spec/actions_specs/slather_spec.rb
@@ -189,7 +189,7 @@ describe Fastlane do
         expect(result).to eq(expected)
       end
 
-      it "works with when binary_file is set to true or false" do
+      it "works with binary_file set to true or false" do
         possible_values = ["true", "false"]
         expected = "slather coverage foo.xcodeproj".gsub(/\s+/, ' ')
 
@@ -203,6 +203,34 @@ describe Fastlane do
 
           expect(result).to eq(expected)
         end
+      end
+
+      it "works with binary_file as string" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          slather({
+            binary_file: 'bar',
+            proj: 'foo.xcodeproj'
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq("slather coverage --binary-file bar foo.xcodeproj")
+      end
+
+      it "works with binary_file as array" do
+        binary_file = ['other', 'stuff']
+        expected = "slather coverage
+                    --binary-file #{binary_file[0]}
+                    --binary-file #{binary_file[1]}
+                    foo.xcodeproj".gsub(/\s+/, ' ')
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          slather({
+            binary_file: #{binary_file},
+            proj: 'foo.xcodeproj'
+          })
+        end").runner.execute(:test)
+
+        expect(result).to eq(expected)
       end
 
       it "works with multiple ignore patterns" do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #14747

### Description
Updated `:binary_file` parameter to accept an array instead of a single string.

### Testing Steps
Run `bundle exec rspec ./fastlane/spec/actions_specs/slather_spec.rb` to verify all slather action tests pass.