### PR TITLE
[gym] Provide bcsymbolmap path to dsymutil for each architecture

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -146,6 +146,7 @@ module Gym
       containing_directory = File.expand_path("..", PackageCommandGenerator.dsym_path)
       bcsymbolmaps_directory = File.expand_path("../../BCSymbolMaps", PackageCommandGenerator.dsym_path)
       available_dsyms = Dir.glob("#{containing_directory}/*.dSYM")
+      uuid_regex = /[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/
 
       if Dir.exist?(bcsymbolmaps_directory)
         UI.message("Mapping dSYM(s) using generated BCSymbolMaps") unless Gym.config[:silent]
@@ -155,12 +156,30 @@ module Gym
           dwarfdump_command << "--uuid #{dsym.shellescape}"
 
           dwarfdump_result = Helper.backticks(dwarfdump_command.join(" "), print: false)
-          architecture_uuids = dwarfdump_result.split("\n").map { |info| info.split(" ")[1] }
+          architecture_infos = dwarfdump_result.split("\n")
+          architecture_uuids = architecture_infos.map do |info|
+            info_array = info.split(" ")
+            uuid = info_array[1]
 
-          architecture_uuids.each do |uuid|
+            if uuid.nil? || !uuid.match(uuid_regex)
+              nil
+            else
+              uuid
+            end
+          end
+
+          architecture_uuids = architecture_uuids.reject(&:nil?)
+
+          symbol_map_paths = architecture_uuids.map do |uuid|
+            "#{bcsymbolmaps_directory.shellescape}/#{uuid}.bcsymbolmap"
+          end
+
+          symbol_map_paths << bcsymbolmaps_directory.shellescape if symbol_map_paths.empty?
+
+          symbol_map_paths.each do |path|
             command = []
             command << "dsymutil"
-            command << "--symbol-map #{bcsymbolmaps_directory.shellescape}/#{uuid}.bcsymbolmap"
+            command << "--symbol-map #{path}"
             command << dsym.shellescape
             Helper.backticks(command.join(" "), print: !Gym.config[:silent])
           end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently `gym` doesn't map bcsymbolmap files with debug symbols for the project frameworks. The problem appears in the log as a warning: 

> [09:44:25]: Mapping dSYM(s) using generated BCSymbolMaps
> [09:44:25]: dsymutil --symbol-map /Users/user/Library/Developer/Xcode/Archives/2019-08-29/MyApp-1.1.0-2\ 2019-08-29\ 09.41.05.xcarchive/BCSymbolMaps /Users/user/Library/Developer/Xcode/Archives/2019-08-29/MyApp-1.0.0-1\ 2019-08-29\ 09.41.05.xcarchive/dSYMs/Alamofire.framework.dSYM
> [09:44:25]: warning: /Users/user/Library/Developer/Xcode/Archives/2019-08-29/MyApp-1.0.0-1 2019-08-29 09.41.05.xcarchive/BCSymbolMaps/Alamofire-armv7.bcsymbolmap: No such file or directory. Not unobfuscating.
> [09:44:25]: warning: /Users/user/Library/Developer/Xcode/Archives/2019-08-29/MyApp-1.0.0-1 2019-08-29 09.41.05.xcarchive/BCSymbolMaps/Alamofire-arm64.bcsymbolmap: No such file or directory. Not unobfuscating.

It can be observed in the logs of at least [16 issues](https://github.com/fastlane/fastlane/issues?utf8=%E2%9C%93&q=No+such+file+or+directory.+Not+unobfuscating). 
These two address the issue directly: #10902 and #14197

As result, dSYM files don't unobfuscate stacktrace completely:

> #0. Crashed: com.apple.main-thread
> 0  libswiftCore.dylib     0x21dee4ce0 specialized \_assertionFailure(_:_:file) + 260
> 1  libswiftCore.dylib      0x21bb071bc \_assertionFailure(_:_:file) + 42
> 2  Alamofire                   0x104e17414 (Missing) 
> 3  MyApp                       0x104471724 TestViewController.simulateCrash() (\<compiler-generated\>)
> ...

### Description
Proposed solution executes `dwarfdump` for each dSYM file to extract UUID of each architecture. For example: 
```
$ dwarfdump --uuid ./dSYMs/Alamofire.framework.dSYM
UUID: 1B8FF487-DC57-3F37-11DF-D466877AECF9 (armv7) ...
UUID: FFA4DD5D-741C-3ECF-34FB-16971D545948 (arm64) ...
```

Bcsymbolmap files are stored in BCSymbolMaps folder in the format `\<architecture UUID\>.bcsymbolmap`. So the goal is to map UUIDs from dSYM file into filenames of each bcsymbolmap.

Then `dsymutil` can link the DWARF debug information from correct path:

> [09:44:25]: Mapping dSYM(s) using generated BCSymbolMaps
> [09:44:25]: $ dsymutil --symbol-map /Users/user/Library/Developer/Xcode/Archives/2019-08-29/MyApp-1.0.0-1\ 2019-08-29\ 09.41.05.xcarchive/BCSymbolMaps/1B8FF487-DC57-3F37-11DF-D466877AECF9.bcsymbolmap /Users/user/Library/Developer/Xcode/Archives/2019-08-29/MyApp-1.0.0-1\ 2019-08-29\ 09.41.05.xcarchive/dSYMs/Alamofire.framework.dSYM
> [09:44:25]: $ dsymutil --symbol-map /Users/user/Library/Developer/Xcode/Archives/2019-08-29/MyApp-1.0.0-1\ 2019-08-29\ 09.41.05.xcarchive/BCSymbolMaps/FFA4DD5D-741C-3ECF-34FB-16971D545948.bcsymbolmap /Users/user/Library/Developer/Xcode/Archives/2019-08-29/MyApp-1.0.0-1\ 2019-08-29\ 09.41.05.xcarchive/dSYMs/Alamofire.framework.dSYM
> ...

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

After rebuilding with `gym` and uploading corrected dSYMs to Crashlytics, the issue is resolved:

> #0. Crashed: com.apple.main-thread
> 0  libswiftCore.dylib     0x21dee4ce0 specialized \_assertionFailure(_:_:file) + 260
> 1  libswiftCore.dylib      0x21bb071bc \_assertionFailure(_:_:file) + 42
> 2  Alamofire                   0x1f01d64c4 TestExceptionClass.produceCrash() + 31 (AFError.swift:31)
> 3  MyApp                       0x104378824 TestViewController.simulateCrash()  + 42 (TestViewController.swift:42)
> ...

