### PR TITLE
[ensure_xcode_version] Implement flexible version check

### DIFF
--- a/fastlane/spec/actions_specs/ensure_xcode_version_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_xcode_version_spec.rb
@@ -1,73 +1,165 @@
 describe Fastlane::Actions::EnsureXcodeVersionAction do
   describe "matching versions" do
-    let(:different_response) { "Xcode 7.3\nBuild version 34a893" }
-    let(:matching_response) { "Xcode 8.0\nBuild version 8A218a" }
-    let(:matching_response_extra_output) { "Couldn't verify that spaceship is up to date\nXcode 8.0\nBuild version 8A218a" }
+    describe "strictly with minor version 8.0" do
+      let(:different_response) { "Xcode 7.3\nBuild version 34a893" }
+      let(:matching_response) { "Xcode 8.0\nBuild version 8A218a" }
+      let(:matching_response_extra_output) { "Couldn't verify that spaceship is up to date\nXcode 8.0\nBuild version 8A218a" }
 
-    it "is successful when the version matches" do
-      expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response)
-      expect(UI).to receive(:success).with(/Driving the lane/)
-      expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
-
-      result = Fastlane::FastFile.new.parse("lane :test do
-        ensure_xcode_version(version: '8.0')
-      end").runner.execute(:test)
-    end
-
-    it "matches even when there is extra output" do
-      expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response_extra_output)
-      expect(UI).to receive(:success).with(/Driving the lane/)
-      expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
-
-      result = Fastlane::FastFile.new.parse("lane :test do
-        ensure_xcode_version(version: '8.0')
-      end").runner.execute(:test)
-    end
-
-    it "presents an error when the version does not match" do
-      expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(different_response)
-      expect(UI).to receive(:user_error!).with("Selected Xcode version doesn't match your requirement.\nExpected: Xcode 8.0\nActual: Xcode 7.3\n")
-
-      result = Fastlane::FastFile.new.parse("lane :test do
-        ensure_xcode_version(version: '8.0')
-      end").runner.execute(:test)
-    end
-
-    it "properly compares versions, not just strings" do
-      expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response)
-      expect(UI).to receive(:success).with(/Driving the lane/)
-      expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
-
-      result = Fastlane::FastFile.new.parse("lane :test do
-        ensure_xcode_version(version: '8')
-      end").runner.execute(:test)
-    end
-
-    describe "loads a .xcode-version file if it exists" do
-      let(:xcode_version_path) { ".xcode-version" }
-      before do
+      it "is successful when the version matches" do
         expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response)
-        expect(Dir).to receive(:glob).with(".xcode-version").and_return([xcode_version_path])
-      end
-
-      it "succeeds if the numbers match" do
         expect(UI).to receive(:success).with(/Driving the lane/)
         expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
 
-        expect(File).to receive(:read).with(xcode_version_path).and_return("8.0")
-
         result = Fastlane::FastFile.new.parse("lane :test do
-          ensure_xcode_version
+          ensure_xcode_version(version: '8.0')
         end").runner.execute(:test)
       end
 
-      it "fails if the numbers don't match" do
-        expect(UI).to receive(:user_error!).with("Selected Xcode version doesn't match your requirement.\nExpected: Xcode 9.0\nActual: Xcode 8.0\n")
-
-        expect(File).to receive(:read).with(xcode_version_path).and_return("9.0")
+      it "matches even when there is extra output" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response_extra_output)
+        expect(UI).to receive(:success).with(/Driving the lane/)
+        expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
 
         result = Fastlane::FastFile.new.parse("lane :test do
-          ensure_xcode_version
+          ensure_xcode_version(version: '8.0')
+        end").runner.execute(:test)
+      end
+
+      it "presents an error when the version does not match" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(different_response)
+        expect(UI).to receive(:user_error!).with("Selected Xcode version doesn't match your requirement.\nExpected: Xcode 8.0\nActual: Xcode 7.3\n")
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8.0')
+        end").runner.execute(:test)
+      end
+
+      it "properly compares versions, not just strings" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response)
+        expect(UI).to receive(:success).with(/Driving the lane/)
+        expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8')
+        end").runner.execute(:test)
+      end
+
+      describe "loads a .xcode-version file if it exists" do
+        let(:xcode_version_path) { ".xcode-version" }
+        before do
+          expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response)
+          expect(Dir).to receive(:glob).with(".xcode-version").and_return([xcode_version_path])
+        end
+
+        it "succeeds if the numbers match" do
+          expect(UI).to receive(:success).with(/Driving the lane/)
+          expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
+
+          expect(File).to receive(:read).with(xcode_version_path).and_return("8.0")
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            ensure_xcode_version
+          end").runner.execute(:test)
+        end
+
+        it "fails if the numbers don't match" do
+          expect(UI).to receive(:user_error!).with("Selected Xcode version doesn't match your requirement.\nExpected: Xcode 9.0\nActual: Xcode 8.0\n")
+
+          expect(File).to receive(:read).with(xcode_version_path).and_return("9.0")
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            ensure_xcode_version
+          end").runner.execute(:test)
+        end
+      end
+    end
+
+    describe "strictly with patch version 8.0.1" do
+      let(:different_response) { "Xcode 7.3\nBuild version 34a893" }
+      let(:matching_response) { "Xcode 8.0.1\nBuild version 8A218a" }
+      let(:matching_response_extra_output) { "Couldn't verify that spaceship is up to date\nXcode 8.0.1\nBuild version 8A218a" }
+
+      it "is successful when the version matches" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response)
+        expect(UI).to receive(:success).with(/Driving the lane/)
+        expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8.0.1')
+        end").runner.execute(:test)
+      end
+
+      it "matches even when there is extra output" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response_extra_output)
+        expect(UI).to receive(:success).with(/Driving the lane/)
+        expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8.0.1')
+        end").runner.execute(:test)
+      end
+
+      it "presents an error when the version does not match" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(different_response)
+        expect(UI).to receive(:user_error!).with("Selected Xcode version doesn't match your requirement.\nExpected: Xcode 8.0\nActual: Xcode 7.3\n")
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8.0')
+        end").runner.execute(:test)
+      end
+    end
+
+    describe "loosely with 8.1.2" do
+      let(:different_response) { "Xcode 7.3\nBuild version 34a893" }
+      let(:matching_response) { "Xcode 8.1.2\nBuild version 8A218a" }
+      let(:matching_response_extra_output) { "Couldn't verify that spaceship is up to date\nXcode 8.1.2\nBuild version 8A218a" }
+
+      it "is successful when the version matches with patch" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response)
+        expect(UI).to receive(:success).with(/Driving the lane/)
+        expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8.1.2', strict: false)
+        end").runner.execute(:test)
+      end
+
+      it "is successful when the version matches with minor" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response)
+        expect(UI).to receive(:success).with(/Driving the lane/)
+        expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8.1', strict: false)
+        end").runner.execute(:test)
+      end
+
+      it "is successful when the version matches with major" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response)
+        expect(UI).to receive(:success).with(/Driving the lane/)
+        expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8', strict: false)
+        end").runner.execute(:test)
+      end
+
+      it "matches even when there is extra output" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(matching_response_extra_output)
+        expect(UI).to receive(:success).with(/Driving the lane/)
+        expect(UI).to receive(:success).with(/Selected Xcode version is correct/)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8.1', strict: false)
+        end").runner.execute(:test)
+      end
+
+      it "presents an error when the version does not match" do
+        expect(Fastlane::Actions::EnsureXcodeVersionAction).to receive(:sh).and_return(different_response)
+        expect(UI).to receive(:user_error!).with("Selected Xcode version doesn't match your requirement.\nExpected: Xcode 8.0\nActual: Xcode 7.3\n")
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          ensure_xcode_version(version: '8.0')
         end").runner.execute(:test)
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Sometimes we want to ignore the `patch` version number (i.e. Bitrise does not keep track of it).
Currently, if we check for Xcode version `11.3` while having the version `11.3.1` installed, the action will fail.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

These changes add more flexibility: 
Instead of matching the whole string `11.3.1`, we can simply split it to an array based on the separator `.` and only care about the version numbers actually specified.

For instance:
Checking for the Xcode version `11.3` while having `11.3.1` will match `11` with `11` and `3` with `3` but discard the last patch version number `1`.

On the other hand, when specifying `11.3.1` while having `11.3` will mismatch with `1` and `nil`. 
