### PR TITLE
[Fastlane.Swift] Add missing FastlaneRunnerAPIVersion comment

### DIFF
--- a/fastlane/swift/Actions.swift
+++ b/fastlane/swift/Actions.swift
@@ -9,3 +9,7 @@
 //
 
 import Foundation
+
+// Please don't remove the lines below
+// They are used to detect outdated files
+// FastlaneRunnerAPIVersion [0.9.56]

--- a/fastlane/swift/Plugins.swift
+++ b/fastlane/swift/Plugins.swift
@@ -9,3 +9,7 @@
 //
 
 import Foundation
+
+// Please don't remove the lines below
+// They are used to detect outdated files
+// FastlaneRunnerAPIVersion [0.9.56]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

FastlaneSwiftRunner is crashing when `// FastlaneRunnerAPIVersion [x.x.x]` is not specified.
See: https://github.com/fastlane/fastlane/issues/15257

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Add missing comment `// FastlaneRunnerAPIVersion [x.x.x]` inside `Actions.swift` and `Plugins.swift`.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Tested on private repository using Fastlane.Swift extensively.
Works again as expected with this change 👍 