### PR TITLE
[supply] Support default changelog

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -136,7 +136,7 @@ Note that these will replace the current images and screenshots on the play stor
 
 ## Changelogs (What's new)
 
-You can add changelog files under the `changelogs/` directory for each locale. The filename should exactly match the [version code](https://developer.android.com/studio/publish/versioning#appversioning) of the APK that it represents. `fastlane supply init` will populate changelog files from existing data on Google Play if no `metadata/` directory exists when it is run.
+You can add changelog files under the `changelogs/` directory for each locale. The filename should exactly match the [version code](https://developer.android.com/studio/publish/versioning#appversioning) of the APK that it represents. You can also provide default notes that will be used if no files match the version code by adding a `default.txt` file. `fastlane supply init` will populate changelog files from existing data on Google Play if no `metadata/` directory exists when it is run.
 
 ```no-highlight
 └── fastlane
@@ -144,10 +144,12 @@ You can add changelog files under the `changelogs/` directory for each locale. T
         └── android
             ├── en-US
             │   └── changelogs
+            │       ├── default.txt
             │       ├── 100000.txt
             │       └── 100100.txt
             └── fr-FR
                 └── changelogs
+                    ├── default.txt
                     └── 100100.txt
 ```
 
@@ -168,7 +170,7 @@ Before performing a new APK upload you may want to check existing track version 
   - Used when uploading with `:apk_path`, `:apk_paths`, `:aab_path`, and `:aab_paths`
   - Can be any string such (example: "October Release" or "Awesome New Feature")
   - Defaults to the version name in app/build.gradle or AndroidManifest.xml
-- `:release_status` 
+- `:release_status`
   - Used when uploading with `:apk_path`, `:apk_paths`, `:aab_path`, and `:aab_paths`
   - Can set as  "draft" to complete the release at some other time
   - Defaults to "completed"

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -197,7 +197,7 @@ module Supply
       else
         default_changelog_path = File.join(Supply.config[:metadata_path], language, Supply::CHANGELOGS_FOLDER_NAME, "default.txt")
         if File.exist?(default_changelog_path)
-          UI.message("Updating default changelog for '#{version_code}' and language '#{language}'...")
+          UI.message("Updating changelog for '#{version_code}' and language '#{language}' to default changelog...")
           changelog_text = File.read(default_changelog_path, encoding: 'UTF-8')
         else
           UI.message("Could not find changelog for '#{version_code}' and language '#{language}' at path #{path}...")

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -195,7 +195,13 @@ module Supply
         UI.message("Updating changelog for '#{version_code}' and language '#{language}'...")
         changelog_text = File.read(path, encoding: 'UTF-8')
       else
-        UI.message("Could not find changelog for '#{version_code}' and language '#{language}' at path #{path}...")
+        default_changelog_path = File.join(Supply.config[:metadata_path], language, Supply::CHANGELOGS_FOLDER_NAME, "default.txt")
+        if File.exist?(default_changelog_path)
+          UI.message("Updating default changelog for '#{version_code}' and language '#{language}'...")
+          changelog_text = File.read(default_changelog_path, encoding: 'UTF-8')
+        else
+          UI.message("Could not find changelog for '#{version_code}' and language '#{language}' at path #{path}...")
+        end
       end
 
       AndroidPublisher::LocalizedText.new({


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently on Android using supply it is needed to create a release notes file for every build. Most release end up including the same release notes so having a way to specify default notes if none are provided can save a lot of time and prevent release without notes.

### Description
This adds support for default release notes when a release note file for the current build does not exist.

It works by looking for a file named `default.txt` if a file with the build number does not exist.

### Testing Steps

Tested in my project by patching fastlane locally and adding a `default.txt` file with some text under the `changelogs` directory. Then I ran my deployment script and checked that the text included in `default.txt` was set as release notes in the google play console.
