### PR TITLE
[acition] adds 'Apple Distribution' as valid authority when verifying builds

### DIFF
--- a/fastlane/lib/fastlane/actions/verify_build.rb
+++ b/fastlane/lib/fastlane/actions/verify_build.rb
@@ -46,7 +46,7 @@ module Fastlane
 
         parts = cert_info.strip.split(/\r?\n/)
         parts.each do |part|
-          if part =~ /\AAuthority=i(Phone|OS)/
+          if part =~ /\AAuthority=(iPhone|iOS|Apple)/
             type = part.split('=')[1].split(':')[0]
             values['provisioning_type'] = type.downcase =~ /distribution/i ? "distribution" : "development"
           end

--- a/fastlane/lib/fastlane/actions/verify_build.rb
+++ b/fastlane/lib/fastlane/actions/verify_build.rb
@@ -46,7 +46,7 @@ module Fastlane
 
         parts = cert_info.strip.split(/\r?\n/)
         parts.each do |part|
-          if part =~ /\AAuthority=(iPhone|iOS|Apple)/
+          if part =~ /\AAuthority=(iPhone|iOS|Apple)\s(Distribution|Development)/
             type = part.split('=')[1].split(':')[0]
             values['provisioning_type'] = type.downcase =~ /distribution/i ? "distribution" : "development"
           end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #16020

`verify_build` command fails when using the new cross-platform distribution certificates.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

The current logic in verify build expects the certificate authority to match a regex of `Authority=i(Phone|OS) Distribution`. 

However, the new cross-platform certificates made available by Apple with Xcode 11 have the certificate authority as `Apple Distribution`, which does not match the regex and causes validation to fail.

This PR addresses the issue by adding `Apple Distribution` as a valid authority option during build validation.

Note that the implementation of the regex has to use a more specific expression because matching only for `(iOS|iPhone|Apple)` will cause `Apple Root CA` and `Apple Worldwide Certificate Authority` certificates to be incorrectly identified as a match.
