### PR TITLE
Add deprecation message to Crashlytic's Beta action

### DIFF
--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -170,6 +170,7 @@ module Fastlane
       def self.details
         [
           "Crashlytics Beta has been deprecated and replaced with Firebase App Distribution.",
+          "Beta will continue working until March 31, 2020.",
           "Check out the [Firebase App Distribution docs](https://github.com/fastlane/fastlane-plugin-firebase_app_distribution) to get started.",
           "",
           "Additionally, you can specify `notes`, `emails`, `groups` and `notifications`.",
@@ -205,6 +206,7 @@ module Fastlane
       def self.deprecated_notes
         [
           "Crashlytics Beta has been deprecated and replaced with Firebase App Distribution.",
+          "Beta will continue working until March 31, 2020.",
           "Check out the [Firebase App Distribution docs](https://github.com/fastlane/fastlane-plugin-firebase_app_distribution) to get started."
         ].join("\n")
       end

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -66,7 +66,7 @@ module Fastlane
       end
 
       def self.description
-        "Upload a new build to [Crashlytics Beta](http://try.crashlytics.com/beta/)"
+        "Refer to [Firebase App Distribution](https://appdistro.page.link/fastlane-repo)"
       end
 
       def self.available_options
@@ -169,6 +169,9 @@ module Fastlane
 
       def self.details
         [
+          "Crashlytics Beta has been deprecated and replaced with Firebase App Distribution.",
+          "Check out the [Firebase App Distribution docs](https://github.com/fastlane/fastlane-plugin-firebase_app_distribution) to get started.",
+          "",
           "Additionally, you can specify `notes`, `emails`, `groups` and `notifications`.",
           "Distributing to Groups: When using the `groups` parameter, it's important to use the group **alias** names for each group you'd like to distribute to. A group's alias can be found in the web UI. If you're viewing the Beta page, you can open the groups dialog by clicking the 'Manage Groups' button.",
           "This action uses the `submit` binary provided by the Crashlytics framework. If the binary is not found in its usual path, you'll need to specify the path manually by using the `crashlytics_path` option."
@@ -196,7 +199,14 @@ module Fastlane
       end
 
       def self.category
-        :beta
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        [
+          "Crashlytics Beta has been deprecated and replaced with Firebase App Distribution.",
+          "Check out the [Firebase App Distribution docs](https://github.com/fastlane/fastlane-plugin-firebase_app_distribution) to get started."
+        ].join("\n")
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Crashlytics Beta is deprecated and has been replaced with Firebase App Distribution. Fabric, along with Crashlytics Beta, are being shut down on March 31, 2020

### Description
Update `crashlytics` action to label it as deprecated and call out Firebase App Distribution as its replacement.

