### PR TITLE
[Fastlane.swift] add options to beforeAll

### DIFF
--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -19,6 +19,7 @@ public protocol LaneFileProtocol: class {
     static func runLane(named: String, parameters: [String : String]) -> Bool
 
     func recordLaneDescriptions()
+    func beforeAll(currentLane: String, parameters: [String : String])
     func beforeAll()
     func afterAll(currentLane: String)
     func onError(currentLane: String, errorInfo: String)
@@ -26,6 +27,7 @@ public protocol LaneFileProtocol: class {
 
 public extension LaneFileProtocol {
     var fastlaneVersion: String { return "" } // default "" because that means any is fine
+    func beforeAll(currentLane: String, parameters: [String : String]) { } // no op by default
     func beforeAll() { } // no op by default
     func afterAll(currentLane: String) { } // no op by default
     func onError(currentLane: String, errorInfo: String) {} // no op by default
@@ -37,7 +39,8 @@ public class LaneFile: NSObject, LaneFileProtocol {
     private(set) static var fastfileInstance: Fastfile?
 
     // Called before any lane is executed.
-    private func setupAllTheThings() {
+    private func setupAllTheThings(lane: String, parameters: [String : String]) {
+        LaneFile.fastfileInstance!.beforeAll(currentLane: lane, parameters: parameters)
         LaneFile.fastfileInstance!.beforeAll()
     }
 
@@ -123,7 +126,7 @@ public class LaneFile: NSObject, LaneFileProtocol {
         }
 
         // call all methods that need to be called before we start calling lanes
-        fastfileInstance.setupAllTheThings()
+        fastfileInstance.setupAllTheThings(lane: named, parameters: parameters)
 
         // We need to catch all possible errors here and display a nice message
         _ = fastfileInstance.perform(NSSelectorFromString(laneMethod), with: parameters)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

To be in line with the ruby implementation, optional parameters to `beforeAll` is added. That includes the current lane name and the parameters passed to that lane.

### Description
<!-- Describe your changes in detail. -->

A new function was added to the `LaneFileProtocol` with the parameters and lane name as its parameters. 

### Testing Steps

1. Create a new fastlane swift project using this branch.
2. Make sure that the old way of using `beforeAll()` still works.
3. Add an implementation of `beforeAll(currentLane:parameters:)` and test call it with `bundle exec fastlane custom dev:true` for example.
