### PR TITLE
[supply] don't apply rollout when value 1 of when uploading and don't call promote or rollout methods when uploading

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -19,7 +19,7 @@ module Supply
         # Only update tracks if we have version codes
         # update_track handle setting rollout if needed
         # Updating a track with empty version codes can completely clear out a track
-        update_track(apk_version_codes) unless apk_version_codes.empty?
+        update_track(apk_version_codes)
       else
         # Only promote or rollout if we don't have version codes
         if Supply.config[:track_promote_to]

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -15,14 +15,18 @@ module Supply
 
       apk_version_codes.concat(Supply.config[:version_codes_to_retain]) if Supply.config[:version_codes_to_retain]
 
-      # Only update tracks if we have version codes
-      # Updating a track with empty version codes can completely clear out a track
-      update_track(apk_version_codes) unless apk_version_codes.empty?
-
-      if Supply.config[:track_promote_to]
-        promote_track
-      elsif !Supply.config[:rollout].nil? && Supply.config[:track].to_s != ""
-        update_rollout
+      if !apk_version_codes.empty?
+        # Only update tracks if we have version codes
+        # update_track handle setting rollout if needed
+        # Updating a track with empty version codes can completely clear out a track
+        update_track(apk_version_codes) unless apk_version_codes.empty?
+      else
+        # Only promote or rollout if we don't have version codes
+        if Supply.config[:track_promote_to]
+          promote_track
+        elsif !Supply.config[:rollout].nil? && Supply.config[:track].to_s != ""
+          update_rollout
+        end
       end
 
       if Supply.config[:validate_only]
@@ -358,8 +362,11 @@ module Supply
       )
 
       if Supply.config[:rollout]
-        track_release.status = Supply::ReleaseStatus::IN_PROGRESS
-        track_release.user_fraction = Supply.config[:rollout].to_f
+        rollout = Supply.config[:rollout].to_f
+        if rollout > 0 && rollout < 1
+          track_release.status = Supply::ReleaseStatus::IN_PROGRESS
+          track_release.user_fraction = rollout
+        end
       end
 
       tracks = client.tracks(Supply.config[:track])


### PR DESCRIPTION
### Motivation and Context
Fixes #15645

When rollout of `1` was sent with an uploaded apk/bundle, `supply` would try to set this which would cause the client to 💥. No reason to rollout of 1 to the client if not rolling out.

### Description
Fixes ☝️ and also not calling `promote_track` or `update_rollout` if apk/bundle is uploaded because  `update_track` does it all for a new apk/bundle.