### PR TITLE
Version bump to 2.142.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,43 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
 </a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-</tr>
-<tr>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
@@ -78,31 +46,101 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+</tr>
+<tr>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
 <img src='https://github.com/joshdholtz.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+</tr>
+<tr>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
 <img src='https://github.com/lacostej.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
 </tr>
 <tr>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
 <td id='aaron-brager'>
 <a href='https://github.com/getaaron'>
@@ -110,17 +148,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
@@ -130,49 +162,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-</tr>
-<tr>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Jorge Revuelta H",
-                        "Maksym Grebenets",
-                        "Olivier Halligon",
-                        "Daniel Jankowski",
-                        "Fumiya Nakamura",
+  spec.authors       = ["Manu Wallner",
                         "Josh Holtz",
-                        "Andrew McBurney",
                         "Iulian Onofrei",
-                        "Kohki Miki",
-                        "Joshua Liebowitz",
-                        "Max Ott",
-                        "Stefan Natchev",
-                        "Jérôme Lacoste",
-                        "Aaron Brager",
-                        "Jan Piotrowski",
-                        "Danielle Tomlinson",
-                        "Jimmy Dee",
-                        "Manu Wallner",
                         "Luka Mirosevic",
+                        "Danielle Tomlinson",
+                        "Joshua Liebowitz",
+                        "Jérôme Lacoste",
+                        "Fumiya Nakamura",
+                        "Aaron Brager",
                         "Felix Krause",
+                        "Olivier Halligon",
                         "Matthew Ellis",
-                        "Helmut Januschka"]
+                        "Daniel Jankowski",
+                        "Maksym Grebenets",
+                        "Max Ott",
+                        "Kohki Miki",
+                        "Jimmy Dee",
+                        "Stefan Natchev",
+                        "Helmut Januschka",
+                        "Andrew McBurney",
+                        "Jan Piotrowski",
+                        "Jorge Revuelta H"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.141.0'.freeze
+  VERSION = '2.142.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.141.0
+// Generated with fastlane 2.142.0

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.141.0
+// Generated with fastlane 2.142.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.141.0
+// Generated with fastlane 2.142.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.141.0
+// Generated with fastlane 2.142.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.141.0
+// Generated with fastlane 2.142.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -102,6 +102,9 @@ protocol ScanfileProtocol: class {
   /// Generate the json compilation database with clang naming convention (compile_commands.json)
   var useClangReportName: Bool { get }
 
+  /// Specify the exact number of test runners that will be spawned during parallel testing. Equivalent to -parallel-testing-worker-count
+  var concurrentWorkers: Int? { get }
+
   /// Constrain the number of simulator devices on which to test concurrently. Equivalent to -maximum-concurrent-test-simulator-destinations
   var maxConcurrentSimulators: Int? { get }
 
@@ -210,6 +213,7 @@ extension ScanfileProtocol {
   var shouldZipBuildProducts: Bool { return false }
   var resultBundle: Bool { return false }
   var useClangReportName: Bool { return false }
+  var concurrentWorkers: Int? { return nil }
   var maxConcurrentSimulators: Int? { return nil }
   var disableConcurrentTesting: Bool { return false }
   var skipBuild: Bool { return false }
@@ -238,4 +242,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.25]
+// FastlaneRunnerAPIVersion [0.9.26]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.141.0
+// Generated with fastlane 2.142.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.141.0
+// Generated with fastlane 2.142.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.141.0':**

* [GitHub Action] enable `stale.yml` workflow (#15890) via Daniel Jankowski
* [match] update an instruction in match/storage/google_cloud_storage.rb (#15898) via Jim Puls
* [ensure_xcode_version] Implement flexible version check (#15906) via Jean Mainguy
* [GitHub Action] update size-label.yml (#16029) via Josh Holtz
* [action] get_github_release  - use GITHUB_API_TOKEN for default for consistency (#15995) via Takeru Chuganji
* [screengrab] Fix escaping issue with adb path (#15981) (#15986) via Cihat Gündüz
* [action] spm - adds xcpretty_args optional parameter (#15922) (#15971) via Kyle Hammond
* [screengrab] re-add locale and `images` to screenshots output path (#15994) via Cihat Gündüz
* [pilot] guard against error when trying to notify testers once a Testflight build is uploaded (#16006) via Rogerio de Paula Assis
* [snapshot] disable Pasteboard sync in snapshot (#16008) via Xaver Lohmüller
* [CI] add ruby version for tests; format structure (#16011) via tenhi
* [scan] macOS testing fixes (#16023) via Benedek Kozma
* [gym] Fix watchOS platform (#16016) via Jean Mainguy
* [action swiftlint - adding Raise if swiftlint error (#16022) via Alfredo Moreira
* [action] default print_log on notarize to false (#16028) via Josh Holtz
* [GitHub Action] use size-label-action to label PRs by size (#16025) via Jan Piotrowski
* [action] add notarize action (#15956) via Berk Çebi
* [fastlane] allow subfolders in the Actions folder (#15958) via Lorenzo Mattei
* [action] Export version in app_store_build_number and latest_testflight_build_number actions (#15946) via Johannes Marbach
* [ensure_git_branch] Add a regex example (#15945) via Peter Kreinz
* [action] SwiftLint :reporter documented and validated (#15941) via Oleksii Kalentiev
* [docs] Include version number in docs commit and PR (#15913) via Jan Piotrowski
* [docs] add documentation link to actions README (#15911) via Jan Piotrowski
* [core] fix cert import into keychain for catalina and productbuild (#15991) via Josh Holtz
* [upload_symbols_to_crashlytics] Add support for --app-id argum… (#15976) via Liam Nichols
* [screengrab] Fix crash granting DUMP permission (#15789) via Rick Clephas
* [s3] fix ipa and dsym docs example comments (#15990) via Ahmed Tarek
* [Fastlane.swift] socket_server_action_command_executor - fix sh error_callback (#15951) via Jean Mainguy
* [scan] Add -parallel-testing-worker-count option (#15949) via Jean Mainguy
* [action] cocoapods - add missing params argument to pod_version (#15947) via Pierluigi D'Andrea
* Update LICENSE (#15953) via Stefan Natchev
