### PR TITLE
[screengrab] Fix regression with metadata folder structure

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -342,7 +342,11 @@ module Screengrab
         # specific name, as expected by supply
         #
         # (Moved to: fastlane/metadata/android/en-US/images/phoneScreenshots)
-        dest_dir = File.join(File.dirname(dest_dir), locale, 'images', device_type_dir_name)
+        if dest_dir.include?("#{locale}/images")
+          dest_dir = File.join(File.dirname(dest_dir), device_type_dir_name)
+        else
+          dest_dir = File.join(File.dirname(dest_dir), locale, 'images', device_type_dir_name)
+        end
 
         FileUtils.mkdir_p(dest_dir)
         FileUtils.cp_r(src_screenshots, dest_dir)


### PR DESCRIPTION
Fixes #16050.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes https://github.com/fastlane/fastlane/issues/16050.

### Description
From the issue linked above and from https://github.com/fastlane/fastlane/pull/15994 it seems that for some users the path on the Android device contains `"#{locale}/images"` and for some it doesn't. So as a solution, I'm simply checking if it contains this part and add it for the users where it doesn't contain it already.

No one seems to have found out why this difference is happening in the first place, but my best guess is that different Android app or system configurations lead to different behaviors. This PR fixes the issue for both cases.

### Testing Steps
This is a small change and I can't test if it fixes the issue, but the reporters of https://github.com/fastlane/fastlane/issues/16050 could easily check and confirm that this fixes it for them.
