### PR TITLE
[spaceship] Fix 'invalid_request' when editing app's localized name.

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_details.rb
+++ b/spaceship/lib/spaceship/tunes/app_details.rb
@@ -80,7 +80,11 @@ module Spaceship
 
       # Push all changes that were made back to App Store Connect
       def save!
-        client.update_app_details!(application.apple_id, raw_data)
+        # Apple no longer accept 'language' in 'localizedMetadata', or itc will return 'invalid_request'
+        raw_data_copy = Spaceship::Base::DataHash.new(raw_data.to_h.deep_dup)
+        locales = raw_data_copy["localizedMetadata"]["value"]
+        locales.each { |local_hash| local_hash.delete("language") }
+        client.update_app_details!(application.apple_id, raw_data_copy)
       rescue Spaceship::Tunes::Error => ex
         if ex.to_s == "operation_failed"
           # That's alright, we get this error message if nothing has changed


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

iTunes Connect App can not change localized name now, when change Tunes::AppDetails' name and use #save! to submit changes to iTunes Connect, itc will response 'invalid_request'. 

Simple code like following can reoccur this bug:

```
edit_app = app.details
edit_app.name.keys.each { |k| edit_app.name[k] = "foo_bar" }
edit_app.save!
```

I solve the problem above by changing JSON content in Tunes::AppDetails#save!


### Description
<!-- Describe your changes in detail. -->

It seems that iTunes Connect API no longer accept "language" value in "localizedMetadata", and I found that "language" is added when creating ```LanguageItem```, in order to avoid any side effect, I just deep_dup ```raw_data``` and remove corresponding key-value pair before client submitting raw JSON.

code like this:

```
def save!
    # Apple no longer accept 'language' in 'localizedMetadata', or itc will return 'invalid_request'
    raw_data_copy = Spaceship::Base::DataHash.new(raw_data.to_h.deep_dup)
    locales = raw_data_copy["localizedMetadata"]["value"]
    locales.each { |local_hash| local_hash.delete("language") }
    client.update_app_details!(application.apple_id, raw_data_copy)
rescue Spaceship::Tunes::Error => ex
    if ex.to_s == "operation_failed"
        # That's alright, we get this error message if nothing has changed
    else
        raise ex
    end
end
```

<!-- Please describe in detail how you tested your changes. -->

I test it by changing localized names of app and compare the result in iTunes Connect web page.