### PR TITLE
Improve device names in capture_ios_screenshots documentation

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
@@ -190,10 +190,16 @@ The `Snapfile` can contain all the options that are also available on `fastlane 
 scheme("UITests")
 
 devices([
-  "iPhone 6",
-  "iPhone 6 Plus",
-  "iPhone 5",
-  "iPhone 4s"
+  "iPad (7th generation)",
+  "iPad Air (3rd generation)",
+  "iPad Pro (11-inch)",
+  "iPad Pro (12.9-inch) (3rd generation)",
+  "iPad Pro (9.7-inch)",
+  "iPhone 11",
+  "iPhone 11 Pro",
+  "iPhone 11 Pro Max",
+  "iPhone 8",
+  "iPhone 8 Plus"
 ])
 
 languages([


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes issue in https://github.com/fastlane/docs/issues/845

### Description
This is the full list I got when running 

> instruments -s devices

on a mac with Xcode 11.3.1, 10.2.1, 11.1, 11

```Apple TV (13.3) 
Apple TV 4K (13.3) 
Apple TV 4K (at 1080p) (13.3) 
Apple Watch Series 4 - 40mm (6.1.1) 
Apple Watch Series 4 - 44mm (6.1.1) 
iPad (5th generation) (10.3.1) 
iPad (5th generation) (11.4) 
iPad (6th generation) (11.4) 
iPad (7th generation) (13.3) 
iPad Air (10.3.1) 
iPad Air (11.4) 
iPad Air (3rd generation) (13.3) 
iPad Air 2 (10.3.1) 
iPad Air 2 (11.4) 
iPad Pro (10.5-inch) (10.3.1) 
iPad Pro (10.5-inch) (11.4) 
iPad Pro (11-inch) (13.3) 
iPad Pro (12.9 inch) (10.3.1) 
iPad Pro (12.9-inch) (11.4) 
iPad Pro (12.9-inch) (2nd generation) (10.3.1) 
iPad Pro (12.9-inch) (2nd generation) (11.4) 
iPad Pro (12.9-inch) (3rd generation) (13.3) 
iPad Pro (9.7 inch) (10.3.1) 
iPad Pro (9.7-inch) (11.4) 
iPad Pro (9.7-inch) (13.3) 
iPhone 11 (13.3) 
iPhone 11 Pro (13.3) 
iPhone 11 Pro (13.3) + Apple Watch Series 5 - 40mm (6.1.1) 
iPhone 11 Pro Max (13.3) 
iPhone 11 Pro Max (13.3) + Apple Watch Series 5 - 44mm (6.1.1) 
iPhone 5 (10.3.1) 
iPhone 5s (10.3.1) 
iPhone 5s (11.4) 
iPhone 6 (10.3.1) 
iPhone 6 (11.4) 
iPhone 6 Plus (10.3.1) 
iPhone 6 Plus (11.4) 
iPhone 6s (10.3.1) 
iPhone 6s (11.4) 
iPhone 6s Plus (10.3.1) 
iPhone 6s Plus (11.4) 
iPhone 7 (10.3.1) 
iPhone 7 (11.4) 
iPhone 7 Plus (10.3.1) 
iPhone 7 Plus (11.4) 
iPhone 8 (11.4) 
iPhone 8 (13.3) 
iPhone 8 Plus (11.4) 
iPhone 8 Plus (13.3) 
iPhone SE (10.3.1) 
iPhone SE (11.4) 
iPhone X (11.4)```