### PR TITLE
[gym] Copy Asset Pack into output directory

### DIFF
--- a/gym/lib/gym/generators/package_command_generator.rb
+++ b/gym/lib/gym/generators/package_command_generator.rb
@@ -49,6 +49,10 @@ module Gym
         generator.apps_path
       end
 
+      def asset_packs_path
+        generator.asset_packs_path
+      end
+
       # The generator we need to use for the currently used Xcode version
       # Since we dropped Xcode 6 support, it's just this class, but maybe we'll have
       # new classes in the future

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -136,6 +136,11 @@ module Gym
         Gym.cache[:apps_path] ||= File.join(temporary_output_path, "Apps")
       end
 
+      # The path to the Apps folder
+      def asset_packs_path
+        Gym.cache[:asset_packs_path] ||= File.join(temporary_output_path, "OnDemandResources")
+      end
+
       private
 
       def normalize_export_options(hash)

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -326,7 +326,6 @@ module Gym
       end
     end
 
-
     # Move Asset Packs folder to the output directory
     # @return (String) The path to the resulting Asset Packs (aka OnDemandResources) folder
     def move_asset_packs

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -39,6 +39,7 @@ module Gym
         move_app_thinning
         move_app_thinning_size_report
         move_apps_folder
+        move_asset_packs
       elsif is_mac
         path = File.expand_path(Gym.config[:output_directory])
         compress_and_move_dsym
@@ -322,6 +323,20 @@ module Gym
         UI.success("Successfully exported Apps folder:")
         UI.message(apps_path)
         apps_path
+      end
+    end
+
+
+    # Move Asset Packs folder to the output directory
+    # @return (String) The path to the resulting Asset Packs (aka OnDemandResources) folder
+    def move_asset_packs
+      if Dir.exist?(PackageCommandGenerator.asset_packs_path)
+        FileUtils.mv(PackageCommandGenerator.asset_packs_path, File.expand_path(Gym.config[:output_directory]), force: true)
+        asset_packs_path = File.join(File.expand_path(Gym.config[:output_directory]), File.basename(PackageCommandGenerator.asset_packs_path))
+
+        UI.success("Successfully exported Asset Pack folder:")
+        UI.message(asset_packs_path)
+        asset_packs_path
       end
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This changes make easier to locate the `assetpack` files generated during the export phase. Before this change, the asset packs were created in the temporary output folder. Gym tool only copied `.ipa`, `.dSym`, and `Apps` folder. 
Locating asset pack files is very helpful if you want to upload automatically your remote assets into a particular server.

<!-- If it fixes an open issue, please link to the issue here. --> 
I opened an issue (https://github.com/fastlane/fastlane/issues/16037) in order to ask the community how was I supposed to access the asset pack files. During my investigation I found out this feature was not implemented, so I implemented myself.

### Description
<!-- Describe your changes in detail. -->
I extended `runner.rb` functionality to copy `OnDemandResources` as `Apps` folder and `ipa` and `dSym` files.
<!-- Please describe in detail how you tested your changes. -->
I installed the gem from my repo and archived my project using fastlane gym. I could see on the console the path to the asset packs output and verified the files were in the expected location.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
In order to verify the functionality works, project should have "Enable On Demand Resources" set to "Yes" in the iOS Project `Build Settings` menu. In addition, at least one assets should have a tag assigned. This tag will appear under iOS Project `Resource Tags` menu.

Gym export options should include the following parameters:
```
export_options: {
        embedOnDemandResourcesAssetPacksInBundle: false,
        onDemandResourcesAssetPacksBaseURL: "https://assets.dummy.com/tags"
}
```
