### PR TITLE
allow update_project_provisioning to always set CODE_SIGNING_IDENTITY, even if it heasn't been set before

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -65,7 +65,7 @@ module Fastlane
             end
 
             if code_signing_identity
-              codesign_build_settings_keys = build_configuration.build_settings.keys.select { |key| key.to_s.match(/CODE_SIGN_IDENTITY.*/) }
+              codesign_build_settings_keys = (build_configuration.build_settings.keys.select { |key| key.to_s.match(/CODE_SIGN_IDENTITY.*/) } + ["CODE_SIGN_IDENTITY"]).uniq
               codesign_build_settings_keys.each do |setting|
                 build_configuration.build_settings[setting] = code_signing_identity
               end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`update_project_provisioning` ignores the `code_sign_identify` attribute if that value hasn't previously been set in the project. It seems that newly created xcode projects don't always have this value.  The current logic only updates existing values.

### Testing Steps
1. Remove the lines that contain `CODE_SIGN_IDENTITY` from your xcode project file
2. execute update_project_provisioning(code_sign_identify: 'iPhone Distribution', build_configuration: 'Release')
3. Note that CODE_SIGN_IDENTITY is present in your project file and set to 'iPhone Distribution'
