### PR TITLE
[GitHub Actions] enable automatic bump of homebrew formula with github action

### DIFF
--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    tags: 'v*'
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v1.4
+        if: "!contains(github.ref, '-')" # skip prereleases
+        with:
+          formula-name: fastlane
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_COMMITTER_TOKEN }}


### PR DESCRIPTION
### Motivation and Context
Want to keep automating all of the release things

### Description
Bumps the `url` and `sha` from the tag that was just made

### Testing Steps
Hopefully this works after next release 🤞 
