### PR TITLE
[match] Fixed `match import` looking for old certificate types only

### DIFF
--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -54,9 +54,9 @@ module Match
 
       case cert_type
       when :development
-        certificate_type = Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DEVELOPMENT
+        certificate_type = Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DEVELOPMENT + "," + Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPMENT
       when :distribution, :enterprise
-        certificate_type = Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION
+        certificate_type = Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION + "," + Spaceship::ConnectAPI::Certificate::CertificateType::DISTRIBUTION
       else
         UI.user_error!("Cert type '#{cert_type}' is not supported")
       end

--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -22,6 +22,8 @@ module Spaceship
       })
 
       module CertificateType
+        DEVELOPMENT = "DEVELOPMENT"
+        DISTRIBUTION = "DISTRIBUTION"
         IOS_DEVELOPMENT = "IOS_DEVELOPMENT"
         IOS_DISTRIBUTION = "IOS_DISTRIBUTION"
         MAC_APP_DISTRIBUTION = "MAC_APP_DISTRIBUTION"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves https://github.com/fastlane/fastlane/issues/15857

Apple seemingly introduced new types for certificates, which the import action of match wasn't supporting yet.


### Description
I simply added the new certificate types next to the existing cert types in the corresponding classes. In order to keep the tool working with the old cert types I'm simply concatenating the filtered list of types.

### Testing Steps
Try importing a certificate that was created recently. It will have a type of `DEVELOPMENT` instead of `IOS_DEVELOPMENT`, etc.
