### PR TITLE
[frameit] prevent fonts to match if the screenshot name contains the language name

### DIFF
--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -535,7 +535,7 @@ module Frameit
         fonts.each do |font|
           if font['supported']
             font['supported'].each do |language|
-              if screenshot.path.include?(language)
+              if screenshot.language == language
                 return font["font"]
               end
             end

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -122,6 +122,10 @@ module Frameit
       return File.mtime(path) > File.mtime(output_path)
     end
 
+    def language
+      @language ||= Pathname.new(path).parent.basename.to_s
+    end
+
     def to_s
       self.path
     end


### PR DESCRIPTION
When frameit tries to match fonts with screenshots, it looks in the screenshot path to see if the font supported language is part of the path. The problem is that if the font name is present in the screenshot filename, a font can match when it’s not desired.

Example:
```
      "fonts": [
        {
          "font": "./fonts/NotoSans-Bold.ttf",
          "supported": ["en-GB", "ca", "cs", "da", "de-DE", "el", "en-US", "es-ES", "es-MX", "fi", "fr-FR", "hr", "hu", "id", "it", "ms", "nl-NL", "no", "pl", "pt-BR", "pt-PT", "ro", "ru", "sk", "sv", "th", "tr", "uk", "vi"]
        },
        {
          "font": "./fonts/NotoSansCJKtc-Regular.ttf",
          "supported": ["zh-Hant", "ja", "ko"]
        }
      ]
```
With this configuration, and a screenshot “ja/iphone6Plus_3_track_framed.png”, Fastlane will return NotoSans-Bold (instead of NotoSansCJKtc-Regular) because the filename includes `tr` which is a language specified for the first font. 

The fix: Instead of looking if the language is part of the filename, we look if the folder name matches the language.

Fix #16140