### PR TITLE
[screengrab] Passing 'specific_device' paremeter to 'adb root' call when 'use_adb_root' is enabled.

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -63,7 +63,7 @@ module Screengrab
 
       # Root is needed to access device paths at /data
       if @config[:use_adb_root]
-        run_adb_command("root", print_all: false, print_command: true)
+        run_adb_command("-s #{device_serial} root", print_all: false, print_command: true)
       end
 
       clear_device_previous_screenshots(device_serial, device_screenshots_paths)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Updated `adb root` command to use `specific_device` so it won't fail in case the user has multiple devices connected. See issue [here](https://github.com/fastlane/fastlane/issues/16170).

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
- Using `device_serial` variable as parameter when calling `adb root`.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
- Run screengrab with and without `specific_device` configuration.
