### PR TITLE
[Fastlane.swift] default tool hash to [:] not {} and test swift generation on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,44 @@ jobs:
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
 
+  "Validate Fastlane.swift Generation":
+    macos:
+      xcode: "11.0.0"
+    environment:
+      CIRCLE_TEST_REPORTS: ~/test-reports
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+    shell: /bin/bash --login -eo pipefail
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+      - restore_cache:
+          keys:
+            - v3-homebrew-{{ epoch }}
+            - v3-homebrew
+      - run:
+          name: Setup Build
+          command: |
+            mkdir -p ~/test-reports
+            echo "2.5" > .ruby-version
+            gem update --system
+            brew untap caskroom/versions
+            brew install shellcheck
+            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
+
+      - save_cache:
+          key: v3-homebrew-{{ epoch }}
+          paths:
+            - /usr/local/Homebrew
+      - save_cache:
+          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+          paths:
+            - .bundle
+
+      - run: bundle exec fastlane generate_swift_api 
+
   "Validate Documentation":
     docker:
       - image: circleci/ruby:2.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,53 +121,6 @@ jobs:
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
 
-  "Execute tests on Ubuntu2":
-    environment:
-      CIRCLE_TEST_REPORTS: ~/test-reports
-      LC_ALL: C.UTF-8
-      LANG: C.UTF-8
-      FASTLANE_ITUNES_TRANSPORTER_PATH: .bundle
-    docker:
-      - image: fastlanetools/ci:0.1.0
-    steps:
-      - checkout
-
-      - restore_cache:
-          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-      - run:
-          name: Setup Build
-          command: |
-            mkdir -p ~/test-reports
-            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
-      - save_cache:
-          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-          paths:
-            - .bundle
-
-      - run:
-          name: Check PR Metadata
-          command: bundle exec danger || echo "danger failed"
-
-      - restore_cache:
-          key: v1-{{ arch }}-rubocop
-
-      - run: bundle exec fastlane execute_tests
-
-      - save_cache:
-          key: v1-{{ arch }}-rubocop
-          paths:
-            - ~/.cache/rubocop_cache
-      - store_test_results:
-          path: ~/test-reports
-      - store_artifacts:
-          path: ~/test-reports/rspec
-          destination: test-reports
-
-      - run:
-          name: Post Test Results to GitHub
-          command: bundle exec danger || echo "danger failed"
-          when: always # Run this even when tests fail
-
   "Execute tests on Ubuntu":
     environment:
       CIRCLE_TEST_REPORTS: ~/test-reports
@@ -214,6 +167,44 @@ jobs:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
+
+  "Validate Fastlane.swift Generation":
+    macos:
+      xcode: "11.0.0"
+    environment:
+      CIRCLE_TEST_REPORTS: ~/test-reports
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+    shell: /bin/bash --login -eo pipefail
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+      - restore_cache:
+          keys:
+            - v3-homebrew-{{ epoch }}
+            - v3-homebrew
+      - run:
+          name: Setup Build
+          command: |
+            mkdir -p ~/test-reports
+            echo "2.5" > .ruby-version
+            gem update --system
+            brew untap caskroom/versions
+            brew install shellcheck
+            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
+
+      - save_cache:
+          key: v3-homebrew-{{ epoch }}
+          paths:
+            - /usr/local/Homebrew
+      - save_cache:
+          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+          paths:
+            - .bundle
+
+      - run: bundle exec fastlane generate_swift_api
 
   "Validate Documentation":
     docker:
@@ -278,6 +269,7 @@ workflows:
       - "Execute tests on macOS (Xcode 9.0.1, Ruby 2.3)"
       - "Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)"
       - "Execute tests on Ubuntu"
+      - "Validate Fastlane.swift Generation"
       - "Validate Documentation"
       - "Lint Source Code"
       - "Execute modules load up tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,43 +121,52 @@ jobs:
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
 
-  "Execute tests on macOS2 (Xcode 11.0.0, Ruby 2.5)":
-    macos:
-      xcode: "11.0.0"
+  "Execute tests on Ubuntu2":
     environment:
       CIRCLE_TEST_REPORTS: ~/test-reports
-      LC_ALL: en_US.UTF-8
-      LANG: en_US.UTF-8
-    shell: /bin/bash --login -eo pipefail
+      LC_ALL: C.UTF-8
+      LANG: C.UTF-8
+      FASTLANE_ITUNES_TRANSPORTER_PATH: .bundle
+    docker:
+      - image: fastlanetools/ci:0.1.0
     steps:
       - checkout
 
       - restore_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-      - restore_cache:
-          keys:
-            - v3-homebrew-{{ epoch }}
-            - v3-homebrew
+          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
       - run:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            echo "2.5" > .ruby-version
-            gem update --system
-            brew untap caskroom/versions
-            brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
-
       - save_cache:
-          key: v3-homebrew-{{ epoch }}
-          paths:
-            - /usr/local/Homebrew
-      - save_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
           paths:
             - .bundle
 
+      - run:
+          name: Check PR Metadata
+          command: bundle exec danger || echo "danger failed"
+
+      - restore_cache:
+          key: v1-{{ arch }}-rubocop
+
       - run: bundle exec fastlane execute_tests
+
+      - save_cache:
+          key: v1-{{ arch }}-rubocop
+          paths:
+            - ~/.cache/rubocop_cache
+      - store_test_results:
+          path: ~/test-reports
+      - store_artifacts:
+          path: ~/test-reports/rspec
+          destination: test-reports
+
+      - run:
+          name: Post Test Results to GitHub
+          command: bundle exec danger || echo "danger failed"
+          when: always # Run this even when tests fail
 
   "Execute tests on Ubuntu":
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
 
-  "Validate Fastlane.swift Generation":
+  "Validate Swift Generation":
     macos:
       xcode: "11.0.0"
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,44 @@ jobs:
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
 
+  "Execute tests on macOS2 (Xcode 11.0.0, Ruby 2.5)":
+    macos:
+      xcode: "11.0.0"
+    environment:
+      CIRCLE_TEST_REPORTS: ~/test-reports
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
+    shell: /bin/bash --login -eo pipefail
+    steps:
+      - checkout
+
+      - restore_cache:
+          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+      - restore_cache:
+          keys:
+            - v3-homebrew-{{ epoch }}
+            - v3-homebrew
+      - run:
+          name: Setup Build
+          command: |
+            mkdir -p ~/test-reports
+            echo "2.5" > .ruby-version
+            gem update --system
+            brew untap caskroom/versions
+            brew install shellcheck
+            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
+
+      - save_cache:
+          key: v3-homebrew-{{ epoch }}
+          paths:
+            - /usr/local/Homebrew
+      - save_cache:
+          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+          paths:
+            - .bundle
+
+      - run: bundle exec fastlane execute_tests
+
   "Execute tests on Ubuntu":
     environment:
       CIRCLE_TEST_REPORTS: ~/test-reports
@@ -167,44 +205,6 @@ jobs:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
           when: always # Run this even when tests fail
-
-  "Validate Swift Generation":
-    macos:
-      xcode: "11.0.0"
-    environment:
-      CIRCLE_TEST_REPORTS: ~/test-reports
-      LC_ALL: en_US.UTF-8
-      LANG: en_US.UTF-8
-    shell: /bin/bash --login -eo pipefail
-    steps:
-      - checkout
-
-      - restore_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-      - restore_cache:
-          keys:
-            - v3-homebrew-{{ epoch }}
-            - v3-homebrew
-      - run:
-          name: Setup Build
-          command: |
-            mkdir -p ~/test-reports
-            echo "2.5" > .ruby-version
-            gem update --system
-            brew untap caskroom/versions
-            brew install shellcheck
-            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
-
-      - save_cache:
-          key: v3-homebrew-{{ epoch }}
-          paths:
-            - /usr/local/Homebrew
-      - save_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-          paths:
-            - .bundle
-
-      - run: bundle exec fastlane generate_swift_api 
 
   "Validate Documentation":
     docker:

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -147,6 +147,7 @@ module Fastlane
         unless default_value.nil?
           if type == "[String : Any]"
             # we can't handle default values for Hashes, yet
+            # see method swift_default_implementations for similar behavior
             default_value = "[:]"
           elsif type != "Bool" && type != "[String]" && type != "Int" && type != "((String) -> Void)"
             default_value = "\"#{default_value}\""
@@ -343,6 +344,10 @@ module Fastlane
         unless default_value.nil?
           if type == "Bool" || type == "[String]" || type == "Int" || default_value.kind_of?(Array)
             default_value = default_value.to_s
+          elsif default_value.kind_of?(Hash)
+            # we can't handle default values for Hashes, yet
+            # see method parameters for similar behavior
+            default_value = "[:]"
           else
             default_value = "\"#{default_value}\""
           end
@@ -364,6 +369,10 @@ module Fastlane
 
         if type == "[String]"
           default_value ||= "[]"
+        end
+
+        if type == "[String : Any]"
+          default_value ||= "[:]"
         end
 
         "  var #{var_for_parameter_name}: #{type} { return #{default_value} }"

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -347,7 +347,7 @@ module Fastlane
           elsif default_value.kind_of?(Hash)
             # we can't handle default values for Hashes, yet
             # see method parameters for similar behavior
-            default_value = "[:]"
+            #default_value = "[:]"
           else
             default_value = "\"#{default_value}\""
           end

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -347,7 +347,7 @@ module Fastlane
           elsif default_value.kind_of?(Hash)
             # we can't handle default values for Hashes, yet
             # see method parameters for similar behavior
-            #default_value = "[:]"
+            default_value = "[:]"
           else
             default_value = "\"#{default_value}\""
           end


### PR DESCRIPTION
### Motivation and Context
Sometimes Fastlane.swift generation fails after a PR and it is unknown until time for a release. So this PR fixes an issue and also runs a test on Fastlane.swift generation so it can be caught earlier

### Description
- Forces tools to use a default hash value of `[:]`
  - This was previously `{}` which is invalid swift
  - Ideally we'll default hash values with actual values but that's a whole thing and will do another day

