### PR TITLE
[download_dsyms] Replace error with message when no dSYM found

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -102,7 +102,8 @@ module Fastlane
 
               unless download_url
                 if !wait_for_dsym_processing || (Time.now - start) > (60 * 5)
-                  UI.error("Could not find any dSYM for #{build.build_version} (#{train.version_string})")
+                  # In some cases, AppStoreConnect does not process the dSYMs, thus no error should be thrown.
+                  UI.message("Could not find any dSYM for #{build.build_version} (#{train.version_string})")
                 else
                   UI.message("Waiting for dSYM file to appear...")
                   sleep(30)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In some cases, AppStoreConnect does not process the dSYMs, thus no error should be thrown.
See: https://github.com/fastlane/fastlane/pull/15049

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Do not use `UI.error` when no dSYMs are found, but `UI.message` instead.