### PR TITLE
[latest_testflight_build_number] Support :platform parameter for non-live builds

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -36,6 +36,7 @@ module Fastlane
           return build_nr
         else
           version_number = params[:version]
+          platform = params[:platform]
 
           # Create filter for get_builds with optional version number
           filter = { app: app.apple_id }
@@ -46,18 +47,25 @@ module Fastlane
             version_number_message = "any version"
           end
 
+          if platform
+            filter["preReleaseVersion.platform"] = Spaceship::ConnectAPI::Platform.map(platform)
+            platform_message = "#{platform} platform"
+          else
+            platform_message = "any platform"
+          end
+
           UI.message("Fetching the latest build number for #{version_number_message}")
 
           # Get latest build for optional version number and return build number if found
           build = Spaceship::ConnectAPI.get_builds(filter: filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1).first
           if build
             build_nr = build.version
-            UI.message("Latest upload for version #{build.app_version} is build: #{build_nr}")
+            UI.message("Latest upload for version #{build.app_version} on #{platform_message} is build: #{build_nr}")
             return build_nr
           end
 
           # Let user know that build couldn't be found
-          UI.important("Could not find a build for #{version_number_message} on App Store Connect")
+          UI.important("Could not find a build for #{version_number_message} on #{platform_message} on App Store Connect")
 
           if params[:initial_build_number].nil?
             UI.user_error!("Could not find a build on App Store Connect - and 'initial_build_number' option is not set")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Support `platform` filter for [latest_testflight_build_number](https://docs.fastlane.tools/actions/latest_testflight_build_number/) action to get only tvOS or only iOS app build number when both are available and might be deployed separately from each other

### Description
- Mapped `platform` to ITC platform when it's not `nil`
- Set it as `preReleaseVersion.platform` filter in [`app/{id}/builds`](https://developer.apple.com/documentation/appstoreconnectapi/list_all_builds_of_an_app) request

⚠️This actually changes the currentent behavior of `latest_testflight_build_number`: before it was taking the latest TestFlight build for ANY platform and now _(when `platform` is not specifically set)_ it will return only build for iOS platform. That might be fixed by removing default value from `platform` field but I guess it might lead to other issues I'm not aware about yet.

### Testing Steps
Any tests which can be written are either integration tests or `available_options` tests.
