### PR TITLE
[deliver] Add skip_auto_detecting_app_version option

### DIFF
--- a/deliver/lib/deliver/detect_values.rb
+++ b/deliver/lib/deliver/detect_values.rb
@@ -59,6 +59,7 @@ module Deliver
 
     def find_version(options)
       return if options[:app_version]
+      return if options[:skip_auto_detecting_app_version]
 
       if options[:ipa]
         options[:app_version] ||= FastlaneCore::IpaFileAnalyser.fetch_app_version(options[:ipa])

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -85,12 +85,6 @@ module Deliver
                                      verify_block: proc do |value|
                                        UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)
                                      end),
-        FastlaneCore::ConfigItem.new(key: :use_latest_build,
-                                     optional: true,
-                                     default_value: false,
-                                     env_name: "DELIVER_USE_LATEST_BUILD",
-                                     description: "Force usage of latest build version",
-                                     is_string: false),
 
         # live version
         FastlaneCore::ConfigItem.new(key: :edit_live,

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -85,6 +85,12 @@ module Deliver
                                      verify_block: proc do |value|
                                        UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)
                                      end),
+        FastlaneCore::ConfigItem.new(key: :use_latest_build,
+                                     optional: true,
+                                     default_value: false,
+                                     env_name: "DELIVER_USE_LATEST_BUILD",
+                                     description: "Force usage of latest build version",
+                                     is_string: false),
 
         # live version
         FastlaneCore::ConfigItem.new(key: :edit_live,

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -133,6 +133,11 @@ module Deliver
                                      description: "Don't update app version for submission",
                                      is_string: false,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :skip_auto_detecting_app_version,
+                                     optional: true,
+                                     default_value: false,
+                                     description: "Don't detecting app version from ipa or pkg",
+                                     is_string: false),
 
         # how to operate
         FastlaneCore::ConfigItem.new(key: :force,

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -42,7 +42,8 @@ module Deliver
         end
       else
         UI.message("Selecting the latest build...")
-        build = wait_for_build(app, app_version)
+        target_app_version = options[:use_latest_build] ? nil : app_version
+        build = wait_for_build(app, target_app_version)
       end
       UI.message("Selecting build #{app_version} (#{build.build_version})...")
 

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -42,8 +42,7 @@ module Deliver
         end
       else
         UI.message("Selecting the latest build...")
-        target_app_version = options[:use_latest_build] ? nil : app_version
-        build = wait_for_build(app, target_app_version)
+        build = wait_for_build(app, app_version)
       end
       UI.message("Selecting build #{app_version} (#{build.build_version})...")
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Due to various circumstances, AppStore and CFBundleShortVersionString versions do not match. app_version is specified in Deliverfile.

If the train version is different from the app version, `tunes_all_builds_for_train(train: app_version)` is called when acquiring a candidate build with wait_for_build, and `ITC.response.error.OPERATION_FAILED` occurs.

With this fix, the latest uploaded build is always sent for review, even if the app_version is specified.

This problem did not occur when using `fastlane 2.114.0`, but subsequent fixes seem to have caused the problem.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
Added option to use latest_version in `wait_for_build(use_latest_build)`, default value is false.
When use_latest_build is true, the same processing as when app version is not specified can be performed by passing nil to wait_for_build.

We confirmed that no error occurred by actually executing the "deliver" action in an application where the AppStore version and CFBundleShortVersionString were different.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
