### PR TITLE
[upload_symbols_to_crashlytics] Add support for --app-id argument (App ID) 

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -10,7 +10,7 @@ module Fastlane
         find_gsp_path(params)
         find_api_token(params)
 
-        if !params[:api_token] && !params[:gsp_path] && !params[:app_id]
+        if !params[:app_id] && !params[:gsp_path] && !params[:api_token]
           UI.user_error!('Either Firebase Crashlytics App ID, path to GoogleService-Info.plist or legacy Fabric API key must be given.')
         end
 

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -10,8 +10,8 @@ module Fastlane
         find_gsp_path(params)
         find_api_token(params)
 
-        if !params[:api_token] && !params[:gsp_path]
-          UI.user_error!('Either Fabric API key or path to Firebase Crashlytics GoogleService-Info.plist must be given.')
+        if !params[:api_token] && !params[:gsp_path] && !params[:app_id]
+          UI.user_error!('Either Firebase Crashlytics App ID, path to GoogleService-Info.plist or legacy Fabric API key must be given.')
         end
 
         dsym_paths = []
@@ -87,7 +87,9 @@ module Fastlane
         UI.message("Uploading '#{path}'...")
         command = []
         command << File.expand_path(params[:binary_path]).shellescape
-        if params[:gsp_path]
+        if params[:app_id]
+          command << "-ai #{params[:app_id].shellescape}"
+        elsif params[:gsp_path]
           command << "-gsp #{params[:gsp_path].shellescape}"
         elsif params[:api_token]
           command << "-a #{params[:api_token]}"
@@ -185,6 +187,14 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find file at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                          UI.user_error!("No Path to GoogleService-Info.plist for Firebase Crashlytics given, pass using `gsp_path: 'path'`") if value.to_s.length == 0
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_id,
+                                       env_name: "CRASHLYTICS_APP_ID",
+                                       sensitive: true,
+                                       optional: true,
+                                       description: "Firebase Crashlytics APP ID",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No App ID for Firebase Crashlytics given, pass using `app_id: 'appId'`") if value.to_s.length == 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :binary_path,
                                        env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_BINARY_PATH",

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -19,6 +19,27 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "uploads dSYM files with app_id" do
+        binary_path = './spec/fixtures/screenshots/screenshot1.png'
+        dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
+        app_id = '0:000000000000:ios:0f0000000ff0ff0'
+
+        command = []
+        command << File.expand_path(File.join("fastlane", binary_path)).shellescape
+        command << "-ai #{app_id}"
+        command << "-p ios"
+        command << File.expand_path(File.join("fastlane", dsym_path)).shellescape
+
+        expect(Fastlane::Actions).to receive(:sh).with(command.join(" "), log: false)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_crashlytics(
+            dsym_path: 'fastlane/#{dsym_path}',
+            app_id: '#{app_id}',
+            binary_path: 'fastlane/#{binary_path}')
+        end").runner.execute(:test)
+      end
+
       it "uploads dSYM files with api_token" do
         binary_path = './spec/fixtures/screenshots/screenshot1.png'
         dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The Firebase SDK Version 6.15.0 (Released on January 14, 2020) includes the first beta of the **Firebase Crashlytics SDK**, the SDK that will supersede the old Fabric/Crashlytics SDKs:

> [**Crashlytics**](https://firebase.google.com/support/release-notes/ios#crashlytics_1)
>
> This Firebase Crashlytics version includes the initial beta release of the Firebase Crashlytics SDK:
>
> - [FEATURE] The SDK is now open-sourced. Take a look in our [GitHub repository](https://github.com/firebase/firebase-ios-sdk/tree/master/Crashlytics).
> - [FEATURE] Added support for Catalyst (note that Crashlytics still supports tvOS and macOS).
> - [FEATURE] Added new APIs that are more consistent with other Firebase SDKs and more intuitive to use. The new APIs also give your users more control over how you collect their data.
> - [REMOVED] Removed the Fabric API Key. Now, Crashlytics uses the GoogleService-Info.plist file to associate your app with your project. If you linked your app from Fabric and want to upgrade to the new SDK, remove the Fabric API key from your run and upload-symbols scripts. We also recommend removing the Fabric section from your app's Info.plist (when you upgrade, Crashlytics uses the new configuration you set up in Firebase).

The new `upload-dsyms` binary that is included in this SDK is mostly the same as the last, however it has since stopped supporting the old `--api-key` (or `-a`) argument that was previously used if you are on the legacy Fabric platform and in its place, a new `--app-id` (or `-ai`) argument has been introduced for setups where specifying a GoogleService-Info.plist file isn't appropriate. 

In our project, we're unable to use the GoogleService-Info.plist file directly since it is not sustainable with the custom build configurations that we have to build so I need to add support for this new argument.

### Description

For clarity, this is the help page of the `upload-dsyms` command from the Crashlytics 3.14.0 Pod:

```
Pods/Crashlytics/iOS/Crashlytics.framework/upload-symbols --help
usage: upload-symbols [flags] -- <paths>
flags:
	-a, --api-key <API key>
		Your Fabric API key, which can be found in the settings area in your fabric.io dashboard. To keep your historic crash data, provide your Fabric API key if you have migrated this app to Firebase. If you onboarded this app via Firebase, please use -gsp, --google-service-plist
	-gsp, --google-service-plist <path to Google service plist>
		Firebase Crashlytics - The path to your apps GoogleService-Info.plist when using upload-symbols with Firebase
	-p, --platform <platform name>
		The platform for which the dSYM was compiled. Either: 'ios', 'mac', 'tvos'
	-bp, --build-secret <build secret>
		The Fabric Build Secret
	-d, --debug
		Output extra debug logging while running
	-bs, --build-phase
		Build Phase Mode is meant to be run as an Xcode Run Script Build Phase. It finds the dSYMs and platform from the build environment variables, instead of having the caller pass them in. With this flag, <paths> and --platform can be omitted.
	-val, --validate
		Only validate the arguments and environment, then stop. This is useful in an Xcode Run Script Build Phase because it won't add to the build time, but it will report errors if the script isn't set up correctly.

<paths>
	list of one or more paths to dSYMs to upload, zip archives containing dSYMs (like those downloaded from iTunes Connect for recompiled bitcode apps), or a directory containing multiple dSYMs to be searched recursively
	Multiple paths of any kind may be provided, such as: "/path/to/.../app-name.dSYM [/path/to/.../build-products-directory /path/to/itunes-connect-archive [...]]"

	Note: archives downloaded from iTunes Connect do not have a .zip file extension. To verify the contents of such an archive, use 'unzip' or manually edit the filename to add the .zip extension and expand in Finder.

upload-symbols -h/--help prints this usage information
upload-symbols -v/--version prints version information
```

And here is the help page the `upload-symbols` tool taken from git@github.com:firebase/firebase-ios-sdk.git@6.15.0

```
$ /Users/liamnichols/Downloads/firebase-ios-sdk-6.15.0/Crashlytics/upload-symbols --help 
usage: upload-symbols [flags] -- <paths>
flags:
	-gsp, --google-service-plist <path to Google service plist>
		The path to your app's GoogleService-Info.plist
	-ai, --app-id <Firebase app id>
		Provide your Firebase app id directly without parsing the Google service plist. This flag will supercede the -gsp, --google-service-plist flag.
	-p, --platform <platform name>
		The platform for which the dSYM was compiled. Either: 'ios', 'mac', 'tvos'. Catalyst apps should be the 'mac' platform.
	-d, --debug
		Output extra debug logging while running
	-bp, --build-phase
		Build Phase Mode is meant to be run as an Xcode Run Script Build Phase. It finds the dSYMs and platform from the build environment variables, instead of having the caller pass them in. With this flag, <paths> and --platform can be omitted.
	-val, --validate
		Only validate the arguments and environment, then stop. This is useful in an Xcode Run Script Build Phase because it won't add to the build time, but it will report errors if the script isn't set up correctly.

<paths>
	list of one or more paths to dSYMs to upload, zip archives containing dSYMs (like those downloaded from iTunes Connect for recompiled bitcode apps), or a directory containing multiple dSYMs to be searched recursively
	Multiple paths of any kind may be provided, such as: "/path/to/.../app-name.dSYM [/path/to/.../build-products-directory /path/to/itunes-connect-archive [...]]"

	Note: archives downloaded from iTunes Connect do not have a .zip file extension. To verify the contents of such an archive, use 'unzip' or manually edit the filename to add the .zip extension and expand in Finder.

upload-symbols -h/--help prints this usage information
upload-symbols -v/--version prints version information
```

The change itself is pretty simple since all I had to do was pass the new argument through. I opted to make the `app_id` take precedence over the `gsp_path` since that follows the documented behavior of the command line tool. 

I haven't however done anything to break the previous behavior. While Firebase Crashlytics is still in beta, I wanted to ensure that there is no change in previous behavior at all however once this becomes the preferred way of using Crashlytics, I suggest that we add a warning that is displayed whenever the action is run using the `api_key` argument since it'll stop working eventually.

One thing I didn't bother looking into was checking if the `binary_path` relates to the old Fabric SDK or the new Crashlytics one since this would allow us to warn/error out before even executing the command in the event that the configuration didn't match up to the version of the binary specified... I think the deprecation warning should kind of cover this enough eventually but worth making you aware of incase you want to look into other ways of warning users.. 

### Testing Steps
The unit tests should cover things already 🙂 
