### PR TITLE
[push_to_git_remote] Avoid using master unexpectedly

### DIFF
--- a/fastlane/lib/fastlane/actions/push_to_git_remote.rb
+++ b/fastlane/lib/fastlane/actions/push_to_git_remote.rb
@@ -5,7 +5,7 @@ module Fastlane
       def self.run(params)
         local_branch = params[:local_branch]
         local_branch ||= Actions.git_branch.gsub(%r{#{params[:remote]}\/}, '') if Actions.git_branch
-        local_branch ||= 'master'
+        UI.user_error!('Failed to get the current branch.') unless local_branch
 
         remote_branch = params[:remote_branch] || local_branch
 

--- a/fastlane/spec/actions_specs/push_to_git_remote_spec.rb
+++ b/fastlane/spec/actions_specs/push_to_git_remote_spec.rb
@@ -93,6 +93,19 @@ describe Fastlane do
 
         expect(result).to eq("git push origin master:master --tags --set-upstream")
       end
+
+      context "runs git push without local_branch" do
+        it "should raise an error if get current branch failed" do
+          allow(Fastlane::Actions).to receive(:git_branch).and_return(nil)
+          expect(FastlaneCore::UI).to receive(:user_error!).with("Failed to get the current branch.").and_call_original
+
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              push_to_git_remote
+            end").runner.execute(:test)
+          end.to raise_error("Failed to get the current branch.")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
There are 31 failures before I change anything, and no new failures appeared after my change.
Am I doing something wrong or should I just ignore them and check this box?
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As I describe in #15615, the **master** branch will be used unexpectedly if `git_branch` failed, and it may cause an accident if the user is running with `force: true`.
So raising an error if `git_branch` failed may be better behavior than using **master** branch.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Raising an error if `git_branch` failed.
I have reconsidered the confirmation and find it's not necessary.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Sorry about the inconvenience. I don't know how to reproduce the issue in actual environment.
I submitted #15615 because `push_to_git_remote` tried to push to the **master** branch but the current branch is a branch named in Japanese instead of **master** in my previous job environment. But I cannot reproduce it in my personal mac even I name the current branch in Japanese.