### PR TITLE
[action] set_github_release: fix return type to use from swift

### DIFF
--- a/fastlane/lib/fastlane/actions/set_github_release.rb
+++ b/fastlane/lib/fastlane/actions/set_github_release.rb
@@ -241,7 +241,7 @@ module Fastlane
       end
 
       def self.return_type
-        :hash_of_strings
+        :hash
       end
 
       def self.authors


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I tried to use `set_github_release` from `Fastlane.swift`, but it failed with following error:

```
INFO [2020-01-13 14:40:41.06]: Successfully uploaded assets
INFO [2020-01-13 14:40:41.06]: ▸ Could not cast value of type '__NSCFBoolean' (0x7fff8a320fa8) to 'NSString' (0x7fff8a897420).     
```

This would solve #13852.

### Description
This failed at following cast, since `fromString` is a response from Github, and contains non-string value.

```swift
func parseDictionary(fromString: String, function: String = #function) -> [String: String] {
    parseDictionaryHelper(fromString: fromString, function: function) as! [String: String]
}
```

This PR would change the metadata of `set_github_release` to fix generated Swift code.

### Testing Steps
#### Confirmed generated test code
Run `bundle exec fastlane generate_swift_api`, then confirm the diff contains following:

```diff
diff --git a/fastlane/swift/Fastlane.swift b/fastlane/swift/Fastlane.swift
index 1e7fe75..b526676 100644
--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -5942,7 +5942,7 @@ Access things like 'html_url', 'tag_name', 'name', 'body'
                                          description: String? = nil,
                                          isDraft: Bool = false,
                                          isPrerelease: Bool = false,
-                                         uploadAssets: [String]? = nil) -> [String : String] {
+                                         uploadAssets: [String]? = nil) -> [String : Any] {
   let command = RubyCommand(commandID: "", methodName: "set_github_release", className: nil, args: [RubyCommand.Argument(name: "repository_name", value: repositoryName),
                                                                                                     RubyCommand.Argument(name: "server_url", value: serverUrl),
                                                                                                     RubyCommand.Argument(name: "api_token", value: apiToken),
```

#### Run with test file
Run with following `Fastlane.swift`.

```swift
import Foundation

class Fastfile: LaneFile {
    func packageLane() {
        setGithubRelease(repositoryName: "knothole/my-repos", apiToken: "<access-token>", tagName: "test-tag", name: "test", commitish: "master", description: "", isPrerelease: true, uploadAssets: ["image.jpeg"])
    }
}
```