### PR TITLE
[deliver] docs: document conflicting options

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -149,12 +149,12 @@ module Deliver
 
         # release
         FastlaneCore::ConfigItem.new(key: :automatic_release,
-                                     description: "Should the app be automatically released once it's approved?",
+                                     description: "Should the app be automatically released once it's approved? Can not be used together with `auto_release_date`)",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :auto_release_date,
                                      env_name: "DELIVER_AUTO_RELEASE_DATE",
-                                     description: "Date in milliseconds for automatically releasing on pending approval",
+                                     description: "Date in milliseconds for automatically releasing on pending approval (Can not be used together with `automatic_release`)",
                                      is_string: false,
                                      optional: true,
                                      conflicting_options: [:automatic_release],

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -149,7 +149,7 @@ module Deliver
 
         # release
         FastlaneCore::ConfigItem.new(key: :automatic_release,
-                                     description: "Should the app be automatically released once it's approved? Can not be used together with `auto_release_date`)",
+                                     description: "Should the app be automatically released once it's approved? (Can not be used together with `auto_release_date`)",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :auto_release_date,


### PR DESCRIPTION
closes https://github.com/fastlane/docs/issues/817
