### PR TITLE
[frameit] Preserve colorspace when composing with background image

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -262,6 +262,7 @@ module Frameit
       left_space = (background.width / 2.0 - image.width / 2.0).round
 
       @image = background.composite(image, "png") do |c|
+        c.colorspace(image.data["colorspace"])
         c.compose("Over")
         c.geometry("+#{left_space}+#{device_top(background)}")
       end

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -262,7 +262,9 @@ module Frameit
       left_space = (background.width / 2.0 - image.width / 2.0).round
 
       @image = background.composite(image, "png") do |c|
-        c.colorspace(image.data["colorspace"])
+        colorspace = image.data["colorspace"]
+        c.colorspace(colorspace) if colorspace
+
         c.compose("Over")
         c.geometry("+#{left_space}+#{device_top(background)}")
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Hello! 👋 This PR attempts to fix issue https://github.com/fastlane/fastlane/issues/15619.

Just like the reporter of the issue, I also have Catalina running on my machine and ran into this issue. This was never an issue pre-Catalina and so I suspect something on Catalina is causing this behavior. I have to admit I don't understand the root cause so I am open to suggestions. I have a section later where I list my concerns with this approach.

You can see the background image I am using is a JPG and has the colorspace sRGB:

```
$ magick --version
Version: ImageMagick 7.0.9-6 Q16 x86_64 2019-11-27 https://imagemagick.org

$ magick identify fastlane/screenshots/background.jpg 
fastlane/screenshots/background.jpg JPEG 2048x1536 2048x1536+0+0 8-bit sRGB 50365B 0.000u 0:00.000
```

The colorspace of my screenshot image before `frameit` is sRGB

```
$ magick identify fastlane/screenshots/en-US/iPhone\ 11-example.png       
fastlane/screenshots/en-US/iPhone 11-example.png PNG 828x1792 828x1792+0+0 8-bit sRGB 130187B 0.000u 0:00.000
```

After running `frameit` you can see the colorspace changes to Gray:

```
$ magick identify fastlane/screenshots/en-US/iPhone\ 11-example_framed.png
fastlane/screenshots/en-US/iPhone 11-example_framed.png PNG 828x1792 828x1792+0+0 8-bit Gray 256c 133225B 0.000u 0:00.000
```

What you end up with is a framed image that is Grayscale when the original source was not.

### Description

I dug around and I found that `frameit` relies on [`mini_magick`](https://github.com/minimagick/minimagick) to do the actual composition of images.

I found that you can force the colorspace by setting the `colorspace` attribute. When composing the background with the front image, I forced the resulting image to have the same colorspace as the front image.

In order to test my change, I changed my project to use my local branch version of `fastlane`. I ran `frameit` with this branch to iterate and see what change would preserve the colorspace. With this patch, I verfied visually that the colorspace is restored to sRGB. I also used `magick` to verify:

```
$ magick identify fastlane/screenshots/en-US/iPhone\ 11-example_framed.png
fastlane/screenshots/en-US/iPhone 11-example_framed.png PNG 828x1792 828x1792+0+0 8-bit sRGB 286680B 0.000u 0:00.000
```

Some concerns I have with this approach:

* I'm not sure if it's safe to assume users of `frameit` all have ImageMagick 6.8.8-3 or above. My limited understanding is that `mini_magick` is just a wrapper that can delegate out to either ImageMagick or GraphicsMagick. I haven't done any testing to see if the hash key `colorspace` exists for machines with GraphicsMagick.
    > Note that MiniMagick::Image#data is supported only on ImageMagick 6.8.8-3 or above, for GraphicsMagick or older versions of ImageMagick use MiniMagick::Image#details.

    Another option is to make the implementation more flexible by falling back to use `details` but I wanted to start with the simplest approach to convey the context and iterate from there if needed. My fear is that the current implementation might set the `colorspace` attribute to `nil`.

* There are several other instances where `Frameit::Editor` is calling [`MiniMagic::Image#composite`](https://github.com/minimagick/minimagick#composite) and the colorspace does not need to be overridden for my use case. I am unsure if other sections in `Frameit::Editor` need colorspace preserved or if we should explore a more elegant implementation to make sure colorspace is always set to some value.

I was really curious about this issue.  Searching online, I found that something similar happened on older versions of IM but I'm pretty sure it's not related since I'm on 7.0.9. At the very least I didn't find it surprising that libraries you depend on can do some quirky things. 😉 

> If the image has 3 identical channels, even if colorspace is RGB, IM by default will set the colorspace to Grayscale. However, in later versions of IM (6.9.2-1 or higher), you can override that behavior with a new -define colorspace:auto-grayscale=off
https://www.imagemagick.org/discourse-server/viewtopic.php?t=28949

### Testing Steps

This was tricky to test so I reconfigured my project's `Gemfile` to point to my local branch `fastlane` and iterated to get a final `frameit` output with the `sRGB` colorspace. I did a lot of `puts` to determine where exactly in the code the conversion was happening. I did run all unit tests to make sure nothing was broken.

I believe what you need to reproduce this issue is:

Environment:

* macOS running Catalina (version 10.15.1)
* fastlane version 2.137.0 (which uses mini_magick 4.9.5)
* magick 7.0.9-6 Q16 x86_64 2019-11-27

Resources:

* A background image JPG with colorspace sRGB
* A PNG image with colorspace sRGB to use to compose with the background.

A lot of this was me just digging around cause I was curious. Please let me know if anything I said is wrong! Thank you 🙇 
