### PR TITLE
[action] update_keychain_access_groups

### DIFF
--- a/fastlane/lib/fastlane/actions/update_keychain_access_groups.rb
+++ b/fastlane/lib/fastlane/actions/update_keychain_access_groups.rb
@@ -1,0 +1,94 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      KEYCHAIN_ACCESS_GROUPS = :KEYCHAIN_ACCESS_GROUPS
+    end
+
+    class UpdateKeychainAccessGroupsAction < Action
+      require 'plist'
+
+      def self.run(params)
+        UI.message("Entitlements File: #{params[:entitlements_file]}")
+        UI.message("New keychain access groups: #{params[:identifiers]}")
+
+        entitlements_file = params[:entitlements_file]
+        UI.user_error!("Could not find entitlements file at path '#{entitlements_file}'") unless File.exist?(entitlements_file)
+
+        # parse entitlements
+        result = Plist.parse_xml(entitlements_file)
+        UI.user_error!("Entitlements file at '#{entitlements_file}' cannot be parsed.") unless result
+
+        # keychain access groups key
+        keychain_access_groups_key = 'keychain-access-groups'
+
+        # get keychain access groups
+        keychain_access_groups_field = result[keychain_access_groups_key]
+        UI.user_error!("No existing keychain access groups field specified. Please specify an keychain access groups in the entitlements file.") unless keychain_access_groups_field
+
+        # set new keychain access groups
+        UI.message("Old keychain access groups: #{keychain_access_groups_field}")
+        result[keychain_access_groups_key] = params[:identifiers]
+
+        # save entitlements file
+        result.save_plist(entitlements_file)
+        UI.message("New keychain access groups: #{result[keychain_access_groups_key]}")
+
+        Actions.lane_context[SharedValues::KEYCHAIN_ACCESS_GROUPS] = result[keychain_access_groups_key]
+      end
+
+      def self.description
+        "This action changes the keychain access groups in the entitlements file"
+      end
+
+      def self.details
+        "Updates the Keychain Group Access Groups in the given Entitlements file, so you can have keychain access groups for the app store build and keychain access groups for an enterprise build."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :entitlements_file,
+                                       env_name: "FL_UPDATE_KEYCHAIN_ACCESS_GROUPS_ENTITLEMENTS_FILE_PATH", # The name of the environment variable
+                                       description: "The path to the entitlement file which contains the keychain access groups", # a short description of this parameter
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass a path to an entitlements file. ") unless value.include?(".entitlements")
+                                         UI.user_error!("Could not find entitlements file") if !File.exist?(value) && !Helper.test?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :identifiers,
+                                       env_name: "FL_UPDATE_KEYCHAIN_ACCESS_GROUPS_IDENTIFIERS",
+                                       description: "An Array of unique identifiers for the keychain access groups. Eg. ['your.keychain.access.groups.identifiers']",
+                                       is_string: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The parameter identifiers need to be an Array.") unless value.kind_of?(Array)
+                                       end)
+        ]
+      end
+
+      def self.output
+        [
+          ['KEYCHAIN_ACCESS_GROUPS', 'The new Keychain Access Groups']
+        ]
+      end
+
+      def self.authors
+        ["yutae"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+
+      def self.example_code
+        [
+          'update_keychain_access_groups(
+            entitlements_file: "/path/to/entitlements_file.entitlements",
+            identifiers: ["your.keychain.access.groups.identifiers"]
+          )'
+        ]
+      end
+
+      def self.category
+        :project
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/update_keychain_access_groups_spec.rb
+++ b/fastlane/spec/actions_specs/update_keychain_access_groups_spec.rb
@@ -1,0 +1,78 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Update Info Plist Integration" do
+      let(:test_path) { "/tmp/fastlane/tests/fastlane" }
+      let(:entitlements_path) { "com.test.entitlements" }
+      let(:new_keychain_access_groups) { 'keychain.access.groups.test' }
+
+      before do
+        # Set up example info.plist
+        FileUtils.mkdir_p(test_path)
+        File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>keychain-access-groups</key><array><string>keychain.access.gorups.test</string></array></dict></plist>')
+      end
+
+      it "updates the keychain access groups of the entitlements file" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            update_keychain_access_groups(
+            entitlements_file: '#{File.join(test_path, entitlements_path)}',
+            identifiers: ['#{new_keychain_access_groups}']
+          )
+        end").runner.execute(:test)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_ACCESS_GROUPS]).to match([new_keychain_access_groups])
+      end
+
+      it "throws an error when the entitlements file does not exist" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            update_keychain_access_groups(
+            entitlements_file: 'abc.#{File.join(test_path, entitlements_path)}',
+            identifiers: ['#{new_keychain_access_groups}']
+          )
+          end").runner.execute(:test)
+        end.to raise_error("Could not find entitlements file at path 'abc.#{File.join(test_path, entitlements_path)}'")
+      end
+
+      it "throws an error when the identifiers are not in an array" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            update_keychain_access_groups(
+            entitlements_file: '#{File.join(test_path, entitlements_path)}',
+            identifiers: '#{new_keychain_access_groups}'
+          )
+          end").runner.execute(:test)
+        end.to raise_error('The parameter identifiers need to be an Array.')
+      end
+
+      it "throws an error when the entitlements file is not parsable" do
+        File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>keychain-access-groups</key><array><string>keychain.access.gorups.</array></dict></plist>')
+
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            update_keychain_access_groups(
+            entitlements_file: '#{File.join(test_path, entitlements_path)}',
+            identifiers: ['#{new_keychain_access_groups}']
+          )
+          end").runner.execute(:test)
+        end.to raise_error("Entitlements file at '#{File.join(test_path, entitlements_path)}' cannot be parsed.")
+      end
+
+      it "throws an error when the entitlements file doesn't contain keychain access groups" do
+        File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict></dict></plist>')
+
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            update_keychain_access_groups(
+            entitlements_file: '#{File.join(test_path, entitlements_path)}',
+            identifiers: ['#{new_keychain_access_groups}']
+          )
+          end").runner.execute(:test)
+        end.to raise_error("No existing keychain access groups field specified. Please specify an keychain access groups in the entitlements file.")
+      end
+
+      after do
+        # Clean up files
+        File.delete(File.join(test_path, entitlements_path))
+      end
+    end
+  end
+end

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -7125,23 +7125,6 @@ func unlockKeychain(path: String = "login",
   _ = runner.executeCommand(command)
 }
 
-
-/**
- This action changes the keychain access groups in the entitlements file
-
- - parameters:
-   - entitlementsFile: The path to the entitlement file which contains the keychain access groups
-   - identifiers: An Array of unique identifiers for the keychain access groups. Eg. ['your.keychain.access.groups.identifiers']
-
- Updates the Keychain Group Access Groups in the given Entitlements file, so you can have keychain access groups for the app store build and keychain access groups for an enterprise build.
-*/
-func updateKeychainAccessGroups(entitlementsFile: String,
-                               identifiers: Any) {
-  let command = RubyCommand(commandID: "", methodName: "update_keychain_access_groups", className: nil, args: [RubyCommand.Argument(name: "entitlements_file", value: entitlementsFile),
-                                                                                                               RubyCommand.Argument(name: "identifiers", value: identifiers)])
-  _ = runner.executeCommand(command)
-}
-
 /**
  This action changes the app group identifiers in the entitlements file
 

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -7125,6 +7125,23 @@ func unlockKeychain(path: String = "login",
   _ = runner.executeCommand(command)
 }
 
+
+/**
+ This action changes the keychain access groups in the entitlements file
+
+ - parameters:
+   - entitlementsFile: The path to the entitlement file which contains the keychain access groups
+   - identifiers: An Array of unique identifiers for the keychain access groups. Eg. ['your.keychain.access.groups.identifiers']
+
+ Updates the Keychain Group Access Groups in the given Entitlements file, so you can have keychain access groups for the app store build and keychain access groups for an enterprise build.
+*/
+func updateKeychainAccessGroups(entitlementsFile: String,
+                               identifiers: Any) {
+  let command = RubyCommand(commandID: "", methodName: "update_keychain_access_groups", className: nil, args: [RubyCommand.Argument(name: "entitlements_file", value: entitlementsFile),
+                                                                                                               RubyCommand.Argument(name: "identifiers", value: identifiers)])
+  _ = runner.executeCommand(command)
+}
+
 /**
  This action changes the app group identifiers in the entitlements file
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In my case, I need to specify different keychain access groups for enterprise and standard.
But fastlane had no associated action.
`update_keychain_access_groups` action changes the keychain access groups in the entitlements file.

> I was inspired by `update_app_group_identifiers` action.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This action updates the Keychain Group Access Groups (key: `keychain-access-groups`) in the given Entitlements file.

I added test code. (`update_keychain_access_groups_spec.rb`)

- updates the keychain access groups of the entitlements file.
- throws an error when the entitlements file does not exist
- throws an error when the identifiers are not in an array
- throws an error when the entitlements file is not parsable
- throws an error when the entitlements file doesn't contain keychain access groups

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

```sh
$ bundle exec rspec ./fastlane/spec/actions_specs/update_keychain_access_groups_spec.rb
```
