### PR TITLE
[CI] Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,10 +112,10 @@ jobs:
       xcode: '11.0.0'
     environment:
       _RUBY_VERSION: '2.5'
-  'Execute tests on macOS (Xcode 11.3.0, Ruby 2.6)':
+  'Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)':
     <<: *tests_macos
     macos:
-      xcode: '11.3.0'
+      xcode: '11.4.0'
     environment:
       _RUBY_VERSION: '2.6'
 
@@ -243,7 +243,7 @@ workflows:
       - 'Execute tests on macOS (Xcode 9.4.1, Ruby 2.3)'
       - 'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)'
       - 'Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)'
-      - 'Execute tests on macOS (Xcode 11.3.0, Ruby 2.6)'
+      - 'Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)'
       - 'Execute tests on Ubuntu'
 
       - "Validate Fastlane.swift Generation"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Circle ci has released [Xcode 11.4 image](https://discuss.circleci.com/t/xcode-11-4-released/35144). It is good to support the latest xcode version that is available.

### Description
Tests are now running on Xcode 11.4.0 instead of 11.3.0
