### PR TITLE
[spaceship] fix service id for Wallet (Passbook)

### DIFF
--- a/spaceship/lib/spaceship/portal/app_service.rb
+++ b/spaceship/lib/spaceship/portal/app_service.rb
@@ -59,11 +59,11 @@ module Spaceship
       NetworkExtension = AppService.new_service("NWEXT04537")
       NFCTagReading = AppService.new_service("NFCTRMAY17")
       PersonalVPN = AppService.new_service("V66P55NK2I")
-      Passbook = AppService.new_service("pass")
+      Passbook = AppService.new_service("passbook")
       PushNotification = AppService.new_service("push")
       SiriKit = AppService.new_service("SI015DKUHP")
       VPNConfiguration = AppService.new_service("V66P55NK2I")
-      Wallet = AppService.new_service("pass")
+      Wallet = AppService.new_service("passbook")
       WirelessAccessory = AppService.new_service("WC421J6T7P")
 
       constants.each do |c|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I wanted to use `update_service` for `Sign In with Apple` with `Spaceship::Portal`.
I started research and I found the service id for wallet has been changed.
Sadly, `Spaceship::Portal` doesn't expose options for `Sign In with Apple`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I'm not sure when they changed the id but this is the current id they use.

Related: https://github.com/fastlane/fastlane/pull/12858

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Follow https://github.com/fastlane/fastlane/blob/master/ToolsAndDebugging.md#compare-the-api-requests (This is not for Spaceship::ConnectAPI)
