### PR TITLE
[action] carthage - add `no-checkout` option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            echo "2.3" > .ruby-version
+            echo "2.4" > .ruby-version
             gem update --system
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
@@ -209,7 +209,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     docker:
-      - image: circleci/ruby:2.3
+      - image: circleci/ruby:2.4
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            echo "2.4" > .ruby-version
+            echo "2.3" > .ruby-version
             gem update --system
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
@@ -209,7 +209,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -21,6 +21,7 @@ module Fastlane
         cmd << "--use-ssh" if params[:use_ssh]
         cmd << "--use-submodules" if params[:use_submodules]
         cmd << "--no-use-binaries" if params[:use_binaries] == false
+        cmd << "--no-checkout" if params[:no_checkout] == true
         cmd << "--no-build" if params[:no_build] == true
         cmd << "--no-skip-current" if params[:no_skip_current] == true
         cmd << "--verbose" if params[:verbose] == true
@@ -91,6 +92,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :use_binaries,
                                        env_name: "FL_CARTHAGE_USE_BINARIES",
                                        description: "Check out dependency repositories even when prebuilt frameworks exist",
+                                       is_string: false,
+                                       type: Boolean,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :no_checkout,
+                                       env_name: "FL_CARTHAGE_NO_CHECKOUT",
+                                       description: "When bootstrapping Carthage do not checkout",
                                        is_string: false,
                                        type: Boolean,
                                        optional: true),

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -121,6 +121,16 @@ describe Fastlane do
         expect(result).to eq("carthage bootstrap")
       end
 
+      it "adds no-checkout flag to command if no_checkout is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              no_checkout: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --no-checkout")
+      end
+
       it "adds no-build flag to command if no_build is set to true" do
         result = Fastlane::FastFile.new.parse("lane :test do
             carthage(


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Latest (ver: 0.33.0) carthage bootstrap command has `--no-checkout` option.
But, carthage action isn't implemented the option.
So, I will add `no_checkout` option to carthage action.

### related PR

I also updated docs.
https://github.com/fastlane/docs/pull/872

### carthage bootstrap option

```
❯ carthage version
0.33.0
❯ carthage help bootstrap
Check out and build the project's dependencies

[--no-checkout]
	skip the checking out of dependencies after updating

[--no-build]
	skip the building of dependencies after updating
	(ignored if --no-checkout option is present)

[--verbose]
	print xcodebuild output inline (ignored if --no-build option is present)

[--log-path (string)]
	path to the xcode build output. A temporary file is used by default

[--new-resolver]
	use the new resolver codeline when calculating dependencies. Default is false

[--configuration (string)]
	the Xcode configuration to build
	(ignored if --no-build option is present)

[--platform (platform)]
	the platforms to build for (one of 'all', 'macOS', 'iOS', 'watchOS', 'tvOS', or comma-separated values of the formers except for 'all')
	(ignored if --no-build option is present)

[--toolchain (string)]
	the toolchain to build with

[--derived-data (string)]
	path to the custom derived data folder

[--cache-builds]
	use cached builds when possible

[--no-use-binaries]
	don't use downloaded binaries when possible

[--use-ssh]
	use SSH for downloading GitHub repositories

[--use-submodules]
	add dependencies as Git submodules

[--color (color)]
	whether to apply color and terminal formatting (one of 'auto', 'always', or 'never')

[--project-directory (string)]
	the directory containing the Carthage project

[<dependency names…>]
	the dependency names to update, checkout and build
```
