### PR TITLE
[screengrab] Fix escaping issue with adb path (#15981)

### DIFF
--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -24,11 +24,7 @@ module Fastlane
           adb_path = File.join(android_home, "platform-tools", "adb")
         end
 
-        if adb_path.start_with?('~')
-          adb_path = File.expand_path(adb_path)
-        end
-
-        self.adb_path = adb_path
+        self.adb_path = File.expand_path(adb_path)
         self.adb_host = adb_host
       end
 

--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -52,7 +52,7 @@ module Fastlane
       def load_all_devices
         self.devices = []
 
-        command = [adb_path.shellescape, host_option, "devices -l"].compact.join(" ")
+        command = [adb_path, host_option, "devices -l"].compact.join(" ")
         output = Actions.sh(command, log: false)
         output.split("\n").each do |line|
           if (result = line.match(/^(\S+)(\s+)(device )/))

--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -24,6 +24,10 @@ module Fastlane
           adb_path = File.join(android_home, "platform-tools", "adb")
         end
 
+        if adb_path.start_with?('~')
+          adb_path = File.expand_path(adb_path)
+        end
+
         self.adb_path = adb_path
         self.adb_host = adb_host
       end
@@ -35,7 +39,7 @@ module Fastlane
       # Run a certain action
       def trigger(command: nil, serial: nil)
         android_serial = serial != "" ? "ANDROID_SERIAL=#{serial}" : nil
-        command = [android_serial, File.expand_path(adb_path).shellescape, host_option, command].compact.join(" ").strip
+        command = [android_serial, adb_path.shellescape, host_option, command].compact.join(" ").strip
         Action.sh(command)
       end
 
@@ -52,7 +56,7 @@ module Fastlane
       def load_all_devices
         self.devices = []
 
-        command = [File.expand_path(adb_path).shellescape, host_option, "devices -l"].compact.join(" ")
+        command = [adb_path.shellescape, host_option, "devices -l"].compact.join(" ")
         output = Actions.sh(command, log: false)
         output.split("\n").each do |line|
           if (result = line.match(/^(\S+)(\s+)(device )/))

--- a/fastlane/lib/fastlane/helper/adb_helper.rb
+++ b/fastlane/lib/fastlane/helper/adb_helper.rb
@@ -35,7 +35,7 @@ module Fastlane
       # Run a certain action
       def trigger(command: nil, serial: nil)
         android_serial = serial != "" ? "ANDROID_SERIAL=#{serial}" : nil
-        command = [android_serial, adb_path.shellescape, host_option, command].compact.join(" ").strip
+        command = [android_serial, File.expand_path(adb_path).shellescape, host_option, command].compact.join(" ").strip
         Action.sh(command)
       end
 
@@ -52,7 +52,7 @@ module Fastlane
       def load_all_devices
         self.devices = []
 
-        command = [adb_path, host_option, "devices -l"].compact.join(" ")
+        command = [File.expand_path(adb_path).shellescape, host_option, "devices -l"].compact.join(" ")
         output = Actions.sh(command, log: false)
         output.split("\n").each do |line|
           if (result = line.match(/^(\S+)(\s+)(device )/))

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -6,7 +6,7 @@ describe Fastlane do
           adb(command: 'test', adb_path: './fastlane/README.md')
         end").runner.execute(:test)
 
-        expect(result).to eq("./fastlane/README.md test")
+        expect(result).to eq("#{File.expand_path('./fastlane/README.md')} test")
       end
 
       it "generates a valid command for commands with multiple parts" do
@@ -14,7 +14,7 @@ describe Fastlane do
           adb(command: 'test command with multiple parts', adb_path: './fastlane/README.md')
         end").runner.execute(:test)
 
-        expect(result).to eq("./fastlane/README.md test command with multiple parts")
+        expect(result).to eq("#{File.expand_path('./fastlane/README.md')} test command with multiple parts")
       end
 
       it "generates a valid command when a non-empty serial is passed" do
@@ -22,7 +22,7 @@ describe Fastlane do
           adb(command: 'test command with non-empty serial', adb_path: './fastlane/README.md', serial: 'emulator-1234')
         end").runner.execute(:test)
 
-        expect(result).to eq("ANDROID_SERIAL=emulator-1234 ./fastlane/README.md test command with non-empty serial")
+        expect(result).to eq("ANDROID_SERIAL=emulator-1234 #{File.expand_path('./fastlane/README.md')} test command with non-empty serial")
       end
 
       it "generates a valid command when an empty serial is passed" do
@@ -30,7 +30,7 @@ describe Fastlane do
           adb(command: 'test command with empty serial', adb_path: './fastlane/README.md', serial: '')
         end").runner.execute(:test)
 
-        expect(result).to eq("./fastlane/README.md test command with empty serial")
+        expect(result).to eq("#{File.expand_path('./fastlane/README.md')} test command with empty serial")
       end
 
       it "picks up path from ANDROID_HOME environment variable" do

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -48,8 +48,8 @@ describe Fastlane do
           adb(command: 'test')
         end").runner.execute(:test)
 
-        path = "/usr/local/android-sdk/with space/platform-tools/adb".shellescape
-        expect(result).to eq("#{File.expand_path(path)} test")
+        path = File.expand_path("/usr/local/android-sdk/with space/platform-tools/adb").shellescape
+        expect(result).to eq("#{path} test")
       end
 
       it "picks up path from ANDROID_SDK_ROOT environment variable" do

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -39,7 +39,7 @@ describe Fastlane do
           adb(command: 'test')
         end").runner.execute(:test)
 
-        expect(result).to eq("/usr/local/android-sdk/platform-tools/adb test")
+        expect(result).to eq("#{File.expand_path('/usr/local/android-sdk/platform-tools/adb')} test")
       end
 
       it "picks up path from ANDROID_HOME environment variable and handles path that has to be made safe" do
@@ -49,7 +49,7 @@ describe Fastlane do
         end").runner.execute(:test)
 
         path = "/usr/local/android-sdk/with space/platform-tools/adb".shellescape
-        expect(result).to eq("#{path} test")
+        expect(result).to eq("#{File.expand_path(path)} test")
       end
 
       it "picks up path from ANDROID_SDK_ROOT environment variable" do
@@ -58,7 +58,7 @@ describe Fastlane do
           adb(command: 'test')
         end").runner.execute(:test)
 
-        expect(result).to eq("/usr/local/android-sdk/platform-tools/adb test")
+        expect(result).to eq("#{File.expand_path('/usr/local/android-sdk/platform-tools/adb')} test")
       end
 
       it "picks up path from ANDROID_SDK environment variable" do
@@ -67,7 +67,7 @@ describe Fastlane do
           adb(command: 'test')
         end").runner.execute(:test)
 
-        expect(result).to eq("/usr/local/android-sdk/platform-tools/adb test")
+        expect(result).to eq("#{File.expand_path('/usr/local/android-sdk/platform-tools/adb')} test")
       end
     end
   end

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -3,7 +3,7 @@ describe Fastlane do
     describe "adb" do
       it "generates a valid command" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          adb(command: 'test', adb_path: './fastlane/README.md')
+          adb(command: 'test', adb_path: './README.md')
         end").runner.execute(:test)
 
         expect(result).to eq("#{File.expand_path('./fastlane/README.md')} test")
@@ -11,7 +11,7 @@ describe Fastlane do
 
       it "generates a valid command for commands with multiple parts" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          adb(command: 'test command with multiple parts', adb_path: './fastlane/README.md')
+          adb(command: 'test command with multiple parts', adb_path: './README.md')
         end").runner.execute(:test)
 
         expect(result).to eq("#{File.expand_path('./fastlane/README.md')} test command with multiple parts")
@@ -19,7 +19,7 @@ describe Fastlane do
 
       it "generates a valid command when a non-empty serial is passed" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          adb(command: 'test command with non-empty serial', adb_path: './fastlane/README.md', serial: 'emulator-1234')
+          adb(command: 'test command with non-empty serial', adb_path: './README.md', serial: 'emulator-1234')
         end").runner.execute(:test)
 
         expect(result).to eq("ANDROID_SERIAL=emulator-1234 #{File.expand_path('./fastlane/README.md')} test command with non-empty serial")
@@ -27,7 +27,7 @@ describe Fastlane do
 
       it "generates a valid command when an empty serial is passed" do
         result = Fastlane::FastFile.new.parse("lane :test do
-          adb(command: 'test command with empty serial', adb_path: './fastlane/README.md', serial: '')
+          adb(command: 'test command with empty serial', adb_path: './README.md', serial: '')
         end").runner.execute(:test)
 
         expect(result).to eq("#{File.expand_path('./fastlane/README.md')} test command with empty serial")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #15981.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I've removed the escaping of the `adb` tool path as that added a `\` in front of the path which caused the issue. There's no need for shellescaping from my understanding of the [examples](https://ruby-doc.org/stdlib-2.5.1/libdoc/shellwords/rdoc/Shellwords.html) and [documentation pages](https://rubyreferences.github.io/rubyref/stdlib/string-utilities/shellwords.html) for paths, especially since this path doesn't include any whitespaces.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Just make sure `fastlane screengrab` is still working on different platforms. I've tested macOS only.