### PR TITLE
[spaceship] add list_pending_agreements to Spaceship::Portal

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -100,6 +100,19 @@ module Spaceship
     end
     private :platform_slug
 
+    def list_pending_agreements(language: "en")
+      r = request(:post) do |req|
+        req.url("account/listPendingAgreements")
+        req.body = {
+          teamId: team_id,
+          languageIsoCode: language
+        }.to_json
+        req.headers['Content-Type'] = 'application/json'
+      end
+
+      return parse_response(r)
+    end
+
     #####################################################
     # @!group Apps
     #####################################################


### PR DESCRIPTION
### Motivation and Context
Sometimes you need to see all the pending agreements for each time you are on 😇 

### Description
Not much to describe 😉 

```rb
require "spaceship"
Spaceship::Portal.login(username, password)
Spaceship::Portal.select_team(team_id: team_id)
resp = Spaceship::Portal.client.list_pending_agreements

if resp && resp["agreements"].empty?
  status = "GOOD".green
else
  status = "BAD".red
end
```