### PR TITLE
[action] remove nightly from update_fastlane

### DIFF
--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -66,6 +66,7 @@ describe Fastlane do
           create_app_on_managed_play_store
           download_from_play_store
           validate_play_store_json_key
+          update_fastlane
         )
       end
 


### PR DESCRIPTION
### Motivation and Context
Remove nightly builds because the bot that uploaded them was not able to have 2FA enabled which made the bot susceptible for take over 😱

### Description
- Deprecated option for `nightly`
- Also removed deprecated `tools` action as super no longer relevant