### PR TITLE
[cocoapods] Add missing params argument to pod_version

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -19,7 +19,7 @@ module Fastlane
 
         cmd << '--no-clean' unless params[:clean]
         cmd << '--no-integrate' unless params[:integrate]
-        cmd << '--clean-install' if params[:clean_install] && pod_version.to_f >= 1.7
+        cmd << '--clean-install' if params[:clean_install] && pod_version(params).to_f >= 1.7
         cmd << '--repo-update' if params[:repo_update]
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]
@@ -42,7 +42,7 @@ module Fastlane
         params[:use_bundle_exec] && shell_out_should_use_bundle_exec?
       end
 
-      def self.pod_version
+      def self.pod_version(params)
         use_bundle_exec?(params) ? `bundle exec pod --version` : `pod --version`
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When the `cocoapods` action was run with `clean_install` fastlane failed with a `Unknown method 'params'` error.

### Description
This error was caused by `pod_version` being called without arguments.

### Testing Steps
To reproduce the issue just run `bundle exec fastlane run cocoapods clean_install:true`

closes #15960
