### PR TITLE
Use size-label-action to label PRs by size

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,0 +1,10 @@
+name: size-label
+on: pull_request
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: size-label
+        uses: "pascalgn/size-label-action@df7ad4303b35cbeb20937dbb12d5a050520e469e"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds the [`size-label-action` GitHub Action](https://github.com/pascalgn/size-label-action) to the repository to label new incoming PRs automatically by size.

I created the labels already:
![image](https://user-images.githubusercontent.com/183673/74607786-08452d80-50dc-11ea-9d81-7fd6c523035c.png)

(The label is structure is different from what we use, if this turns out to be useful I would create a PR to the action's repo to make the structure configurable [from `size/` to `size: ` for example])
