### PR TITLE
[snapshot] Add iPhone 11 series devices to reports_generator

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -77,6 +77,9 @@ module Snapshot
       {
         # snapshot in Xcode 9 saves screenshots with the SIMULATOR_DEVICE_NAME
         # which includes spaces
+        'iPhone 11 Pro Max' => "iPhone 11 Pro Max",
+        'iPhone 11 Pro' => "iPhone 11 Pro",
+        'iPhone 11' => "iPhone 11",
         'iPhone XS Max' => "iPhone XS Max",
         'iPhone XS' => "iPhone XS",
         'iPhone XR' => "iPhone XR",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This pull request closes #15326 by adding support for iPhone 11 series to `reports_generator`.

### Description
The problem (iPhone 11 series devices not showing up in HTML reports) was resolved with a straightforward extension of `xcode_9_and_above_device_name_mappings`.

### Testing Steps
Can be easily tested by including iPhone 11 (Pro, Pro Max) in `Snapfile`, running `fastlane snapshot` and verifying they are now included in `screenshots.html`