### PR TITLE
[fastlane_core] allow passing in Hash options via cli/env as json

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -2,6 +2,7 @@ require_relative '../ui/ui'
 require_relative '../ui/errors/fastlane_error'
 require_relative '../helper'
 require_relative '../module'
+require 'json'
 
 module FastlaneCore
   class ConfigItem
@@ -240,6 +241,12 @@ module FastlaneCore
       elsif allow_shell_conversion
         return value.shelljoin if value.kind_of?(Array)
         return value.map { |k, v| "#{k.to_s.shellescape}=#{v.shellescape}" }.join(' ') if value.kind_of?(Hash)
+      elsif data_type == Hash && value.kind_of?(String)
+        begin
+          parsed = JSON.parse(value)
+          return parsed if parsed.kind_of?(Hash)
+        rescue JSON::ParserError
+        end
       elsif data_type != String
         # Special treatment if the user specified true, false or YES, NO
         # There is no boolean type, so we just do it here

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -228,6 +228,7 @@ module FastlaneCore
       true
     end
 
+    # rubocop:disable Metrics/PerceivedComplexity
     # Returns an updated value type (if necessary)
     def auto_convert_value(value)
       return nil if value.nil?
@@ -256,6 +257,7 @@ module FastlaneCore
           return false
         end
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       return value # fallback to not doing anything
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context

Some fastlane options are defined as `Hash`es, and cannot currently be specified when using the fastlane cli or environment variables.

cc #16294 #16307 

### Description

Hash options can be set via the cli/env using JSON syntax.

### Testing Steps

Ran `fastlane pilot distribute` with `PILOT_BETA_APP_REVIEW_INFO='{"contact_first_name":"...",...}'` set.