### PR TITLE
[fastlane] fix parsing of action name

### DIFF
--- a/fastlane/lib/fastlane/action.rb
+++ b/fastlane/lib/fastlane/action.rb
@@ -121,7 +121,7 @@ module Fastlane
 
     # instead of "AddGitAction", this will return "add_git" to print it to the user
     def self.action_name
-      self.name.split('::').last.gsub('Action', '').fastlane_underscore
+      self.name.split('::').last.gsub(/Action$/, '').fastlane_underscore
     end
 
     def self.lane_context

--- a/fastlane/spec/action_spec.rb
+++ b/fastlane/spec/action_spec.rb
@@ -5,6 +5,11 @@ describe Fastlane do
         expect(Fastlane::Actions::IpaAction.action_name).to eq('ipa')
         expect(Fastlane::Actions::IncrementBuildNumberAction.action_name).to eq('increment_build_number')
       end
+
+      it "only removes the last occurrence of Action" do
+        Fastlane::Actions.load_external_actions("./fastlane/spec/fixtures/actions")
+        expect(Fastlane::Actions::ActionFromActionAction.action_name).to eq('action_from_action')
+      end
     end
 
     describe "Easy access to the lane context" do
@@ -74,7 +79,7 @@ describe Fastlane do
           pwd: Dir.pwd
         }
         expect(ff.runner.execute(:something, :ios)).to eq(response)
-        expect(Fastlane::Actions.executed_actions.map { |a| a[:name] }).to eq(['from'])
+        expect(Fastlane::Actions.executed_actions.map { |a| a[:name] }).to eq(['action_from_action'])
       end
 
       it "shows only actions called from Fastfile" do
@@ -83,7 +88,7 @@ describe Fastlane do
         Fastlane::Actions.executed_actions.clear
 
         ff.runner.execute(:something, :ios)
-        expect(Fastlane::Actions.executed_actions.map { |a| a[:name] }).to eq(['from', 'example'])
+        expect(Fastlane::Actions.executed_actions.map { |a| a[:name] }).to eq(['action_from_action', 'example_action'])
       end
 
       it "shows an appropriate error message when trying to directly call an action" do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently the `action_name` of an action is derived from the respective class name by splitting of all namespace components and replacing all occurrences of `Action` in the name. This leads to a problem when the action name actually contains the word `Action`, e.g. like the test stub `ActionFromActionAction`, for which `action_name` currently returns `from`. However, the correct action name would be `action_from_action`.

### Description
This PR changes `Action.action_name` to only remove a single trailing `Action` from the class name instead of all occurrences of `Action`.