### PR TITLE
[action] setup_jenkins with match

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -106,8 +106,8 @@ module Fastlane
         [
           list,
           "This action helps with Jenkins integration. Creates own derived data for each job. All build results like IPA files and archives will be stored in the `./output` directory.",
-          "The action also works with [Keychains and Provisioning Profiles Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Keychains+and+Provisioning+Profiles+Plugin), the selected keychain will be automatically unlocked and the selected code signing identity will be used." 
-          "[Match](https://docs.fastlane.tools/actions/match/) will be also set up to use the unlocked keychain, and set in read-only mode."
+          "The action also works with [Keychains and Provisioning Profiles Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Keychains+and+Provisioning+Profiles+Plugin), the selected keychain will be automatically unlocked and the selected code signing identity will be used.",
+          "[Match](https://docs.fastlane.tools/actions/match/) will be also set up to use the unlocked keychain, and set in read-only mode.",
           "By default this action will only work when _fastlane_ is executed on a CI system."
         ].join("\n")
       end

--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -43,9 +43,9 @@ module Fastlane
             add_to_search_list: params[:add_keychain_to_search_list],
             set_default: params[:set_default_keychain]
           )
-          ENV['MATCH_KEYCHAIN_NAME'] = keychain_path
-          ENV['MATCH_KEYCHAIN_PASSWORD'] = params[:keychain_password]
-          ENV["MATCH_READONLY"] = true.to_s
+          ENV['MATCH_KEYCHAIN_NAME'] ||= keychain_path
+          ENV['MATCH_KEYCHAIN_PASSWORD'] ||= params[:keychain_password]
+          ENV["MATCH_READONLY"] ||= true.to_s
         end
 
         # Code signing identity
@@ -107,7 +107,7 @@ module Fastlane
           list,
           "This action helps with Jenkins integration. Creates own derived data for each job. All build results like IPA files and archives will be stored in the `./output` directory.",
           "The action also works with [Keychains and Provisioning Profiles Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Keychains+and+Provisioning+Profiles+Plugin), the selected keychain will be automatically unlocked and the selected code signing identity will be used.",
-          "[Match](https://docs.fastlane.tools/actions/match/) will be also set up to use the unlocked keychain, and set in read-only mode.",
+          "[Match](https://docs.fastlane.tools/actions/match/) will be also set up to use the unlocked keychain and set in read-only mode, if its environment variables were not yet defined.",
           "By default this action will only work when _fastlane_ is executed on a CI system."
         ].join("\n")
       end

--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -40,6 +40,9 @@ module Fastlane
             add_to_search_list: params[:add_keychain_to_search_list],
             set_default: params[:set_default_keychain]
           )
+          ENV['MATCH_KEYCHAIN_NAME'] = keychain_path
+          ENV['MATCH_KEYCHAIN_PASSWORD'] = params[:keychain_password]
+          ENV["MATCH_READONLY"] = true.to_s
         end
 
         # Code signing identity

--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -14,7 +14,10 @@ module Fastlane
         "SCAN_DERIVED_DATA_PATH",
         "SCAN_OUTPUT_DIRECTORY",
         "SCAN_RESULT_BUNDLE",
-        "XCODE_DERIVED_DATA_PATH"
+        "XCODE_DERIVED_DATA_PATH",
+        "MATCH_KEYCHAIN_NAME",
+        "MATCH_KEYCHAIN_PASSWORD",
+        "MATCH_READONLY"
       ].freeze
 
       def self.run(params)
@@ -93,6 +96,7 @@ module Fastlane
       def self.details
         list = <<-LIST.markdown_list(true)
           Adds and unlocks keychains from Jenkins 'Keychains and Provisioning Profiles Plugin'
+          Sets unlocked keychain to be used by Match
           Sets code signing identity from Jenkins 'Keychains and Provisioning Profiles Plugin'
           Sets output directory to './output' (gym, scan and backup_xcarchive)
           Sets derived data path to './derivedData' (xcodebuild, gym, scan and clear_derived_data, carthage)
@@ -102,7 +106,9 @@ module Fastlane
         [
           list,
           "This action helps with Jenkins integration. Creates own derived data for each job. All build results like IPA files and archives will be stored in the `./output` directory.",
-          "The action also works with [Keychains and Provisioning Profiles Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Keychains+and+Provisioning+Profiles+Plugin), the selected keychain will be automatically unlocked and the selected code signing identity will be used. By default this action will only work when _fastlane_ is executed on a CI system."
+          "The action also works with [Keychains and Provisioning Profiles Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Keychains+and+Provisioning+Profiles+Plugin), the selected keychain will be automatically unlocked and the selected code signing identity will be used." 
+          "[Match](https://docs.fastlane.tools/actions/match/) will be also set up to use the unlocked keychain, and set in read-only mode."
+          "By default this action will only work when _fastlane_ is executed on a CI system."
         ].join("\n")
       end
 

--- a/fastlane/spec/actions_specs/setup_jenkins_spec.rb
+++ b/fastlane/spec/actions_specs/setup_jenkins_spec.rb
@@ -30,6 +30,9 @@ describe Fastlane do
         expect(ENV["SCAN_OUTPUT_DIRECTORY"]).to be_nil
         expect(ENV["SCAN_RESULT_BUNDLE"]).to be_nil
         expect(ENV["XCODE_DERIVED_DATA_PATH"]).to be_nil
+        expect(ENV["MATCH_KEYCHAIN_NAME"]).to be_nil
+        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to be_nil
+        expect(ENV["MATCH_READONLY"]).to be_nil
       end
 
       it "works when forced" do
@@ -104,6 +107,32 @@ describe Fastlane do
               unlock_keychain: false
             )
           end").runner.execute(:test)
+
+          expect(ENV["MATCH_KEYCHAIN_NAME"]).to be_nil
+          expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to be_nil
+          expect(ENV["MATCH_READONLY"]).to be_nil
+        end
+
+        it "unlock keychain" do
+          allow(Fastlane::Actions::UnlockKeychainAction).to receive(:run).and_return(nil)
+
+          keychain_path = Tempfile.new("foo").path
+          ENV["KEYCHAIN_PATH"] = keychain_path
+
+          expect(UI).to receive(:message).with("Unlocking keychain: \"#{keychain_path}\".")
+          expect(UI).to receive(:message).with(/Set output directory path to:/)
+          expect(UI).to receive(:message).with(/Set derived data path to:/)
+          expect(UI).to receive(:message).with("Set result bundle.")
+
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins(
+              keychain_password: 'password'
+            )
+          end").runner.execute(:test)
+
+          expect(ENV["MATCH_KEYCHAIN_NAME"]).to eq(keychain_path)
+          expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eq("password")
+          expect(ENV["MATCH_READONLY"]).to eq("true")
         end
 
         it "set code signing identity" do

--- a/fastlane/spec/actions_specs/setup_jenkins_spec.rb
+++ b/fastlane/spec/actions_specs/setup_jenkins_spec.rb
@@ -135,6 +135,20 @@ describe Fastlane do
           expect(ENV["MATCH_READONLY"]).to eq("true")
         end
 
+        it "does not setup match if previously set" do
+          ENV["MATCH_KEYCHAIN_NAME"] = keychain_name = "keychain_name"
+          ENV["MATCH_KEYCHAIN_PASSWORD"] = keychain_password = "keychain_password"
+          ENV["MATCH_READONLY"] = "false"
+
+          Fastlane::FastFile.new.parse("lane :test do
+            setup_jenkins
+          end").runner.execute(:test)
+
+          expect(ENV["MATCH_KEYCHAIN_NAME"]).to eq(keychain_name)
+          expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eq(keychain_password)
+          expect(ENV["MATCH_READONLY"]).to eq("false")
+        end
+
         it "set code signing identity" do
           ENV["CODE_SIGNING_IDENTITY"] = "Code signing"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

`setup_ci` action already handles Match, though by reading `ENV["MATCH_KEYCHAIN_NAME"]`
In a setup where default keychain is not `login.keychain`, and Jenkins is used as CI system, Match needs to be set up separately, because it will try to still use `login.keychain`. This leads to this piece of code being present in projects:

```
before_all do
    setup_jenkins(
      keychain_path: ENV["BUILD_KEYCHAIN"],
      keychain_password: ENV["BUILD_KEYCHAIN_PASSWORD"],
      set_code_signing_identity: false)

    # setup fastlane match with same keychain and password as just unlocked with setup_jenkins
    ENV["MATCH_KEYCHAIN_NAME"] = File.basename(ENV["BUILD_KEYCHAIN"]) if ENV["BUILD_KEYCHAIN"]
    ENV["MATCH_KEYCHAIN_PASSWORD"] = ENV["BUILD_KEYCHAIN_PASSWORD"] if ENV["BUILD_KEYCHAIN_PASSWORD"]
end
```
because otherwise `setup_jenkins` would unlock a BUILD_KEYCHAIN, but match would by default try to to install certificates and keys into `login.keychain`.

### Description
With that change, setup_jenkins will make sure the unlocked keychain will be used also by Match.
Environment variables used by Fastlane Match are set if a keychain is unlocked by `setup_jenkins`

### Testing Steps

Can be tested by creating a test keychain: `bundle exec fastlane run create_keychain name:test.keychain password:test unlock:true`
Then trying to use before_all pasted earlier, and running a lane that uses Match, example:
`FL_SETUP_JENKINS_FORCE=true BUILD_KEYCHAIN=~/Library/Keychains/test.keychain BUILD_KEYCHAIN_PASSWORD=test bundle exec fastlane build`
