### PR TITLE
Update crashlytics deprecation date to May 4, 2020

### DIFF
--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -170,7 +170,7 @@ module Fastlane
       def self.details
         [
           "Crashlytics Beta has been deprecated and replaced with Firebase App Distribution.",
-          "Beta will continue working until March 31, 2020.",
+          "Beta will continue working until May 4, 2020.",
           "Check out the [Firebase App Distribution docs](https://github.com/fastlane/fastlane-plugin-firebase_app_distribution) to get started.",
           "",
           "Additionally, you can specify `notes`, `emails`, `groups` and `notifications`.",
@@ -206,7 +206,7 @@ module Fastlane
       def self.deprecated_notes
         [
           "Crashlytics Beta has been deprecated and replaced with Firebase App Distribution.",
-          "Beta will continue working until March 31, 2020.",
+          "Beta will continue working until May 4, 2020.",
           "Check out the [Firebase App Distribution docs](https://github.com/fastlane/fastlane-plugin-firebase_app_distribution) to get started."
         ].join("\n")
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
Update Fabric Crashlytics Beta deprecation date to May 4, 2020
