### PR TITLE
Run `fastlane-env-reminder` only for opened issues

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,5 +1,7 @@
 name: Processing issues
-on: issues
+on: 
+  issues:
+    types: [opened]
 
 jobs:   
   fastlane-env:


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

`fastlane-env-reminder` GitHub Action is executed too often - for any event related to the issues: https://help.github.com/en/articles/events-that-trigger-workflows#issues-event-issues. 

This PR is about triggering it **only** for `issues: opened` events. 

<!-- If it fixes an open issue, please link to the issue here. -->

closes https://github.com/fastlane/github-actions/issues/9. 
