### PR TITLE
[deliver] Fix crash when metadata_path is outside of the fastlane path

### DIFF
--- a/deliver/lib/deliver/html_generator.rb
+++ b/deliver/lib/deliver/html_generator.rb
@@ -35,8 +35,8 @@ module Deliver
     # Returns a path relative to FastlaneFolder.path
     # This is needed as the Preview.html file is located inside FastlaneFolder.path
     def render_relative_path(export_path, path)
-      export_path = Pathname.new(export_path)
-      path = Pathname.new(path).relative_path_from(export_path)
+      export_path = Pathname.new(File.expand_path(export_path))
+      path = Pathname.new(File.expand_path(path)).relative_path_from(export_path)
       return path.to_path
     end
 

--- a/deliver/spec/html_generator_spec.rb
+++ b/deliver/spec/html_generator_spec.rb
@@ -38,6 +38,22 @@ describe Deliver::HtmlGenerator do
       end
     end
 
+    context 'with an app icon' do
+      let(:options) do
+        {
+          name: { 'en-US' => 'Fastlane Demo' },
+          description: { 'en-US' => 'Demo description' },
+          app_icon: 'fastlane/metadata/app_icon.png'
+        }
+      end
+
+      it 'renders HTML' do
+        capture = render(options, screenshots)
+        expect(capture).to match(/<html>/)
+        expect(capture).to include('app_icon.png')
+      end
+    end
+
     private
 
     def render(options, screenshots)


### PR DESCRIPTION
:key:

When calling deliver when `metadata_path` points outside of `fastlane/` folder, deliver fails with the following error: `#<ArgumentError: different prefix: "/" and "fastlane">`

The issue is that in [html_generator.rb](https://github.com/fastlane/fastlane/blob/5e23f949f4c943f484d48249a39f2662b56f466d/deliver/lib/deliver/html_generator.rb#L39), `path` and `export_path` must be relative to each other. If one of the path is an absolute path (eg. `export_path` is `/var/tmp/something`) and the other one relative (eg. `path` is always `./fastlane`), then `PathName#relative_path_from` fails.

Note: the spec for HtmlGenerator actually reveal the issue as soon as you include `app_icon` in the options: in the specs, the export path is set to a temporary directory, which reproduces the exact above issue.

Likely fixes old auto-closed bugs: #14219, #13853

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.