### PR TITLE
[socket_server_action_command_executor] Fix sh error_callback

### DIFF
--- a/fastlane/lib/fastlane/server/socket_server_action_command_executor.rb
+++ b/fastlane/lib/fastlane/server/socket_server_action_command_executor.rb
@@ -83,7 +83,7 @@ module Fastlane
 
       case command.method_name
       when "sh"
-        error_callback = proc { |string_value| closure_argument_value = string_value }
+        error_callback = proc { |string_value| closure_argument_value = string_value } if parameter_map[:error_callback]
         command_param = parameter_map[:command]
         log_param = parameter_map[:log]
         action_return = Fastlane::FastFile.sh(command_param, log: log_param, error_callback: error_callback)

--- a/fastlane/swift/RubyCommand.swift
+++ b/fastlane/swift/RubyCommand.swift
@@ -49,7 +49,7 @@ struct RubyCommand: RubyCommandable {
                     let typeJson: String
                     if let type = type {
                         typeJson = ", \"value_type\" : \"\(type.typeString)\""
-                    }else {
+                    } else {
                         typeJson = ""
                     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In Fastlane.swift, the `sh` action never fails, whether an `error_callback` is given or not.
It was intended for the `error_callback` to be optional, however, the `socket_server_action_command_executor` was setting a `proc` anyway.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Setting a `proc` as error callback only when an actual `error_callback` is given fixes the issue.
