### PR TITLE
[action] Added custom option to testfairy upload

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -92,6 +92,8 @@ module Fastlane
             [key, value]
           when :options
             [key, options_to_client.call(value).join(',')]
+          when :custom
+            [key, value]
           else
             UI.user_error!("Unknown parameter: #{key}")
           end
@@ -223,6 +225,11 @@ module Fastlane
                                        env_name: "FL_TESTFAIRY_OPTIONS",
                                        description: "Array of options (shake,video_only_wifi,anonymous)",
                                        default_value: []),
+          FastlaneCore::ConfigItem.new(key: :custom,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_CUSTOM",
+                                       description: "Array of custom options. Contact support@testfairy.com for more information",
+                                       default_value: ''),
           FastlaneCore::ConfigItem.new(key: :timeout,
                                        env_name: "FL_TESTFAIRY_TIMEOUT",
                                        description: "Request timeout in seconds",
@@ -252,7 +259,7 @@ module Fastlane
       end
 
       def self.authors
-        ["taka0125", "tcurdt"]
+        ["taka0125", "tcurdt", "vijaysharm"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/spec/actions_specs/testfairy_spec.rb
+++ b/fastlane/spec/actions_specs/testfairy_spec.rb
@@ -110,7 +110,8 @@ describe Fastlane do
               api_key: 'thisistest',
               upload_url: 'https://your-subdomain.testfairy.com',
               comment: 'Test Comment!',
-              testers_groups: ['group1', 'group2']
+              testers_groups: ['group1', 'group2'],
+              custom: 'custom argument'
             })
           end").runner.execute(:test)
         end.not_to(raise_error)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This feature is for some of our clients that requires the need to pass a one-off parameter to our servers while uploading. This is not for general use.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
Ive added a parameter named "custom" that can be used to pass optional strings up to TestFairy while uploading IPAs or APKs. 
<!-- Please describe in detail how you tested your changes. -->
I ran the included the test suites and observed that no errors were found. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I ran the documented command `bundle exec rspec`. 