### PR TITLE
[snapshot] Erase simulator only when erase_simulator is true

### DIFF
--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -58,7 +58,9 @@ module Snapshot
 
       device_types.each do |type|
         if launcher_config.erase_simulator || launcher_config.localize_simulator || !launcher_config.dark_mode.nil?
-          erase_simulator(type)
+          if launcher_config.erase_simulator
+            erase_simulator(type)
+          end
           if launcher_config.localize_simulator
             localize_simulator(type, language, locale)
           end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Some users expect that running localize_simulator (true) is independent of erase_simulator
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/fastlane/fastlane/issues/16266

### Description
<!-- Describe your changes in detail. -->
Now snapshot will only erase simulators if erase_simulator is true

### Testing Steps
Run snapshot with localize_simulator: true,  erase_simulator: false
Expected outcome: simulator will not be erased
