### PR TITLE
[match,crashlytics] Fix unknown method error

### DIFF
--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -108,7 +108,7 @@ module Fastlane
 
             UI.important("Downloading Crashlytics Support Library - this might take a minute...")
             result = http_conn.request_get(uri.path)
-            UI.error!("#{result.message} (#{result.code})") unless result.kind_of?(Net::HTTPSuccess)
+            UI.error("#{result.message} (#{result.code})") unless result.kind_of?(Net::HTTPSuccess)
             File.write(zip_path, result.body)
 
             # Now unzip the file

--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -72,7 +72,7 @@ module Match
         cert.certificate_content == cert_contents_base_64
       end
 
-      UI.error!("This certificate cannot be imported - the certificate contents did not match with any available on the Developer Portal") if matching_cert.nil?
+      UI.user_error!("This certificate cannot be imported - the certificate contents did not match with any available on the Developer Portal") if matching_cert.nil?
 
       # Make dir if doesn't exist
       FileUtils.mkdir_p(output_dir)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When importing an existing certificate the error was hidden and resulted in a "crash" with an unknown method invocation.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This PR fixes the method invocation by removing the exclamation mark.

The choice was either to go with `user_error!` or `error`. I decided to use `error` as it's closer to the original implementation but really it should be a `user_error!` as the error is only thrown if something doesn't match, i.e. the input certificate is not found on the Dev Portal.

__I am happy to go with `user_error!` if you wish so.__

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Try using the import action with a certificate that's not available on the Developer Portal.