### PR TITLE
Version bump to 2.141.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
 <img src='https://github.com/AliSoftware.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+</tr>
+<tr>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
@@ -46,17 +78,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
@@ -66,55 +98,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-</tr>
-<tr>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
 <img src='https://github.com/giginet.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
 </td>
 <td id='aaron-brager'>
 <a href='https://github.com/getaaron'>
@@ -122,31 +110,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
-</tr>
-<tr>
 <td id='joshua-liebowitz'>
 <a href='https://github.com/taquitos'>
 <img src='https://github.com/taquitos.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
@@ -154,13 +128,52 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+</tr>
+<tr>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
 </td>
 </tr>
+<tr>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
 </table>
 
 Special thanks to all [contributors](https://github.com/fastlane/fastlane/graphs/contributors) for extending and improving _fastlane_.

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,26 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Olivier Halligon",
-                        "Jan Piotrowski",
-                        "Manu Wallner",
-                        "Kohki Miki",
-                        "Stefan Natchev",
-                        "Josh Holtz",
-                        "Jérôme Lacoste",
+  spec.authors       = ["Jorge Revuelta H",
                         "Maksym Grebenets",
-                        "Andrew McBurney",
-                        "Joshua Liebowitz",
-                        "Matthew Ellis",
-                        "Jimmy Dee",
+                        "Olivier Halligon",
+                        "Daniel Jankowski",
                         "Fumiya Nakamura",
-                        "Felix Krause",
-                        "Danielle Tomlinson",
-                        "Helmut Januschka",
-                        "Aaron Brager",
+                        "Josh Holtz",
+                        "Andrew McBurney",
                         "Iulian Onofrei",
+                        "Kohki Miki",
+                        "Joshua Liebowitz",
+                        "Max Ott",
+                        "Stefan Natchev",
+                        "Jérôme Lacoste",
+                        "Aaron Brager",
+                        "Jan Piotrowski",
+                        "Danielle Tomlinson",
+                        "Jimmy Dee",
+                        "Manu Wallner",
                         "Luka Mirosevic",
-                        "Jorge Revuelta H"]
+                        "Felix Krause",
+                        "Matthew Ellis",
+                        "Helmut Januschka"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.140.0'.freeze
+  VERSION = '2.141.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.140.0
+// Generated with fastlane 2.141.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -57,10 +57,10 @@ protocol DeliverfileProtocol: class {
   /// Rejects the previously submitted build if it's in a state where it's possible
   var rejectIfPossible: Bool { get }
 
-  /// Should the app be automatically released once it's approved?
+  /// Should the app be automatically released once it's approved? (Can not be used together with `auto_release_date`)
   var automaticRelease: Bool { get }
 
-  /// Date in milliseconds for automatically releasing on pending approval
+  /// Date in milliseconds for automatically releasing on pending approval (Can not be used together with `automatic_release`)
   var autoReleaseDate: String? { get }
 
   /// Enable the phased release feature of iTC
@@ -246,4 +246,4 @@ extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.18]
+// FastlaneRunnerAPIVersion [0.9.19]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -441,8 +441,8 @@ func appledoc(input: Any,
    - overwriteScreenshots: Clear all previously uploaded screenshots before uploading the new ones
    - submitForReview: Submit the new version for Review after uploading everything
    - rejectIfPossible: Rejects the previously submitted build if it's in a state where it's possible
-   - automaticRelease: Should the app be automatically released once it's approved?
-   - autoReleaseDate: Date in milliseconds for automatically releasing on pending approval
+   - automaticRelease: Should the app be automatically released once it's approved? (Can not be used together with `auto_release_date`)
+   - autoReleaseDate: Date in milliseconds for automatically releasing on pending approval (Can not be used together with `automatic_release`)
    - phasedRelease: Enable the phased release feature of iTC
    - resetRatings: Reset the summary rating when you release a new version of the application
    - priceTier: The price tier of this application
@@ -871,7 +871,7 @@ func buildAndroidApp(task: String? = nil,
 }
 
 /**
- Alias for the `build_ios_app` action
+ Easily build and sign your app (via _gym_)
 
  - parameters:
    - workspace: Path to the workspace file
@@ -884,6 +884,7 @@ func buildAndroidApp(task: String? = nil,
    - silent: Hide all information that's not necessary while building
    - codesigningIdentity: The name of the code signing identity to use. It has to match the name exactly. e.g. 'iPhone Distribution: SunApps GmbH'
    - skipPackageIpa: Should we skip packaging the ipa?
+   - skipPackagePkg: Should we skip packaging the pkg?
    - includeSymbols: Should the ipa file include symbols?
    - includeBitcode: Should the ipa file include bitcode?
    - exportMethod: Method used to export the archive. Valid values are: app-store, ad-hoc, package, enterprise, development, developer-id
@@ -892,6 +893,8 @@ func buildAndroidApp(task: String? = nil,
    - skipBuildArchive: Export ipa from previously built xcarchive. Uses archive_path as source
    - skipArchive: After building, don't archive, effectively not including -archivePath param
    - skipCodesigning: Build without codesigning
+   - catalystPlatform: Platform to build when using a Catalyst enabled app. Valid values are: ios, macos
+   - installerCertName: Full name of 3rd Party Mac Developer Installer or Deveoper ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
    - buildPath: The directory in which the archive should be stored in
    - archivePath: The path to the created archive
    - derivedDataPath: The directory where built products and other derived data will go
@@ -914,6 +917,7 @@ func buildAndroidApp(task: String? = nil,
    - analyzeBuildTime: Analyze the project build time and store the output in 'culprits.txt' file
    - xcprettyUtf: Have xcpretty use unicode encoding when reporting builds
    - skipProfileDetection: Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used
+   - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
 
  - returns: The absolute path to the generated ipa file
 
@@ -929,6 +933,7 @@ func buildApp(workspace: String? = nil,
               silent: Bool = false,
               codesigningIdentity: String? = nil,
               skipPackageIpa: Bool = false,
+              skipPackagePkg: Bool = false,
               includeSymbols: Bool? = nil,
               includeBitcode: Bool? = nil,
               exportMethod: String? = nil,
@@ -937,6 +942,8 @@ func buildApp(workspace: String? = nil,
               skipBuildArchive: Bool? = nil,
               skipArchive: Bool? = nil,
               skipCodesigning: Bool? = nil,
+              catalystPlatform: String? = nil,
+              installerCertName: String? = nil,
               buildPath: String? = nil,
               archivePath: String? = nil,
               derivedDataPath: String? = nil,
@@ -958,7 +965,8 @@ func buildApp(workspace: String? = nil,
               xcprettyReportJson: String? = nil,
               analyzeBuildTime: Bool? = nil,
               xcprettyUtf: Bool? = nil,
-              skipProfileDetection: Bool = false) {
+              skipProfileDetection: Bool = false,
+              clonedSourcePackagesPath: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "build_app", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                            RubyCommand.Argument(name: "project", value: project),
                                                                                            RubyCommand.Argument(name: "scheme", value: scheme),
@@ -969,6 +977,7 @@ func buildApp(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "silent", value: silent),
                                                                                            RubyCommand.Argument(name: "codesigning_identity", value: codesigningIdentity),
                                                                                            RubyCommand.Argument(name: "skip_package_ipa", value: skipPackageIpa),
+                                                                                           RubyCommand.Argument(name: "skip_package_pkg", value: skipPackagePkg),
                                                                                            RubyCommand.Argument(name: "include_symbols", value: includeSymbols),
                                                                                            RubyCommand.Argument(name: "include_bitcode", value: includeBitcode),
                                                                                            RubyCommand.Argument(name: "export_method", value: exportMethod),
@@ -977,6 +986,8 @@ func buildApp(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "skip_build_archive", value: skipBuildArchive),
                                                                                            RubyCommand.Argument(name: "skip_archive", value: skipArchive),
                                                                                            RubyCommand.Argument(name: "skip_codesigning", value: skipCodesigning),
+                                                                                           RubyCommand.Argument(name: "catalyst_platform", value: catalystPlatform),
+                                                                                           RubyCommand.Argument(name: "installer_cert_name", value: installerCertName),
                                                                                            RubyCommand.Argument(name: "build_path", value: buildPath),
                                                                                            RubyCommand.Argument(name: "archive_path", value: archivePath),
                                                                                            RubyCommand.Argument(name: "derived_data_path", value: derivedDataPath),
@@ -998,12 +1009,13 @@ func buildApp(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "xcpretty_report_json", value: xcprettyReportJson),
                                                                                            RubyCommand.Argument(name: "analyze_build_time", value: analyzeBuildTime),
                                                                                            RubyCommand.Argument(name: "xcpretty_utf", value: xcprettyUtf),
-                                                                                           RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection)])
+                                                                                           RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection),
+                                                                                           RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
   _ = runner.executeCommand(command)
 }
 
 /**
- Easily build and sign your app (via _gym_)
+ Alias for the `build_app` action but only for iOS
 
  - parameters:
    - workspace: Path to the workspace file
@@ -1046,6 +1058,7 @@ func buildApp(workspace: String? = nil,
    - analyzeBuildTime: Analyze the project build time and store the output in 'culprits.txt' file
    - xcprettyUtf: Have xcpretty use unicode encoding when reporting builds
    - skipProfileDetection: Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used
+   - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
 
  - returns: The absolute path to the generated ipa file
 
@@ -1090,7 +1103,8 @@ func buildIosApp(workspace: String? = nil,
                  xcprettyReportJson: String? = nil,
                  analyzeBuildTime: Bool? = nil,
                  xcprettyUtf: Bool? = nil,
-                 skipProfileDetection: Bool = false) {
+                 skipProfileDetection: Bool = false,
+                 clonedSourcePackagesPath: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "build_ios_app", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                RubyCommand.Argument(name: "project", value: project),
                                                                                                RubyCommand.Argument(name: "scheme", value: scheme),
@@ -1130,7 +1144,146 @@ func buildIosApp(workspace: String? = nil,
                                                                                                RubyCommand.Argument(name: "xcpretty_report_json", value: xcprettyReportJson),
                                                                                                RubyCommand.Argument(name: "analyze_build_time", value: analyzeBuildTime),
                                                                                                RubyCommand.Argument(name: "xcpretty_utf", value: xcprettyUtf),
-                                                                                               RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection)])
+                                                                                               RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection),
+                                                                                               RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
+  _ = runner.executeCommand(command)
+}
+
+/**
+ Alias for the `build_app` action but only for macOS
+
+ - parameters:
+   - workspace: Path to the workspace file
+   - project: Path to the project file
+   - scheme: The project's scheme. Make sure it's marked as `Shared`
+   - clean: Should the project be cleaned before building it?
+   - outputDirectory: The directory in which the ipa file should be stored in
+   - outputName: The name of the resulting ipa file
+   - configuration: The configuration to use when building the app. Defaults to 'Release'
+   - silent: Hide all information that's not necessary while building
+   - codesigningIdentity: The name of the code signing identity to use. It has to match the name exactly. e.g. 'iPhone Distribution: SunApps GmbH'
+   - skipPackagePkg: Should we skip packaging the pkg?
+   - includeSymbols: Should the ipa file include symbols?
+   - includeBitcode: Should the ipa file include bitcode?
+   - exportMethod: Method used to export the archive. Valid values are: app-store, ad-hoc, package, enterprise, development, developer-id
+   - exportOptions: Path to an export options plist or a hash with export options. Use 'xcodebuild -help' to print the full set of available options
+   - exportXcargs: Pass additional arguments to xcodebuild for the package phase. Be sure to quote the setting names and values e.g. OTHER_LDFLAGS="-ObjC -lstdc++"
+   - skipBuildArchive: Export ipa from previously built xcarchive. Uses archive_path as source
+   - skipArchive: After building, don't archive, effectively not including -archivePath param
+   - skipCodesigning: Build without codesigning
+   - installerCertName: Full name of 3rd Party Mac Developer Installer or Deveoper ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
+   - buildPath: The directory in which the archive should be stored in
+   - archivePath: The path to the created archive
+   - derivedDataPath: The directory where built products and other derived data will go
+   - resultBundle: Should an Xcode result bundle be generated in the output directory
+   - resultBundlePath: Path to the result bundle directory to create. Ignored if `result_bundle` if false
+   - buildlogPath: The directory where to store the build log
+   - sdk: The SDK that should be used for building the application
+   - toolchain: The toolchain that should be used for building the application (e.g. com.apple.dt.toolchain.Swift_2_3, org.swift.30p620160816a)
+   - destination: Use a custom destination for building the app
+   - exportTeamId: Optional: Sometimes you need to specify a team id when exporting the ipa file
+   - xcargs: Pass additional arguments to xcodebuild for the build phase. Be sure to quote the setting names and values e.g. OTHER_LDFLAGS="-ObjC -lstdc++"
+   - xcconfig: Use an extra XCCONFIG file to build your app
+   - suppressXcodeOutput: Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path
+   - disableXcpretty: Disable xcpretty formatting of build output
+   - xcprettyTestFormat: Use the test (RSpec style) format for build output
+   - xcprettyFormatter: A custom xcpretty formatter to use
+   - xcprettyReportJunit: Have xcpretty create a JUnit-style XML report at the provided path
+   - xcprettyReportHtml: Have xcpretty create a simple HTML report at the provided path
+   - xcprettyReportJson: Have xcpretty create a JSON compilation database at the provided path
+   - analyzeBuildTime: Analyze the project build time and store the output in 'culprits.txt' file
+   - xcprettyUtf: Have xcpretty use unicode encoding when reporting builds
+   - skipProfileDetection: Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used
+   - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+
+ - returns: The absolute path to the generated ipa file
+
+ More information: https://fastlane.tools/gym
+*/
+func buildMacApp(workspace: String? = nil,
+                 project: String? = nil,
+                 scheme: String? = nil,
+                 clean: Bool = false,
+                 outputDirectory: String = ".",
+                 outputName: String? = nil,
+                 configuration: String? = nil,
+                 silent: Bool = false,
+                 codesigningIdentity: String? = nil,
+                 skipPackagePkg: Bool = false,
+                 includeSymbols: Bool? = nil,
+                 includeBitcode: Bool? = nil,
+                 exportMethod: String? = nil,
+                 exportOptions: [String : Any]? = nil,
+                 exportXcargs: String? = nil,
+                 skipBuildArchive: Bool? = nil,
+                 skipArchive: Bool? = nil,
+                 skipCodesigning: Bool? = nil,
+                 installerCertName: String? = nil,
+                 buildPath: String? = nil,
+                 archivePath: String? = nil,
+                 derivedDataPath: String? = nil,
+                 resultBundle: Bool = false,
+                 resultBundlePath: String? = nil,
+                 buildlogPath: String = "~/Library/Logs/gym",
+                 sdk: String? = nil,
+                 toolchain: String? = nil,
+                 destination: String? = nil,
+                 exportTeamId: String? = nil,
+                 xcargs: String? = nil,
+                 xcconfig: String? = nil,
+                 suppressXcodeOutput: Bool? = nil,
+                 disableXcpretty: Bool? = nil,
+                 xcprettyTestFormat: Bool? = nil,
+                 xcprettyFormatter: String? = nil,
+                 xcprettyReportJunit: String? = nil,
+                 xcprettyReportHtml: String? = nil,
+                 xcprettyReportJson: String? = nil,
+                 analyzeBuildTime: Bool? = nil,
+                 xcprettyUtf: Bool? = nil,
+                 skipProfileDetection: Bool = false,
+                 clonedSourcePackagesPath: String? = nil) {
+  let command = RubyCommand(commandID: "", methodName: "build_mac_app", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
+                                                                                               RubyCommand.Argument(name: "project", value: project),
+                                                                                               RubyCommand.Argument(name: "scheme", value: scheme),
+                                                                                               RubyCommand.Argument(name: "clean", value: clean),
+                                                                                               RubyCommand.Argument(name: "output_directory", value: outputDirectory),
+                                                                                               RubyCommand.Argument(name: "output_name", value: outputName),
+                                                                                               RubyCommand.Argument(name: "configuration", value: configuration),
+                                                                                               RubyCommand.Argument(name: "silent", value: silent),
+                                                                                               RubyCommand.Argument(name: "codesigning_identity", value: codesigningIdentity),
+                                                                                               RubyCommand.Argument(name: "skip_package_pkg", value: skipPackagePkg),
+                                                                                               RubyCommand.Argument(name: "include_symbols", value: includeSymbols),
+                                                                                               RubyCommand.Argument(name: "include_bitcode", value: includeBitcode),
+                                                                                               RubyCommand.Argument(name: "export_method", value: exportMethod),
+                                                                                               RubyCommand.Argument(name: "export_options", value: exportOptions),
+                                                                                               RubyCommand.Argument(name: "export_xcargs", value: exportXcargs),
+                                                                                               RubyCommand.Argument(name: "skip_build_archive", value: skipBuildArchive),
+                                                                                               RubyCommand.Argument(name: "skip_archive", value: skipArchive),
+                                                                                               RubyCommand.Argument(name: "skip_codesigning", value: skipCodesigning),
+                                                                                               RubyCommand.Argument(name: "installer_cert_name", value: installerCertName),
+                                                                                               RubyCommand.Argument(name: "build_path", value: buildPath),
+                                                                                               RubyCommand.Argument(name: "archive_path", value: archivePath),
+                                                                                               RubyCommand.Argument(name: "derived_data_path", value: derivedDataPath),
+                                                                                               RubyCommand.Argument(name: "result_bundle", value: resultBundle),
+                                                                                               RubyCommand.Argument(name: "result_bundle_path", value: resultBundlePath),
+                                                                                               RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
+                                                                                               RubyCommand.Argument(name: "sdk", value: sdk),
+                                                                                               RubyCommand.Argument(name: "toolchain", value: toolchain),
+                                                                                               RubyCommand.Argument(name: "destination", value: destination),
+                                                                                               RubyCommand.Argument(name: "export_team_id", value: exportTeamId),
+                                                                                               RubyCommand.Argument(name: "xcargs", value: xcargs),
+                                                                                               RubyCommand.Argument(name: "xcconfig", value: xcconfig),
+                                                                                               RubyCommand.Argument(name: "suppress_xcode_output", value: suppressXcodeOutput),
+                                                                                               RubyCommand.Argument(name: "disable_xcpretty", value: disableXcpretty),
+                                                                                               RubyCommand.Argument(name: "xcpretty_test_format", value: xcprettyTestFormat),
+                                                                                               RubyCommand.Argument(name: "xcpretty_formatter", value: xcprettyFormatter),
+                                                                                               RubyCommand.Argument(name: "xcpretty_report_junit", value: xcprettyReportJunit),
+                                                                                               RubyCommand.Argument(name: "xcpretty_report_html", value: xcprettyReportHtml),
+                                                                                               RubyCommand.Argument(name: "xcpretty_report_json", value: xcprettyReportJson),
+                                                                                               RubyCommand.Argument(name: "analyze_build_time", value: analyzeBuildTime),
+                                                                                               RubyCommand.Argument(name: "xcpretty_utf", value: xcprettyUtf),
+                                                                                               RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection),
+                                                                                               RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
   _ = runner.executeCommand(command)
 }
 
@@ -1308,6 +1461,8 @@ func captureAndroidScreenshots(androidHome: String? = nil,
    - testTargetName: The name of the target you want to test (if you desire to override the Target Application from Xcode)
    - namespaceLogFiles: Separate the log files per device and per language
    - concurrentSimulators: Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
+   - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
+   - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
 */
 func captureIosScreenshots(workspace: String? = nil,
                            project: String? = nil,
@@ -1342,7 +1497,9 @@ func captureIosScreenshots(workspace: String? = nil,
                            resultBundle: Bool = false,
                            testTargetName: String? = nil,
                            namespaceLogFiles: Any? = nil,
-                           concurrentSimulators: Bool = true) {
+                           concurrentSimulators: Bool = true,
+                           disableSlideToType: Bool = false,
+                           clonedSourcePackagesPath: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "capture_ios_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                          RubyCommand.Argument(name: "project", value: project),
                                                                                                          RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -1376,7 +1533,9 @@ func captureIosScreenshots(workspace: String? = nil,
                                                                                                          RubyCommand.Argument(name: "result_bundle", value: resultBundle),
                                                                                                          RubyCommand.Argument(name: "test_target_name", value: testTargetName),
                                                                                                          RubyCommand.Argument(name: "namespace_log_files", value: namespaceLogFiles),
-                                                                                                         RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators)])
+                                                                                                         RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
+                                                                                                         RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
+                                                                                                         RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
   _ = runner.executeCommand(command)
 }
 
@@ -1418,6 +1577,8 @@ func captureIosScreenshots(workspace: String? = nil,
    - testTargetName: The name of the target you want to test (if you desire to override the Target Application from Xcode)
    - namespaceLogFiles: Separate the log files per device and per language
    - concurrentSimulators: Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
+   - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
+   - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
 */
 func captureScreenshots(workspace: String? = nil,
                         project: String? = nil,
@@ -1452,7 +1613,9 @@ func captureScreenshots(workspace: String? = nil,
                         resultBundle: Bool = false,
                         testTargetName: String? = nil,
                         namespaceLogFiles: Any? = nil,
-                        concurrentSimulators: Bool = true) {
+                        concurrentSimulators: Bool = true,
+                        disableSlideToType: Bool = false,
+                        clonedSourcePackagesPath: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "capture_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                      RubyCommand.Argument(name: "project", value: project),
                                                                                                      RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -1486,7 +1649,9 @@ func captureScreenshots(workspace: String? = nil,
                                                                                                      RubyCommand.Argument(name: "result_bundle", value: resultBundle),
                                                                                                      RubyCommand.Argument(name: "test_target_name", value: testTargetName),
                                                                                                      RubyCommand.Argument(name: "namespace_log_files", value: namespaceLogFiles),
-                                                                                                     RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators)])
+                                                                                                     RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
+                                                                                                     RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
+                                                                                                     RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
   _ = runner.executeCommand(command)
 }
 
@@ -1563,6 +1728,7 @@ func carthage(command: String = "bootstrap",
 
  - parameters:
    - development: Create a development certificate instead of a distribution one
+   - type: Create specific certificate type (takes precedence over :development)
    - force: Create a certificate even if an existing certificate exists
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
    - username: Your Apple ID Username
@@ -1578,6 +1744,7 @@ func carthage(command: String = "bootstrap",
  Use this action to download the latest code signing identity.
 */
 func cert(development: Bool = false,
+          type: String? = nil,
           force: Bool = false,
           generateAppleCerts: Bool = true,
           username: String,
@@ -1587,8 +1754,9 @@ func cert(development: Bool = false,
           outputPath: String = ".",
           keychainPath: String,
           keychainPassword: String? = nil,
-          platform: Any = "ios") {
+          platform: String = "ios") {
   let command = RubyCommand(commandID: "", methodName: "cert", className: nil, args: [RubyCommand.Argument(name: "development", value: development),
+                                                                                      RubyCommand.Argument(name: "type", value: type),
                                                                                       RubyCommand.Argument(name: "force", value: force),
                                                                                       RubyCommand.Argument(name: "generate_apple_certs", value: generateAppleCerts),
                                                                                       RubyCommand.Argument(name: "username", value: username),
@@ -2145,6 +2313,7 @@ func createKeychain(name: String? = nil,
    - title: The title of the pull request
    - body: The contents of the pull request
    - labels: The labels for the pull request
+   - milestone: The milestone ID (Integer) for the pull request
    - head: The name of the branch where your changes are implemented (defaults to the current branch name)
    - base: The name of the branch you want your changes pulled into (defaults to `master`)
    - apiUrl: The URL of GitHub API - used when the Enterprise (default to `https://api.github.com`)
@@ -2159,6 +2328,7 @@ func createPullRequest(apiToken: String,
                        title: String,
                        body: String? = nil,
                        labels: [String]? = nil,
+                       milestone: String? = nil,
                        head: String? = nil,
                        base: String = "master",
                        apiUrl: String = "https://api.github.com",
@@ -2170,6 +2340,7 @@ func createPullRequest(apiToken: String,
                                                                                                      RubyCommand.Argument(name: "title", value: title),
                                                                                                      RubyCommand.Argument(name: "body", value: body),
                                                                                                      RubyCommand.Argument(name: "labels", value: labels),
+                                                                                                     RubyCommand.Argument(name: "milestone", value: milestone),
                                                                                                      RubyCommand.Argument(name: "head", value: head),
                                                                                                      RubyCommand.Argument(name: "base", value: base),
                                                                                                      RubyCommand.Argument(name: "api_url", value: apiUrl),
@@ -2278,8 +2449,8 @@ func deleteKeychain(name: String? = nil,
    - overwriteScreenshots: Clear all previously uploaded screenshots before uploading the new ones
    - submitForReview: Submit the new version for Review after uploading everything
    - rejectIfPossible: Rejects the previously submitted build if it's in a state where it's possible
-   - automaticRelease: Should the app be automatically released once it's approved?
-   - autoReleaseDate: Date in milliseconds for automatically releasing on pending approval
+   - automaticRelease: Should the app be automatically released once it's approved? (Can not be used together with `auto_release_date`)
+   - autoReleaseDate: Date in milliseconds for automatically releasing on pending approval (Can not be used together with `automatic_release`)
    - phasedRelease: Enable the phased release feature of iTC
    - resetRatings: Reset the summary rating when you release a new version of the application
    - priceTier: The price tier of this application
@@ -2586,7 +2757,7 @@ func downloadDsyms(username: String,
 func downloadFromPlayStore(packageName: String,
                            versionName: String? = nil,
                            track: String = "production",
-                           metadataPath: String = "./metadata",
+                           metadataPath: String? = nil,
                            key: String? = nil,
                            issuer: String? = nil,
                            jsonKey: String? = nil,
@@ -2941,6 +3112,7 @@ func getBuildNumberRepository(useHgRevisionNumber: Bool = false) {
 
  - parameters:
    - development: Create a development certificate instead of a distribution one
+   - type: Create specific certificate type (takes precedence over :development)
    - force: Create a certificate even if an existing certificate exists
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
    - username: Your Apple ID Username
@@ -2956,6 +3128,7 @@ func getBuildNumberRepository(useHgRevisionNumber: Bool = false) {
  Use this action to download the latest code signing identity.
 */
 func getCertificates(development: Bool = false,
+                     type: String? = nil,
                      force: Bool = false,
                      generateAppleCerts: Bool = true,
                      username: String,
@@ -2965,8 +3138,9 @@ func getCertificates(development: Bool = false,
                      outputPath: String = ".",
                      keychainPath: String,
                      keychainPassword: String? = nil,
-                     platform: Any = "ios") {
+                     platform: String = "ios") {
   let command = RubyCommand(commandID: "", methodName: "get_certificates", className: nil, args: [RubyCommand.Argument(name: "development", value: development),
+                                                                                                  RubyCommand.Argument(name: "type", value: type),
                                                                                                   RubyCommand.Argument(name: "force", value: force),
                                                                                                   RubyCommand.Argument(name: "generate_apple_certs", value: generateAppleCerts),
                                                                                                   RubyCommand.Argument(name: "username", value: username),
@@ -3470,7 +3644,7 @@ func gradle(task: String? = nil,
 }
 
 /**
- Alias for the `build_ios_app` action
+ Alias for the `build_app` action
 
  - parameters:
    - workspace: Path to the workspace file
@@ -3483,6 +3657,7 @@ func gradle(task: String? = nil,
    - silent: Hide all information that's not necessary while building
    - codesigningIdentity: The name of the code signing identity to use. It has to match the name exactly. e.g. 'iPhone Distribution: SunApps GmbH'
    - skipPackageIpa: Should we skip packaging the ipa?
+   - skipPackagePkg: Should we skip packaging the pkg?
    - includeSymbols: Should the ipa file include symbols?
    - includeBitcode: Should the ipa file include bitcode?
    - exportMethod: Method used to export the archive. Valid values are: app-store, ad-hoc, package, enterprise, development, developer-id
@@ -3491,6 +3666,8 @@ func gradle(task: String? = nil,
    - skipBuildArchive: Export ipa from previously built xcarchive. Uses archive_path as source
    - skipArchive: After building, don't archive, effectively not including -archivePath param
    - skipCodesigning: Build without codesigning
+   - catalystPlatform: Platform to build when using a Catalyst enabled app. Valid values are: ios, macos
+   - installerCertName: Full name of 3rd Party Mac Developer Installer or Deveoper ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
    - buildPath: The directory in which the archive should be stored in
    - archivePath: The path to the created archive
    - derivedDataPath: The directory where built products and other derived data will go
@@ -3513,6 +3690,7 @@ func gradle(task: String? = nil,
    - analyzeBuildTime: Analyze the project build time and store the output in 'culprits.txt' file
    - xcprettyUtf: Have xcpretty use unicode encoding when reporting builds
    - skipProfileDetection: Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used
+   - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
 
  - returns: The absolute path to the generated ipa file
 
@@ -3528,6 +3706,7 @@ func gym(workspace: Any? = gymfile.workspace,
          silent: Bool = gymfile.silent,
          codesigningIdentity: Any? = gymfile.codesigningIdentity,
          skipPackageIpa: Bool = gymfile.skipPackageIpa,
+         skipPackagePkg: Bool = gymfile.skipPackagePkg,
          includeSymbols: Bool? = gymfile.includeSymbols,
          includeBitcode: Bool? = gymfile.includeBitcode,
          exportMethod: Any? = gymfile.exportMethod,
@@ -3536,6 +3715,8 @@ func gym(workspace: Any? = gymfile.workspace,
          skipBuildArchive: Bool? = gymfile.skipBuildArchive,
          skipArchive: Bool? = gymfile.skipArchive,
          skipCodesigning: Bool? = gymfile.skipCodesigning,
+         catalystPlatform: Any? = gymfile.catalystPlatform,
+         installerCertName: Any? = gymfile.installerCertName,
          buildPath: Any? = gymfile.buildPath,
          archivePath: Any? = gymfile.archivePath,
          derivedDataPath: Any? = gymfile.derivedDataPath,
@@ -3557,7 +3738,8 @@ func gym(workspace: Any? = gymfile.workspace,
          xcprettyReportJson: Any? = gymfile.xcprettyReportJson,
          analyzeBuildTime: Bool? = gymfile.analyzeBuildTime,
          xcprettyUtf: Bool? = gymfile.xcprettyUtf,
-         skipProfileDetection: Bool = gymfile.skipProfileDetection) {
+         skipProfileDetection: Bool = gymfile.skipProfileDetection,
+         clonedSourcePackagesPath: Any? = gymfile.clonedSourcePackagesPath) {
   let command = RubyCommand(commandID: "", methodName: "gym", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                      RubyCommand.Argument(name: "project", value: project),
                                                                                      RubyCommand.Argument(name: "scheme", value: scheme),
@@ -3568,6 +3750,7 @@ func gym(workspace: Any? = gymfile.workspace,
                                                                                      RubyCommand.Argument(name: "silent", value: silent),
                                                                                      RubyCommand.Argument(name: "codesigning_identity", value: codesigningIdentity),
                                                                                      RubyCommand.Argument(name: "skip_package_ipa", value: skipPackageIpa),
+                                                                                     RubyCommand.Argument(name: "skip_package_pkg", value: skipPackagePkg),
                                                                                      RubyCommand.Argument(name: "include_symbols", value: includeSymbols),
                                                                                      RubyCommand.Argument(name: "include_bitcode", value: includeBitcode),
                                                                                      RubyCommand.Argument(name: "export_method", value: exportMethod),
@@ -3576,6 +3759,8 @@ func gym(workspace: Any? = gymfile.workspace,
                                                                                      RubyCommand.Argument(name: "skip_build_archive", value: skipBuildArchive),
                                                                                      RubyCommand.Argument(name: "skip_archive", value: skipArchive),
                                                                                      RubyCommand.Argument(name: "skip_codesigning", value: skipCodesigning),
+                                                                                     RubyCommand.Argument(name: "catalyst_platform", value: catalystPlatform),
+                                                                                     RubyCommand.Argument(name: "installer_cert_name", value: installerCertName),
                                                                                      RubyCommand.Argument(name: "build_path", value: buildPath),
                                                                                      RubyCommand.Argument(name: "archive_path", value: archivePath),
                                                                                      RubyCommand.Argument(name: "derived_data_path", value: derivedDataPath),
@@ -3597,7 +3782,8 @@ func gym(workspace: Any? = gymfile.workspace,
                                                                                      RubyCommand.Argument(name: "xcpretty_report_json", value: xcprettyReportJson),
                                                                                      RubyCommand.Argument(name: "analyze_build_time", value: analyzeBuildTime),
                                                                                      RubyCommand.Argument(name: "xcpretty_utf", value: xcprettyUtf),
-                                                                                     RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection)])
+                                                                                     RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection),
+                                                                                     RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
   _ = runner.executeCommand(command)
 }
 
@@ -4232,7 +4418,8 @@ func makeChangelogFromJenkins(fallbackChangelog: String = "",
  Alias for the `sync_code_signing` action
 
  - parameters:
-   - type: Define the profile type, can be appstore, adhoc, development, enterprise
+   - type: Define the profile type, can be appstore, adhoc, development, enterprise, developer_id
+   - additionalCertTypes: Create additional cert types needed for macOS installers (valid values: mac_installer_distribution, developer_id_installer)
    - readonly: Only fetch existing certificates and profiles, don't generate new ones
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
    - skipProvisioningProfiles: Skip syncing provisioning profiles
@@ -4258,7 +4445,7 @@ func makeChangelogFromJenkins(fallbackChangelog: String = "",
    - forceForNewDevices: Renew the provisioning profiles if the device count on the developer portal has changed. Ignored for profile type 'appstore'
    - skipConfirmation: Disables confirmation prompts during nuke, answering them with yes
    - skipDocs: Skip generation of a README.md for the created git repository
-   - platform: Set the provisioning profile's platform to work with (i.e. ios, tvos)
+   - platform: Set the provisioning profile's platform to work with (i.e. ios, tvos, macos)
    - templateName: The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
    - outputPath: Path in which to export certificates, key and profile
    - verbose: Print out extra information and all commands
@@ -4266,6 +4453,7 @@ func makeChangelogFromJenkins(fallbackChangelog: String = "",
  More information: https://docs.fastlane.tools/actions/match/
 */
 func match(type: Any = matchfile.type,
+           additionalCertTypes: [String]? = matchfile.additionalCertTypes,
            readonly: Bool = matchfile.readonly,
            generateAppleCerts: Bool = matchfile.generateAppleCerts,
            skipProvisioningProfiles: Bool = matchfile.skipProvisioningProfiles,
@@ -4296,6 +4484,7 @@ func match(type: Any = matchfile.type,
            outputPath: Any? = matchfile.outputPath,
            verbose: Bool = matchfile.verbose) {
   let command = RubyCommand(commandID: "", methodName: "match", className: nil, args: [RubyCommand.Argument(name: "type", value: type),
+                                                                                       RubyCommand.Argument(name: "additional_cert_types", value: additionalCertTypes),
                                                                                        RubyCommand.Argument(name: "readonly", value: readonly),
                                                                                        RubyCommand.Argument(name: "generate_apple_certs", value: generateAppleCerts),
                                                                                        RubyCommand.Argument(name: "skip_provisioning_profiles", value: skipProvisioningProfiles),
@@ -5417,6 +5606,7 @@ func rubyVersion() {
    - destination: Use only if you're a pro, use the other options instead
    - customReportFileName: **DEPRECATED!** Use `--output_files` instead - Sets custom full report file name when generating a single report
    - xcodebuildCommand: Allows for override of the default `xcodebuild` command
+   - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
    - failBuild: Should this step stop the build if the tests fail? Set this to false if you're using trainer
 
  More information: https://docs.fastlane.tools/actions/scan/
@@ -5477,6 +5667,7 @@ func runTests(workspace: String? = nil,
               destination: Any? = nil,
               customReportFileName: String? = nil,
               xcodebuildCommand: String = "env NSUnbufferedIO=YES xcodebuild",
+              clonedSourcePackagesPath: String? = nil,
               failBuild: Bool = true) {
   let command = RubyCommand(commandID: "", methodName: "run_tests", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                            RubyCommand.Argument(name: "project", value: project),
@@ -5534,6 +5725,7 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "destination", value: destination),
                                                                                            RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
                                                                                            RubyCommand.Argument(name: "xcodebuild_command", value: xcodebuildCommand),
+                                                                                           RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
                                                                                            RubyCommand.Argument(name: "fail_build", value: failBuild)])
   _ = runner.executeCommand(command)
 }
@@ -5672,6 +5864,7 @@ func say(text: Any,
    - destination: Use only if you're a pro, use the other options instead
    - customReportFileName: **DEPRECATED!** Use `--output_files` instead - Sets custom full report file name when generating a single report
    - xcodebuildCommand: Allows for override of the default `xcodebuild` command
+   - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
    - failBuild: Should this step stop the build if the tests fail? Set this to false if you're using trainer
 
  More information: https://docs.fastlane.tools/actions/scan/
@@ -5732,6 +5925,7 @@ func scan(workspace: Any? = scanfile.workspace,
           destination: Any? = scanfile.destination,
           customReportFileName: Any? = scanfile.customReportFileName,
           xcodebuildCommand: Any = scanfile.xcodebuildCommand,
+          clonedSourcePackagesPath: Any? = scanfile.clonedSourcePackagesPath,
           failBuild: Bool = scanfile.failBuild) {
   let command = RubyCommand(commandID: "", methodName: "scan", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -5789,6 +5983,7 @@ func scan(workspace: Any? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "destination", value: destination),
                                                                                       RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
                                                                                       RubyCommand.Argument(name: "xcodebuild_command", value: xcodebuildCommand),
+                                                                                      RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
                                                                                       RubyCommand.Argument(name: "fail_build", value: failBuild)])
   _ = runner.executeCommand(command)
 }
@@ -5975,7 +6170,7 @@ Access things like 'html_url', 'tag_name', 'name', 'body'
                                          description: String? = nil,
                                          isDraft: Bool = false,
                                          isPrerelease: Bool = false,
-                                         uploadAssets: [String]? = nil) -> [String : String] {
+                                         uploadAssets: [String]? = nil) -> [String : Any] {
   let command = RubyCommand(commandID: "", methodName: "set_github_release", className: nil, args: [RubyCommand.Argument(name: "repository_name", value: repositoryName),
                                                                                                     RubyCommand.Argument(name: "server_url", value: serverUrl),
                                                                                                     RubyCommand.Argument(name: "api_token", value: apiToken),
@@ -6462,6 +6657,8 @@ func slather(buildDirectory: String? = nil,
    - testTargetName: The name of the target you want to test (if you desire to override the Target Application from Xcode)
    - namespaceLogFiles: Separate the log files per device and per language
    - concurrentSimulators: Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
+   - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
+   - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
 */
 func snapshot(workspace: Any? = snapshotfile.workspace,
               project: Any? = snapshotfile.project,
@@ -6496,7 +6693,9 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
               resultBundle: Bool = snapshotfile.resultBundle,
               testTargetName: Any? = snapshotfile.testTargetName,
               namespaceLogFiles: Any? = snapshotfile.namespaceLogFiles,
-              concurrentSimulators: Bool = snapshotfile.concurrentSimulators) {
+              concurrentSimulators: Bool = snapshotfile.concurrentSimulators,
+              disableSlideToType: Bool = snapshotfile.disableSlideToType,
+              clonedSourcePackagesPath: Any? = snapshotfile.clonedSourcePackagesPath) {
   let command = RubyCommand(commandID: "", methodName: "snapshot", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                           RubyCommand.Argument(name: "project", value: project),
                                                                                           RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -6530,7 +6729,9 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
                                                                                           RubyCommand.Argument(name: "result_bundle", value: resultBundle),
                                                                                           RubyCommand.Argument(name: "test_target_name", value: testTargetName),
                                                                                           RubyCommand.Argument(name: "namespace_log_files", value: namespaceLogFiles),
-                                                                                          RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators)])
+                                                                                          RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
+                                                                                          RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
+                                                                                          RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
   _ = runner.executeCommand(command)
 }
 
@@ -6756,7 +6957,7 @@ func supply(packageName: String,
             releaseStatus: String = "completed",
             track: String = "production",
             rollout: String? = nil,
-            metadataPath: String = "./metadata",
+            metadataPath: String? = nil,
             key: String? = nil,
             issuer: String? = nil,
             jsonKey: String? = nil,
@@ -6869,7 +7070,8 @@ func swiftlint(mode: Any = "lint",
  Easily sync your certificates and profiles across your team (via _match_)
 
  - parameters:
-   - type: Define the profile type, can be appstore, adhoc, development, enterprise
+   - type: Define the profile type, can be appstore, adhoc, development, enterprise, developer_id
+   - additionalCertTypes: Create additional cert types needed for macOS installers (valid values: mac_installer_distribution, developer_id_installer)
    - readonly: Only fetch existing certificates and profiles, don't generate new ones
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
    - skipProvisioningProfiles: Skip syncing provisioning profiles
@@ -6895,7 +7097,7 @@ func swiftlint(mode: Any = "lint",
    - forceForNewDevices: Renew the provisioning profiles if the device count on the developer portal has changed. Ignored for profile type 'appstore'
    - skipConfirmation: Disables confirmation prompts during nuke, answering them with yes
    - skipDocs: Skip generation of a README.md for the created git repository
-   - platform: Set the provisioning profile's platform to work with (i.e. ios, tvos)
+   - platform: Set the provisioning profile's platform to work with (i.e. ios, tvos, macos)
    - templateName: The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
    - outputPath: Path in which to export certificates, key and profile
    - verbose: Print out extra information and all commands
@@ -6903,6 +7105,7 @@ func swiftlint(mode: Any = "lint",
  More information: https://docs.fastlane.tools/actions/match/
 */
 func syncCodeSigning(type: String = "development",
+                     additionalCertTypes: [String]? = nil,
                      readonly: Bool = false,
                      generateAppleCerts: Bool = true,
                      skipProvisioningProfiles: Bool = false,
@@ -6928,11 +7131,12 @@ func syncCodeSigning(type: String = "development",
                      forceForNewDevices: Bool = false,
                      skipConfirmation: Bool = false,
                      skipDocs: Bool = false,
-                     platform: Any = "ios",
+                     platform: String = "ios",
                      templateName: String? = nil,
                      outputPath: String? = nil,
                      verbose: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "sync_code_signing", className: nil, args: [RubyCommand.Argument(name: "type", value: type),
+                                                                                                   RubyCommand.Argument(name: "additional_cert_types", value: additionalCertTypes),
                                                                                                    RubyCommand.Argument(name: "readonly", value: readonly),
                                                                                                    RubyCommand.Argument(name: "generate_apple_certs", value: generateAppleCerts),
                                                                                                    RubyCommand.Argument(name: "skip_provisioning_profiles", value: skipProvisioningProfiles),
@@ -7349,7 +7553,7 @@ func updateKeychainAccessGroups(entitlementsFile: String,
    - plistPath: Path to plist file
    - block: A block to process plist with custom logic
 
- This action allows you to modify any `plist` file.
+ This action allows you to modify any value inside any `plist` file.
 */
 func updatePlist(plistPath: String? = nil,
                  block: Any) {
@@ -7565,8 +7769,8 @@ func uploadSymbolsToSentry(apiHost: String = "https://app.getsentry.com/api/0",
    - overwriteScreenshots: Clear all previously uploaded screenshots before uploading the new ones
    - submitForReview: Submit the new version for Review after uploading everything
    - rejectIfPossible: Rejects the previously submitted build if it's in a state where it's possible
-   - automaticRelease: Should the app be automatically released once it's approved?
-   - autoReleaseDate: Date in milliseconds for automatically releasing on pending approval
+   - automaticRelease: Should the app be automatically released once it's approved? (Can not be used together with `auto_release_date`)
+   - autoReleaseDate: Date in milliseconds for automatically releasing on pending approval (Can not be used together with `automatic_release`)
    - phasedRelease: Enable the phased release feature of iTC
    - resetRatings: Reset the summary rating when you release a new version of the application
    - priceTier: The price tier of this application
@@ -7784,7 +7988,7 @@ func uploadToPlayStore(packageName: String,
                        releaseStatus: String = "completed",
                        track: String = "production",
                        rollout: String? = nil,
-                       metadataPath: String = "./metadata",
+                       metadataPath: String? = nil,
                        key: String? = nil,
                        issuer: String? = nil,
                        jsonKey: String? = nil,
@@ -8283,7 +8487,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode-11.2.1.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode-11.3.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -8428,4 +8632,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.68]
+// FastlaneRunnerAPIVersion [0.9.69]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.140.0
+// Generated with fastlane 2.141.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -30,6 +30,9 @@ protocol GymfileProtocol: class {
   /// Should we skip packaging the ipa?
   var skipPackageIpa: Bool { get }
 
+  /// Should we skip packaging the pkg?
+  var skipPackagePkg: Bool { get }
+
   /// Should the ipa file include symbols?
   var includeSymbols: Bool? { get }
 
@@ -53,6 +56,12 @@ protocol GymfileProtocol: class {
 
   /// Build without codesigning
   var skipCodesigning: Bool? { get }
+
+  /// Platform to build when using a Catalyst enabled app. Valid values are: ios, macos
+  var catalystPlatform: String? { get }
+
+  /// Full name of 3rd Party Mac Developer Installer or Deveoper ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
+  var installerCertName: String? { get }
 
   /// The directory in which the archive should be stored in
   var buildPath: String? { get }
@@ -119,6 +128,9 @@ protocol GymfileProtocol: class {
 
   /// Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used
   var skipProfileDetection: Bool { get }
+
+  /// Sets a custom path for Swift Package Manager dependencies
+  var clonedSourcePackagesPath: String? { get }
 }
 
 extension GymfileProtocol {
@@ -132,6 +144,7 @@ extension GymfileProtocol {
   var silent: Bool { return false }
   var codesigningIdentity: String? { return nil }
   var skipPackageIpa: Bool { return false }
+  var skipPackagePkg: Bool { return false }
   var includeSymbols: Bool? { return nil }
   var includeBitcode: Bool? { return nil }
   var exportMethod: String? { return nil }
@@ -140,6 +153,8 @@ extension GymfileProtocol {
   var skipBuildArchive: Bool? { return nil }
   var skipArchive: Bool? { return nil }
   var skipCodesigning: Bool? { return nil }
+  var catalystPlatform: String? { return nil }
+  var installerCertName: String? { return nil }
   var buildPath: String? { return nil }
   var archivePath: String? { return nil }
   var derivedDataPath: String? { return nil }
@@ -162,8 +177,9 @@ extension GymfileProtocol {
   var analyzeBuildTime: Bool? { return nil }
   var xcprettyUtf: Bool? { return nil }
   var skipProfileDetection: Bool { return false }
+  var clonedSourcePackagesPath: String? { return nil }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.17]
+// FastlaneRunnerAPIVersion [0.9.18]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.140.0
+// Generated with fastlane 2.141.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -1,7 +1,10 @@
 protocol MatchfileProtocol: class {
 
-  /// Define the profile type, can be appstore, adhoc, development, enterprise
+  /// Define the profile type, can be appstore, adhoc, development, enterprise, developer_id
   var type: String { get }
+
+  /// Create additional cert types needed for macOS installers (valid values: mac_installer_distribution, developer_id_installer)
+  var additionalCertTypes: [String]? { get }
 
   /// Only fetch existing certificates and profiles, don't generate new ones
   var readonly: Bool { get }
@@ -78,7 +81,7 @@ protocol MatchfileProtocol: class {
   /// Skip generation of a README.md for the created git repository
   var skipDocs: Bool { get }
 
-  /// Set the provisioning profile's platform to work with (i.e. ios, tvos)
+  /// Set the provisioning profile's platform to work with (i.e. ios, tvos, macos)
   var platform: String { get }
 
   /// The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
@@ -93,6 +96,7 @@ protocol MatchfileProtocol: class {
 
 extension MatchfileProtocol {
   var type: String { return "development" }
+  var additionalCertTypes: [String]? { return nil }
   var readonly: Bool { return false }
   var generateAppleCerts: Bool { return true }
   var skipProvisioningProfiles: Bool { return false }
@@ -126,4 +130,4 @@ extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.12]
+// FastlaneRunnerAPIVersion [0.9.13]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.140.0
+// Generated with fastlane 2.141.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.140.0
+// Generated with fastlane 2.141.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -168,6 +168,9 @@ protocol ScanfileProtocol: class {
   /// Allows for override of the default `xcodebuild` command
   var xcodebuildCommand: String { get }
 
+  /// Sets a custom path for Swift Package Manager dependencies
+  var clonedSourcePackagesPath: String? { get }
+
   /// Should this step stop the build if the tests fail? Set this to false if you're using trainer
   var failBuild: Bool { get }
 }
@@ -229,9 +232,10 @@ extension ScanfileProtocol {
   var destination: String? { return nil }
   var customReportFileName: String? { return nil }
   var xcodebuildCommand: String { return "env NSUnbufferedIO=YES xcodebuild" }
+  var clonedSourcePackagesPath: String? { return nil }
   var failBuild: Bool { return true }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.24]
+// FastlaneRunnerAPIVersion [0.9.25]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.140.0
+// Generated with fastlane 2.141.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.140.0
+// Generated with fastlane 2.141.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -101,6 +101,12 @@ protocol SnapshotfileProtocol: class {
 
   /// Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
   var concurrentSimulators: Bool { get }
+
+  /// Disable the simulator from showing the 'Slide to type' prompt
+  var disableSlideToType: Bool { get }
+
+  /// Sets a custom path for Swift Package Manager dependencies
+  var clonedSourcePackagesPath: String? { get }
 }
 
 extension SnapshotfileProtocol {
@@ -138,8 +144,10 @@ extension SnapshotfileProtocol {
   var testTargetName: String? { return nil }
   var namespaceLogFiles: String? { return nil }
   var concurrentSimulators: Bool { return true }
+  var disableSlideToType: Bool { return false }
+  var clonedSourcePackagesPath: String? { return nil }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.6]
+// FastlaneRunnerAPIVersion [0.9.7]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.140.0':**

* [match] add mac and catalyst support for match (#15918) via Josh Holtz
* [gym, deliver, actions] allow gym to create .pkg for macOS apps and Catalyst apps for App Store upload and new `build_mac_app` action (#12195) via Josh Holtz
* [spaceship] delete beta feedback (#15940) via Tim Sneed
* [GitHub Actions] Disable `pull-requests.yml` workflow (#15881) via Daniel Jankowski
* [match] Change http_auth_header capitalization (#15928) via sakul1991
* [gym, scan] resolve SwiftPM dependencies before fetching build settings (#15505) via Bruno Guidolim
* [fastlane] import multiple files from git (#15804) via Pavlo Pakholka
* [spaceship] replenish IAP status (#15872) via Rdd7
* [action] introduce milestone support for create_pull_request action (#15873) via Kohki Miki
* [action] rix return type of set_github_release action, since it might contain non-string value (#15883) via knothole
* [GitHub Actions] Enable `communicate-on-pull-request-released` GitHub Action (#15889) via Daniel Jankowski
* [docs] remove old Fastfile documentation (#15912) via Jan Piotrowski
* [docs] deliver document conflicting options (#15914) via Jan Piotrowski
* [snapshot] add support for disabling "KeyboardContinuousPathEnabled" (#15933) via Andreas Ganske
* [docs] update team.json (#15869) via Josh Holtz
* [docs] extend update_plist documentation from 1 to 6 code-examples (#15861) via matthiaszarzecki
