### PR TITLE
[action] plugin_scores: Revert support for rendering multiline description of plugin actions on docs

### DIFF
--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -294,7 +294,6 @@ module Fastlane
         end
 
         # Parses the file to find all included actions
-        # rubocop:disable PerceivedComplexity
         def parse_file(file, debug_state: false)
           lines = File.read(file).lines
           actions = []
@@ -326,13 +325,7 @@ module Fastlane
               end
             when :in_method
               if (string_statement = string_statement_from_line(line))
-                # Multiline support for `description` method
-                if last_method_name == 'description'
-                  # rubocop:disable BlockNesting
-                  last_string_statement.concat(string_statement) unless last_string_statement.nil?
-                else
-                  last_string_statement = string_statement
-                end
+                last_string_statement = string_statement
               end
               if is_block?(line)
                 self.state << :in_block


### PR DESCRIPTION
Reverts fastlane/fastlane#15212 due to regression spotted at https://github.com/fastlane/docs/pull/864. 

To **not block** future `fastlane` releases and being able to update the docs with each release, this PR reverts the docs regression introduced by multiline description support in [this PR](https://github.com/fastlane/docs/pull/864). 

https://github.com/fastlane/fastlane/issues/15201 should be re-opened once we merge this one. 

🙇 