### PR TITLE
[snapshot] Add support for disabling "KeyboardContinuousPathEnabled"

### DIFF
--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -224,7 +224,7 @@ module Snapshot
                                      is_string: false),
         FastlaneCore::ConfigItem.new(key: :disable_slide_to_type,
                                      env_name: "SNAPSHOT_DISABLE_SLIDE_TO_TYPE",
-                                     description: "Enabling this option will disable the simulator from showing the 'Slide to type' prompt",
+                                     description: "Disable the simulator from showing the 'Slide to type' prompt",
                                      default_value: false,
                                      optional: true,
                                      is_string: false)

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -221,6 +221,12 @@ module Snapshot
                                      env_name: "SNAPSHOT_EXECUTE_CONCURRENT_SIMULATORS",
                                      description: "Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9",
                                      default_value: true,
+                                     is_string: false),
+        FastlaneCore::ConfigItem.new(key: :disable_slide_to_type,
+                                     env_name: "SNAPSHOT_DISABLE_SLIDE_TO_TYPE",
+                                     description: "Enabling this option will disable the simulator from showing the 'Slide to type' prompt",
+                                     default_value: false,
+                                     optional: true,
                                      is_string: false)
       ]
     end

--- a/snapshot/lib/snapshot/simulator_launchers/launcher_configuration.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/launcher_configuration.rb
@@ -11,6 +11,7 @@ module Snapshot
     attr_accessor :dark_mode
     attr_accessor :reinstall_app
     attr_accessor :app_identifier
+    attr_accessor :disable_slide_to_type
 
     # xcode 8
     attr_accessor :number_of_retries
@@ -41,6 +42,7 @@ module Snapshot
       @output_simulator_logs = snapshot_config[:output_simulator_logs]
       @output_directory = snapshot_config[:output_directory]
       @concurrent_simulators = snapshot_config[:concurrent_simulators]
+      @disable_slide_to_type = snapshot_config[:disable_slide_to_type]
 
       launch_arguments = Array(snapshot_config[:launch_arguments])
       # if more than 1 set of arguments, use a tuple with an index

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -67,6 +67,9 @@ module Snapshot
           # no need to reinstall if device has been erased
           uninstall_app(type)
         end
+        if launcher_config.disable_slide_to_type
+          disable_slide_to_type(type)
+        end
       end
     end
 
@@ -136,6 +139,14 @@ module Snapshot
         UI.message("Setting interface style #{device_type} (UserInterfaceStyleMode=#{dark_mode})")
         plist_path = "#{ENV['HOME']}/Library/Developer/CoreSimulator/Devices/#{device_udid}/data/Library/Preferences/com.apple.uikitservices.userInterfaceStyleMode.plist"
         File.write(plist_path, Plist::Emit.dump(plist))
+      end
+    end
+
+    def disable_slide_to_type(device_type)
+      device_udid = TestCommandGenerator.device_udid(device_type)
+      if device_udid
+        UI.message("Disabling slide to type on #{device_type}")
+        FastlaneCore::Simulator.disable_slide_to_type(udid: device_udid)
       end
     end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
iOS 13 introduced the "slide to type" keyboard. The intro screen for this is shown, whenever the keyboard is shown until it is completed. A tutorial like this gets in the way of making screenshots.

![](https://user-images.githubusercontent.com/595623/69903404-853ff100-1390-11ea-96d8-0f9b546d7627.png)

### Description
This adds an option to `snapshot` to disable the "slide to type" intro of the keyboard in the simulator. 
It is analog to how #15749 is implemented and calls the same method #15749 introduces.
