### PR TITLE
[fastlane] attempt to require lib in Fastfile before warning

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -26,10 +26,15 @@ module Fastlane
                 'you should turn off smart quotes in your editor of choice.')
       end
 
-      content.scan(/^\s*require (.*)/).each do |current|
+      content.scan(/^\s*require ["'](.*?)["']/).each do |current|
         gem_name = current.last
         next if gem_name.include?(".") # these are local gems
-        UI.important("You have required a gem, if this is a third party gem, please use `fastlane_require #{gem_name}` to ensure the gem is installed locally.")
+
+        begin
+          require(gem_name)
+        rescue LoadError
+          UI.important("You have required a gem, if this is a third party gem, please use `fastlane_require '#{gem_name}'` to ensure the gem is installed locally.")
+        end
       end
 
       parse(content, @path)

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -12,6 +12,18 @@ describe Fastlane do
           Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileInvalid')
         end.to raise_exception("Could not find action, lane or variable 'laneasdf'. Check out the documentation for more details: https://docs.fastlane.tools/actions")
       end
+
+      it "prints a warning if an uninstalled library is required" do
+        expect_any_instance_of(Fastlane::FastFile).to receive(:parse)
+        expect(UI).to receive(:important).with("You have required a gem, if this is a third party gem, please use `fastlane_require 'some_remote_gem'` to ensure the gem is installed locally.")
+        Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileRequireUninstalledGem')
+      end
+
+      it "does not print a warning if required library is installed" do
+        expect_any_instance_of(Fastlane::FastFile).to receive(:parse)
+        expect(UI).not_to(receive(:important))
+        Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileRequireInstalledGem')
+      end
     end
 
     describe "#sh" do

--- a/fastlane/spec/fixtures/fastfiles/FastfileRequireInstalledGem
+++ b/fastlane/spec/fixtures/fastfiles/FastfileRequireInstalledGem
@@ -1,0 +1,1 @@
+require "base64" # reliably present on all Ruby installs

--- a/fastlane/spec/fixtures/fastfiles/FastfileRequireUninstalledGem
+++ b/fastlane/spec/fixtures/fastfiles/FastfileRequireUninstalledGem
@@ -1,0 +1,1 @@
+require "some_remote_gem"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context

See #15211 for issue details

### Description

Prior to warning the user about a missing gem (with installation guide), attempt to require the library. This avoids issues where the library being required is not actually a gem but a local Ruby file or gem provided by Ruby's stdlib.

Tested with RSpec with new tests & fixtures added.

### Testing Steps

1. `bundle exec rspec`

You can also test manually by using something like `require 'base64'` inside of a Fastfile and expecting no warning. You should still see a warning with any gem that is not installed on your system (i.e. anything that will lead to a LoadError).