### PR TITLE
[supply] fixes some issue with version codes not being found and allows promote with rollout now

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -19,11 +19,12 @@ module Supply
       # Updating a track with empty version codes can completely clear out a track
       update_track(apk_version_codes) unless apk_version_codes.empty?
 
-      if !Supply.config[:rollout].nil? && Supply.config[:track].to_s != ""
+      if Supply.config[:track_promote_to]
+        promote_track
+      elsif !Supply.config[:rollout].nil? && Supply.config[:track].to_s != ""
         update_rollout
       end
 
-      promote_track if Supply.config[:track_promote_to]
 
       if Supply.config[:validate_only]
         UI.message("Validating all track and release changes with Google Play...")
@@ -42,7 +43,12 @@ module Supply
       client.begin_edit(package_name: Supply.config[:package_name])
 
       if (!Supply.config[:skip_upload_metadata] || !Supply.config[:skip_upload_images] || !Supply.config[:skip_upload_changelogs] || !Supply.config[:skip_upload_screenshots]) && metadata_path
+        # Use version code from config if version codes is empty and no nil or empty string
         version_codes = [Supply.config[:version_code]] if version_codes.empty?
+        version_codes = version_codes.select do |version_code|
+          version_codes.to_s != "" 
+        end
+
         version_codes.each do |version_code|
           UI.user_error!("Could not find folder #{metadata_path}") unless File.directory?(metadata_path)
 
@@ -84,8 +90,9 @@ module Supply
 
       track = tracks.first
       releases = track.releases
+
       releases = releases.select { |r| r.status == status } if status
-      releases = releases.select { |r| r.version_codes.map(&:to_s).include?(version_code.to_s) }
+      releases = releases.select { |r| r.version_codes.map(&:to_s).include?(version_code.to_s) } if version_code
 
       if releases.size > 1
         UI.user_error!("More than one release found in this track. Please specify with the :version_code option to select a release.")
@@ -96,10 +103,12 @@ module Supply
 
     def update_rollout
       track, release = fetch_track_and_release!(Supply.config[:track], Supply.config[:version_code], Supply::ReleaseStatus::IN_PROGRESS)
+      UI.user_error!("Unable to find the requested track - '#{Supply.config[:track]}'") unless track
+      UI.user_error!("Unable to find the requested release on track - '#{Supply.config[:track]}'") unless release
+
       version_code = release.version_codes.first
 
       UI.message("Updating #{version_code}'s rollout to '#{Supply.config[:rollout]}' on track '#{Supply.config[:track]}'...")
-      UI.user_error!("Unable to find the requested track - '#{Supply.config[:track]}'") unless track
 
       if track && release
         completed = Supply.config[:rollout].to_f == 1
@@ -149,6 +158,10 @@ module Supply
         releases = releases.select do |release|
           release.version_codes.include?(Supply.config[:version_code].to_s)
         end
+      else
+        releases = releases.select do |release|
+          release.status == Supply::ReleaseStatus::COMPLETED
+        end
       end
 
       if releases.size == 0
@@ -157,8 +170,16 @@ module Supply
         UI.user_error!("Track '#{Supply.config[:track]}' has more than one release - use :version_code to filter the release to promote")
       end
 
-      release = track_from.releases.first
+      release = releases.first
       track_to = client.tracks(Supply.config[:track_promote_to]).first
+
+      if Supply.config[:rollout]
+        release.status = Supply::ReleaseStatus::IN_PROGRESS
+        release.user_fraction = Supply.config[:rollout]
+      else
+        release.status = Supply::ReleaseStatus::COMPLETED
+        release.user_fraction = nil
+      end
 
       if track_to
         # Its okay to set releases to an array containing the newest release

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -25,7 +25,6 @@ module Supply
         update_rollout
       end
 
-
       if Supply.config[:validate_only]
         UI.message("Validating all track and release changes with Google Play...")
         client.validate_current_edit!
@@ -45,8 +44,8 @@ module Supply
       if (!Supply.config[:skip_upload_metadata] || !Supply.config[:skip_upload_images] || !Supply.config[:skip_upload_changelogs] || !Supply.config[:skip_upload_screenshots]) && metadata_path
         # Use version code from config if version codes is empty and no nil or empty string
         version_codes = [Supply.config[:version_code]] if version_codes.empty?
-        version_codes = version_codes.select do |version_code|
-          version_codes.to_s != "" 
+        version_codes = version_codes.reject do |version_code|
+          version_codes.to_s == ""
         end
 
         version_codes.each do |version_code|

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -182,9 +182,14 @@ describe Supply do
         allow(client).to receive(:track_version_codes).and_return(version_codes)
         allow(client).to receive(:update_track).with(config[:track], 0.1, nil)
         allow(client).to receive(:update_track).with(config[:track_promote_to], 0.1, version_codes)
+
+        allow(release).to receive(:status).and_return(Supply::ReleaseStatus::COMPLETED)
       end
 
       it 'should only update track once' do
+        expect(release).to receive(:status=).with(Supply::ReleaseStatus::COMPLETED)
+        expect(release).to receive(:user_fraction=).with(nil)
+
         expect(client).not_to(receive(:update_track).with(config[:track], anything))
         expect(client).to receive(:update_track).with(config[:track_promote_to], track).once
         subject


### PR DESCRIPTION
### Motivation and Context
Fixes #15644
Fixes #15638
Fixed #15639

### Description
- Promote and rollout
  - These two used to be able to work on top each other but it seemed like it wasn't behaving properly
  - Promote
    - Looks for a completed status release and promotes that (unless a version code is specified)
    - It will then set the status as "in progress" and a user fraction if `:rollout` is percentage (this fixes an issue where a promote couldn't be rollout - it had to be completed)
- Fixed issue in `fetch_track_and_release` where it was filtering over version code if version code was nil so added an if check there
