### PR TITLE
[gemspec] ensure excon version is at least 0.71.0 (CVE-2019-16779)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
           command: |
             mkdir -p ~/test-reports
             echo "2.3" > .ruby-version
-            gem update --system
             brew untap caskroom/versions
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
@@ -83,7 +82,6 @@ jobs:
           command: |
             mkdir -p ~/test-reports
             echo "2.5" > .ruby-version
-            gem update --system
             brew untap caskroom/versions
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
@@ -190,7 +188,6 @@ jobs:
           command: |
             mkdir -p ~/test-reports
             echo "2.5" > .ruby-version
-            gem update --system
             brew untap caskroom/versions
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('babosa', '>= 1.0.2', "< 2.0.0")
   spec.add_dependency('colored') # colored terminal output
   spec.add_dependency('commander-fastlane', '>= 4.4.6', '< 5.0.0') # CLI parser
-  spec.add_dependency('excon', '>= 0.45.0', '< 1.0.0') # Great HTTP Client
+  spec.add_dependency('excon', '>= 0.71.0', '< 1.0.0') # Great HTTP Client
   spec.add_dependency('faraday-cookie_jar', '~> 0.0.6')
   spec.add_dependency('faraday', '~> 0.17') # Used for deploygate, hockey and testfairy actions
   spec.add_dependency('faraday_middleware', '~> 0.13.1') # same as faraday


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
A recent vulnerability in `excon` has been reported for versions before 0.71.0: https://github.com/excon/excon/security/advisories/GHSA-q58g-455p-8vw9

### Description
This PR changes the version requirement so that it excludes vulnerable versions of `excon`.

### Testing Steps
All tests pass