### PR TITLE
[action] cocoapods - add `--deployment`

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -23,6 +23,8 @@ module Fastlane
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
+        cmd << '--deployment'  if params[:deployment]
+        cmd << "--project-directory=#{pramas[:project_directory]}"  if params[:project_directory]
 
         Actions.sh(cmd.join(' '), error_callback: lambda { |result|
           if !params[:repo_update] && params[:try_repo_update_on_error]
@@ -94,6 +96,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :try_repo_update_on_error,
                                        env_name: "FL_COCOAPODS_TRY_REPO_UPDATE_ON_ERROR",
                                        description: 'Retry with --repo-update if action was finished with error',
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :deployment,
+                                       env_name: "FL_COCOAPODS_DEPLOYMENT",
+                                       description: 'Disallow any changes to the Podfile or the Podfile.lock during installation',
                                        optional: true,
                                        is_string: false,
                                        default_value: false,

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -24,7 +24,6 @@ module Fastlane
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
         cmd << '--deployment'  if params[:deployment]
-        cmd << "--project-directory=#{pramas[:project_directory]}"  if params[:project_directory]
 
         Actions.sh(cmd.join(' '), error_callback: lambda { |result|
           if !params[:repo_update] && params[:try_repo_update_on_error]

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -24,7 +24,7 @@ module Fastlane
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]
         cmd << '--no-ansi' unless params[:ansi]
-        cmd << '--deployment'  if params[:deployment]
+        cmd << '--deployment' if params[:deployment]
 
         Actions.sh(cmd.join(' '), error_callback: lambda { |result|
           if !params[:repo_update] && params[:try_repo_update_on_error]

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -81,6 +81,16 @@ describe Fastlane do
         expect(result).to eq("bundle exec pod install --no-ansi")
       end
 
+      it "adds deployment to command if deployment is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            deployment: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod install --deployment")
+      end
+
       it "changes directory if podfile is set to the Podfile path" do
         result = Fastlane::FastFile.new.parse("lane :test do
           cocoapods(


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Latest cocoapods (ver: 1.8.3) has `--deployment` and `--project-directory` options.
I think `--project-directory` option is same `podfile` option in cocoapods action.
But `--deployment` option is not covered in cocoapods action. So I added.

### Options check

- CocoaPods ver: 1.6.0

```
$ bundle exec pod install help

Usage:

    $ pod install

      Downloads all dependencies defined in `Podfile` and creates an Xcode Pods
      library project in `./Pods`.

      The Xcode project file should be specified in your `Podfile` like this:

          project 'path/to/XcodeProject.xcodeproj'

      If no project is specified, then a search for an Xcode project will be made. If
      more than one Xcode project is found, the command will raise an error.

      This will configure the project to reference the Pods static library, add a
      build configuration file, and add a post build script to copy Pod resources.

      This may return one of several error codes if it encounters problems. * `1`
      Generic error code * `31` Spec not found (i.e out-of-date source repos, mistyped
      Pod name etc...)

Options:

    --repo-update                       Force running `pod repo update` before install
    --deployment                        Disallow any changes to the Podfile or the
                                        Podfile.lock during installation
    --project-directory=/project/dir/   The path to the root of the project directory
    --silent                            Show nothing
    --verbose                           Show more debugging information
    --no-ansi                           Show output without ANSI codes
    --help                              Show help banner of specified command
```

- CocoaPods ver: 1.7.0 ~

```
$ bundle exec pod install help

Usage:

    $ pod install

      Downloads all dependencies defined in `Podfile` and creates an Xcode Pods
      library project in `./Pods`.

      The Xcode project file should be specified in your `Podfile` like this:

          project 'path/to/XcodeProject.xcodeproj'

      If no project is specified, then a search for an Xcode project will be made. If
      more than one Xcode project is found, the command will raise an error.

      This will configure the project to reference the Pods static library, add a
      build configuration file, and add a post build script to copy Pod resources.

      This may return one of several error codes if it encounters problems. * `1`
      Generic error code * `31` Spec not found (i.e out-of-date source repos, mistyped
      Pod name etc...)

Options:

    --repo-update                       Force running `pod repo update` before install
    --deployment                        Disallow any changes to the Podfile or the
                                        Podfile.lock during installation
    --clean-install                     Ignore the contents of the project cache and
                                        force a full pod installation. This only
                                        applies to projects that have enabled
                                        incremental installation
    --project-directory=/project/dir/   The path to the root of the project directory
    --silent                            Show nothing
    --verbose                           Show more debugging information
    --no-ansi                           Show output without ANSI codes
    --help                              Show help banner of specified command
```