### PR TITLE
[download_dsyms] Added 'live' version parameter to only download live_version dSYMs

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -240,7 +240,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        short_option: "-v",
                                        env_name: "DOWNLOAD_DSYMS_VERSION",
-                                       description: "The app version for dSYMs you wish to download, pass in 'latest' to download only the latest build's dSYMs or pass in 'live' to download only the latest live verion dSYMs",
+                                       description: "The app version for dSYMs you wish to download, pass in 'latest' to download only the latest build's dSYMs or 'live' to download only the live verion dSYMs",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :build_number,
                                        short_option: "-b",

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -31,7 +31,7 @@ module Fastlane
         # Set version if it is latest
         if version == 'latest'
           # Try to grab the edit version first, else fallback to live version
-          UI.message("Looking for latest or live version...")
+          UI.message("Looking for latest version...")
           latest_version = app.edit_version(platform: platform) || app.live_version(platform: platform)
 
           UI.user_error!("Could not find latest version for your app, please try setting a specific version") if latest_version.version.nil?

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -240,7 +240,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        short_option: "-v",
                                        env_name: "DOWNLOAD_DSYMS_VERSION",
-                                       description: "The app version for dSYMs you wish to download, pass in 'latest' to download only the latest build's dSYMs. Pass in 'live' to download only the latest live build's dSYMs.",
+                                       description: "The app version for dSYMs you wish to download, pass in 'latest' to download only the latest build's dSYMs or pass in 'live' to download only the latest live verion dSYMs",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :build_number,
                                        short_option: "-b",

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -31,7 +31,7 @@ module Fastlane
         # Set version if it is latest
         if version == 'latest'
           # Try to grab the edit version first, else fallback to live version
-          UI.message("Looking for latest version...")
+          UI.message("Looking for latest or live version...")
           latest_version = app.edit_version(platform: platform) || app.live_version(platform: platform)
 
           UI.user_error!("Could not find latest version for your app, please try setting a specific version") if latest_version.version.nil?
@@ -45,6 +45,15 @@ module Fastlane
             version = latest_candidate_build.train_version
             build_number = latest_candidate_build.build_version
           end
+        elsif version == 'live'
+          UI.message("Looking for latest live version...")
+          latest_live_version = app.live_version(platform: platform)
+
+          UI.user_error!("Could not find latest live version for your app, please try setting a specific version") if latest_live_version.version.nil?
+
+          # No need to search for candidates, because released App Store version should only have one build
+          version = latest_live_version.version
+          build_number = latest_live_version.build_version
         end
 
         # Make sure output_directory has a slash on the end
@@ -231,7 +240,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        short_option: "-v",
                                        env_name: "DOWNLOAD_DSYMS_VERSION",
-                                       description: "The app version for dSYMs you wish to download, pass in 'latest' to download only the latest build's dSYMs",
+                                       description: "The app version for dSYMs you wish to download, pass in 'latest' to download only the latest build's dSYMs. Pass in 'live' to download only the latest live build's dSYMs.",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :build_number,
                                        short_option: "-b",
@@ -280,6 +289,7 @@ module Fastlane
         [
           'download_dsyms',
           'download_dsyms(version: "1.0.0", build_number: "345")',
+          'download_dsyms(version: "live")',
           'download_dsyms(min_version: "1.2.3")'
         ]
       end

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -46,10 +46,10 @@ module Fastlane
             build_number = latest_candidate_build.build_version
           end
         elsif version == 'live'
-          UI.message("Looking for latest live version...")
+          UI.message("Looking for live version...")
           latest_live_version = app.live_version(platform: platform)
 
-          UI.user_error!("Could not find latest live version for your app, please try setting a specific version") if latest_live_version.version.nil?
+          UI.user_error!("Could not find live version for your app, please try setting 'latest' or a specific version") if latest_live_version.version.nil?
 
           # No need to search for candidates, because released App Store version should only have one build
           version = latest_live_version.version

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -47,13 +47,13 @@ module Fastlane
           end
         elsif version == 'live'
           UI.message("Looking for live version...")
-          latest_live_version = app.live_version(platform: platform)
+          live_version = app.live_version(platform: platform)
 
-          UI.user_error!("Could not find live version for your app, please try setting 'latest' or a specific version") if latest_live_version.version.nil?
+          UI.user_error!("Could not find live version for your app, please try setting 'latest' or a specific version") if live_version.nil?
 
           # No need to search for candidates, because released App Store version should only have one build
-          version = latest_live_version.version
-          build_number = latest_live_version.build_version
+          version = live_version.version
+          build_number = live_version.build_version
         end
 
         # Make sure output_directory has a slash on the end

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -4,6 +4,7 @@ describe Fastlane do
       # 1 app, 2 trains/versions, 2 builds each
       let(:app) { double('app') }
       let(:version) { double('version') }
+      let(:live_version) { double('live_version') }
       let(:train) { double('train') }
       let(:train2) { double('train2') }
       let(:build) { double('build') }
@@ -70,6 +71,36 @@ describe Fastlane do
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build2.build_version, nil)
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: 'latest')
+          end").runner.execute(:test)
+        end
+      end
+
+      context 'when version is live' do
+        before do
+          # live
+          allow(app).to receive(:live_version).and_return(live_version)
+          allow(live_version).to receive(:version).and_return('1.0.0')
+          allow(live_version).to receive(:build_version).and_return('42')
+          allow(live_version).to receive(:candidate_builds).and_return([build])
+          allow(build).to receive(:build_version).and_return('42')
+          allow(build).to receive(:upload_date).and_return(1_547_196_482_000)
+          # latest
+          allow(app).to receive(:edit_version).and_return(version)
+          allow(version).to receive(:version).and_return('2.0.0')
+          allow(version).to receive(:candidate_builds).and_return([build2, build3])
+          allow(build2).to receive(:train_version).and_return('2.0.0')
+          allow(build2).to receive(:upload_date).and_return(1_547_145_145_000)
+          allow(build3).to receive(:train_version).and_return('2.0.0')
+          allow(build3).to receive(:build_version).and_return('2')
+          allow(build3).to receive(:upload_date).and_return(1_547_196_482_000)
+        end
+        it 'downloads only dsyms of latest live build in latest train' do
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, build3])
+          expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '42', platform: :ios).and_return(build_detail)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build.build_version, nil)
+
+          Fastlane::FastFile.new.parse("lane :test do
+              download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: 'live')
           end").runner.execute(:test)
         end
       end

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -94,7 +94,7 @@ describe Fastlane do
           allow(build3).to receive(:build_version).and_return('2')
           allow(build3).to receive(:upload_date).and_return(1_547_196_482_000)
         end
-        it 'downloads only dsyms of latest live build in latest train' do
+        it 'downloads only dsyms of live build' do
           expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, build3])
           expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '42', platform: :ios).and_return(build_detail)
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build.build_version, nil)

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -84,15 +84,6 @@ describe Fastlane do
           allow(live_version).to receive(:candidate_builds).and_return([build])
           allow(build).to receive(:build_version).and_return('42')
           allow(build).to receive(:upload_date).and_return(1_547_196_482_000)
-          # latest
-          allow(app).to receive(:edit_version).and_return(version)
-          allow(version).to receive(:version).and_return('2.0.0')
-          allow(version).to receive(:candidate_builds).and_return([build2, build3])
-          allow(build2).to receive(:train_version).and_return('2.0.0')
-          allow(build2).to receive(:upload_date).and_return(1_547_145_145_000)
-          allow(build3).to receive(:train_version).and_return('2.0.0')
-          allow(build3).to receive(:build_version).and_return('2')
-          allow(build3).to receive(:upload_date).and_return(1_547_196_482_000)
         end
         it 'downloads only dsyms of live build' do
           expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, build3])


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This should fix https://github.com/fastlane/fastlane/issues/15308

### Description
Added a new `if version == 'live'` next to `if version == 'latest'` check to only fetch the dSYMs of latest live version.

### Testing Steps
Added a new test in `fastlane/spec/actions_specs/download_dsyms_spec.rb`