### PR TITLE
[scan] removing duplicate settings of config

### DIFF
--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -10,17 +10,10 @@ module Fastlane
     class RunTestsAction < Action
       def self.run(values)
         require 'scan'
-        plist_files_before = []
+        manager = Scan::Manager.new
 
         begin
-          destination = values[:destination] # save destination value which can be later overridden
-          Scan.config = values if values[:derived_data_path].to_s.empty? # we set this here to auto-detect missing values, which we need later on
-          unless values[:derived_data_path].to_s.empty?
-            plist_files_before = test_summary_filenames(values[:derived_data_path])
-          end
-
-          values[:destination] = destination # restore destination value
-          Scan::Manager.new.work(values)
+          manager.work(values)
 
           zip_build_products_path = Scan.cache[:zip_build_products_path]
           Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = zip_build_products_path if zip_build_products_path
@@ -37,8 +30,10 @@ module Fastlane
           end
         ensure
           unless values[:derived_data_path].to_s.empty?
+            plist_files_before = manager.plist_files_before || []
+
             Actions.lane_context[SharedValues::SCAN_DERIVED_DATA_PATH] = values[:derived_data_path]
-            plist_files_after = test_summary_filenames(values[:derived_data_path])
+            plist_files_after = manager.test_summary_filenames(values[:derived_data_path])
             all_test_summaries = (plist_files_after - plist_files_before)
             Actions.lane_context[SharedValues::SCAN_GENERATED_PLIST_FILES] = all_test_summaries
             Actions.lane_context[SharedValues::SCAN_GENERATED_PLIST_FILE] = all_test_summaries.last
@@ -84,18 +79,6 @@ module Fastlane
       end
 
       private_class_method
-
-      def self.test_summary_filenames(derived_data_path)
-        files = []
-
-        # Xcode < 10
-        files += Dir["#{derived_data_path}/**/Logs/Test/*TestSummaries.plist"]
-
-        # Xcode 10
-        files += Dir["#{derived_data_path}/**/Logs/Test/*.xcresult/TestSummaries.plist"]
-
-        return files
-      end
 
       def self.example_code
         [

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -66,17 +66,7 @@ module Fastlane
                                        env_name: "SCAN_FAIL_BUILD",
                                        description: "Should this step stop the build if the tests fail? Set this to false if you're using trainer",
                                        is_string: false,
-                                       default_value: true),
-          FastlaneCore::ConfigItem.new(key: :app_name,
-                                       env_name: "SCAN_APP_NAME",
-                                       optional: true,
-                                       description: "Name of the target which is being build or tested",
-                                       is_string: true),
-          FastlaneCore::ConfigItem.new(key: :deployment_target_version,
-                                       env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
-                                       optional: true,
-                                       description: "Target version of the app being build or tested. Used to filter out simulator version",
-                                       is_string: true)
+                                       default_value: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -14,7 +14,6 @@ module Fastlane
 
         begin
           destination = values[:destination] # save destination value which can be later overridden
-          Scan.config = values # we set this here to auto-detect missing values, which we need later on
           unless values[:derived_data_path].to_s.empty?
             plist_files_before = test_summary_filenames(values[:derived_data_path])
           end

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -14,12 +14,13 @@ module Fastlane
 
         begin
           destination = values[:destination] # save destination value which can be later overridden
+          Scan.config = values if values[:derived_data_path].to_s.empty? # we set this here to auto-detect missing values, which we need later on
           unless values[:derived_data_path].to_s.empty?
             plist_files_before = test_summary_filenames(values[:derived_data_path])
           end
 
           values[:destination] = destination # restore destination value
-          Scan::Manager.new.work(values)
+          Scan::Manager.new.work(values) 
 
           zip_build_products_path = Scan.cache[:zip_build_products_path]
           Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = zip_build_products_path if zip_build_products_path
@@ -65,7 +66,17 @@ module Fastlane
                                        env_name: "SCAN_FAIL_BUILD",
                                        description: "Should this step stop the build if the tests fail? Set this to false if you're using trainer",
                                        is_string: false,
-                                       default_value: true)
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :app_name,
+                                       env_name: "SCAN_APP_NAME",
+                                       optional: true,
+                                       description: "Name of the target which is being build or tested",
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :deployment_target_version,
+                                       env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
+                                       optional: true,
+                                       description: "Target version of the app being build or tested. Used to filter out simulator version",
+                                       is_string: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -20,7 +20,7 @@ module Fastlane
           end
 
           values[:destination] = destination # restore destination value
-          Scan::Manager.new.work(values) 
+          Scan::Manager.new.work(values)
 
           zip_build_products_path = Scan.cache[:zip_build_products_path]
           Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = zip_build_products_path if zip_build_products_path

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -108,7 +108,7 @@ module Scan
     def self.detect_simulator(devices, requested_os_type, deployment_target_key, default_device_name, simulator_type_descriptor)
       require 'set'
 
-      deployment_target_version = Scan.project.build_settings(key: deployment_target_key) || '0'
+      deployment_target_version = get_deployment_target_version(deployment_target_key)
 
       simulators = filter_simulators(
         FastlaneCore::DeviceManager.simulators(requested_os_type).tap do |array|
@@ -215,5 +215,11 @@ module Scan
         Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]
       end
     end
+    
+    #get deployment target version
+    def self.get_deployment_target_version(deployment_target_key)
+       Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
+    end
+    
   end
 end

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -216,9 +216,9 @@ module Scan
       end
     end
     
-    #get deployment target version
+    # get deployment target version
     def self.get_deployment_target_version(deployment_target_key)
-       Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
+      Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
     end
     
   end

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -215,11 +215,11 @@ module Scan
         Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]
       end
     end
-    
+
     # get deployment target version
     def self.get_deployment_target_version(deployment_target_key)
       Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
     end
-    
+
   end
 end

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -220,6 +220,5 @@ module Scan
     def self.get_deployment_target_version(deployment_target_key)
       Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
     end
-
   end
 end

--- a/scan/lib/scan/manager.rb
+++ b/scan/lib/scan/manager.rb
@@ -4,8 +4,13 @@ require_relative 'runner'
 
 module Scan
   class Manager
+    attr_accessor :plist_files_before
+
     def work(options)
-      Scan.config = options
+      Scan.config = options # we set this here to auto-detect missing values, which we need later on
+      unless options[:derived_data_path].to_s.empty?
+        self.plist_files_before = test_summary_filenames(Scan.config[:derived_data_path])
+      end
 
       # Also print out the path to the used Xcode installation
       # We go 2 folders up, to not show "Contents/Developer/"
@@ -16,6 +21,18 @@ module Scan
                                              title: "Summary for scan #{Fastlane::VERSION}")
 
       return Runner.new.run
+    end
+
+    def test_summary_filenames(derived_data_path)
+      files = []
+
+      # Xcode < 10
+      files += Dir["#{derived_data_path}/**/Logs/Test/*TestSummaries.plist"]
+
+      # Xcode 10
+      files += Dir["#{derived_data_path}/**/Logs/Test/*.xcresult/TestSummaries.plist"]
+
+      return files
     end
   end
 end

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -310,7 +310,7 @@ module Scan
                                      verify_block: proc do |value|
                                        UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
-        
+
         # build settings
         FastlaneCore::ConfigItem.new(key: :app_name,
                                     env_name: "SCAN_APP_NAME",
@@ -322,7 +322,7 @@ module Scan
                                     optional: true,
                                     description: "Target version of the app being build or tested. Used to filter out simulator version",
                                     is_string: true),
-        
+
         # slack
         FastlaneCore::ConfigItem.new(key: :slack_url,
                                      short_option: "-i",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -311,17 +311,17 @@ module Scan
                                        UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
         
-        #build settings
+        # build settings
         FastlaneCore::ConfigItem.new(key: :app_name,
-               env_name: "SCAN_APP_NAME",
-               optional: true,
-               description: "Name of the target which is being build or tested",
-               is_string: true),
+                                    env_name: "SCAN_APP_NAME",
+                                    optional: true,
+                                    description: "Name of the target which is being build or tested",
+                                    is_string: true),
         FastlaneCore::ConfigItem.new(key: :deployment_target_version,
-              env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
-              optional: true,
-              description: "Target version of the app being build or tested. Used to filter out simulator version",
-              is_string: true),
+                                    env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
+                                    optional: true,
+                                    description: "Target version of the app being build or tested. Used to filter out simulator version",
+                                    is_string: true),
         
         # slack
         FastlaneCore::ConfigItem.new(key: :slack_url,

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -315,7 +315,7 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :app_name,
                                     env_name: "SCAN_APP_NAME",
                                     optional: true,
-                                    description: "Name of the target which is being build or tested",
+                                    description: "App name to use in slack message and logfile name",
                                     is_string: true),
         FastlaneCore::ConfigItem.new(key: :deployment_target_version,
                                     env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -310,7 +310,19 @@ module Scan
                                      verify_block: proc do |value|
                                        UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
-
+        
+        #build settings
+        FastlaneCore::ConfigItem.new(key: :app_name,
+               env_name: "SCAN_APP_NAME",
+               optional: true,
+               description: "Name of the target which is being build or tested",
+               is_string: true),
+        FastlaneCore::ConfigItem.new(key: :deployment_target_version,
+              env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
+              optional: true,
+              description: "Target version of the app being build or tested. Used to filter out simulator version",
+              is_string: true),
+        
         # slack
         FastlaneCore::ConfigItem.new(key: :slack_url,
                                      short_option: "-i",

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -44,7 +44,7 @@ module Scan
       end
 
       Fastlane::Actions::SlackAction.run({
-        message: "#{Scan.project.app_name} Tests:\n#{Scan.config[:slack_message]}",
+        message: "#{Scan.config[:app_name] || Scan.project.app_name} Tests:\n#{Scan.config[:slack_message]}",
         channel: channel,
         slack_url: Scan.config[:slack_url].to_s,
         success: results[:build_errors].to_i == 0 && results[:failures].to_i == 0,

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -120,7 +120,7 @@ module Scan
 
     # Store the raw file
     def xcodebuild_log_path
-      file_name = "#{Scan.project.app_name}-#{Scan.config[:scheme]}.log"
+      file_name = "#{Scan.config[:app_name] || Scan.project.app_name}-#{Scan.config[:scheme]}.log"
       containing = File.expand_path(Scan.config[:buildlog_path])
       FileUtils.mkdir_p(containing)
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Whenever scan or run_tests is used in Fastfile it executes
xcodebuild showbuildsettings two times with same parameters which increases overall build time

Resolves https://github.com/fastlane/fastlane/issues/15717

### Description
Scan.config is initialized when manager is called here which does the job of using build settings for the parameters from scheme.

I have tested this change with project i am working on where run_tests is 27 times for around 14 schemes in total without any issue.

**UPDATED**: Passing SCAN_DERIVED_DATA_PATH, SCAN_APP_NAME and SCAN_DEPLOYMENT_TARGET_VERSION from env file will **not make any cal**l to buildsettings which **saved total of 57 minutes** for my project.

### Testing Steps
scan or run_tests actions with required parameters
