### PR TITLE
[supply] fix error when downloading metadata with drafts

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -222,6 +222,10 @@ module Supply
     def release_listings(version)
       ensure_active_edit!
 
+      p "asdf"
+      # p version
+      # p tracks
+
       # Verify that tracks have releases
       filtered_tracks = tracks.select { |t| !t.releases.nil? && t.releases.any? { |r| r.name == version } }
 
@@ -244,7 +248,9 @@ module Supply
         UI.message("Found '#{version}' in '#{filtered_track.track}' track.")
       end
 
-      filtered_release = filtered_track.releases.first { |r| r.name == version }
+      filtered_release = filtered_track.releases.find { |r| !r.name.nil? && r.name == version }
+
+      p filtered_release
 
       # Since we can release on Alpha/Beta without release notes.
       if filtered_release.release_notes.nil?
@@ -258,13 +264,13 @@ module Supply
     end
 
     def latest_version(track)
-      latest_version = tracks.select { |t| t.track == Supply::Tracks::DEFAULT }.map(&:releases).flatten.reject{ |r| !r }.max_by(&:name)
+      latest_version = tracks.select { |t| t.track == Supply::Tracks::DEFAULT }.map(&:releases).flatten.reject { |r| r.name.nil? }.max_by(&:name)
 
       # Check if user specified '--track' option if version information from 'production' track is nil
       if latest_version.nil? && track == Supply::Tracks::DEFAULT
         UI.user_error!(%(Unable to find latest version information from "#{Supply::Tracks::DEFAULT}" track. Please specify track information by using the '--track' option.))
       else
-        latest_version = tracks.select { |t| t.track == track }.map(&:releases).flatten.max_by(&:name)
+        latest_version = tracks.select { |t| t.track == track }.map(&:releases).flatten.reject { |r| r.name.nil? }.max_by(&:name)
       end
 
       return latest_version

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -244,7 +244,7 @@ module Supply
         UI.message("Found '#{version}' in '#{filtered_track.track}' track.")
       end
 
-      filtered_release = filtered_track.releases.find { |r| !r.name.nil? && r.name == version }
+      filtered_release = filtered_track.releases.first { |r| !r.name.nil? && r.name == version }
 
       # Since we can release on Alpha/Beta without release notes.
       if filtered_release.release_notes.nil?

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -222,10 +222,6 @@ module Supply
     def release_listings(version)
       ensure_active_edit!
 
-      p "asdf"
-      # p version
-      # p tracks
-
       # Verify that tracks have releases
       filtered_tracks = tracks.select { |t| !t.releases.nil? && t.releases.any? { |r| r.name == version } }
 
@@ -249,8 +245,6 @@ module Supply
       end
 
       filtered_release = filtered_track.releases.find { |r| !r.name.nil? && r.name == version }
-
-      p filtered_release
 
       # Since we can release on Alpha/Beta without release notes.
       if filtered_release.release_notes.nil?

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -258,7 +258,7 @@ module Supply
     end
 
     def latest_version(track)
-      latest_version = tracks.select { |t| t.track == Supply::Tracks::DEFAULT }.map(&:releases).flatten.max_by(&:name)
+      latest_version = tracks.select { |t| t.track == Supply::Tracks::DEFAULT }.map(&:releases).flatten.reject{ |r| !r }.max_by(&:name)
 
       # Check if user specified '--track' option if version information from 'production' track is nil
       if latest_version.nil? && track == Supply::Tracks::DEFAULT


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I got the following error when a draft existed in the Play Console:

``` 
/home/max/.gem/ruby/2.7.0/gems/fastlane-2.143.0/supply/lib/supply/client.rb:264:in `each': \e[31m[!] comparison of String with nil failed\e[0m (ArgumentError)
```

When inspecting the current releases I found the draft with no name:

`[#<Google::Apis::AndroidpublisherV3::TrackRelease:0x00005568f7aeda48 @status="draft">, #<Google::Apis::AndroidpublisherV3::TrackRelease:0x00005568f7aec940 @status="completed", @name="2020.1.0", @release_notes=[...], @version_codes=["100001"]>]`

### Description
The ignores releases in draft mode

### Testing Steps
Created a draft to check whether the error occurs.
Checked again after applying the patch and it worked.
