### PR TITLE
[action] fix a type error in the Swift setupCi action.

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_ci.rb
@@ -93,7 +93,7 @@ module Fastlane
                                        env_name: "FL_SETUP_CI_PROVIDER",
                                        description: "CI provider. If none is set, the provider is detected automatically",
                                        is_string: true,
-                                       default_value: false,
+                                       optional: true,
                                        verify_block: proc do |value|
                                          value = value.to_s
                                          # Validate both 'travis' and 'circleci' for backwards compatibility, even


### PR DESCRIPTION
`provider` should be an optional String, not a Bool. This fixes the following error when using the action:

```
[!] 'provider' value must be a String! Found FalseClass instead.
```

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
