### PR TITLE
[gemspec] Change xcodeproj dependency to be 1.13.0 minimum to fix Swift Package Manager (SPM) support

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = Dir["*/lib"]
 
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
-  spec.add_dependency('xcodeproj', '>= 1.8.1', '< 2.0.0') # Modify Xcode projects
+  spec.add_dependency('xcodeproj', '>= 1.13.0', '< 2.0.0') # Modify Xcode projects
   spec.add_dependency('xcpretty', '~> 0.3.0') # prettify xcodebuild output
   spec.add_dependency('terminal-notifier', '>= 2.0.0', '< 3.0.0') # macOS notifications
   spec.add_dependency('terminal-table', '>= 1.4.5', '< 2.0.0') # Actions documentation


### PR DESCRIPTION
# Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I had an issue with Xcode 11 projects using Swift Package Manager dependencies, where it would fail with an error "/Users/hannes/.fastlane/bin/bundle/lib/ruby/gems/2.2.0/gems/xcodeproj-1.8.2/lib/xcodeproj/project.rb:227:in `initialize_from_file': [!] [Xcodeproj] Unknown object version. (RuntimeError)", which I mentioned in #15454.
It seemed due to `xcodeproj` being of a too old version. `xcodeproj` was updated to 1.13.0 to fix this issue.

### Changes
I updated the xcodeproj dependency to be 1.13.0 minimum.

### Tested
I changed the Gemfile in my app directory to point to fastlane on the PR branch.
I updated ruby on macOS via `brew update && brew upgrade`.
I ran `bundle install` in my app directory, which updated fastlane's dependencies including xcodeproj.
I ran `bundle exec fastlane deploy_appstore` which caused a successful build with `gym`
