### PR TITLE
[match] Fix for git_basic_authorization option

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -118,7 +118,7 @@ module Match
         FastlaneCore::ConfigItem.new(key: :git_basic_authorization,
                                      env_name: "MATCH_GIT_BASIC_AUTHORIZATION",
                                      sensitive: true,
-                                     description: "Use a basic authorization header to access the git repo (e.g.: access via HTTPS, GitHub Actions, etc)",
+                                     description: "Use a basic authorization header to access the git repo (e.g.: access via HTTPS, GitHub Actions, etc), usually a string in Base64",
                                      optional: true,
                                      default_value: nil),
 

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -69,7 +69,7 @@ module Match
         self.working_directory = Dir.mktmpdir
 
         command = "git clone #{self.git_url.shellescape} #{self.working_directory.shellescape}"
-        command << " -c http.extraheader='AUTHORIZATION: basic #{self.git_basic_authorization.shellescape}'" unless self.git_basic_authorization.nil?
+        command << " -c http.extraheader='AUTHORIZATION: basic #{self.git_basic_authorization}'" unless self.git_basic_authorization.nil?
 
         if self.shallow_clone
           command << " --depth 1 --no-single-branch"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
PR #15324 added the option to set basic authorization to `match`. After some discussion on the PR itself, a bug was found.
This bug was fixed and I also added a hint to use this option.
