### PR TITLE
[action] fix app_store_build_number so it works with macOS builds.

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -24,7 +24,7 @@ module Fastlane
         Spaceship::Tunes.select_team(team_id: params[:team_id], team_name: params[:team_name])
         UI.message("Login successful")
 
-        app = Spaceship::Tunes::Application.find(params[:app_identifier])
+        app = Spaceship::Tunes::Application.find(params[:app_identifier], mac: params[:platform] == "osx")
         UI.user_error!("Could not find an app on App Store Connect with app_identifier: #{params[:app_identifier]}") unless app
         if params[:live]
           UI.message("Fetching the latest build number for live-version")

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -110,7 +110,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -64,7 +64,7 @@ module Fastlane
                                        is_string: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, or appletvos") unless %('ios', 'appletvos').include?(value)
+                                         UI.user_error!("The platform can only be ios, osx, or appletvos") unless %('osx', ios', 'appletvos').include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",


### PR DESCRIPTION
🔑

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Previously `app_store_build_number` and `latest_testflight_build_number` didn't retrieve the build number for macOS builds submitted to App Store Connect.  This kept us from easily automating build number incrementing for macOS builds.

### Description
The change simply sets the named "mac" parameter appropriately based on the provided parameters when attempting to find an application in `app_store_build_number`.  This allows `Application.find` to use the mac filter when requested and locate the macOS app to return the build number.

There is another change in `latest_testflight_build_number` that allows the "osx" value to be used as the platform parameter since it is now supported by the underlying `app_store_build_number` that `latest_testflight_build_number` calls.

### Testing Steps
Run the commands with platform:"osx" to verify that they work with Mac App Store builds:

`bundle exec fastlane run app_store_build_number app_identifier:"bundle id" username:"username" platform:"osx"`

`bundle exec fastlane run latest_testflight_build_number app_identifier:"bundle id" username:"username" platform:"osx"`