### PR TITLE
[supply] fix error when no tracks are returned

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -345,6 +345,7 @@ module Supply
       ensure_active_edit!
 
       all_tracks = call_google_api { client.list_edit_tracks(current_package_name, current_edit.id) }.tracks
+      all_tracks = [] unless all_tracks
 
       if tracknames.length > 0
         all_tracks = all_tracks.select { |track| tracknames.include?(track.track) }


### PR DESCRIPTION
I fixed an error in Supply's Client.tracks method. When there are no
active releases for an application in the Google Play console, the call
to the Edit.tracks:list Google Play API succeeds, but the JSON response
is not including the tracks array. This results in the all_tracks
variable being nil and the call to all_tracks.select fails with a nil
reference error. I added a line that will default the all_tracks
variable to an empty array if all_tracks is nil which fixes the error.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #15718 

Supply was crashing when attempting to publish a newer style Android Application Bundle (AAB) file to Google Play instead of an APK bundle. The crash was due to a nil reference error to an array of tracks received from Google Play's API.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

While debugging the call that failed, I noticed that when I did not have any active tracks for my application in Google Play, the call to the [Edit.tracks:list](https://developers.google.com/android-publisher/api-ref/edits/tracks/list) API succeeded, but was not returning the `tracks` array in the response. As a result, the `all_tracks` variable in `Client.tracks` was being returned as a `nil` value. The following call to `all_tracks.select` was failing since `all_tracks` was nil.

I fixed the issue by adding a line of code that will set `all_tracks` to an empty array if the value of `all_tracks` is nil.

I rarely program in Ruby, so please let me know if my way of handling the `nil` check is not the preferred approach.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I ran the fix against my application and Google Play with the following scenarios:

1. No active tracks; I verified that Supply would create the `production` track and upload the AAB.
2. I deleted the application uploaded in test 1 and left the `production` track active and verified that the AAB was successfully uploaded to the `production` track.