### PR TITLE
[spaceship] Change provisioning profile update request to match what Apple Developer passes

### DIFF
--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -457,7 +457,7 @@ module Spaceship
             devices.map(&:id),
             mac: mac?,
             sub_platform: tvos? ? 'tvOS' : nil,
-            template_name: template_name
+            template_name: is_template_profile ? template.purpose_name : nil
           )
         end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Issue: #14283 
Original pull request: #14284

When trying to update a provisioning profile using Spaceship, We’ve been getting the unexpected response such as `There was an error generating the provisioning profile ...`.

@brentdur took a look at Spaceship’s request vs the request that the Apple Developer Portal sends, there was a difference in the `template` field in the request body. Spaceship was using `template.purpose_display_name`, which results in the request data resembling template `Company (Development)`. Apple Developer Portal users the equivalent of `template.purpose_name`, which results in the request data being template `company-development`.

### Description

Based on original #14284, apply same change to use `template.purpose_name`, however keep public method `template_name` for unnecessary backward compatibility break.