### PR TITLE
[snapshot] Add -only-testing and -skip-testing options from scan

### DIFF
--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -37,8 +37,8 @@ module Scan
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
       options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
       options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
-      options << "-parallel-testing-worker-count #{config[:concurrent_workers]}" if config[:concurrent_workers]
       if FastlaneCore::Helper.xcode_at_least?(10)
+        options << "-parallel-testing-worker-count #{config[:concurrent_workers]}" if config[:concurrent_workers]
         options << "-maximum-concurrent-test-simulator-destinations #{config[:max_concurrent_simulators]}" if config[:max_concurrent_simulators]
         options << "-disable-concurrent-testing" if config[:disable_concurrent_testing]
       end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -238,7 +238,7 @@ describe Scan do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         result = @test_command_generator.generate
-        expect(result).to include("-parallel-testing-worker-count 4")
+        expect(result).to include("-parallel-testing-worker-count 4") if FastlaneCore::Helper.xcode_at_least?(10)
       end
     end
 

--- a/snapshot/lib/snapshot/detect_values.rb
+++ b/snapshot/lib/snapshot/detect_values.rb
@@ -30,6 +30,9 @@ module Snapshot
 
       Snapshot.project.select_scheme(preferred_to_include: "UITests")
 
+      coerce_to_array_of_strings(:only_testing)
+      coerce_to_array_of_strings(:skip_testing)
+
       # Devices
       if config[:devices].nil? && !Snapshot.project.mac?
         config[:devices] = []
@@ -66,6 +69,18 @@ module Snapshot
       elsif Snapshot.project.mac?
         config[:devices] = ["Mac"]
       end
+    end
+
+    def self.coerce_to_array_of_strings(config_key)
+      config_value = Snapshot.config[config_key]
+
+      return if config_value.nil?
+
+      # splitting on comma allows us to support comma-separated lists of values
+      # from the command line, even though the ConfigItem is not defined as an
+      # Array type
+      config_value = config_value.split(',') unless config_value.kind_of?(Array)
+      Snapshot.config[config_key] = config_value.map(&:to_s)
     end
   end
 end

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -5,6 +5,11 @@ require_relative 'module'
 
 module Snapshot
   class Options
+    def self.verify_type(item_name, acceptable_types, value)
+      type_ok = [Array, String].any? { |type| value.kind_of?(type) }
+      UI.user_error!("'#{item_name}' should be of type #{acceptable_types.join(' or ')} but found: #{value.class.name}") unless type_ok
+    end
+
     def self.available_options
       output_directory = (File.directory?("fastlane") ? "fastlane/screenshots" : "screenshots")
 
@@ -237,7 +242,23 @@ module Snapshot
                                      env_name: "SNAPSHOT_TESTPLAN",
                                      description: "The testplan associated with the scheme that should be used for testing",
                                      is_string: true,
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :only_testing,
+                                     env_name: "SNAPSHOT_ONLY_TESTING",
+                                     description: "Array of strings matching Test Bundle/Test Suite/Test Cases to run",
+                                     optional: true,
+                                     is_string: false,
+                                     verify_block: proc do |value|
+                                       verify_type('only_testing', [Array, String], value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :skip_testing,
+                                     env_name: "SNAPSHOT_SKIP_TESTING",
+                                     description: "Array of strings matching Test Bundle/Test Suite/Test Cases to skip",
+                                     optional: true,
+                                     is_string: false,
+                                     verify_block: proc do |value|
+                                       verify_type('skip_testing', [Array, String], value)
+                                     end)
       ]
     end
   end

--- a/snapshot/lib/snapshot/test_command_generator_base.rb
+++ b/snapshot/lib/snapshot/test_command_generator_base.rb
@@ -30,6 +30,11 @@ module Snapshot
           options << "-testPlan '#{config[:testplan]}'" if config[:testplan]
         end
         options << config[:xcargs] if config[:xcargs]
+
+        # detect_values will ensure that these values are present as Arrays if
+        # they are present at all
+        options += config[:only_testing].map { |test_id| "-only-testing:#{test_id.shellescape}" } if config[:only_testing]
+        options += config[:skip_testing].map { |test_id| "-skip-testing:#{test_id.shellescape}" } if config[:skip_testing]
         return options
       end
 
@@ -91,7 +96,8 @@ module Snapshot
         language_key = locale || language
 
         unless Snapshot.cache[:result_bundle_path][language_key]
-          path = File.join(Snapshot.config[:output_directory], "test_output", language_key, Snapshot.config[:scheme]) + ".test_result"
+          ext = FastlaneCore::Helper.xcode_version.to_i >= 11 ? '.xcresult' : '.test_result'
+          path = File.join(Snapshot.config[:output_directory], "test_output", language_key, Snapshot.config[:scheme]) + ext
           if File.directory?(path)
             FileUtils.remove_dir(path)
           end

--- a/snapshot/lib/snapshot/test_command_generator_base.rb
+++ b/snapshot/lib/snapshot/test_command_generator_base.rb
@@ -96,7 +96,7 @@ module Snapshot
         language_key = locale || language
 
         unless Snapshot.cache[:result_bundle_path][language_key]
-          ext = FastlaneCore::Helper.xcode_version.to_i >= 11 ? '.xcresult' : '.test_result'
+          ext = FastlaneCore::Helper.xcode_at_least?(11) ? '.xcresult' : '.test_result'
           path = File.join(Snapshot.config[:output_directory], "test_output", language_key, Snapshot.config[:scheme]) + ext
           if File.directory?(path)
             FileUtils.remove_dir(path)

--- a/snapshot/spec/detect_values_spec.rb
+++ b/snapshot/spec/detect_values_spec.rb
@@ -1,0 +1,35 @@
+describe Snapshot do
+  describe Snapshot::DetectValues do
+    describe "value coercion" do
+      it "coerces only_testing to be an array", requires_xcodebuild: true do
+        options = {
+            project: "./snapshot/example/Example.xcodeproj",
+            scheme: "ExampleUITests",
+            only_testing: "Bundle/SuiteA"
+        }
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        expect(Snapshot.config[:only_testing]).to eq(["Bundle/SuiteA"])
+      end
+
+      it "coerces skip_testing to be an array", requires_xcodebuild: true do
+        options = {
+            project: "./snapshot/example/Example.xcodeproj",
+            scheme: "ExampleUITests",
+            skip_testing: "Bundle/SuiteA,Bundle/SuiteB"
+        }
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        expect(Snapshot.config[:skip_testing]).to eq(["Bundle/SuiteA", "Bundle/SuiteB"])
+      end
+
+      it "leaves skip_testing as an array", requires_xcodebuild: true do
+        options = {
+            project: "./snapshot/example/Example.xcodeproj",
+            scheme: "ExampleUITests",
+            skip_testing: ["Bundle/SuiteA", "Bundle/SuiteB"]
+        }
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        expect(Snapshot.config[:skip_testing]).to eq(["Bundle/SuiteA", "Bundle/SuiteB"])
+      end
+    end
+  end
+end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -273,6 +273,42 @@ describe Snapshot do
           expect(command.join('')).to include("-testPlan 'simple'") if FastlaneCore::Helper.xcode_at_least?(11)
         end
       end
+
+      context "only-testing" do
+        it "only tests the test bundle/suite/cases specified in only_testing when the input is an array", requires_xcode: true do
+          configure(options.merge(only_testing: %w(TestBundleA/TestSuiteB TestBundleC)))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to include("-only-testing:TestBundleA/TestSuiteB")
+          expect(command.join('')).to include("-only-testing:TestBundleC")
+        end
+
+        it "only tests the test bundle/suite/cases specified in only_testing when the input is a string", requires_xcode: true do
+          configure(options.merge(only_testing: 'TestBundleA/TestSuiteB'))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to include("-only-testing:TestBundleA/TestSuiteB")
+          expect(command.join('')).not_to(include("-only-testing:TestBundleC"))
+        end
+      end
+
+      context "skip-testing" do
+        it "does not test the test bundle/suite/cases specified in skip_testing when the input is an array", requires_xcode: true do
+          configure(options.merge(skip_testing: %w(TestBundleA/TestSuiteB TestBundleC)))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to include("-skip-testing:TestBundleA/TestSuiteB")
+          expect(command.join('')).to include("-skip-testing:TestBundleC")
+        end
+
+        it "does not test the test bundle/suite/cases specified in skip_testing when the input is a string", requires_xcode: true do
+          configure(options.merge(skip_testing: 'TestBundleA/TestSuiteB'))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to include("-skip-testing:TestBundleA/TestSuiteB")
+          expect(command.join('')).not_to(include("-skip-testing:TestBundleC"))
+        end
+      end
     end
 
     describe "Valid macOS Configuration" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

To make retrying mechanisms possible, we need to leverage the `-only-testing` and `-skip-testing` options that already exist in `scan`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This change brings both the options `-only-testing` and `-skip-testing` from `scan` to `snapshot`.
The `snapshot` implementation is extremely similar, if not identical, to the `scan` implementation.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I have tested this change in my project and I was able to create a retrying mechanism, that only do so with failing tests.