### PR TITLE
Don't call base64 encoding "encryption"

### DIFF
--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -17,7 +17,7 @@ module Match
       UI.user_error!("Certificate does not exist at path: #{cert_path}") unless File.exist?(cert_path)
       UI.user_error!("Private key does not exist at path: #{p12_path}") unless File.exist?(p12_path)
 
-      # Base64 encrypt contents to find match from API to find a cert ID
+      # Base64 encode contents to find match from API to find a cert ID
       cert_contents_base_64 = Base64.strict_encode64(File.open(cert_path).read)
 
       # Storage


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Base64 encoding isn't encryption ([common misunderstanding](https://www.di-mgt.com.au/encode_encrypt.html))

### Description
change "encryption" to "encoding"

### Testing Steps
None needed, this is just a comment change