### PR TITLE
[fastlane] migrate from AWS-SDK v2 to AWS-SDK v3

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -111,7 +111,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('emoji_regex', '>= 0.1', '< 2.0') # Used to scan for Emoji in the changelog
 
-  spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used in match for S3 storage
+  spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used for S3 storage in fastlane match
 
   # Development only
   spec.add_development_dependency('rake', '< 12')

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -111,7 +111,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('emoji_regex', '>= 0.1', '< 2.0') # Used to scan for Emoji in the changelog
 
-  spec.add_dependency('aws-sdk', '~> 3.0') # Used in match for S3 storage
+  spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used in match for S3 storage
 
   # Development only
   spec.add_development_dependency('rake', '< 12')

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -111,7 +111,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('emoji_regex', '>= 0.1', '< 2.0') # Used to scan for Emoji in the changelog
 
-  spec.add_dependency('aws-sdk', '~> 2.3') # Used in match for S3 storage
+  spec.add_dependency('aws-sdk', '~> 3.0') # Used in match for S3 storage
 
   # Development only
   spec.add_development_dependency('rake', '< 12')

--- a/fastlane/lib/fastlane/helper/s3_client_helper.rb
+++ b/fastlane/lib/fastlane/helper/s3_client_helper.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 module Fastlane
   module Helper


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Fixes https://github.com/fastlane/fastlane/issues/16130.
Repairs https://github.com/fastlane/fastlane/pull/15200.

### Description
Currently Fastlane uses AWS-SDK v2 and is deprecated.
We could easily migrate to v3 just by changing the version number (via https://docs.aws.amazon.com/sdk-for-ruby/v3/api/ - Upgrade from version 2 - `If you depend on aws-sdk or aws-sdk-resources, you don't need to change anything. Meanwhile we recommend you to revisit following options to explore modularization benefits.`), but because we need only S3 part of the library, and AWS-SDK V3 introduced modularization, it makes sense not to include 200 sub-dependencies, but point only to the required one.

### Testing Steps
Everything mentioned in Checklist.

### Other notes
Introducing AWS-SDK in latest Fastlane causes a lot of issues so I think there **should** be a minor hotfix release.