### PR TITLE
[fastlane] specifiable step name for sh action

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -195,6 +195,7 @@ module Fastlane
     #  sh("ls")
     #  sh("ls", log: false)
     #  sh(command: "ls")
+    #  sh(command: "ls", step_name: "listing the files")
     #  sh(command: "ls", log: false)
     def sh(*args, &b)
       # First accepts hash (or named keywords) like other actions
@@ -212,8 +213,8 @@ module Fastlane
       end
     end
 
-    def self.sh(*command, log: true, error_callback: nil, &b)
-      command_header = log ? Actions.shell_command_from_args(*command) : "shell command"
+    def self.sh(*command, step_name: nil, log: true, error_callback: nil, &b)
+      command_header = log ? step_name || Actions.shell_command_from_args(*command) : "shell command"
       Actions.execute_action(command_header) do
         Actions.sh_no_action(*command, log: log, error_callback: error_callback, &b)
       end

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -33,24 +33,56 @@ describe Fastlane do
 
       context "with command argument" do
         it "passes command as string with default log and error_callback" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("git commit").and_call_original
+
           expect(Fastlane::Actions).to receive(:sh_no_action)
             .with("git commit", log: true, error_callback: nil)
           @ff.sh("git commit")
         end
 
         it "passes command as string and log with default error_callback" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("git commit").and_call_original
+
+          expect(Fastlane::Actions).to receive(:sh_no_action)
+            .with("git commit", log: true, error_callback: nil)
+          @ff.sh("git commit", log: true)
+        end
+
+        it "passes command as string, step_name, and log false with default error_callback" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("shell command").and_call_original
+
           expect(Fastlane::Actions).to receive(:sh_no_action)
             .with("git commit", log: false, error_callback: nil)
-          @ff.sh("git commit", log: false)
+          @ff.sh("git commit", step_name: "some_name", log: false)
+        end
+
+        it "passes command as string, step_name, and log true with default error_callback" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("some_name").and_call_original
+
+          expect(Fastlane::Actions).to receive(:sh_no_action)
+            .with("git commit", log: true, error_callback: nil)
+          @ff.sh("git commit", step_name: "some_name", log: true)
         end
 
         it "passes command as array with default log and error_callback" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("git commit").and_call_original
+
+          expect(Fastlane::Actions).to receive(:sh_no_action)
+            .with("git", "commit", log: true, error_callback: nil)
+          @ff.sh("git", "commit")
+        end
+
+        it "passes command as array with default log and error_callback" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("git commit").and_call_original
+
           expect(Fastlane::Actions).to receive(:sh_no_action)
             .with("git", "commit", log: true, error_callback: nil)
           @ff.sh("git", "commit")
         end
 
         it "yields the status, result and command" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("git commit").and_call_original
+
           proc = proc {}
           expect(Fastlane::Actions).to receive(:sh_no_action)
             .with("git", "commit", log: true, error_callback: nil) do |*args, &block|
@@ -62,24 +94,32 @@ describe Fastlane do
 
       context "with named command keyword" do
         it "passes command as string with default log and error_callback" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("git commit").and_call_original
+
           expect(Fastlane::Actions).to receive(:sh_no_action)
             .with("git commit", log: true, error_callback: nil)
           @ff.sh(command: "git commit")
         end
 
         it "passes command as string and log with default error_callback" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("shell command").and_call_original
+
           expect(Fastlane::Actions).to receive(:sh_no_action)
             .with("git commit", log: false, error_callback: nil)
           @ff.sh(command: "git commit", log: false)
         end
 
         it "passes command as array with default log and error_callback" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("git commit").and_call_original
+
           expect(Fastlane::Actions).to receive(:sh_no_action)
             .with("git", "commit", log: true, error_callback: nil)
           @ff.sh(command: ["git", "commit"])
         end
 
         it "yields the status, result and command" do
+          expect(Fastlane::Actions).to receive(:execute_action).with("git commit").and_call_original
+
           proc = proc {}
           expect(Fastlane::Actions).to receive(:sh_no_action)
             .with("git", "commit", log: true, error_callback: nil) do |*args, &block|


### PR DESCRIPTION
Complete the `:step_name` feature introduced in #14423 so that `sh` stp also suppoert it

cf  (pointed out in https://github.com/fastlane/docs/pull/811)


### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. (pointed out in https://github.com/fastlane/docs/pull/811)

### Motivation and Context
Oversight of previous feature added feature pointed out by @alessioarsuffi

A test might be added, but I was unsure where it should be.

