### PR TITLE
[screengrab] Let users set clean status bar

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
@@ -171,7 +171,39 @@ If you're having trouble getting your device unlocked and the screen activated t
 
 ## Clean Status Bar
 
-You can use [QuickDemo](https://github.com/PSPDFKit-labs/QuickDemo) to clean up the status bar for your screenshots.
+Screengrab can clean your status bar to make your screenshots even more beautiful.  
+Note: the clean status bar feature is only supported on devices with *API level >= 23*.
+
+To use the clean status bar feature add the following lines to your src/debug/AndroidManifest.xml
+```xml
+<!-- Indicates the use of the clean status bar feature -->
+<uses-feature android:name="tools.fastlane.screengrab.cleanstatusbar"/>
+<!-- Allows for changing the status bar -->
+<uses-permission android:name="android.permission.DUMP"/>
+```
+
+After that you can enable and disable the clean status bar at any moment during your tests.  
+In most cases you probably want to do this in the @BeforeClass and @AfterClass methods.
+```java
+@BeforeClass
+public static void beforeAll() {
+    CleanStatusBar.enableWithDefaults();
+}
+
+@AfterClass
+public static void afterAll() {
+    CleanStatusBar.disable();
+}
+```
+
+Have a look at the methods of the `CleanStatusBar` class to customize the status bar even more.  
+You could for example show the Bluetooth icon and the LTE text.
+```java
+new CleanStatusBar()
+    .setBluetoothState(BluetoothState.DISCONNECTED)
+    .setMobileNetworkDataType(MobileDataType.LTE)
+    .enable();
+```
 
 # Advanced _screengrab_
 

--- a/screengrab/example/src/androidTest/java/tools/fastlane/localetester/JUnit4StyleTests.java
+++ b/screengrab/example/src/androidTest/java/tools/fastlane/localetester/JUnit4StyleTests.java
@@ -2,6 +2,7 @@ package tools.fastlane.localetester;
 
 import androidx.test.rule.ActivityTestRule;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -11,6 +12,9 @@ import org.junit.runners.JUnit4;
 
 import tools.fastlane.screengrab.Screengrab;
 import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy;
+import tools.fastlane.screengrab.cleanstatusbar.BluetoothState;
+import tools.fastlane.screengrab.cleanstatusbar.CleanStatusBar;
+import tools.fastlane.screengrab.cleanstatusbar.MobileDataType;
 import tools.fastlane.screengrab.locale.LocaleTestRule;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -31,6 +35,16 @@ public class JUnit4StyleTests {
     @BeforeClass
     public static void beforeAll() {
         Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
+
+        new CleanStatusBar()
+                .setMobileNetworkDataType(MobileDataType.LTE)
+                .setBluetoothState(BluetoothState.DISCONNECTED)
+                .enable();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        CleanStatusBar.disable();
     }
 
     @Test

--- a/screengrab/example/src/androidTest/java/tools/fastlane/localetester/JUnit4StyleTests.java
+++ b/screengrab/example/src/androidTest/java/tools/fastlane/localetester/JUnit4StyleTests.java
@@ -37,7 +37,7 @@ public class JUnit4StyleTests {
         Screengrab.setDefaultScreenshotStrategy(new UiAutomatorScreenshotStrategy());
 
         new CleanStatusBar()
-                .setMobileNetworkDataType(MobileDataType.LTE)
+                .setMobileNetworkDataType(MobileDataType.THREEG)
                 .setBluetoothState(BluetoothState.DISCONNECTED)
                 .enable();
     }

--- a/screengrab/example/src/debug/AndroidManifest.xml
+++ b/screengrab/example/src/debug/AndroidManifest.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="tools.fastlane.localetester"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+          xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-feature android:name="tools.fastlane.screengrab.cleanstatusbar"/>
 
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" />
+    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.DUMP" tools:ignore="ProtectedPermissions" />
 
 </manifest>

--- a/screengrab/lib/screengrab/options.rb
+++ b/screengrab/lib/screengrab/options.rb
@@ -141,7 +141,16 @@ module Screengrab
         FastlaneCore::ConfigItem.new(key: :adb_host,
                                      env_name: 'SCREENGRAB_ADB_HOST',
                                      description: "Configure the host used by adb to connect, allows running on remote devices farm",
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :clean_status_bar,
+                                     env_name: 'SCREENGRAB_CLEAN_STATUS_BAR',
+                                     description: "Enabling this option will clean the status bar",
+                                     default_value: false,
+                                     type: Boolean),
+        FastlaneCore::ConfigItem.new(key: :clean_status_bar_config,
+                                     description: "Specifies the configuration for the clean status bar",
+                                     default_value: {},
+                                     type: Hash)
       ]
     end
   end

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -395,14 +395,14 @@ module Screengrab
     def enable_clean_status_bar(device_serial, app_apk_path)
       return unless device_api_version(device_serial) >= 23
 
-      # Check if the app want's to use the clean status bar feature
+      # Check if the app wants to use the clean status bar feature
       badging_dump = @executor.execute(command: "#{@android_env.aapt_path} dump badging #{app_apk_path}",
                                        print_all: true, print_command: true)
       return unless badging_dump.include?('uses-feature: name=\'tools.fastlane.screengrab.cleanstatusbar\'')
 
       UI.message('Enabling clean status bar')
 
-      # Make sure the app has the DUMP permission
+      # Make sure the app requests the DUMP permission
       unless badging_dump.include?('uses-permission: name=\'android.permission.DUMP\'')
         UI.user_error!("The clean status bar feature requires the android.permission.DUMP permission but it could not be found in your app APK")
       end

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -388,7 +388,7 @@ module Screengrab
     end
 
     def device_api_version(device_serial)
-      run_adb_command("adb -s #{device_serial} shell getprop ro.build.version.sdk",
+      run_adb_command("-s #{device_serial} shell getprop ro.build.version.sdk",
                       print_all: true, print_command: true).to_i
     end
 
@@ -408,11 +408,11 @@ module Screengrab
       end
 
       # Grant the DUMP permission
-      run_adb_command("adb -s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.DUMP",
+      run_adb_command("-s #{device_serial} shell pm grant #{@config[:app_package_name]} android.permission.DUMP",
                       print_all: true, print_command: true)
 
       # Enable the SystemUI demo mode
-      run_adb_command("adb -s #{device_serial} shell settings put global sysui_demo_allowed 1",
+      run_adb_command("-s #{device_serial} shell settings put global sysui_demo_allowed 1",
                       print_all: true, print_command: true)
     end
   end

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/BarsMode.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/BarsMode.java
@@ -1,0 +1,23 @@
+package tools.fastlane.screengrab.cleanstatusbar;
+
+import android.support.annotation.NonNull;
+
+public enum BarsMode {
+
+    OPAQUE("opaque"),
+    TRANSLUCENT("translucent"),
+    SEMI_TRANSPARENT("semi-transparent"),
+    TRANSPARENT("transparent"),
+    WARNING("warning");
+
+    private final String value;
+
+    BarsMode(@NonNull String value) {
+        this.value = value;
+    }
+
+    @NonNull
+    public String getValue() {
+        return value;
+    }
+}

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/BarsMode.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/BarsMode.java
@@ -1,6 +1,6 @@
 package tools.fastlane.screengrab.cleanstatusbar;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public enum BarsMode {
 

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/BluetoothState.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/BluetoothState.java
@@ -1,0 +1,21 @@
+package tools.fastlane.screengrab.cleanstatusbar;
+
+import android.support.annotation.NonNull;
+
+public enum BluetoothState {
+
+    CONNECTED("connected"),
+    DISCONNECTED("disconnected"),
+    HIDE("hide");
+
+    private final String value;
+
+    BluetoothState(@NonNull String value) {
+        this.value = value;
+    }
+
+    @NonNull
+    public String getValue() {
+        return value;
+    }
+}

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/BluetoothState.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/BluetoothState.java
@@ -1,6 +1,6 @@
 package tools.fastlane.screengrab.cleanstatusbar;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public enum BluetoothState {
 

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/CleanStatusBar.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/CleanStatusBar.java
@@ -1,0 +1,364 @@
+package tools.fastlane.screengrab.cleanstatusbar;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.test.InstrumentationRegistry;
+import android.util.Log;
+
+public class CleanStatusBar {
+    private static final String TAG = "Screengrab";
+
+    private int batteryLevel = 100;
+    private boolean batteryPlugged = false;
+    private boolean batteryPowerSave = false;
+    private IconVisibility airplaneModeVisibility = IconVisibility.HIDE;
+    private boolean networkFullyConnected = true;
+    private IconVisibility wifiVisibility = IconVisibility.SHOW;
+    @Nullable
+    private Integer wifiLevel = 4;
+    private IconVisibility mobileNetworkVisibility = IconVisibility.SHOW;
+    private MobileDataType mobileNetworkDataType = MobileDataType.HIDE;
+    @Nullable
+    private Integer mobileNetworkLevel = 4;
+    private IconVisibility carrierNetworkChangeVisibility = IconVisibility.HIDE;
+    private int numberOfSims = 1;
+    private IconVisibility noSimVisibility = IconVisibility.HIDE;
+    private BarsMode barsMode = BarsMode.TRANSPARENT;
+    private VolumeState volumeState = VolumeState.HIDE;
+    private BluetoothState bluetoothState = BluetoothState.HIDE;
+    private IconVisibility locationVisibility = IconVisibility.HIDE;
+    private IconVisibility alarmVisibility = IconVisibility.HIDE;
+    private IconVisibility syncVisibility = IconVisibility.HIDE;
+    private IconVisibility ttyVisibility = IconVisibility.HIDE;
+    private IconVisibility eriVisibility = IconVisibility.HIDE;
+    private IconVisibility muteVisibility = IconVisibility.HIDE;
+    private IconVisibility speakerphoneVisibility = IconVisibility.HIDE;
+    private boolean showNotifications = false;
+    private String clock = "1230";
+
+    /**
+     * Enables the clean status bar with the default configuration
+     */
+    public static void enableWithDefaults()
+    {
+        new CleanStatusBar().enable();
+    }
+
+    /**
+     * Disables the clean status bar
+     */
+    public static void disable()
+    {
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return;
+        sendCommand(InstrumentationRegistry.getTargetContext(), "exit");
+    }
+
+    /**
+     * Sets the battery level
+     * @param batteryLevel the battery level.
+     *                     It must be between 0 and 100.
+     */
+    public CleanStatusBar setBatteryLevel(int batteryLevel) {
+        if(batteryLevel < 0 || batteryLevel > 100)
+            throw new IllegalArgumentException("Battery level must be between 0 and 100");
+        this.batteryLevel = batteryLevel;
+        return this;
+    }
+
+    /**
+     * Sets if the battery is being charged
+     * @param batteryPlugged true if the battery is being charged, false otherwise
+     */
+    public CleanStatusBar setBatteryPlugged(boolean batteryPlugged) {
+        this.batteryPlugged = batteryPlugged;
+        return this;
+    }
+
+    /**
+     * Sets if the power save mode is enabled
+     * @param batteryPowerSave true if the power save mode is enabled, false otherwise
+     */
+    public CleanStatusBar setBatteryPowerSave(boolean batteryPowerSave) {
+        this.batteryPowerSave = batteryPowerSave;
+        return this;
+    }
+
+    /**
+     * Sets the airplane mode icon visibility
+     * @param airplaneModeVisibility the airplane mode {@link IconVisibility}
+     */
+    public CleanStatusBar setAirplaneModeVisibility(@NonNull IconVisibility airplaneModeVisibility) {
+        this.airplaneModeVisibility = airplaneModeVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the MCS state to fully connected
+     * @param networkFullyConnected true if the MCS state is fully connected, false otherwise
+     */
+    public CleanStatusBar setNetworkFullyConnected(boolean networkFullyConnected) {
+        this.networkFullyConnected = networkFullyConnected;
+        return this;
+    }
+
+    /**
+     * Sets the wifi icon visibility
+     * @param wifiVisibility the wifi {@link IconVisibility}
+     */
+    public CleanStatusBar setWifiVisibility(@NonNull IconVisibility wifiVisibility) {
+        this.wifiVisibility = wifiVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the wifi level
+     * @param wifiLevel the wifi level.
+     *                  It must be between 0 and 4.
+     *                  Set this to null to indicate a disconnected state
+     */
+    public CleanStatusBar setWifiLevel(@Nullable Integer wifiLevel) {
+        if(wifiLevel != null && (wifiLevel < 0 || wifiLevel > 4))
+            throw new IllegalArgumentException("Wifi level must be null or between 0 and 4");
+        this.wifiLevel = wifiLevel;
+        return this;
+    }
+
+    /**
+     * Sets the mobile network icon visibility
+     * @param mobileNetworkVisibility the mobile network {@link IconVisibility}
+     */
+    public CleanStatusBar setMobileNetworkVisibility(@NonNull IconVisibility mobileNetworkVisibility) {
+        this.mobileNetworkVisibility = mobileNetworkVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the mobile network data type
+     * @param mobileNetworkDataType the {@link MobileDataType}
+     */
+    public CleanStatusBar setMobileNetworkDataType(@NonNull MobileDataType mobileNetworkDataType) {
+        this.mobileNetworkDataType = mobileNetworkDataType;
+        return this;
+    }
+
+    /**
+     * Sets the mobile network level
+     * @param mobileNetworkLevel the mobile network level.
+     *                           It must be between 0 and 4.
+     *                           Set this to null to indicate a disconnected state
+     */
+    public CleanStatusBar setMobileNetworkLevel(@Nullable Integer mobileNetworkLevel) {
+        if(mobileNetworkLevel != null && (mobileNetworkLevel < 0 || mobileNetworkLevel > 4))
+            throw new IllegalArgumentException("Mobile network level must be null or between 0 and 4");
+        this.mobileNetworkLevel = mobileNetworkLevel;
+        return this;
+    }
+
+    /**
+     * Sets the carrier network change visibility
+     * @param carrierNetworkChangeVisibility the carrier network change {@link IconVisibility}
+     */
+    public CleanStatusBar setCarrierNetworkChangeVisibility(@NonNull IconVisibility carrierNetworkChangeVisibility) {
+        this.carrierNetworkChangeVisibility = carrierNetworkChangeVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the number of sims
+     * @param numberOfSims the number of sims.
+     *                     This must be between 1 and 8
+     */
+    public CleanStatusBar setNumberOfSims(int numberOfSims) {
+        if(numberOfSims < 1 || numberOfSims > 8)
+            throw new IllegalArgumentException("Number of sims must be between 1 and 8");
+        this.numberOfSims = numberOfSims;
+        return this;
+    }
+
+    /**
+     * Sets the no sim icon visibility
+     * @param noSimVisibility the no sim {@link IconVisibility}
+     */
+    public CleanStatusBar setNoSimVisibility(@NonNull IconVisibility noSimVisibility) {
+        this.noSimVisibility = noSimVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the mode of the SystemUI bars
+     * @param barsMode the {@link BarsMode} of the SystemUI
+     */
+    public CleanStatusBar setBarsMode(@NonNull BarsMode barsMode) {
+        this.barsMode = barsMode;
+        return this;
+    }
+
+    /**
+     * Sets the volume state
+     * @param volumeState the {@link VolumeState}
+     */
+    public CleanStatusBar setVolumeState(@NonNull VolumeState volumeState) {
+        this.volumeState = volumeState;
+        return this;
+    }
+
+    /**
+     * Sets the bluetooth state
+     * @param bluetoothState the {@link BluetoothState}
+     */
+    public CleanStatusBar setBluetoothState(@NonNull BluetoothState bluetoothState) {
+        this.bluetoothState = bluetoothState;
+        return this;
+    }
+
+    /**
+     * Sets the location icon visibility
+     * @param locationVisibility the location {@link IconVisibility}
+     */
+    public CleanStatusBar setLocationVisibility(@NonNull IconVisibility locationVisibility) {
+        this.locationVisibility = locationVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the alarm icon visibility
+     * @param alarmVisibility the alarm {@link IconVisibility}
+     */
+    public CleanStatusBar setAlarmVisibility(@NonNull IconVisibility alarmVisibility) {
+        this.alarmVisibility = alarmVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the sync icon visibility
+     * @param syncVisibility the sync {@link IconVisibility}
+     */
+    public CleanStatusBar setSyncVisibility(@NonNull IconVisibility syncVisibility) {
+        this.syncVisibility = syncVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the TTY icon visibility
+     * @param ttyVisibility the TTY {@link IconVisibility}
+     */
+    public CleanStatusBar setTtyVisibility(@NonNull IconVisibility ttyVisibility) {
+        this.ttyVisibility = ttyVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the CDMA ERI icon visibility
+     * @param eriVisibility the CDMA ERI {@link IconVisibility}
+     */
+    public CleanStatusBar setEriVisibility(@NonNull IconVisibility eriVisibility) {
+        this.eriVisibility = eriVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the mute icon visibility
+     * @param muteVisibility the mute {@link IconVisibility}
+     */
+    public CleanStatusBar setMuteVisibility(@NonNull IconVisibility muteVisibility) {
+        this.muteVisibility = muteVisibility;
+        return this;
+    }
+
+    /**
+     * Sets the speakerphone icon visibility
+     * @param speakerphoneVisibility the speakerphone {@link IconVisibility}
+     */
+    public CleanStatusBar setSpeakerphoneVisibility(@NonNull IconVisibility speakerphoneVisibility) {
+        this.speakerphoneVisibility = speakerphoneVisibility;
+        return this;
+    }
+
+    /**
+     * Sets if the notifications are shown
+     * @param showNotifications true if the notifications should be shown, false otherwise
+     */
+    public CleanStatusBar setShowNotifications(boolean showNotifications) {
+        this.showNotifications = showNotifications;
+        return this;
+    }
+
+    /**
+     * Sets the time of the clock
+     * @param clock the time of the clock.
+     *              This must be a string of 4 integers
+     */
+    public CleanStatusBar setClock(@NonNull String clock) {
+        if(!clock.matches("^[0-9]{4}$"))
+            throw new IllegalArgumentException("The clock must be a string of 4 integers");
+        this.clock = clock;
+        return this;
+    }
+
+    /**
+     * Enables the clean status bar with the current configuration.
+     * Changing the configuration after calling this method doesn't effect the status bar.
+     * Always call this method after changing the configuration.
+     */
+    public void enable()
+    {
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            Log.w(TAG, "Clean status bar is only supported on Android 6.0 and above");
+            return;
+        }
+
+        Context context = InstrumentationRegistry.getTargetContext();
+
+        sendCommand(context, "battery", "level", Integer.toString(batteryLevel),
+                "plugged", batteryPlugged ? "true" : "false",
+                "powersave" , batteryPowerSave ? "true" : "false");
+
+        sendCommand(context, "network", "wifi", wifiVisibility.getValue(),
+                "level", wifiLevel == null ? "null" : Integer.toString(wifiLevel));
+        sendCommand(context, "network", "nosim", noSimVisibility.getValue());
+        sendCommand(context, "network", "airplane", airplaneModeVisibility.getValue());
+        // Some network commands conflict...
+        if(airplaneModeVisibility == IconVisibility.HIDE) {
+            sendCommand(context,"network", "sims", Integer.toString(numberOfSims));
+            sendCommand(context,"network", "carriernetworkchange", carrierNetworkChangeVisibility.getValue());
+            if(carrierNetworkChangeVisibility == IconVisibility.HIDE) {
+                sendCommand(context, "network", "mobile", mobileNetworkVisibility.getValue(),
+                        "level", mobileNetworkLevel == null ? "null" : Integer.toString(mobileNetworkLevel),
+                        "datatype", mobileNetworkDataType.getValue());
+            }
+        }
+        // For some reason this needs to run after all the other network commands
+        sendCommand(context, "network", "fully", networkFullyConnected ? "true" : "false");
+
+        sendCommand(context, "bars", "mode", barsMode.getValue());
+
+        sendCommand(context, "status", "volume", volumeState.getValue());
+        sendCommand(context, "status", "bluetooth", bluetoothState.getValue());
+        sendCommand(context, "status", "location", locationVisibility.getValue());
+        sendCommand(context, "status", "alarm", alarmVisibility.getValue());
+        sendCommand(context, "status", "sync", syncVisibility.getValue());
+        sendCommand(context, "status", "tty", ttyVisibility.getValue());
+        sendCommand(context, "status", "eri", eriVisibility.getValue());
+        sendCommand(context, "status", "mute", muteVisibility.getValue());
+        sendCommand(context, "status", "speakerphone", speakerphoneVisibility.getValue());
+
+        sendCommand(context, "notifications", "visible", showNotifications ? "true" : "false");
+
+        sendCommand(context, "clock", "hhmm", clock);
+    }
+
+    private static void sendCommand(@NonNull Context context, @NonNull String... commands)
+    {
+        if ((commands.length - 1) % 2 != 0)
+            throw new IllegalArgumentException();
+        Intent intent = new Intent("com.android.systemui.demo")
+                .putExtra("command", commands[0]);
+        for (int i = 1; i < commands.length; i += 2) {
+            intent.putExtra(commands[i], commands[i + 1]);
+        }
+        context.sendBroadcast(intent);
+    }
+}

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/CleanStatusBar.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/CleanStatusBar.java
@@ -3,10 +3,11 @@ package tools.fastlane.screengrab.cleanstatusbar;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.test.InstrumentationRegistry;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.InstrumentationRegistry;
 
 public class CleanStatusBar {
     private static final String TAG = "Screengrab";

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/IconVisibility.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/IconVisibility.java
@@ -1,6 +1,6 @@
 package tools.fastlane.screengrab.cleanstatusbar;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public enum IconVisibility {
 

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/IconVisibility.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/IconVisibility.java
@@ -1,0 +1,20 @@
+package tools.fastlane.screengrab.cleanstatusbar;
+
+import android.support.annotation.NonNull;
+
+public enum IconVisibility {
+
+    SHOW("show"),
+    HIDE("hide");
+
+    private final String value;
+
+    IconVisibility(@NonNull String value) {
+        this.value = value;
+    }
+
+    @NonNull
+    public String getValue() {
+        return value;
+    }
+}

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/MobileDataType.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/MobileDataType.java
@@ -1,0 +1,27 @@
+package tools.fastlane.screengrab.cleanstatusbar;
+
+import android.support.annotation.NonNull;
+
+public enum MobileDataType {
+
+    ONEX("1x"),
+    THREEG("3g"),
+    FOURG("4g"),
+    E("e"),
+    G("g"),
+    H("h"),
+    LTE("lte"),
+    ROAM("roam"),
+    HIDE("hide");
+
+    private final String value;
+
+    MobileDataType(@NonNull String value) {
+        this.value = value;
+    }
+
+    @NonNull
+    public String getValue() {
+        return value;
+    }
+}

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/MobileDataType.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/MobileDataType.java
@@ -1,6 +1,6 @@
 package tools.fastlane.screengrab.cleanstatusbar;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public enum MobileDataType {
 

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/VolumeState.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/VolumeState.java
@@ -1,0 +1,21 @@
+package tools.fastlane.screengrab.cleanstatusbar;
+
+import android.support.annotation.NonNull;
+
+public enum VolumeState {
+
+    SILENT("silent"),
+    VIBRATE("vibrate"),
+    HIDE("hide");
+
+    private final String value;
+
+    VolumeState(@NonNull String value) {
+        this.value = value;
+    }
+
+    @NonNull
+    public String getValue() {
+        return value;
+    }
+}

--- a/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/VolumeState.java
+++ b/screengrab/screengrab-lib/src/main/java/tools.fastlane.screengrab/cleanstatusbar/VolumeState.java
@@ -1,6 +1,6 @@
 package tools.fastlane.screengrab.cleanstatusbar;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public enum VolumeState {
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The goal is to automatically enable and disable the clean status bar so that you don't have to do this manually with for example the QuickDemo app.

### Description
I have added the options `clean_status_bar` and `clean_status_bar_config` to `screengrab`.
With `clean_status_bar` the clean status bar can be enabled. 
Use the `clean_status_bar_config` option to customise the appearance of the clean status bar.

The configuration options are based on the commands described here:
https://android.googlesource.com/platform/frameworks/base/+/master/packages/SystemUI/docs/demo_mode.md

### ToDos
- We probably need some documentation for the possible configuration keys and their values
- It seems that the configuration for the mobile network icons are reset when screengrab changes the local to anything other then the device local. Maybe we should move this functionality to the `screengrab-lib` so that it can set the clean status bar after every local change?

@janpio any thoughts?