### PR TITLE
Version bump to 2.137.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,38 +34,6 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-</tr>
-<tr>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
 <img src='https://github.com/milch.png?size=140'>
@@ -78,17 +46,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
@@ -104,17 +72,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
@@ -122,11 +84,49 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+</tr>
+<tr>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 </tr>
 <tr>
@@ -136,11 +136,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
 <td id='joshua-liebowitz'>
 <a href='https://github.com/taquitos'>
@@ -148,17 +154,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,26 +15,26 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Danielle Tomlinson",
-                        "Jimmy Dee",
-                        "Helmut Januschka",
+  spec.authors       = ["Josh Holtz",
                         "Olivier Halligon",
                         "Joshua Liebowitz",
-                        "Josh Holtz",
-                        "Manu Wallner",
-                        "Jan Piotrowski",
-                        "Kohki Miki",
-                        "Stefan Natchev",
-                        "Jorge Revuelta H",
-                        "Fumiya Nakamura",
-                        "Jérôme Lacoste",
-                        "Felix Krause",
-                        "Maksym Grebenets",
-                        "Iulian Onofrei",
-                        "Matthew Ellis",
                         "Aaron Brager",
+                        "Andrew McBurney",
+                        "Kohki Miki",
+                        "Manu Wallner",
+                        "Felix Krause",
                         "Luka Mirosevic",
-                        "Andrew McBurney"]
+                        "Stefan Natchev",
+                        "Iulian Onofrei",
+                        "Danielle Tomlinson",
+                        "Jimmy Dee",
+                        "Jérôme Lacoste",
+                        "Jan Piotrowski",
+                        "Matthew Ellis",
+                        "Helmut Januschka",
+                        "Fumiya Nakamura",
+                        "Maksym Grebenets",
+                        "Jorge Revuelta H"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.136.0'.freeze
+  VERSION = '2.137.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.136.0
+// Generated with fastlane 2.137.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1219,8 +1219,6 @@ func bundleInstall(binstubs: String? = nil,
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - useTimestampSuffix: Add timestamp suffix to screenshot filename
    - adbHost: Configure the host used by adb to connect, allows running on remote devices farm
-   - cleanStatusBar: Enabling this option will clean the status bar
-   - cleanStatusBarConfig: Specifies the configuration for the clean status bar
 */
 func captureAndroidScreenshots(androidHome: String? = nil,
                                buildToolsVersion: String? = nil,
@@ -1243,9 +1241,7 @@ func captureAndroidScreenshots(androidHome: String? = nil,
                                exitOnTestFailure: Bool = true,
                                reinstallApp: Bool = false,
                                useTimestampSuffix: Bool = true,
-                               adbHost: String? = nil,
-                               cleanStatusBar: Bool = false,
-                               cleanStatusBarConfig: [String : Any] = [:]) {
+                               adbHost: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "capture_android_screenshots", className: nil, args: [RubyCommand.Argument(name: "android_home", value: androidHome),
                                                                                                              RubyCommand.Argument(name: "build_tools_version", value: buildToolsVersion),
                                                                                                              RubyCommand.Argument(name: "locales", value: locales),
@@ -1267,9 +1263,7 @@ func captureAndroidScreenshots(androidHome: String? = nil,
                                                                                                              RubyCommand.Argument(name: "exit_on_test_failure", value: exitOnTestFailure),
                                                                                                              RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                                              RubyCommand.Argument(name: "use_timestamp_suffix", value: useTimestampSuffix),
-                                                                                                             RubyCommand.Argument(name: "adb_host", value: adbHost),
-                                                                                                             RubyCommand.Argument(name: "clean_status_bar", value: cleanStatusBar),
-                                                                                                             RubyCommand.Argument(name: "clean_status_bar_config", value: cleanStatusBarConfig)])
+                                                                                                             RubyCommand.Argument(name: "adb_host", value: adbHost)])
   _ = runner.executeCommand(command)
 }
 
@@ -1582,7 +1576,7 @@ func carthage(command: String = "bootstrap",
 */
 func cert(development: Bool = false,
           force: Bool = false,
-          generateAppleCerts: Bool = false,
+          generateAppleCerts: Bool = true,
           username: String,
           teamId: String? = nil,
           teamName: String? = nil,
@@ -2583,7 +2577,7 @@ func downloadDsyms(username: String,
 func downloadFromPlayStore(packageName: String,
                            versionName: String? = nil,
                            track: String = "production",
-                           metadataPath: String? = nil,
+                           metadataPath: String = "./metadata",
                            key: String? = nil,
                            issuer: String? = nil,
                            jsonKey: String? = nil,
@@ -2635,8 +2629,8 @@ func echo(message: String? = nil) {
 /**
  Raises an exception if not using `bundle exec` to run fastlane
 
- This action will check if you are using bundle exec to run fastlane.
- You can put it into `before_all` and make sure that fastlane is run using `bundle exec fastlane` command.
+ This action will check if you are using `bundle exec` to run fastlane.
+ You can put it into `before_all` to make sure that fastlane is ran using the `bundle exec fastlane` command.
 */
 func ensureBundleExec() {
   let command = RubyCommand(commandID: "", methodName: "ensure_bundle_exec", className: nil, args: [])
@@ -2954,7 +2948,7 @@ func getBuildNumberRepository(useHgRevisionNumber: Bool = false) {
 */
 func getCertificates(development: Bool = false,
                      force: Bool = false,
-                     generateAppleCerts: Bool = false,
+                     generateAppleCerts: Bool = true,
                      username: String,
                      teamId: String? = nil,
                      teamName: String? = nil,
@@ -5338,7 +5332,7 @@ func rubocop() {
  Verifies the minimum ruby version required
 
  Add this to your `Fastfile` to require a certain version of _ruby_.
- Put it at the top of your `Fastfile to ensure that _fastlane_ is executed appropriately.
+ Put it at the top of your `Fastfile` to ensure that _fastlane_ is executed appropriately.
 */
 func rubyVersion() {
   let command = RubyCommand(commandID: "", methodName: "ruby_version", className: nil, args: [])
@@ -5815,8 +5809,6 @@ func scp(username: String,
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - useTimestampSuffix: Add timestamp suffix to screenshot filename
    - adbHost: Configure the host used by adb to connect, allows running on remote devices farm
-   - cleanStatusBar: Enabling this option will clean the status bar
-   - cleanStatusBarConfig: Specifies the configuration for the clean status bar
 */
 func screengrab(androidHome: Any? = screengrabfile.androidHome,
                 buildToolsVersion: Any? = screengrabfile.buildToolsVersion,
@@ -5839,9 +5831,7 @@ func screengrab(androidHome: Any? = screengrabfile.androidHome,
                 exitOnTestFailure: Bool = screengrabfile.exitOnTestFailure,
                 reinstallApp: Bool = screengrabfile.reinstallApp,
                 useTimestampSuffix: Bool = screengrabfile.useTimestampSuffix,
-                adbHost: Any? = screengrabfile.adbHost,
-                cleanStatusBar: Bool = screengrabfile.cleanStatusBar,
-                cleanStatusBarConfig: [String : Any] = screengrabfile.cleanStatusBarConfig) {
+                adbHost: Any? = screengrabfile.adbHost) {
   let command = RubyCommand(commandID: "", methodName: "screengrab", className: nil, args: [RubyCommand.Argument(name: "android_home", value: androidHome),
                                                                                             RubyCommand.Argument(name: "build_tools_version", value: buildToolsVersion),
                                                                                             RubyCommand.Argument(name: "locales", value: locales),
@@ -5863,9 +5853,7 @@ func screengrab(androidHome: Any? = screengrabfile.androidHome,
                                                                                             RubyCommand.Argument(name: "exit_on_test_failure", value: exitOnTestFailure),
                                                                                             RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                             RubyCommand.Argument(name: "use_timestamp_suffix", value: useTimestampSuffix),
-                                                                                            RubyCommand.Argument(name: "adb_host", value: adbHost),
-                                                                                            RubyCommand.Argument(name: "clean_status_bar", value: cleanStatusBar),
-                                                                                            RubyCommand.Argument(name: "clean_status_bar_config", value: cleanStatusBarConfig)])
+                                                                                            RubyCommand.Argument(name: "adb_host", value: adbHost)])
   _ = runner.executeCommand(command)
 }
 
@@ -6732,7 +6720,7 @@ func supply(packageName: String,
             releaseStatus: String = "completed",
             track: String = "production",
             rollout: String? = nil,
-            metadataPath: String? = nil,
+            metadataPath: String = "./metadata",
             key: String? = nil,
             issuer: String? = nil,
             jsonKey: String? = nil,
@@ -6879,7 +6867,7 @@ func swiftlint(mode: Any = "lint",
 */
 func syncCodeSigning(type: String = "development",
                      readonly: Bool = false,
-                     generateAppleCerts: Bool = false,
+                     generateAppleCerts: Bool = true,
                      skipProvisioningProfiles: Bool = false,
                      appIdentifier: [String],
                      username: String,
@@ -6969,6 +6957,7 @@ func teamName() {
    - autoUpdate: Allows an easy upgrade of all users to the current version. To enable set to 'on'
    - notify: Send email to testers
    - options: Array of options (shake,video_only_wifi,anonymous)
+   - custom: Array of custom options. Contact support@testfairy.com for more information
    - timeout: Request timeout in seconds
 
  You can retrieve your API key on [your settings page](https://free.testfairy.com/settings/)
@@ -6984,6 +6973,7 @@ func testfairy(apiKey: String,
                autoUpdate: String = "off",
                notify: String = "off",
                options: [String] = [],
+               custom: String = "",
                timeout: Int? = nil) {
   let command = RubyCommand(commandID: "", methodName: "testfairy", className: nil, args: [RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                            RubyCommand.Argument(name: "ipa", value: ipa),
@@ -6996,6 +6986,7 @@ func testfairy(apiKey: String,
                                                                                            RubyCommand.Argument(name: "auto_update", value: autoUpdate),
                                                                                            RubyCommand.Argument(name: "notify", value: notify),
                                                                                            RubyCommand.Argument(name: "options", value: options),
+                                                                                           RubyCommand.Argument(name: "custom", value: custom),
                                                                                            RubyCommand.Argument(name: "timeout", value: timeout)])
   _ = runner.executeCommand(command)
 }
@@ -7754,7 +7745,7 @@ func uploadToPlayStore(packageName: String,
                        releaseStatus: String = "completed",
                        track: String = "production",
                        rollout: String? = nil,
-                       metadataPath: String? = nil,
+                       metadataPath: String = "./metadata",
                        key: String? = nil,
                        issuer: String? = nil,
                        jsonKey: String? = nil,
@@ -8211,7 +8202,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode-10.3.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode-11.2.1.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -8356,4 +8347,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.64]
+// FastlaneRunnerAPIVersion [0.9.65]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.136.0
+// Generated with fastlane 2.137.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.136.0
+// Generated with fastlane 2.137.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -91,7 +91,7 @@ protocol MatchfileProtocol: class {
 extension MatchfileProtocol {
   var type: String { return "development" }
   var readonly: Bool { return false }
-  var generateAppleCerts: Bool { return false }
+  var generateAppleCerts: Bool { return true }
   var skipProvisioningProfiles: Bool { return false }
   var appIdentifier: [String] { return [] }
   var username: String { return "" }
@@ -122,4 +122,4 @@ extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.10]
+// FastlaneRunnerAPIVersion [0.9.11]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.136.0
+// Generated with fastlane 2.137.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.136.0
+// Generated with fastlane 2.137.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.136.0
+// Generated with fastlane 2.137.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -65,12 +65,6 @@ protocol ScreengrabfileProtocol: class {
 
   /// Configure the host used by adb to connect, allows running on remote devices farm
   var adbHost: String? { get }
-
-  /// Enabling this option will clean the status bar
-  var cleanStatusBar: Bool { get }
-
-  /// Specifies the configuration for the clean status bar
-  var cleanStatusBarConfig: [String : Any] { get }
 }
 
 extension ScreengrabfileProtocol {
@@ -96,10 +90,8 @@ extension ScreengrabfileProtocol {
   var reinstallApp: Bool { return false }
   var useTimestampSuffix: Bool { return true }
   var adbHost: String? { return nil }
-  var cleanStatusBar: Bool { return false }
-  var cleanStatusBarConfig: [String : Any] { return [:] }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.12]
+// FastlaneRunnerAPIVersion [0.9.13]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.136.0
+// Generated with fastlane 2.137.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.136.0':**

* [supply] error track or track_promote_to are rollout as that is no longer used by Google Play and causing errors (#15692) via Josh Holtz
* [supply] upload meta in same commit to fix issue with validate_only (#15691) via Josh Holtz
* [action] gradle: Add support for mapping.txt file (#15597) via NicoEkino
* [screengrab] address issue #15674 - make sure aapt is available before trying to clean status bar (#15684) via Hiroto Nakamura
* [screengrab] Remove unused clean status bar options (#15679) via Rick Clephas
* [action] added custom option to testfairy upload (#15670) via Vijay Sharma
* [supply] don't apply rollout when value 1 of when uploading and don't call promote or rollout methods when uploading (#15668) via Josh Holtz
* [ensure_bundle_exec] Fix wording in action error message and d… (#15596) via Iulian Onofrei
* [fastlane] fix typo in code comment (#15604) via Iulian Onofrei
* [action] fix formatting in ruby_version action's details (#15605) via Iulian Onofrei
