### PR TITLE
[screengrab] fix screengrab folder name

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -146,7 +146,7 @@ module Screengrab
         "/data/user/0/#{app_package_name}/files/#{app_package_name}/screengrab/#{locale}/images/screenshots"
       end
 
-      return ["/data/data/#{app_package_name}/app_screengrab"] + locale_paths
+      return ["/data/data/#{app_package_name}/screengrab"] + locale_paths
     end
 
     def clear_device_previous_screenshots(device_serial, device_screenshots_paths)

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -143,10 +143,17 @@ module Screengrab
 
     def determine_internal_screenshots_paths(app_package_name, locales)
       locale_paths = locales.map do |locale|
-        "/data/user/0/#{app_package_name}/files/#{app_package_name}/screengrab/#{locale}/images/screenshots"
-      end
+        [
+          "/data/user/0/#{app_package_name}/files/#{app_package_name}/screengrab/#{locale}/images/screenshots",
 
-      return ["/data/data/#{app_package_name}/screengrab"] + locale_paths
+          # https://github.com/fastlane/fastlane/issues/15653#issuecomment-578541663
+          "/data/data/#{app_package_name}/files/#{app_package_name}/screengrab/#{locale}/images/screenshots"
+        ]
+      end.flatten
+
+      return ["/data/data/#{app_package_name}/app_screengrab"] +
+             ["/data/data/#{app_package_name}/screengrab"] +
+             locale_paths
     end
 
     def clear_device_previous_screenshots(device_serial, device_screenshots_paths)
@@ -289,6 +296,7 @@ module Screengrab
       Dir.mktmpdir do |tempdir|
         device_screenshots_paths.each do |device_path|
           if_device_path_exists(device_serial, device_path) do |path|
+            next unless path.include?(locale)
             run_adb_command("-s #{device_serial} pull #{path} #{tempdir}",
                             print_all: false,
                             print_command: true)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/fastlane/fastlane/issues/15653#issuecomment-562642978
Fixes #16050

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
screengrab companion java library doesn't write to `app_screengrab` folder, but ruby part still tries to read screenshots from there. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
https://github.com/fastlane/fastlane/issues/15653#issuecomment-592065897