### PR TITLE
Allow subfolders in the Actions folder

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -373,7 +373,7 @@ module Fastlane
       # (a plugin may contain any number of actions)
       version_number = Fastlane::ActionCollector.determine_version(gem_name)
       references = Fastlane.const_get(module_name).all_classes.collect do |path|
-        next unless File.dirname(path).end_with?("/actions") # we only want to match actions
+        next unless File.dirname(path).include?("/actions") # we only want to match actions
 
         File.basename(path).gsub("_action", "").gsub(".rb", "").to_sym # the _action is optional
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Sometimes it can useful to be able to organise actions into subfolders. `Fastlane` already supports this, in fact the actions that live in a subfolder of the `actions` folder are found and used. 
The only issue is that they are not shown in the initial dashboard and, if there are no actions in the root `Actions/` folder, a warning is shown at every run.

### Description
This change makes `Fastlane` look for actions also in subfolders of the `action` folder when the plugin is discovered and loaded by considering all the folders that have `/actions` in the path and not only the ones that have it has the last part of the path.

