### PR TITLE
[create_pull_request] Add `draft` option 

### DIFF
--- a/fastlane/lib/fastlane/actions/create_pull_request.rb
+++ b/fastlane/lib/fastlane/actions/create_pull_request.rb
@@ -15,6 +15,7 @@ module Fastlane
           'base' => params[:base]
         }
         payload['body'] = params[:body] if params[:body]
+        payload['draft'] = params[:draft] if params[:draft]
 
         GithubApiAction.run(
           server_url: params[:api_url],
@@ -176,6 +177,11 @@ module Fastlane
                                        description: "The contents of the pull request",
                                        is_string: true,
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :draft,
+                                       env_name: "GITHUB_PULL_REQUEST_DRAFT",
+                                       description: "Indicates whether the pull request is a draft",
+                                       type: Boolean,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :labels,
                                        env_name: "GITHUB_PULL_REQUEST_LABELS",
                                        description: "The labels for the pull request",
@@ -226,7 +232,7 @@ module Fastlane
       end
 
       def self.author
-        ["seei", "tommeier", "marumemomo", "elneruda"]
+        ["seei", "tommeier", "marumemomo", "elneruda", "kagemiku"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/spec/actions_specs/create_pull_request_spec.rb
+++ b/fastlane/spec/actions_specs/create_pull_request_spec.rb
@@ -15,6 +15,16 @@ describe Fastlane do
               }
             ).to_return(status: 201, body: response_body, headers: {})
 
+          stub_request(:post, "https://api.github.com/repos/fastlane/fastlane/pulls").
+            with(
+              body: '{"title":"test PR","head":"git rev-parse --abbrev-ref HEAD","base":"master","draft":true}',
+              headers: {
+                'Authorization' => 'Basic MTIzNDU2Nzg5',
+                'Host' => 'api.github.com:443',
+                'User-Agent' => 'fastlane-github_api'
+              }
+            ).to_return(status: 201, body: response_body, headers: {})
+
           number = JSON.parse(response_body)["number"]
           stub_request(:patch, "https://api.github.com/repos/fastlane/fastlane/issues/#{number}").
             with(
@@ -84,6 +94,21 @@ describe Fastlane do
                 api_token: '123456789',
                 title: 'test PR',
                 repo: 'fastlane/fastlane',
+              )
+            end
+          ").runner.execute(:test)
+
+          expect(result).to eq('https://github.com/fastlane/fastlane/pull/1347')
+        end
+
+        it 'correctly submits to github as a draft pull request' do
+          result = Fastlane::FastFile.new.parse("
+            lane :test do
+              create_pull_request(
+                api_token: '123456789',
+                title: 'test PR',
+                repo: 'fastlane/fastlane',
+                draft: true,
               )
             end
           ").runner.execute(:test)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

As discussed in #15167, GitHub API accepts `draft` option when creating PR.  It was under preview for a long time, but now it's not under preview, we can use it without any additional headers.  

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This PR introduces `draft` option to `create_pull_request` fastlane action.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
We can test this option by adding `draft` option:
```sh
$ bundle exec fastlane run create_pull_request api_token:token repo:owner/repo-name title:test head:test-branch base:master draft:true
```