### PR TITLE
[scan] fix incorrect scan error message when suppressing build output

### DIFF
--- a/scan/lib/scan/error_handler.rb
+++ b/scan/lib/scan/error_handler.rb
@@ -6,8 +6,13 @@ module Scan
     class << self
       # @param [String] The output of the errored build
       # This method should raise an exception in any case, as the return code indicated a failed build
-      def handle_build_error(output)
-        # The order of the handling below is import
+      def handle_build_error(output, log_path)
+        # The order of the handling below is important
+
+        instruction = 'See the log'
+        location = Scan.config[:suppress_xcode_output] ? "here: '#{log_path}'" : "above"
+        details = "#{instruction} #{location}."
+
         case output
         when /US\-ASCII/
           print("Your shell environment is not correctly configured")
@@ -23,7 +28,7 @@ module Scan
           print("For more information visit this stackoverflow answer:")
           print("https://stackoverflow.com/a/17031697/445598")
         when /Testing failed/
-          UI.build_failure!("Error building the application - see the log above")
+          UI.build_failure!("Error building the application. #{details}")
         when /Executed/, /Failing tests:/
           # this is *really* important:
           # we don't want to raise an exception here
@@ -38,7 +43,7 @@ module Scan
           # followed by a list of tests that failed.
           return
         end
-        UI.build_failure!("Error building/testing the application - see the log above")
+        UI.build_failure!("Error building/testing the application. #{details}")
       end
 
       private

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -67,7 +67,7 @@ module Scan
                                               error: proc do |error_output|
                                                 begin
                                                   exit_status = $?.exitstatus
-                                                  ErrorHandler.handle_build_error(error_output)
+                                                  ErrorHandler.handle_build_error(error_output, @test_command_generator.xcodebuild_log_path)
                                                 rescue => ex
                                                   SlackPoster.new.run({
                                                     build_errors: 1

--- a/scan/spec/error_handler_spec.rb
+++ b/scan/spec/error_handler_spec.rb
@@ -32,14 +32,14 @@ describe Scan do
           })
         end
 
-        it "reports a build failure" do
+        it "reports a build failure", requires_xcodebuild: true do
           output = File.open(output_path, &:read)
           expect do
             Scan::ErrorHandler.handle_build_error(output, log_path)
           end.to(raise_error(FastlaneCore::Interface::FastlaneBuildFailure))
         end
 
-        it "mentions log above when not suppressing output" do
+        it "mentions log above when not suppressing output", requires_xcodebuild: true do
           expect(FastlaneCore::UI).to receive(:build_failure!).with("Error building the application. See the log above.")
 
           output = File.open(output_path, &:read)
@@ -48,7 +48,7 @@ describe Scan do
           end.to(raise_error)
         end
 
-        it "mentions log file when suppressing output" do
+        it "mentions log file when suppressing output", requires_xcodebuild: true do
           Scan.config[:suppress_xcode_output] = true
 
           expect(FastlaneCore::UI).to receive(:build_failure!).with("Error building the application. See the log here: '#{log_path}'.")

--- a/scan/spec/error_handler_spec.rb
+++ b/scan/spec/error_handler_spec.rb
@@ -2,29 +2,61 @@ require 'scan'
 
 describe Scan do
   describe Scan::ErrorHandler do
+    let(:log_path) { '~/scan.log' }
+
     describe "handle_build_error" do
       describe "when parsing parallel test failure output" do
         it "does not report a build failure" do
           output = File.open('./scan/spec/fixtures/parallel_testing_failure.log', &:read)
           expect do
-            Scan::ErrorHandler.handle_build_error(output)
+            Scan::ErrorHandler.handle_build_error(output, log_path)
           end.to_not(raise_error(FastlaneCore::Interface::FastlaneBuildFailure))
         end
       end
+
       describe "when parsing non-parallel test failure output" do
         it "does not report a build failure" do
           output = File.open('./scan/spec/fixtures/non_parallel_testing_failure.log', &:read)
           expect do
-            Scan::ErrorHandler.handle_build_error(output)
+            Scan::ErrorHandler.handle_build_error(output, log_path)
           end.to_not(raise_error(FastlaneCore::Interface::FastlaneBuildFailure))
         end
       end
+
       describe "when parsing early failure output" do
+        let(:output_path) { './scan/spec/fixtures/early_testing_failure.log' }
+
+        before(:each) {
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            project: './scan/examples/standard/app.xcodeproj',
+          })
+        }
+
         it "reports a build failure" do
-          output = File.open('./scan/spec/fixtures/early_testing_failure.log', &:read)
+          output = File.open(output_path, &:read)
           expect do
-            Scan::ErrorHandler.handle_build_error(output)
+            Scan::ErrorHandler.handle_build_error(output, log_path)
           end.to(raise_error(FastlaneCore::Interface::FastlaneBuildFailure))
+        end
+
+        it "mentions log above when not suppressing output" do
+          expect(FastlaneCore::UI).to receive(:build_failure!).with("Error building the application. See the log above.")
+
+          output = File.open(output_path, &:read)
+          expect do
+            Scan::ErrorHandler.handle_build_error(output, log_path)
+          end.to(raise_error)
+        end
+
+        it "mentions log file when suppressing output" do
+          Scan.config[:suppress_xcode_output] = true
+
+          expect(FastlaneCore::UI).to receive(:build_failure!).with("Error building the application. See the log here: '#{log_path}'.")
+
+          output = File.open(output_path, &:read)
+          expect do
+            Scan::ErrorHandler.handle_build_error(output, log_path)
+          end.to(raise_error)
         end
       end
     end

--- a/scan/spec/error_handler_spec.rb
+++ b/scan/spec/error_handler_spec.rb
@@ -26,11 +26,11 @@ describe Scan do
       describe "when parsing early failure output" do
         let(:output_path) { './scan/spec/fixtures/early_testing_failure.log' }
 
-        before(:each) {
+        before(:each) do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
-            project: './scan/examples/standard/app.xcodeproj',
+            project: './scan/examples/standard/app.xcodeproj'
           })
-        }
+        end
 
         it "reports a build failure" do
           output = File.open(output_path, &:read)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

When the Xcode output was suppressed (`suppress_xcode_output`) and `scan` failed, the error message contained "see the log above". It now mentions the path to the file that contains the log in this case.

<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->