### PR TITLE
[swiftlint] add support for the --no-cache flag on autocorrect and lint

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -19,7 +19,7 @@ module Fastlane
         command << " --reporter #{params[:reporter]}" if params[:reporter]
         command << supported_option_switch(params, :quiet, "0.9.0", true)
         command << supported_option_switch(params, :format, "0.11.0", true) if params[:mode] == :autocorrect
-        command << " --no-cache" if params[:no_cache] and (params[:mode] == :autocorrect or params[:mode] == :lint)
+        command << supported_no_cache_option(params) if params[:no_cache]
         command << " --compiler-log-path #{params[:compiler_log_path].shellescape}" if params[:compiler_log_path]
 
         if params[:files]
@@ -41,11 +41,19 @@ module Fastlane
           raise if params[:raise_if_swiftlint_error]
         end
       end
-
+      
       # Get current SwiftLint version
       def self.swiftlint_version(executable: nil)
         binary = executable || 'swiftlint'
         Gem::Version.new(`#{binary} version`.chomp)
+      end
+      
+      def self.supported_no_cache_option(params)
+        if (params[:mode] == :autocorrect || params[:mode] == :lint)
+          return " --no-cache"
+        else
+          return ""
+        end
       end
 
       # Return "--option" switch if option is on and current SwiftLint version is greater or equal than min version.

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -19,6 +19,7 @@ module Fastlane
         command << " --reporter #{params[:reporter]}" if params[:reporter]
         command << supported_option_switch(params, :quiet, "0.9.0", true)
         command << supported_option_switch(params, :format, "0.11.0", true) if params[:mode] == :autocorrect
+        command << " --no-cache" if params[:no_cache] and (params[:mode] == :autocorrect or params[:mode] == :lint)
         command << " --compiler-log-path #{params[:compiler_log_path].shellescape}" if params[:compiler_log_path]
 
         if params[:files]
@@ -135,6 +136,12 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :format,
                                        description: "Format code when mode is :autocorrect",
+                                       default_value: false,
+                                       is_string: false,
+                                       type: Boolean,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :no_cache,
+                                       description: "Ignore the cache when mode is :autocorrect or :lint",
                                        default_value: false,
                                        is_string: false,
                                        type: Boolean,

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -13,14 +13,7 @@ module Fastlane
 
         command = (params[:executable] || "swiftlint").dup
         command << " #{params[:mode]}"
-        command << " --path #{params[:path].shellescape}" if params[:path]
-        command << supported_option_switch(params, :strict, "0.9.2", true)
-        command << " --config #{params[:config_file].shellescape}" if params[:config_file]
-        command << " --reporter #{params[:reporter]}" if params[:reporter]
-        command << supported_option_switch(params, :quiet, "0.9.0", true)
-        command << supported_option_switch(params, :format, "0.11.0", true) if params[:mode] == :autocorrect
-        command << supported_no_cache_option(params) if params[:no_cache]
-        command << " --compiler-log-path #{params[:compiler_log_path].shellescape}" if params[:compiler_log_path]
+        command << optional_flags(params)
 
         if params[:files]
           if version < Gem::Version.new('0.5.1')
@@ -40,6 +33,19 @@ module Fastlane
           handle_swiftlint_error(params[:ignore_exit_status], $?.exitstatus)
           raise if params[:raise_if_swiftlint_error]
         end
+      end
+
+      def self.optional_flags(params)
+        command = ""
+        command << " --path #{params[:path].shellescape}" if params[:path]
+        command << supported_option_switch(params, :strict, "0.9.2", true)
+        command << " --config #{params[:config_file].shellescape}" if params[:config_file]
+        command << " --reporter #{params[:reporter]}" if params[:reporter]
+        command << supported_option_switch(params, :quiet, "0.9.0", true)
+        command << supported_option_switch(params, :format, "0.11.0", true) if params[:mode] == :autocorrect
+        command << supported_no_cache_option(params) if params[:no_cache]
+        command << " --compiler-log-path #{params[:compiler_log_path].shellescape}" if params[:compiler_log_path]
+        return command
       end
 
       # Get current SwiftLint version

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -41,15 +41,15 @@ module Fastlane
           raise if params[:raise_if_swiftlint_error]
         end
       end
-      
+
       # Get current SwiftLint version
       def self.swiftlint_version(executable: nil)
         binary = executable || 'swiftlint'
         Gem::Version.new(`#{binary} version`.chomp)
       end
-      
+
       def self.supported_no_cache_option(params)
-        if (params[:mode] == :autocorrect || params[:mode] == :lint)
+        if params[:mode] == :autocorrect || params[:mode] == :lint
           return " --no-cache"
         else
           return ""
@@ -218,3 +218,4 @@ module Fastlane
     end
   end
 end
+d

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -218,4 +218,3 @@ module Fastlane
     end
   end
 end
-d

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -352,7 +352,7 @@ describe Fastlane do
           expect(result).to eq("swiftlint autocorrect")
         end
       end
-      
+
       context "when specify no-cache option" do
         it "adds no-cache option if mode is :autocorrect" do
           result = Fastlane::FastFile.new.parse("lane :test do
@@ -364,7 +364,7 @@ describe Fastlane do
 
           expect(result).to eq("swiftlint autocorrect --no-cache")
         end
-        
+
         it "adds no-cache option if mode is :lint" do
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
@@ -387,7 +387,7 @@ describe Fastlane do
           expect(result).to eq("swiftlint analyze")
         end
       end
-      
+
       context "when specify false for no-cache option" do
         it "doesn't add no-cache option if mode is :autocorrect" do
           result = Fastlane::FastFile.new.parse("lane :test do
@@ -399,7 +399,7 @@ describe Fastlane do
 
           expect(result).to eq("swiftlint autocorrect")
         end
-        
+
         it "doesn't add no-cache option if mode is :lint" do
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -352,6 +352,65 @@ describe Fastlane do
           expect(result).to eq("swiftlint autocorrect")
         end
       end
+      
+      context "when specify no-cache option" do
+        it "adds no-cache option if mode is :autocorrect" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :autocorrect,
+              no_cache: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint autocorrect --no-cache")
+        end
+        
+        it "adds no-cache option if mode is :lint" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :lint,
+              no_cache: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint --no-cache")
+        end
+
+        it "omits format option if mode is :analyze" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :analyze,
+              no_cache: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint analyze")
+        end
+      end
+      
+      context "when specify false for no-cache option" do
+        it "doesn't add no-cache option if mode is :autocorrect" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :autocorrect,
+              no_cache: false
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint autocorrect")
+        end
+        
+        it "doesn't add no-cache option if mode is :lint" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :lint,
+              no_cache: false
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint")
+        end
+      end
 
       context "when using analyzer mode" do
         it "adds compiler-log-path option" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This PR allows to pass the --no-cache flag to the autocorrect and lint commands. This helps to solve some weird behavior when formatting the code and the cache becomes stale causing lost of chunks of code.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
Added an option (like --format) to allow passing --no-cache flag.
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
Updated the unit test to append the --no-cache flag if present to lint and autocorrect commands.
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
