### PR TITLE
[gym] remove is_string option on skip_codesigning

### DIFF
--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -137,7 +137,6 @@ module Gym
         FastlaneCore::ConfigItem.new(key: :skip_codesigning,
                                      env_name: "GYM_SKIP_CODESIGNING",
                                      description: "Build without codesigning",
-                                     is_string: false,
                                      type: Boolean,
                                      optional: true),
         # Very optional


### PR DESCRIPTION
### Motivation and Context
Fix failing master tests

### Description
Master tests are failing due to new lint rules on `is_string` and a PR being merged that included it that didn't have the new linting rules yet 🙃
