### PR TITLE
[gym] Move AppStoreInfo.plist to build output directory if generated …

### DIFF
--- a/gym/lib/gym/generators/package_command_generator.rb
+++ b/gym/lib/gym/generators/package_command_generator.rb
@@ -53,6 +53,10 @@ module Gym
         generator.asset_packs_path
       end
 
+      def appstore_info_path
+        generator.appstore_info_path
+      end
+
       # The generator we need to use for the currently used Xcode version
       # Since we dropped Xcode 6 support, it's just this class, but maybe we'll have
       # new classes in the future

--- a/gym/lib/gym/generators/package_command_generator.rb
+++ b/gym/lib/gym/generators/package_command_generator.rb
@@ -49,10 +49,6 @@ module Gym
         generator.apps_path
       end
 
-      def appstore_info_path
-        generator.appstore_info_path
-      end
-
       def asset_packs_path
         generator.asset_packs_path
       end

--- a/gym/lib/gym/generators/package_command_generator.rb
+++ b/gym/lib/gym/generators/package_command_generator.rb
@@ -49,6 +49,10 @@ module Gym
         generator.apps_path
       end
 
+      def appstore_info_path
+        generator.appstore_info_path
+      end
+
       def asset_packs_path
         generator.asset_packs_path
       end

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -141,6 +141,10 @@ module Gym
         Gym.cache[:asset_packs_path] ||= File.join(temporary_output_path, "OnDemandResources")
       end
 
+      def appstore_info_path
+        Gym.cache[:appstore_info_path] ||= File.join(temporary_output_path, "AppStoreInfo.plist")
+      end
+
       private
 
       def normalize_export_options(hash)

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -50,6 +50,7 @@ module Gym
 
           package_app
           path = move_pkg
+          move_appstore_info
           return path
         end
         copy_files_from_path(File.join(BuildCommandGenerator.archive_path, "Products/usr/local/bin/*")) if Gym.project.command_line_tool?
@@ -324,6 +325,18 @@ module Gym
         UI.success("Successfully exported Apps folder:")
         UI.message(apps_path)
         apps_path
+      end
+    end
+
+    # Move the AppStoreInfo.plist folder to the output directory
+    def move_appstore_info
+      if File.exist?(PackageCommandGenerator.appstore_info_path)
+        FileUtils.mv(PackageCommandGenerator.appstore_info_path, File.expand_path(Gym.config[:output_directory]), force: true)
+        appstore_info_path = File.join(File.expand_path(Gym.config[:output_directory]), File.basename(PackageCommandGenerator.appstore_info_path))
+
+        UI.success("Successfully exported the AppStoreInfo.plist file:")
+        UI.message(appstore_info_path)
+        appstore_info_path
       end
     end
 

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -328,18 +328,6 @@ module Gym
       end
     end
 
-    # Move the AppStoreInfo.plist folder to the output directory
-    def move_appstore_info
-      if File.exist?(PackageCommandGenerator.appstore_info_path)
-        FileUtils.mv(PackageCommandGenerator.appstore_info_path, File.expand_path(Gym.config[:output_directory]), force: true)
-        appstore_info_path = File.join(File.expand_path(Gym.config[:output_directory]), File.basename(PackageCommandGenerator.appstore_info_path))
-
-        UI.success("Successfully exported the AppStoreInfo.plist file:")
-        UI.message(appstore_info_path)
-        appstore_info_path
-      end
-    end
-
     # Move Asset Packs folder to the output directory
     # @return (String) The path to the resulting Asset Packs (aka OnDemandResources) folder
     def move_asset_packs

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -40,6 +40,7 @@ module Gym
         move_app_thinning_size_report
         move_apps_folder
         move_asset_packs
+        move_appstore_info
       elsif is_mac
         path = File.expand_path(Gym.config[:output_directory])
         compress_and_move_dsym
@@ -336,6 +337,18 @@ module Gym
         UI.success("Successfully exported Asset Pack folder:")
         UI.message(asset_packs_path)
         asset_packs_path
+      end
+    end
+
+    # Move the AppStoreInfo.plist folder to the output directory
+    def move_appstore_info
+      if File.exist?(PackageCommandGenerator.appstore_info_path)
+        FileUtils.mv(PackageCommandGenerator.appstore_info_path, File.expand_path(Gym.config[:output_directory]), force: true)
+        appstore_info_path = File.join(File.expand_path(Gym.config[:output_directory]), File.basename(PackageCommandGenerator.appstore_info_path))
+
+        UI.success("Successfully exported the AppStoreInfo.plist file:")
+        UI.message(appstore_info_path)
+        appstore_info_path
       end
     end
 

--- a/gym/spec/package_command_generator_xcode7_spec.rb
+++ b/gym/spec/package_command_generator_xcode7_spec.rb
@@ -233,6 +233,7 @@ describe Gym do
       expect(Gym::PackageCommandGeneratorXcode7.app_thinning_path).to match(%r{#{Dir.tmpdir}/gym_output.+/app-thinning.plist})
       expect(Gym::PackageCommandGeneratorXcode7.app_thinning_size_report_path).to match(%r{#{Dir.tmpdir}/gym_output.+/App Thinning Size Report.txt})
       expect(Gym::PackageCommandGeneratorXcode7.apps_path).to match(%r{#{Dir.tmpdir}/gym_output.+/Apps})
+      expect(Gym::PackageCommandGeneratorXcode7.appstore_info_path).to match(%r{#{Dir.tmpdir}/gym_output.+/AppStoreInfo.plist})
     end
   end
 end


### PR DESCRIPTION
…(#16131)

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. (I don't think necessary since this is expected behaviour and other similar files aren't documented)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#16131 has all details.

### Description
<!-- Describe your changes in detail. -->
In the same place we move other files generated when an IPA file is generated, we now also check for `AppStoreInfo.plist` and move it to gyms output directory. I followed how it was done for other similar optional generated files that are enabled by `exportOptions.plist` entries.
<!-- Please describe in detail how you tested your changes. -->
I built an app with the following `exportOptions.plist` with `app-store` export method and `generateAppStoreInformation` set to `true`:
```xml
	<key>method</key>
	<string>app-store</string>
	<key>generateAppStoreInformation</key>
	<true/>
```

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Use gym to export an IPA with an `exportOptions.plist` with the above mentioned keys. In the xcodebuild output directory you'll find an `AppStoreInfo.plist` file, if this works, you'll find it in the gym output directory too. If the `exportOptions.plist` has `generateAppStoreInformation` set to `false` instead, the file won't be generated, so should not exist in the gym output directory.
