### PR TITLE
[pilot] Deploy Specific Builds to TestFlight Using Pilot

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -118,9 +118,17 @@ module Pilot
 
       # Get latest uploaded build if no build specified
       if build.nil?
-        UI.important("No build specified - fetching latest build")
+        app_version = config[:app_version]
+        build_number = config[:build_number]
+        if build_number.nil?
+          if app_version.nil?
+            UI.important("No build specified - fetching latest build")
+          else
+            UI.important("No build specified - fetching latest build for version #{app_version}")
+          end
+        end
         platform = Spaceship::ConnectAPI::Platform.map(fetch_app_platform)
-        build ||= Spaceship::ConnectAPI::Build.all(app_id: app.id, sort: "-uploadedDate", platform: platform, limit: 1).first
+        build ||= Spaceship::ConnectAPI::Build.all(app_id: app.id, version: app_version, build_number: build_number, sort: "-uploadedDate", platform: platform, limit: 1).first
       end
 
       # Verify the build has all the includes that we need

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -162,6 +162,14 @@ module Pilot
                                     env_name: "PILOT_NOTIFY_EXTERNAL_TESTERS",
                                     description: "Should notify external testers?",
                                     default_value: true),
+        FastlaneCore::ConfigItem.new(key: :app_version,
+                                     env_name: "PILOT_APP_VERSION",
+                                     description: "The version number of the application build to distribute. If the version number is not specified, then the most recent build uploaded to TestFlight will be distributed. If specified, the most recent build for the version number will be distributed",
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :build_number,
+                                     env_name: "PILOT_BUILD_NUMBER",
+                                     description: "The build number of the application build to distribute. If the build number is not specified, the most recent build is distributed",
+                                     optional: true),
 
         # testers
         FastlaneCore::ConfigItem.new(key: :first_name,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

For my projects, I am using a CI/CD process utilizing multiple stages. My projects perform automated builds using GitHub Actions or Azure DevOps pipelines. Once the builds are successful, I am using Azure DevOps release pipelines to implement a multi-stage deployment. For example:

1. Build the iOS application and export using an ad-hoc profile. Upload the application to Microsoft App Center for internal testing by QA. Manual approval is required to advance to the next stage.
2. Build the iOS application and export using an App Store profile. Upload the application to Apple's TestFlight service and expose for internal testing by the product owner and stakeholders. Manual approval is required to advance to the next stage.
3. Submit the TestFlight build for external testing by beta testers and early adopters. Manual approval is required to advance to the next stage.
4. Submit the application to the App Store. Run snapshot and frameit to generate app images and use deliver to update the application metadata.

By default, when running `fastlane pilot distribute` to promote a build that has already been uploaded to TestFlight, Pilot will search for and use the latest build that has been published to TestFlight for the application. This is problematic in a DevOps scenario. For example:

1. 1.0.0 is released to the App Store and that pipeline is completed.
2. I begin working on 1.1.0 and implementing new features. I use pipelines to send out new builds to internal testers using TestFlight.
3. I discover bugs in 1.0.0 and decide to fix them. I create a new branch for a 1.0.1 release. A new 1.0.1 gets published to TestFlight for internal testing and validation.
4. 1.1.0 is feature complete and I create a release branch for it. I publish the first release candidate build to TestFlight for testing and validation by internal testers.
5. I start building new features for a 2.0.0 release and start sending out beta builds via TestFlight for internal testers.
6. I make updates to the 1.1.0 release branch after feedback from testers. I publish updated builds to TestFlight for internal testing.
7. I'm ready to promote the 1.0.1 hotfix to external testers to external testers before releasing it on the App Store. I cannot use `fastlane pilot deliver` to automate promoting the 1.0.1 build because the most recent build was for the 1.1.0 release candidate build.
8. I'm ready to promote 2.0.0 to my external beta testers. The most recent build is 1.1.0 and `fastlane pilot deliver` can't select the `2.0.0` build.
9. I'm ready to promote the 1.1.0 RC build to external testers. `fastlane pilot deliver` succeeds, because the 1.1.0 build is the latest build.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I added two command line arguments to Pilot for use when running the `deliver` command as a one-off:

* `--app-version`: This specifies the version number to use to select an application build. If not specified, the default behavior will use the most recent build uploaded to TestFlight.
* `--build-number`: The build number of the TestFlight build to submit for external testing. If not specified but `--app-version` is used, then the most recent build for that application version will be selected. If neither `--app-version` nor `--build-number` are specified, then the current behavior will be used to select the most recent build uploaded to TestFlight.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I did not see any automated tests around command line usage of the `pilot distribute` command, so I did not add any. I tested manually.

I used my existing project that is using GitHub Actions for CI and Azure DevOps for CD. I ran the following commands to verify that the correct build was submitted for review on TestFlight:

1. `fastlane pilot deliver --distribute-external true -g "Beta Testers"`: The most recent build was selected and submitted for review.
2. `fastlane pilot deliver --distribute-external true -g "Beta Testers" -app-version 1.0.0`: The most recent build for the 1.0.0 release was selected and submitted for review.
3. `fastlane pilot deliver --distribute-external true -g "Beta Testers" --app-version 1.0.0 --build-number 52`: The specified build was selected and submitted for review.
4. `fastlane pilot deliver --distribute-external true -g "Beta Testers" -app-version 0.1.0`: There was no 0.1.0 version in TestFlight and no builds submitted for review.
5. `fastlane pilot deliver --distribute-external true -g "Beta Testers" --app-version 1.0.0 --build-number 53`: (52 was the highest build) No builds were submitted for review.