### PR TITLE
[screengrab] Skip clean status bar if aapt not found

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -395,6 +395,11 @@ module Screengrab
     def enable_clean_status_bar(device_serial, app_apk_path)
       return unless device_api_version(device_serial) >= 23
 
+      unless @android_env.aapt_path
+        UI.error("The `aapt` command could not be found, so status bar could not be cleaned. Make sure android_home is configured for screengrab or ANDROID_HOME is set in the environment")
+        return
+      end
+
       # Check if the app wants to use the clean status bar feature
       badging_dump = @executor.execute(command: "#{@android_env.aapt_path} dump badging #{app_apk_path}",
                                        print_all: true, print_command: true)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Addresses issue #15674 - Like the validate_apk method, enable_clean_status_bar should also check for aapt before trying to execute `aapt dump badging ...` so it doesn't fail, but just runs screengrab as it would have done in previous versions.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Just added an if check to verify that `@android_env.aapt_path` is not empty. Tested by running `bundle exec fastlane screengrab` on example screengrab project.
