### PR TITLE
[clean_build_artifacts] Remove references to downloaded files after they are deleted

### DIFF
--- a/fastlane/lib/fastlane/actions/clean_build_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/clean_build_artifacts.rb
@@ -21,6 +21,9 @@ module Fastlane
           File.delete(file)
         end
 
+        Actions.lane_context[Actions::SharedValues::SIGH_PROFILE_PATHS] = nil
+        Actions.lane_context[Actions::SharedValues::DSYM_PATHS] = nil
+
         UI.success('Cleaned up build artifacts 🐙')
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When attempting to download dSYMs for multiple apps it should be possible to clear the references for the dSYMs that have been deleted.

See https://github.com/fastlane/fastlane/issues/16177

### Description
Calling `clean_build_artifacts` now removes the references to the deleted files.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
