### PR TITLE
[gym] let dsymutil figure out which .bcsymbolmap files to use.

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -146,7 +146,6 @@ module Gym
       containing_directory = File.expand_path("..", PackageCommandGenerator.dsym_path)
       bcsymbolmaps_directory = File.expand_path("../../BCSymbolMaps", PackageCommandGenerator.dsym_path)
       available_dsyms = Dir.glob("#{containing_directory}/*.dSYM")
-      uuid_regex = /[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/
 
       if Dir.exist?(bcsymbolmaps_directory)
         UI.message("Mapping dSYM(s) using generated BCSymbolMaps") unless Gym.config[:silent]

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -163,37 +163,39 @@ module Gym
             uuid = info_array[1]
             dwarf_file_path = info_array[3]
 
-            unless uuid.nil? || !uuid.match(uuid_regex)
-              # Find bcsymbolmap file to be used:
-              #  - if a <uuid>.plist file exists, we will extract uuid of bcsymbolmap and use it
-              #  - if a <uuid>.bcsymbolmap file exists, we will use it
-              #  - otherwise let dsymutil figure it out
-              symbol_map_path = nil
-              split_dwarf_file_path = File.split(dwarf_file_path)
-              dsym_plist_file_path = File.join(split_dwarf_file_path[0], "..", "#{uuid}.plist")
-              if File.exists?(dsym_plist_file_path)
-                dsym_plist = Plist.parse_xml(dsym_plist_file_path)
-                original_uuid = dsym_plist['DBGOriginalUUID']
-                possible_symbol_map_path = "#{bcsymbolmaps_directory}/#{original_uuid}.bcsymbolmap"
-                if File.exists?(possible_symbol_map_path)
-                  symbol_map_path = possible_symbol_map_path.shellescape
-                end
-              end
-              if symbol_map_path.nil?
-                possible_symbol_map_path = File.join(bcsymbolmaps_directory, "#{uuid}.plist")
-                if File.exists?(possible_symbol_map_path)
-                  symbol_map_path = possible_symbol_map_path.shellescape
-                end
-              end
-              if symbol_map_path.nil?
-                symbol_map_path = bcsymbolmaps_directory.shellescape
-              end
-              command = []
-              command << "dsymutil"
-              command << "--symbol-map #{symbol_map_path}"
-              command << dsym.shellescape
-              Helper.backticks(command.join(" "), print: !Gym.config[:silent])
+            if uuid.nil? || !uuid.match(uuid_regex)
+              next
             end
+
+            # Find bcsymbolmap file to be used:
+            #  - if a <uuid>.plist file exists, we will extract uuid of bcsymbolmap and use it
+            #  - if a <uuid>.bcsymbolmap file exists, we will use it
+            #  - otherwise let dsymutil figure it out
+            symbol_map_path = nil
+            split_dwarf_file_path = File.split(dwarf_file_path)
+            dsym_plist_file_path = File.join(split_dwarf_file_path[0], "..", "#{uuid}.plist")
+            if File.exist?(dsym_plist_file_path)
+              dsym_plist = Plist.parse_xml(dsym_plist_file_path)
+              original_uuid = dsym_plist['DBGOriginalUUID']
+              possible_symbol_map_path = "#{bcsymbolmaps_directory}/#{original_uuid}.bcsymbolmap"
+              if File.exist?(possible_symbol_map_path)
+                symbol_map_path = possible_symbol_map_path.shellescape
+              end
+            end
+            if symbol_map_path.nil?
+              possible_symbol_map_path = File.join(bcsymbolmaps_directory, "#{uuid}.plist")
+              if File.exist?(possible_symbol_map_path)
+                symbol_map_path = possible_symbol_map_path.shellescape
+              end
+            end
+            if symbol_map_path.nil?
+              symbol_map_path = bcsymbolmaps_directory.shellescape
+            end
+            command = []
+            command << "dsymutil"
+            command << "--symbol-map #{symbol_map_path}"
+            command << dsym.shellescape
+            Helper.backticks(command.join(" "), print: !Gym.config[:silent])
           end
         end
       end

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -183,7 +183,7 @@ module Gym
               end
             end
             if symbol_map_path.nil?
-              possible_symbol_map_path = File.join(bcsymbolmaps_directory, "#{uuid}.plist")
+              possible_symbol_map_path = File.join(bcsymbolmaps_directory, "#{uuid}.bcsymbolmap")
               if File.exist?(possible_symbol_map_path)
                 symbol_map_path = possible_symbol_map_path.shellescape
               end

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -146,43 +146,15 @@ module Gym
       containing_directory = File.expand_path("..", PackageCommandGenerator.dsym_path)
       bcsymbolmaps_directory = File.expand_path("../../BCSymbolMaps", PackageCommandGenerator.dsym_path)
       available_dsyms = Dir.glob("#{containing_directory}/*.dSYM")
-      uuid_regex = /[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/
 
       if Dir.exist?(bcsymbolmaps_directory)
         UI.message("Mapping dSYM(s) using generated BCSymbolMaps") unless Gym.config[:silent]
         available_dsyms.each do |dsym|
-          dwarfdump_command = []
-          dwarfdump_command << "dwarfdump"
-          dwarfdump_command << "--uuid #{dsym.shellescape}"
-
-          dwarfdump_result = Helper.backticks(dwarfdump_command.join(" "), print: false)
-          architecture_infos = dwarfdump_result.split("\n")
-          architecture_uuids = architecture_infos.map do |info|
-            info_array = info.split(" ")
-            uuid = info_array[1]
-
-            if uuid.nil? || !uuid.match(uuid_regex)
-              nil
-            else
-              uuid
-            end
-          end
-
-          architecture_uuids = architecture_uuids.reject(&:nil?)
-
-          symbol_map_paths = architecture_uuids.map do |uuid|
-            "#{bcsymbolmaps_directory.shellescape}/#{uuid}.bcsymbolmap"
-          end
-
-          symbol_map_paths << bcsymbolmaps_directory.shellescape if symbol_map_paths.empty?
-
-          symbol_map_paths.each do |path|
-            command = []
-            command << "dsymutil"
-            command << "--symbol-map #{path}"
-            command << dsym.shellescape
-            Helper.backticks(command.join(" "), print: !Gym.config[:silent])
-          end
+          command = []
+          command << "dsymutil"
+          command << "--symbol-map #{bcsymbolmaps_directory.shellescape}"
+          command << dsym.shellescape
+          Helper.backticks(command.join(" "), print: !Gym.config[:silent])
         end
       end
 

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -146,15 +146,55 @@ module Gym
       containing_directory = File.expand_path("..", PackageCommandGenerator.dsym_path)
       bcsymbolmaps_directory = File.expand_path("../../BCSymbolMaps", PackageCommandGenerator.dsym_path)
       available_dsyms = Dir.glob("#{containing_directory}/*.dSYM")
+      uuid_regex = /[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/
 
       if Dir.exist?(bcsymbolmaps_directory)
         UI.message("Mapping dSYM(s) using generated BCSymbolMaps") unless Gym.config[:silent]
         available_dsyms.each do |dsym|
-          command = []
-          command << "dsymutil"
-          command << "--symbol-map #{bcsymbolmaps_directory.shellescape}"
-          command << dsym.shellescape
-          Helper.backticks(command.join(" "), print: !Gym.config[:silent])
+          dwarfdump_command = []
+          dwarfdump_command << "dwarfdump"
+          dwarfdump_command << "--uuid #{dsym.shellescape}"
+
+          # Extract uuids
+          dwarfdump_result = Helper.backticks(dwarfdump_command.join(" "), print: false)
+          architecture_infos = dwarfdump_result.split("\n")
+          architecture_infos.each do |info|
+            info_array = info.split(" ", 4)
+            uuid = info_array[1]
+            dwarf_file_path = info_array[3]
+
+            unless uuid.nil? || !uuid.match(uuid_regex)
+              # Find bcsymbolmap file to be used:
+              #  - if a <uuid>.plist file exists, we will extract uuid of bcsymbolmap and use it
+              #  - if a <uuid>.bcsymbolmap file exists, we will use it
+              #  - otherwise let dsymutil figure it out
+              symbol_map_path = nil
+              split_dwarf_file_path = File.split(dwarf_file_path)
+              dsym_plist_file_path = File.join(split_dwarf_file_path[0], "..", "#{uuid}.plist")
+              if File.exists?(dsym_plist_file_path)
+                dsym_plist = Plist.parse_xml(dsym_plist_file_path)
+                original_uuid = dsym_plist['DBGOriginalUUID']
+                possible_symbol_map_path = "#{bcsymbolmaps_directory}/#{original_uuid}.bcsymbolmap"
+                if File.exists?(possible_symbol_map_path)
+                  symbol_map_path = possible_symbol_map_path.shellescape
+                end
+              end
+              if symbol_map_path.nil?
+                possible_symbol_map_path = File.join(bcsymbolmaps_directory, "#{uuid}.plist")
+                if File.exists?(possible_symbol_map_path)
+                  symbol_map_path = possible_symbol_map_path.shellescape
+                end
+              end
+              if symbol_map_path.nil?
+                symbol_map_path = bcsymbolmaps_directory.shellescape
+              end
+              command = []
+              command << "dsymutil"
+              command << "--symbol-map #{symbol_map_path}"
+              command << dsym.shellescape
+              Helper.backticks(command.join(" "), print: !Gym.config[:silent])
+            end
+          end
         end
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Sometimes we end up with partly symbolicated crash reports after using the dSYM.zip file generated by fastlane. It turns out that fastlane sometimes fails to combine DWARF files and .bcsymbolmap files.

### Description
Alongside a DWARF file, there may be an associated .plist file containing the key `DBGOriginalUUID` with an UUID as the value. This UUID points to the .bcsymbolmap file to be used for converting _hidden symbols.

The `dsymutil` utility used to combine a DWARF and a.bcsymbolmap allows a directory containing .bcsymbolmap files to be specified, instead of specifying a single .bcsymbolmap file. This lets `dsymutil` figure out which .bcsymbolmap file to use, simplifying the fastlane code.