### PR TITLE
[app_store_build_number/latest_testflight_build_number ] Export version in SharedValues

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -1,14 +1,18 @@
+require 'ostruct'
+
 module Fastlane
   module Actions
     module SharedValues
       LATEST_BUILD_NUMBER = :LATEST_BUILD_NUMBER
+      LATEST_VERSION = :LATEST_VERSION
     end
 
     class AppStoreBuildNumberAction < Action
       def self.run(params)
         require 'spaceship'
 
-        build_nr = get_build_number(params)
+        result = get_build_number(params)
+        build_nr = result.build_nr
 
         # Convert build_nr to int (for legacy use) if no "." in string
         if build_nr.kind_of?(String) && !build_nr.include?(".")
@@ -16,6 +20,9 @@ module Fastlane
         end
 
         Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER] = build_nr
+        Actions.lane_context[SharedValues::LATEST_VERSION] = result.build_v
+
+        return build_nr
       end
 
       def self.get_build_number(params)
@@ -33,7 +40,7 @@ module Fastlane
 
           UI.message("Latest upload for live-version #{app.live_version.version} is build: #{build_nr}")
 
-          return build_nr
+          return OpenStruct.new({ build_nr: build_nr, build_v: app.live_version.version })
         else
           version_number = params[:version]
           platform = params[:platform]
@@ -61,7 +68,7 @@ module Fastlane
           if build
             build_nr = build.version
             UI.message("Latest upload for version #{build.app_version} on #{platform_message} is build: #{build_nr}")
-            return build_nr
+            return OpenStruct.new({ build_nr: build_nr, build_v: build.app_version })
           end
 
           # Let user know that build couldn't be found
@@ -72,7 +79,7 @@ module Fastlane
           else
             build_nr = params[:initial_build_number]
             UI.message("Using initial build number of #{build_nr}")
-            return build_nr
+            return OpenStruct.new({ build_nr: build_nr, build_v: version_number })
           end
         end
       end
@@ -159,7 +166,8 @@ module Fastlane
 
       def self.output
         [
-          ['LATEST_BUILD_NUMBER', 'The latest build number of either live or testflight version']
+          ['LATEST_BUILD_NUMBER', 'The latest build number of either live or testflight version'],
+          ['LATEST_VERSION', 'The version of the latest build number']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -4,12 +4,17 @@ module Fastlane
   module Actions
     module SharedValues
       LATEST_TESTFLIGHT_BUILD_NUMBER = :LATEST_TESTFLIGHT_BUILD_NUMBER
+      LATEST_TESTFLIGHT_VERSION = :LATEST_TESTFLIGHT_VERSION
     end
 
     class LatestTestflightBuildNumberAction < Action
       def self.run(params)
-        build_number = AppStoreBuildNumberAction.run(params)
-        Actions.lane_context[SharedValues::LATEST_TESTFLIGHT_BUILD_NUMBER] = build_number
+        AppStoreBuildNumberAction.run(params)
+        build_nr = Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER]
+        build_v = Actions.lane_context[SharedValues::LATEST_VERSION]
+        Actions.lane_context[SharedValues::LATEST_TESTFLIGHT_BUILD_NUMBER] = build_nr
+        Actions.lane_context[SharedValues::LATEST_TESTFLIGHT_VERSION] = build_v
+        return build_nr
       end
 
       #####################################################
@@ -93,7 +98,8 @@ module Fastlane
 
       def self.output
         [
-          ['LATEST_TESTFLIGHT_BUILD_NUMBER', 'The latest build number of the latest version of the app uploaded to TestFlight']
+          ['LATEST_TESTFLIGHT_BUILD_NUMBER', 'The latest build number of the latest version of the app uploaded to TestFlight'],
+          ['LATEST_TESTFLIGHT_VERSION', 'The version of the latest build number']
         ]
       end
 

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "app_store_build_number" do
@@ -23,7 +25,7 @@ describe Fastlane do
       end
 
       it "returns value as string (with build number as version string)" do
-        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_number).and_return("1.2.3")
+        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_number).and_return(OpenStruct.new({ build_nr: "1.2.3", build_v: "foo" }))
 
         result = Fastlane::FastFile.new.parse("lane :test do
           app_store_build_number(username: 'name@example.com', app_identifier: 'x.y.z')
@@ -33,7 +35,7 @@ describe Fastlane do
       end
 
       it "returns value as integer (with build number as version number)" do
-        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_number).and_return("3")
+        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_number).and_return(OpenStruct.new({ build_nr: "3", build_v: "foo" }))
 
         result = Fastlane::FastFile.new.parse("lane :test do
           app_store_build_number(username: 'name@example.com', app_identifier: 'x.y.z')


### PR DESCRIPTION
This adds the version as second export parameter to the mentioned actions. This
is useful when the live version is queried.

Fixes: #15735

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

See linked issue.

### Description

See commit message.

### Testing Steps

Run the two actions.