### PR TITLE
Fix frameit rotation bug

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -60,8 +60,8 @@ module Frameit
     end
 
     def rotation_for_device_orientation
-      return 90 if self.screenshot.landscape_right?
-      return -90 if self.screenshot.landscape_left?
+      return -90 if self.screenshot.landscape_right?
+      return 90 if self.screenshot.landscape_left?
       return 0
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
The original rotation degree is wrong.
The home button is on the bottom in portrait frame. Hence, when :landscape_right(home button on the right side) is set the frame should rotate -90 (counterclockwise), and 90(clockwise) degree when :landscape_left is set.

<!-- Please describe in detail how you tested your changes. -->
Run the code

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
