### PR TITLE
[action] cocoapods - add `--clean-install`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            echo "2.3" > .ruby-version
+            echo "2.4" > .ruby-version
             gem update --system
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            echo "2.4" > .ruby-version
+            echo "2.3" > .ruby-version
             gem update --system
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
@@ -209,7 +209,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     docker:
-      - image: circleci/ruby:2.3
+      - image: circleci/ruby:2.4
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -116,7 +116,7 @@ module Fastlane
           # Deprecated
           FastlaneCore::ConfigItem.new(key: :clean,
                                        env_name: "FL_COCOAPODS_CLEAN",
-                                       description: "(Option renamed as --clean-install) Remove SCM directories",
+                                       description: "(Option renamed as clean_install) Remove SCM directories",
                                        deprecated: true,
                                        is_string: false,
                                        default_value: true),

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -14,15 +14,18 @@ module Fastlane
           cmd << ["cd '#{podfile_folder}' &&"]
         end
 
-        cmd << ['bundle exec'] if params[:use_bundle_exec] && shell_out_should_use_bundle_exec?
+        cmd << ['bundle exec'] if use_bundle_exec?(params)
         cmd << ['pod install']
 
-        cmd << '--no-clean' unless params[:clean]
-        cmd << '--no-integrate' unless params[:integrate]
+        cmd << '--clean-install' if params[:clean_install] && pod_version.to_f >= 1.7
         cmd << '--repo-update' if params[:repo_update]
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
+
+        # deprecated options
+        cmd << '--no-clean' unless params[:clean]
+        cmd << '--no-integrate' unless params[:integrate]
 
         Actions.sh(cmd.join(' '), error_callback: lambda { |result|
           if !params[:repo_update] && params[:try_repo_update_on_error]
@@ -34,6 +37,14 @@ module Fastlane
             call_error_callback(params, result)
           end
         })
+      end
+
+      def self.use_bundle_exec?(params)
+        params[:use_bundle_exec] && shell_out_should_use_bundle_exec?
+      end
+
+      def self.pod_version
+        use_bundle_exec(params)? ? `bundle exec pod --version` : `pod --version`
       end
 
       def self.call_error_callback(params, result)
@@ -55,6 +66,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :repo_update,
                                        env_name: "FL_COCOAPODS_REPO_UPDATE",
                                        description: "Add `--repo-update` flag to `pod install` command",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :clean_install,
+                                       env_name: "FL_COCOAPODS_CLEAN_INSTALL",
+                                       description: "Execute a full pod installation ignoring the content of the project cache",
                                        is_string: false,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :silent,
@@ -102,7 +118,7 @@ module Fastlane
           # Deprecated
           FastlaneCore::ConfigItem.new(key: :clean,
                                        env_name: "FL_COCOAPODS_CLEAN",
-                                       description: "(Option removed from cocoapods) Remove SCM directories",
+                                       description: "(Option renamed as --clean-install) Remove SCM directories",
                                        deprecated: true,
                                        is_string: false,
                                        default_value: true),

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -17,15 +17,13 @@ module Fastlane
         cmd << ['bundle exec'] if use_bundle_exec?(params)
         cmd << ['pod install']
 
+        cmd << '--no-clean' unless params[:clean]
+        cmd << '--no-integrate' unless params[:integrate]
         cmd << '--clean-install' if params[:clean_install] && pod_version.to_f >= 1.7
         cmd << '--repo-update' if params[:repo_update]
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
-
-        # deprecated options
-        cmd << '--no-clean' unless params[:clean]
-        cmd << '--no-integrate' unless params[:integrate]
 
         Actions.sh(cmd.join(' '), error_callback: lambda { |result|
           if !params[:repo_update] && params[:try_repo_update_on_error]
@@ -44,7 +42,7 @@ module Fastlane
       end
 
       def self.pod_version
-        use_bundle_exec(params)? ? `bundle exec pod --version` : `pod --version`
+        use_bundle_exec?(params) ? `bundle exec pod --version` : `pod --version`
       end
 
       def self.call_error_callback(params, result)

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -51,6 +51,32 @@ describe Fastlane do
         expect(result).to eq("bundle exec pod install --repo-update")
       end
 
+      it "if clean_install is set to true " do
+        it "add clean_install to command if pod version is 1.7 and over" do
+          allow (Fastlane::Actions::CocoapodsAction).to receive(:pod_version).and_return('1.7')
+
+          result = Fastlane::Fastfile.new.parse("lane :test do
+            cocoapods(
+              clean_install: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("bundle exec pod install --clean_install")
+        end
+
+        it "does not add clean_install to command if pod version is less than 1.7" do
+          allow (Fastlane::Actions::CocoapodsAction).to receive(:pod_version).and_return('1.6')
+
+          result = Fastlane::Fastfile.new.parse("lane :test do
+            cocoapods(
+              clean_install: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("bundle exec pod install")
+        end
+      end
+
       it "adds silent to command if silent is set to true" do
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -51,30 +51,28 @@ describe Fastlane do
         expect(result).to eq("bundle exec pod install --repo-update")
       end
 
-      it "if clean_install is set to true " do
-        it "add clean_install to command if pod version is 1.7 and over" do
-          allow (Fastlane::Actions::CocoapodsAction).to receive(:pod_version).and_return('1.7')
+      it "add clean_install to command if clean_install is set to true, and  pod version is 1.7 and over" do
+        allow(Fastlane::Actions::CocoapodsAction).to receive(:pod_version).and_return('1.7')
 
-          result = Fastlane::Fastfile.new.parse("lane :test do
-            cocoapods(
-              clean_install: true
-            )
-          end").runner.execute(:test)
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            clean_install: true
+          )
+        end").runner.execute(:test)
 
-          expect(result).to eq("bundle exec pod install --clean_install")
-        end
+        expect(result).to eq("bundle exec pod install --clean-install")
+      end
 
-        it "does not add clean_install to command if pod version is less than 1.7" do
-          allow (Fastlane::Actions::CocoapodsAction).to receive(:pod_version).and_return('1.6')
+      it "does not add clean_install to command if clean_install is set to true, and pod version is less than 1.7" do
+        allow(Fastlane::Actions::CocoapodsAction).to receive(:pod_version).and_return('1.6')
 
-          result = Fastlane::Fastfile.new.parse("lane :test do
-            cocoapods(
-              clean_install: true
-            )
-          end").runner.execute(:test)
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            clean_install: true
+          )
+        end").runner.execute(:test)
 
-          expect(result).to eq("bundle exec pod install")
-        end
+        expect(result).to eq("bundle exec pod install")
       end
 
       it "adds silent to command if silent is set to true" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`--no-clean` option has removed and deprecated in fastlane for some time, but `--clean-install` option has introduced from CocoaPods version 1.7.0.
https://github.com/CocoaPods/CocoaPods/releases

So, I add the option to cocoapods action to use same option.

### related PR

I also updated docs.
https://github.com/fastlane/docs/pull/871

### Description

If `clean_install` option is true and  pods version is 1.7 or more, `--clean-install` option is added to pod install command.

### Options check

- CocoaPods ver: 1.6.0

```
$ bundle exec pod install help

Usage:

    $ pod install

      Downloads all dependencies defined in `Podfile` and creates an Xcode Pods
      library project in `./Pods`.

      The Xcode project file should be specified in your `Podfile` like this:

          project 'path/to/XcodeProject.xcodeproj'

      If no project is specified, then a search for an Xcode project will be made. If
      more than one Xcode project is found, the command will raise an error.

      This will configure the project to reference the Pods static library, add a
      build configuration file, and add a post build script to copy Pod resources.

      This may return one of several error codes if it encounters problems. * `1`
      Generic error code * `31` Spec not found (i.e out-of-date source repos, mistyped
      Pod name etc...)

Options:

    --repo-update                       Force running `pod repo update` before install
    --deployment                        Disallow any changes to the Podfile or the
                                        Podfile.lock during installation
    --project-directory=/project/dir/   The path to the root of the project directory
    --silent                            Show nothing
    --verbose                           Show more debugging information
    --no-ansi                           Show output without ANSI codes
    --help                              Show help banner of specified command
```

- CocoaPods ver: 1.7.0 ~

```
$ bundle exec pod install help

Usage:

    $ pod install

      Downloads all dependencies defined in `Podfile` and creates an Xcode Pods
      library project in `./Pods`.

      The Xcode project file should be specified in your `Podfile` like this:

          project 'path/to/XcodeProject.xcodeproj'

      If no project is specified, then a search for an Xcode project will be made. If
      more than one Xcode project is found, the command will raise an error.

      This will configure the project to reference the Pods static library, add a
      build configuration file, and add a post build script to copy Pod resources.

      This may return one of several error codes if it encounters problems. * `1`
      Generic error code * `31` Spec not found (i.e out-of-date source repos, mistyped
      Pod name etc...)

Options:

    --repo-update                       Force running `pod repo update` before install
    --deployment                        Disallow any changes to the Podfile or the
                                        Podfile.lock during installation
    --clean-install                     Ignore the contents of the project cache and
                                        force a full pod installation. This only
                                        applies to projects that have enabled
                                        incremental installation
    --project-directory=/project/dir/   The path to the root of the project directory
    --silent                            Show nothing
    --verbose                           Show more debugging information
    --no-ansi                           Show output without ANSI codes
    --help                              Show help banner of specified command
```