### PR TITLE
[action] Add a configurable timeout to download_dsyms action

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -26,6 +26,7 @@ module Fastlane
         platform = params[:platform]
         output_directory = params[:output_directory]
         wait_for_dsym_processing = params[:wait_for_dsym_processing]
+        wait_timeout = params[:wait_timeout]
         min_version = Gem::Version.new(params[:min_version]) if params[:min_version]
 
         # Set version if it is latest
@@ -110,7 +111,7 @@ module Fastlane
               end
 
               unless download_url
-                if !wait_for_dsym_processing || (Time.now - start) > (60 * 5)
+                if !wait_for_dsym_processing || (Time.now - start) > wait_timeout
                   # In some cases, AppStoreConnect does not process the dSYMs, thus no error should be thrown.
                   UI.message("Could not find any dSYM for #{build.build_version} (#{train.version_string})")
                 else
@@ -263,7 +264,14 @@ module Fastlane
                                        description: "Wait for dSYMs to process",
                                        optional: true,
                                        default_value: false,
-                                       type: Boolean)
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :wait_timeout,
+                                       short_option: "-t",
+                                       env_name: "DOWNLOAD_DSYMS_WAIT_TIMEOUT",
+                                       description: "Number of seconds to wait for dSYMs to process",
+                                       optional: true,
+                                       default_value: 300,
+                                       type: Integer)
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adds the enhancement requested in this issue: https://github.com/fastlane/fastlane/issues/15385 (closes #15385)
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
Changes the fixed timeout of 5 minutes to a parameter that is used when wait_for_dsym_processing is enabled.

Tested by uploading a build to App Store Connect, then running the action with timeout set to 60 seconds and observing it timing out as the dSYMs were not available. Running again without setting a timeout resulted in it timing out after 5 minutes. A final run with timeout set to 900 seconds succeeded after 8 minutes.
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
