### PR TITLE
[match][sigh][gym] migrate to new App Store Connect API and improve building with Catalyst

### DIFF
--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -46,6 +46,10 @@ module Fastlane
                                                                                             type: Match.profile_type_sym(params[:type]),
                                                                                         platform: params[:platform])
 
+          if params[:derive_catalyst_app_identifier]
+            app_identifier = "maccatalyst.#{app_identifier}"
+          end
+
           mapping[app_identifier] = ENV[env_variable_name]
         end
 

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -45,6 +45,11 @@ module Fastlane
           env_variable_name = Match::Utils.environment_variable_name_profile_name(app_identifier: app_identifier,
                                                                                             type: Match.profile_type_sym(params[:type]),
                                                                                         platform: params[:platform])
+
+          if params[:platform].to_s == :catalyst.to_s
+            app_identifier = "maccatalyst.#{app_identifier}"
+          end
+
           mapping[app_identifier] = ENV[env_variable_name]
         end
 

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -46,10 +46,6 @@ module Fastlane
                                                                                             type: Match.profile_type_sym(params[:type]),
                                                                                         platform: params[:platform])
 
-          if params[:platform].to_s == :catalyst.to_s
-            app_identifier = "maccatalyst.#{app_identifier}"
-          end
-
           mapping[app_identifier] = ENV[env_variable_name]
         end
 

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -144,7 +144,10 @@ module Gym
     # Is it an iOS device or a Mac?
     def self.detect_platform
       return if Gym.config[:destination]
-      platform = if Gym.project.mac? || Gym.building_mac_catalyst_for_mac?
+
+      platform = if Gym.building_mac_catalyst_for_ios?
+                   "iOS"
+                 elsif Gym.project.mac? || Gym.building_mac_catalyst_for_mac?
                    min_xcode8? ? "macOS" : "OS X"
                  elsif Gym.project.tvos?
                    "tvOS"

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -145,12 +145,12 @@ module Gym
     def self.detect_platform
       return if Gym.config[:destination]
 
-      platform = if Gym.building_mac_catalyst_for_ios?
-                   "iOS"
-                 elsif Gym.project.mac? || Gym.building_mac_catalyst_for_mac?
-                   min_xcode8? ? "macOS" : "OS X"
-                 elsif Gym.project.tvos?
+      platform = if Gym.project.tvos?
                    "tvOS"
+                 elsif Gym.building_for_ios?
+                   "iOS"
+                 elsif Gym.building_for_mac?
+                   min_xcode8? ? "macOS" : "OS X"
                  else
                    "iOS"
                  end

--- a/gym/lib/gym/module.rb
+++ b/gym/lib/gym/module.rb
@@ -25,6 +25,22 @@ module Gym
       require 'gym/xcodebuild_fixes/generic_archive_fix'
     end
 
+    def building_for_ios?
+      if !Gym.project.mac?
+        return Gym.project.ios? || Gym.project.tvos? || Gym.project.watchos?
+      else
+        return building_mac_catalyst_for_ios?
+      end
+    end
+
+    def building_for_mac?
+      if Gym.project.supports_mac_catalyst?
+        return building_mac_catalyst_for_mac?
+      else
+        return Gym.project.mac?
+      end
+    end
+
     def building_mac_catalyst_for_ios?
       Gym.project.supports_mac_catalyst? && Gym.config[:catalyst_platform] == "ios"
     end

--- a/gym/lib/gym/module.rb
+++ b/gym/lib/gym/module.rb
@@ -27,6 +27,7 @@ module Gym
 
     def building_for_ios?
       if !Gym.project.mac?
+        return false if building_mac_catalyst_for_mac?
         return Gym.project.ios? || Gym.project.tvos? || Gym.project.watchos?
       else
         return building_mac_catalyst_for_ios?

--- a/gym/lib/gym/module.rb
+++ b/gym/lib/gym/module.rb
@@ -33,7 +33,7 @@ module Gym
         # Can be iOS project and build for mac if catalyst
         return false if building_mac_catalyst_for_mac?
 
-        # Can be iOs project if iOS, tvOS, or watchOS
+        # Can be iOS project if iOS, tvOS, or watchOS
         return Gym.project.ios? || Gym.project.tvos? || Gym.project.watchos?
       end
     end

--- a/gym/lib/gym/module.rb
+++ b/gym/lib/gym/module.rb
@@ -26,16 +26,21 @@ module Gym
     end
 
     def building_for_ios?
-      if !Gym.project.mac?
-        return false if building_mac_catalyst_for_mac?
-        return Gym.project.ios? || Gym.project.tvos? || Gym.project.watchos?
-      else
+      if Gym.project.mac?
+        # Can be building for iOS if mac project and catalyst
         return building_mac_catalyst_for_ios?
+      else
+        # Can be iOS project and build for mac if catalyst
+        return false if building_mac_catalyst_for_mac?
+
+        # Can be iOs project if iOS, tvOS, or watchOS
+        return Gym.project.ios? || Gym.project.tvos? || Gym.project.watchos?
       end
     end
 
     def building_for_mac?
       if Gym.project.supports_mac_catalyst?
+        # Can be a mac project and not build mac if catalyst
         return building_mac_catalyst_for_mac?
       else
         return Gym.project.mac?

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -13,7 +13,6 @@ require_relative 'error_handler'
 module Gym
   class Runner
     # @return (String) The path to the resulting ipa
-    # rubocop:disable Metrics/PerceivedComplexity
     def run
       unless Gym.config[:skip_build_archive]
         build_app

--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -14,7 +14,13 @@ module Match
         specific_cert_type = cert_type.to_s
       end
 
+      platform = params[:platform]
+      if platform.to_s == :catalyst.to_s
+        platform = :macos.to_s
+      end
+
       arguments = FastlaneCore::Configuration.create(Cert::Options.available_options, {
+        platform: platform,
         development: params[:type] == "development",
         type: specific_cert_type,
         generate_apple_certs: params[:generate_apple_certs],

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -243,6 +243,11 @@ module Match
                                        pt = %w(tvos ios macos catalyst)
                                        UI.user_error!("Unsupported platform, must be: #{pt}") unless pt.include?(value)
                                      end),
+        FastlaneCore::ConfigItem.new(key: :derive_catalyst_app_identifier,
+                                     env_name: "MATCH_DERIVE_CATALYST_APP_IDENTIFIER",
+                                     description: "Enable this if you have the Mac Catalyst capability enabled. Prepends 'maccatalyst.' to the app identifier for the provisioning profile mapping",
+                                     type: Boolean,
+                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :template_name,
                                      env_name: "MATCH_PROVISIONING_PROFILE_TEMPLATE_NAME",
                                      description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. \"Apple Pay Pass Suppression Development\")",

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -235,12 +235,12 @@ module Match
         FastlaneCore::ConfigItem.new(key: :platform,
                                      short_option: '-o',
                                      env_name: "MATCH_PLATFORM",
-                                     description: "Set the provisioning profile's platform to work with (i.e. ios, tvos, macos)",
+                                     description: "Set the provisioning profile's platform to work with (i.e. ios, tvos, macos, catalyst)",
                                      default_value: default_platform,
                                      default_value_dynamic: true,
                                      verify_block: proc do |value|
                                        value = value.to_s
-                                       pt = %w(tvos ios macos)
+                                       pt = %w(tvos ios macos catalyst)
                                        UI.user_error!("Unsupported platform, must be: #{pt}") unless pt.include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :template_name,

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -245,7 +245,7 @@ module Match
                                      end),
         FastlaneCore::ConfigItem.new(key: :derive_catalyst_app_identifier,
                                      env_name: "MATCH_DERIVE_CATALYST_APP_IDENTIFIER",
-                                     description: "Enable this if you have the Mac Catalyst capability enabled. Prepends 'maccatalyst.' to the app identifier for the provisioning profile mapping",
+                                     description: "Enable this if you have the Mac Catalyst capability enabled and your project was created with Xcode 11.3 or earlier. Prepends 'maccatalyst.' to the app identifier for the provisioning profile mapping",
                                      type: Boolean,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :template_name,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -219,7 +219,11 @@ module Match
       profile_name = names.join("_").gsub("*", '\*') # this is important, as it shouldn't be a wildcard
       base_dir = File.join(prefixed_working_directory, "profiles", prov_type.to_s)
 
-      extension = params[:platform].to_s == :macos.to_s ? ".provisionprofile" : ".mobileprovision"
+      extension = ".mobileprovision"
+      if [:macos.to_s, :catalyst.to_s].include?(params[:platform].to_s)
+        extension = ".provisionprofile"
+      end
+
       profiles = Dir[File.join(base_dir, "#{profile_name}#{extension}")]
       if Helper.mac?
         keychain_path = FastlaneCore::Helper.keychain_path(params[:keychain_name]) unless params[:keychain_name].nil?
@@ -320,7 +324,7 @@ module Match
             Spaceship.device.all_ios_profile_devices.count
           when :tvos
             Spaceship.device.all_apple_tvs.count
-          when :mac
+          when :mac, :catalyst
             Spaceship.device.all_macs.count
           else
             Spaceship.device.all.count

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -212,7 +212,7 @@ module Match
       prov_type = Match.profile_type_sym(params[:type])
 
       names = [Match::Generator.profile_type_name(prov_type), app_identifier]
-      if params[:platform].to_s == :tvos.to_s
+      if params[:platform].to_s == :tvos.to_s || params[:platform].to_s == :catalyst.to_s
         names.push(params[:platform])
       end
 
@@ -228,6 +228,9 @@ module Match
       if Helper.mac?
         keychain_path = FastlaneCore::Helper.keychain_path(params[:keychain_name]) unless params[:keychain_name].nil?
       end
+
+      require 'pp'
+      pp(profiles)
 
       # Install the provisioning profiles
       profile = profiles.last

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -207,6 +207,7 @@ module Match
       return File.basename(cert_path).gsub(".cer", "") # Certificate ID
     end
 
+    # rubocop:disable Metrics/PerceivedComplexity
     # @return [String] The UUID of the provisioning profile so we can verify it with the Apple Developer Portal
     def fetch_provisioning_profile(params: nil, certificate_id: nil, app_identifier: nil, working_directory: nil)
       prov_type = Match.profile_type_sym(params[:type])
@@ -224,13 +225,11 @@ module Match
         extension = ".provisionprofile"
       end
 
-      profiles = Dir[File.join(base_dir, "#{profile_name}#{extension}")]
+      profile_file = "#{profile_name}#{extension}"
+      profiles = Dir[File.join(base_dir, profile_file)]
       if Helper.mac?
         keychain_path = FastlaneCore::Helper.keychain_path(params[:keychain_name]) unless params[:keychain_name].nil?
       end
-
-      require 'pp'
-      pp(profiles)
 
       # Install the provisioning profiles
       profile = profiles.last
@@ -249,7 +248,7 @@ module Match
 
       if profile.nil? || force
         if params[:readonly]
-          UI.error("No matching provisioning profiles found for '#{profile_name}'")
+          UI.error("No matching provisioning profiles found for '#{profile_file}'")
           UI.error("A new one cannot be created because you enabled `readonly`")
           if Dir.exist?(base_dir) # folder for `prov_type` does not exist on first match use for that type
             all_profiles = Dir.entries(base_dir).reject { |f| f.start_with?(".") }
@@ -310,6 +309,7 @@ module Match
 
       return uuid
     end
+    # rubocop:enable Metrics/PerceivedComplexity
 
     def device_count_different?(profile: nil, keychain_path: nil, platform: nil)
       return false unless profile

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -46,6 +46,10 @@ module Match
     end
 
     def certificates_exists(username: nil, certificate_ids: [], platform: nil)
+      if platform == :catalyst.to_s
+        platform = :macos.to_s
+      end
+
       Spaceship.certificate.all(mac: platform == "macos").each do |cert|
         certificate_ids.delete(cert.id)
       end
@@ -61,16 +65,12 @@ module Match
     end
 
     def profile_exists(username: nil, uuid: nil, platform: nil)
-      is_mac = platform == "macos"
-      found = Spaceship.provisioning_profile.all(mac: is_mac).find do |profile|
-        profile.uuid == uuid
-      end
+      puts("LOOKING FOR UUID: #{uuid}")
 
-      # Look for iOS after looking for macOS (needed for Catalyst apps)
-      if !found && is_mac
-        found = Spaceship.provisioning_profile.all(mac: false).find do |profile|
-          profile.uuid == uuid
-        end
+      require 'pp'
+      found = Spaceship::ConnectAPI::Profile.all.find do |profile|
+        pp(profile)
+        profile.uuid == uuid
       end
 
       unless found

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -65,11 +65,7 @@ module Match
     end
 
     def profile_exists(username: nil, uuid: nil, platform: nil)
-      puts("LOOKING FOR UUID: #{uuid}")
-
-      require 'pp'
       found = Spaceship::ConnectAPI::Profile.all.find do |profile|
-        pp(profile)
         profile.uuid == uuid
       end
 

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -65,6 +65,8 @@ module Match
     end
 
     def profile_exists(username: nil, uuid: nil, platform: nil)
+      # App Store Connect API does not allow filter of profile by platform or uuid (as of 2020-07-30)
+      # Need to fetch all profiles and search for uuid on client side
       found = Spaceship::ConnectAPI::Profile.all.find do |profile|
         profile.uuid == uuid
       end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -208,6 +208,7 @@ describe "Build Manager" do
         allow(mock_base_client).to receive(:team_id).and_return('')
 
         allow(Spaceship::ConnectAPI).to receive(:post_beta_app_review_submissions) # pretend it worked.
+        allow(Spaceship::ConnectAPI::TestFlight).to receive(:instance).and_return(mock_base_client)
 
         # Allow build to return app, buidl_beta_detail, and pre_release_version
         # These are models that are expected to usually be included in the build passed into distribute

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -208,7 +208,6 @@ describe "Build Manager" do
         allow(mock_base_client).to receive(:team_id).and_return('')
 
         allow(Spaceship::ConnectAPI).to receive(:post_beta_app_review_submissions) # pretend it worked.
-        allow(Spaceship::ConnectAPI::TestFlight).to receive(:instance).and_return(mock_base_client)
 
         # Allow build to return app, buidl_beta_detail, and pre_release_version
         # These are models that are expected to usually be included in the build passed into distribute

--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -1,5 +1,7 @@
 require 'spaceship'
 
+require 'base64'
+
 require_relative 'manager'
 require_relative 'module'
 
@@ -12,35 +14,39 @@ module Sigh
       Spaceship.select_team
       UI.message("Successfully logged in")
 
+      if download_xcode_profiles
+        UI.deprecated("The App Store Connect API does not support querying for Xcode managed profiles: --download_code_profiles is deprecated")
+      end
+
       case Sigh.config[:platform].to_s
       when 'ios'
-        download_profiles(Spaceship.provisioning_profile.all(xcode: download_xcode_profiles))
-        xcode_profiles_downloaded?(xcode: download_xcode_profiles, supported: true)
+        profile_types = [
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE,
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE,
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC,
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT
+        ]
       when 'macos'
-        download_profiles(Spaceship.provisioning_profile.all(mac: true, xcode: download_xcode_profiles))
-        xcode_profiles_downloaded?(xcode: download_xcode_profiles, supported: true)
+        profile_types = [
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE,
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT
+        ]
+      when 'catalyst'
+        profile_types = [
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE,
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
+        ]
       when 'tvos'
-        download_profiles(Spaceship.provisioning_profile.all_tvos)
-        xcode_profiles_downloaded?(xcode: download_xcode_profiles, supported: false)
+        profile_types = [
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE,
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE,
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC,
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT
+        ]
       end
-    end
 
-    # @param xcode [Bool] Whether or not the user passed the download_xcode_profiles flag
-    # @param supported [Bool] Whether or not this platform supports downloading xcode profiles at all
-    def xcode_profiles_downloaded?(xcode: false, supported: false)
-      if supported
-        if xcode
-          UI.message("This run also included all Xcode managed provisioning profiles, as you used the `--download_xcode_profiles` flag")
-        elsif !xcode
-          UI.message("All Xcode managed provisioning profiles were ignored on this, to include them use the `--download_xcode_profiles` flag")
-        end
-
-      elsif !supported
-        if xcode
-          UI.important("Downloading Xcode managed profiles is not supported for platform #{Sigh.config[:platform]}")
-          return
-        end
-      end
+      profiles = Spaceship::ConnectAPI::Profile.all(filter: {profileType: profile_types.join(",")}, includes: "bundleId")
+      download_profiles(profiles)
     end
 
     # @param profiles [Array] Array of all the provisioning profiles we want to download
@@ -57,18 +63,49 @@ module Sigh
       end
     end
 
+    def pretty_type(profile_type)
+      case profile_type
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT
+        "Development"
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE
+        "AppStore"
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC
+        "AdHoc"
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE
+        "InHouse"
+      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT
+        "Development"
+      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE
+        "AppStore"
+      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT
+        "Direct"
+      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT
+        "Development"
+      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE
+        "AppStore"
+      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC
+        "AdHoc"
+      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE
+        "InHouse"
+      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
+        "Development"
+      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
+        "AppStore"
+      end
+    end
+
     # @param profile [ProvisioningProfile] A profile we plan to download and store
     def download_profile(profile)
       FileUtils.mkdir_p(Sigh.config[:output_path])
 
-      type_name = profile.class.pretty_type
-      profile_name = "#{type_name}_#{profile.uuid}_#{profile.app.bundle_id}"
+      type_name = pretty_type(profile.profile_type)
+      profile_name = "#{type_name}_#{profile.uuid}_#{profile.bundle_id.identifier}"
 
       if Sigh.config[:platform].to_s == 'tvos'
         profile_name += "_tvos"
       end
 
-      if Sigh.config[:platform].to_s == 'macos'
+      if ['macos', 'catalyst'].include?(Sigh.config[:platform].to_s)
         profile_name += '.provisionprofile'
       else
         profile_name += '.mobileprovision'
@@ -76,7 +113,8 @@ module Sigh
 
       output_path = File.join(Sigh.config[:output_path], profile_name)
       File.open(output_path, "wb") do |f|
-        f.write(profile.download)
+        content = Base64.decode64(profile.profile_content)
+        f.write(content)
       end
 
       Manager.install_profile(output_path) unless Sigh.config[:skip_install]

--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -45,7 +45,7 @@ module Sigh
         ]
       end
 
-      profiles = Spaceship::ConnectAPI::Profile.all(filter: {profileType: profile_types.join(",")}, includes: "bundleId")
+      profiles = Spaceship::ConnectAPI::Profile.all(filter: { profileType: profile_types.join(",") }, includes: "bundleId")
       download_profiles(profiles)
     end
 

--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -68,36 +68,7 @@ module Sigh
     end
 
     def pretty_type(profile_type)
-      case profile_type
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT
-        "Development"
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE
-        "AppStore"
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC
-        "AdHoc"
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE
-        "InHouse"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT
-        "Development"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE
-        "AppStore"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT
-        "Direct"
-      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT
-        "Development"
-      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE
-        "AppStore"
-      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC
-        "AdHoc"
-      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE
-        "InHouse"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
-        "Development"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
-        "AppStore"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
-        "Direct"
-      end
+      return Sigh.profile_pretty_type(profile_type)
     end
 
     # @param profile [ProvisioningProfile] A profile we plan to download and store

--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -95,6 +95,8 @@ module Sigh
         "Development"
       when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
         "AppStore"
+      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
+        "Direct"
       end
     end
 

--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -29,12 +29,14 @@ module Sigh
       when 'macos'
         profile_types = [
           Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE,
-          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT,
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT
         ]
       when 'catalyst'
         profile_types = [
           Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE,
-          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT,
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
         ]
       when 'tvos'
         profile_types = [

--- a/sigh/lib/sigh/download_all.rb
+++ b/sigh/lib/sigh/download_all.rb
@@ -47,6 +47,8 @@ module Sigh
         ]
       end
 
+      # Filtering on 'profileType' seems to be undocumented as of 2020-07-30
+      # but works on both web session and official API
       profiles = Spaceship::ConnectAPI::Profile.all(filter: { profileType: profile_types.join(",") }, includes: "bundleId")
       download_profiles(profiles)
     end

--- a/sigh/lib/sigh/module.rb
+++ b/sigh/lib/sigh/module.rb
@@ -5,6 +5,32 @@ module Sigh
   # Use this to just setup the configuration attribute and set it later somewhere else
   class << self
     attr_accessor :config
+
+    def profile_pretty_type(profile_type)
+      require 'spaceship'
+
+      case profile_type
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT,
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
+        "Development"
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE,
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
+        "AppStore"
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC,
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC
+        "AdHoc"
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE,
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE
+        "InHouse"
+      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
+        "Direct"
+      end
+    end
   end
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -131,12 +131,12 @@ module Sigh
         FastlaneCore::ConfigItem.new(key: :platform,
                                      short_option: '-p',
                                      env_name: "SIGH_PLATFORM",
-                                     description: "Set the provisioning profile's platform (i.e. ios, tvos, macos)",
+                                     description: "Set the provisioning profile's platform (i.e. ios, tvos, macos, catalyst)",
                                      is_string: false,
                                      default_value: "ios",
                                      verify_block: proc do |value|
                                        value = value.to_s
-                                       pt = %w(macos tvos ios)
+                                       pt = %w(macos tvos ios catalyst)
                                        UI.user_error!("Unsupported platform, must be: #{pt}") unless pt.include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :readonly,

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -131,7 +131,7 @@ module Sigh
         FastlaneCore::ConfigItem.new(key: :platform,
                                      short_option: '-p',
                                      env_name: "SIGH_PLATFORM",
-                                     description: "Set the provisioning profile's platform (i.e. ios, tvos)",
+                                     description: "Set the provisioning profile's platform (i.e. ios, tvos, macos)",
                                      is_string: false,
                                      default_value: "ios",
                                      verify_block: proc do |value|

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -214,10 +214,10 @@ module Sigh
     def certificates_for_profile_and_platform
       case Sigh.config[:platform].to_s
       when 'ios', 'tvos'
-        if profile_type == Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT 
+        if profile_type == Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT
           certificates = Spaceship.certificate.development.all +
                          Spaceship.certificate.apple_development.all
-        elsif profile_type == Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE 
+        elsif profile_type == Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE
           # Enterprise accounts don't have access to Apple Distribution certificates
           certificates = Spaceship.certificate.in_house.all
         # handles case where the desired certificate type is adhoc but the account is an enterprise account
@@ -233,7 +233,7 @@ module Sigh
         end
 
       when 'macos', 'catalyst'
-        if profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT 
+        if profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
           certificates = Spaceship.certificate.mac_development.all +
                          Spaceship.certificate.apple_development.all
         elsif profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -85,7 +85,7 @@ module Sigh
     def fetch_profiles
       UI.message("Fetching profiles...")
 
-      results = Spaceship::ConnectAPI::Profile.all(filter: {profileType: profile_type}, includes: "bundleId,certificates").select do |profile|
+      results = Spaceship::ConnectAPI::Profile.all(filter: { profileType: profile_type }, includes: "bundleId,certificates").select do |profile|
         profile.bundle_id.identifier == Sigh.config[:app_identifier]
       end
 
@@ -173,7 +173,6 @@ module Sigh
 
     # Create a new profile and return it
     def create_profile!
-      cert = certificate_to_use
       app_identifier = Sigh.config[:app_identifier]
       name = Sigh.config[:provisioning_name] || [app_identifier, profile_type_pretty_type].join(' ')
 
@@ -334,7 +333,7 @@ module Sigh
     # Makes sure the current App ID exists. If not, it will show an appropriate error message
     def ensure_app_exists!
       if Sigh.config[:platform].to_s == 'macos'
-        platform = Spaceship::ConnectAPI::Platform::MACOS
+        platform = Spaceship::ConnectAPI::Platform::MAC_OS
       else
         platform = Spaceship::ConnectAPI::Platform::IOS
       end

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -214,16 +214,16 @@ module Sigh
     def certificates_for_profile_and_platform
       case Sigh.config[:platform].to_s
       when 'ios', 'tvos'
-        if profile_type == Spaceship.provisioning_profile.Development
+        if profile_type == Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT 
           certificates = Spaceship.certificate.development.all +
                          Spaceship.certificate.apple_development.all
-        elsif profile_type == Spaceship.provisioning_profile.InHouse
+        elsif profile_type == Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE 
           # Enterprise accounts don't have access to Apple Distribution certificates
           certificates = Spaceship.certificate.in_house.all
         # handles case where the desired certificate type is adhoc but the account is an enterprise account
         # the apple dev portal api has a weird quirk in it where if you query for distribution certificates
         # for enterprise accounts, you get nothing back even if they exist.
-        elsif profile_type == Spaceship.provisioning_profile.AdHoc && Spaceship.client && Spaceship.client.in_house?
+        elsif (profile_type == Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC) && Spaceship.client && Spaceship.client.in_house?
           # Enterprise accounts don't have access to Apple Distribution certificates
           certificates = Spaceship.certificate.in_house.all
         else
@@ -233,13 +233,13 @@ module Sigh
         end
 
       when 'macos', 'catalyst'
-        if profile_type == Spaceship.provisioning_profile.Development
+        if profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT 
           certificates = Spaceship.certificate.mac_development.all +
                          Spaceship.certificate.apple_development.all
-        elsif profile_type == Spaceship.provisioning_profile.AppStore
+        elsif profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
           certificates = Spaceship.certificate.mac_app_distribution.all +
                          Spaceship.certificate.apple_distribution.all
-        elsif profile_type == Spaceship.provisioning_profile.Direct
+        elsif profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT
           certificates = Spaceship.certificate.developer_id_application.all
         else
           certificates = Spaceship.certificate.mac_app_distribution.all +

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -165,9 +165,9 @@ module Sigh
       when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE
         "InHouse"
       when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
-        "Development Catalyst"
+        "Development"
       when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
-        "AppStore Catalyst"
+        "AppStore"
       end
     end
 
@@ -311,9 +311,11 @@ module Sigh
 
       if Sigh.config[:platform].to_s == 'tvos'
         profile_name += "_tvos"
+      elsif Sigh.config[:platform].to_s == 'catalyst'
+        profile_name += "_catalyst"
       end
 
-      if Sigh.config[:platform].to_s == 'macos'
+      if ['macos', 'catalyst'].include?(Sigh.config[:platform].to_s)
         profile_name += '.provisionprofile'
       else
         profile_name += '.mobileprovision'

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -136,8 +136,6 @@ module Sigh
           end
         end
 
-        STDERR.puts("UGH - #{installed}")
-
         # Don't need to check if certificate is valid because it comes with the
         # profile in the response
         installed

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -44,7 +44,7 @@ module Sigh
 
       UI.user_error!("Something went wrong fetching the latest profile") unless profile
 
-      if profile_type == Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE
+      if [Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE, Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE].include?(profile_type)
         ENV["SIGH_PROFILE_ENTERPRISE"] = "1"
       else
         ENV.delete("SIGH_PROFILE_ENTERPRISE")
@@ -71,12 +71,12 @@ module Sigh
       when "macos"
         @profile_type = Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE
         @profile_type = Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT if Sigh.config[:development]
+        @profile_type = Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT if Sigh.config[:developer_id]
       when "catalyst"
         @profile_type = Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
         @profile_type = Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT if Sigh.config[:development]
+        @profile_type = Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT if Sigh.config[:developer_id]
       end
-
-      @profile_type = Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT if Sigh.config[:developer_id]
 
       @profile_type
     end
@@ -168,6 +168,8 @@ module Sigh
         "Development"
       when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
         "AppStore"
+      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
+        "Direct"
       end
     end
 

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -174,7 +174,6 @@ module Sigh
       name = Sigh.config[:provisioning_name] || [app_identifier, profile_type_pretty_type].join(' ')
 
       unless Sigh.config[:skip_fetch_profiles]
-        # TODO: need to fix this
         profile = Spaceship::ConnectAPI::Profile.all.find { |p| p.name == name }
         if profile
           UI.user_error!("The name '#{name}' is already taken, and fail_on_name_taken is true") if Sigh.config[:fail_on_name_taken]

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -144,33 +144,24 @@ module Sigh
 
     def profile_type_pretty_type
       case profile_type
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT,
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
         "Development"
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE,
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
         "AppStore"
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC,
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC
         "AdHoc"
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE
+      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE,
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE
         "InHouse"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT
-        "Development"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE
-        "AppStore"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT
-        "Direct"
-      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT
-        "Development"
-      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE
-        "AppStore"
-      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC
-        "AdHoc"
-      when Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE
-        "InHouse"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
-        "Development"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
-        "AppStore"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
+      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT,
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
         "Direct"
       end
     end
@@ -181,7 +172,9 @@ module Sigh
       name = Sigh.config[:provisioning_name] || [app_identifier, profile_type_pretty_type].join(' ')
 
       unless Sigh.config[:skip_fetch_profiles]
-        if Spaceship.provisioning_profile.all(mac: Sigh.config[:platform].to_s == 'macos').find { |p| p.name == name }
+        # TODO: need to fix this
+        profile = Spaceship::ConnectAPI::Profile.all.find { |p| p.name == name }
+        if profile
           UI.user_error!("The name '#{name}' is already taken, and fail_on_name_taken is true") if Sigh.config[:fail_on_name_taken]
           UI.error("The name '#{name}' is already taken, using another one.")
           name += " #{Time.now.to_i}"

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -136,6 +136,8 @@ module Sigh
           end
         end
 
+        STDERR.puts("UGH - #{installed}")
+
         # Don't need to check if certificate is valid because it comes with the
         # profile in the response
         installed

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -143,27 +143,7 @@ module Sigh
     end
 
     def profile_type_pretty_type
-      case profile_type
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT,
-        Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT,
-        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT,
-        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
-        "Development"
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE,
-        Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE,
-        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE,
-        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
-        "AppStore"
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC,
-        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC
-        "AdHoc"
-      when Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE,
-        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE
-        "InHouse"
-      when Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT,
-        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
-        "Direct"
-      end
+      return Sigh.profile_pretty_type(profile_type)
     end
 
     # Create a new profile and return it

--- a/sigh/spec/manager_spec.rb
+++ b/sigh/spec/manager_spec.rb
@@ -5,6 +5,15 @@ describe Sigh do
       ENV["DELIVER_PASSWORD"] = "123"
     end
 
+    let(:mock_base_client) { "fake api base client" }
+
+    before(:each) do
+      allow(mock_base_client).to receive(:login)
+      allow(mock_base_client).to receive(:team_id).and_return('')
+
+      allow(Spaceship::ConnectAPI::Provisioning::Client).to receive(:instance).and_return(mock_base_client)
+    end
+
     it "Successful run" do
       sigh_stub_spaceship
       options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true }

--- a/sigh/spec/manager_spec.rb
+++ b/sigh/spec/manager_spec.rb
@@ -15,7 +15,8 @@ describe Sigh do
     end
 
     it "Successful run" do
-      sigh_stub_spaceship
+      sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: "com.krausefx.app", all_app_identifiers: ["com.krausefx.app"])
+
       options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true }
       Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
 
@@ -25,7 +26,8 @@ describe Sigh do
     end
 
     it "Invalid profile not force run" do
-      sigh_stub_spaceship(valid_profile = false, expect_create = true)
+      sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: "com.krausefx.app", all_app_identifiers: ["com.krausefx.app"], app_identifier_and_profile_names: { "com.krausefx.app" => ["No dupe here"] }, valid_profiles: false)
+
       options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true }
       Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
 
@@ -35,7 +37,8 @@ describe Sigh do
     end
 
     it "Invalid profile force run" do
-      sigh_stub_spaceship(valid_profile = false, expect_create = true, expect_delete = true)
+      sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: "com.krausefx.app", all_app_identifiers: ["com.krausefx.app"], app_identifier_and_profile_names: { "com.krausefx.app" => ["No dupe here"] }, valid_profiles: false, expect_delete: true)
+
       options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true, force: true }
       Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
 
@@ -45,7 +48,8 @@ describe Sigh do
     end
 
     it "Existing profile fail on name taken" do
-      sigh_stub_spaceship(valid_profile = true, expect_create = false, expect_delete = true, fail_delete = true)
+      sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: nil, all_app_identifiers: ["com.krausefx.app"], app_identifier_and_profile_names: { "com.krausefx.app" => ["com.krausefx.app AppStore"] })
+
       options = { app_identifier: "com.krausefx.app", skip_install: true, fail_on_name_taken: true, skip_certificate_verification: true, force: true }
       Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
 

--- a/sigh/spec/runner_spec.rb
+++ b/sigh/spec/runner_spec.rb
@@ -1,0 +1,177 @@
+describe Sigh do
+  describe Sigh::Runner do
+    before do
+      ENV["DELIVER_USER"] = "test@fastlane.tools"
+      ENV["DELIVER_PASSWORD"] = "123"
+    end
+
+    let(:fake_runner) { Sigh::Runner.new }
+    let(:mock_base_client) { "fake api base client" }
+
+    before(:each) do
+      allow(mock_base_client).to receive(:login)
+      allow(mock_base_client).to receive(:team_id).and_return('')
+
+      allow(Spaceship::ConnectAPI::Provisioning::Client).to receive(:instance).and_return(mock_base_client)
+    end
+
+    describe "#run" do
+    end
+
+    describe "#profile_type" do
+      profile_types = {
+        "ios" => {
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE => { in_house: false, options: { platform: "ios" } },
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE => { in_house: true, options: { platform: "ios" } },
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC => { in_house: false, options: { platform: "ios", adhoc: true } },
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT => { in_house: false, options: { platform: "ios", development: true } }
+        },
+        "tvos" => {
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE => { in_house: false, options: { platform: "tvos" } },
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE => { in_house: true, options: { platform: "tvos" } },
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC => { in_house: false, options: { platform: "tvos", adhoc: true } },
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT => { in_house: false, options: { platform: "tvos", development: true } }
+        },
+        "macos" => {
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE => { in_house: false, options: { platform: "macos" } },
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT => { in_house: false, options: { platform: "macos", development: true } },
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT => { in_house: false, options: { platform: "macos", developer_id: true } }
+        },
+        "catalyst" => {
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE => { in_house: false, options: { platform: "catalyst" } },
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT => { in_house: false, options: { platform: "catalyst", development: true } },
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT => { in_house: false, options: { platform: "catalyst", developer_id: true } }
+        }
+      }
+
+      # Iterates over platforms
+      profile_types.each do |platform, test|
+        context platform do
+          # Creates test for each profile type in platform
+          test.each do |type, test_options|
+            it type do
+              sigh_stub_spaceship_connect(inhouse: test_options[:in_house])
+
+              Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, test_options[:options])
+              expect(fake_runner.profile_type).to eq(type)
+            end
+          end
+        end
+      end
+    end
+
+    describe "#fetch_profiles" do
+    end
+
+    describe "#profile_type_pretty_type" do
+      profile_types = {
+        Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE => "AppStore",
+        Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE => "InHouse",
+        Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC => "AdHoc",
+        Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT => "Development",
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE => "AppStore",
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE => "InHouse",
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC => "AdHoc",
+        Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT => "Development",
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE => "AppStore",
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT => "Development",
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT => "Direct",
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE => "AppStore",
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT => "Development",
+        Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT => "Direct"
+      }
+
+      # Creates test for each profile type
+      profile_types.each do |type, pretty_type|
+        it "#{type} - #{pretty_type}" do
+          allow(fake_runner).to receive(:profile_type).and_return(type)
+          expect(fake_runner.profile_type_pretty_type).to eq(pretty_type)
+        end
+      end
+    end
+
+    describe "#create_profile!" do
+      context "successfully creates profile" do
+        it "skips fetching of profiles" do
+          sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: "com.krausefx.app", all_app_identifiers: ["com.krausefx.app"])
+
+          allow(Spaceship).to receive(:client).and_return(mock_base_client)
+          allow(mock_base_client).to receive(:in_house?).and_return(false)
+
+          options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true, skip_fetch_profiles: true }
+          Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+          profile = fake_runner.create_profile!
+
+          expect(profile.name).to eq("com.krausefx.app AppStore")
+          expect(profile.bundle_id.identifier).to eq("com.krausefx.app")
+        end
+
+        it "skips fetches profiles with no duplicate name" do
+          sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: "com.krausefx.app", all_app_identifiers: ["com.krausefx.app"], profile_names: ["No dupe here"])
+
+          allow(Spaceship).to receive(:client).and_return(mock_base_client)
+          allow(mock_base_client).to receive(:in_house?).and_return(false)
+
+          options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true, skip_fetch_profiles: true }
+          Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+          profile = fake_runner.create_profile!
+
+          expect(profile.name).to eq("com.krausefx.app AppStore")
+          expect(profile.bundle_id.identifier).to eq("com.krausefx.app")
+        end
+
+        it "fetches profiles with duplicate name and appends timestamp" do
+          sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: "com.krausefx.app", all_app_identifiers: ["com.krausefx.app"], profile_names: ["com.krausefx.app AppStore"])
+
+          expect(Time).to receive(:now).and_return("1234")
+
+          allow(Spaceship).to receive(:client).and_return(mock_base_client)
+          allow(mock_base_client).to receive(:in_house?).and_return(false)
+
+          options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true, skip_fetch_profiles: false }
+          Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+          profile = fake_runner.create_profile!
+
+          expect(profile.name).to eq("com.krausefx.app AppStore 1234")
+          expect(profile.bundle_id.identifier).to eq("com.krausefx.app")
+        end
+      end
+
+      context "raises error" do
+        it "when cannot find bundle id" do
+          sigh_stub_spaceship_connect(inhouse: false, all_app_identifiers: [])
+
+          allow(Spaceship).to receive(:client).and_return(mock_base_client)
+          allow(mock_base_client).to receive(:in_house?).and_return(false)
+
+          options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true, skip_fetch_profiles: true }
+          Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+          expect do
+            fake_runner.create_profile!
+          end.to raise_error("Could not find App with App Identifier 'com.krausefx.app'")
+        end
+
+        it "when name already taken" do
+          sigh_stub_spaceship_connect(inhouse: false, all_app_identifiers: ["com.krausefx.app"], profile_names: ["com.krausefx.app AppStore"])
+
+          allow(Spaceship).to receive(:client).and_return(mock_base_client)
+          allow(mock_base_client).to receive(:in_house?).and_return(false)
+
+          options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true, skip_fetch_profiles: false, fail_on_name_taken: true }
+          Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+          expect do
+            fake_runner.create_profile!
+          end.to raise_error("The name 'com.krausefx.app AppStore' is already taken, and fail_on_name_taken is true")
+        end
+      end
+    end
+
+    describe "#download_profile" do
+    end
+  end
+end

--- a/sigh/spec/spec_helper.rb
+++ b/sigh/spec/spec_helper.rb
@@ -1,3 +1,66 @@
+def sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: nil, all_app_identifiers: [], profile_names: [])
+  allow(Spaceship).to receive(:login).and_return(nil)
+  allow(Spaceship).to receive(:client).and_return("client")
+  allow(Spaceship).to receive(:select_team).and_return(nil)
+
+  allow(Spaceship.client).to receive(:in_house?).and_return(inhouse)
+
+  bundle_ids = all_app_identifiers.map do |id|
+    Spaceship::ConnectAPI::BundleId.new("123", {
+      identifier: id,
+      name: id,
+      seedId: "seed",
+      platform: "IOS"
+    })
+  end
+
+  allow(Spaceship::ConnectAPI::BundleId).to receive(:find).with(anything).and_return(nil)
+  bundle_ids.each do |bundle_id|
+    allow(Spaceship::ConnectAPI::BundleId).to receive(:find).with(bundle_id.identifier).and_return(bundle_id)
+  end
+
+  if create_profile_app_identifier
+    bundle_id = bundle_ids.find { |b| b.identifier == create_profile_app_identifier }
+    expect(Spaceship::ConnectAPI::Profile).to receive(:create).with(anything) do |value|
+      profile = Spaceship::ConnectAPI::Profile.new("123", {
+        name: value[:name],
+        platform: "IOS"
+      })
+      allow(profile).to receive(:bundle_id).and_return(bundle_id)
+
+      profile
+    end
+  end
+
+  allow(Spaceship::ConnectAPI::Profile).to receive(:all).and_return(
+    profile_names.map do |name|
+      profile = Spaceship::ConnectAPI::Profile.new("123", {
+        name: name,
+        platform: "IOS"
+      })
+      allow(profile).to receive(:bundle_id).and_return(bundle_id)
+
+      profile
+    end
+  )
+
+  # Stubs production to only receive certs
+  certificate = "certificate"
+  allow(certificate).to receive(:id).and_return("id")
+
+  certs = [Spaceship.certificate.production]
+  certs.each do |current|
+    allow(current).to receive(:all).and_return([certificate])
+  end
+
+  # apple_distribution also gets called for Xcode 11 profiles
+  # so need to stub and empty array return
+  certs = [Spaceship.certificate.apple_distribution]
+  certs.each do |current|
+    allow(current).to receive(:all).and_return([])
+  end
+end
+
 def sigh_stub_spaceship(valid_profile = true, expect_create = false, expect_delete = false, fail_delete = false)
   profile = "profile"
   certificate = "certificate"

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -164,6 +164,8 @@ module Spaceship
 
         raise UnexpectedResponse, "Temporary App Store Connect error: #{response.body}" if response.body['statusCode'] == 'ERROR'
 
+        store_csrf_tokens(response)
+
         return Spaceship::ConnectAPI::Response.new(body: response.body, status: response.status, client: self)
       end
 

--- a/spaceship/lib/spaceship/connect_api/model.rb
+++ b/spaceship/lib/spaceship/connect_api/model.rb
@@ -152,7 +152,7 @@ module Spaceship
               id == included_data["id"] && type == included_data["type"]
             end
 
-            inflate_model(relationship_data, included)
+            inflate_model(relationship_data, included) if relationship_data
           end
 
           # Map a hash or an array of data

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -20,11 +20,6 @@ module Spaceship
         "bundleIdCapabilities" => 'bundle_id_capabilities'
       })
 
-      module Platform
-        IOS = "IOS"
-        MAC_OS = "MAC_OS"
-      end
-
       def self.type
         return "bundleIds"
       end
@@ -38,8 +33,8 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.find(identifier)
-        return all(filter: { identifier: identifier }).find do |app|
+      def self.find(identifier, platform: nil)
+        return all(filter: { identifier: identifier, platform: platform }).find do |app|
           app.identifier == identifier
         end
       end

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -38,6 +38,12 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
+      def self.find(identifier)
+        return all(filter: { identifier: identifier }).find do |app|
+          app.identifier == identifier
+        end
+      end
+
       def self.get(bundle_id_id: nil, includes: nil)
         return Spaceship::ConnectAPI.get_bundle_id(bundle_id_id: bundle_id_id, includes: includes).first
       end

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -1,4 +1,5 @@
 require_relative '../model'
+require_relative './bundle_id_capability'
 module Spaceship
   class ConnectAPI
     class BundleId
@@ -25,6 +26,16 @@ module Spaceship
       end
 
       #
+      # Helpers
+      #
+
+      def supports_catalyst?
+        return bundle_id_capabilities.any? do |capability|
+          capability.is_type?(Spaceship::ConnectAPI::BundleIdCapability::Type::MARZIPAN)
+        end
+      end
+
+      #
       # API
       #
 
@@ -33,8 +44,8 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.find(identifier, platform: nil)
-        return all(filter: { identifier: identifier, platform: platform }).find do |app|
+      def self.find(identifier, platform: nil, includes: nil)
+        return all(filter: { identifier: identifier, platform: platform }, includes: includes).find do |app|
           app.identifier == identifier
         end
       end

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -45,7 +45,7 @@ module Spaceship
       end
 
       def self.find(identifier, includes: nil)
-        return all(filter: { identifier: identifier}, includes: includes).find do |app|
+        return all(filter: { identifier: identifier }, includes: includes).find do |app|
           app.identifier == identifier
         end
       end

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -44,8 +44,8 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.find(identifier, platform: nil, includes: nil)
-        return all(filter: { identifier: identifier, platform: platform }, includes: includes).find do |app|
+      def self.find(identifier, includes: nil)
+        return all(filter: { identifier: identifier}, includes: includes).find do |app|
           app.identifier == identifier
         end
       end

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id_capability.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id_capability.rb
@@ -4,21 +4,55 @@ module Spaceship
     class BundleIdCapability
       include Spaceship::ConnectAPI::Model
 
-      attr_accessor :capabilityType
-      attr_accessor :bundleIdCapabilitiesSettingOption
+      attr_accessor :capability_type
+      attr_accessor :settings
 
       attr_mapping({
-        "capabilityType" => "capabilityType",
-        "settings" => "email"
+        "capabilityType" => "capability_type",
+        "settings" => "settings"
       })
 
-      module Platform
-        IOS = "IOS"
-        MAC_OS = "MAC_OS"
+      module Type
+        ICLOUD = "ICLOUD"
+        IN_APP_PURCHASE = "IN_APP_PURCHASE"
+        GAME_CENTER = "GAME_CENTER"
+        PUSH_NOTIFICATIONS = "PUSH_NOTIFICATIONS"
+        WALLET = "WALLET"
+        INTER_APP_AUDIO = "INTER_APP_AUDIO"
+        MAPS = "MAPS"
+        ASSOCIATED_DOMAINS = "ASSOCIATED_DOMAINS"
+        PERSONAL_VPN = "PERSONAL_VPN"
+        APP_GROUPS = "APP_GROUPS"
+        HEALTHKIT = "HEALTHKIT"
+        HOMEKIT = "HOMEKIT"
+        WIRELESS_ACCESSORY_CONFIGURATION = "WIRELESS_ACCESSORY_CONFIGURATION"
+        APPLE_PAY = "APPLE_PAY"
+        DATA_PROTECTION = "DATA_PROTECTION"
+        SIRIKIT = "SIRIKIT"
+        NETWORK_EXTENSIONS = "NETWORK_EXTENSIONS"
+        MULTIPATH = "MULTIPATH"
+        HOT_SPOT = "HOT_SPOT"
+        NFC_TAG_READING = "NFC_TAG_READING"
+        CLASSKIT = "CLASSKIT"
+        AUTOFILL_CREDENTIAL_PROVIDER = "AUTOFILL_CREDENTIAL_PROVIDER"
+        ACCESS_WIFI_INFORMATION = "ACCESS_WIFI_INFORMATION"
+
+        # Undocumented as of 2020-06-09
+        MARZIPAN = "MARZIPAN" # Catalyst
       end
 
       def self.type
         return "bundleIdCapabilities"
+      end
+
+      #
+      # Helpers
+      #
+
+      def is_type?(type)
+        # JWT session returns type under "capability_type" attribute
+        # Web session returns type under "id" attribute but with "P7GJR49W72_" prefixed
+        return capability_type == type || id.end_with?(type)
       end
 
       #

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -13,6 +13,8 @@ module Spaceship
       attr_accessor :profile_type
       attr_accessor :expiration_date
 
+      attr_accessor :bundle_id
+
       attr_mapping({
         "name" => "name",
         "platform" => "platform",
@@ -21,7 +23,9 @@ module Spaceship
         "createdDate" => "created_date",
         "profileState" => "profile_state",
         "profileType" => "profile_type",
-        "expirationDate" => "expiration_date"
+        "expirationDate" => "expiration_date",
+
+        "bundleId" => "bundle_id"
       })
 
       module ProfileState

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -41,6 +41,12 @@ module Spaceship
         TVOS_APP_STORE = "TVOS_APP_STORE"
         TVOS_APP_ADHOC = "TVOS_APP_ADHOC"
         TVOS_APP_INHOUSE = "TVOS_APP_INHOUSE"
+
+        # Not support by official App Store Connect API
+        # Only works with Developer Portal (web session) implementation
+        # Last checked: 2020-03-09
+        MAC_CATALYST_APP_DEVELOPMENT = "MAC_CATALYST_APP_DEVELOPMENT"
+        MAC_CATALYST_APP_STORE = "MAC_CATALYST_APP_STORE"
       end
 
       def self.type
@@ -54,6 +60,18 @@ module Spaceship
       def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
         resps = Spaceship::ConnectAPI.get_profiles(filter: filter, includes: includes).all_pages
         return resps.flat_map(&:to_models)
+      end
+
+      def self.create(name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil)
+        return Spaceship::ConnectAPI.post_profiles(
+          bundle_id_id: bundle_id_id,
+          certificates: certificate_ids,
+          devices: device_ids,
+          attributes: {
+            name: name,
+            profileType: profile_type
+          }
+        )
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -14,6 +14,7 @@ module Spaceship
       attr_accessor :expiration_date
 
       attr_accessor :bundle_id
+      attr_accessor :certificates
 
       attr_mapping({
         "name" => "name",
@@ -25,7 +26,8 @@ module Spaceship
         "profileType" => "profile_type",
         "expirationDate" => "expiration_date",
 
-        "bundleId" => "bundle_id"
+        "bundleId" => "bundle_id",
+        "certificates" => "certificates"
       })
 
       module ProfileState
@@ -57,6 +59,10 @@ module Spaceship
         return "profiles"
       end
 
+      def valid?
+        return profile_state == ProfileState::ACTIVE
+      end
+
       #
       # API
       #
@@ -67,7 +73,7 @@ module Spaceship
       end
 
       def self.create(name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil)
-        return Spaceship::ConnectAPI.post_profiles(
+        resp = Spaceship::ConnectAPI.post_profiles(
           bundle_id_id: bundle_id_id,
           certificates: certificate_ids,
           devices: device_ids,
@@ -76,6 +82,7 @@ module Spaceship
             profileType: profile_type
           }
         )
+        return resp.to_models.first
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -84,6 +84,10 @@ module Spaceship
         )
         return resp.to_models.first
       end
+
+      def delete!
+        return Spaceship::ConnectAPI.delete_profile(profile_id: id)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -47,12 +47,9 @@ module Spaceship
         TVOS_APP_STORE = "TVOS_APP_STORE"
         TVOS_APP_ADHOC = "TVOS_APP_ADHOC"
         TVOS_APP_INHOUSE = "TVOS_APP_INHOUSE"
-
-        # Not support by official App Store Connect API
-        # Only works with Developer Portal (web session) implementation
-        # Last checked: 2020-03-09
         MAC_CATALYST_APP_DEVELOPMENT = "MAC_CATALYST_APP_DEVELOPMENT"
         MAC_CATALYST_APP_STORE = "MAC_CATALYST_APP_STORE"
+        MAC_CATALYST_APP_DIRECT = "MAC_CATALYST_APP_DIRECT"
       end
 
       def self.type

--- a/spaceship/lib/spaceship/connect_api/provisioning/client.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/client.rb
@@ -33,7 +33,7 @@ module Spaceship
         #
 
         def get(url_or_path, params = nil)
-          # The Provisioning App Store Connect API needs to be proxied through a 
+          # The Provisioning App Store Connect API needs to be proxied through a
           # POST request if using web session
           return proxy_get(url_or_path, params) if web_session?
 

--- a/spaceship/lib/spaceship/connect_api/provisioning/client.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/client.rb
@@ -48,6 +48,14 @@ module Spaceship
           super(url_or_path, body)
         end
 
+        def delete(url_or_path, params = nil)
+          # The Provisioning App Store Connect API needs to be proxied through a
+          # POST request if using web session
+          return proxy_delete(url_or_path, params) if web_session?
+
+          super(url_or_path, params)
+        end
+
         def proxy_get(url_or_path, params = nil)
           encoded_params = Faraday::NestedParamsEncoder.encode(params)
           body = { "urlEncodedQueryParams" => encoded_params, "teamId" => team_id }
@@ -69,6 +77,20 @@ module Spaceship
             req.url(url_or_path)
             req.body = body.to_json
             req.headers['Content-Type'] = 'application/vnd.api+json'
+            req.headers['X-Requested-With'] = 'XMLHttpRequest'
+          end
+          handle_response(response)
+        end
+
+        def proxy_delete(url_or_path, params = nil)
+          encoded_params = Faraday::NestedParamsEncoder.encode(params)
+          body = { "urlEncodedQueryParams" => encoded_params, "teamId" => team_id }
+
+          response = request(:post) do |req|
+            req.url(url_or_path)
+            req.body = body.to_json
+            req.headers['Content-Type'] = 'application/vnd.api+json'
+            req.headers['X-HTTP-Method-Override'] = 'DELETE'
             req.headers['X-Requested-With'] = 'XMLHttpRequest'
           end
           handle_response(response)

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -43,6 +43,41 @@ module Spaceship
         params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
         Client.instance.get("profiles", params)
       end
+
+      def post_profiles(bundle_id_id: nil, certificates: nil, devices: nil, attributes: {})
+        body = {
+          data: {
+            attributes: attributes,
+            type: "profiles",
+            relationships: {
+              bundleId: {
+                data: {
+                  type: "bundleIds",
+                  id: bundle_id_id
+                }
+              },
+              certificates: {
+                data: certificates.map do |certificate|
+                  {
+                    type: "certificates",
+                    id: certificate
+                  }
+                end
+              },
+              devices: {
+                data: (devices || []).map do |certificate|
+                  {
+                    type: "devices",
+                    id: devices
+                  }
+                end
+              }
+            }
+          }
+        }
+
+        Client.instance.post("profiles", body)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -78,6 +78,12 @@ module Spaceship
 
         Client.instance.post("profiles", body)
       end
+
+      def delete_profile(profile_id: nil)
+        raise "Profile id is nil" if profile_id.nil?
+
+        Client.instance.delete("profiles/#{profile_id}")
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation and Context
- Allow `sigh` (and `match`) to create Catalyst profiles
- Migrate `sigh` (and `match`) to use App Store Connect API to allow for optional JWT auth (in the future)

### Description
- Rewrote `sigh` to use App Store Connect API
  - `download_all` now uses `Spaceship::ConnectAPI::Profile` and deprecates option for Xcode managed profiles
  - Added new `catalyst` option to `:platforms`
  - Replaced a lot of API logic in `Sigh::Runner`
  - Created all new tests for `Sigh::Runner`
  - Reworked tests for `Sigh::Manager`
- Rewrote `match` to use App Store Connect API
  - Added new `catalyst` option to `:platforms`
  - Added new option `:derive_catalyst_app_identifier` for if your Catalyst app using a derived app identifier (mainly used if your Catalyst app was created in Xcode 11.3 or earlier)
  - Certificate generator will generate a Mac cert if `catalyst` platform
  - Profile saved will have a  `.provisionprofile` extension if `catalyst` platform
  - `SpaceshipEnsure` uses `Spaceship::ConnectAPI` to see if profile exists
- Updated `gym` to have better building logic for iOS, macOS, or Catalyst

### Testing Steps

Update `Gemfile` to 👇 and run `bundle install` or `bundle update fastlane`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-appstore-connect-api-sigh"
```
