### PR TITLE
Version bump to 2.139.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,87 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
 <img src='https://github.com/AliSoftware.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-</tr>
-<tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
@@ -122,11 +46,55 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+</tr>
+<tr>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 </tr>
 <tr>
@@ -136,17 +104,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
@@ -154,11 +122,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+</tr>
+<tr>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
 </tr>
 </table>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,26 +15,26 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Jorge Revuelta H",
-                        "Joshua Liebowitz",
+  spec.authors       = ["Kohki Miki",
                         "Josh Holtz",
-                        "Danielle Tomlinson",
-                        "Kohki Miki",
-                        "Luka Mirosevic",
-                        "Iulian Onofrei",
-                        "Stefan Natchev",
-                        "Maksym Grebenets",
-                        "Manu Wallner",
-                        "Aaron Brager",
-                        "Matthew Ellis",
-                        "Felix Krause",
-                        "Jan Piotrowski",
-                        "Jérôme Lacoste",
                         "Helmut Januschka",
-                        "Fumiya Nakamura",
+                        "Jorge Revuelta H",
+                        "Jimmy Dee",
+                        "Jérôme Lacoste",
+                        "Iulian Onofrei",
+                        "Manu Wallner",
+                        "Stefan Natchev",
                         "Andrew McBurney",
+                        "Jan Piotrowski",
+                        "Felix Krause",
+                        "Danielle Tomlinson",
+                        "Aaron Brager",
+                        "Joshua Liebowitz",
+                        "Matthew Ellis",
+                        "Maksym Grebenets",
+                        "Luka Mirosevic",
                         "Olivier Halligon",
-                        "Jimmy Dee"]
+                        "Fumiya Nakamura"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.138.0'.freeze
+  VERSION = '2.139.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.138.0
+// Generated with fastlane 2.139.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -2146,6 +2146,8 @@ func createKeychain(name: String? = nil,
    - base: The name of the branch you want your changes pulled into (defaults to `master`)
    - apiUrl: The URL of GitHub API - used when the Enterprise (default to `https://api.github.com`)
    - assignees: The assignees for the pull request
+   - reviewers: The reviewers (slug) for the pull request
+   - teamReviewers: The team reviewers (slug) for the pull request
 
  - returns: The pull request URL when successful
 */
@@ -2157,7 +2159,9 @@ func createPullRequest(apiToken: String,
                        head: String? = nil,
                        base: String = "master",
                        apiUrl: String = "https://api.github.com",
-                       assignees: [String]? = nil) {
+                       assignees: [String]? = nil,
+                       reviewers: [String]? = nil,
+                       teamReviewers: [String]? = nil) {
   let command = RubyCommand(commandID: "", methodName: "create_pull_request", className: nil, args: [RubyCommand.Argument(name: "api_token", value: apiToken),
                                                                                                      RubyCommand.Argument(name: "repo", value: repo),
                                                                                                      RubyCommand.Argument(name: "title", value: title),
@@ -2166,7 +2170,9 @@ func createPullRequest(apiToken: String,
                                                                                                      RubyCommand.Argument(name: "head", value: head),
                                                                                                      RubyCommand.Argument(name: "base", value: base),
                                                                                                      RubyCommand.Argument(name: "api_url", value: apiUrl),
-                                                                                                     RubyCommand.Argument(name: "assignees", value: assignees)])
+                                                                                                     RubyCommand.Argument(name: "assignees", value: assignees),
+                                                                                                     RubyCommand.Argument(name: "reviewers", value: reviewers),
+                                                                                                     RubyCommand.Argument(name: "team_reviewers", value: teamReviewers)])
   _ = runner.executeCommand(command)
 }
 
@@ -4077,10 +4083,13 @@ func jira(url: String,
 /**
  Get the most recent git tag
 
+ - parameter pattern: Pattern to filter tags when looking for last one. Limit tags to ones matching given shell glob. If pattern lacks ?, *, or [, * at the end is implied
+
  If you are using this action on a **shallow clone**, *the default with some CI systems like Bamboo*, you need to ensure that you have also pulled all the git tags appropriately. Assuming your git repo has the correct remote set you can issue `sh('git fetch --tags')`.
+ Pattern parameter allows you to filter to a subset of tags.
 */
-@discardableResult func lastGitTag() -> String {
-  let command = RubyCommand(commandID: "", methodName: "last_git_tag", className: nil, args: [])
+@discardableResult func lastGitTag(pattern: String? = nil) -> String {
+  let command = RubyCommand(commandID: "", methodName: "last_git_tag", className: nil, args: [RubyCommand.Argument(name: "pattern", value: pattern)])
   return runner.executeCommand(command)
 }
 
@@ -4667,7 +4676,7 @@ func pem(development: Bool = false,
    - localizedBuildInfo: Localized beta app test info for what's new
    - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
-   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)
+   - skipWaitingForBuildProcessing: If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
    - usesNonExemptEncryption: Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist
    - distributeExternal: Should the build be distributed to external testers?
@@ -5354,6 +5363,7 @@ func rubyVersion() {
    - skipDetectDevices: Should skip auto detecting of devices if none were specified
    - forceQuitSimulator: Enabling this option will automatically killall Simulator processes before the run
    - resetSimulator: Enabling this option will automatically erase the simulator before running the application
+   - disableSlideToType: Enabling this option will disable the simulator from showing the 'Slide to type' prompt
    - prelaunchSimulator: Enabling this option will launch the first simulator prior to calling any xcodebuild command
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
@@ -5411,6 +5421,7 @@ func runTests(workspace: String? = nil,
               skipDetectDevices: Bool = false,
               forceQuitSimulator: Bool = false,
               resetSimulator: Bool = false,
+              disableSlideToType: Bool = true,
               prelaunchSimulator: Bool? = nil,
               reinstallApp: Bool = false,
               appIdentifier: String? = nil,
@@ -5465,6 +5476,7 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "skip_detect_devices", value: skipDetectDevices),
                                                                                            RubyCommand.Argument(name: "force_quit_simulator", value: forceQuitSimulator),
                                                                                            RubyCommand.Argument(name: "reset_simulator", value: resetSimulator),
+                                                                                           RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
                                                                                            RubyCommand.Argument(name: "prelaunch_simulator", value: prelaunchSimulator),
                                                                                            RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                            RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
@@ -5600,6 +5612,7 @@ func say(text: Any,
    - skipDetectDevices: Should skip auto detecting of devices if none were specified
    - forceQuitSimulator: Enabling this option will automatically killall Simulator processes before the run
    - resetSimulator: Enabling this option will automatically erase the simulator before running the application
+   - disableSlideToType: Enabling this option will disable the simulator from showing the 'Slide to type' prompt
    - prelaunchSimulator: Enabling this option will launch the first simulator prior to calling any xcodebuild command
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
@@ -5657,6 +5670,7 @@ func scan(workspace: Any? = scanfile.workspace,
           skipDetectDevices: Bool = scanfile.skipDetectDevices,
           forceQuitSimulator: Bool = scanfile.forceQuitSimulator,
           resetSimulator: Bool = scanfile.resetSimulator,
+          disableSlideToType: Bool = scanfile.disableSlideToType,
           prelaunchSimulator: Bool? = scanfile.prelaunchSimulator,
           reinstallApp: Bool = scanfile.reinstallApp,
           appIdentifier: Any? = scanfile.appIdentifier,
@@ -5711,6 +5725,7 @@ func scan(workspace: Any? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "skip_detect_devices", value: skipDetectDevices),
                                                                                       RubyCommand.Argument(name: "force_quit_simulator", value: forceQuitSimulator),
                                                                                       RubyCommand.Argument(name: "reset_simulator", value: resetSimulator),
+                                                                                      RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
                                                                                       RubyCommand.Argument(name: "prelaunch_simulator", value: prelaunchSimulator),
                                                                                       RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                       RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
@@ -6006,7 +6021,7 @@ func setPodKey(useBundleExec: Bool = true,
 
  - parameters:
    - force: Force setup, even if not executed by CI
-   - provider: CI provider
+   - provider: CI provider. If none is set, the provider is detected automatically
 
  - Creates a new temporary keychain for use with match|
  - Switches match to `readonly` mode to not create new profiles/cert on CI|
@@ -7014,7 +7029,7 @@ func testfairy(apiKey: String,
    - localizedBuildInfo: Localized beta app test info for what's new
    - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
-   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)
+   - skipWaitingForBuildProcessing: If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
    - usesNonExemptEncryption: Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist
    - distributeExternal: Should the build be distributed to external testers?
@@ -7817,6 +7832,45 @@ func uploadToPlayStore(packageName: String,
 }
 
 /**
+ Upload binaries to Google Play Internal App Sharing (via _supply_)
+
+ - parameters:
+   - packageName: The package name of the application to use
+   - jsonKey: The path to a file containing service account JSON, used to authenticate with Google
+   - jsonKeyData: The raw service account JSON data used to authenticate with Google
+   - apk: Path to the APK file to upload
+   - apkPaths: An array of paths to APK files to upload
+   - aab: Path to the AAB file to upload
+   - aabPaths: An array of paths to AAB files to upload
+   - rootUrl: Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/
+   - timeout: Timeout for read, open, and send (in seconds)
+
+ - returns: Returns a string containing the download URL for the uploaded APK/AAB (or array of strings if multiple were uploaded).
+
+ More information: https://docs.fastlane.tools/actions/upload_to_play_store_internal_app_sharing/
+*/
+func uploadToPlayStoreInternalAppSharing(packageName: String,
+                                         jsonKey: String? = nil,
+                                         jsonKeyData: String? = nil,
+                                         apk: String? = nil,
+                                         apkPaths: [String]? = nil,
+                                         aab: String? = nil,
+                                         aabPaths: [String]? = nil,
+                                         rootUrl: String? = nil,
+                                         timeout: Int = 300) {
+  let command = RubyCommand(commandID: "", methodName: "upload_to_play_store_internal_app_sharing", className: nil, args: [RubyCommand.Argument(name: "package_name", value: packageName),
+                                                                                                                           RubyCommand.Argument(name: "json_key", value: jsonKey),
+                                                                                                                           RubyCommand.Argument(name: "json_key_data", value: jsonKeyData),
+                                                                                                                           RubyCommand.Argument(name: "apk", value: apk),
+                                                                                                                           RubyCommand.Argument(name: "apk_paths", value: apkPaths),
+                                                                                                                           RubyCommand.Argument(name: "aab", value: aab),
+                                                                                                                           RubyCommand.Argument(name: "aab_paths", value: aabPaths),
+                                                                                                                           RubyCommand.Argument(name: "root_url", value: rootUrl),
+                                                                                                                           RubyCommand.Argument(name: "timeout", value: timeout)])
+  _ = runner.executeCommand(command)
+}
+
+/**
  Upload new binary to App Store Connect for TestFlight beta testing (via _pilot_)
 
  - parameters:
@@ -7833,7 +7887,7 @@ func uploadToPlayStore(packageName: String,
    - localizedBuildInfo: Localized beta app test info for what's new
    - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
-   - skipWaitingForBuildProcessing: Don't wait for the build to process. If set to true, the changelog won't be set, `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan)
+   - skipWaitingForBuildProcessing: If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
    - usesNonExemptEncryption: Provide the 'Uses Non-Exempt Encryption' for export compliance. This is used if there is 'ITSAppUsesNonExemptEncryption' is not set in the Info.plist
    - distributeExternal: Should the build be distributed to external testers?
@@ -8211,7 +8265,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode-11.2.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode-11.3.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -8356,4 +8410,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.66]
+// FastlaneRunnerAPIVersion [0.9.67]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.138.0
+// Generated with fastlane 2.139.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.138.0
+// Generated with fastlane 2.139.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.138.0
+// Generated with fastlane 2.139.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.138.0
+// Generated with fastlane 2.139.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -24,6 +24,9 @@ protocol ScanfileProtocol: class {
   /// Enabling this option will automatically erase the simulator before running the application
   var resetSimulator: Bool { get }
 
+  /// Enabling this option will disable the simulator from showing the 'Slide to type' prompt
+  var disableSlideToType: Bool { get }
+
   /// Enabling this option will launch the first simulator prior to calling any xcodebuild command
   var prelaunchSimulator: Bool? { get }
 
@@ -172,6 +175,7 @@ extension ScanfileProtocol {
   var skipDetectDevices: Bool { return false }
   var forceQuitSimulator: Bool { return false }
   var resetSimulator: Bool { return false }
+  var disableSlideToType: Bool { return true }
   var prelaunchSimulator: Bool? { return nil }
   var reinstallApp: Bool { return false }
   var appIdentifier: String? { return nil }
@@ -222,4 +226,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.22]
+// FastlaneRunnerAPIVersion [0.9.23]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.138.0
+// Generated with fastlane 2.139.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.138.0
+// Generated with fastlane 2.139.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.138.0':**

* [gym] using the correct build command when `skip_archive` is used (#15838) via Jakub
* [actions] always setup keychain when running `setup_ci` on a CI (#15542) via Sven Münnich
* [fastlane] fix parsing of action name (#15547) via Sven Münnich
* [action] create_pull_request: add reviewers and/or team_reviewers option (#15558) via Paul Nicolas
* [pilot] improves testflight metadata upload (#15617) via Rogerio de Paula Assis
* [deliver] fix a bug that deliver fails to find version (#15612) via Takeru Chuganji
* [github actions] enable automatic bump of homebrew formula with github action (#15836) via Josh Holtz
* [GitHub Actions] update pull-requests.yml workflow (#15837) via Daniel Jankowski
* [frameit] preserve colorspace when composing with background image (#15741) via David Kim
* [scan] add support for disabling "KeyboardContinuousPathEnabled" (#15749) via Alex Trott
* [action] last_git_tag: Provided parameter that specifies filter pattern when looking for last available tag (#15795) via Artur Rybak
* [action] add temp keychain to search list in setup_ci action (#15825) via Ilya
* [GitHub Actions] enable `communicate-on-pull-request-merged` (#15808) via Daniel Jankowski
* [action] add `upload_to_play_store_internal_app_sharing` action (#15822) via Andrew Havens
* [doc, deliver] add proxy config file path for Xcode11 #15819 (#15831) via kainosk.obata
* [ci] improve circleci cache (#15833) via tenhi
