### PR TITLE
[spaceship] Removes raising exception when build_beta_detail is nil

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -79,8 +79,7 @@ module Spaceship
       end
 
       def ready_for_internal_testing?
-        raise "No build_beta_detail included" unless build_beta_detail
-        return build_beta_detail.ready_for_internal_testing?
+        return build_beta_detail.nil? == false && build_beta_detail.ready_for_internal_testing?
       end
 
       def ready_for_beta_submission?


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Fixes #15138

### Important notes

The boolean value that returns from the method being changed is only used [here](https://github.com/fastlane/fastlane/blob/bf2f4ddc04cfcccfa553258a9bab244ba75d116b/pilot/lib/pilot/build_manager.rb#L158)