### PR TITLE
[upload_symbols_to_crashlytics] Prefer Firebase Crashlytics's upload-symbols to Fabric

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -130,7 +130,7 @@ module Fastlane
       end
 
       def self.find_binary_path(params)
-        params[:binary_path] ||= (Dir["/Applications/Fabric.app/**/upload-symbols"] + Dir["./Pods/**/upload-symbols"]).last
+        params[:binary_path] ||= (Dir["/Applications/Fabric.app/**/upload-symbols"] + Dir["./Pods/Fabric/upload-symbols"] + Dir["./Pods/FirebaseCrashlytics/upload-symbols"]).last
         UI.user_error!("Failed to find Fabric's upload_symbols binary at /Applications/Fabric.app/**/upload-symbols or ./Pods/**/upload-symbols. Please specify the location of the binary explicitly by using the binary_path option") unless params[:binary_path]
 
         params[:binary_path] = File.expand_path(params[:binary_path])


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
![image](https://user-images.githubusercontent.com/14349/79073862-79d7db80-7d1b-11ea-8db8-4d31c057a670.png)

According to the Firebase documentation, if user has upgraded to Firebase Crashlytics, we should use `FirebaseCrashlytics`'s `upload-symbols` cli instead of `Fabric`'s one.

Currently, Fastlane action `upload_symbols_to_crashlytics` finds the cli automatically but if both presented, it will use the legacy Fabric one.

Though it's not common to have both Fabric & FirebaseCrashlytics installed, for those affected by this issue, it's quite hard to find the root cause.

Possible related issue: #16168.
### Description

Instead of finding binary using `Dir["./Pods/**/upload-symbols"]`, I expand it to `Dir["./Pods/Fabric/upload-symbols"] + Dir["./Pods/FirebaseCrashlytics/upload-symbols"]` and take the last found one.

Tested on a sample repo with both Pod installed.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
