### PR TITLE
Version bump to 2.145.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,61 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-</tr>
-<tr>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
 <img src='https://github.com/lmirosevic.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
 <td id='jan-piotrowski'>
 <a href='https://github.com/janpio'>
@@ -96,63 +46,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
-</tr>
-<tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
 </a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-</tr>
-<tr>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
 </td>
 <td id='matthew-ellis'>
 <a href='https://github.com/matthewellis'>
@@ -162,17 +66,113 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+</td>
+</tr>
+<tr>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+</tr>
+<tr>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+</tr>
+<tr>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/endocrimes'>
 <img src='https://github.com/endocrimes.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Danielle Tomlinson",
-                        "Max Ott",
-                        "Daniel Jankowski",
-                        "Helmut Januschka",
-                        "Josh Holtz",
-                        "Kohki Miki",
-                        "Iulian Onofrei",
-                        "Felix Krause",
-                        "Matthew Ellis",
-                        "Stefan Natchev",
-                        "Olivier Halligon",
+  spec.authors       = ["Daniel Jankowski",
+                        "Danielle Tomlinson",
                         "Luka Mirosevic",
-                        "Jan Piotrowski",
-                        "Joshua Liebowitz",
-                        "Maksym Grebenets",
+                        "Josh Holtz",
+                        "Iulian Onofrei",
                         "Fumiya Nakamura",
-                        "Jimmy Dee",
-                        "Jorge Revuelta H",
-                        "Jérôme Lacoste",
-                        "Andrew McBurney",
                         "Aaron Brager",
-                        "Manu Wallner"]
+                        "Olivier Halligon",
+                        "Felix Krause",
+                        "Maksym Grebenets",
+                        "Jérôme Lacoste",
+                        "Joshua Liebowitz",
+                        "Jorge Revuelta H",
+                        "Helmut Januschka",
+                        "Jimmy Dee",
+                        "Stefan Natchev",
+                        "Andrew McBurney",
+                        "Manu Wallner",
+                        "Max Ott",
+                        "Kohki Miki",
+                        "Jan Piotrowski",
+                        "Matthew Ellis"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.144.0'.freeze
+  VERSION = '2.145.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.144.0
+// Generated with fastlane 2.145.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -2761,7 +2761,7 @@ func downloadDsyms(username: String,
 func downloadFromPlayStore(packageName: String,
                            versionName: String? = nil,
                            track: String = "production",
-                           metadataPath: String = "./metadata",
+                           metadataPath: String? = nil,
                            key: String? = nil,
                            issuer: String? = nil,
                            jsonKey: String? = nil,
@@ -4480,7 +4480,7 @@ func makeChangelogFromJenkins(fallbackChangelog: String = "",
    - googleCloudProjectId: ID of the Google Cloud project to use for authentication
    - s3Region: Name of the S3 region
    - s3AccessKey: S3 access key
-   - s3SecretAccessKey: S3 secret secret access key
+   - s3SecretAccessKey: S3 secret access key
    - s3Bucket: Name of the S3 bucket
    - keychainName: Keychain the items should be imported to
    - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
@@ -6338,7 +6338,7 @@ func setPodKey(useBundleExec: Bool = true,
  This action helps with CI integration. Add this to the top of your Fastfile if you use CI.
 */
 func setupCi(force: Bool = false,
-             provider: Bool = false) {
+             provider: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "setup_ci", className: nil, args: [RubyCommand.Argument(name: "force", value: force),
                                                                                           RubyCommand.Argument(name: "provider", value: provider)])
   _ = runner.executeCommand(command)
@@ -6674,7 +6674,7 @@ func slather(buildDirectory: String? = nil,
              show: Bool = false,
              sourceDirectory: String? = nil,
              outputDirectory: String? = nil,
-             ignore: Any? = nil,
+             ignore: [String]? = nil,
              verbose: Bool? = nil,
              useBundleExec: Bool = false,
              binaryBasename: Bool = false,
@@ -7055,7 +7055,7 @@ func supply(packageName: String,
             releaseStatus: String = "completed",
             track: String = "production",
             rollout: String? = nil,
-            metadataPath: String = "./metadata",
+            metadataPath: String? = nil,
             key: String? = nil,
             issuer: String? = nil,
             jsonKey: String? = nil,
@@ -7197,7 +7197,7 @@ func swiftlint(mode: Any = "lint",
    - googleCloudProjectId: ID of the Google Cloud project to use for authentication
    - s3Region: Name of the S3 region
    - s3AccessKey: S3 access key
-   - s3SecretAccessKey: S3 secret secret access key
+   - s3SecretAccessKey: S3 secret access key
    - s3Bucket: Name of the S3 bucket
    - keychainName: Keychain the items should be imported to
    - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
@@ -8143,7 +8143,7 @@ func uploadToPlayStore(packageName: String,
                        releaseStatus: String = "completed",
                        track: String = "production",
                        rollout: String? = nil,
-                       metadataPath: String = "./metadata",
+                       metadataPath: String? = nil,
                        key: String? = nil,
                        issuer: String? = nil,
                        jsonKey: String? = nil,
@@ -8642,7 +8642,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode-11.2.1.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode-11.4.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -8787,4 +8787,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.72]
+// FastlaneRunnerAPIVersion [0.9.73]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.144.0
+// Generated with fastlane 2.145.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.144.0
+// Generated with fastlane 2.145.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -69,7 +69,7 @@ protocol MatchfileProtocol: class {
   /// S3 access key
   var s3AccessKey: String? { get }
 
-  /// S3 secret secret access key
+  /// S3 secret access key
   var s3SecretAccessKey: String? { get }
 
   /// Name of the S3 bucket
@@ -146,4 +146,4 @@ extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.14]
+// FastlaneRunnerAPIVersion [0.9.15]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.144.0
+// Generated with fastlane 2.145.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.144.0
+// Generated with fastlane 2.145.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.144.0
+// Generated with fastlane 2.145.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.144.0
+// Generated with fastlane 2.145.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.144.0':**

* [match] remove documentation typo (#16256) via Theodore
* [supply] fix error when downloading metadata with drafts (#16185) via Max Ammann
* [action] fix a type error in the Swift setupCi action. (#16153) via Ingmar Stein
* [spaceship] fix 2FA to handle sms fallback for accounts with no trusted devices (#16162) via Josh Siegel
* [gym] Gym::DetectValues test date fix (#16181) via Kyle Hammond
* [action] adds 'Apple Distribution' as valid authority when verifying builds (#16196) via Rogerio de Paula Assis
* [action] swift lint - Changing the :ignore parameter to an Array (#16206) via Sergiu Todirașcu
* [spaceship] fixed Spaceship doc deeplink (#16207) via Jonas Schmid
* [match] mention that Amazon S3 and Google Cloud are available options (#16225) via Theodore
* [action] `get_version_number` resolves version numbers from xcconfig files (#16230) via Nathan Wong
* [spaceship] add list_pending_agreements to Spaceship::Portal (#16217) via Josh Holtz
* [scan] fix issue with spaces in testplan option (#16205) via James Sherlock
