### PR TITLE
[scan] Add testPlan option to scan

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -124,6 +124,11 @@ module Scan
                                      end),
 
         # other test options
+        FastlaneCore::ConfigItem.new(key: :testPlan,
+                                     env_name: "SCAN_TESTPLAN",
+                                     description: "The testplan associated with the scheme that should be used for testing",
+                                     is_string: true,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :xctestrun,
                                      short_option: "-X",
                                      env_name: "SCAN_XCTESTRUN",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -124,7 +124,7 @@ module Scan
                                      end),
 
         # other test options
-        FastlaneCore::ConfigItem.new(key: :testPlan,
+        FastlaneCore::ConfigItem.new(key: :testplan,
                                      env_name: "SCAN_TESTPLAN",
                                      description: "The testplan associated with the scheme that should be used for testing",
                                      is_string: true,

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -45,7 +45,7 @@ module Scan
       options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
       options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
       options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
-      options << "-testPlan #{config[:testPlan]}" if config[:testPlan]
+      options << "-testPlan #{config[:testplan]}" if config[:testplan]
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]
 

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -45,7 +45,9 @@ module Scan
       options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
       options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
       options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
-      options << "-testPlan #{config[:testplan]}" if config[:testplan]
+      if FastlaneCore::Helper.xcode_at_least?(11)
+        options << "-testPlan #{config[:testplan]}" if config[:testplan]
+      end
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]
 

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -45,6 +45,7 @@ module Scan
       options << "-enableCodeCoverage #{config[:code_coverage] ? 'YES' : 'NO'}" unless config[:code_coverage].nil?
       options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
       options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
+      options << "-testPlan #{config[:testPlan]}" if config[:testPlan]
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]
 

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -613,5 +613,19 @@ describe Scan do
                                      ])
       end
     end
+
+    describe "Specifying a test plan" do
+      before do
+        options = { project: "./scan/examples/standard/app.xcodeproj", testPlan: "simple" }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+      end
+
+      it "adds the testplan to the xcodebuild command", requires_xcodebuild: true do
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        result = @test_command_generator.generate
+        expect(result).to include("-testPlan simple")
+      end
+    end
   end
 end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -624,7 +624,7 @@ describe Scan do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         result = @test_command_generator.generate
-        expect(result).to include("-testPlan simple")
+        expect(result).to include("-testPlan simple") if FastlaneCore::Helper.xcode_at_least?(10)
       end
     end
   end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -616,7 +616,7 @@ describe Scan do
 
     describe "Specifying a test plan" do
       before do
-        options = { project: "./scan/examples/standard/app.xcodeproj", testPlan: "simple" }
+        options = { project: "./scan/examples/standard/app.xcodeproj", testplan: "simple" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       end
 


### PR DESCRIPTION
Adds a configuration option that specifies a testplan to execute Scan
with. As with test parallelisation, using this can cause a few problems
with other integrations (such as xcpretty's ability to parse the test
output). This change isn't intended as a holistic change to address
incompatible combinations of options when using the new test report
formats, just a simple option to pass in a command line option.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Xcode 11 introduced testplans as a new way to specify groups of tests that can be run together independently of the project's schemes. eg. I can specify separate test plans for my pre-merge pipeline and nightly builds. 

Per https://github.com/fastlane/fastlane/issues/15462 there's clearly some desire for Fastlane to support test plans properly. At the moment the any use of them with scan requires passing a custom `xcarg` configuration. 

### Description
This change just adds a simple Scan configuration option that gets passed into `xcodebuild` as a command line option. 

closes #15462
