### PR TITLE
[action] last_git_tag: Provided parameter that specifies filter pattern when looking for last available tag

### DIFF
--- a/fastlane/lib/fastlane/actions/last_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/last_git_tag.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class LastGitTagAction < Action
       def self.run(params)
-        Actions.last_git_tag_name
+        Actions.last_git_tag_name(true, params[:pattern])
       end
 
       #####################################################
@@ -14,7 +14,12 @@ module Fastlane
       end
 
       def self.available_options
-        []
+        [
+          FastlaneCore::ConfigItem.new(key: :pattern,
+                                       description: "Pattern to filter tags when looking for last one. Limit tags to ones matching given shell glob. If pattern lacks ?, *, or [, /* at the end is implied",
+                                       default_value: nil,
+                                       optional: true)
+        ]
       end
 
       def self.output
@@ -26,7 +31,7 @@ module Fastlane
       end
 
       def self.authors
-        ["KrauseFx"]
+        ["KrauseFx", "wedkarz"]
       end
 
       def self.is_supported?(platform)
@@ -34,12 +39,16 @@ module Fastlane
       end
 
       def self.details
-        "If you are using this action on a **shallow clone**, *the default with some CI systems like Bamboo*, you need to ensure that you have also pulled all the git tags appropriately. Assuming your git repo has the correct remote set you can issue `sh('git fetch --tags')`."
+        [
+          "If you are using this action on a **shallow clone**, *the default with some CI systems like Bamboo*, you need to ensure that you have also pulled all the git tags appropriately. Assuming your git repo has the correct remote set you can issue `sh('git fetch --tags')`.",
+          "Pattern parameter allows you to filter to a subset of tags."
+        ].join("\n")
       end
 
       def self.example_code
         [
-          'last_git_tag'
+          'last_git_tag',
+          'last_git_tag(pattern: "release/v1.0/")'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/last_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/last_git_tag.rb
@@ -16,7 +16,7 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :pattern,
-                                       description: "Pattern to filter tags when looking for last one. Limit tags to ones matching given shell glob. If pattern lacks ?, *, or [, /* at the end is implied",
+                                       description: "Pattern to filter tags when looking for last one. Limit tags to ones matching given shell glob. If pattern lacks ?, *, or [, * at the end is implied",
                                        default_value: nil,
                                        optional: true)
         ]

--- a/fastlane/spec/actions_specs/last_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/last_git_tag_spec.rb
@@ -10,6 +10,17 @@ describe Fastlane do
         describe = %W(git describe --tags #{tag_name}).shelljoin
         expect(result).to eq(describe)
       end
+
+      it "Returns nothing for jibberish tag pattern match" do
+        tag_pattern = "jibberish"
+        result = Fastlane::FastFile.new.parse("lane :test do
+          last_git_tag(pattern: \"#{tag_pattern}\")
+        end").runner.execute(:test)
+
+        tag_name = %W(git rev-list --tags=#{tag_pattern} --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        expect(result).to eq(describe)
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
In my case, I am tagging any commit that is resulting in downloadable build. This now happens from multiple release branches. Every tag is prefixed with the project name and branch.
Having the ability to filter out only tags specific to a given branch I would be able to continue using release notes generation from changes/commits that occurred between tags.
It has been working properly when only one branch has been used for the purpose of tagging and release notes creation.

### Description
Changes aren't really implementing anything new, rather exposing additional parameters that are passed to git CLI, so that we can pass the `:pattern` parameter as fastlane option.

### Testing Steps
Additional test case inside `last_git_tag_spec.rb`, running `bundle exec rspec ./fastlane/spec/actions_specs/last_git_tag_spec.rb`.

Verification of action within project by modified Gemfile and running e.g `bundle exec fastlane run last_git_tag pattern:"foo/bar"` where `foo/bar` is pattern/prefix for filtered tag.
