### PR TITLE
[spaceship] Fix 2FA to handle sms fallback for accounts with no trusted devices

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -206,10 +206,16 @@ module Spaceship
       return true
     end
 
+    # For reference in case auth behavior changes:
+    # The "noTrustedDevices" field is only present
+    # in the response for `GET /appleauth/auth`
+
+    # Account is not signed into any devices that can display a verification code
     def sms_fallback(response)
       response.body["noTrustedDevices"]
     end
 
+    # see `sms_fallback` + account has only one trusted number for receiving an sms
     def sms_automatically_sent(response)
       (response.body["trustedPhoneNumbers"] || []).count == 1 && sms_fallback(response)
     end

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -191,6 +191,14 @@ module Spaceship
       return true
     end
 
+    def sms_fallback(response)
+      response.body["noTrustedDevices"]
+    end
+
+    def sms_automatically_sent(response)
+      (response.body["trustedPhoneNumbers"] || []).count == 1 && sms_fallback(response)
+    end
+
     # extracted into its own method for testing
     def ask_for_2fa_code(text)
       ask(text)

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -218,6 +218,11 @@ module Spaceship
       ask(text)
     end
 
+    # extracted into its own method for testing
+    def choose_phone_number(opts)
+      choose(*opts)
+    end
+
     def phone_id_from_number(phone_numbers, phone_number)
       characters_to_remove_from_phone_numbers = ' \-()"'
 
@@ -269,9 +274,9 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
       available = phone_numbers.collect do |current|
         current['numberWithDialCode']
       end
-      chosen = choose(*available)
+      chosen = choose_phone_number(available)
       phone_id = phone_id_from_masked_number(phone_numbers, chosen)
-
+      
       request_two_factor_code_from_phone(phone_id, chosen, code_length)
     end
 

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -134,8 +134,9 @@ module Spaceship
 
         phone_number = env_2fa_sms_default_phone_number
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
+        # don't request sms if no trusted devices and env default is the only trusted number,
+        # code was automatically sent
         should_request_code = !sms_automatically_sent(response)
-
         code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length, should_request_code)
       elsif sms_automatically_sent(response) # sms fallback, code was automatically sent

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -134,7 +134,7 @@ module Spaceship
 
         phone_number = env_2fa_sms_default_phone_number
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
-        should_request_code = !sms_automatically_sent(response) 
+        should_request_code = !sms_automatically_sent(response)
 
         code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length, should_request_code)
@@ -154,7 +154,7 @@ module Spaceship
         puts("(You can also set the environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` to automate this)")
         puts("(Read more at: https://github.com/fastlane/fastlane/blob/master/spaceship/docs/Authentication.md#auto-select-sms-via-spaceship-2fa-sms-default-phone-number)")
         puts("")
-        
+
         code = ask_for_2fa_code("Please enter the #{code_length} digit code:")
         code_type = 'trusteddevice'
         body = { "securityCode" => { "code" => code.to_s } }.to_json
@@ -276,7 +276,7 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
       end
       chosen = choose_phone_number(available)
       phone_id = phone_id_from_masked_number(phone_numbers, chosen)
-      
+
       request_two_factor_code_from_phone(phone_id, chosen, code_length)
     end
 
@@ -294,7 +294,7 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
         # we use `Spaceship::TunesClient.new.handle_itc_response`
         # since this might be from the Dev Portal, but for 2 step
         Spaceship::TunesClient.new.handle_itc_response(r.body)
-      
+
         puts("Successfully requested text message to #{phone_number}")
       end
 

--- a/spaceship/spec/fixtures/appleauth_2fa_no_trusted_devices.json
+++ b/spaceship/spec/fixtures/appleauth_2fa_no_trusted_devices.json
@@ -1,0 +1,45 @@
+{
+    "trustedPhoneNumbers": [
+        {
+            "numberWithDialCode": "+49 •••• •••••85",
+            "pushMode": "sms",
+            "obfuscatedNumber": "•••• •••••85",
+            "id": 1
+        }
+    ],
+    "phoneNumber": {
+        "numberWithDialCode": "+49 •••• •••••85",
+        "pushMode": "sms",
+        "obfuscatedNumber": "•••• •••••85",
+        "id": 1
+    },
+    "securityCode": {
+        "length": 6,
+        "tooManyCodesSent": false,
+        "tooManyCodesValidated": false,
+        "securityCodeLocked": false,
+        "securityCodeCooldown": false
+    },
+    "mode": "sms",
+    "type": "verification",
+    "authenticationType": "hsa2",
+    "recoveryUrl": "https://iforgot.apple.com/phone/add?prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+    "cantUsePhoneNumberUrl": "https://iforgot.apple.com/iforgot/phone/add?context=cantuse&prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+    "recoveryWebUrl": "https://iforgot.apple.com/password/verify/appleid?prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+    "repairPhoneNumberUrl": "https://gsa.apple.com/appleid/account/manage/repair/verify/phone",
+    "repairPhoneNumberWebUrl": "https://appleid.apple.com/widget/account/repair?#!repair",
+    "noTrustedDevices": true,
+    "aboutTwoFactorAuthenticationUrl": "https://support.apple.com/kb/HT204921",
+    "autoVerified": false,
+    "showAutoVerificationUI": false,
+    "trustedPhoneNumber": {
+        "numberWithDialCode": "+49 •••• •••••85",
+        "pushMode": "sms",
+        "obfuscatedNumber": "•••• •••••85",
+        "id": 1
+    },
+    "hsa2Account": true,
+    "restrictedAccount": false,
+    "supportsRecovery": true,
+    "managedAccount": false
+}

--- a/spaceship/spec/fixtures/appleauth_2fa_no_trusted_devices_two_numbers.json
+++ b/spaceship/spec/fixtures/appleauth_2fa_no_trusted_devices_two_numbers.json
@@ -1,0 +1,45 @@
+{
+    "trustedPhoneNumbers": [
+        {
+            "numberWithDialCode": "+49 •••• •••••85",
+            "pushMode": "sms",
+            "obfuscatedNumber": "•••• •••••85",
+            "id": 1
+        },
+        {
+            "numberWithDialCode": "+49 ••••• •••••81",
+            "pushMode": "sms",
+            "obfuscatedNumber": "••••• •••••81",
+            "id": 2
+        }
+    ],
+    "securityCode": {
+        "length": 6,
+        "tooManyCodesSent": false,
+        "tooManyCodesValidated": false,
+        "securityCodeLocked": false,
+        "securityCodeCooldown": false
+    },
+    "mode": "sms",
+    "type": "verification",
+    "authenticationType": "hsa2",
+    "recoveryUrl": "https://iforgot.apple.com/phone/add?prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+    "cantUsePhoneNumberUrl": "https://iforgot.apple.com/iforgot/phone/add?context=cantuse&prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+    "recoveryWebUrl": "https://iforgot.apple.com/password/verify/appleid?prs_account_nm=email@example.org&autoSubmitAccount=true&appId=142",
+    "repairPhoneNumberUrl": "https://gsa.apple.com/appleid/account/manage/repair/verify/phone",
+    "repairPhoneNumberWebUrl": "https://appleid.apple.com/widget/account/repair?#!repair",
+    "noTrustedDevices": true,
+    "aboutTwoFactorAuthenticationUrl": "https://support.apple.com/kb/HT204921",
+    "autoVerified": false,
+    "showAutoVerificationUI": false,
+    "trustedPhoneNumber": {
+        "numberWithDialCode": "+49 •••• •••••85",
+        "pushMode": "sms",
+        "obfuscatedNumber": "•••• •••••85",
+        "id": 1
+    },
+    "hsa2Account": true,
+    "restrictedAccount": false,
+    "supportsRecovery": true,
+    "managedAccount": false
+}

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -42,13 +42,22 @@ class TunesStubbing
         to_return(status: 200, body: "", headers: {})
 
       # 2FA: Request security code to trusted phone
-      stub_request(:put, "https://idmsa.apple.com/appleauth/auth/verify/phone").
-        with(body: "{\"phoneNumber\":{\"id\":1},\"mode\":\"sms\"}").
-        to_return(status: 200, body: "", headers: {})
+      [1, 2].each do |id|
+        stub_request(:put, "https://idmsa.apple.com/appleauth/auth/verify/phone").
+          with(body: "{\"phoneNumber\":{\"id\":#{id}},\"mode\":\"sms\"}").
+          to_return(status: 200, body: "", headers: {})
+      end
 
       # 2FA: Submit security code from trusted phone for verification
-      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode").
-        with(body: "{\"securityCode\":{\"code\":\"123\"},\"phoneNumber\":{\"id\":1},\"mode\":\"sms\"}").
+      [1, 2].each do |id|
+        stub_request(:post, "https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode").
+          with(body: "{\"securityCode\":{\"code\":\"123\"},\"phoneNumber\":{\"id\":#{id}},\"mode\":\"sms\"}").
+          to_return(status: 200, body: "", headers: {})
+      end
+
+      # 2FA: Submit security code from trusted device for verification
+      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode").
+        with(body: "{\"securityCode\":{\"code\":\"123\"}}").
         to_return(status: 200, body: "", headers: {})
 
       # 2FA: Trust computer

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -71,7 +71,7 @@ describe Spaceship::Client do
 
     context 'when SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER is not set' do
       context 'with trusted devices' do
-        let(:response) do 
+        let(:response) do
           response = OpenStruct.new
           response.body = trusted_devices_response
           return response
@@ -79,36 +79,36 @@ describe Spaceship::Client do
 
         it 'works with input sms' do
           expect(subject).to receive(:ask_for_2fa_code).twice.and_return('sms', '123')
-  
+
           bool = subject.handle_two_factor(response)
           expect(bool).to eq(true)
-  
+
           # sms should be sent despite having trusted devices
           expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: 1 }, mode: "sms" })
           expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: 1 }, mode: "sms" })
           expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
         end
-        
+
         it 'does not request sms code, and submits code correctly' do
-          bool = subject.handle_two_factor(response)  
+          bool = subject.handle_two_factor(response)
           expect(bool).to eq(true)
-  
+
           expect(WebMock).to have_not_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone')
           expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode')
-          expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode').with(body: { securityCode: { code: "123" }})
+          expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode').with(body: { securityCode: { code: "123" } })
         end
       end
 
       context 'with no trusted devices' do
-         # sms fallback, will be sent automatically
+        # sms fallback, will be sent automatically
         context "with exactly one phone number" do
           it "does not request sms code, and sends the correct request" do
             response = OpenStruct.new
             response.body = no_trusted_devices_response
-  
+
             bool = subject.handle_two_factor(response)
             expect(bool).to eq(true)
-            
+
             expect(WebMock).to have_not_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone')
             expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
             expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: 1 }, mode: "sms" })
@@ -119,7 +119,7 @@ describe Spaceship::Client do
         context 'with at least two phone numbers' do
           let(:phone_id) { 2 }
           let(:phone_number) { "+49 ••••• •••••81" }
-          let(:response) do 
+          let(:response) do
             response = OpenStruct.new
             response.body = no_trusted_devices_two_numbers_response
             return response
@@ -139,7 +139,7 @@ describe Spaceship::Client do
           it 'requests sms code, and submits code correctly' do
             bool = subject.handle_two_factor(response)
             expect(bool).to eq(true)
-    
+
             expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
             expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: phone_id }, mode: "sms" }).once
             expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: phone_id }, mode: "sms" })
@@ -151,12 +151,12 @@ describe Spaceship::Client do
     context 'when SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER is set' do
       let(:phone_number) { '+49 123 4567885' }
       let(:phone_id) { 1 }
-      let(:response) do 
+      let(:response) do
         response = OpenStruct.new
         response.body = trusted_devices_response
         return response
       end
-        
+
       before do
         ENV['SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER'] = phone_number
       end
@@ -189,7 +189,7 @@ describe Spaceship::Client do
         it 'requests sms code, and submits code correctly' do
           bool = subject.handle_two_factor(response)
           expect(bool).to eq(true)
-  
+
           expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
           expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: phone_id }, mode: "sms" }).once
           expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: phone_id }, mode: "sms" })
@@ -202,10 +202,10 @@ describe Spaceship::Client do
           it "does not request sms code, and sends the correct request" do
             response = OpenStruct.new
             response.body = no_trusted_devices_response
-  
+
             bool = subject.handle_two_factor(response)
             expect(bool).to eq(true)
-            
+
             expect(WebMock).to have_not_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone')
             expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
             expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: 1 }, mode: "sms" })
@@ -216,12 +216,12 @@ describe Spaceship::Client do
           # sets env var to the second phone number in this context
           let(:phone_number) { '+49 123 4567881' }
           let(:phone_id) { 2 }
-          let(:response) do 
+          let(:response) do
             response = OpenStruct.new
             response.body = no_trusted_devices_two_numbers_response
             return response
           end
-          
+
           # making sure we use env var for phone number selection
           it 'does not prompt user to choose number' do
             # rubocop:disable Style/MethodCallWithArgsParentheses

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -10,6 +10,10 @@ describe Spaceship::Client do
       '123'
     end
 
+    def choose_phone_number(opts)
+      opts.first
+    end
+
     def store_cookie(path: nil)
       true
     end
@@ -61,34 +65,105 @@ describe Spaceship::Client do
   end
 
   describe 'handle_two_factor' do
-    let(:response_fixture) { File.read(File.join('spaceship', 'spec', 'fixtures', 'client_appleauth_auth_2fa_response.json'), encoding: 'utf-8') }
-    let(:response) { OpenStruct.new }
-    before do
-      response.body = JSON.parse(response_fixture)
+    let(:trusted_devices_response) { JSON.parse(File.read(File.join('spaceship', 'spec', 'fixtures', 'client_appleauth_auth_2fa_response.json'), encoding: 'utf-8')) }
+    let(:no_trusted_devices_response) { JSON.parse(File.read(File.join('spaceship', 'spec', 'fixtures', 'appleauth_2fa_no_trusted_devices.json'), encoding: 'utf-8')) }
+    let(:no_trusted_devices_two_numbers_response) { JSON.parse(File.read(File.join('spaceship', 'spec', 'fixtures', 'appleauth_2fa_no_trusted_devices_two_numbers.json'), encoding: 'utf-8')) }
+
+    context 'when SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER is not set' do
+      context 'with trusted devices' do
+        let(:response) do 
+          response = OpenStruct.new
+          response.body = trusted_devices_response
+          return response
+        end
+        
+        it 'does not request sms code, and submits code correctly' do
+          bool = subject.handle_two_factor(response)  
+          expect(bool).to eq(true)
+  
+          expect(WebMock).to have_not_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone')
+          expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode')
+          expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode').with(body: { securityCode: { code: "123" }})
+        end
+      end
+
+      context 'with no trusted devices' do
+         # sms fallback, will be sent automatically
+        context "with exactly one phone number" do
+          it "does not request sms code, and sends the correct request" do
+            response = OpenStruct.new
+            response.body = no_trusted_devices_response
+  
+            bool = subject.handle_two_factor(response)
+            expect(bool).to eq(true)
+            
+            expect(WebMock).to have_not_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone')
+            expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
+            expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: 1 }, mode: "sms" })
+          end
+        end
+
+        # sms fallback, won't be sent automatically
+        context 'with at least two phone numbers' do
+          let(:phone_id) { 2 }
+          let(:phone_number) { "+49 ••••• •••••81" }
+          let(:response) do 
+            response = OpenStruct.new
+            response.body = no_trusted_devices_two_numbers_response
+            return response
+          end
+
+          before do
+            allow(subject).to receive(:choose_phone_number).and_return(phone_number)
+          end
+
+          it 'prompts user to choose number' do
+            expect(subject).to receive(:choose_phone_number)
+
+            bool = subject.handle_two_factor(response)
+            expect(bool).to eq(true)
+          end
+
+          it 'requests sms code, and submits code correctly' do
+            bool = subject.handle_two_factor(response)
+            expect(bool).to eq(true)
+    
+            expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
+            expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: phone_id }, mode: "sms" }).once
+            expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: phone_id }, mode: "sms" })
+          end
+        end
+      end
     end
 
-    describe 'with SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER set' do
+    context 'when SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER is set' do
+      let(:phone_number) { '+49 123 4567885' }
+      let(:phone_id) { 1 }
+      let(:response) do 
+        response = OpenStruct.new
+        response.body = trusted_devices_response
+        return response
+      end
+        
+      before do
+        ENV['SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER'] = phone_number
+      end
+
       after do
         ENV.delete('SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER')
       end
 
-      it 'to a known phone number returns true (and sends the correct requests)' do
-        phone_number = '+49 123 4567885'
-        ENV['SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER'] = phone_number
-
-        response = OpenStruct.new
-        response.body = JSON.parse(response_fixture)
+      it 'providing a known phone number returns true (and sends the correct requests)' do
         bool = subject.handle_two_factor(response)
-
         expect(bool).to eq(true)
 
         # expected requests
-        expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: 1 }, mode: "sms" })
-        expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: 1 }, mode: "sms" })
+        expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: phone_id }, mode: "sms" }).once
+        expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: phone_id }, mode: "sms" })
         expect(WebMock).to have_requested(:get, 'https://idmsa.apple.com/appleauth/auth/2sv/trust')
       end
 
-      it 'to a unknown phone number throws an exception' do
+      it 'providing an unknown phone number throws an exception' do
         phone_number = '+49 123 4567800'
         ENV['SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER'] = phone_number
 
@@ -96,11 +171,65 @@ describe Spaceship::Client do
           bool = subject.handle_two_factor(response)
         end.to raise_error(Spaceship::Tunes::Error)
       end
-    end
 
-    describe 'with SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER not set' do
-      # 1. input of pushed code
-      # 2. input of `sms`, then selection of phone, then input of sms-ed code
+      context 'with trusted devices' do
+        # make sure sms overrides device verification when env var is set
+        it 'requests sms code, and submits code correctly' do
+          bool = subject.handle_two_factor(response)
+          expect(bool).to eq(true)
+  
+          expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
+          expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: phone_id }, mode: "sms" }).once
+          expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: phone_id }, mode: "sms" })
+        end
+      end
+
+      context 'with no trusted devices' do
+        # sms fallback, will be sent automatically
+        context "with exactly one phone number" do
+          it "does not request sms code, and sends the correct request" do
+            response = OpenStruct.new
+            response.body = no_trusted_devices_response
+  
+            bool = subject.handle_two_factor(response)
+            expect(bool).to eq(true)
+            
+            expect(WebMock).to have_not_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone')
+            expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
+            expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: 1 }, mode: "sms" })
+          end
+        end
+
+        context 'with at least two phone numbers' do
+          # sets env var to the second phone number in this context
+          let(:phone_number) { '+49 123 4567881' }
+          let(:phone_id) { 2 }
+          let(:response) do 
+            response = OpenStruct.new
+            response.body = no_trusted_devices_two_numbers_response
+            return response
+          end
+          
+          # making sure we use env var for phone number selection
+          it 'does not prompt user to choose number' do
+            # rubocop:disable Style/MethodCallWithArgsParentheses
+            expect(subject).not_to receive(:choose_phone_number)
+            # rubocop:enable Style/MethodCallWithArgsParentheses
+
+            bool = subject.handle_two_factor(response)
+            expect(bool).to eq(true)
+          end
+
+          it 'requests sms code, and submits code correctly' do
+            bool = subject.handle_two_factor(response)
+            expect(bool).to eq(true)
+
+            expect(WebMock).to have_not_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/trusteddevice/securitycode')
+            expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: phone_id }, mode: "sms" }).once
+            expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: phone_id }, mode: "sms" })
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Issue: #16108 

If a user has 2FA enabled but is not logged into an Apple device with their Apple ID (no trusted devices), auth will default to SMS for verification. For an account with no trusted devices, if a user only has one trusted phone number associated with their account, an SMS verification code will automatically be sent to that number. If they have more than one trusted phone number, an SMS won’t be sent until it’s explicitly requested.

Trusted phone numbers have a separate endpoint, but Spaceship currently posts 2FA codes to the trusted devices endpoint for all cases (except when the default number env var is set). For accounts with no trusted devices, if a user with one trusted number enters the SMS code they automatically received, Spaceship exits with an Unauthorized Error. If the account has more than one trusted number, the user won’t have received a 2FA code at all and will have nothing to enter into the prompt.

The current workaround is to enter `sms` when prompted by Fastlane for the 2FA code which will force Fastlane to have the user select a phone number, request a new SMS code, and post the code to the correct endpoint.

### Description
Checks for `"noTrustedDevices"` field to determine SMS fallback, adds logic to handle the different possible cases, one number/multiple numbers, default number env var set/not set.

Also added new fixtures and a bunch of tests for handling the different verification paths, hitting the right endpoints, and just filling out coverage for the 2FA flow in general.

### Testing Steps
`bundle exec rspec ./spaceship/spec/two_step_or_factor_client_spec.rb` or run `Spaceship::Portal.login("<apple_id>")` from a rake task to manually test the behavior.

### Review Notes
* The Unauthorized Error people are seeing is actually a side effect - `Spaceship::TunesClient#handle_itc_response` doesn’t catch the invalid code error when hitting the wrong endpoint (same for wrong code but correct endpoint), so the rescue block on `line 143` doesn’t execute, `store_session` gets called, returns a 401, and exits with Unauthorized Error - I can open a separate PR for this, have an easy fix saved locally.
* I think the 2FA code can really use a refactor - the tight coupling between methods makes accounting for these new cases (and testing) a bit hacky, and can cause some things to break like the incorrect code recursive retry (which currently doesn't work bec of the broken invalid code error handling^) - I have a partial refactor saved locally.
* The `does not prompt user to choose number` test is brittle because the test will pass if `choose_phone_number` is ever removed or its name changes, but wasn’t sure how else to test it.
* Note that the `"noTrustedDevices"` field seems to only be present in the initial response for `GET /appleauth/auth` and not subsequent requests. Two other fields persist, `"mode"` and `"type"`, but seem to only be present once an sms has already been sent (e.g. initial response when one trusted number bec auto sent; after explicitly requesting an sms when two numbers). 
* I also have a bunch of Charles recordings for different cases which could be useful to save for the future, but would have to find a way to redact them properly.