### PR TITLE
[frameit] Change framefile.json load path to support Screengrab and Supply

### DIFF
--- a/frameit/lib/frameit/runner.rb
+++ b/frameit/lib/frameit/runner.rb
@@ -82,8 +82,12 @@ module Frameit
     # Loads the config (colors, background, texts, etc.)
     # Don't use this method to access the actual text and use `fetch_texts` instead
     def create_config(screenshot_path)
+      # Screengrab pulls screenshots to a different folder location
+      # frameit only handles two levels of folders, to not break
+      # compatibility with Supply we look into a different path for Android
+      # Issue https://github.com/fastlane/fastlane/issues/16289
       config_path = File.join(File.expand_path("..", screenshot_path), "Framefile.json")
-      config_path = File.join(File.expand_path("../..", screenshot_path), "Framefile.json") unless File.exist?(config_path)
+      config_path = File.join(File.expand_path("../../../..", screenshot_path), "Framefile.json") unless File.exist?(config_path)
       file = ConfigParser.new.load(config_path)
       return {} unless file # no config file at all
       file.fetch_value(screenshot_path)

--- a/frameit/lib/frameit/runner.rb
+++ b/frameit/lib/frameit/runner.rb
@@ -87,6 +87,7 @@ module Frameit
       # compatibility with Supply we look into a different path for Android
       # Issue https://github.com/fastlane/fastlane/issues/16289
       config_path = File.join(File.expand_path("..", screenshot_path), "Framefile.json")
+      config_path = File.join(File.expand_path("../..", screenshot_path), "Framefile.json") unless File.exist?(config_path)
       config_path = File.join(File.expand_path("../../../..", screenshot_path), "Framefile.json") unless File.exist?(config_path)
       file = ConfigParser.new.load(config_path)
       return {} unless file # no config file at all


### PR DESCRIPTION
Issue https://github.com/fastlane/fastlane/issues/16289
When using screengrab and frameit, frameit doesnt load properly
the config file because it matches the current iOS setup,
to be able to load the android properly we need to fully extend the
path.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR fixes this issue: https://github.com/fastlane/fastlane/issues/16289
I noticed that frameit expects the Framefile.json to be in a specific folder location, but when using it with screengrab and supply it doesn't support the folder structure, I saw the in the PR `ea4d8a2`
the method `create_config` was created but isn't considering the actual support to supply/screengrab, the screenshots have added the frame but it doesn't add the background.

### Description
I've just extended the path to be 4 levels deep.
Since I couldn't see much value in add a test for this specific method I tested loading from different paths, but if you guys think that might be cool I can add it.

### Testing Steps
Just created a new test in the config_parser_spec to simulate it to be and tested in a local project.
I can add the test if it's ok.