### PR TITLE
Resolve multiple -t parameters overriding each other for iTMSTransporter

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -154,7 +154,7 @@ module FastlaneCore
       # As there was no communication from Apple, we don't know if this is a temporary
       # server outage, or something they changed without giving a heads-up
       if ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"].to_s.length == 0
-        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV"
+        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV,Signiant"
       end
       return ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"]
     end
@@ -170,7 +170,6 @@ module FastlaneCore
         "-p #{shell_escaped_password(password)}",
         "-f \"#{source}\"",
         additional_upload_parameters, # that's here, because the user might overwrite the -t option
-        "-t Signiant",
         "-k 100000",
         ("-WONoPause true" if Helper.windows?), # Windows only: process instantly returns instead of waiting for key press
         ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?)
@@ -255,7 +254,6 @@ module FastlaneCore
         "-p #{password.shellescape}",
         "-f #{source.shellescape}",
         additional_upload_parameters, # that's here, because the user might overwrite the -t option
-        '-t Signiant',
         '-k 100000',
         ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?),
         '2>&1' # cause stderr to be written to stdout

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -20,8 +20,7 @@ describe FastlaneCore do
         "-u #{email.shellescape}",
         "-p #{escaped_password}",
         "-f \"/tmp/my.app.id.itmsp\"",
-        "-t DAV",
-        "-t Signiant",
+        "-t DAV,Signiant",
         "-k 100000",
         ("-WONoPause true" if FastlaneCore::Helper.windows?),
         ("-itc_provider #{provider_short_name}" if provider_short_name)
@@ -72,8 +71,7 @@ describe FastlaneCore do
         "-u #{email.shellescape}",
         "-p #{password.shellescape}",
         "-f /tmp/my.app.id.itmsp",
-        "-t DAV",
-        "-t Signiant",
+        "-t DAV,Signiant",
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
@@ -136,8 +134,7 @@ describe FastlaneCore do
         "-u #{email.shellescape}",
         "-p #{password.shellescape}",
         "-f /tmp/my.app.id.itmsp",
-        "-t DAV",
-        "-t Signiant",
+        "-t DAV,Signiant",
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When using pilot and setting the DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS environment variable to -t DAV, the iTMSTransporter command is still attempting to use Signiant UDP upload and not attempting DAV at all.

It appears that the latest iTMSTransporter released recently doesn't allow multiple `-t` parameters, and only uses the last provided value to choose the transporter.

This fixes issue https://github.com/fastlane/fastlane/issues/15375

### Description
Instead of having `-t Signiant` hardcoded in, this updates the `additional_upload_parameters` method to use a comma-delimited list by default, thus avoiding override.

### Testing Steps
Ensure you do not have `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` env var set and run pilot verbosely - observe the parameters passed to iTMSTransporter.
