### PR TITLE
[download_dsyms] Do not attempt to download Dsyms if the dsym_url is missing

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -113,8 +113,12 @@ module Fastlane
               break
             end
 
-            self.download(download_url, app.bundle_id, train.version_string, build.build_version, output_directory)
-            break if build_number
+            if download_url
+              self.download(download_url, app.bundle_id, train.version_string, build.build_version, output_directory)
+              break if build_number
+            else
+              UI.message("No dSYM URL for #{build.build_version} (#{train.version_string})")
+            end
           end
         end
 

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -9,7 +9,9 @@ describe Fastlane do
       let(:build) { double('build') }
       let(:build2) { double('build2') }
       let(:build3) { double('build3') }
+      let(:empty_build) { double('empty_build') }
       let(:build_detail) { double('build_detail') }
+      let(:empty_build_detail) { double('empty_build_detail') }
       let(:download_url) { 'https://example.com/myapp-dsym' }
       before do
         # login
@@ -20,26 +22,30 @@ describe Fastlane do
         allow(app).to receive(:tunes_all_build_trains).and_return([train, train2])
         # build_detail + download
         allow(build_detail).to receive(:dsym_url).and_return(download_url)
+        allow(empty_build_detail).to receive(:dsym_url).and_return(nil)
         allow(app).to receive(:bundle_id).and_return('tools.fastlane.myapp')
         allow(train).to receive(:version_string).and_return('1.0.0')
         allow(train2).to receive(:version_string).and_return('2.0.0')
         allow(build).to receive(:build_version).and_return('1')
         allow(build2).to receive(:build_version).and_return('2')
+        allow(empty_build).to receive(:build_version).and_return('3')
         allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)
       end
 
       context 'with no special options' do
         it 'downloads all dsyms of all builds in all trains' do
           expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, empty_build])
           expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '1', platform: :ios).and_return(build_detail)
           expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '2', platform: :ios).and_return(build_detail)
           expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '1', platform: :ios).and_return(build_detail)
           expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
+          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '3', platform: :ios).and_return(empty_build_detail)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build.build_version, nil)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build2.build_version, nil)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build.build_version, nil)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build2.build_version, nil)
+          expect(Fastlane::Actions::DownloadDsymsAction).not_to(receive(:download))
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp')
           end").runner.execute(:test)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -→

Resolves #15270

We have a Jenkins to job that uploads all dsyms to the Firebase (Crashlytics) and uses `download_dsyms` lane to download them from the App Store Connect Page. Earlier versions of our app do not have a dsym download link and the download_dsyms fails with the error `URI(is not URI?) `
```
/Users/hudson/.rvm/rubies/ruby-2.3.8/lib/ruby/2.3.0/uri/rfc3986_parser.rb:18:in `rescue in split': [!] bad URI(is not URI?):  (URI::InvalidURIError)
	from /Users/hudson/.rvm/rubies/ruby-2.3.8/lib/ruby/2.3.0/uri/rfc3986_parser.rb:15:in `split'
	from /Users/hudson/.rvm/rubies/ruby-2.3.8/lib/ruby/2.3.0/uri/rfc3986_parser.rb:73:in `parse'
	from /Users/hudson/.rvm/rubies/ruby-2.3.8/lib/ruby/2.3.0/uri/common.rb:227:in `parse'
	from /Users/hudson/.rvm/gems/ruby-2.3.8@executor-2/gems/fastlane-2.130.0/fastlane/lib/fastlane/actions/download_dsyms.rb:146:in `download_file'
	from /Users/hudson/.rvm/gems/ruby-2.3.8@executor-2/gems/fastlane-2.130.0/fastlane/lib/fastlane/actions/download_dsyms.rb:128:in `download'
...
```

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I added a check if the download_url is empty else show a message that dsym url is missing.
Moreover, I added a unit test for this case.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Tested it in our project without the fix(failing) and with the fix(works as expected).
