### PR TITLE
[pilot] Guard against error when trying to notify testers once a Testflight build is uploaded

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -481,12 +481,16 @@ module Pilot
     end
 
     def update_build_beta_details(build, info)
-      build_beta_detail = build.build_beta_detail
-
       attributes = {}
       attributes[:autoNotifyEnabled] = info[:auto_notify_enabled] if info.key?(:auto_notify_enabled)
-
-      Spaceship::ConnectAPI.patch_build_beta_details(build_beta_details_id: build_beta_detail.id, attributes: attributes)
+      build_beta_detail = build.build_beta_detail
+      if build_beta_detail
+        Spaceship::ConnectAPI.patch_build_beta_details(build_beta_details_id: build_beta_detail.id, attributes: attributes)
+      else
+        if attributes[:autoNotifyEnabled]
+          UI.important("Unable to auto notify testers as the build did include beta detail information")
+        end
+      end
     end
   end
   # rubocop:enable Metrics/ClassLength

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -484,6 +484,8 @@ module Pilot
       attributes = {}
       attributes[:autoNotifyEnabled] = info[:auto_notify_enabled] if info.key?(:auto_notify_enabled)
       build_beta_detail = build.build_beta_detail
+
+      # https://github.com/fastlane/fastlane/pull/16006
       if build_beta_detail
         Spaceship::ConnectAPI.patch_build_beta_details(build_beta_details_id: build_beta_detail.id, attributes: attributes)
       else

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -490,7 +490,7 @@ module Pilot
         Spaceship::ConnectAPI.patch_build_beta_details(build_beta_details_id: build_beta_detail.id, attributes: attributes)
       else
         if attributes[:autoNotifyEnabled]
-          UI.important("Unable to auto notify testers as the build did not include beta detail information - this is likely a temporary issue on Testflight.")
+          UI.important("Unable to auto notify testers as the build did not include beta detail information - this is likely a temporary issue on TestFlight.")
         end
       end
     end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -488,7 +488,7 @@ module Pilot
         Spaceship::ConnectAPI.patch_build_beta_details(build_beta_details_id: build_beta_detail.id, attributes: attributes)
       else
         if attributes[:autoNotifyEnabled]
-          UI.important("Unable to auto notify testers as the build did include beta detail information")
+          UI.important("Unable to auto notify testers as the build did not include beta detail information - this is likely a temporary issue on Testflight.")
         end
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Fixes #15138 - this PR adds a guard against nil values that may unexpectedly come back from the API, effectively allowing fastlane to succeed even if this issue is encountered (which I believe is a reasonable action).

### Description

For unknown reasons - likely outside of our control - the payload returned from a build uploaded to Testflight may or may not include what is defined on fastlane's  `build` model as `build_beta_details`.

In such cases even though a build has been uploaded successfully and a change log is set, fastlane still crashes due to an unexpected nil value when trying to set the `autoNotify` flag on the build.

This PR guards against that nil value and if absent, logs a warning to the UI letting the user know that the action wasn't performed due to the missing required information.
