### PR TITLE
[supply] Save changelog files as version code instead of version name

### DIFF
--- a/supply/lib/supply/setup.rb
+++ b/supply/lib/supply/setup.rb
@@ -98,9 +98,11 @@ module Supply
         FileUtils.mkdir_p(containing)
       end
 
-      path = File.join(containing, "#{release_listing.version}.txt")
-      UI.message("Writing to #{path}...")
-      File.write(path, release_listing.release_notes)
+      release_listing.versioncodes.each do |versioncode|
+        path = File.join(containing, "#{versioncode}.txt")
+        UI.message("Writing to #{path}...")
+        File.write(path, release_listing.release_notes)
+      end
     end
 
     private


### PR DESCRIPTION
Google Play expects changelog files to be named for the version code to which they will be applied

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR fixes #16253 

### Description
During supply init/setup, downloaded changelog files are named with the version code instead of the version name of the current release. This makes the downloaded changelog file names consistent with what the supply uploader is expecting when uploading to Google Play.

### Testing Steps
These changes were tested with an active Google Play release that only had a single APK (and therefore, only a single version code) assigned to it. In theory, these changes should also work for a release that has multiple APKs assigned to it, but I wasn't able to test this scenario.
