### PR TITLE
[spaceship] ignore corrupted cookie file

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -571,7 +571,7 @@ module Spaceship
         end
       rescue => ex
         puts(ex.to_s)
-        puts("Continuing with other login methods")
+        puts("Continuing with normal login.")
       end
       return false
     end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -571,7 +571,7 @@ module Spaceship
         end
       rescue => ex
         puts(ex.to_s)
-        puts("Continue with normal login")
+        puts("Continuing with other login methods")
       end
       return false
     end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -563,10 +563,15 @@ module Spaceship
     #####################################################
 
     def load_session_from_file
-      if File.exist?(persistent_cookie_path)
-        puts("Loading session from '#{persistent_cookie_path}'") if Spaceship::Globals.verbose?
-        @cookie.load(persistent_cookie_path)
-        return true
+      begin
+        if File.exist?(persistent_cookie_path)
+          puts("Loading session from '#{persistent_cookie_path}'") if Spaceship::Globals.verbose?
+          @cookie.load(persistent_cookie_path)
+          return true
+        end
+      rescue => ex
+        puts(ex.to_s)
+        puts("Continue with normal login")
       end
       return false
     end


### PR DESCRIPTION
Other than the session in the environment, the session on disk is not provided by the user, so we should not fail if the session cookie is corrupted, instead just fetch a new one.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For random reasons we had errors in the cookie yaml on one of our buildnodes. Since the persistent cookie can be reobtained, fastlane should not crash, if there is something wrong with it.
### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Catch the possible errors when parsing the session cookie.
### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
