### PR TITLE
[scan] Fix issue with spaces in testplan option

### DIFF
--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -31,7 +31,7 @@ module Scan
       config = Scan.config
 
       options = []
-      options += project_path_array unless config[:xcrun]
+      options += project_path_array unless config[:xctestrun]
       options << "-sdk '#{config[:sdk]}'" if config[:sdk]
       options << destination # generated in `detect_values`
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -31,7 +31,8 @@ module Scan
       config = Scan.config
 
       options = []
-      options += project_path_array unless config[:xctestrun]
+      options += project_path_array unless config[:xc
+        run]
       options << "-sdk '#{config[:sdk]}'" if config[:sdk]
       options << destination # generated in `detect_values`
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
@@ -46,7 +47,7 @@ module Scan
       options << "-enableAddressSanitizer #{config[:address_sanitizer] ? 'YES' : 'NO'}" unless config[:address_sanitizer].nil?
       options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
       if FastlaneCore::Helper.xcode_at_least?(11)
-        options << "-testPlan #{config[:testplan]}" if config[:testplan]
+        options << "-testPlan '#{config[:testplan]}'" if config[:testplan]
       end
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -31,8 +31,7 @@ module Scan
       config = Scan.config
 
       options = []
-      options += project_path_array unless config[:xc
-        run]
+      options += project_path_array unless config[:xcrun]
       options << "-sdk '#{config[:sdk]}'" if config[:sdk]
       options << destination # generated in `detect_values`
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]


### PR DESCRIPTION
Follows on from #16043 - Prevents an issue caused by test plans which have spaces in the name.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixed a bug we noticed when updating our app to use test plans. We have a test plan with a space in the name which is not captured here.

```
210 [12:46:39]: ▸ sh: -c: line 0: syntax error near unexpected token `('
resultBundlePath './fastlane/test_output/UI Tests.xcresult' -testPlan UI Tests (Video) clean build
```

(Second line trimmed just to show the problematic part)