### PR TITLE
[scan] Set an extension of resultBundlePath as ".xcresult" when using Xcode 11

### DIFF
--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -149,11 +149,8 @@ module Scan
 
     def result_bundle_path
       unless Scan.cache[:result_bundle_path]
-        if FastlaneCore::Helper.xcode_version.to_i >= 11
-          path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".xcresult"
-        else
-          path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".test_result"
-        end
+        ext = FastlaneCore::Helper.xcode_version.to_i >= 11 ? '.xcresult' : '.test_result'
+        path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ext
         if File.directory?(path)
           FileUtils.remove_dir(path)
         end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -149,7 +149,11 @@ module Scan
 
     def result_bundle_path
       unless Scan.cache[:result_bundle_path]
-        path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".test_result"
+        if FastlaneCore::Helper.xcode_version.to_i >= 11
+          path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".xcresult"
+        else
+          path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ".test_result"
+        end
         if File.directory?(path)
           FileUtils.remove_dir(path)
         end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -308,7 +308,7 @@ describe Scan do
 
     describe "Result Bundle Example" do
       it "uses the correct build command with the example project when using Xcode 10 or earlier", requires_xcodebuild: true do
-        allow(FastlaneCore::Helper.xcode_version).to receive(:xcode_version).and_return('10')
+        allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('10')
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }
@@ -329,7 +329,7 @@ describe Scan do
       end
 
       it "uses the correct build command with the example project when using Xcode 11 or later", requires_xcodebuild: true do
-        allow(FastlaneCore::Helper.xcode_version).to receive(:xcode_version).and_return('11')
+        allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('11')
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -308,7 +308,7 @@ describe Scan do
 
     describe "Result Bundle Example" do
       it "uses the correct build command with the example project when using Xcode 10 or earlier", requires_xcodebuild: true do
-        allow(FastlaneCore::Helper.xcode_version).to recieve(:xcode_version).and_return('10')
+        allow(FastlaneCore::Helper.xcode_version).to receive(:xcode_version).and_return('10')
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }
@@ -329,7 +329,7 @@ describe Scan do
       end
 
       it "uses the correct build command with the example project when using Xcode 11 or later", requires_xcodebuild: true do
-        allow(FastlaneCore::Helper.xcode_version).to recieve(:xcode_version).and_return('11')
+        allow(FastlaneCore::Helper.xcode_version).to receive(:xcode_version).and_return('11')
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -307,7 +307,8 @@ describe Scan do
     end
 
     describe "Result Bundle Example" do
-      it "uses the correct build command with the example project", requires_xcodebuild: true do
+      it "uses the correct build command with the example project when using Xcode 10 or earlier", requires_xcodebuild: true do
+        allow(FastlaneCore::Helper.xcode_version).to recieve(:xcode_version).and_return('10')
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }
@@ -322,6 +323,27 @@ describe Scan do
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
                                        "-resultBundlePath './fastlane/test_output/app.test_result'",
+                                       :build,
+                                       :test
+                                     ])
+      end
+
+      it "uses the correct build command with the example project when using Xcode 11 or later", requires_xcodebuild: true do
+        allow(FastlaneCore::Helper.xcode_version).to recieve(:xcode_version).and_return('11')
+        log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+        options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle: true, scheme: 'app' }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = @test_command_generator.generate
+        expect(result).to start_with([
+                                       "set -o pipefail &&",
+                                       "env NSUnbufferedIO=YES xcodebuild",
+                                       "-scheme app",
+                                       "-project ./scan/examples/standard/app.xcodeproj",
+                                       "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-resultBundlePath './fastlane/test_output/app.xcresult'",
                                        :build,
                                        :test
                                      ])


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Since Xcode 11, Result Bundle is implemented.

https://developer.apple.com/documentation/xcode_release_notes/xcode_11_release_notes?language=objc

```
The format of result bundles changed in Xcode 11. 
A result bundle is an asset produced by Xcode 11 with the xcresult file extension that contains information about the build, tests, code coverage, and more. 
```

To open Result Bundle by Xcode 11, the extension must be ".xcresult".
But in fastlane,  the extension is always set ".test_result" when a scan action receives the param `result_bundle:true`.

So, I fixed that the extension is set ".xcresult" when using Xcode11.

### Description

I also discover that a symbolic link file is generated  when an extension of Result Bundle is set other than ".xcresult".

The related issue is below.
https://github.com/fastlane/fastlane/issues/15438

I think in order to resolve like this issue, the extension should be ".xcresult" when using Xcode 11.