### PR TITLE
[action] add `upload_to_play_store_internal_app_sharing` action

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -104,7 +104,7 @@ Gem::Specification.new do |spec|
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.
-  spec.add_dependency('google-api-client', '>= 0.21.2', '< 0.24.0') # Google API Client to access Play Publishing API
+  spec.add_dependency('google-api-client', '>= 0.29.2', '< 0.37.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
 
   spec.add_dependency('emoji_regex', '>= 0.1', '< 2.0') # Used to scan for Emoji in the changelog

--- a/fastlane/lib/fastlane/actions/upload_to_play_store_internal_app_sharing.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_play_store_internal_app_sharing.rb
@@ -1,0 +1,181 @@
+module Fastlane
+  module Actions
+    class UploadToPlayStoreInternalAppSharingAction < Action
+      def self.run(params)
+        require 'supply'
+
+        # If no APK params were provided, try to fill in the values from lane context, preferring
+        # the multiple APKs over the single APK if set.
+        if params[:apk_paths].nil? && params[:apk].nil?
+          all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] || []
+          if all_apk_paths.size > 1
+            params[:apk_paths] = all_apk_paths
+          else
+            params[:apk] = Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+          end
+        end
+
+        # If no AAB param was provided, try to fill in the value from lane context.
+        # First GRADLE_ALL_AAB_OUTPUT_PATHS if only one
+        # Else from GRADLE_AAB_OUTPUT_PATH
+        if params[:aab].nil?
+          all_aab_paths = Actions.lane_context[SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS] || []
+          if all_aab_paths.count == 1
+            params[:aab] = all_aab_paths.first
+          else
+            params[:aab] = Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+          end
+        end
+
+        Supply.config = params # we already have the finished config
+
+        Supply::Uploader.new.perform_upload_to_internal_app_sharing
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload binaries to Google Play Internal App Sharing (via _supply_)"
+      end
+
+      def self.details
+        "More information: https://docs.fastlane.tools/actions/upload_to_play_store_internal_app_sharing/"
+      end
+
+      def self.available_options
+        @options ||= [
+          FastlaneCore::ConfigItem.new(key: :package_name,
+                                       env_name: "SUPPLY_PACKAGE_NAME",
+                                       short_option: "-p",
+                                       description: "The package name of the application to use",
+                                       code_gen_sensitive: true,
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:package_name),
+                                       default_value_dynamic: true),
+          FastlaneCore::ConfigItem.new(key: :json_key,
+                                       env_name: "SUPPLY_JSON_KEY",
+                                       short_option: "-j",
+                                       conflicting_options: [:json_key_data],
+                                       description: "The path to a file containing service account JSON, used to authenticate with Google",
+                                       code_gen_sensitive: true,
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
+                                       default_value_dynamic: true,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+                                         UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :json_key_data,
+                                       env_name: "SUPPLY_JSON_KEY_DATA",
+                                       short_option: "-c",
+                                       description: "The raw service account JSON data used to authenticate with Google",
+                                       conflicting_options: [:json_key],
+                                       code_gen_sensitive: true,
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
+                                       default_value_dynamic: true,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         begin
+                                           JSON.parse(value)
+                                         rescue JSON::ParserError
+                                           UI.user_error!("Could not parse service account json: JSON::ParseError")
+                                         end
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :apk,
+                                       env_name: "SUPPLY_APK",
+                                       short_option: "-b",
+                                       description: "Path to the APK file to upload",
+                                       conflicting_options: [:apk_paths, :aab, :aab_paths],
+                                       code_gen_sensitive: true,
+                                       default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
+                                       default_value_dynamic: true,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not find apk file at path '#{value}'") unless File.exist?(value)
+                                         UI.user_error!("apk file is not an apk") unless value.end_with?('.apk')
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :apk_paths,
+                                       env_name: "SUPPLY_APK_PATHS",
+                                       short_option: "-u",
+                                       description: "An array of paths to APK files to upload",
+                                       conflicting_options: [:apk, :aab, :aab_paths],
+                                       code_gen_sensitive: true,
+                                       type: Array,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
+                                         value.each do |path|
+                                           UI.user_error!("Could not find apk file at path '#{path}'") unless File.exist?(path)
+                                           UI.user_error!("file at path '#{path}' is not an apk") unless path.end_with?('.apk')
+                                         end
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :aab,
+                                       env_name: "SUPPLY_AAB",
+                                       short_option: "-f",
+                                       description: "Path to the AAB file to upload",
+                                       conflicting_options: [:apk, :apk_paths, :aab_paths],
+                                       code_gen_sensitive: true,
+                                       default_value: Dir["*.aab"].last || Dir[File.join("app", "build", "outputs", "bundle", "release", "bundle.aab")].last,
+                                       default_value_dynamic: true,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not find aab file at path '#{value}'") unless File.exist?(value)
+                                         UI.user_error!("aab file is not an aab") unless value.end_with?('.aab')
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :aab_paths,
+                                       env_name: "SUPPLY_AAB_PATHS",
+                                       short_option: "-z",
+                                       description: "An array of paths to AAB files to upload",
+                                       conflicting_options: [:apk, :apk_paths, :aab],
+                                       code_gen_sensitive: true,
+                                       type: Array,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)
+                                         value.each do |path|
+                                           UI.user_error!("Could not find aab file at path '#{path}'") unless File.exist?(path)
+                                           UI.user_error!("file at path '#{path}' is not an aab") unless path.end_with?('.aab')
+                                         end
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+                                       env_name: "SUPPLY_TIMEOUT",
+                                       optional: true,
+                                       description: "Timeout for read, open, and send (in seconds)",
+                                       type: Integer,
+                                       default_value: 300), # 5 minutes
+          FastlaneCore::ConfigItem.new(key: :root_url,
+                                       env_name: "SUPPLY_ROOT_URL",
+                                       description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not parse URL '#{value}'") unless value =~ URI.regexp
+                                       end)
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        "Returns a string containing the download URL for the uploaded APK/AAB (or array of strings if multiple were uploaded)."
+      end
+
+      def self.authors
+        ["andrewhavens"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+
+      def self.example_code
+        ["upload_to_play_store_internal_app_sharing"]
+      end
+
+      def self.category
+        :production
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/upload_to_play_store_internal_app_sharing.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_play_store_internal_app_sharing.rb
@@ -54,9 +54,6 @@ module Fastlane
         options.delete_if { |option| options_to_keep.include?(option.key) == false }
       end
 
-      def self.output
-      end
-
       def self.return_value
         "Returns a string containing the download URL for the uploaded APK/AAB (or array of strings if multiple were uploaded)."
       end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -58,6 +58,7 @@ describe Fastlane do
           sync_code_signing
           upload_to_app_store
           upload_to_play_store
+          upload_to_play_store_internal_app_sharing
           upload_to_testflight
           puts
           println

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -310,6 +310,19 @@ module Supply
       return result_upload.version_code
     end
 
+    def upload_apk_to_internal_app_sharing(package_name, path_to_apk)
+      # NOTE: This Google API is a little different. It doesn't require an active edit.
+      result_upload = call_google_api do
+        client.uploadapk_internalappsharingartifact(
+          package_name,
+          upload_source: path_to_apk,
+          content_type: "application/octet-stream"
+        )
+      end
+
+      return result_upload.download_url
+    end
+
     def upload_mapping(path_to_mapping, apk_version_code)
       ensure_active_edit!
 
@@ -338,6 +351,19 @@ module Supply
       end
 
       return result_upload.version_code
+    end
+
+    def upload_bundle_to_internal_app_sharing(package_name, path_to_aab)
+      # NOTE: This Google API is a little different. It doesn't require an active edit.
+      result_upload = call_google_api do
+        client.uploadbundle_internalappsharingartifact(
+          package_name,
+          upload_source: path_to_aab,
+          content_type: "application/octet-stream"
+        )
+      end
+
+      return result_upload.download_url
     end
 
     # Get a list of all tracks - returns the list

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -42,6 +42,34 @@ module Supply
       end
     end
 
+    def perform_upload_to_internal_app_sharing
+      download_urls = []
+
+      package_name = Supply.config[:package_name]
+
+      apk_paths = [Supply.config[:apk]] unless (apk_paths = Supply.config[:apk_paths])
+      apk_paths.compact!
+      apk_paths.each do |apk_path|
+        download_url = client.upload_apk_to_internal_app_sharing(package_name, apk_path)
+        download_urls << download_url
+        UI.success("Successfully uploaded APK to Internal App Sharing URL: #{download_url}")
+      end
+
+      aab_paths = [Supply.config[:aab]] unless (aab_paths = Supply.config[:aab_paths])
+      aab_paths.compact!
+      aab_paths.each do |aab_path|
+        download_url = client.upload_bundle_to_internal_app_sharing(package_name, aab_path)
+        download_urls << download_url
+        UI.success("Successfully uploaded AAB to Internal App Sharing URL: #{download_url}")
+      end
+
+      if download_urls.count == 1
+        return download_urls.first
+      else
+        return download_urls
+      end
+    end
+
     def perform_upload_meta(version_codes)
       if (!Supply.config[:skip_upload_metadata] || !Supply.config[:skip_upload_images] || !Supply.config[:skip_upload_changelogs] || !Supply.config[:skip_upload_screenshots]) && metadata_path
         # Use version code from config if version codes is empty and no nil or empty string

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -53,6 +53,8 @@ describe Supply do
         expect(subject.class.method_defined?(:upload_edit_image)).to eq(true)
         expect(subject.class.method_defined?(:deleteall_edit_image)).to eq(true)
         expect(subject.class.method_defined?(:upload_edit_expansionfile)).to eq(true)
+        expect(subject.class.method_defined?(:uploadapk_internalappsharingartifact)).to eq(true)
+        expect(subject.class.method_defined?(:uploadbundle_internalappsharingartifact)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Adds support for uploading Android builds to the Play Store Internal App Sharing by introducing a new action called `upload_to_play_store_internal_app_sharing`. Fixes #15636. This PR also closes #15696.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This PR adds `upload_apk_to_internal_app_sharing` and `upload_bundle_to_internal_app_sharing` methods to the `Supply::Client` class, which are called from a new method `perform_upload_to_internal_app_sharing` within the `Supply::Uploader` class. The return value is the download URL of the uploaded APK/AAB (or array of URLs if multiple were uploaded).

This PR also bumps the minimum required `google-api-client` version in order to add support for uploading to Internal App Sharing.

I have compared the changes from the previous maximum version (0.23.9) to the new minimum version (0.29.2) and can confirm that they are only minor/insignificant changes. https://github.com/googleapis/google-api-ruby-client/compare/0.23.9...0.29.2 I have also compared to the latest release (0.36.1) and have confirmed the same. https://github.com/googleapis/google-api-ruby-client/compare/0.29.2...0.36.1 So I have set the maximum version to `< 0.37.0`.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I have manually tested that this code works by uploading my app to the Play Store Internal App Sharing.