### PR TITLE
[gym] using the correct build command when `skip_archive` is used

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -51,6 +51,7 @@ module Gym
 
         buildactions = []
         buildactions << :clean if config[:clean]
+        buildactions << :build if config[:skip_archive]
         buildactions << :archive unless config[:skip_archive]
 
         buildactions

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -18,6 +18,9 @@ module Gym
         build_app
       end
       verify_archive unless Gym.config[:skip_archive]
+
+      return nil if Gym.config[:skip_archive]
+
       FileUtils.mkdir_p(File.expand_path(Gym.config[:output_directory]))
 
       if Gym.project.ios? || Gym.project.tvos?
@@ -97,9 +100,11 @@ module Gym
                                                 ErrorHandler.handle_build_error(output)
                                               end)
 
-      mark_archive_as_built_by_gym(BuildCommandGenerator.archive_path)
-      UI.success("Successfully stored the archive. You can find it in the Xcode Organizer.") unless Gym.config[:archive_path].nil?
-      UI.verbose("Stored the archive in: " + BuildCommandGenerator.archive_path)
+      unless Gym.config[:skip_archive]
+        mark_archive_as_built_by_gym(BuildCommandGenerator.archive_path)
+        UI.success("Successfully stored the archive. You can find it in the Xcode Organizer.") unless Gym.config[:archive_path].nil?
+        UI.verbose("Stored the archive in: " + BuildCommandGenerator.archive_path)
+      end
 
       post_build_app
     end

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -88,6 +88,25 @@ describe Gym do
                            ])
     end
 
+    it "uses the correct build command when `skip_archive` is used", requires_xcodebuild: true do
+      log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
+
+      options = { project: "./gym/examples/standard/Example.xcodeproj", scheme: 'Example', skip_archive: true }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      result = Gym::BuildCommandGenerator.generate
+      expect(result).to eq([
+                             "set -o pipefail &&",
+                             "xcodebuild",
+                             "-scheme Example",
+                             "-project ./gym/examples/standard/Example.xcodeproj",
+                             "-destination 'generic/platform=iOS'",
+                             :build,
+                             "| tee #{log_path.shellescape}",
+                             "| xcpretty"
+                           ])
+    end
+
     describe "Standard Example" do
       before do
         options = { project: "./gym/examples/standard/Example.xcodeproj", scheme: 'Example' }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Just wanted to PR a quick fix for `gym` command.

Fixes #11971

When running `gym --skip-archive` the generated `xcodebuild` command does not specify any action/"build command" to use because `archive` action is not added (as expected).

The issue is that the `xcodebuild` still works because when no action is specified it uses `build` action by default. Unfortunately, this breaks when `clean` option is added: `gym --skip-archive --clean` as the generated command will now contain `clean` action, and because this is the only action specified the generated command only performs "clean" and no build - this is **unexpected**.

It also silently crashes with error `xattr: No such file: *.xcarchive` as there is no archive to mark at the next step:
https://github.com/fastlane/fastlane/blob/18c78326d0afec17256e98ed401441b8aa7f74fa/gym/lib/gym/runner.rb#L93-L100

This PR fixes both.

<!-- ### Description -->
<!-- Describe your changes in detail. -->

<!-- Please describe in detail how you tested your changes. -->

<!-- ### Testing Steps -->
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
