### PR TITLE
[swift] Fix `submissionInformation` data type in `DeliverfileProtocol`

### DIFF
--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -76,7 +76,9 @@ protocol DeliverfileProtocol: class {
   var appRatingConfigPath: String? { get }
 
   /// Extra information for the submission (e.g. compliance specifications, IDFA settings)
-  var submissionInformation: String? { get }
+  /// Look at the Spaceship's app_submission.rb file for options.
+  /// https://github.com/artsy/eigen/blob/faa02e2746194d8d7c11899474de9c517435eca4/fastlane/Fastfile#L131-L149
+  var submissionInformation: [String : Any?]? { get }
 
   /// The ID of your App Store Connect team if you're in multiple teams
   var teamId: String? { get }
@@ -207,7 +209,7 @@ extension DeliverfileProtocol {
   var resetRatings: Bool { return false }
   var priceTier: String? { return nil }
   var appRatingConfigPath: String? { return nil }
-  var submissionInformation: String? { return nil }
+  var submissionInformation: [String : Any?]? { return nil }
   var teamId: String? { return nil }
   var teamName: String? { return nil }
   var devPortalTeamId: String? { return nil }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently, `submissionInformation` data type is `String` in `DeliverfileProtocol`
However, if `submissionInformation` is returned in String, `deliver` action fails in app review submission

### Description
I changed `submissionInformation` data type to `[String: Any?]` which is `submissionInformation` data type in Ruby Fastlane

After changed, `delivery` action completed the application review submission.

![Changed submissionInformation](https://user-images.githubusercontent.com/24635384/75418381-a657b400-5976-11ea-8dcd-742f9bb21c0a.png)

![submissionInformation Result](https://user-images.githubusercontent.com/24635384/75418385-a9eb3b00-5976-11ea-9f74-4dfc26cdd3c3.png)
