### PR TITLE
[fastlane] warn user during load_plugins when failure to find action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
             mkdir -p ~/test-reports
             echo "2.5" > .ruby-version
             gem update --system
+            brew untap caskroom/versions
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
             mkdir -p ~/test-reports
             echo "2.3" > .ruby-version
             gem update --system
+            brew untap caskroom/versions
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
 

--- a/fastlane/lib/fastlane/environment_printer.rb
+++ b/fastlane/lib/fastlane/environment_printer.rb
@@ -50,11 +50,11 @@ module Fastlane
     end
 
     def self.print_loaded_plugins
-      ENV["FASTLANE_ENV_PRINTER"] = "enabled"
       env_output =  "### Loaded fastlane plugins:\n"
       env_output << "\n"
       plugin_manager = Fastlane::PluginManager.new
-      plugin_manager.load_plugins
+      plugin_manager.load_plugins(print_table: false)
+
       if plugin_manager.available_plugins.length <= 0
         env_output << "**No plugins Loaded**\n"
       else

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -278,7 +278,7 @@ module Fastlane
     #   fastlane-plugin-[plugin_name]
     # This will make sure to load the action
     # and all its helpers
-    def load_plugins
+    def load_plugins(print_table: true)
       UI.verbose("Checking if there are any plugins that should be loaded...")
 
       loaded_plugins = false
@@ -311,7 +311,7 @@ module Fastlane
         UI.error("Please follow the troubleshooting guide: #{TROUBLESHOOTING_URL}")
       end
 
-      skip_print_plugin_info = self.plugin_references.empty? || CLIToolsDistributor.running_version_command? || FastlaneCore::Env.truthy?("FASTLANE_ENV_PRINTER")
+      skip_print_plugin_info = self.plugin_references.empty? || CLIToolsDistributor.running_version_command? || !print_table
 
       # We want to avoid printing output other than the version number if we are running `fastlane -v`
       print_plugin_information(self.plugin_references) unless skip_print_plugin_info
@@ -319,9 +319,12 @@ module Fastlane
 
     # Prints a table all the plugins that were loaded
     def print_plugin_information(references)
+      no_action_found = false
+
       rows = references.collect do |current|
         if current[1][:actions].empty?
           # Something is wrong with this plugin, no available actions
+          no_action_found = true
           [current[0].red, current[1][:version_number], "No actions found".red]
         else
           [current[0], current[1][:version_number], current[1][:actions].join("\n")]
@@ -335,6 +338,13 @@ module Fastlane
         headings: ["Plugin", "Version", "Action"]
       }))
       puts("")
+
+      if no_action_found
+        puts("[!] No actions were found while loading one or more plugins".red)
+        puts("    Please use `bundle exec fastlane` with plugins".red)
+        puts("    More info - https://docs.fastlane.tools/plugins/using-plugins/#run-with-plugins".red)
+        puts("")
+      end
     end
 
     #####################################################

--- a/fastlane/spec/plugins_specs/plugin_manager_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_manager_spec.rb
@@ -196,7 +196,28 @@ describe Fastlane do
         expect(Fastlane::FastlaneRequire).to receive(:install_gem_if_needed).with(gem_name: plugin_name, require_gem: true)
         expect(Fastlane::Crashlytics).to receive(:all_classes).and_return(["/actions/#{plugin_name}.rb"])
         expect(UI).to receive(:important).with("Plugin 'Crashlytics' overwrites already loaded action '#{plugin_name}'")
-        pm.load_plugins
+
+        expect do
+          pm.load_plugins
+        end.to_not(output(/No actions were found while loading one or more plugins/).to_stdout)
+      end
+    end
+
+    describe "Plugins not loaded" do
+      it "shows a warning if a plugin isn't loaded" do
+        module Fastlane::Crashlytics
+        end
+
+        pm = Fastlane::PluginManager.new
+        plugin_name = "crashlytics"
+        expect(pm).to receive(:available_plugins).and_return([plugin_name])
+        expect(Fastlane::FastlaneRequire).to receive(:install_gem_if_needed).with(gem_name: plugin_name, require_gem: true)
+
+        expect(pm).to receive(:store_plugin_reference).and_raise(StandardError.new)
+
+        expect do
+          pm.load_plugins
+        end.to output(/No actions were found while loading one or more plugins/).to_stdout
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/15506
Fixes https://github.com/fastlane-community/fastlane-plugin-firebase_app_distribution/issues/15

And bonus fix for failing CI with https://github.com/Homebrew/brew/issues/6112#issuecomment-520950707

### Motivation and Context
Give users some more help when plugins fail to load without an actions

### Description
- Add a message with a link to new doc that also explains
- Also added a new optional parameter onto `load_plugins` to prevent the setting of `ENV["FASTLANE_ENV_PRINTER"]` which was causing test failures due to the environment variables never being cleared out

![Screen Shot 2019-10-22 at 2 54 43 PM](https://user-images.githubusercontent.com/401294/67329705-d7b00700-f4e0-11e9-8206-952d70e4d2e1.png)


### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
