### PR TITLE
[action] increment_version_number: New default value for bump_type

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -43,6 +43,9 @@ module Fastlane
           version_array = current_version.split(".").map(&:to_i)
 
           case params[:bump_type]
+          when "bump"
+            version_array[-1] = version_array[-1] + 1
+            next_version_number = version_array.join(".")
           when "patch"
             UI.user_error!(version_token_error) if version_array.count < 3
             version_array[2] = version_array[2] + 1
@@ -109,9 +112,9 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :bump_type,
                                        env_name: "FL_VERSION_NUMBER_BUMP_TYPE",
                                        description: "The type of this version bump. Available: patch, minor, major",
-                                       default_value: "patch",
+                                       default_value: "bump",
                                        verify_block: proc do |value|
-                                         UI.user_error!("Available values are 'patch', 'minor' and 'major'") unless ['patch', 'minor', 'major'].include?(value)
+                                         UI.user_error!("Available values are 'patch', 'minor' and 'major'") unless ['bump', 'patch', 'minor', 'major'].include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :version_number,
                                        env_name: "FL_VERSION_NUMBER_VERSION_NUMBER",
@@ -148,7 +151,7 @@ module Fastlane
 
       def self.example_code
         [
-          'increment_version_number # Automatically increment patch version number',
+          'increment_version_number # Automatically increment version number',
           'increment_version_number(
             bump_type: "patch" # Automatically increment patch version number
           )',

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -1,16 +1,22 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Increment Version Number Integration" do
-      it "increments all targets' patch version number (from 1.0.0 to 1.0.1)" do
-        expect(Fastlane::Actions).to receive(:sh)
-          .with(/agvtool what-marketing-version/, any_args)
-          .once
-          .and_return("1.0.0")
-        Fastlane::FastFile.new.parse("lane :test do
-          increment_version_number
-        end").runner.execute(:test)
+      {
+          "1" => "2",
+          "1.1" => "1.2",
+          "1.1.1" => "1.1.2"
+      }.each do |from_version, to_version|
+        it "increments all targets' version number from #{from_version} to #{to_version}" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool what-marketing-version/, any_args)
+            .once
+            .and_return(from_version)
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number
+          end").runner.execute(:test)
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.0.1/)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version #{to_version}/)
+        end
       end
 
       ["1.0", "10"].each do |version|
@@ -22,7 +28,7 @@ describe Fastlane do
 
           expect do
             Fastlane::FastFile.new.parse("lane :test do
-              increment_version_number
+              increment_version_number(bump_type: 'patch')
             end").runner.execute(:test)
           end.to raise_error("Can't increment version")
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change was requested because the default 'bump version' call would fail with a less than help error, if your current version did not include all three semantic fields (major minor and patch).  The default parameter assumes the user is trying to specifically bump the patch version, yet the error explains that the current version is not able to be incremented because it doesn't have the correct format of A or A.B or A.B.C

https://github.com/fastlane/fastlane/issues/15676

### Description
A new default parameter was added called 'bump'.  This 4th case (along with the existing major minor and patch) exists as the default way to bump a correctly formatted version, of the least significant digit. i.e. the default will now bump 1 -> 2 and 1.1 -> 1.2 and 1.1.1 -> 1.1.2

The tests that were added test the cases listed above.  Give that the method is already determining through a proven regex that the version number is in a valid format, each of the three types of semantic versions were tested to ensure the correct output.

### Testing Steps
bundle exec rspec ./fastlane/spec/actions_specs/increment_version_number_action_spec.rb
