### PR TITLE
[deliver] Add fix for app_version and build_number matching

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -36,7 +36,11 @@ module Deliver
 
       if options[:build_number] && options[:build_number] != "latest"
         UI.message("Selecting existing build-number: #{options[:build_number]}")
-        build = v.candidate_builds.detect { |a| a.build_version == options[:build_number] }
+        if app_version
+          build = v.candidate_builds.detect { |a| a.build_version == options[:build_number] && a.train_version == app_version}
+        else
+          build = v.candidate_builds.detect { |a| a.build_version == options[:build_number]}
+        end
         unless build
           UI.user_error!("Build number: #{options[:build_number]} does not exist")
         end

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -37,9 +37,9 @@ module Deliver
       if options[:build_number] && options[:build_number] != "latest"
         UI.message("Selecting existing build-number: #{options[:build_number]}")
         if app_version
-          build = v.candidate_builds.detect { |a| a.build_version == options[:build_number] && a.train_version == app_version}
+          build = v.candidate_builds.detect { |a| a.build_version == options[:build_number] && a.train_version == app_version }
         else
-          build = v.candidate_builds.detect { |a| a.build_version == options[:build_number]}
+          build = v.candidate_builds.detect { |a| a.build_version == options[:build_number] }
         end
         unless build
           UI.user_error!("Build number: #{options[:build_number]} does not exist")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/13356
If we use build_number and app_version action in deliver, it selects the build of any version it finds. It does not take the app_version into consideration.

For example given lane:
```ruby
lane :submit_review do
  deliver(
    build_number: '12',
    submit_for_review: true,
    app_version: '2.0'
  )
end
```
If there are many app versions that have build number 12, it will select the build **12** from random app version instead of **2.0.**

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

In select_build method, when app_version number is given, it will find the build corresponding to it.
I tested these changes manually with my app.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
