### PR TITLE
[download_dsyms] Remove leading zeros from version string

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -56,6 +56,11 @@ module Fastlane
           version = live_version.version
           build_number = live_version.build_version
         end
+        
+        # Remove leading zeros from version string (eg. 1.02 -> 1.2)
+        if version
+          version = version.split(".").map{ |p| p.to_i }.join(".")
+        end
 
         # Make sure output_directory has a slash on the end
         if output_directory && !output_directory.end_with?('/')

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -56,10 +56,10 @@ module Fastlane
           version = live_version.version
           build_number = live_version.build_version
         end
-        
+
         # Remove leading zeros from version string (eg. 1.02 -> 1.2)
         if version
-          version = version.split(".").map{ |p| p.to_i }.join(".")
+          version = version.split(".").map(&:to_i).join(".")
         end
 
         # Make sure output_directory has a slash on the end

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -61,8 +61,8 @@ describe Fastlane do
         end
       end
 
-      context 'with no special options' do
-        it 'downloads all dsyms of all builds in all trains' do
+      context 'with version with leading zero' do
+        it 'downloads all dsyms of all builds in train 1.07.0' do
           expect(app).to receive(:tunes_all_builds_for_train).and_return([build3])
           expect(app).to receive(:tunes_build_details).with(train: '1.7.0', build_number: '3', platform: :ios).and_return(build_detail)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build3.build_version, nil)

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -7,9 +7,11 @@ describe Fastlane do
       let(:live_version) { double('live_version') }
       let(:train) { double('train') }
       let(:train2) { double('train2') }
+      let(:train3) { double('train3') }
       let(:build) { double('build') }
       let(:build2) { double('build2') }
       let(:build3) { double('build3') }
+      let(:build4) { double('build4') }
       let(:empty_build) { double('empty_build') }
       let(:build_detail) { double('build_detail') }
       let(:empty_build_detail) { double('empty_build_detail') }
@@ -20,35 +22,52 @@ describe Fastlane do
         allow(Spaceship::Tunes).to receive(:select_team)
         allow(Spaceship::Application).to receive(:find).and_return(app)
         # trains
-        allow(app).to receive(:tunes_all_build_trains).and_return([train, train2])
+        allow(app).to receive(:tunes_all_build_trains).and_return([train, train2, train3])
         # build_detail + download
         allow(build_detail).to receive(:dsym_url).and_return(download_url)
         allow(empty_build_detail).to receive(:dsym_url).and_return(nil)
         allow(app).to receive(:bundle_id).and_return('tools.fastlane.myapp')
         allow(train).to receive(:version_string).and_return('1.0.0')
-        allow(train2).to receive(:version_string).and_return('2.0.0')
+        allow(train2).to receive(:version_string).and_return('1.7.0')
+        allow(train3).to receive(:version_string).and_return('2.0.0')
         allow(build).to receive(:build_version).and_return('1')
         allow(build2).to receive(:build_version).and_return('2')
-        allow(empty_build).to receive(:build_version).and_return('3')
+        allow(build3).to receive(:build_version).and_return('3')
+        allow(build4).to receive(:build_version).and_return('4')
+        allow(empty_build).to receive(:build_version).and_return('5')
         allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)
       end
 
       context 'with no special options' do
         it 'downloads all dsyms of all builds in all trains' do
           expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build3])
           expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, empty_build])
           expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '1', platform: :ios).and_return(build_detail)
           expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '2', platform: :ios).and_return(build_detail)
+          expect(app).to receive(:tunes_build_details).with(train: '1.7.0', build_number: '3', platform: :ios).and_return(build_detail)
           expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '1', platform: :ios).and_return(build_detail)
           expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
-          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '3', platform: :ios).and_return(empty_build_detail)
+          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '5', platform: :ios).and_return(empty_build_detail)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build.build_version, nil)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build2.build_version, nil)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build.build_version, nil)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build2.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build3.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build2.build_version, nil)
           expect(Fastlane::Actions::DownloadDsymsAction).not_to(receive(:download))
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp')
+          end").runner.execute(:test)
+        end
+      end
+
+      context 'with no special options' do
+        it 'downloads all dsyms of all builds in all trains' do
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build3])
+          expect(app).to receive(:tunes_build_details).with(train: '1.7.0', build_number: '3', platform: :ios).and_return(build_detail)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build3.build_version, nil)
+          Fastlane::FastFile.new.parse("lane :test do
+              download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: '1.07.0')
           end").runner.execute(:test)
         end
       end
@@ -68,7 +87,7 @@ describe Fastlane do
         it 'downloads only dsyms of latest build in latest train' do
           expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, build3])
           expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build2.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build2.build_version, nil)
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: 'latest')
           end").runner.execute(:test)
@@ -101,8 +120,8 @@ describe Fastlane do
           expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
           expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '1', platform: :ios).and_return(build_detail)
           expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build.build_version, nil)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build2.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build2.build_version, nil)
 
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', min_version: '2.0.0')


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The `download_dsyms` action fails when an app's version has a leading zero in one of its parts, such as a version "4.07". AppStore reports this version as "4.7", so the action fails to find its dSYM files, since "4.07" != "4.7".

### Description
When it finds the version, split the string using the dot symbol, then convert each part to integer and join everything back using the same dot symbol.

"4.07" -> ["4", "07"] -> [4, 7] -> "4.7"

### Testing Steps
1. Increment a app's version on its Info.plist, adding a leading zero to a part of its version string.
2. Build, archive and upload it to AppStore connect
3. Run `fastlane run download_dsyms` or a lane that has this action set up
4. The dSYM zip file should be downloaded successfully
