### PR TITLE
[action] plugin_scores: Fix support for rendering single line description of plugin actions on docs

### DIFF
--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -327,9 +327,8 @@ module Fastlane
             when :in_method
               if (string_statement = string_statement_from_line(line))
                 # Multiline support for `description` method
-                if last_method_name == 'description'
-                  # rubocop:disable BlockNesting
-                  last_string_statement.concat(string_statement) unless last_string_statement.nil?
+                if last_method_name == 'description' && !last_string_statement.nil?
+                  last_string_statement.concat(string_statement)
                 else
                   last_string_statement = string_statement
                 end

--- a/fastlane/spec/fixtures/plugins/multi_line_description_action.rb
+++ b/fastlane/spec/fixtures/plugins/multi_line_description_action.rb
@@ -1,0 +1,26 @@
+require 'fastlane/action'
+
+module Fastlane
+  module Actions
+    class MultiLineDescriptionAction < Action
+      def self.run(params)
+        # Do nothing
+      end
+
+      def self.description
+        'This is ' \
+        'multi line description.'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :hello,
+            description: 'A hello value',
+            optional: true
+          )
+        ]
+      end
+    end
+  end
+end

--- a/fastlane/spec/fixtures/plugins/single_line_description_action.rb
+++ b/fastlane/spec/fixtures/plugins/single_line_description_action.rb
@@ -1,0 +1,25 @@
+require 'fastlane/action'
+
+module Fastlane
+  module Actions
+    class SingleLineDescriptionAction < Action
+      def self.run(params)
+        # Do nothing
+      end
+
+      def self.description
+        "This is single line description."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :hello,
+            description: 'A hello value',
+            optional: true
+          )
+        ]
+      end
+    end
+  end
+end

--- a/fastlane/spec/helper/plugin_scores_helper_spec.rb
+++ b/fastlane/spec/helper/plugin_scores_helper_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../helper/plugin_scores_helper.rb'
+
+describe Fastlane::Helper::PluginScoresHelper::FastlaneActionFileParser do
+  describe 'parsing' do
+    it "parses single line action's description" do
+      action_file = './fastlane/spec/fixtures/plugins/single_line_description_action.rb'
+      actions = Fastlane::Helper::PluginScoresHelper::FastlaneActionFileParser.new.parse_file(File.expand_path(action_file))
+      expect(actions.length).to equal(1)
+      expect(actions.first.description).to match('This is single line description.') if actions.length == 1
+    end
+
+    it "parses multi line action's description" do
+      action_file = './fastlane/spec/fixtures/plugins/multi_line_description_action.rb'
+      actions = Fastlane::Helper::PluginScoresHelper::FastlaneActionFileParser.new.parse_file(File.expand_path(action_file))
+      expect(actions.length).to equal(1)
+      expect(actions.first.description).to match('This is multi line description.') if actions.length == 1
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix rendering of a single line description of plugin actions on docs due to regression spotted at fastlane/docs#864.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Fix single line action's description parsing. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Added unit tests to `FastlaneActionFileParser` for single and multi lines description. 

I did run the docs locally. 

**Before**

<img width="1107" alt="Screen Shot 2019-09-04 at 07 30 33" src="https://user-images.githubusercontent.com/10795657/64231880-03573d80-cef1-11e9-82da-f0cf9fefaa0d.png">

**After**

<img width="1219" alt="Screen Shot 2019-09-04 at 08 30 52" src="https://user-images.githubusercontent.com/10795657/64231892-094d1e80-cef1-11e9-8daf-19070a711d73.png">