### PR TITLE
[screengrab] update bintray plugin to 0.9.1 so releases work again

### DIFF
--- a/screengrab/screengrab-lib/build.gradle
+++ b/screengrab/screengrab-lib/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.8.1'
+        classpath 'com.novoda:bintray-release:0.9.1'
     }
 }
 


### PR DESCRIPTION
### Motivation and Context
Needed to be able to release to bintray

### Description
Upgraded to the latest version 😊 Proof it worked 👉  https://bintray.com/fastlane/fastlane/screengrab/2.0.0
