### PR TITLE
[action] get_version_number: Supports when INFOPLIST_FILE is specified as an absolute path

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -91,7 +91,7 @@ module Fastlane
       end
 
       def self.get_plist!(folder, target, configuration = nil)
-        plist_files = target.resolved_build_setting("INFOPLIST_FILE")
+        plist_files = target.resolved_build_setting("INFOPLIST_FILE", true)
         plist_files_count = plist_files.values.compact.uniq.count
 
         # Get plist file for specified configuration
@@ -113,7 +113,12 @@ module Fastlane
           plist_file.gsub!("$(SRCROOT)/", "")
         end
 
-        plist_file = File.absolute_path(File.join(folder, plist_file))
+        # plist_file can be `Relative` or `Absolute` path.
+        # Make to `Absolute` path when plist_file is `Relative` path
+        unless File.exist?(plist_file)
+          plist_file = File.absolute_path(File.join(folder, plist_file))
+        end
+
         UI.user_error!("Cannot find plist file: #{plist_file}") unless File.exist?(plist_file)
 
         plist_file

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -125,6 +125,32 @@ describe Fastlane do
         expect(result).to eq("3.37.0")
       end
 
+      it "gets the correct version when info-plist is absolute path", requires_xcodeproj: true do
+        begin
+          # given
+          # copy TargetAbsolutePath-Info.plist to /tmp/fastlane_get_version_number_action_spec/
+          info_plist = File.absolute_path("./fastlane/spec/fixtures/actions/get_version_number/TargetAbsolutePath-Info.plist")
+          temp_folder_for_test = "/tmp/fastlane_get_version_number_action_spec/"
+          FileUtils.mkdir_p(temp_folder_for_test)
+          FileUtils.cp_r(info_plist, temp_folder_for_test)
+          temp_info_plist = File.path(temp_folder_for_test + "TargetAbsolutePath-Info.plist")
+          expect(File.file?(temp_info_plist)).not_to(be false)
+
+          # when
+          result = Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj: '#{path}', target: 'TargetAbsolutePath')
+          end").runner.execute(:test)
+
+          # then
+          expect(result).to eq("3.37.4")
+        ensure
+          # after
+          # remove /tmp/fastlane_get_version_number_action_spec/
+          FileUtils.rm_r(temp_folder_for_test)
+          expect(File.file?(temp_info_plist)).to be false
+        end
+      end
+
       it "raises if one target and specified wrong target name", requires_xcodeproj: true do
         allow_any_instance_of(Xcodeproj::Project).to receive(:targets).and_wrap_original do |m, *args|
           [m.call(*args).first]

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -118,6 +118,13 @@ describe Fastlane do
         expect(result).to eq("1.5.9")
       end
 
+      it "gets the correct version when info-plist is relative path", requires_xcodeproj: true do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '#{path}', target: 'TargetRelativePath')
+        end").runner.execute(:test)
+        expect(result).to eq("3.37.0")
+      end
+
       it "raises if one target and specified wrong target name", requires_xcodeproj: true do
         allow_any_instance_of(Xcodeproj::Project).to receive(:targets).and_wrap_original do |m, *args|
           [m.call(*args).first]

--- a/fastlane/spec/fixtures/actions/get_version_number/TargetAbsolutePath-Info.plist
+++ b/fastlane/spec/fixtures/actions/get_version_number/TargetAbsolutePath-Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.37.4</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fastlane/spec/fixtures/actions/get_version_number/TargetRelativePath-Info.plist
+++ b/fastlane/spec/fixtures/actions/get_version_number/TargetRelativePath-Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.37.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
@@ -143,6 +143,11 @@
 		60E0C933238E9B1200524513 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82EB2056A51B00BAAFD1 /* Assets.xcassets */; };
 		60E0C936238E9B1200524513 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82ED2056A51B00BAAFD1 /* LaunchScreen.storyboard */; };
 		60E0C945238E9E5F00524513 /* TargetRelativePath-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 60E0C944238E9E5F00524513 /* TargetRelativePath-Info.plist */; };
+		60E0C94D2390F87500524513 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E42056A51B00BAAFD1 /* AppDelegate.swift */; };
+		60E0C9512390F87500524513 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E62056A51B00BAAFD1 /* ViewController.swift */; };
+		60E0C9542390F87500524513 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82E82056A51B00BAAFD1 /* Main.storyboard */; };
+		60E0C9562390F87700524513 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82EB2056A51B00BAAFD1 /* Assets.xcassets */; };
+		60E0C9592390F87700524513 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82ED2056A51B00BAAFD1 /* LaunchScreen.storyboard */; };
 		A066E5F423253F0F0053B487 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E62056A51B00BAAFD1 /* ViewController.swift */; };
 		A066E5F523253F0F0053B487 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E42056A51B00BAAFD1 /* AppDelegate.swift */; };
 		A066E5F823253F0F0053B487 /* TargetDifferentConfigurations-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83AD2057215F00BAAFD1 /* TargetDifferentConfigurations-Debug.plist */; };
@@ -222,6 +227,8 @@
 		4AA286FF2300242600067244 /* TargetVariableParentheses-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "TargetVariableParentheses-Info.plist"; sourceTree = "<group>"; };
 		60E0C927238E9B1000524513 /* TargetRelativePath.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetRelativePath.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60E0C944238E9E5F00524513 /* TargetRelativePath-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetRelativePath-Info.plist"; sourceTree = "<group>"; };
+		60E0C94A2390F87500524513 /* TargetAbsolutePath.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetAbsolutePath.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		60E0C95A2390F87700524513 /* TargetAbsolutePath-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetAbsolutePath-Info.plist"; sourceTree = "<group>"; };
 		A066E60823253F0F0053B487 /* TargetVariableCurlyBraces.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetVariableCurlyBraces.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A066E60A23253FAB0053B487 /* TargetVariableCurlyBraces-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetVariableCurlyBraces-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -332,6 +339,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		60E0C9472390F87500524513 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A066E5F623253F0F0053B487 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -362,6 +376,7 @@
 				03F663DB23538CFD00D4B92F /* TargetVariableCurlyBracesBuildSettings-Info.plist */,
 				03F663DC23538CFD00D4B92F /* TargetVariableParenthesesBuildSettings-Info.plist */,
 				60E0C944238E9E5F00524513 /* TargetRelativePath-Info.plist */,
+				60E0C95A2390F87700524513 /* TargetAbsolutePath-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -384,6 +399,7 @@
 				03F663C123538BA700D4B92F /* TargetVariableParenthesesBuildSettings.app */,
 				03F663D923538BB200D4B92F /* TargetVariableCurlyBracesBuildSettings.app */,
 				60E0C927238E9B1000524513 /* TargetRelativePath.app */,
+				60E0C94A2390F87500524513 /* TargetAbsolutePath.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -408,6 +424,18 @@
 				03AB82F92056A51B00BAAFD1 /* get_version_numberTests.swift */,
 			);
 			path = get_version_numberTests;
+			sourceTree = "<group>";
+		};
+		60E0C94B2390F87500524513 /* TargetAbsolutePath */ = {
+			isa = PBXGroup;
+			children = (
+				60E0C94C2390F87500524513 /* AppDelegate.swift */,
+				60E0C9502390F87500524513 /* ViewController.swift */,
+				60E0C9522390F87500524513 /* Main.storyboard */,
+				60E0C9552390F87700524513 /* Assets.xcassets */,
+				60E0C9572390F87700524513 /* LaunchScreen.storyboard */,
+			);
+			path = TargetAbsolutePath;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -671,6 +699,23 @@
 			productReference = 60E0C927238E9B1000524513 /* TargetRelativePath.app */;
 			productType = "com.apple.product-type.application";
 		};
+		60E0C9492390F87500524513 /* TargetAbsolutePath */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 60E0C95D2390F87700524513 /* Build configuration list for PBXNativeTarget "TargetAbsolutePath" */;
+			buildPhases = (
+				60E0C9462390F87500524513 /* Sources */,
+				60E0C9472390F87500524513 /* Frameworks */,
+				60E0C9482390F87500524513 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TargetAbsolutePath;
+			productName = TargetAbsolutePath;
+			productReference = 60E0C94A2390F87500524513 /* TargetAbsolutePath.app */;
+			productType = "com.apple.product-type.application";
+		};
 		A066E5F223253F0F0053B487 /* TargetVariableCurlyBraces */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A066E60523253F0F0053B487 /* Build configuration list for PBXNativeTarget "TargetVariableCurlyBraces" */;
@@ -750,6 +795,9 @@
 					60E0C926238E9B1000524513 = {
 						ProvisioningStyle = Automatic;
 					};
+					60E0C9492390F87500524513 = {
+						ProvisioningStyle = Automatic;
+					};
 					A066E5F223253F0F0053B487 = {
 						ProvisioningStyle = Automatic;
 					};
@@ -785,6 +833,7 @@
 				03F663AB23538BA700D4B92F /* TargetVariableParenthesesBuildSettings */,
 				03F663C323538BB200D4B92F /* TargetVariableCurlyBracesBuildSettings */,
 				60E0C926238E9B1000524513 /* TargetRelativePath */,
+				60E0C9492390F87500524513 /* TargetAbsolutePath */,
 			);
 		};
 /* End PBXProject section */
@@ -992,6 +1041,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		60E0C9482390F87500524513 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60E0C9592390F87700524513 /* LaunchScreen.storyboard in Resources */,
+				60E0C9562390F87700524513 /* Assets.xcassets in Resources */,
+				60E0C9542390F87500524513 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A066E5F723253F0F0053B487 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1144,6 +1203,15 @@
 			files = (
 				60E0C92E238E9B1000524513 /* ViewController.swift in Sources */,
 				60E0C92A238E9B1000524513 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		60E0C9462390F87500524513 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60E0C9512390F87500524513 /* ViewController.swift in Sources */,
+				60E0C94D2390F87500524513 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1813,6 +1881,36 @@
 			};
 			name = Release;
 		};
+		60E0C95B2390F87700524513 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "/tmp/fastlane_get_version_number_action_spec/TargetAbsolutePath-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		60E0C95C2390F87700524513 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "/tmp/fastlane_get_version_number_action_spec/TargetAbsolutePath-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
 		A066E60623253F0F0053B487 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1999,6 +2097,15 @@
 			buildConfigurations = (
 				60E0C938238E9B1200524513 /* Debug */,
 				60E0C939238E9B1200524513 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		60E0C95D2390F87700524513 /* Build configuration list for PBXNativeTarget "TargetAbsolutePath" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				60E0C95B2390F87700524513 /* Debug */,
+				60E0C95C2390F87700524513 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
@@ -138,6 +138,11 @@
 		4AA286F82300242500067244 /* TargetC_internal-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83492056AEC500BAAFD1 /* TargetC_internal-Info.plist */; };
 		4AA286F92300242500067244 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82E82056A51B00BAAFD1 /* Main.storyboard */; };
 		4AA286FA2300242500067244 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83262056AADB00BAAFD1 /* Info.plist */; };
+		60E0C92A238E9B1000524513 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E42056A51B00BAAFD1 /* AppDelegate.swift */; };
+		60E0C92E238E9B1000524513 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E62056A51B00BAAFD1 /* ViewController.swift */; };
+		60E0C933238E9B1200524513 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82EB2056A51B00BAAFD1 /* Assets.xcassets */; };
+		60E0C936238E9B1200524513 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03AB82ED2056A51B00BAAFD1 /* LaunchScreen.storyboard */; };
+		60E0C945238E9E5F00524513 /* TargetRelativePath-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 60E0C944238E9E5F00524513 /* TargetRelativePath-Info.plist */; };
 		A066E5F423253F0F0053B487 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E62056A51B00BAAFD1 /* ViewController.swift */; };
 		A066E5F523253F0F0053B487 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03AB82E42056A51B00BAAFD1 /* AppDelegate.swift */; };
 		A066E5F823253F0F0053B487 /* TargetDifferentConfigurations-Debug.plist in Resources */ = {isa = PBXBuildFile; fileRef = 03AB83AD2057215F00BAAFD1 /* TargetDifferentConfigurations-Debug.plist */; };
@@ -215,6 +220,8 @@
 		03F663DC23538CFD00D4B92F /* TargetVariableParenthesesBuildSettings-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetVariableParenthesesBuildSettings-Info.plist"; sourceTree = "<group>"; };
 		4AA286FE2300242500067244 /* TargetVariableParentheses.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetVariableParentheses.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4AA286FF2300242600067244 /* TargetVariableParentheses-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "TargetVariableParentheses-Info.plist"; sourceTree = "<group>"; };
+		60E0C927238E9B1000524513 /* TargetRelativePath.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetRelativePath.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		60E0C944238E9E5F00524513 /* TargetRelativePath-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetRelativePath-Info.plist"; sourceTree = "<group>"; };
 		A066E60823253F0F0053B487 /* TargetVariableCurlyBraces.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TargetVariableCurlyBraces.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A066E60A23253FAB0053B487 /* TargetVariableCurlyBraces-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TargetVariableCurlyBraces-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -318,6 +325,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		60E0C924238E9B1000524513 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A066E5F623253F0F0053B487 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -347,6 +361,7 @@
 				03AB82E22056A51B00BAAFD1 /* Products */,
 				03F663DB23538CFD00D4B92F /* TargetVariableCurlyBracesBuildSettings-Info.plist */,
 				03F663DC23538CFD00D4B92F /* TargetVariableParenthesesBuildSettings-Info.plist */,
+				60E0C944238E9E5F00524513 /* TargetRelativePath-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -368,6 +383,7 @@
 				A066E60823253F0F0053B487 /* TargetVariableCurlyBraces.app */,
 				03F663C123538BA700D4B92F /* TargetVariableParenthesesBuildSettings.app */,
 				03F663D923538BB200D4B92F /* TargetVariableCurlyBracesBuildSettings.app */,
+				60E0C927238E9B1000524513 /* TargetRelativePath.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -638,6 +654,23 @@
 			productReference = 4AA286FE2300242500067244 /* TargetVariableParentheses.app */;
 			productType = "com.apple.product-type.application";
 		};
+		60E0C926238E9B1000524513 /* TargetRelativePath */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 60E0C93A238E9B1200524513 /* Build configuration list for PBXNativeTarget "TargetRelativePath" */;
+			buildPhases = (
+				60E0C923238E9B1000524513 /* Sources */,
+				60E0C924238E9B1000524513 /* Frameworks */,
+				60E0C925238E9B1000524513 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TargetRelativePath;
+			productName = TargetRelativePath;
+			productReference = 60E0C927238E9B1000524513 /* TargetRelativePath.app */;
+			productType = "com.apple.product-type.application";
+		};
 		A066E5F223253F0F0053B487 /* TargetVariableCurlyBraces */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A066E60523253F0F0053B487 /* Build configuration list for PBXNativeTarget "TargetVariableCurlyBraces" */;
@@ -714,6 +747,9 @@
 					4AA286E82300242500067244 = {
 						ProvisioningStyle = Automatic;
 					};
+					60E0C926238E9B1000524513 = {
+						ProvisioningStyle = Automatic;
+					};
 					A066E5F223253F0F0053B487 = {
 						ProvisioningStyle = Automatic;
 					};
@@ -748,6 +784,7 @@
 				A066E5F223253F0F0053B487 /* TargetVariableCurlyBraces */,
 				03F663AB23538BA700D4B92F /* TargetVariableParenthesesBuildSettings */,
 				03F663C323538BB200D4B92F /* TargetVariableCurlyBracesBuildSettings */,
+				60E0C926238E9B1000524513 /* TargetRelativePath */,
 			);
 		};
 /* End PBXProject section */
@@ -945,6 +982,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		60E0C925238E9B1000524513 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60E0C945238E9E5F00524513 /* TargetRelativePath-Info.plist in Resources */,
+				60E0C936238E9B1200524513 /* LaunchScreen.storyboard in Resources */,
+				60E0C933238E9B1200524513 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A066E5F723253F0F0053B487 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1088,6 +1135,15 @@
 			files = (
 				4AA286EA2300242500067244 /* ViewController.swift in Sources */,
 				4AA286EB2300242500067244 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		60E0C923238E9B1000524513 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60E0C92E238E9B1000524513 /* ViewController.swift in Sources */,
+				60E0C92A238E9B1000524513 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1727,6 +1783,36 @@
 			};
 			name = Release;
 		};
+		60E0C938238E9B1200524513 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "$(SRCROOT)/../get_version_number/TargetRelativePath-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		60E0C939238E9B1200524513 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "$(SRCROOT)/../get_version_number/TargetRelativePath-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "tools.fastlane.get-version-number";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
 		A066E60623253F0F0053B487 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1904,6 +1990,15 @@
 			buildConfigurations = (
 				4AA286FC2300242500067244 /* Debug */,
 				4AA286FD2300242500067244 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		60E0C93A238E9B1200524513 /* Build configuration list for PBXNativeTarget "TargetRelativePath" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				60E0C938238E9B1200524513 /* Debug */,
+				60E0C939238E9B1200524513 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
* When `INFOPLIST_FILE` is specified as an absolute path, `get_version_number` doesn't work.
  * Projects made with [xcodegen](https://github.com/yonaskolb/XcodeGen) are often set as absolute path.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
1. In [`resolved_build_setting`](https://www.rubydoc.info/gems/xcodeproj/Xcodeproj%2FProject%2FObject%2FAbstractTarget:resolved_build_setting), return plist_files using the `resolve_against_xcconfig` option.
2. plist_file can be `Relative` or `Absolute` path.
3. Make to `Absolute` path when plist_file is `Relative` path.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
1. Create iOS-Single-View-App on Xcode.
2. Replace `INFOPLIST_FILE` to an absolute path on `Project.xcodeproj/project.pbxproj`.
3. Run `bundle exec fastlane get_version_number` and make sure it's correct version.
