### PR TITLE
Revert "pin faraday to < 0.16.0 (#15399)"

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -77,7 +77,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('excon', '>= 0.45.0', '< 1.0.0') # Great HTTP Client
   spec.add_dependency('faraday-cookie_jar', '~> 0.0.6')
   spec.add_dependency('faraday', '~> 0.17') # Used for deploygate, hockey and testfairy actions
-  spec.add_dependency('faraday_middleware', '~> 0.15.4') # same as faraday
+  spec.add_dependency('faraday_middleware', '~> 0.13.1') # same as faraday
   spec.add_dependency('fastimage', '>= 2.1.0', '< 3.0.0') # fetch the image sizes from the screenshots
   spec.add_dependency('gh_inspector', '>= 1.1.2', '< 2.0.0') # search for issues on GitHub when something goes wrong
   spec.add_dependency('highline', '>= 1.7.2', '< 2.0.0') # user inputs (e.g. passwords)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -75,8 +75,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('colored') # colored terminal output
   spec.add_dependency('commander-fastlane', '>= 4.4.6', '< 5.0.0') # CLI parser
   spec.add_dependency('excon', '>= 0.45.0', '< 1.0.0') # Great HTTP Client
-  spec.add_dependency('faraday', '< 0.16.0') # Used for deploygate, hockey and testfairy actions
-  spec.add_dependency('faraday_middleware', '< 0.16.0') # same as faraday
   spec.add_dependency('faraday-cookie_jar', '~> 0.0.6')
   spec.add_dependency('fastimage', '>= 2.1.0', '< 3.0.0') # fetch the image sizes from the screenshots
   spec.add_dependency('gh_inspector', '>= 1.1.2', '< 2.0.0') # search for issues on GitHub when something goes wrong
@@ -89,6 +87,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3')
   spec.add_dependency('dotenv', '>= 2.1.1', '< 3.0.0')
   spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
+  spec.add_dependency('faraday', '~> 0.9') # Used for deploygate, hockey and testfairy actions
+  spec.add_dependency('faraday_middleware', '~> 0.9') # same as faraday
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -76,6 +76,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency('commander-fastlane', '>= 4.4.6', '< 5.0.0') # CLI parser
   spec.add_dependency('excon', '>= 0.45.0', '< 1.0.0') # Great HTTP Client
   spec.add_dependency('faraday-cookie_jar', '~> 0.0.6')
+  spec.add_dependency('faraday', '~> 0.17') # Used for deploygate, hockey and testfairy actions
+  spec.add_dependency('faraday_middleware', '~> 0.17') # same as faraday
   spec.add_dependency('fastimage', '>= 2.1.0', '< 3.0.0') # fetch the image sizes from the screenshots
   spec.add_dependency('gh_inspector', '>= 1.1.2', '< 2.0.0') # search for issues on GitHub when something goes wrong
   spec.add_dependency('highline', '>= 1.7.2', '< 2.0.0') # user inputs (e.g. passwords)
@@ -87,8 +89,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3')
   spec.add_dependency('dotenv', '>= 2.1.1', '< 3.0.0')
   spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
-  spec.add_dependency('faraday', '~> 0.9') # Used for deploygate, hockey and testfairy actions
-  spec.add_dependency('faraday_middleware', '~> 0.9') # same as faraday
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -77,7 +77,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('excon', '>= 0.45.0', '< 1.0.0') # Great HTTP Client
   spec.add_dependency('faraday-cookie_jar', '~> 0.0.6')
   spec.add_dependency('faraday', '~> 0.17') # Used for deploygate, hockey and testfairy actions
-  spec.add_dependency('faraday_middleware', '~> 0.17') # same as faraday
+  spec.add_dependency('faraday_middleware', '~> 0.15.4') # same as faraday
   spec.add_dependency('fastimage', '>= 2.1.0', '< 3.0.0') # fetch the image sizes from the screenshots
   spec.add_dependency('gh_inspector', '>= 1.1.2', '< 2.0.0') # search for issues on GitHub when something goes wrong
   spec.add_dependency('highline', '>= 1.7.2', '< 2.0.0') # user inputs (e.g. passwords)


### PR DESCRIPTION
This reverts commit 596a388da317f847100587668002ce80f25f1ed0.

Now that `faraday` released a new version that undoes the problems, we can go back to using their newest version.