### PR TITLE
[ci] stop google api client errors about outdated ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
       - image: circleci/ruby:2.3
     steps:
       - checkout
-      
+
       - restore_cache:
           key: v1-ubuntu-gems-{{ checksum "Gemfile" }}
       - run:
@@ -187,7 +187,7 @@ jobs:
 
   "Lint Source Code":
     docker:
-      - image: circleci/ruby:2.3
+      - image: circleci/ruby:2.5
     steps:
       - checkout
 


### PR DESCRIPTION
🔑
Fixes warning in the linter output in CI:
WARNING: You are running Ruby 2.3.8, which is nearing end-of-life.
The Google Cloud API clients work best on supported versions of Ruby.
Consider upgrading to Ruby 2.4 or later.
See https://www.ruby-lang.org/en/downloads/branches/ for more info on
the Ruby maintenance schedule. To suppress this message, set the
GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable.
