### PR TITLE
[action] Add organization to sonar action parameters

### DIFF
--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -20,10 +20,12 @@ module Fastlane
         sonar_scanner_args << "-Dsonar.sourceEncoding=\"#{params[:source_encoding]}\"" if params[:source_encoding]
         sonar_scanner_args << "-Dsonar.login=\"#{params[:sonar_login]}\"" if params[:sonar_login]
         sonar_scanner_args << "-Dsonar.host.url=\"#{params[:sonar_url]}\"" if params[:sonar_url]
+        sonar_scanner_args << "-Dsonar.organization=\"#{params[:sonar_organization]}\"" if params[:sonar_organization]
         sonar_scanner_args << "-Dsonar.branch.name=\"#{params[:branch_name]}\"" if params[:branch_name]
         sonar_scanner_args << "-Dsonar.pullrequest.branch=\"#{params[:pull_request_branch]}\"" if params[:pull_request_branch]
         sonar_scanner_args << "-Dsonar.pullrequest.base=\"#{params[:pull_request_base]}\"" if params[:pull_request_base]
         sonar_scanner_args << "-Dsonar.pullrequest.key=\"#{params[:pull_request_key]}\"" if params[:pull_request_key]
+
         sonar_scanner_args << params[:sonar_runner_args] if params[:sonar_runner_args]
 
         command = [
@@ -102,6 +104,11 @@ module Fastlane
                                        description: "Pass the url of the Sonar server",
                                        optional: true,
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :sonar_organization,
+                                       env_name: "FL_SONAR_ORGANIZATION",
+                                       description: "Key of the organization on SonarCloud",
+                                       optional: true,
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :branch_name,
                                        env_name: "FL_SONAR_RUNNER_BRANCH_NAME",
                                        description: "Pass the branch name which is getting scanned",
@@ -144,6 +151,15 @@ module Fastlane
             project_version: "1.0",
             project_name: "iOS - AwesomeApp",
             sources_path: File.expand_path("../AwesomeApp")
+          )',
+          'sonar(
+            project_key: "name.gretzki.awesomeApp",
+            project_version: "1.0",
+            project_name: "iOS - AwesomeApp",
+            sources_path: File.expand_path("../AwesomeApp"),
+            sonar_organization: "myOrg",
+            sonar_login: "123456abcdef",
+            sonar_url: "https://sonarcloud.io"
           )'
         ]
       end

--- a/fastlane/spec/actions_specs/sonar_spec.rb
+++ b/fastlane/spec/actions_specs/sonar_spec.rb
@@ -39,6 +39,7 @@ describe Fastlane do
             source_encoding: 'utf-8',
             sonar_login: 'sonar-login',
             sonar_url: 'http://www.sonarqube.com',
+            sonar_organization: 'org-key',
             branch_name: 'branch-name',
             pull_request_branch: 'pull-request-branch-name',
             pull_request_base: 'pull-request-base',
@@ -56,6 +57,7 @@ describe Fastlane do
                     -Dsonar.sourceEncoding=\"utf-8\"
                     -Dsonar.login=\"sonar-login\"
                     -Dsonar.host.url=\"http://www.sonarqube.com\"
+                    -Dsonar.organization=\"org-key\"
                     -Dsonar.branch.name=\"branch-name\"
                     -Dsonar.pullrequest.branch=\"pull-request-branch-name\"
                     -Dsonar.pullrequest.base=\"pull-request-base\"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Removes the need to pass in organization through the `sonar_runner_args` parameter to clean up fastfile a little bit. Also adds an example to the documentation to show that this action works with SonarCloud (hosted SonarQube).

### Description
Add organization parameter to the sonar action.
Tested with rspec, and by running my fastfile that previously needed `-Dsonar.organization=myorg` in the `sonar_runner_args` parameter.
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

