### PR TITLE
[fastlane] fix grammar from "setup" to "set up"

### DIFF
--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -113,7 +113,7 @@ module Fastlane
         rows: FastlaneCore::PrintTable.transform_output(rows)
       )
 
-      UI.message("Welcome to fastlane! Here's what your app is setup to do:")
+      UI.message("Welcome to fastlane! Here's what your app is set up to do:")
 
       puts(table)
 


### PR DESCRIPTION
Setup = noun. Set up = verb. https://www.merriam-webster.com/dictionary/setup#note-1

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
