### PR TITLE
[snapshot] Fix warning in SnapshotHelper.swift

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -38,22 +38,13 @@ func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
 }
 
 enum SnapshotError: Error, CustomDebugStringConvertible {
-    case cannotDetectUser
-    case cannotFindHomeDirectory
     case cannotFindSimulatorHomeDirectory
-    case cannotAccessSimulatorHomeDirectory(String)
     case cannotRunOnPhysicalDevice
 
     var debugDescription: String {
         switch self {
-        case .cannotDetectUser:
-            return "Couldn't find Snapshot configuration files - can't detect current user "
-        case .cannotFindHomeDirectory:
-            return "Couldn't find Snapshot configuration files - can't detect `Users` dir"
         case .cannotFindSimulatorHomeDirectory:
             return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
-        case .cannotAccessSimulatorHomeDirectory(let simulatorHostHome):
-            return "Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?"
         case .cannotRunOnPhysicalDevice:
             return "Can't use Snapshot on a physical device."
         }
@@ -75,7 +66,7 @@ open class Snapshot: NSObject {
         Snapshot.waitForAnimations = waitForAnimations
 
         do {
-            let cacheDir = try pathPrefix()
+            let cacheDir = try getCacheDirectory()
             Snapshot.cacheDirectory = cacheDir
             setLanguage(app)
             setLocale(app)
@@ -206,34 +197,22 @@ open class Snapshot: NSObject {
         _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
 
-    class func pathPrefix() throws -> URL? {
-        let homeDir: URL
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
         // on OSX config is stored in /Users/<username>/Library
         // and on iOS/tvOS/WatchOS it's in simulator's home dir
         #if os(OSX)
-            guard let user = ProcessInfo().environment["USER"] else {
-                throw SnapshotError.cannotDetectUser
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
             }
-
-            guard let usersDir = FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
-                throw SnapshotError.cannotFindHomeDirectory
-            }
-
-            homeDir = usersDir.appendingPathComponent(user)
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
         #else
-            #if arch(i386) || arch(x86_64)
-                guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
-                    throw SnapshotError.cannotFindSimulatorHomeDirectory
-                }
-                guard let homeDirUrl = URL(string: simulatorHostHome) else {
-                    throw SnapshotError.cannotAccessSimulatorHomeDirectory(simulatorHostHome)
-                }
-                homeDir = URL(fileURLWithPath: homeDirUrl.path)
-            #else
-                throw SnapshotError.cannotRunOnPhysicalDevice
-            #endif
+            throw SnapshotError.cannotRunOnPhysicalDevice
         #endif
-        return homeDir.appendingPathComponent("Library/Caches/tools.fastlane")
     }
 }
 
@@ -300,4 +279,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.21]
+// SnapshotHelperVersion [1.22]


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Get rid of this warning when using the `SnapshotHelper.swift` supplied by `snapshot`:
> SnapshotHelper.swift:236:9: Code after 'throw' will never be executed

### Description
I removed the `#else` branch that was doing `throw SnapshotError.cannotRunOnPhysicalDevice` and reorganised the code to make sure that no code is executed after a `throw`.

### Testing Steps
In order to test this change, compile the `SnapshotHelper.swift` with Xcode 11.4 and ensure that no warning is produced.