### PR TITLE
[GitHub Action] Enable `stale.yml` workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Closing stale issues
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+        days-before-stale: 30
+        days-before-close: 7
+        stale-issue-message: > 
+          There hasn't been any activity on this issue recently. Due to the high number of incoming GitHub notifications, we have to clean some of the old issues, as many of them have already been resolved with the latest updates.
+          
+          Please make sure to update to the latest `fastlane` version and check if that solves the issue. Let us know if that works for you by adding a comment :+1:
+          
+          Friendly reminder: contributions are always welcome! Check out [CONTRIBUTING.md](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md) for more information on how to help with `fastlane` and feel free to tackle this issue yourself :muscle:
+        stale-pr-message: 'There has not been any activity on this pull request recently. Due to the high number of incoming GitHub notifications, we have to clean some of the old pull requests. Let us know if the work is still in-progress by adding a comment :+1:'
+        stale-issue-label: 'status: waiting-for-reply'
+        exempt-issue-label: 'status: auto-closed'
+        stale-pr-label: 'status: needs-attention'
+        exempt-pr-label: 'status: auto-closed'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Motivation and Context

We are working on a bot's code migration to GitHub Actions 👉 fastlane/github-actions#3.
This PR is about enabling `stale` workflow.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

The workflow introduced in this PR uses an existing GitHub Action called [stale](https://github.com/actions/stale). There will be some changes comparing to the existing bot's behaviour:

* the comment will be added to a pull request when marking the pr as stale (feel free to suggest a message to be posted --> `stale-pr-message`)
* the comment will **not** be added to an issue / a pull request when marking as closed ([the bot adds the following comment](https://github.com/fastlane/fastlane/issues/15757#issuecomment-573438071) --> "This issue will be auto-closed because there hasn't been any activity for a few months. Feel free to open a new one if you still experience this problem 👍")
* the time for marking a pull request as stale (adding `status: needs-attention` label) will change from 14 days to 30 days
* the label `status: waiting-for-reply` won't be removed automatically when a user adds a comment to a stale issue. Please check [opened issue](https://github.com/actions/stale/issues/21) on GitHub Actions `stale` project for more details

Enabling this workflow will not conflict with an [`issue-bot`](https://github.com/fastlane/issue-bot/blob/457348717d99e5ffde34ca1619e7253ed51ec172/bot.rb) processing flow. The bot will not mark a pull request or an issue as stale if it has a desired label added.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

The workflow file used for testing the action 👇 

```yml
name: Closing stale issues
on:
  schedule:
  - cron: "0 0 * * *"

jobs:
  stale:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/stale@v1
      with:
        repo-token: ${{ secrets.BOT_GITHUB_TOKEN }}
        days-before-stale: 1
        days-before-close: 1
        stale-issue-message: > 
          There hasn't been any activity on this issue recently. Due to the high number of incoming GitHub notifications, we have to clean some of the old issues, as many of them have already been resolved with the latest updates.
          
          Please make sure to update to the latest `fastlane` version and check if that solves the issue. Let us know if that works for you by adding a comment :+1:
          
          Friendly reminder: contributions are always welcome! Check out [CONTRIBUTING.md](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md) for more information on how to help with `fastlane` and feel free to tackle this issue yourself :muscle:
        stale-pr-message: 'There has not been any activity on this pull request recently. Due to the high number of incoming GitHub notifications, we have to clean some of the old pull requests. Let us know if the work is still in-progress by adding a comment :+1:'
        stale-issue-label: 'status: waiting-for-reply'
        exempt-issue-label: 'status: auto-closed'
        stale-pr-label: 'status: needs-attention'
        exempt-pr-label: 'status: auto-closed'
```

The results (an issue and a pull request) 👇 

![image](https://user-images.githubusercontent.com/10795657/73242691-f0961b80-41a5-11ea-939b-27b2e3aac394.png)

![image](https://user-images.githubusercontent.com/10795657/73242893-74e89e80-41a6-11ea-9c9a-3663834a4fb2.png)


Note: `BOT_GITHUB_TOKEN` is set to my personal access token, that's why you see mine avatar 😉 

🎊 🎊 