### PR TITLE
[fastlane] Lock signet to 0.11 for under Ruby 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
           name: Setup Build
           # Build gem from fastlane.gemspec and install locally
           command: |
-            gem update --system && gem install $(echo $(gem build fastlane.gemspec) | sed 's/.*File: //')
+            sudo gem update --system && gem install $(echo $(gem build fastlane.gemspec) | sed 's/.*File: //')
 
       - run: /bin/bash ./test_modules/run_tests.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     docker:
-      - image: fastlanetools/ci:0.1.0
+      - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     docker:
-      - image: circleci/ruby:2.3
+      - image: fastlanetools/ci:0.1.0
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
           name: Setup Build
           # Build gem from fastlane.gemspec and install locally
           command: |
-            gem install $(echo $(gem build fastlane.gemspec) | sed 's/.*File: //')
+            gem update --system && gem install $(echo $(gem build fastlane.gemspec) | sed 's/.*File: //')
 
       - run: /bin/bash ./test_modules/run_tests.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
           name: Setup Build
           # Build gem from fastlane.gemspec and install locally
           command: |
-            sudo gem update --system && gem install $(echo $(gem build fastlane.gemspec) | sed 's/.*File: //')
+            gem install $(echo $(gem build fastlane.gemspec) | sed 's/.*File: //')
 
       - run: /bin/bash ./test_modules/run_tests.sh
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -92,7 +92,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
 
-  # need to lock 0.11 and under when using less than Ruby 2.4
+  # need to lock 0.11 and under when using less than Ruby 2.4 to prevent install issues when using 'gem install'
+  # 'gem install' does not respect Ruby versions when and would try installing 0.12 on Ruby 2.3 or less
+  # https://github.com/fastlane/fastlane/pull/15483
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4')
     spec.add_dependency('signet', '<= 0.11') # Because yeah
   end

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -91,7 +91,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
-  #spec.add_dependency('signet', '>= 0.9') # Because yeah
+  spec.add_dependency('signet', '~> 0.9') # Because yeah
   # Space to test something
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -91,6 +91,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
+  spec.add_dependency('signet', '>= 0.9') # Because yeah
   # Space to test something
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -91,7 +91,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
-  spec.add_dependency('signet', '~> 0.9') # Because yeah
+  spec.add_dependency('signet', '0.11') # Because yeah
   # Space to test something
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,7 +97,7 @@ Gem::Specification.new do |spec|
   # https://github.com/fastlane/fastlane/pull/15483
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4')
     spec.add_dependency('signet', '<= 0.11') # Because yeah
-    STDERR.puts "WARNING: Locking to a potentially insecure version of 'signet' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.4 or later"
+    STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.4 or later")
   end
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -91,6 +91,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
+  # Space to test something
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,6 +97,7 @@ Gem::Specification.new do |spec|
   # https://github.com/fastlane/fastlane/pull/15483
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4')
     spec.add_dependency('signet', '<= 0.11') # Because yeah
+    STDERR.puts "WARNING: Locking to a potentially insecure version of 'signet' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.4 or later"
   end
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -91,7 +91,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
-  spec.add_dependency('signet', '>= 0.9') # Because yeah
+  #spec.add_dependency('signet', '>= 0.9') # Because yeah
   # Space to test something
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -92,10 +92,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
 
-  if true
-    spec.add_dependency('signet', '0.11') # Because yeah
+  # need to lock 0.11 and under when using less than Ruby 2.4
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4')
+    spec.add_dependency('signet', '<= 0.11') # Because yeah
   end
-  # Space to test something
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -91,7 +91,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '~> 2.1.0') # Used for generating authentication tokens for AppStore connect api
-  spec.add_dependency('signet', '0.11') # Because yeah
+
+  if true
+    spec.add_dependency('signet', '0.11') # Because yeah
+  end
   # Space to test something
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.


### PR DESCRIPTION
### Motivation and Context
Fixes #15484
Fixes issues fixed by #15471 without minimum Ruby version bump

### Description
The issue raised with `signet` [requiring Ruby version 2.4.0](https://github.com/googleapis/signet/pull/145) does not occur when running `bundler install` or `bundle update` (because bundler respects Ruby version requirements when installing) but was with `gem install` (which does not respect Ruby versions when resolving dependencies).

This fix with manually check if the Ruby version is less than 2.4 and if so it will lock the `signet` dependency to less than `0.11`.

### Testing Steps

#### bundler with Ruby 2.3
Installed `signet (0.11)`

```sh
bundle update
```

#### bundler with Ruby 2.4
Installed `signet (0.12)`

```sh
bundle update
```

#### gem install with Ruby 2.3
Installed `signet (0.11)`

```sh
gem cleanup fastlane
gem cleanup signet
gem install $(echo $(gem build fastlane.gemspec) | sed 's/.*File: //')
gem list | grep signet
```

#### gem install Ruby 2.4
Installed `signet (0.12)`

```sh
gem cleanup fastlane
gem cleanup signet
gem install $(echo $(gem build fastlane.gemspec) | sed 's/.*File: //')
gem list | grep signet
```
