### PR TITLE
[spaceship][pilot] Expire TestFlight Builds

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -154,21 +154,11 @@ module Pilot
 
       return if config[:skip_submission]
       if options[:reject_build_waiting_for_review]
-        waiting_for_review_build = build.app.get_builds(filter: { "betaAppReviewSubmission.betaReviewState" => "WAITING_FOR_REVIEW" }, includes: "betaAppReviewSubmission,preReleaseVersion").first
-        unless waiting_for_review_build.nil?
-          UI.important("Another build is already in review. Going to remove that build and submit the new one.")
-          UI.important("Deleting beta app review submission for build: #{waiting_for_review_build.app_version} - #{waiting_for_review_build.version}")
-          waiting_for_review_build.beta_app_review_submission.delete!
-          UI.success("Deleted beta app review submission for previous build: #{waiting_for_review_build.app_version} - #{waiting_for_review_build.version}")
-        end
+        reject_build_waiting_for_review(build)
       end
 
       if options[:expire_previous_builds]
-        builds_to_expire = build.app.get_builds.reject do |asc_build|
-          asc_build.id == build.id
-        end
-
-        builds_to_expire.each(&:expire!)
+        expire_previous_builds(build)
       end
 
       if !build.ready_for_internal_testing? && options[:skip_waiting_for_build_processing]
@@ -321,6 +311,24 @@ module Pilot
 
     def should_update_localized_build_information?(options)
       !options[:localized_build_info].nil?
+    end
+
+    def reject_build_waiting_for_review(build)
+      waiting_for_review_build = build.app.get_builds(filter: { "betaAppReviewSubmission.betaReviewState" => "WAITING_FOR_REVIEW" }, includes: "betaAppReviewSubmission,preReleaseVersion").first
+      unless waiting_for_review_build.nil?
+        UI.important("Another build is already in review. Going to remove that build and submit the new one.")
+        UI.important("Deleting beta app review submission for build: #{waiting_for_review_build.app_version} - #{waiting_for_review_build.version}")
+        waiting_for_review_build.beta_app_review_submission.delete!
+        UI.success("Deleted beta app review submission for previous build: #{waiting_for_review_build.app_version} - #{waiting_for_review_build.version}")
+      end
+    end
+
+    def expire_previous_builds(build)
+      builds_to_expire = build.app.get_builds.reject do |asc_build|
+        asc_build.id == build.id
+      end
+
+      builds_to_expire.each(&:expire!)
     end
 
     # If itc_provider was explicitly specified, use it.

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -163,6 +163,14 @@ module Pilot
         end
       end
 
+      if options[:expire_previous_builds]
+        builds_to_expire = build.app.get_builds.reject do |asc_build|
+          asc_build.id == build.id
+        end
+
+        builds_to_expire.each(&:expire!)
+      end
+
       if !build.ready_for_internal_testing? && options[:skip_waiting_for_build_processing]
         # Meta can be uploaded for a build still in processing
         # Returning before distribute if skip_waiting_for_build_processing

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -170,6 +170,11 @@ module Pilot
                                      env_name: "PILOT_BUILD_NUMBER",
                                      description: "The build number of the application build to distribute. If the build number is not specified, the most recent build is distributed",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :expire_previous_builds,
+                                     is_string: false,
+                                     env_name: "PILOT_EXPIRE_PREVIOUS_BUILDS",
+                                     description: "Should expire previous builds?",
+                                     default_value: false),
 
         # testers
         FastlaneCore::ConfigItem.new(key: :first_name,

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -158,6 +158,18 @@ module Spaceship
       def post_beta_app_review_submission
         return Spaceship::ConnectAPI.post_beta_app_review_submissions(build_id: id)
       end
+
+      def expire!
+        Spaceship::ConnectAPI::TestFlight::Client.instance.patch("builds/#{id}", {
+          :data => {
+            :attributes => {
+              :expired => true
+            },
+            :id => id,
+            :type => Build.type
+          }
+        })
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -160,15 +160,7 @@ module Spaceship
       end
 
       def expire!
-        Spaceship::ConnectAPI::TestFlight::Client.instance.patch("builds/#{id}", {
-          data: {
-            attributes: {
-              expired: true
-            },
-            id: id,
-            type: Build.type
-          }
-        })
+        return Spaceship::ConnectAPI.patch_builds(build_id: id, attributes: { expired: true })
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -161,12 +161,12 @@ module Spaceship
 
       def expire!
         Spaceship::ConnectAPI::TestFlight::Client.instance.patch("builds/#{id}", {
-          :data => {
-            :attributes => {
-              :expired => true
+          data: {
+            attributes: {
+              expired: true
             },
-            :id => id,
-            :type => Build.type
+            id: id,
+            type: Build.type
           }
         })
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

~This is a WIP/Proposal for adding the ability to expire a build. I think calling into the client instance directly in the Build class is probably not a great idea and would probably be better to add this is a class method on `Spaceship::ConnectAPI` like all of the other helper methods do. I mostly wanted to open this up for feedback and get some clarification on how I should write tests for this (if at all?). I'm not much of a Rubyist other than what I need to write for my Fastfiles, so I'm not very familiar with much of the tooling used.~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Currently, the only way to expire a TestFlight build is to dig into the client and craft a patch request manually. Since this is a fairly common part of managing the lifecycle of a beta test, it seems like a good candidate for adding it to the API surface of Build
<!-- If it fixes an open issue, please link to the issue here. -->
~It is somewhat related to #13080 as it would provide the plumbing necessary to enable that behavior without digging directly into the ConnectAPI client.~ With the pilot additions this would resolve #13080 

### Description
<!-- Describe your changes in detail. -->
Adds a method to Build that allows it to be expired by calling into  ~the singleton instance of `Spaceship::ConnectAPI::TestFlight::Client`~ `Spaceship::ConnectAPI.patch_builds`
<!-- Please describe in detail how you tested your changes. -->
This is implemented in the same manner that I currently use in my organization to expire old builds

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
** This is how I utilize it in my Fastfile **
```ruby
lane :expire_test_flight_build do |options|
    app_identifier = CredentialsManger::AppfileConfig.try_fetch_value(:app_identifier)
    version = options[:version]
    build_version = options[:build_number]

    build = Spaceship::ConnectAPI::App.find(app_identifier)
        .get_builds(includes: "preReleaseVersion")
        .find do |build|
            build.pre_release_version.version == version and build.version == build_version
        end

    build.expire!
end
```

I do not currently have an application I can test the pilot additions against in App Store Connect
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
