### PR TITLE
[gym] Fix watchOS platform

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -294,6 +294,10 @@ module FastlaneCore
       supported_platforms.include?(:iOS)
     end
 
+    def watchos?
+      supported_platforms.include?(:watchOS)
+    end
+
     def supported_platforms
       supported_platforms = build_settings(key: "SUPPORTED_PLATFORMS")
       if supported_platforms.nil?

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -25,11 +25,11 @@ module Gym
 
       # Determine platform to archive
       is_mac = Gym.project.mac? || Gym.building_mac_catalyst_for_mac?
-      is_ios = !is_mac && (Gym.project.ios? || Gym.project.tvos?)
+      is_ios = !is_mac && (Gym.project.ios? || Gym.project.tvos? || Gym.project.watchos?)
 
       # Archive
       if is_ios
-        fix_generic_archive # See https://github.com/fastlane/fastlane/pull/4325
+        fix_generic_archive unless Gym.project.watchos? # See https://github.com/fastlane/fastlane/pull/4325
         return BuildCommandGenerator.archive_path if Gym.config[:skip_package_ipa]
 
         package_app


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When building using `gym` for an independent WatchOS App, `gym` is currently returning `No output path received from gym` (see issue https://github.com/fastlane/fastlane/issues/16009).

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

The problem lies when checking the `supported_platforms`, the `watchOS` platform was not taken into account.
Adding support for the `watchOS` platform and skipping the `fix_generic_archive` for the `watchOS` platform let `gym` complete the archive and export of the build successfully.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Testing locally, with an independent WatchOS App, `gym` successfully output the ipa and uploading to Testflight was successful as well.