### PR TITLE
[spaceship]: fix a bug that fail to get reviews with version id

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -400,7 +400,7 @@ module Spaceship
         rating_url << "sort=REVIEW_SORT_ORDER_MOST_RECENT"
         rating_url << "&index=#{index}"
         rating_url << "&storefront=#{storefront}" unless storefront.empty?
-        rating_url << "&version_id=#{version_id}" unless version_id.empty?
+        rating_url << "&versionId=#{version_id}" unless version_id.empty?
 
         r = request(:get, rating_url)
         all_reviews.concat(parse_response(r, 'data')['reviews'])

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -43,6 +43,21 @@ describe Spaceship::Tunes::AppRatings do
       expect(reviews.first.nickname).to eq("Reviewer1")
     end
 
+    it "contains the right information with version id" do
+      TunesStubbing.itc_stub_ratings
+      ratings = app.ratings
+      reviews = ratings.reviews("", "1")
+
+      expect(reviews.count).to eq(4)
+      expect(reviews.first.store_front).to eq("NZ")
+      expect(reviews.first.id).to eq(1_000_000_000)
+      expect(reviews.first.rating).to eq(2)
+      expect(reviews.first.title).to eq("Title 1")
+      expect(reviews.first.review).to eq("Review 1")
+      expect(reviews.first.last_modified).to eq(1_463_887_020_000)
+      expect(reviews.first.nickname).to eq("Reviewer1")
+    end
+
     it "contains the right information with upto_date" do
       TunesStubbing.itc_stub_ratings
       ratings = app.ratings

--- a/spaceship/spec/tunes/fixtures/review_by_version_id.json
+++ b/spaceship/spec/tunes/fixtures/review_by_version_id.json
@@ -1,0 +1,60 @@
+{
+    "data": {
+        "reviewCount": 4,
+        "reviews": [{
+            "value": {
+                "id": 1000000000,
+                "rating": 2,
+                "title": "Title 1",
+                "review": "Review 1",
+                "lastModified": 1463887020000,
+                "nickname": "Reviewer1",
+                "storeFront": "NZ",
+                "developerResponse": {
+                    "isHidden": false,
+                    "lastModified": 1490782551000,
+                    "pendingState": "CREATE",
+                    "response": "Thank You",
+                    "responseId": 28516
+                }
+ 
+            }
+        }, {
+            "value": {
+                "id": 1000000001,
+                "rating": 2,
+                "title": "Title 2",
+                "review": "Review 2",
+                "lastModified": 1459152540000,
+                "nickname": "Reviewer2",
+                "storeFront": "NZ"
+           }
+        }, {
+            "value": {
+                "id": 1000000002,
+                "rating": 4,
+                "title": "Title 3",
+                "review": "Review 3",
+                "lastModified": 1455870780000,
+                "nickname": "Reviewer3",
+                "storeFront": "NZ"
+            }
+        }, {
+            "value": {
+                "id": 1000000003,
+                "rating": 5,
+                "title": "Title 4",
+                "review": "Review 4",
+                "lastModified": 1453490460000,
+                "nickname": "Reviewer4",
+                "storeFront": "NZ"
+            }
+        }]
+    },
+    "messages": {
+        "warn": null,
+        "error": null,
+        "info": null
+    },
+    "statusCode": "SUCCESS"
+}

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -105,6 +105,9 @@ class TunesStubbing
 
       stub_request(:get, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/reviews?index=0&sort=REVIEW_SORT_ORDER_MOST_RECENT&storefront=US").
         to_return(status: 200, body: itc_read_fixture_file('review_by_storefront.json'), headers: { 'Content-Type' => 'application/json' })
+
+      stub_request(:get, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/reviews?index=0&sort=REVIEW_SORT_ORDER_MOST_RECENT&versionId=1").
+        to_return(status: 200, body: itc_read_fixture_file('review_by_version_id.json'), headers: { 'Content-Type' => 'application/json' })
     end
 
     def itc_stub_build_details


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

![Jietu20200106-172913](https://user-images.githubusercontent.com/18638838/71809101-519c6900-30aa-11ea-8990-3af967a2b8c0.jpg)

It looks like the parameter name of the API that gets reviews with version id is `versionId` instead of `version_id`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Add the same spec as the API that gets reviews with storefront. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

`bundle exec rspec`
