### PR TITLE
[action] force google_play_track_version_codes to return array of ints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
 
   "Validate Documentation":
     docker:
-      - image: circleci/ruby:2.3
+      - image: circleci/ruby:2.4
     steps:
       - checkout
 

--- a/fastlane/lib/fastlane/actions/google_play_track_version_codes.rb
+++ b/fastlane/lib/fastlane/actions/google_play_track_version_codes.rb
@@ -23,7 +23,8 @@ module Fastlane
         # AndroidpublisherV3 returns version codes as array of strings
         # even though version codes need to be integers
         # https://github.com/fastlane/fastlane/issues/15622
-        (Supply::Reader.new.track_version_codes || []).flat_map(&:to_i)
+        version_codes = Supply::Reader.new.track_version_codes || []
+        return version_codes.compact.map(&:to_i)
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/google_play_track_version_codes.rb
+++ b/fastlane/lib/fastlane/actions/google_play_track_version_codes.rb
@@ -20,7 +20,10 @@ module Fastlane
 
         Supply.config = params
 
-        Supply::Reader.new.track_version_codes
+        # AndroidpublisherV3 returns version codes as array of strings
+        # even though version codes need to be integers
+        # https://github.com/fastlane/fastlane/issues/15622
+        (Supply::Reader.new.track_version_codes || []).flat_map(&:to_i)
       end
 
       #####################################################


### PR DESCRIPTION
### Motivation and Context
Fixes #15622

### Description
`AndroidpublisherV2` previously returned version codes as array of integers but `AndroidpublisherV3` now returns array of strings. Version codes can only be strings (otherwise `gradle` will 💣 ) so mapping strings to integers for this actions.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
