### PR TITLE
[spaceship] Add ability to create a beta group to Spaceship

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -104,9 +104,15 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def create_beta_group(group_name: nil, publicLinkEnabled: false, publicLinkLimit: 10_000, publicLinkLimitEnabled: false)
-        resps = Spaceship::ConnectAPI.create_beta_group(app_id: id, group_name: group_name, publicLinkEnabled: publicLinkEnabled, publicLinkLimit: publicLinkLimit, publicLinkLimitEnabled: publicLinkLimitEnabled).all_pages
-        return resps.flat_map(&:to_models)
+      def create_beta_group(group_name: nil, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
+        resps = Spaceship::ConnectAPI.create_beta_group(
+          app_id: id,
+          group_name: group_name,
+          public_link_enabled: public_link_enabled,
+          public_link_limit: public_link_limit,
+          public_link_limit_enabled: public_link_limit_enabled
+        ).all_pages
+        return resps.flat_map(&:to_models).first
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -103,6 +103,11 @@ module Spaceship
         resps = Spaceship::ConnectAPI.get_beta_groups(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
         return resps.flat_map(&:to_models)
       end
+
+      def create_beta_group(group_name: nil, publicLinkEnabled: false, publicLinkLimit: 10_000, publicLinkLimitEnabled: false)
+        resps = Spaceship::ConnectAPI.create_beta_group(app_id: id, group_name: group_name, publicLinkEnabled: publicLinkEnabled, publicLinkLimit: publicLinkLimit, publicLinkLimitEnabled: publicLinkLimitEnabled).all_pages
+        return resps.flat_map(&:to_models)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -181,14 +181,14 @@ module Spaceship
         Client.instance.post("builds/#{build_id}/relationships/betaGroups", body)
       end
 
-      def create_beta_group(app_id: nil, group_name: nil, publicLinkEnabled: false, publicLinkLimit: 10_000, publicLinkLimitEnabled: false)
+      def create_beta_group(app_id: nil, group_name: nil, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
         body = {
           data: {
             attributes: {
               name: group_name,
-              publicLinkEnabled: publicLinkEnabled,
-              publicLinkLimit: publicLinkLimit,
-              publicLinkLimitEnabled: publicLinkLimitEnabled
+              publicLinkEnabled: public_link_enabled,
+              publicLinkLimit: public_link_limit,
+              publicLinkLimitEnabled: public_link_limit_enabled
             },
             relationships: {
               app: {

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -181,6 +181,29 @@ module Spaceship
         Client.instance.post("builds/#{build_id}/relationships/betaGroups", body)
       end
 
+      def create_beta_group(app_id: nil, group_name: nil, publicLinkEnabled: false, publicLinkLimit: 10_000, publicLinkLimitEnabled: false)
+        body = {
+          data: {
+            attributes: {
+              name: group_name,
+              publicLinkEnabled: publicLinkEnabled,
+              publicLinkLimit: publicLinkLimit,
+              publicLinkLimitEnabled: publicLinkLimitEnabled
+            },
+            relationships: {
+              app: {
+                data: {
+                  id: app_id,
+                  type: "apps"
+                }
+              }
+            },
+            type: "betaGroups"
+          }
+        }
+        Client.instance.post("betaGroups", body)
+      end
+
       #
       # betaTesters
       #

--- a/spaceship/spec/connect_api/fixtures/testflight/beta_create_group.json
+++ b/spaceship/spec/connect_api/fixtures/testflight/beta_create_group.json
@@ -1,0 +1,16 @@
+{
+    "data" : {
+      "type" : "betaGroups",
+      "id" : "123456789",
+      "attributes" : {
+        "name" : "Brand New Group",
+        "createdDate" : "2018-04-15T18:13:40Z",
+        "isInternalGroup" : false,
+        "publicLinkEnabled" : false,
+        "publicLinkId" : "abcd1234",
+        "publicLinkLimitEnabled" : false,
+        "publicLinkLimit" : 10000,
+        "publicLink" : "https://testflight.apple.com/join/abcd1234"
+      }
+    }
+}

--- a/spaceship/spec/connect_api/models/app_spec.rb
+++ b/spaceship/spec/connect_api/models/app_spec.rb
@@ -41,5 +41,12 @@ describe Spaceship::ConnectAPI::App do
       model = Spaceship::ConnectAPI::App.find("com.joshholtz.FastlaneTest")
       expect(model.bundle_id).to eq("com.joshholtz.FastlaneTest")
     end
+
+    it 'creates beta group' do
+      app = Spaceship::ConnectAPI::App.find("com.joshholtz.FastlaneTest")
+
+      model = app.create_beta_group(group_name: "Brand New Group", public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
+      expect(model.id).to eq("123456789")
+    end
   end
 end

--- a/spaceship/spec/connect_api/models/beta_group_spec.rb
+++ b/spaceship/spec/connect_api/models/beta_group_spec.rb
@@ -23,24 +23,4 @@ describe Spaceship::ConnectAPI::BetaGroup do
       expect(model.public_link).to eq("https://testflight.apple.com/join/abcd1234")
     end
   end
-
-  describe '#Spaceship::ConnectAPI' do
-    it '#create_beta_group' do
-      app_response = Spaceship::ConnectAPI.get_apps
-      app = app_response.first
-      response = app.create_beta_group(group_name: "Brand New Group")
-
-      expect(response.count).to eq(1)
-      response.each do |model|
-        expect(model).to be_an_instance_of(Spaceship::ConnectAPI::BetaGroup)
-      end
-
-      model = response.first
-      expect(model.id).to eq("123456789")
-      expect(model.name).to eq("Brand New Group")
-      expect(model.public_link_enabled).to eq(false)
-      expect(model.public_link_limit_enabled).to eq(false)
-      expect(model.public_link_limit).to eq(10_000)
-    end
-  end
 end

--- a/spaceship/spec/connect_api/models/beta_group_spec.rb
+++ b/spaceship/spec/connect_api/models/beta_group_spec.rb
@@ -23,4 +23,24 @@ describe Spaceship::ConnectAPI::BetaGroup do
       expect(model.public_link).to eq("https://testflight.apple.com/join/abcd1234")
     end
   end
+
+  describe '#Spaceship::ConnectAPI' do
+    it '#create_beta_group' do
+      app_response = Spaceship::ConnectAPI.get_apps
+      app = app_response.first
+      response = app.create_beta_group(group_name: "Brand New Group")
+
+      expect(response.count).to eq(1)
+      response.each do |model|
+        expect(model).to be_an_instance_of(Spaceship::ConnectAPI::BetaGroup)
+      end
+
+      model = response.first
+      expect(model.id).to eq("123456789")
+      expect(model.name).to eq("Brand New Group")
+      expect(model.public_link_enabled).to eq(false)
+      expect(model.public_link_limit_enabled).to eq(false)
+      expect(model.public_link_limit).to eq(10_000)
+    end
+  end
 end

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -63,6 +63,9 @@ class ConnectAPIStubbing
       def stub_beta_groups
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/betaGroups").
           to_return(status: 200, body: read_fixture_file('beta_groups.json'), headers: { 'Content-Type' => 'application/json' })
+
+        stub_request(:post, "https://appstoreconnect.apple.com/iris/v1/betaGroups").
+          to_return(status: 200, body: read_fixture_file('beta_create_group.json'), headers: { 'Content-Type' => 'application/json' })
       end
 
       def stub_beta_testers


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The Spaceship::TestFlight::Group endpoint is no longer being maintained since the conversion to the ConnectAPI. As a result there's no way to create beta groups for test flight using Spaceship.

<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/fastlane/fastlane/issues/15810
Though I couldn't find documentation, the method `Spaceship::ConnectAPI::App.find("YOUR_BUNDLE_ID").get_beta_groups` works to list the groups, but you can't create a new group, which is what this commit enables.

### Description
<!-- Describe your changes in detail. -->
I've created a method that creates a beta test group for TestFlight.

To do this, I've added a create_beta_group() method to the Spaceship::ConnectAPI::App object which calls another new method called Spaceship::ConnectAPI::create_beta_group(), which makes a post request to https://api.appstoreconnect.apple.com/v1/betaGroups
(https://developer.apple.com/documentation/appstoreconnectapi/create_a_beta_group#http-body)

The group_name must be provided, publicLinkEnabled defaults to false, publicLinkLimit defaults to the max of 10_000, publicLinkLimitEnabled defaults to false. I'm not sure these are the right defaults, please give me your feedback if I should change them.

Finally, I've added a test case and fixture to stubb the api call.

Note: I did not update any documentation. If there's a place to show examples for Spaceship please point me to it and I'll update it.

<!-- Please describe in detail how you tested your changes. -->
I've added a test case that can be run with 
```bash
bundle exec rspec spaceship
```

The easiest way to test it on an actual app is from the spaceship playground. From your app's project directory run:
```bash
bundle exec fastlane spaceship
```
From the resulting prompt run:
```ruby
Spaceship::ConnectAPI::App.find("YOUR_BUNDLE_ID").create_beta_group(group_name: "New Test Group")
```
You can verify the group was created from the Apple Developer portal by:
1. Navigate to https://appstoreconnect.apple.com/
2. Click My Apps
3. Click the app corresponding to YOUR_BUNDLE_ID
4. Click "TestFlight" from the navigation menu
5. Verify "New Test Group" was created as seen under "Testers & Groups" in the left sidebar.

You can also check that the group was created from the spaceship playground:
```ruby
Spaceship::ConnectAPI::App.find("YOUR_BUNDLE_ID").get_beta_groups
```

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
