### PR TITLE
[spm] Adds xcpretty_args optional parameter (#15922)

### DIFF
--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -15,6 +15,9 @@ module Fastlane
         end
         if params[:xcpretty_output]
           cmd += ["2>&1", "|", "xcpretty", "--#{params[:xcpretty_output]}"]
+          if params[:xcpretty_args]
+            cmd << (params[:xcpretty_args]).to_s
+          end
           cmd = %w(set -o pipefail &&) + cmd
         end
 
@@ -67,6 +70,11 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass a valid xcpretty output type: (#{xcpretty_output_types.join('|')})") unless xcpretty_output_types.include?(value)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :xcpretty_args,
+                                       env_name: "FL_SPM_XCPRETTY_ARGS",
+                                       description: "Pass in xcpretty additional command line arguments (e.g. '--test --no-color' or '--tap --no-utf'), requires xcpretty_output to be specified also",
+                                       type: String,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        short_option: "-v",
                                        env_name: "FL_SPM_VERBOSE",

--- a/fastlane/spec/actions_specs/spm_spec.rb
+++ b/fastlane/spec/actions_specs/spm_spec.rb
@@ -222,6 +222,18 @@ describe Fastlane do
           end.to raise_error(/^Please pass a valid xcpretty output type: /)
         end
 
+        it "passes additional arguments to xcpretty if specified" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(
+                command: '#{command}',
+                xcpretty_output: 'simple',
+                xcpretty_args: '--tap --no-utf'
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("set -o pipefail && swift package #{command} 2>&1 | xcpretty --simple --tap --no-utf")
+        end
+
         it "set pipefail with xcpretty" do
           result = Fastlane::FastFile.new.parse("lane :test do
               spm(


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
_It looks like the docs for the actions will be auto-generated from the `spm.rb` file, so I don't think there's anything else to do._

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Adds `xcpretty_args` as an optional parameter to the `spm` command.  More details can be found in the linked issue.
Closes #15922 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I added the `xcpretty_args` as an available option to the SPM command (mostly copying the same-named option from the `run_tests` option list).

I added a unit test that specified the additional parameter to the command, ensuring that it resulted in the desired shell script command.  The other unit tests still pass with no changes, showing that `xcpretty_args` is not a required option.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I tested locally in a Swift Package Manager package folder by adding `xcpretty_args: "-r junit -o testresults.xml"` to my `spm` call, ran the lane with my local fastlane repo, and saw the desired testresults.xml file be generated.
