### PR TITLE
[spaceship] delete beta feedback

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/beta_feedback.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_feedback.rb
@@ -66,6 +66,10 @@ module Spaceship
       def self.all(filter: {}, includes: "tester,build,screenshots", limit: nil, sort: nil)
         return Spaceship::ConnectAPI.get_beta_feedback(filter: filter, includes: includes, limit: limit, sort: sort)
       end
+
+      def delete!
+        return Spaceship::ConnectAPI.delete_beta_feedback(feedback_id: self.id)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -326,6 +326,12 @@ module Spaceship
         params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
         Client.instance.get("betaFeedbacks", params)
       end
+
+      def delete_beta_feedback(feedback_id: nil)
+        raise "Feedback id is nil" if feedback_id.nil?
+
+        Client.instance.delete("betaFeedbacks/#{feedback_id}")
+      end
     end
   end
 end

--- a/spaceship/spec/connect_api/models/beta_feedback_spec.rb
+++ b/spaceship/spec/connect_api/models/beta_feedback_spec.rb
@@ -46,4 +46,11 @@ describe Spaceship::ConnectAPI::BetaFeedback do
       expect(model.screenshots.first.image_assets.first["height"]).to eq(4032)
     end
   end
+
+  it "deletes a feedback" do
+    response = Spaceship::ConnectAPI.get_beta_feedback
+    feedback = response.first
+    expect(Spaceship::ConnectAPI).to receive(:delete_beta_feedback).with(feedback_id: feedback.id)
+    feedback.delete!
+  end
 end

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -55,6 +55,11 @@ class ConnectAPIStubbing
           to_return(status: 200, body: read_fixture_file('beta_feedbacks.json'), headers: { 'Content-Type' => 'application/json' })
       end
 
+      def stub_beta_feedbacks_delete
+        stub_request(:delete, "https://appstoreconnect.apple.com/iris/v1/betaFeedbacks/987654321").
+          to_return(status: 200, body: "", headers: {})
+      end
+
       def stub_beta_groups
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/betaGroups").
           to_return(status: 200, body: read_fixture_file('beta_groups.json'), headers: { 'Content-Type' => 'application/json' })

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -80,6 +80,7 @@ def before_each_spaceship
   ConnectAPIStubbing::TestFlight.stub_beta_build_localizations
   ConnectAPIStubbing::TestFlight.stub_beta_build_metrics
   ConnectAPIStubbing::TestFlight.stub_beta_feedbacks
+  ConnectAPIStubbing::TestFlight.stub_beta_feedbacks_delete
   ConnectAPIStubbing::TestFlight.stub_beta_groups
   ConnectAPIStubbing::TestFlight.stub_beta_testers
   ConnectAPIStubbing::TestFlight.stub_beta_tester_metrics


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adds the ability to delete beta feedback items from Testflight builds.

⚠️Even though this uses the App Store Connect API through ConnectAPI, this is not a documented and public feature of the API.

### Description
I added a delete function to beta feedback. 

Tested by following the instructions and deleted some of the feedback items I have in my queue, as well as a unit test to ensure the correct functions are called. 

### Testing Steps
```
lane :connect_feedback_delete do
  fastlane_require 'spaceship'

  Spaceship::Tunes.login
  Spaceship::Tunes.select_team

  # Gets app
  app = Spaceship::ConnectAPI::App.find(ENV["TEST_APP_BUNDLE"])

  # Gets feedback for an app (default includes screenshots and tester info)
  feedbacks = app.get_beta_feedback

# Finds the feedback to delete
  feedbackToDelete = feedbacks.select { feedback | feedback.id == "ID OF YOUR FEEDBACK" }.first
  feedbackToDelete.delete!
```
