### PR TITLE
Adding Raise if swiftlint error

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -36,7 +36,8 @@ module Fastlane
         begin
           Actions.sh(command)
         rescue
-          handle_swiftlint_error(params[:ignore_exit_status], $?.exitstatus)
+          handle_swiftlint_error(params[:ignore_exit_status], $?.exitstatus
+          raise if params[:raise_if_swiftlint_error]
         end
       end
 
@@ -106,6 +107,13 @@ module Fastlane
                                        is_string: false,
                                        type: Boolean,
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :raise_if_swiftlint_error,
+                                       description: "Raises an error if swiftlint fails, so you can fail CI/CD jobs if necessary \
+                                                    (true/false)",
+                                       default_value: false,
+                                       is_string: false,
+                                       type: Boolean,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :reporter,
                                        description: 'Choose output reporter',
                                        is_string: true,
@@ -161,7 +169,9 @@ module Fastlane
               "AppDelegate.swift",
               "path/to/project/Model.swift"
             ],
+            raise_if_swiftlint_error: true,      # Allow fastlane to return raise an error if swiftlint fails
             ignore_exit_status: true              # Allow fastlane to continue even if SwiftLint returns a non-zero exit status
+
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -169,7 +169,7 @@ module Fastlane
               "AppDelegate.swift",
               "path/to/project/Model.swift"
             ],
-            raise_if_swiftlint_error: true,      # Allow fastlane to return raise an error if swiftlint fails
+            raise_if_swiftlint_error: true,      # Allow fastlane to raise an error if swiftlint fails
             ignore_exit_status: true              # Allow fastlane to continue even if SwiftLint returns a non-zero exit status
 
           )'

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -36,7 +36,7 @@ module Fastlane
         begin
           Actions.sh(command)
         rescue
-          handle_swiftlint_error(params[:ignore_exit_status], $?.exitstatus
+          handle_swiftlint_error(params[:ignore_exit_status], $?.exitstatus)
           raise if params[:raise_if_swiftlint_error]
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The SwiftLint action runs the action but always returns a 0 exit code. Even though the UI of the shell command depicts an error if it occurred, it does not help when I'm trying to run this in an automated fashion. 

My particular case scenario is I'm running swiftlint as part of the Pull Request Builder Process in Jenkins using Groovy. To run it I execute Fastlane as:
`var result = sh(script:'fastlane swiftlint', returnStatus:true)`
This allows me in Jenkins to have a Shell command to fail and not stop the execution of the Pipeline. Allowing me to notify who needs to be notified, set status gate of the PR to failed while continuing down the PR gates.

With the changes now I'm able to toggle the option and return a non-zero status code for the swiftlint run. Thus setting the PR gate to failure while proceeding with the execution of other gate tests on the PR.

The issue I raised is:
[https://github.com/fastlane/fastlane/issues/15901](url)


### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I added a new Fastlane option:
```
FastlaneCore::ConfigItem.new(key: :raise_if_swiftlint_error,
                                       description: "Raises an error if swiftlint fails, so you can fail CI/CD jobs if necessary \
                                                    (true/false)",
                                       default_value: false,
                                       is_string: false,
                                       type: Boolean,
                                       optional: true),
```

I added the example in the self.example_code section:
```
def self.example_code
        [
          'swiftlint(
            mode: :lint,                          # SwiftLint mode: :lint (default) or :autocorrect
            path: "/path/to/lint",                 # Specify path to lint (optional)
            output_file: "swiftlint.result.json", # The path of the output file (optional)
            config_file: ".swiftlint-ci.yml",     # The path of the configuration file (optional)
            files: [                              # List of files to process (optional)
              "AppDelegate.swift",
              "path/to/project/Model.swift"
            ],
            raise_if_swiftlint_error: true,      # Allow fastlane to return raise an error if swiftlint fails
            ignore_exit_status: true              # Allow fastlane to continue even if SwiftLint returns a non-zero exit status

          )'
        ]
      end
```

Lastly, I added to the section where Action is executed. After handling a swiftlint error, I raise the error if the flag/option is toggled:
```
begin
          Actions.sh(command)
        rescue
          handle_swiftlint_error(params[:ignore_exit_status], $?.exitstatus)
          raise if params[:raise_if_swiftlint_error]
        end
      end
```

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
