### PR TITLE
[frameit] Added device names for new iPad sizes

### DIFF
--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -45,6 +45,10 @@ module Frameit
         return 'iPhone 4'
       when sizes::IOS_IPAD
         return 'iPad Air 2'
+      when sizes::IOS_IPAD_10_5
+        return 'iPad Pro (10.5-inch)'
+      when sizes::IOS_IPAD_11
+        return 'iPad Pro (11-inch)'
       when sizes::IOS_IPAD_PRO
         return 'iPad Pro'
       when sizes::IOS_IPAD_PRO_12_9


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

By having the correct device names set fastlane/frameit can match device frames to screenshots. These were not set for the 10.5 inch iPad Pro and the 11 inch iPad Pro.

Now when having custom device frames for these devices (official ones are not available yet) frameit will match them correctly. This has been discussed in #14713: [here](https://github.com/fastlane/fastlane/issues/14713#issuecomment-535044785) and lays the groundwork for me closing that issue not just for the there named 12.9 inch iPad Pro, but also for the 10.5 inch one and the 11 inch one.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

The switch case statement has been amended by these two devices.
