### PR TITLE
[pilot] improves testflight metadata upload

### DIFF
--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -173,7 +173,7 @@ func appaloosa(binary: String,
    - note: Notes you wish to add to the uploaded app
 
  If you provide a `public_key`, this will overwrite an existing application. If you want to have this build as a new app version, you shouldn't provide this value.
-
+ 
  To integrate appetize into your GitHub workflow check out the [device_grid guide](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/device_grid/README.md).
 */
 func appetize(apiHost: String = "api.appetize.io",
@@ -484,7 +484,7 @@ func appledoc(input: Any,
    - app: The (spaceship) app ID of the app you want to use/modify
 
  Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.
-
+ 
  If you don't want a PDF report for App Store builds, use the `:force` option.
  This is useful when running _fastlane_ on your Continuous Integration server:
  `_upload_to_app_store_(force: true)`
@@ -1732,7 +1732,7 @@ func checkAppStoreMetadata(appIdentifier: String,
  - parameter excludePattern: Exclude all files from clearing that match the given Regex pattern: e.g. '.*.mobileprovision'
 
  This action deletes the files that get created in your repo as a result of running the _gym_ and _sigh_ commands. It doesn't delete the `fastlane/report.xml` though, this is probably more suited for the .gitignore.
-
+ 
  Useful if you quickly want to send out a test build by dropping down to the command line and typing something like `fastlane beta`, without leaving your repo in a messy state afterwards.
 */
 func cleanBuildArtifacts(excludePattern: String? = nil) {
@@ -2312,7 +2312,7 @@ func deleteKeychain(name: String? = nil,
    - app: The (spaceship) app ID of the app you want to use/modify
 
  Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.
-
+ 
  If you don't want a PDF report for App Store builds, use the `:force` option.
  This is useful when running _fastlane_ on your Continuous Integration server:
  `_upload_to_app_store_(force: true)`
@@ -3105,7 +3105,7 @@ func getManagedPlayStorePublishingRights(jsonKey: String? = nil,
    - provisioningName: The name of the profile that is used on the Apple Developer Portal
    - ignoreProfilesWithDifferentName: Use in combination with :provisioning_name - when true only profiles matching this exact name will be downloaded
    - outputPath: Directory in which the profile should be stored
-   - certId: The ID of the code signing certificate to use (e.g. 78ADL6LVAA)
+   - certId: The ID of the code signing certificate to use (e.g. 78ADL6LVAA) 
    - certOwnerName: The certificate name to use for new profiles, or to renew with. (e.g. "Felix Krause")
    - filename: Filename to use for the generated provisioning profile (must include .mobileprovision)
    - skipFetchProfiles: Skips the verification of existing profiles which is useful if you have thousands of profiles
@@ -3735,7 +3735,7 @@ func hipchat(message: String = "",
 
  HockeyApp will be no longer supported and will be transitioned into App Center on November 16, 2019.
  Please migrate over to [App Center](https://github.com/Microsoft/fastlane-plugin-appcenter/)
-
+ 
  Symbols will also be uploaded automatically if a `app.dSYM.zip` file is found next to `app.ipa`. In case it is located in a different place you can specify the path explicitly in the `:dsym` parameter.
  More information about the available options can be found in the [HockeyApp Docs](http://support.hockeyapp.net/kb/api/api-versions#upload-version).
 */
@@ -4664,9 +4664,9 @@ func pem(development: Bool = false,
    - betaAppDescription: Provide the 'Beta App Description' when uploading a new build
    - betaAppFeedbackEmail: Provide the beta app email when uploading a new build
    - localizedBuildInfo: Localized beta app test info for what's new
-   - changelog: Provide the 'What to Test' text when uploading a new build.
+   - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
-   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps.
+   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
    - usesNonExemptEncryption: Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist
    - distributeExternal: Should the build be distributed to external testers?
@@ -4754,9 +4754,9 @@ func pilot(username: String,
  [31mNo description provided[0m
 
  - parameters:
-   - outputPath:
-   - templatePath:
-   - cachePath:
+   - outputPath: 
+   - templatePath: 
+   - cachePath: 
 */
 func pluginScores(outputPath: String,
                   templatePath: String,
@@ -5517,8 +5517,8 @@ func runTests(workspace: String? = nil,
  Generates a plist file and uploads all to AWS S3
 
  - parameters:
-   - ipa: .ipa file for the build
-   - dsym: zipped .dsym package for the build
+   - ipa: .ipa file for the build 
+   - dsym: zipped .dsym package for the build 
    - uploadMetadata: Upload relevant metadata for this build
    - plistTemplatePath: plist template path
    - plistFileName: uploaded plist filename
@@ -5526,13 +5526,13 @@ func runTests(workspace: String? = nil,
    - htmlFileName: uploaded html filename
    - versionTemplatePath: version erb template path
    - versionFileName: uploaded version filename
-   - accessKey: AWS Access Key ID
-   - secretAccessKey: AWS Secret Access Key
+   - accessKey: AWS Access Key ID 
+   - secretAccessKey: AWS Secret Access Key 
    - bucket: AWS bucket name
-   - region: AWS region (for bucket creation)
-   - path: S3 'path'. Values from Info.plist will be substituted for keys wrapped in {}
-   - source: Optional source directory e.g. ./build
-   - acl: Uploaded object permissions e.g public_read (default), private, public_read_write, authenticated_read
+   - region: AWS region (for bucket creation) 
+   - path: S3 'path'. Values from Info.plist will be substituted for keys wrapped in {}  
+   - source: Optional source directory e.g. ./build 
+   - acl: Uploaded object permissions e.g public_read (default), private, public_read_write, authenticated_read 
 
  Upload a new build to Amazon S3 to distribute the build to beta testers.
  Works for both Ad Hoc and Enterprise signed applications. This step will generate the necessary HTML, plist, and version files for you.
@@ -6139,7 +6139,7 @@ func setupTravis(force: Bool = false) {
    - provisioningName: The name of the profile that is used on the Apple Developer Portal
    - ignoreProfilesWithDifferentName: Use in combination with :provisioning_name - when true only profiles matching this exact name will be downloaded
    - outputPath: Directory in which the profile should be stored
-   - certId: The ID of the code signing certificate to use (e.g. 78ADL6LVAA)
+   - certId: The ID of the code signing certificate to use (e.g. 78ADL6LVAA) 
    - certOwnerName: The certificate name to use for new profiles, or to renew with. (e.g. "Felix Krause")
    - filename: Filename to use for the generated provisioning profile (must include .mobileprovision)
    - skipFetchProfiles: Skips the verification of existing profiles which is useful if you have thousands of profiles
@@ -6265,7 +6265,7 @@ func slackTrain() {
 }
 
 /**
-
+ 
 */
 func slackTrainCrash() {
   let command = RubyCommand(commandID: "", methodName: "slack_train_crash", className: nil, args: [])
@@ -7012,7 +7012,7 @@ func testfairy(apiKey: String,
    - localizedBuildInfo: Localized beta app test info for what's new
    - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
-   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps.
+   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
    - usesNonExemptEncryption: Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist
    - distributeExternal: Should the build be distributed to external testers?
@@ -7226,9 +7226,9 @@ func updateAppIdentifier(xcodeproj: String,
    - nightly: **DEPRECATED!** Nightly builds are no longer being made available - Opt-in to install and use nightly fastlane builds
 
  This action will update fastlane to the most recent version - major version updates will not be performed automatically, as they might include breaking changes. If an update was performed, fastlane will be restarted before the run continues.
-
+ 
  If you are using rbenv or rvm, everything should be good to go. However, if you are using the system's default ruby, some additional setup is needed for this action to work correctly. In short, fastlane needs to be able to access your gem library without running in `sudo` mode.
-
+ 
  The simplest possible fix for this is putting the following lines into your `~/.bashrc` or `~/.zshrc` file:|
  |
  ```bash|
@@ -7237,7 +7237,7 @@ func updateAppIdentifier(xcodeproj: String,
  ```|
  >|
  After the above changes, restart your terminal, then run `mkdir $GEM_HOME` to create the new gem directory. After this, you're good to go!
-
+ 
  Recommended usage of the `update_fastlane` action is at the top inside of the `before_all` block, before running any other action.
 */
 func updateFastlane(noUpdate: Bool = false,
@@ -7573,7 +7573,7 @@ func uploadSymbolsToSentry(apiHost: String = "https://app.getsentry.com/api/0",
    - app: The (spaceship) app ID of the app you want to use/modify
 
  Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.
-
+ 
  If you don't want a PDF report for App Store builds, use the `:force` option.
  This is useful when running _fastlane_ on your Continuous Integration server:
  `_upload_to_app_store_(force: true)`
@@ -7831,7 +7831,7 @@ func uploadToPlayStore(packageName: String,
    - localizedBuildInfo: Localized beta app test info for what's new
    - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
-   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps.
+   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
    - usesNonExemptEncryption: Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist
    - distributeExternal: Should the build be distributed to external testers?
@@ -8340,7 +8340,7 @@ func parseInt(fromString: String, function: String = #function) -> Int {
   verbose(message: "parsing an Int from data: \(fromString), from function: \(function)")
   return NSString(string: fromString.trimmingCharacters(in: .punctuationCharacters)).integerValue
 }
-
+      
 let deliverfile: Deliverfile = Deliverfile()
 let gymfile: Gymfile = Gymfile()
 let matchfile: Matchfile = Matchfile()

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -173,7 +173,7 @@ func appaloosa(binary: String,
    - note: Notes you wish to add to the uploaded app
 
  If you provide a `public_key`, this will overwrite an existing application. If you want to have this build as a new app version, you shouldn't provide this value.
- 
+
  To integrate appetize into your GitHub workflow check out the [device_grid guide](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/device_grid/README.md).
 */
 func appetize(apiHost: String = "api.appetize.io",
@@ -484,7 +484,7 @@ func appledoc(input: Any,
    - app: The (spaceship) app ID of the app you want to use/modify
 
  Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.
- 
+
  If you don't want a PDF report for App Store builds, use the `:force` option.
  This is useful when running _fastlane_ on your Continuous Integration server:
  `_upload_to_app_store_(force: true)`
@@ -1732,7 +1732,7 @@ func checkAppStoreMetadata(appIdentifier: String,
  - parameter excludePattern: Exclude all files from clearing that match the given Regex pattern: e.g. '.*.mobileprovision'
 
  This action deletes the files that get created in your repo as a result of running the _gym_ and _sigh_ commands. It doesn't delete the `fastlane/report.xml` though, this is probably more suited for the .gitignore.
- 
+
  Useful if you quickly want to send out a test build by dropping down to the command line and typing something like `fastlane beta`, without leaving your repo in a messy state afterwards.
 */
 func cleanBuildArtifacts(excludePattern: String? = nil) {
@@ -2312,7 +2312,7 @@ func deleteKeychain(name: String? = nil,
    - app: The (spaceship) app ID of the app you want to use/modify
 
  Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.
- 
+
  If you don't want a PDF report for App Store builds, use the `:force` option.
  This is useful when running _fastlane_ on your Continuous Integration server:
  `_upload_to_app_store_(force: true)`
@@ -3105,7 +3105,7 @@ func getManagedPlayStorePublishingRights(jsonKey: String? = nil,
    - provisioningName: The name of the profile that is used on the Apple Developer Portal
    - ignoreProfilesWithDifferentName: Use in combination with :provisioning_name - when true only profiles matching this exact name will be downloaded
    - outputPath: Directory in which the profile should be stored
-   - certId: The ID of the code signing certificate to use (e.g. 78ADL6LVAA) 
+   - certId: The ID of the code signing certificate to use (e.g. 78ADL6LVAA)
    - certOwnerName: The certificate name to use for new profiles, or to renew with. (e.g. "Felix Krause")
    - filename: Filename to use for the generated provisioning profile (must include .mobileprovision)
    - skipFetchProfiles: Skips the verification of existing profiles which is useful if you have thousands of profiles
@@ -3735,7 +3735,7 @@ func hipchat(message: String = "",
 
  HockeyApp will be no longer supported and will be transitioned into App Center on November 16, 2019.
  Please migrate over to [App Center](https://github.com/Microsoft/fastlane-plugin-appcenter/)
- 
+
  Symbols will also be uploaded automatically if a `app.dSYM.zip` file is found next to `app.ipa`. In case it is located in a different place you can specify the path explicitly in the `:dsym` parameter.
  More information about the available options can be found in the [HockeyApp Docs](http://support.hockeyapp.net/kb/api/api-versions#upload-version).
 */
@@ -4664,9 +4664,9 @@ func pem(development: Bool = false,
    - betaAppDescription: Provide the 'Beta App Description' when uploading a new build
    - betaAppFeedbackEmail: Provide the beta app email when uploading a new build
    - localizedBuildInfo: Localized beta app test info for what's new
-   - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
+   - changelog: Provide the 'What to Test' text when uploading a new build.
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
-   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)
+   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps.
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
    - usesNonExemptEncryption: Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist
    - distributeExternal: Should the build be distributed to external testers?
@@ -4754,9 +4754,9 @@ func pilot(username: String,
  [31mNo description provided[0m
 
  - parameters:
-   - outputPath: 
-   - templatePath: 
-   - cachePath: 
+   - outputPath:
+   - templatePath:
+   - cachePath:
 */
 func pluginScores(outputPath: String,
                   templatePath: String,
@@ -5517,8 +5517,8 @@ func runTests(workspace: String? = nil,
  Generates a plist file and uploads all to AWS S3
 
  - parameters:
-   - ipa: .ipa file for the build 
-   - dsym: zipped .dsym package for the build 
+   - ipa: .ipa file for the build
+   - dsym: zipped .dsym package for the build
    - uploadMetadata: Upload relevant metadata for this build
    - plistTemplatePath: plist template path
    - plistFileName: uploaded plist filename
@@ -5526,13 +5526,13 @@ func runTests(workspace: String? = nil,
    - htmlFileName: uploaded html filename
    - versionTemplatePath: version erb template path
    - versionFileName: uploaded version filename
-   - accessKey: AWS Access Key ID 
-   - secretAccessKey: AWS Secret Access Key 
+   - accessKey: AWS Access Key ID
+   - secretAccessKey: AWS Secret Access Key
    - bucket: AWS bucket name
-   - region: AWS region (for bucket creation) 
-   - path: S3 'path'. Values from Info.plist will be substituted for keys wrapped in {}  
-   - source: Optional source directory e.g. ./build 
-   - acl: Uploaded object permissions e.g public_read (default), private, public_read_write, authenticated_read 
+   - region: AWS region (for bucket creation)
+   - path: S3 'path'. Values from Info.plist will be substituted for keys wrapped in {}
+   - source: Optional source directory e.g. ./build
+   - acl: Uploaded object permissions e.g public_read (default), private, public_read_write, authenticated_read
 
  Upload a new build to Amazon S3 to distribute the build to beta testers.
  Works for both Ad Hoc and Enterprise signed applications. This step will generate the necessary HTML, plist, and version files for you.
@@ -6139,7 +6139,7 @@ func setupTravis(force: Bool = false) {
    - provisioningName: The name of the profile that is used on the Apple Developer Portal
    - ignoreProfilesWithDifferentName: Use in combination with :provisioning_name - when true only profiles matching this exact name will be downloaded
    - outputPath: Directory in which the profile should be stored
-   - certId: The ID of the code signing certificate to use (e.g. 78ADL6LVAA) 
+   - certId: The ID of the code signing certificate to use (e.g. 78ADL6LVAA)
    - certOwnerName: The certificate name to use for new profiles, or to renew with. (e.g. "Felix Krause")
    - filename: Filename to use for the generated provisioning profile (must include .mobileprovision)
    - skipFetchProfiles: Skips the verification of existing profiles which is useful if you have thousands of profiles
@@ -6265,7 +6265,7 @@ func slackTrain() {
 }
 
 /**
- 
+
 */
 func slackTrainCrash() {
   let command = RubyCommand(commandID: "", methodName: "slack_train_crash", className: nil, args: [])
@@ -7012,7 +7012,7 @@ func testfairy(apiKey: String,
    - localizedBuildInfo: Localized beta app test info for what's new
    - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
-   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)
+   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps.
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
    - usesNonExemptEncryption: Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist
    - distributeExternal: Should the build be distributed to external testers?
@@ -7226,9 +7226,9 @@ func updateAppIdentifier(xcodeproj: String,
    - nightly: **DEPRECATED!** Nightly builds are no longer being made available - Opt-in to install and use nightly fastlane builds
 
  This action will update fastlane to the most recent version - major version updates will not be performed automatically, as they might include breaking changes. If an update was performed, fastlane will be restarted before the run continues.
- 
+
  If you are using rbenv or rvm, everything should be good to go. However, if you are using the system's default ruby, some additional setup is needed for this action to work correctly. In short, fastlane needs to be able to access your gem library without running in `sudo` mode.
- 
+
  The simplest possible fix for this is putting the following lines into your `~/.bashrc` or `~/.zshrc` file:|
  |
  ```bash|
@@ -7237,7 +7237,7 @@ func updateAppIdentifier(xcodeproj: String,
  ```|
  >|
  After the above changes, restart your terminal, then run `mkdir $GEM_HOME` to create the new gem directory. After this, you're good to go!
- 
+
  Recommended usage of the `update_fastlane` action is at the top inside of the `before_all` block, before running any other action.
 */
 func updateFastlane(noUpdate: Bool = false,
@@ -7573,7 +7573,7 @@ func uploadSymbolsToSentry(apiHost: String = "https://app.getsentry.com/api/0",
    - app: The (spaceship) app ID of the app you want to use/modify
 
  Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.
- 
+
  If you don't want a PDF report for App Store builds, use the `:force` option.
  This is useful when running _fastlane_ on your Continuous Integration server:
  `_upload_to_app_store_(force: true)`
@@ -7831,7 +7831,7 @@ func uploadToPlayStore(packageName: String,
    - localizedBuildInfo: Localized beta app test info for what's new
    - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
-   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)
+   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps.
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
    - usesNonExemptEncryption: Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist
    - distributeExternal: Should the build be distributed to external testers?
@@ -8340,7 +8340,7 @@ func parseInt(fromString: String, function: String = #function) -> Int {
   verbose(message: "parsing an Int from data: \(fromString), from function: \(function)")
   return NSString(string: fromString.trimmingCharacters(in: .punctuationCharacters)).integerValue
 }
-      
+
 let deliverfile: Deliverfile = Deliverfile()
 let gymfile: Gymfile = Gymfile()
 let matchfile: Matchfile = Matchfile()

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -6,7 +6,7 @@ module FastlaneCore
   class BuildWatcher
     class << self
       # @return The build we waited for. This method will always return a build
-      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, app_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false, requires_full_processing: true, return_spaceship_testflight_build: true)
+      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, app_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false, skip_full_processing: false, return_spaceship_testflight_build: true)
         # Warn about train_version being removed in the future
         if train_version
           UI.deprecated(":train_version is no longer a used argument on FastlaneCore::BuildWatcher. Please use :app_version instead.")
@@ -36,7 +36,7 @@ module FastlaneCore
           # block the worker running this task until it is completed. In some cases,
           # having a build resource appear in AppStoreConnect (matched_build) may be enough (i.e. setting a changelog)
           # so here we may choose to skip the full processing of the build if requires_full_processing == false
-          if matched_build && (requires_full_processing == false || matched_build.processed?)
+          if matched_build && (skip_full_processing || matched_build.processed?)
             if return_spaceship_testflight_build
               return matched_build.to_testflight_build
             else

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -6,7 +6,7 @@ module FastlaneCore
   class BuildWatcher
     class << self
       # @return The build we waited for. This method will always return a build
-      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, app_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false, skip_full_processing: false, return_spaceship_testflight_build: true)
+      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, app_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false, return_when_build_appears: false, return_spaceship_testflight_build: true)
         # Warn about train_version being removed in the future
         if train_version
           UI.deprecated(":train_version is no longer a used argument on FastlaneCore::BuildWatcher. Please use :app_version instead.")
@@ -35,8 +35,8 @@ module FastlaneCore
           # Processing of builds by AppStoreConnect can be a very time consuming task and will
           # block the worker running this task until it is completed. In some cases,
           # having a build resource appear in AppStoreConnect (matched_build) may be enough (i.e. setting a changelog)
-          # so here we may choose to skip the full processing of the build if requires_full_processing == false
-          if matched_build && (skip_full_processing || matched_build.processed?)
+          # so here we may choose to skip the full processing of the build if return_when_build_appears is true
+          if matched_build && (return_when_build_appears || matched_build.processed?)
             if return_spaceship_testflight_build
               return matched_build.to_testflight_build
             else

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -6,7 +6,7 @@ module FastlaneCore
   class BuildWatcher
     class << self
       # @return The build we waited for. This method will always return a build
-      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, app_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false, return_spaceship_testflight_build: true)
+      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, app_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false, requires_full_processing: true, return_spaceship_testflight_build: true)
         # Warn about train_version being removed in the future
         if train_version
           UI.deprecated(":train_version is no longer a used argument on FastlaneCore::BuildWatcher. Please use :app_version instead.")
@@ -32,7 +32,11 @@ module FastlaneCore
 
           report_status(build: matched_build)
 
-          if matched_build && matched_build.processed?
+          # Processing of builds by AppStoreConnect can be a very time consuming task and will
+          # block the worker running this task until it is completed. In some cases,
+          # having a build resource appear in AppStoreConnect (matched_build) may be enough (i.e. setting a changelog)
+          # so here we may choose to skip the full processing of the build if requires_full_processing == false
+          if matched_build && (requires_full_processing == false || matched_build.processed?)
             if return_spaceship_testflight_build
               return matched_build.to_testflight_build
             else

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -37,6 +37,15 @@ describe FastlaneCore::BuildWatcher do
       expect(found_build).to eq(ready_build)
     end
 
+    it 'returns a build that is still processing when return_when_build_appears is true' do
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([processing_build])
+
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_when_build_appears: true, return_spaceship_testflight_build: false)
+
+      expect(found_build).to eq(processing_build)
+    end
+
     it 'returns a ready to submit build with train_version and build_version truncated' do
       expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([])
       expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([ready_build])

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -155,10 +155,12 @@ module Pilot
         end
       end
 
-      # Meta can be uploaded for a build still in processing so
-      # Returning before distribute if skip_waiting_for_build_processing
-      # because can't distribute an app that is still processing
-      return if options[:skip_waiting_for_build_processing] && !build.ready_for_internal_testing?
+      if !build.ready_for_internal_testing? && options[:skip_waiting_for_build_processing]
+        # Meta can be uploaded for a build still in processing
+        # Returning before distribute if skip_waiting_for_build_processing
+        # because can't distribute an app that is still processing
+        return
+      end
 
       distribute_build(build, options)
       type = options[:distribute_external] ? 'External' : 'Internal'

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -44,7 +44,7 @@ module Pilot
       skip_full_processing = false
       if config[:skip_waiting_for_build_processing]
         if config[:changelog].nil?
-          UI.important("`skip_waiting_for_build_processing` used, and no `changelog` supplied - skipping waiting for build processing")
+          UI.important("`skip_waiting_for_build_processing` used and no `changelog` supplied - skipping waiting for build processing")
           return
         else
           skip_full_processing = true
@@ -55,7 +55,7 @@ module Pilot
       login unless should_login_in_start
 
       UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-      UI.message("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the rest of the processing steps.")
+      UI.message("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
 
       latest_build = wait_for_build_processing_to_be_complete(skip_full_processing)
       distribute(options, build: latest_build)

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -132,7 +132,9 @@ module Pilot
         FastlaneCore::ConfigItem.new(key: :skip_waiting_for_build_processing,
                                      short_option: "-z",
                                      env_name: "PILOT_SKIP_WAITING_FOR_BUILD_PROCESSING",
-                                     description: "Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)",
+                                     description: "If set to true, the `distribute_external` option won't work and no build will be distributed to testers. " \
+                                      "(You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). " \
+                                      "If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :update_build_info_on_upload,

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -98,8 +98,15 @@ describe "Build Manager" do
         })
       ]
     end
+    let(:build_beta_detail_still_processing) do
+      Spaceship::ConnectAPI::BuildBetaDetail.new("321", {
+        internal_build_state: Spaceship::ConnectAPI::BuildBetaDetail::InternalState::PROCESSING,
+        external_build_state: Spaceship::ConnectAPI::BuildBetaDetail::ExternalState::PROCESSING
+      })
+    end
     let(:build_beta_detail) do
       Spaceship::ConnectAPI::BuildBetaDetail.new("321", {
+        internal_build_state: Spaceship::ConnectAPI::BuildBetaDetail::InternalState::READY_FOR_BETA_TESTING,
         external_build_state: Spaceship::ConnectAPI::BuildBetaDetail::ExternalState::READY_FOR_BETA_SUBMISSION
       })
     end
@@ -151,6 +158,18 @@ describe "Build Manager" do
     end
 
     describe "distribute success" do
+      let(:distribute_options_skip_waiting_non_localized_changelog) do
+        {
+          apple_id: 'mock_apple_id',
+          app_identifier: 'mock_app_id',
+          distribute_external: false,
+          skip_submission: false,
+          skip_waiting_for_build_processing: true,
+          notify_external_testers: true,
+          uses_non_exempt_encryption: false,
+          changelog: "log of changing"
+        }
+      end
       let(:distribute_options_non_localized) do
         {
           apple_id: 'mock_apple_id',
@@ -177,11 +196,59 @@ describe "Build Manager" do
         # Allow build to return app, buidl_beta_detail, and pre_release_version
         # These are models that are expected to usually be included in the build passed into distribute
         allow(ready_to_submit_mock_build).to receive(:app).and_return(app)
-        allow(ready_to_submit_mock_build).to receive(:build_beta_detail).and_return(build_beta_detail)
         allow(ready_to_submit_mock_build).to receive(:pre_release_version).and_return(pre_release_version)
       end
 
-      it "updates non-localized  demo_account_required, notify_external_testers, beta_app_feedback_email, and beta_app_description" do
+      it "updates non-localized changelog and doesn't distribute" do
+        allow(ready_to_submit_mock_build).to receive(:build_beta_detail).and_return(build_beta_detail_still_processing)
+
+        options = distribute_options_skip_waiting_non_localized_changelog
+
+        # Expect a beta app review detail to be patched
+        expect(Spaceship::ConnectAPI).to receive(:patch_beta_app_review_detail).with({
+          app_id: ready_to_submit_mock_build.app_id,
+          attributes: { demoAccountRequired: options[:demo_account_required] }
+        })
+
+        # Expect beta build localizations to be fetched
+        expect(Spaceship::ConnectAPI).to receive(:get_beta_build_localizations).with({
+          filter: { build: ready_to_submit_mock_build.id },
+          includes: nil,
+          limit: nil,
+          sort: nil
+        }).and_return(Spaceship::ConnectAPI::Response.new)
+        expect(ready_to_submit_mock_build).to receive(:get_beta_build_localizations).and_wrap_original do |m, *args|
+          m.call(*args)
+          build_localizations
+        end
+
+        # Expect beta build localizations to be patched with a UI.success after
+        mock_api_client_beta_build_localizations.each do |localization|
+          expect(Spaceship::ConnectAPI).to receive(:patch_beta_build_localizations).with({
+            localization_id: localization['id'],
+            attributes: {
+              whatsNew: options[:changelog]
+            }
+          })
+        end
+        expect(FastlaneCore::UI).to receive(:success).with("Successfully set the changelog for build")
+
+        # Expect build beta details to be patched
+        expect(Spaceship::ConnectAPI).to receive(:patch_build_beta_details).with({
+          build_beta_details_id: build_beta_detail.id,
+          attributes: { autoNotifyEnabled: options[:notify_external_testers] }
+        })
+
+        # Don't expect success messages
+        expect(FastlaneCore::UI).to_not(receive(:message).with(/Distributing new build to testers/))
+        expect(FastlaneCore::UI).to_not(receive(:success).with(/Successfully distributed build to/))
+
+        fake_build_manager.distribute(options, build: ready_to_submit_mock_build)
+      end
+
+      it "updates non-localized demo_account_required, notify_external_testers, beta_app_feedback_email, and beta_app_description and distributes" do
+        allow(ready_to_submit_mock_build).to receive(:build_beta_detail).and_return(build_beta_detail)
+
         options = distribute_options_non_localized
 
         # Expect App.find to be called from within Pilot::Manager
@@ -278,7 +345,7 @@ describe "Build Manager" do
           m.call(*args)
         end
 
-        # Except success messages
+        # Expect success messages
         expect(FastlaneCore::UI).to receive(:message).with(/Distributing new build to testers/)
         expect(FastlaneCore::UI).to receive(:success).with(/Successfully distributed build to/)
 

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -78,6 +78,11 @@ module Spaceship
         return processing_state != ProcessingState::PROCESSING
       end
 
+      def ready_for_internal_testing?
+        raise "No build_beta_detail included" unless build_beta_detail
+        return build_beta_detail.ready_for_internal_testing?
+      end
+
       def ready_for_beta_submission?
         raise "No build_beta_detail included" unless build_beta_detail
         return build_beta_detail.ready_for_beta_submission?

--- a/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
@@ -47,6 +47,10 @@ module Spaceship
       #
       # Helpers
       #
+      #
+      def ready_for_internal_testing?
+        return internal_build_state == InternalState::READY_FOR_BETA_TESTING
+      end
 
       def ready_for_beta_submission?
         return external_build_state == ExternalState::READY_FOR_BETA_SUBMISSION

--- a/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
@@ -10,6 +10,7 @@ module Spaceship
       attr_accessor :external_build_state
 
       module InternalState
+        PROCESSING = "PROCESSING"
         PROCESSING_EXCEPTION = "PROCESSING_EXCEPTION"
         MISSING_EXPORT_COMPLIANCE = "MISSING_EXPORT_COMPLIANCE"
         READY_FOR_BETA_TESTING = "READY_FOR_BETA_TESTING"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The current `upload_to_testflight` action allows users to submit a `changelog` to AppStoreConnect once the build has completed processing.

It turns out that **full** processing is actually not required for the changelog to be submitted. Once a build **appears** in AppStoreConnect, we are able to send the changelog information upstream without waiting for the full processing of the build to occur.

The goal of this PR is to introduce a slight change in behavior to `upload_to_testflight`, where if a user specifically sets `skip_waiting_for_build_processing` to `true` but also includes a `changelog`, we honor the changelog request by only waiting until the build appears on AppStoreConnect, and then bailing (the current behavior is to simply ignore the changelog, which is often un-intuitive and most likely undesirable).

### Description

This PR changes the internal of `build_manager` and `build_watcher` slightly.

On `build_manager` we determine whether the `skip_waiting_for_build_processing` was set to `true` and `changelog` is not `nil`.

Under this condition, we pass a new `skip_full_processing` variable to the `build_watcher` that allows us to poll the build on AppStoreConnect and bypass the most time consuming part of the processing which happens after the build appears on AppStoreConnect.

Note that this change is an implementation detail that hasn't had any effect on existing tests. I'd be more than happy to add a new test for this scenario but based on the existing tests it felt unnecessary and perhaps redundant but I'm happy to be convinced otherwise.

### Testing Steps

Run `fastlane run testflight skip_waiting_for_build_processing:true changelog:"test"` and ensure that once an IPA is uploaded, that the polling of the build only waits for the build to appear on AppStoreConnect and successfuly exist the process.
