### PR TITLE
[snapshot] disable Pasteboard sync

### DIFF
--- a/snapshot/lib/snapshot/fixes/simulator_shared_pasteboard.rb
+++ b/snapshot/lib/snapshot/fixes/simulator_shared_pasteboard.rb
@@ -1,0 +1,16 @@
+require_relative '../module'
+
+module Snapshot
+  module Fixes
+    # Becoming first responder can trigger Pasteboard sync, which can stall and crash the simulator
+    # See https://twitter.com/steipete/status/1227551552317140992
+
+    class SharedPasteboardFix
+      def self.patch
+        UI.verbose("Patching simulator to disable Pasteboard automatic sync")
+
+        Helper.backticks("defaults write com.apple.iphonesimulator PasteboardAutomaticSync -bool false", print: FastlaneCore::Globals.verbose?)
+      end
+    end
+  end
+end

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -53,6 +53,7 @@ module Snapshot
 
       Fixes::SimulatorZoomFix.patch
       Fixes::HardwareKeyboardFix.patch
+      Fixes::SharedPasteboardFix.patch
 
       device_types.each do |type|
         if launcher_config.erase_simulator || launcher_config.localize_simulator || !launcher_config.dark_mode.nil?

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -5,6 +5,7 @@ require_relative '../test_command_generator'
 require_relative '../collector'
 require_relative '../fixes/hardware_keyboard_fix'
 require_relative '../fixes/simulator_zoom_fix'
+require_relative '../fixes/simulator_shared_pasteboard'
 
 module Snapshot
   class SimulatorLauncherBase


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
As pointed out by [Peter Steinberger on Twitter](https://twitter.com/steipete/status/1227551552317140992), the Pasteboard sharing of the Simulator can cause issues during UI Tests. `UIResponder.becomeFirstResponder` can trigger the Pasteboard sync, which can lead to stalls.

This PR disables Pasteboard automatic sync on a system level for all launched simulators.

### Description
I chose to implement this in the `Snapshot::Fixes` module for two reasons:
+ Ideally, Pasteboard automatic sharing shouldn't interfere with UI tests, but it does. 
+ The implementation and intent of the code is very similar to the other Fixes

### Testing Steps

1. Turn on Simulator Pasteboard Automatic Sync:
`defaults write com.apple.iphonesimulator PasteboardAutomaticSync -bool true`
The command `defaults read com.apple.iphonesimulator PasteboardAutomaticSync` should return `1`.
2. Run `fastlane snapshot`
3. The command `defaults read com.apple.iphonesimulator PasteboardAutomaticSync` should return `0`.