### PR TITLE
[pilot] Remove redundant update_review_detail call

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -215,8 +215,11 @@ module Pilot
     end
 
     def update_beta_app_meta(options, build)
-      # Setting account required wth AppStore Connect API
-      update_review_detail(build, { demo_account_required: options[:demo_account_required] })
+      # If demo_account_required is a parameter, it should added into beta_app_review_info
+      unless options[:demo_account_required].nil?
+        options[:beta_app_review_info] = {} if options[:beta_app_review_info].nil?
+        options[:beta_app_review_info][:demo_account_required] = options[:demo_account_required]
+      end
 
       if should_update_beta_app_review_info(options)
         update_review_detail(build, options[:beta_app_review_info])

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -211,12 +211,6 @@ describe "Build Manager" do
 
         options = distribute_options_skip_waiting_non_localized_changelog
 
-        # Expect a beta app review detail to be patched
-        expect(Spaceship::ConnectAPI).to receive(:patch_beta_app_review_detail).with({
-          app_id: ready_to_submit_mock_build.app_id,
-          attributes: { demoAccountRequired: options[:demo_account_required] }
-        })
-
         # Expect beta build localizations to be fetched
         expect(Spaceship::ConnectAPI).to receive(:get_beta_build_localizations).with({
           filter: { build: ready_to_submit_mock_build.id },


### PR DESCRIPTION
🔑
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Pilot has recently started failing in my automated build script when distributing the TestFlight to external testers. Other users have reported similar symptoms (in the issue linked below), including a "Test Information" section being wiped on App Store Connect. I suspect this is happening due to an unnecessary call being made to Apple's `/betaAppReviewDetails` endpoint even when we don't pass the `beta_app_review_info` or `demo_account_required` parameters to `pilot`. The intended logic would seem that we only want to call it if the parameter was explicitly passed, since the logic that follows right after is a conditional check for `should_update_beta_app_review_info(options)`.

The current workaround is to explicitly pass `beta_app_review_info` (i.e. contact information) to `pilot`. This prevents the contact information from being wiped from the TestFlight settings, however this is not ideal.

Fixes issue: https://github.com/fastlane/fastlane/issues/16294

### Description
There are two consecutive calls to `update_review_detail()` inside `update_beta_app_meta()`. The first call is not required, because `demo_account_required` should be one of the fields for `beta_app_review_info`. 

This fix checks when `demo_account_required` is passed to pilot and merges it into the `beta_app_review_info` hash.

A test case was removed because the test input doesn't contain `demo_account_required`, so the expectation should be that it doesn't call `update_review_detail()` anymore.

### Testing Steps
Call `fastlane pilot` to upload an app, and pass an external tester group to trigger the beta app review, but do not pass `beta_app_review_info` as a parameter.

Expected Result: Pilot should return successfully without failing during distribution.
