### PR TITLE
[spaceship] fix launcher create profile

### DIFF
--- a/spaceship/lib/spaceship/launcher.rb
+++ b/spaceship/lib/spaceship/launcher.rb
@@ -73,27 +73,50 @@ module Spaceship
 
     # @return (Class) Access the apps for this spaceship
     def app
+      set_common_client
       Spaceship::Portal::App.set_client(@client)
     end
 
     # @return (Class) Access the app groups for this spaceship
     def app_group
+      set_common_client
       Spaceship::Portal::AppGroup.set_client(@client)
     end
 
     # @return (Class) Access the devices for this spaceship
     def device
+      set_common_client
       Spaceship::Portal::Device.set_client(@client)
     end
 
     # @return (Class) Access the certificates for this spaceship
     def certificate
+      set_common_client
       Spaceship::Portal::Certificate.set_client(@client)
     end
 
     # @return (Class) Access the provisioning profiles for this spaceship
     def provisioning_profile
+      set_common_client
       Spaceship::Portal::ProvisioningProfile.set_client(@client)
+    end
+
+    private
+
+    def set_common_client
+      Spaceship::Portal::AppGroup.set_client(@client)
+      Spaceship::Portal::App.set_client(@client)
+      Spaceship::Portal::Certificate.set_client(@client)
+      Spaceship::Portal::CloudContainer.set_client(@client)
+      Spaceship::Portal::Device.set_client(@client)
+      Spaceship::Portal::Invite.set_client(@client)
+      Spaceship::Portal::Key.set_client(@client)
+      Spaceship::Portal::Merchant.set_client(@client)
+      Spaceship::Portal::Passbook.set_client(@client)
+      Spaceship::Portal::Person.set_client(@client)
+      Spaceship::Portal::Persons.set_client(@client)
+      Spaceship::Portal::ProvisioningProfile.set_client(@client)
+      Spaceship::Portal::WebsitePush.set_client(@client)
     end
   end
 end

--- a/spaceship/lib/spaceship/launcher.rb
+++ b/spaceship/lib/spaceship/launcher.rb
@@ -110,7 +110,6 @@ module Spaceship
       Spaceship::Portal::CloudContainer.set_client(@client)
       Spaceship::Portal::Device.set_client(@client)
       Spaceship::Portal::Invite.set_client(@client)
-      Spaceship::Portal::Key.set_client(@client)
       Spaceship::Portal::Merchant.set_client(@client)
       Spaceship::Portal::Passbook.set_client(@client)
       Spaceship::Portal::Person.set_client(@client)

--- a/spaceship/spec/launcher_spec.rb
+++ b/spaceship/spec/launcher_spec.rb
@@ -70,6 +70,10 @@ describe Spaceship do
       it "shouldn't fail if provisioning_profile creation is invoked before app and device" do
         clean_launcher = Spaceship::Launcher.new
         clean_launcher.login(username, password)
+        
+        expect(clean_launcher.client).to receive(:create_provisioning_profile!).with('Delete Me', 'adhoc', '2UMR2S6PAA', "XC5PH8DAAA", ["AAAAAAAAAA", "BBBBBBBBBB", "CCCCCCCCCC", "DDDDDDDDDD"], mac: false, sub_platform: nil, template_name: nil) do
+          JSON.parse(PortalStubbing.adp_read_fixture_file('create_profile_success.json'))
+        end
 
         expect do
           clean_launcher.provisioning_profile.ad_hoc.create!(

--- a/spaceship/spec/launcher_spec.rb
+++ b/spaceship/spec/launcher_spec.rb
@@ -70,7 +70,7 @@ describe Spaceship do
       it "shouldn't fail if provisioning_profile creation is invoked before app and device" do
         clean_launcher = Spaceship::Launcher.new
         clean_launcher.login(username, password)
-        
+
         expect(clean_launcher.client).to receive(:create_provisioning_profile!).with('Delete Me', 'adhoc', '2UMR2S6PAA', "XC5PH8DAAA", ["AAAAAAAAAA", "BBBBBBBBBB", "CCCCCCCCCC", "DDDDDDDDDD"], mac: false, sub_platform: nil, template_name: nil) do
           JSON.parse(PortalStubbing.adp_read_fixture_file('create_profile_success.json'))
         end

--- a/spaceship/spec/launcher_spec.rb
+++ b/spaceship/spec/launcher_spec.rb
@@ -4,6 +4,7 @@ describe Spaceship do
     let(:password) { 'so_secret' }
     let(:spaceship1) { Spaceship::Launcher.new }
     let(:spaceship2) { Spaceship::Launcher.new }
+    let(:certificate) { Spaceship::Certificate.all.first }
 
     before do
       spaceship1.login(username, password)
@@ -59,10 +60,22 @@ describe Spaceship do
         Spaceship::Certificate.set_client(nil)
         Spaceship::ProvisioningProfile.set_client(nil)
       end
+
       it "shouldn't fail if provisioning_profile is invoked before app and device" do
         clean_launcher = Spaceship::Launcher.new
         clean_launcher.login(username, password)
         expect(clean_launcher.provisioning_profile.all.count).to eq(7)
+      end
+
+      it "shouldn't fail if provisioning_profile creation is invoked before app and device" do
+        clean_launcher = Spaceship::Launcher.new
+        clean_launcher.login(username, password)
+
+        expect do
+          clean_launcher.provisioning_profile.ad_hoc.create!(
+            bundle_id: 'net.sunapps.1', certificate: certificate, name: 'Delete Me'
+          )
+        end.to_not(raise_error)
       end
 
       it "shouldn't fail if trying to create new apns_certificate before app is invoked" do


### PR DESCRIPTION
 [spaceship] fix Spaceship::Launcher raise an error when creating a provisioning profile (#15662)


  
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
FIX issue (#15662)


### Description
add set_common_client to set the client of Spaceship::Portal::XXXX  to fix the issue


### Testing Steps

