### PR TITLE
[delivery] Resolves issue uploading iPad Pro 4th gen screenshots

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -316,6 +316,7 @@ module Deliver
     def self.resolve_ipadpro_conflict_if_needed(screen_size, filename)
       is_3rd_gen = [
         "iPad Pro (12.9-inch) (3rd generation)", # default simulator name has this
+        "iPad Pro (12.9-inch) (4th generation)", # default simulator name has this
         "ipadPro129" # downloaded screenshots name has this
       ].any? { |key| filename.include?(key) }
       if is_3rd_gen

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -15,16 +15,23 @@ describe Deliver::AppScreenshot do
   ScreenSize = Deliver::AppScreenshot::ScreenSize
 
   describe "#initialize" do
-    context "when filename doesn't contain '(3rd generation)'" do
+    context "when filename doesn't contain 'iPad Pro (3rd generation)' or 'iPad Pro (4th generation)'" do
       it "returns iPad Pro(12.9-inch)" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch){2732x2048}.png", "de-DE")
         expect(screenshot.screen_size).to eq(ScreenSize::IOS_IPAD_PRO)
       end
     end
 
-    context "when filename contains '(3rd generation)'" do
+    context "when filename contains 'iPad Pro (3rd generation)'" do
       it "returns iPad Pro(12.9-inch) 3rd generation" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (3rd generation){2732x2048}.png", "de-DE")
+        expect(screenshot.screen_size).to eq(ScreenSize::IOS_IPAD_PRO_12_9)
+      end
+    end
+
+    context "when filename contains 'iPad Pro (4th generation)'" do
+      it "returns iPad Pro(12.9-inch) 3rd generation" do
+        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (4th generation){2732x2048}.png", "de-DE")
         expect(screenshot.screen_size).to eq(ScreenSize::IOS_IPAD_PRO_12_9)
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Resolves issue:  https://github.com/fastlane/fastlane/issues/16262

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Xcode 11.4 introduces new default Simulator for iPad Pro  - "iPad Pro (12.9 inch) (4th generation)".  AppStore Connect web interface now (Apr 2020) has two slots for iPad Pro 12.9" - "iPad Pro (12.9 inch) 2nd generation" with device type "iPadPro" and "iPad Pro 12.9 3rd gen" with device type "iPadPro129". 

fastlane 2.145 mistakenly recognises screenshots created for the 4gen iPad Pro as created for device type "iPadPro" and puts 2nd and 4th gens screenshots to the same slot.

The problem was in resolve_ipadpro_conflict_if_needed() function which uses simulator name to resolve conflicts (2nd gen/3rd/4th gens have the same screen size). I added new simulator name to the list.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Added new unit tests to the app_screenshot_spec.rb, to recognize this corner case. 
`bundle exec rspec deliver/spec/app_screenshot_spec.rb` to test.

To test in real world, you need to have a project with screenshots made on 2nd and 4th gens iPad Pros 12.9" simulators. There is no need to submit screenshots to the App Store, preview html clearly shows the issues.

