### PR TITLE
[action] Improve get_version_number: fallback to project settings if no MARKETING_VERSION is set for target

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -18,19 +18,13 @@ module Fastlane
         plist_file = get_plist!(folder, target, configuration)
         version_number = get_version_number_from_plist!(plist_file)
 
-        # Get from build settings if needed (ex: $(MARKETING_VERSION) is default in Xcode 11)
+        # Get from build settings (or project settings) if needed (ex: $(MARKETING_VERSION) is default in Xcode 11)
         if version_number =~ /\$\(([\w\-]+)\)/
-          version_number = get_version_number_from_build_settings!(target, $1, configuration)
-
-          # Read $(MARKETING_VERSION) from project settings if version_number is not set in target settings
-          version_number ||= get_version_number_from_build_settings!(project, $1, configuration)
+          version_number = get_version_number_from_build_settings!(target, $1, configuration) || get_version_number_from_build_settings!(project, $1, configuration)
 
         # ${MARKETING_VERSION} also works
         elsif version_number =~ /\$\{([\w\-]+)\}/
-          version_number = get_version_number_from_build_settings!(target, $1, configuration)
-
-          # Read ${MARKETING_VERSION} from project settings if version_number is not set in target settings
-          version_number ||= get_version_number_from_build_settings!(project, $1, configuration)
+          version_number = get_version_number_from_build_settings!(target, $1, configuration) || get_version_number_from_build_settings!(project, $1, configuration)
         end
 
         # Error out if version_number is not set

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -25,17 +25,17 @@ module Fastlane
         elsif version_number =~ /\$\{([\w\-]+)\}/
           version_number = get_version_number_from_build_settings!(target, $1, configuration)
         end
-        
+
         # Check if version_number is not set and try retrieving value from project settings
         if version_number.nil?
-            version_number = get_version_number_from_project_settings(project, configuration)
+            version_number = get_version_number_from_build_settings!(project, $1, configuration)
         end
-        
+
         # Error out if version_number is not set
         if version_number.nil?
             UI.user_error!("Unable to find Xcode build setting: #{$1}")
         end
-        
+
         # Store the number in the shared hash
         Actions.lane_context[SharedValues::VERSION_NUMBER] = version_number
 
@@ -83,18 +83,6 @@ module Fastlane
         target
       end
 
-      def self.get_version_number_from_project_settings(project, configuration = nil)
-          # loop through project configurations and return MARKETING_VERSION
-          project.build_configurations.each do |config|
-              if config.name == "Release"
-                  value = config.build_settings["MARKETING_VERSION"]
-                  return value if value
-              end
-           end
-          
-          return nil
-      end
-
       def self.get_version_number_from_build_settings!(target, variable, configuration = nil)
         target.build_configurations.each do |config|
           if configuration.nil? || config.name == configuration
@@ -102,7 +90,7 @@ module Fastlane
             return value if value
           end
         end
-        
+
         return nil
       end
 

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -21,14 +21,16 @@ module Fastlane
         # Get from build settings if needed (ex: $(MARKETING_VERSION) is default in Xcode 11)
         if version_number =~ /\$\(([\w\-]+)\)/
           version_number = get_version_number_from_build_settings!(target, $1, configuration)
+
+          # Read $(MARKETING_VERSION) from project settings if version_number is not set in target settings
+          version_number ||= get_version_number_from_build_settings!(project, $1, configuration)
+
         # ${MARKETING_VERSION} also works
         elsif version_number =~ /\$\{([\w\-]+)\}/
           version_number = get_version_number_from_build_settings!(target, $1, configuration)
-        end
 
-        # Check if version_number is not set and try retrieving value from project settings
-        if version_number.nil?
-          version_number = get_version_number_from_build_settings!(project, $1, configuration)
+          # Read ${MARKETING_VERSION} from project settings if version_number is not set in target settings
+          version_number ||= get_version_number_from_build_settings!(project, $1, configuration)
         end
 
         # Error out if version_number is not set

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -28,12 +28,12 @@ module Fastlane
 
         # Check if version_number is not set and try retrieving value from project settings
         if version_number.nil?
-            version_number = get_version_number_from_build_settings!(project, $1, configuration)
+          version_number = get_version_number_from_build_settings!(project, $1, configuration)
         end
 
         # Error out if version_number is not set
         if version_number.nil?
-            UI.user_error!("Unable to find Xcode build setting: #{$1}")
+          UI.user_error!("Unable to find Xcode build setting: #{$1}")
         end
 
         # Store the number in the shared hash

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -25,7 +25,17 @@ module Fastlane
         elsif version_number =~ /\$\{([\w\-]+)\}/
           version_number = get_version_number_from_build_settings!(target, $1, configuration)
         end
-
+        
+        # Check if version_number is not set and try retrieving value from project settings
+        if version_number.nil?
+            version_number = get_version_number_from_project_settings(project, configuration)
+        end
+        
+        # Error out if version_number is not set
+        if version_number.nil?
+            UI.user_error!("Unable to find Xcode build setting: #{$1}")
+        end
+        
         # Store the number in the shared hash
         Actions.lane_context[SharedValues::VERSION_NUMBER] = version_number
 
@@ -73,6 +83,18 @@ module Fastlane
         target
       end
 
+      def self.get_version_number_from_project_settings(project, configuration = nil)
+          # loop through project configurations and return MARKETING_VERSION
+          project.build_configurations.each do |config|
+              if config.name == "Release"
+                  value = config.build_settings["MARKETING_VERSION"]
+                  return value if value
+              end
+           end
+          
+          return nil
+      end
+
       def self.get_version_number_from_build_settings!(target, variable, configuration = nil)
         target.build_configurations.each do |config|
           if configuration.nil? || config.name == configuration
@@ -80,8 +102,8 @@ module Fastlane
             return value if value
           end
         end
-
-        UI.user_error!("Unable to find Xcode build setting: #{variable}")
+        
+        return nil
       end
 
       def self.get_plist!(folder, target, configuration = nil)

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -12,18 +12,36 @@ describe Fastlane do
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version number for 'TargetVariableParentheses'", requires_xcodeproj: true do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetVariableParentheses')
-        end").runner.execute(:test)
-        expect(result).to eq("4.3.2")
+      context "Target Settings" do
+        it "gets the correct version number for 'TargetVariableParentheses'", requires_xcodeproj: true do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj: '#{path}', target: 'TargetVariableParentheses')
+          end").runner.execute(:test)
+          expect(result).to eq("4.3.2")
+        end
+
+        it "gets the correct version number for 'TargetVariableCurlyBraces'", requires_xcodeproj: true do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj: '#{path}', target: 'TargetVariableCurlyBraces')
+          end").runner.execute(:test)
+          expect(result).to eq("4.3.2")
+        end
       end
 
-      it "gets the correct version number for 'TargetVariableCurlyBraces'", requires_xcodeproj: true do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetVariableCurlyBraces')
-        end").runner.execute(:test)
-        expect(result).to eq("4.3.2")
+      context "Project Settings" do
+        it "gets the correct version number for 'TargetVariableParenthesesBuildSettings'", requires_xcodeproj: true do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj: '#{path}', target: 'TargetVariableParenthesesBuildSettings')
+          end").runner.execute(:test)
+          expect(result).to eq("7.6.5")
+        end
+
+        it "gets the correct version number for 'TargetVariableCurlyBracesBuildSettings'", requires_xcodeproj: true do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj: '#{path}', target: 'TargetVariableCurlyBracesBuildSettings')
+          end").runner.execute(:test)
+          expect(result).to eq("7.6.5")
+        end
       end
 
       it "gets the correct version number for 'TargetATests'", requires_xcodeproj: true do

--- a/fastlane/spec/fixtures/actions/get_version_number/TargetVariableCurlyBracesBuildSettings-Info.plist
+++ b/fastlane/spec/fixtures/actions/get_version_number/TargetVariableCurlyBracesBuildSettings-Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MARKETING_VERSION}</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fastlane/spec/fixtures/actions/get_version_number/TargetVariableParenthesesBuildSettings-Info.plist
+++ b/fastlane/spec/fixtures/actions/get_version_number/TargetVariableParenthesesBuildSettings-Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
@@ -91,6 +91,38 @@
 		03CFC576206409ED00CD6CB1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82EB2056A51B00BAAFD1 /* Assets.xcassets */; };
 		03CFC577206409ED00CD6CB1 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83062056A5D600BAAFD1 /* Info.plist */; };
 		03CFC578206409ED00CD6CB1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82E82056A51B00BAAFD1 /* Main.storyboard */; };
+		03F663AD23538BA700D4B92F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E62056A51B00BAAFD1 /* ViewController.swift */; };
+		03F663AE23538BA700D4B92F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E42056A51B00BAAFD1 /* AppDelegate.swift */; };
+		03F663B123538BA700D4B92F /* TargetDifferentConfigurations-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83AD2057215F00BAAFD1 /* TargetDifferentConfigurations-Debug.plist */; };
+		03F663B223538BA700D4B92F /* TargetC_production-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83482056AEC500BAAFD1 /* TargetC_production-Info.plist */; };
+		03F663B323538BA700D4B92F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82ED2056A51B00BAAFD1 /* LaunchScreen.storyboard */; };
+		03F663B423538BA700D4B92F /* TargetA-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83042056A5D000BAAFD1 /* TargetA-Info.plist */; };
+		03F663B523538BA700D4B92F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82EB2056A51B00BAAFD1 /* Assets.xcassets */; };
+		03F663B623538BA700D4B92F /* Plist-For-D-Target.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83992056B2CD00BAAFD1 /* Plist-For-D-Target.plist */; };
+		03F663B723538BA700D4B92F /* SampleProject-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83972056B29A00BAAFD1 /* SampleProject-Info.plist */; };
+		03F663B823538BA700D4B92F /* TargetDifferentConfigurations-Release.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83AE2057215F00BAAFD1 /* TargetDifferentConfigurations-Release.plist */; };
+		03F663B923538BA700D4B92F /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83062056A5D600BAAFD1 /* Info.plist */; };
+		03F663BA23538BA700D4B92F /* TargetB-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83242056AAD200BAAFD1 /* TargetB-Info.plist */; };
+		03F663BB23538BA700D4B92F /* TargetC_internal-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83492056AEC500BAAFD1 /* TargetC_internal-Info.plist */; };
+		03F663BC23538BA700D4B92F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82E82056A51B00BAAFD1 /* Main.storyboard */; };
+		03F663BD23538BA700D4B92F /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83262056AADB00BAAFD1 /* Info.plist */; };
+		03F663C523538BB200D4B92F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E62056A51B00BAAFD1 /* ViewController.swift */; };
+		03F663C623538BB200D4B92F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E42056A51B00BAAFD1 /* AppDelegate.swift */; };
+		03F663C923538BB200D4B92F /* TargetDifferentConfigurations-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83AD2057215F00BAAFD1 /* TargetDifferentConfigurations-Debug.plist */; };
+		03F663CA23538BB200D4B92F /* TargetC_production-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83482056AEC500BAAFD1 /* TargetC_production-Info.plist */; };
+		03F663CB23538BB200D4B92F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82ED2056A51B00BAAFD1 /* LaunchScreen.storyboard */; };
+		03F663CC23538BB200D4B92F /* TargetA-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83042056A5D000BAAFD1 /* TargetA-Info.plist */; };
+		03F663CD23538BB200D4B92F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82EB2056A51B00BAAFD1 /* Assets.xcassets */; };
+		03F663CE23538BB200D4B92F /* Plist-For-D-Target.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83992056B2CD00BAAFD1 /* Plist-For-D-Target.plist */; };
+		03F663CF23538BB200D4B92F /* SampleProject-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83972056B29A00BAAFD1 /* SampleProject-Info.plist */; };
+		03F663D023538BB200D4B92F /* TargetDifferentConfigurations-Release.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83AE2057215F00BAAFD1 /* TargetDifferentConfigurations-Release.plist */; };
+		03F663D123538BB200D4B92F /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83062056A5D600BAAFD1 /* Info.plist */; };
+		03F663D223538BB200D4B92F /* TargetB-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83242056AAD200BAAFD1 /* TargetB-Info.plist */; };
+		03F663D323538BB200D4B92F /* TargetC_internal-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83492056AEC500BAAFD1 /* TargetC_internal-Info.plist */; };
+		03F663D423538BB200D4B92F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82E82056A51B00BAAFD1 /* Main.storyboard */; };
+		03F663D523538BB200D4B92F /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83262056AADB00BAAFD1 /* Info.plist */; };
+		03F663DD23538CFE00D4B92F /* TargetVariableCurlyBracesBuildSettings-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03F663DB23538CFD00D4B92F /* TargetVariableCurlyBracesBuildSettings-Info.plist */; };
+		03F663DE23538CFE00D4B92F /* TargetVariableParenthesesBuildSettings-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03F663DC23538CFD00D4B92F /* TargetVariableParenthesesBuildSettings-Info.plist */; };
 		4AA286EA2300242500067244 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E62056A51B00BAAFD1 /* ViewController.swift */; };
 		4AA286EB2300242500067244 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E42056A51B00BAAFD1 /* AppDelegate.swift */; };
 		4AA286EE2300242500067244 /* TargetDifferentConfigurations-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83AD2057215F00BAAFD1 /* TargetDifferentConfigurations-Debug.plist */; };
@@ -177,6 +209,10 @@
 		03AB83AE2057215F00BAAFD1 /* TargetDifferentConfigurations-Release.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetDifferentConfigurations-Release.plist"; sourceTree = "<group>"; };
 		03CFC57C206409ED00CD6CB1 /* TargetSRC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetSRC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		03CFC57D206409ED00CD6CB1 /* TargetSRC.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = TargetSRC.plist; sourceTree = "<group>"; };
+		03F663C123538BA700D4B92F /* TargetVariableParenthesesBuildSettings.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetVariableParenthesesBuildSettings.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		03F663D923538BB200D4B92F /* TargetVariableCurlyBracesBuildSettings.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetVariableCurlyBracesBuildSettings.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		03F663DB23538CFD00D4B92F /* TargetVariableCurlyBracesBuildSettings-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetVariableCurlyBracesBuildSettings-Info.plist"; sourceTree = "<group>"; };
+		03F663DC23538CFD00D4B92F /* TargetVariableParenthesesBuildSettings-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetVariableParenthesesBuildSettings-Info.plist"; sourceTree = "<group>"; };
 		4AA286FE2300242500067244 /* TargetVariableParentheses.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetVariableParentheses.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4AA286FF2300242600067244 /* TargetVariableParentheses-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "TargetVariableParentheses-Info.plist"; sourceTree = "<group>"; };
 		A066E60823253F0F0053B487 /* TargetVariableCurlyBraces.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetVariableCurlyBraces.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -261,6 +297,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		03F663AF23538BA700D4B92F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		03F663C723538BB200D4B92F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4AA286EC2300242500067244 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -295,6 +345,8 @@
 				03AB82E32056A51B00BAAFD1 /* get_version_number */,
 				03AB82F82056A51B00BAAFD1 /* get_version_numberTests */,
 				03AB82E22056A51B00BAAFD1 /* Products */,
+				03F663DB23538CFD00D4B92F /* TargetVariableCurlyBracesBuildSettings-Info.plist */,
+				03F663DC23538CFD00D4B92F /* TargetVariableParenthesesBuildSettings-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -314,6 +366,8 @@
 				03CFC57C206409ED00CD6CB1 /* TargetSRC.app */,
 				4AA286FE2300242500067244 /* TargetVariableParentheses.app */,
 				A066E60823253F0F0053B487 /* TargetVariableCurlyBraces.app */,
+				03F663C123538BA700D4B92F /* TargetVariableParenthesesBuildSettings.app */,
+				03F663D923538BB200D4B92F /* TargetVariableCurlyBracesBuildSettings.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -533,6 +587,40 @@
 			productReference = 03CFC57C206409ED00CD6CB1 /* TargetSRC.app */;
 			productType = "com.apple.product-type.application";
 		};
+		03F663AB23538BA700D4B92F /* TargetVariableParenthesesBuildSettings */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 03F663BE23538BA700D4B92F /* Build configuration list for PBXNativeTarget "TargetVariableParenthesesBuildSettings" */;
+			buildPhases = (
+				03F663AC23538BA700D4B92F /* Sources */,
+				03F663AF23538BA700D4B92F /* Frameworks */,
+				03F663B023538BA700D4B92F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TargetVariableParenthesesBuildSettings;
+			productName = get_version_number;
+			productReference = 03F663C123538BA700D4B92F /* TargetVariableParenthesesBuildSettings.app */;
+			productType = "com.apple.product-type.application";
+		};
+		03F663C323538BB200D4B92F /* TargetVariableCurlyBracesBuildSettings */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 03F663D623538BB200D4B92F /* Build configuration list for PBXNativeTarget "TargetVariableCurlyBracesBuildSettings" */;
+			buildPhases = (
+				03F663C423538BB200D4B92F /* Sources */,
+				03F663C723538BB200D4B92F /* Frameworks */,
+				03F663C823538BB200D4B92F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TargetVariableCurlyBracesBuildSettings;
+			productName = get_version_number;
+			productReference = 03F663D923538BB200D4B92F /* TargetVariableCurlyBracesBuildSettings.app */;
+			productType = "com.apple.product-type.application";
+		};
 		4AA286E82300242500067244 /* TargetVariableParentheses */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4AA286FB2300242500067244 /* Build configuration list for PBXNativeTarget "TargetVariableParentheses" */;
@@ -617,6 +705,12 @@
 					03CFC56E206409ED00CD6CB1 = {
 						ProvisioningStyle = Automatic;
 					};
+					03F663AB23538BA700D4B92F = {
+						ProvisioningStyle = Automatic;
+					};
+					03F663C323538BB200D4B92F = {
+						ProvisioningStyle = Automatic;
+					};
 					4AA286E82300242500067244 = {
 						ProvisioningStyle = Automatic;
 					};
@@ -652,6 +746,8 @@
 				03B8E43E20729336001D1742 /* AggTarget */,
 				4AA286E82300242500067244 /* TargetVariableParentheses */,
 				A066E5F223253F0F0053B487 /* TargetVariableCurlyBraces */,
+				03F663AB23538BA700D4B92F /* TargetVariableParenthesesBuildSettings */,
+				03F663C323538BB200D4B92F /* TargetVariableCurlyBracesBuildSettings */,
 			);
 		};
 /* End PBXProject section */
@@ -665,7 +761,9 @@
 				03AB834A2056AEC500BAAFD1 /* TargetC_production-Info.plist in Resources */,
 				03AB82EF2056A51B00BAAFD1 /* LaunchScreen.storyboard in Resources */,
 				03AB83052056A5D000BAAFD1 /* TargetA-Info.plist in Resources */,
+				03F663DE23538CFE00D4B92F /* TargetVariableParenthesesBuildSettings-Info.plist in Resources */,
 				03AB82EC2056A51B00BAAFD1 /* Assets.xcassets in Resources */,
+				03F663DD23538CFE00D4B92F /* TargetVariableCurlyBracesBuildSettings-Info.plist in Resources */,
 				03AB839A2056B2CD00BAAFD1 /* Plist-For-D-Target.plist in Resources */,
 				03AB83982056B29B00BAAFD1 /* SampleProject-Info.plist in Resources */,
 				03AB83B02057215F00BAAFD1 /* TargetDifferentConfigurations-Release.plist in Resources */,
@@ -784,6 +882,46 @@
 				03CFC576206409ED00CD6CB1 /* Assets.xcassets in Resources */,
 				03CFC577206409ED00CD6CB1 /* Info.plist in Resources */,
 				03CFC578206409ED00CD6CB1 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		03F663B023538BA700D4B92F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03F663B123538BA700D4B92F /* TargetDifferentConfigurations-Debug.plist in Resources */,
+				03F663B223538BA700D4B92F /* TargetC_production-Info.plist in Resources */,
+				03F663B323538BA700D4B92F /* LaunchScreen.storyboard in Resources */,
+				03F663B423538BA700D4B92F /* TargetA-Info.plist in Resources */,
+				03F663B523538BA700D4B92F /* Assets.xcassets in Resources */,
+				03F663B623538BA700D4B92F /* Plist-For-D-Target.plist in Resources */,
+				03F663B723538BA700D4B92F /* SampleProject-Info.plist in Resources */,
+				03F663B823538BA700D4B92F /* TargetDifferentConfigurations-Release.plist in Resources */,
+				03F663B923538BA700D4B92F /* Info.plist in Resources */,
+				03F663BA23538BA700D4B92F /* TargetB-Info.plist in Resources */,
+				03F663BB23538BA700D4B92F /* TargetC_internal-Info.plist in Resources */,
+				03F663BC23538BA700D4B92F /* Main.storyboard in Resources */,
+				03F663BD23538BA700D4B92F /* Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		03F663C823538BB200D4B92F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03F663C923538BB200D4B92F /* TargetDifferentConfigurations-Debug.plist in Resources */,
+				03F663CA23538BB200D4B92F /* TargetC_production-Info.plist in Resources */,
+				03F663CB23538BB200D4B92F /* LaunchScreen.storyboard in Resources */,
+				03F663CC23538BB200D4B92F /* TargetA-Info.plist in Resources */,
+				03F663CD23538BB200D4B92F /* Assets.xcassets in Resources */,
+				03F663CE23538BB200D4B92F /* Plist-For-D-Target.plist in Resources */,
+				03F663CF23538BB200D4B92F /* SampleProject-Info.plist in Resources */,
+				03F663D023538BB200D4B92F /* TargetDifferentConfigurations-Release.plist in Resources */,
+				03F663D123538BB200D4B92F /* Info.plist in Resources */,
+				03F663D223538BB200D4B92F /* TargetB-Info.plist in Resources */,
+				03F663D323538BB200D4B92F /* TargetC_internal-Info.plist in Resources */,
+				03F663D423538BB200D4B92F /* Main.storyboard in Resources */,
+				03F663D523538BB200D4B92F /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -926,6 +1064,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		03F663AC23538BA700D4B92F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03F663AD23538BA700D4B92F /* ViewController.swift in Sources */,
+				03F663AE23538BA700D4B92F /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		03F663C423538BB200D4B92F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03F663C523538BB200D4B92F /* ViewController.swift in Sources */,
+				03F663C623538BB200D4B92F /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4AA286E92300242500067244 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1015,6 +1171,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 7.6.5;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1033,6 +1190,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				MARKETING_VERSION = 7.6.5;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1072,6 +1230,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 7.6.5;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1084,6 +1243,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				MARKETING_VERSION = 7.6.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1473,6 +1633,66 @@
 			};
 			name = Release;
 		};
+		03F663BF23538BA700D4B92F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "$(SRCROOT)/TargetVariableParenthesesBuildSettings-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		03F663C023538BA700D4B92F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "$(SRCROOT)/TargetVariableParenthesesBuildSettings-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		03F663D723538BB200D4B92F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "$(SRCROOT)/TargetVariableCurlyBracesBuildSettings-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		03F663D823538BB200D4B92F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "$(SRCROOT)/TargetVariableCurlyBracesBuildSettings-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
 		4AA286FC2300242500067244 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1657,6 +1877,24 @@
 			buildConfigurations = (
 				03CFC57A206409ED00CD6CB1 /* Debug */,
 				03CFC57B206409ED00CD6CB1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		03F663BE23538BA700D4B92F /* Build configuration list for PBXNativeTarget "TargetVariableParenthesesBuildSettings" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				03F663BF23538BA700D4B92F /* Debug */,
+				03F663C023538BA700D4B92F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		03F663D623538BB200D4B92F /* Build configuration list for PBXNativeTarget "TargetVariableCurlyBracesBuildSettings" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				03F663D723538BB200D4B92F /* Debug */,
+				03F663D823538BB200D4B92F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/xcshareddata/xcschemes/TargetA.xcscheme
+++ b/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/xcshareddata/xcschemes/TargetA.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03AB82E02056A51B00BAAFD1"
+            BuildableName = "TargetA.app"
+            BlueprintName = "TargetA"
+            ReferencedContainer = "container:get_version_number.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -59,17 +68,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "03AB82E02056A51B00BAAFD1"
-            BuildableName = "TargetA.app"
-            BlueprintName = "TargetA"
-            ReferencedContainer = "container:get_version_number.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -91,8 +89,6 @@
             ReferencedContainer = "container:get_version_number.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
https://github.com/fastlane/fastlane/issues/15322

### Description
`get_version_number_from_build_settings` now returns `nil` if no version number is found instead of throwing an error
the `run` method will throw the error if version_number is not set
it will look into the project settings for `variable` (in this case `MARKETING_VERSION`) if there is no `version_number` set after checking the target

### Testing Steps
`bundle exec fastlane store` resulted with the correct value after these changes