### PR TITLE
Version bump to 2.144.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,55 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-</tr>
-<tr>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
@@ -90,19 +46,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+</tr>
+<tr>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
 <img src='https://github.com/milch.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-</tr>
-<tr>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 <td id='daniel-jankowski'>
 <a href='https://github.com/mollyIV'>
@@ -110,31 +90,19 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+</tr>
+<tr>
 <td id='joshua-liebowitz'>
 <a href='https://github.com/taquitos'>
 <img src='https://github.com/taquitos.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-</tr>
-<tr>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
 <td id='jimmy-dee'>
 <a href='https://github.com/jdee'>
@@ -142,37 +110,69 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'>Jimmy Dee</h4>
 </td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-</tr>
-<tr>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
 <td id='aaron-brager'>
 <a href='https://github.com/getaaron'>
 <img src='https://github.com/getaaron.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+</tr>
+<tr>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+</tr>
+<tr>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Joshua Liebowitz",
+  spec.authors       = ["Danielle Tomlinson",
+                        "Max Ott",
+                        "Daniel Jankowski",
+                        "Helmut Januschka",
+                        "Josh Holtz",
+                        "Kohki Miki",
+                        "Iulian Onofrei",
+                        "Felix Krause",
+                        "Matthew Ellis",
                         "Stefan Natchev",
+                        "Olivier Halligon",
+                        "Luka Mirosevic",
+                        "Jan Piotrowski",
+                        "Joshua Liebowitz",
+                        "Maksym Grebenets",
+                        "Fumiya Nakamura",
+                        "Jimmy Dee",
+                        "Jorge Revuelta H",
+                        "Jérôme Lacoste",
                         "Andrew McBurney",
                         "Aaron Brager",
-                        "Fumiya Nakamura",
-                        "Daniel Jankowski",
-                        "Kohki Miki",
-                        "Jorge Revuelta H",
-                        "Matthew Ellis",
-                        "Luka Mirosevic",
-                        "Iulian Onofrei",
-                        "Danielle Tomlinson",
-                        "Josh Holtz",
-                        "Manu Wallner",
-                        "Jimmy Dee",
-                        "Helmut Januschka",
-                        "Felix Krause",
-                        "Jérôme Lacoste",
-                        "Olivier Halligon",
-                        "Max Ott",
-                        "Jan Piotrowski",
-                        "Maksym Grebenets"]
+                        "Manu Wallner"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.143.0'.freeze
+  VERSION = '2.144.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.143.0
+// Generated with fastlane 2.144.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -2122,7 +2122,7 @@ func copyArtifacts(keepOriginal: Bool = true,
 }
 
 /**
- Upload a new build to [Crashlytics Beta](http://try.crashlytics.com/beta/)
+ Refer to [Firebase App Distribution](https://appdistro.page.link/fastlane-repo)
 
  - parameters:
    - ipaPath: Path to your IPA file. Optional if you use the _gym_ or _xcodebuild_ action
@@ -2137,6 +2137,10 @@ func copyArtifacts(keepOriginal: Bool = true,
    - notifications: Crashlytics notification option (true/false)
    - debug: Crashlytics debug option (true/false)
 
+ Crashlytics Beta has been deprecated and replaced with Firebase App Distribution.
+ Beta will continue working until May 4, 2020.
+ Check out the [Firebase App Distribution docs](https://github.com/fastlane/fastlane-plugin-firebase_app_distribution) to get started.
+ 
  Additionally, you can specify `notes`, `emails`, `groups` and `notifications`.
  Distributing to Groups: When using the `groups` parameter, it's important to use the group **alias** names for each group you'd like to distribute to. A group's alias can be found in the web UI. If you're viewing the Beta page, you can open the groups dialog by clicking the 'Manage Groups' button.
  This action uses the `submit` binary provided by the Crashlytics framework. If the binary is not found in its usual path, you'll need to specify the path manually by using the `crashlytics_path` option.
@@ -5071,6 +5075,7 @@ func pluginScores(outputPath: String,
    - platforms: Lint against specific platforms (defaults to all platforms supported by the podspec). Multiple platforms must be comma-delimited (available since cocoapods >= 1.6)
    - skipImportValidation: Lint skips validating that the pod can be imported (available since cocoapods >= 1.3)
    - skipTests: Lint skips building and running tests during validation (available since cocoapods >= 1.3)
+   - analyze: Validate with the Xcode Static Analysis tool (available since cocoapods >= 1.6.1)
 
  Test the syntax of your Podfile by linting the pod against the files of its directory
 */
@@ -5092,7 +5097,8 @@ func podLibLint(useBundleExec: Bool = true,
                 noSubspecs: Bool = false,
                 platforms: String? = nil,
                 skipImportValidation: Bool = false,
-                skipTests: Bool = false) {
+                skipTests: Bool = false,
+                analyze: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "pod_lib_lint", className: nil, args: [RubyCommand.Argument(name: "use_bundle_exec", value: useBundleExec),
                                                                                               RubyCommand.Argument(name: "podspec", value: podspec),
                                                                                               RubyCommand.Argument(name: "verbose", value: verbose),
@@ -5111,7 +5117,8 @@ func podLibLint(useBundleExec: Bool = true,
                                                                                               RubyCommand.Argument(name: "no_subspecs", value: noSubspecs),
                                                                                               RubyCommand.Argument(name: "platforms", value: platforms),
                                                                                               RubyCommand.Argument(name: "skip_import_validation", value: skipImportValidation),
-                                                                                              RubyCommand.Argument(name: "skip_tests", value: skipTests)])
+                                                                                              RubyCommand.Argument(name: "skip_tests", value: skipTests),
+                                                                                              RubyCommand.Argument(name: "analyze", value: analyze)])
   _ = runner.executeCommand(command)
 }
 
@@ -5640,6 +5647,7 @@ func rubyVersion() {
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
+   - testplan: The testplan associated with the scheme that should be used for testing
    - xctestrun: Run tests using the provided `.xctestrun` file
    - toolchain: The toolchain that should be used for building the application (e.g. `com.apple.dt.toolchain.Swift_2_3, org.swift.30p620160816a`)
    - clean: Should the project be cleaned before building it?
@@ -5702,6 +5710,7 @@ func runTests(workspace: String? = nil,
               appIdentifier: String? = nil,
               onlyTesting: Any? = nil,
               skipTesting: Any? = nil,
+              testplan: String? = nil,
               xctestrun: String? = nil,
               toolchain: Any? = nil,
               clean: Bool = false,
@@ -5761,6 +5770,7 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                            RubyCommand.Argument(name: "only_testing", value: onlyTesting),
                                                                                            RubyCommand.Argument(name: "skip_testing", value: skipTesting),
+                                                                                           RubyCommand.Argument(name: "testplan", value: testplan),
                                                                                            RubyCommand.Argument(name: "xctestrun", value: xctestrun),
                                                                                            RubyCommand.Argument(name: "toolchain", value: toolchain),
                                                                                            RubyCommand.Argument(name: "clean", value: clean),
@@ -5901,6 +5911,7 @@ func say(text: Any,
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
+   - testplan: The testplan associated with the scheme that should be used for testing
    - xctestrun: Run tests using the provided `.xctestrun` file
    - toolchain: The toolchain that should be used for building the application (e.g. `com.apple.dt.toolchain.Swift_2_3, org.swift.30p620160816a`)
    - clean: Should the project be cleaned before building it?
@@ -5963,6 +5974,7 @@ func scan(workspace: Any? = scanfile.workspace,
           appIdentifier: Any? = scanfile.appIdentifier,
           onlyTesting: Any? = scanfile.onlyTesting,
           skipTesting: Any? = scanfile.skipTesting,
+          testplan: Any? = scanfile.testplan,
           xctestrun: Any? = scanfile.xctestrun,
           toolchain: Any? = scanfile.toolchain,
           clean: Bool = scanfile.clean,
@@ -6022,6 +6034,7 @@ func scan(workspace: Any? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                       RubyCommand.Argument(name: "only_testing", value: onlyTesting),
                                                                                       RubyCommand.Argument(name: "skip_testing", value: skipTesting),
+                                                                                      RubyCommand.Argument(name: "testplan", value: testplan),
                                                                                       RubyCommand.Argument(name: "xctestrun", value: xctestrun),
                                                                                       RubyCommand.Argument(name: "toolchain", value: toolchain),
                                                                                       RubyCommand.Argument(name: "clean", value: clean),
@@ -7123,6 +7136,7 @@ func supply(packageName: String,
    - quiet: Don't print status logs like 'Linting <file>' & 'Done linting'
    - executable: Path to the `swiftlint` executable on your machine
    - format: Format code when mode is :autocorrect
+   - noCache: Ignore the cache when mode is :autocorrect or :lint
    - compilerLogPath: Compiler log path when mode is :analyze
 */
 func swiftlint(mode: Any = "lint",
@@ -7137,6 +7151,7 @@ func swiftlint(mode: Any = "lint",
                quiet: Bool = false,
                executable: String? = nil,
                format: Bool = false,
+               noCache: Bool = false,
                compilerLogPath: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "swiftlint", className: nil, args: [RubyCommand.Argument(name: "mode", value: mode),
                                                                                            RubyCommand.Argument(name: "path", value: path),
@@ -7150,6 +7165,7 @@ func swiftlint(mode: Any = "lint",
                                                                                            RubyCommand.Argument(name: "quiet", value: quiet),
                                                                                            RubyCommand.Argument(name: "executable", value: executable),
                                                                                            RubyCommand.Argument(name: "format", value: format),
+                                                                                           RubyCommand.Argument(name: "no_cache", value: noCache),
                                                                                            RubyCommand.Argument(name: "compiler_log_path", value: compilerLogPath)])
   _ = runner.executeCommand(command)
 }
@@ -7554,6 +7570,42 @@ func updateAppIdentifier(xcodeproj: String,
   let command = RubyCommand(commandID: "", methodName: "update_app_identifier", className: nil, args: [RubyCommand.Argument(name: "xcodeproj", value: xcodeproj),
                                                                                                        RubyCommand.Argument(name: "plist_path", value: plistPath),
                                                                                                        RubyCommand.Argument(name: "app_identifier", value: appIdentifier)])
+  _ = runner.executeCommand(command)
+}
+
+/**
+ Configures Xcode's Codesigning options
+
+ - parameters:
+   - path: Path to your Xcode project
+   - useAutomaticSigning: Defines if project should use automatic signing
+   - teamId: Team ID, is used when upgrading project
+   - targets: Specify targets you want to toggle the signing mech. (default to all targets)
+   - codeSignIdentity: Code signing identity type (iPhone Developer, iPhone Distribution)
+   - profileName: Provisioning profile name to use for code signing
+   - profileUuid: Provisioning profile UUID to use for code signing
+   - bundleIdentifier: Application Product Bundle Identifier
+
+ - returns: The current status (boolean) of codesigning after modification
+
+ Configures Xcode's Codesigning options of all targets in the project
+*/
+func updateCodeSigningSettings(path: String,
+                               useAutomaticSigning: Bool = false,
+                               teamId: String? = nil,
+                               targets: [String]? = nil,
+                               codeSignIdentity: String? = nil,
+                               profileName: String? = nil,
+                               profileUuid: String? = nil,
+                               bundleIdentifier: String? = nil) {
+  let command = RubyCommand(commandID: "", methodName: "update_code_signing_settings", className: nil, args: [RubyCommand.Argument(name: "path", value: path),
+                                                                                                              RubyCommand.Argument(name: "use_automatic_signing", value: useAutomaticSigning),
+                                                                                                              RubyCommand.Argument(name: "team_id", value: teamId),
+                                                                                                              RubyCommand.Argument(name: "targets", value: targets),
+                                                                                                              RubyCommand.Argument(name: "code_sign_identity", value: codeSignIdentity),
+                                                                                                              RubyCommand.Argument(name: "profile_name", value: profileName),
+                                                                                                              RubyCommand.Argument(name: "profile_uuid", value: profileUuid),
+                                                                                                              RubyCommand.Argument(name: "bundle_identifier", value: bundleIdentifier)])
   _ = runner.executeCommand(command)
 }
 
@@ -8735,4 +8787,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.71]
+// FastlaneRunnerAPIVersion [0.9.72]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.143.0
+// Generated with fastlane 2.144.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.143.0
+// Generated with fastlane 2.144.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.143.0
+// Generated with fastlane 2.144.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.143.0
+// Generated with fastlane 2.144.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -42,6 +42,9 @@ protocol ScanfileProtocol: class {
   /// Array of strings matching Test Bundle/Test Suite/Test Cases to skip
   var skipTesting: String? { get }
 
+  /// The testplan associated with the scheme that should be used for testing
+  var testplan: String? { get }
+
   /// Run tests using the provided `.xctestrun` file
   var xctestrun: String? { get }
 
@@ -193,6 +196,7 @@ extension ScanfileProtocol {
   var appIdentifier: String? { return nil }
   var onlyTesting: String? { return nil }
   var skipTesting: String? { return nil }
+  var testplan: String? { return nil }
   var xctestrun: String? { return nil }
   var toolchain: String? { return nil }
   var clean: Bool { return false }
@@ -242,4 +246,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.26]
+// FastlaneRunnerAPIVersion [0.9.27]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.143.0
+// Generated with fastlane 2.144.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.143.0
+// Generated with fastlane 2.144.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.143.0':**

* [core] suppress output of PlistBuddy when disabling "KeyboardContinuousPathEnabled" (#16123) via Rob Nadin
* [gym] copy Asset Pack into output directory (#16117) via Carles Roig
* [scan] add testPlan option to scan (#16043) via Nathan Wong
* [match] provisioning Profiles Import and Windows Support (#16188) via Dimitar Tachev
* [action] generate update_code_signing_settings action instead of deprecated automatic_code_signing (#15900) via Atsuto Yamashita
* [pod_lib_lint] add "analyze" option (#16190) via Kyle Hammond
* [action] update crashlytics deprecation date to May 4, 2020 (#16189) via Alex Singer
* [supply] fixing empty track use case (#16161) via androidseb
* [action] add deprecation message to Crashlytic's Beta action (#16157) via Alex Singer
* [spaceship] add ability to create a beta group to Spaceship (#16180) via C.J. Windisch
* [deliver] provide 'env_name' to each config option that didn't previously have one and that isn't a hash (#16179) via Liam Nichols
* [action] clean_build_artificates - remove references to downloaded files after they are deleted (#16178) via Guy Kogus
* [fastlane] migrate from AWS-SDK v2 to AWS-SDK v3 (#16143) via Jakub Kašpar
* [spaceship] add a check in app_version.setup_screenshots to also check if there is an app_preview already uploaded (#14738) via Pavlos Chrisochoidis
* [action] swiftlint - add support for the --no-cache flag on autocorrect (#16132) via Ignacio Calderon
* [GitHub Actions] remove size-label action (#16125) via Jan Piotrowski
