### PR TITLE
[GitHub Actions] Enable `communicate-on-pull-request-released`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Processing release
+on: 
+  release:
+    types: [published]
+
+jobs:   
+  communicate-on-pull-request-released:
+    name: communicate on pull request released
+    runs-on: ubuntu-latest
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@master
+      with:
+        ref: refs/heads/master
+    - name: Communicate on PR released
+      uses: fastlane/github-actions/communicate-on-pull-request-released@latest
+      with:
+        repo-token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

We are working on a bot's code migration to GitHub Actions 👉  fastlane/github-actions#3. 
This PR is about enabling `communicate-on-pull-request-released`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I created a new workflow file called `release.yml`. To get a better understanding of workflow syntax, please check [this document](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions).

Enabling this workflow will not conflict with an `issue-bot` processing flow due to:

https://github.com/fastlane/issue-bot/blob/457348717d99e5ffde34ca1619e7253ed51ec172/bot.rb#L164-L169

☝️ A bot will not mark a pull request as released if a pull request has `status: released` label. This label will be added by GitHub Action as soon as a pull request is released.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I used exactly the same workflow file `release.yml` on my private repo in order to test it. The results are below.

Release 👇 

<img width="964" alt="Screen Shot 2020-01-13 at 12 43 38" src="https://user-images.githubusercontent.com/10795657/72258669-f1a84400-360e-11ea-945e-37a65350f502.png">

Pull request 👇 

<img width="1026" alt="Screen Shot 2020-01-13 at 12 43 12" src="https://user-images.githubusercontent.com/10795657/72258660-ea813600-360e-11ea-9129-bac5f0f9ed8e.png">

Referenced Issue 👇 

<img width="1022" alt="Screen Shot 2020-01-13 at 12 43 27" src="https://user-images.githubusercontent.com/10795657/72258678-f7058e80-360e-11ea-8424-794d09defacb.png">

Actions Preview 👇 

<img width="1920" alt="Screen Shot 2020-01-13 at 14 12 40" src="https://user-images.githubusercontent.com/10795657/72258688-fd940600-360e-11ea-861d-f8cd8b0d45b6.png">

🎉 