### PR TITLE
Replace map.flatten with flat_map

### DIFF
--- a/fastlane/lib/fastlane/actions/copy_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/copy_artifacts.rb
@@ -16,7 +16,7 @@ module Fastlane
         # If any of the paths include "*", we assume that we are referring to the Unix entries
         # e.g /tmp/fastlane/* refers to all the files in /tmp/fastlane
         # We use Dir.glob to expand all those paths, this would create an array of arrays though, so flatten
-        artifacts = artifacts_to_search.map { |f| f.include?("*") ? Dir.glob(f) : f }.flatten
+        artifacts = artifacts_to_search.flat_map { |f| f.include?("*") ? Dir.glob(f) : f }
 
         UI.verbose("Copying artifacts #{artifacts.join(', ')} to #{target_path}")
         UI.verbose(params[:keep_original] ? "Keeping original files" : "Not keeping original files")

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -45,7 +45,7 @@ module Fastlane
         end
         supported_platforms = all_platforms.select { |platform| self.is_supported?(platform.to_sym) }
 
-        existing_devices = supported_platforms.map { |platform| Spaceship::Device.all(mac: platform == "mac") }.flatten
+        existing_devices = supported_platforms.flat_map { |platform| Spaceship::Device.all(mac: platform == "mac") }
 
         device_objs = new_devices.map do |device|
           next if existing_devices.map(&:udid).include?(device[0])

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
@@ -190,7 +190,7 @@ module Snapshot
           hash[name] = ["No tests were executed"]
         else
           tests = Array(summary.data.first[:tests])
-          hash[name] = tests.map { |test| Array(test[:failures]).map { |failure| failure[:failure_message] } }.flatten
+          hash[name] = tests.flat_map { |test| Array(test[:failures]).map { |failure| failure[:failure_message] } }
         end
       end
     end

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -32,7 +32,7 @@ module Spaceship
 
       def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
         resps = Spaceship::ConnectAPI.get_apps(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
 
       def self.find(bundle_id)
@@ -54,7 +54,7 @@ module Spaceship
         filter[:apps] = id
 
         resps = Spaceship::ConnectAPI.get_beta_testers(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
 
       #
@@ -66,7 +66,7 @@ module Spaceship
         filter[:app] = id
 
         resps = Spaceship::ConnectAPI.get_builds(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
 
       def get_build_deliveries(filter: {}, includes: nil, limit: nil, sort: nil)
@@ -74,7 +74,7 @@ module Spaceship
         filter[:app] = id
 
         resps = Spaceship::ConnectAPI.get_build_deliveries(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
 
       def get_beta_app_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
@@ -82,7 +82,7 @@ module Spaceship
         filter[:app] = id
 
         resps = Spaceship::ConnectAPI.get_beta_app_localizations(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
 
       def get_beta_groups(filter: {}, includes: nil, limit: nil, sort: nil)
@@ -90,7 +90,7 @@ module Spaceship
         filter[:app] = id
 
         resps = Spaceship::ConnectAPI.get_beta_groups(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -109,7 +109,7 @@ module Spaceship
           sort: sort,
           limit: limit
         ).all_pages
-        models = resps.map(&:to_models).flatten
+        models = resps.flat_map(&:to_models)
 
         # Filtering after models are fetched since there is no way to do this in a query param filter
         if platform
@@ -138,7 +138,7 @@ module Spaceship
           sort: sort,
           limit: limit
         ).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
 
       def get_build_beta_details(filter: {}, includes: nil, limit: nil, sort: nil)
@@ -148,7 +148,7 @@ module Spaceship
           sort: sort,
           limit: limit
         ).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
 
       def post_beta_app_review_submission

--- a/spaceship/lib/spaceship/connect_api/models/build_delivery.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build_delivery.rb
@@ -29,7 +29,7 @@ module Spaceship
           filter: { app: app_id, cfBundleShortVersionString: version, cfBundleVersion: build_number },
           limit: 1
         ).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -35,7 +35,7 @@ module Spaceship
 
       def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
         resps = Spaceship::ConnectAPI.get_bundle_ids(filter: filter, includes: includes).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
 
       def self.get(bundle_id_id: nil, includes: nil)

--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -41,7 +41,7 @@ module Spaceship
 
       def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
         resps = Spaceship::ConnectAPI.get_certificates(filter: filter, includes: includes).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -46,7 +46,7 @@ module Spaceship
 
       def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
         resps = Spaceship::ConnectAPI.get_devices(filter: filter, includes: includes).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -53,7 +53,7 @@ module Spaceship
 
       def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
         resps = Spaceship::ConnectAPI.get_profiles(filter: filter, includes: includes).all_pages
-        return resps.map(&:to_models).flatten
+        return resps.flat_map(&:to_models)
       end
     end
   end

--- a/spaceship/spec/tunes/iap_subscription_pricing_tier_spec.rb
+++ b/spaceship/spec/tunes/iap_subscription_pricing_tier_spec.rb
@@ -20,7 +20,7 @@ describe Spaceship::Tunes::IAPSubscriptionPricingTier do
     end
 
     describe "Subscription Pricing Tier Info" do
-      subject { pricing_tiers.map(&:pricing_info).flatten }
+      subject { pricing_tiers.flat_map(&:pricing_info) }
 
       it "correctly creates all 155 pricing infos for each country" do
         expect(subject).to all(be_an(Spaceship::Tunes::IAPSubscriptionPricingInfo))


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`flat_map` is 1.6 faster than `map.flatten`

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This PR replaces `map.flatten` with `flat_map` which in turn makes our code faster.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
