### PR TITLE
Improve rubyzip security behavior to be able to continue using 1.3.0

### DIFF
--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -37,6 +37,7 @@ module FastlaneCore
 
     def self.fetch_info_plist_file(path)
       UI.user_error!("Could not find file at path '#{path}'") unless File.exist?(path)
+      Zip.validate_entry_sizes = true # https://github.com/rubyzip/rubyzip/releases/tag/v2.0.0
       Zip::File.open(path, "rb") do |zipfile|
         file = zipfile.glob('**/Payload/*.app/Info.plist').first
         return nil unless file


### PR DESCRIPTION
As per https://github.com/rubyzip/rubyzip/releases/tag/v2.0.0 rubyzip 2.x changed the default behavior of `validate_entry_sizes` to `true` to improve security:

![image](https://user-images.githubusercontent.com/183673/75118763-26330500-567d-11ea-928b-f15289ae5f11.png)

As we can not upgrade to rubyzip 2.x as we want to continue older Ruby versions that are unfortunately bundled with older macOS versions, I applied the suggested "workaround" from the release notes in all (1) locations where we actually use `Zip`:

> If you are using an older version of ruby and can't yet upgrade to 2.x, you can still use 1.3.0 and set the option to `true`.

closes #15970