### PR TITLE
[deliver] fix a bug that deliver fails to find version

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -58,11 +58,17 @@ module Deliver
       start = Time.now
       build = nil
 
+      use_latest_version = app_version.nil?
+
       loop do
         # Sometimes candidate_builds don't appear immediately after submission
         # Wait for candidate_builds to appear on App Store Connect
         # Issue https://github.com/fastlane/fastlane/issues/10411
-        candidate_builds = app.latest_version.candidate_builds
+        if use_latest_version
+          candidate_builds = app.latest_version.candidate_builds
+        else
+          candidate_builds = app.tunes_all_builds_for_train(train: app_version)
+        end
         if (candidate_builds || []).count == 0
           UI.message("Waiting for candidate builds to appear...")
           if (Time.now - start) > (60 * 5)

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -57,8 +57,9 @@ describe Deliver::SubmitForReview do
         # Stub Time.now to return current time on first call and 6 minutes later on second
         before { allow(Time).to receive(:now).and_return(time_now, (time_now + 60 * 6)) }
         it 'throws a UI error' do
-          allow(fake_app).to receive(:latest_version).and_return(fake_version)
-          allow(fake_version).to receive(:candidate_builds).and_return([])
+          allow(fake_app).to receive(:tunes_all_builds_for_train)
+            .with(train: "1.2.3")
+            .and_return([])
           expect do
             review_submitter.wait_for_build(fake_app, "1.2.3")
           end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not find any available candidate builds on App Store Connect to submit")
@@ -71,8 +72,9 @@ describe Deliver::SubmitForReview do
         let(:fake_builds) { make_fake_builds(1) }
 
         it 'finds the one build' do
-          allow(fake_app).to receive(:latest_version).and_return(fake_version)
-          allow(fake_version).to receive(:candidate_builds).and_return(fake_builds)
+          allow(fake_app).to receive(:tunes_all_builds_for_train)
+            .with(train: "1.2.3")
+            .and_return(fake_builds)
           only_build = fake_builds.first
           expect(review_submitter.wait_for_build(fake_app, "1.2.3")).to eq(only_build)
         end
@@ -136,8 +138,9 @@ describe Deliver::SubmitForReview do
         end
 
         it 'does not find the one build until the candidate is corrected' do
-          allow(fake_app).to receive(:latest_version).and_return(fake_version)
-          allow(fake_version).to receive(:candidate_builds).and_return(fake_builds_with_trimmed_zero, fake_builds_with_trimmed_zero, fake_builds)
+          allow(fake_app).to receive(:tunes_all_builds_for_train)
+            .with(train: "1.02.3")
+            .and_return(fake_builds_with_trimmed_zero, fake_builds_with_trimmed_zero, fake_builds)
           allow(review_submitter).to receive(:sleep)
           expect(review_submitter.wait_for_build(fake_app, "1.02.3")).to equal(fake_builds.first)
         end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`deliver` fails to select version for app submission when:
* You set 'latest' to __build_number__ and set a specific version to __app_version__ parameters
* There is newer version available on App Store Connect

### Description

This was happening because `wait_for_build` in `submit_for_review` always looks for the __latest__ version regardless of the version specified.

### Testing Steps

n/a