### PR TITLE
Remove old DAV workaround; remove defaulting to Signiant for iTMS transporter

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -147,17 +147,6 @@ module FastlaneCore
         end
       end
     end
-
-    def additional_upload_parameters
-      # Workaround because the traditional transporter broke on 1st March 2018
-      # More information https://github.com/fastlane/fastlane/issues/11958
-      # As there was no communication from Apple, we don't know if this is a temporary
-      # server outage, or something they changed without giving a heads-up
-      if ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"].to_s.length == 0
-        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV"
-      end
-      return ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"]
-    end
   end
 
   # Generates commands and executes the iTMSTransporter through the shell script it provides by the same name
@@ -169,8 +158,7 @@ module FastlaneCore
         "-u #{username.shellescape}",
         "-p #{shell_escaped_password(password)}",
         "-f \"#{source}\"",
-        additional_upload_parameters, # that's here, because the user might overwrite the -t option
-        "-t Signiant",
+        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         "-k 100000",
         ("-WONoPause true" if Helper.windows?), # Windows only: process instantly returns instead of waiting for key press
         ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?)
@@ -254,8 +242,7 @@ module FastlaneCore
         "-u #{username.shellescape}",
         "-p #{password.shellescape}",
         "-f #{source.shellescape}",
-        additional_upload_parameters, # that's here, because the user might overwrite the -t option
-        '-t Signiant',
+        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"], # that's here, because the user might overwrite the -t option
         '-k 100000',
         ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?),
         '2>&1' # cause stderr to be written to stdout

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -20,8 +20,6 @@ describe FastlaneCore do
         "-u #{email.shellescape}",
         "-p #{escaped_password}",
         "-f \"/tmp/my.app.id.itmsp\"",
-        "-t DAV",
-        "-t Signiant",
         "-k 100000",
         ("-WONoPause true" if FastlaneCore::Helper.windows?),
         ("-itc_provider #{provider_short_name}" if provider_short_name)
@@ -72,8 +70,6 @@ describe FastlaneCore do
         "-u #{email.shellescape}",
         "-p #{password.shellescape}",
         "-f /tmp/my.app.id.itmsp",
-        "-t DAV",
-        "-t Signiant",
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
@@ -136,8 +132,6 @@ describe FastlaneCore do
         "-u #{email.shellescape}",
         "-p #{password.shellescape}",
         "-f /tmp/my.app.id.itmsp",
-        "-t DAV",
-        "-t Signiant",
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Per Apple's latest Transporter documentation, we should not be passing a specific transporter, and allowing it to automatically determine what to use.
https://help.apple.com/itc/transporteruserguide/#/apdATD1E1288-D1E1A1303-D1E1288A1126
> Apple recommends you don’t specify the -t transport and instead allow Transporter to use automatic transport discovery to determine the best transport mode for your packages. If you need to specify -t transport, you should revert back to automatic transport discovery soon as possible. If the specified transport can’t be used due to errors or server unavailability, Transporter chooses another transport based on the transport preference order. Transporter chooses additional transports until all available transport options are exhausted, at which point the delivery fails. You can specify the delivery methods in the order you want, separated by commas (,). For example, -t Aspera,DAV,Signiant. If you specify only one transport option (-t Aspera), Transporter uses that option and if it fails the delivery fails with no fall back options.

This also solves https://github.com/fastlane/fastlane/issues/15375

### Description
Removing the old workaround from https://github.com/fastlane/fastlane/issues/11958 that doesn't seem to be needed any longer, and removed the fallback/default of using Signiant.

Removing these entirely should avoid breaking existing deployments where `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` environment variable is used to override the transporter.

### Testing Steps
Attempt to upload an IPA to TestFlight via `pilot`