### PR TITLE
[pilot] mark Hash options with is_string:false

### DIFF
--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -75,6 +75,7 @@ module Pilot
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :beta_app_review_info,
                                      type: Hash,
+                                     is_string: false,
                                      env_name: "PILOT_BETA_APP_REVIEW_INFO",
                                      description: "Beta app review information for contact info and demo account",
                                      optional: true,
@@ -86,6 +87,7 @@ module Pilot
         # app detail
         FastlaneCore::ConfigItem.new(key: :localized_app_info,
                                      type: Hash,
+                                     is_string: false,
                                      env_name: "PILOT_LOCALIZED_APP_INFO",
                                      description: "Localized beta app test info for description, feedback email, marketing url, and privacy policy",
                                      optional: true,
@@ -109,6 +111,7 @@ module Pilot
         # build review info
         FastlaneCore::ConfigItem.new(key: :localized_build_info,
                                      type: Hash,
+                                     is_string: false,
                                      env_name: "PILOT_LOCALIZED_BUILD_INFO",
                                      description: "Localized beta app test info for what's new",
                                      optional: true,


### PR DESCRIPTION
In #16294 we discovered that `PILOT_BETA_APP_REVIEW_INFO` cannot be set via the pilot distribute cli. The options are listed as `STRING` in `pilot distribute --help` incorrectly.