### PR TITLE
[get_github_release] Use GITHUB_API_TOKEN for default for consistency

### DIFF
--- a/fastlane/lib/fastlane/actions/get_github_release.rb
+++ b/fastlane/lib/fastlane/actions/get_github_release.rb
@@ -129,6 +129,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "FL_GITHUB_RELEASE_API_TOKEN",
                                        sensitive: true,
+                                       default_value: ENV["GITHUB_API_TOKEN"],
                                        description: "GitHub Personal Token (required for private repositories)",
                                        optional: true)
         ]

--- a/fastlane/lib/fastlane/actions/get_github_release.rb
+++ b/fastlane/lib/fastlane/actions/get_github_release.rb
@@ -129,7 +129,9 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :api_token,
                                        env_name: "FL_GITHUB_RELEASE_API_TOKEN",
                                        sensitive: true,
+                                       code_gen_sensitive: true,
                                        default_value: ENV["GITHUB_API_TOKEN"],
+                                       default_value_dynamic: true,
                                        description: "GitHub Personal Token (required for private repositories)",
                                        optional: true)
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Other GitHub related actions use `GITHUB_API_TOKEN` but `get_github_release` does not. For consistency I thought it is better to use `GITHUB_API_TOKEN` here too.

### Description

Just use `ENV['GITHUB_API_TOKEN']` as the default value.

### Testing Steps

n/a
