### PR TITLE
[spaceship] Add retrieve-create of iap shared secret to Spaceship::Tunes

### DIFF
--- a/spaceship/lib/spaceship/tunes/iap.rb
+++ b/spaceship/lib/spaceship/tunes/iap.rb
@@ -134,13 +134,13 @@ module Spaceship
 
       # generate app-specific shared secret (or regenerate if exists)
       def generate_shared_secret
-        client.handle_shared_secret(method: :post, app_id: self.application.apple_id)
+        client.generate_shared_secret(app_id: self.application.apple_id)
       end
 
       # retrieve app-specific shared secret
       # @param create (Boolean) Create new shared secret if does not exist
       def get_shared_secret(create: false)
-        secret = client.handle_shared_secret(method: :get, app_id: self.application.apple_id)
+        secret = client.get_shared_secret(app_id: self.application.apple_id)
         if create && secret.nil?
           secret = generate_shared_secret
         end

--- a/spaceship/lib/spaceship/tunes/iap.rb
+++ b/spaceship/lib/spaceship/tunes/iap.rb
@@ -132,6 +132,21 @@ module Spaceship
         return nil
       end
 
+      # generate app-specific shared secret (or regenerate if exists)
+      def generate_shared_secret
+        client.handle_shared_secret(method: :post, app_id: self.application.apple_id)
+      end
+
+      # retrieve app-specific shared secret
+      # @param create (Boolean) Create new shared secret if does not exist
+      def get_shared_secret(create: false)
+        secret = client.handle_shared_secret(method: :get, app_id: self.application.apple_id)
+        if create && secret.nil?
+          secret = generate_shared_secret
+        end
+        secret
+      end
+
       private
 
       def find_product_with_retries(product_id, max_tries)

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1422,6 +1422,14 @@ module Spaceship
       handle_itc_response(r.body)
     end
 
+    # Creates or retrieves app-spesific shared secret key
+    # :get - retrieve, :post - create
+    def handle_shared_secret(method: nil, app_id: nil)
+      r = request(method, "ra/apps/#{app_id}/iaps/appSharedSecret")
+      data = parse_response(r, 'data')
+      data['sharedSecret']
+    end
+
     #####################################################
     # @!group Sandbox Testers
     #####################################################

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1422,7 +1422,7 @@ module Spaceship
       handle_itc_response(r.body)
     end
 
-    # Creates or retrieves app-spesific shared secret key
+    # Creates or retrieves app-specific shared secret key
     # :get - retrieve, :post - create
     def handle_shared_secret(method: nil, app_id: nil)
       r = request(method, "ra/apps/#{app_id}/iaps/appSharedSecret")

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -1422,10 +1422,16 @@ module Spaceship
       handle_itc_response(r.body)
     end
 
-    # Creates or retrieves app-specific shared secret key
-    # :get - retrieve, :post - create
-    def handle_shared_secret(method: nil, app_id: nil)
-      r = request(method, "ra/apps/#{app_id}/iaps/appSharedSecret")
+    # Retrieves app-specific shared secret key
+    def get_shared_secret(app_id: nil)
+      r = request(:get, "ra/apps/#{app_id}/iaps/appSharedSecret")
+      data = parse_response(r, 'data')
+      data['sharedSecret']
+    end
+
+    # Generates app-specific shared secret key
+    def generate_shared_secret(app_id: nil)
+      r = request(:post, "ra/apps/#{app_id}/iaps/appSharedSecret")
       data = parse_response(r, 'data')
       data['sharedSecret']
     end

--- a/spaceship/spec/tunes/fixtures/iap_shared_secret_1.json
+++ b/spaceship/spec/tunes/fixtures/iap_shared_secret_1.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "sharedSecret": "44bbb0448db49ebf4ec4c5e2e6a35541"
+  }
+}

--- a/spaceship/spec/tunes/fixtures/iap_shared_secret_2.json
+++ b/spaceship/spec/tunes/fixtures/iap_shared_secret_2.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "sharedSecret": "86a25648c89c1a96b3d4a88355670e07"
+  }
+}

--- a/spaceship/spec/tunes/iap_spec.rb
+++ b/spaceship/spec/tunes/iap_spec.rb
@@ -9,6 +9,20 @@ describe Spaceship::Tunes::IAP do
       expect(app.in_app_purchases.all.first.class).to eq(Spaceship::Tunes::IAPList)
     end
 
+    it "Finds shared secret key" do
+      secret = app.in_app_purchases.get_shared_secret
+      expect(secret.class).to eq(String)
+      expect(secret.length).to be(32)
+    end
+
+    it "Generates new shared secret key" do
+      old_secret = app.in_app_purchases.get_shared_secret
+      new_secret = app.in_app_purchases.generate_shared_secret
+      expect(old_secret).not_to(eq(new_secret))
+      expect(new_secret.class).to eq(String)
+      expect(new_secret.length).to be(32)
+    end
+
     it "Finds a specific product" do
       expect(app.in_app_purchases.find("go.find.me")).not_to(eq(nil))
       expect(app.in_app_purchases.find("go.find.me").reference_name).to eq("localizeddemo")

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -359,6 +359,16 @@ class TunesStubbing
         to_return(status: 200, body: itc_read_fixture_file("iap_price_goal_calc.json"),
                  headers: { "Content-Type" => "application/json" })
 
+      # get shared secret
+      stub_request(:get, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/iaps/appSharedSecret").
+        to_return(status: 200, body: itc_read_fixture_file("iap_shared_secret_1.json"),
+                 headers: { "Content-Type" => "application/json" })
+
+      # generate new shared secret
+      stub_request(:post, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/iaps/appSharedSecret").
+        to_return(status: 200, body: itc_read_fixture_file("iap_shared_secret_2.json"),
+                 headers: { "Content-Type" => "application/json" })
+
       # delete iap
       stub_request(:delete, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/iaps/1194457865").
         to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
I was working on iOS project in a remote team. Once someone was implementing in-app purchases functionality and regenerated shared secret key. Unluckily, at the same time I was testing other iaps in the app. Having fastlane as a helping tool which lanes prevent a lot of other cases of such scenarios in the project, I thought being able to retrieve actual shared secret via Spaceship and set in the project somehow would be a useful feature.

### Description
Retrieve currently existing shared secret (or create if does not exist)
```ruby
Spaceship::Tunes.login
app = Spaceship::Tunes::Application.find('bundle_identifier')
secret = app.in_app_purchases.get_shared_secret(create: true)
```

Generate (or regenerate if exists) new app-specific shared secret
```ruby
Spaceship::Tunes.login
app = Spaceship::Tunes::Application.find('bundle_identifier')
secret = app.in_app_purchases.generate_shared_secret
```