### PR TITLE
[Fastlane.swift] Fix string_callback type override

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -96,7 +96,7 @@ module Fastlane
       elsif type_override == Boolean
         return "Bool"
       elsif type_override == :string_callback
-        return "((String) -> Void)"
+        return "@escaping (String) -> Void"
       else
         return default_type
       end
@@ -104,7 +104,7 @@ module Fastlane
 
     def override_default_value_if_not_correct_type(param_name: nil, param_type: nil, default_value: nil)
       return "[]" if param_type == "[String]" && default_value == ""
-      return "{_ in }" if param_type == "((String) -> Void)"
+      return "{_ in }" if param_type == "@escaping (String) -> Void"
 
       return default_value
     end
@@ -119,7 +119,7 @@ module Fastlane
 
       optional_specifier = ""
       # if we are optional and don't have a default value, we'll need to use ?
-      optional_specifier = "?" if (optional && default_value.nil?) && type != "((String) -> Void)"
+      optional_specifier = "?" if (optional && default_value.nil?) && type != "@escaping (String) -> Void"
 
       # If we have a default value of true or false, we can infer it is a Bool
       if default_value.class == FalseClass
@@ -149,7 +149,7 @@ module Fastlane
             # we can't handle default values for Hashes, yet
             # see method swift_default_implementations for similar behavior
             default_value = "[:]"
-          elsif type != "Bool" && type != "[String]" && type != "Int" && type != "((String) -> Void)"
+          elsif type != "Bool" && type != "[String]" && type != "Int" && type != "@escaping (String) -> Void"
             default_value = "\"#{default_value}\""
           end
         end

--- a/fastlane/swift/RubyCommand.swift
+++ b/fastlane/swift/RubyCommand.swift
@@ -49,7 +49,7 @@ struct RubyCommand: RubyCommandable {
                     let typeJson: String
                     if let type = type {
                         typeJson = ", \"value_type\" : \"\(type.typeString)\""
-                    }else {
+                    } else {
                         typeJson = ""
                     }
 

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -255,9 +255,7 @@ module FastlaneCore
 
     # Determines the defined data type of this ConfigItem
     def data_type
-      if @data_type.kind_of?(Symbol)
-        nil
-      elsif @data_type
+      if @data_type
         @data_type
       else
         (@is_string ? String : nil)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Up until now, `:string_callback` was mapped to `Any?` instead of `(String) -> Void` when generating the Swift API.
Thus, there was no way to get a hook to callback functions when using Fastlane Swift, i.e. the `sh` action which takes an `error_callback` parameter.

Open issue: https://github.com/fastlane/fastlane/issues/15720

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

The issue lied in the way the `ConfigItem` `data_type` was built, returning nil when `data_type` is of kind `Symbol`.
Fixing the above issue, as well as adding the Swift `@escaping` solved the issue and I was able to test using:

```
sh(command: "exit 1", errorCallback: { fatalError($0) })
```

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

```
sh(command: "exit 1", errorCallback: { fatalError($0) })
```

### Known Issues

```
sh(command: "exit 1", errorCallback: { println(message: $0) })
```

Will make the runner get stuck.
