### PR TITLE
Fastlane env no longer fails if you don't have git installed

### DIFF
--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -295,11 +295,9 @@ module Fastlane
     end
 
     def self.git_version
-      begin
-        return `git --version`.strip.split("\n").first
-      rescue => ex
-        return "not found"
-      end
+      return `git --version`.strip.split("\n").first
+    rescue
+      return "not found"
     end
   end
 end

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -211,7 +211,7 @@ module Fastlane
         "OS" => os_version,
         "Ruby" => RUBY_VERSION,
         "Bundler?" => Helper.bundler?,
-        "Git" => `git --version`.strip.split("\n").first,
+        "Git" => git_version,
         "Installation Source" => anonymized_path($PROGRAM_NAME),
         "Host" => "#{product} #{version} (#{build})",
         "Ruby Lib Dir" => anonymized_path(RbConfig::CONFIG['libdir']),
@@ -292,6 +292,14 @@ module Fastlane
     def self.copy_to_clipboard(string)
       require 'open3'
       Open3.popen3('pbcopy') { |input, _, _| input << string }
+    end
+
+    def self.git_version
+      begin
+        return `git --version`.strip.split("\n").first
+      rescue => ex
+        return "not found"
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes issue https://github.com/fastlane/fastlane/issues/15414

### Description
Wrapped the call to `git version` in a rescue block so it displays "not found" instead of an unhandled exception. 

Tested locally by renaming the git binary in /usr/local/bin. Table row displays "Git: not found". Renamed the binary back and the version was displayed.
