### PR TITLE
[screengrab] Re-add locale and `images` to screenshots output path

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -309,7 +309,8 @@ module Screengrab
 
       # Because we can't guarantee the screenshot output directory will be empty when we pull, we determine
       # success based on whether there are more screenshots there than when we started.
-      if starting_screenshot_count == ending_screenshot_count
+      # This is only applicable though when `clear_previous_screenshots` is set to `true`.
+      if starting_screenshot_count == ending_screenshot_count && @config[:clear_previous_screenshots]
         UI.error("Make sure you've used Screengrab.screenshot() in your tests and that your expected tests are being run.")
         UI.abort_with_message!("No screenshots were detected 📷❌")
       end

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -73,9 +73,7 @@ module Screengrab
 
       validate_apk(app_apk_path)
 
-      run_tests(device_serial, app_apk_path, tests_apk_path, test_classes_to_use, test_packages_to_use, @config[:launch_arguments])
-
-      number_of_screenshots = pull_screenshots_from_device(device_serial, device_screenshots_paths, device_type_dir_name)
+      number_of_screenshots = run_tests(device_type_dir_name, device_screenshots_paths, device_serial, app_apk_path, tests_apk_path, test_classes_to_use, test_packages_to_use, @config[:launch_arguments])
 
       ReportsGenerator.new.generate
 
@@ -230,12 +228,14 @@ module Screengrab
       end
     end
 
-    def run_tests(device_serial, app_apk_path, tests_apk_path, test_classes_to_use, test_packages_to_use, launch_arguments)
+    def run_tests(device_type_dir_name, device_screenshots_paths, device_serial, app_apk_path, tests_apk_path, test_classes_to_use, test_packages_to_use, launch_arguments)
       unless @config[:reinstall_app]
         install_apks(device_serial, app_apk_path, tests_apk_path)
         grant_permissions(device_serial)
         enable_clean_status_bar(device_serial, app_apk_path)
       end
+
+      number_of_screenshots = 0
 
       @config[:locales].each do |locale|
         if @config[:reinstall_app]
@@ -244,11 +244,13 @@ module Screengrab
           grant_permissions(device_serial)
           enable_clean_status_bar(device_serial, app_apk_path)
         end
-        run_tests_for_locale(locale, device_serial, test_classes_to_use, test_packages_to_use, launch_arguments)
+        number_of_screenshots += run_tests_for_locale(device_type_dir_name, device_screenshots_paths, locale, device_serial, test_classes_to_use, test_packages_to_use, launch_arguments)
       end
+
+      number_of_screenshots
     end
 
-    def run_tests_for_locale(locale, device_serial, test_classes_to_use, test_packages_to_use, launch_arguments)
+    def run_tests_for_locale(device_type_dir_name, device_screenshots_paths, locale, device_serial, test_classes_to_use, test_packages_to_use, launch_arguments)
       UI.message("Running tests for locale: #{locale}")
 
       instrument_command = ["-s #{device_serial} shell am instrument --no-window-animation -w",
@@ -271,10 +273,12 @@ module Screengrab
           UI.error("Tests failed")
         end
       end
+
+      pull_screenshots_from_device(locale, device_serial, device_screenshots_paths, device_type_dir_name)
     end
 
-    def pull_screenshots_from_device(device_serial, device_screenshots_paths, device_type_dir_name)
-      UI.message("Pulling captured screenshots from the device")
+    def pull_screenshots_from_device(locale, device_serial, device_screenshots_paths, device_type_dir_name)
+      UI.message("Pulling captured screenshots for locale #{locale} from the device")
       starting_screenshot_count = screenshot_file_names_in(@config[:output_directory], device_type_dir_name).length
 
       UI.verbose("Starting screenshot count is: #{starting_screenshot_count}")
@@ -296,7 +300,7 @@ module Screengrab
         #
         # Therefore, we'll move the pulled screenshots from their genericly named folder to one named by the
         # user provided device_type option value to match the directory structure that supply expects
-        move_pulled_screenshots(tempdir, device_type_dir_name)
+        move_pulled_screenshots(locale, tempdir, device_type_dir_name)
       end
 
       ending_screenshot_count = screenshot_file_names_in(@config[:output_directory], device_type_dir_name).length
@@ -313,7 +317,7 @@ module Screengrab
       ending_screenshot_count - starting_screenshot_count
     end
 
-    def move_pulled_screenshots(pull_dir, device_type_dir_name)
+    def move_pulled_screenshots(locale, pull_dir, device_type_dir_name)
       # Glob pattern that finds the pulled screenshots directory for each locale
       # Possible matches:
       #   [pull_dir]/en-US/images/screenshots
@@ -337,7 +341,7 @@ module Screengrab
         # specific name, as expected by supply
         #
         # (Moved to: fastlane/metadata/android/en-US/images/phoneScreenshots)
-        dest_dir = File.join(File.dirname(dest_dir), device_type_dir_name)
+        dest_dir = File.join(File.dirname(dest_dir), locale, 'images', device_type_dir_name)
 
         FileUtils.mkdir_p(dest_dir)
         FileUtils.cp_r(src_screenshots, dest_dir)

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -77,7 +77,7 @@ module Screengrab
 
       ReportsGenerator.new.generate
 
-      UI.success("Captured #{number_of_screenshots} screenshots! 📷✨")
+      UI.success("Captured #{number_of_screenshots} new screenshots! 📷✨")
     end
 
     def select_device

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -36,9 +36,12 @@ describe Screengrab::Runner do
         config[:use_timestamp_suffix] = true
       end
       it 'sets custom launch_arguments' do
+        # Don't actually try to pull screenshot from device
+        allow(@runner).to receive(:pull_screenshots_from_device)
+
         expect(mock_executor).to receive(:execute)
           .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp true \\\n-e username hjanuschka -e build_type x500 \\\n/"))
-        @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, config[:launch_arguments])
+        @runner.run_tests_for_locale('device', 'path', 'en-US', device_serial, test_classes_to_use, test_packages_to_use, config[:launch_arguments])
       end
     end
 
@@ -59,9 +62,12 @@ describe Screengrab::Runner do
           end
 
           it 'prints an error and exits the program' do
+            # Don't actually try to pull screenshot from device
+            allow(@runner).to receive(:pull_screenshots_from_device)
+
             expect(ui).to receive(:test_failure!).with("Tests failed for locale en-US on device #{device_serial}").and_call_original
 
-            expect { @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil) }.to raise_fastlane_test_failure
+            expect { @runner.run_tests_for_locale('devie', 'path', 'en-US', device_serial, test_classes_to_use, test_packages_to_use, nil) }.to raise_fastlane_test_failure
           end
         end
 
@@ -71,9 +77,12 @@ describe Screengrab::Runner do
           end
 
           it 'prints an error and does not exit the program' do
+            # Don't actually try to pull screenshot from device
+            allow(@runner).to receive(:pull_screenshots_from_device)
+
             expect(ui).to receive(:error).with("Tests failed").and_call_original
 
-            @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
+            @runner.run_tests_for_locale('device', 'path', 'en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
           end
         end
       end
@@ -89,9 +98,12 @@ describe Screengrab::Runner do
           )
         end
         it 'sets appendTimestamp as false' do
+          # Don't actually try to pull screenshot from device
+          allow(@runner).to receive(:pull_screenshots_from_device)
+
           expect(mock_executor).to receive(:execute)
             .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp false \\\n/androidx.test.runner.AndroidJUnitRunner"))
-          @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
+          @runner.run_tests_for_locale('device', 'path', 'en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
         end
       end
 
@@ -104,9 +116,12 @@ describe Screengrab::Runner do
           )
         end
         it 'should set appendTimestamp by default' do
+          # Don't actually try to pull screenshot from device
+          allow(@runner).to receive(:pull_screenshots_from_device)
+
           expect(mock_executor).to receive(:execute)
             .with(hash_including(command: "adb -s device_serial shell am instrument --no-window-animation -w \\\n-e testLocale en_US \\\n-e endingLocale en_US \\\n-e appendTimestamp true \\\n/androidx.test.runner.AndroidJUnitRunner"))
-          @runner.run_tests_for_locale('en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
+          @runner.run_tests_for_locale('device', 'path', 'en-US', device_serial, test_classes_to_use, test_packages_to_use, nil)
         end
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves https://github.com/fastlane/fastlane/issues/15690
Resolves https://github.com/fastlane/fastlane/issues/14584

The output of the screenshots taken with `screengrab` were not including the locale any more, which broke several features. For example, I got my outputs for all languages to `fastlane/metadata/android/phoneScreenshots`. This also broke any links within the `screenshots.html` file.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This PR is doing the move step of the screenshots per language instead of only once at the end.