### PR TITLE
[match] Fix S3 errors for match nuke and sync

### DIFF
--- a/fastlane/lib/fastlane/helper/s3_client_helper.rb
+++ b/fastlane/lib/fastlane/helper/s3_client_helper.rb
@@ -7,16 +7,14 @@ module Fastlane
 
       def initialize(access_key: nil, secret_access_key: nil, region: nil)
         creds = Aws::Credentials.new(access_key, secret_access_key)
-        Aws.config.update({
+        Aws.config.update(
           region: region,
           credentials: creds
-        })
-
-        @client = Aws::S3::Client.new
+        )
       end
 
       def list_buckets
-        return @client.list_buckets
+        return client.list_buckets
       end
 
       def upload_file(bucket_name, file_name, file_data, acl)
@@ -40,17 +38,24 @@ module Fastlane
         obj.public_url.to_s
       end
 
-      def delete_file(bucket, file_name)
+      def delete_file(bucket_name, file_name)
         bucket = find_bucket!(bucket_name)
-        bucket.objects[file_name].delete
+        file = bucket.object(file_name)
+        file.delete
       end
 
       def find_bucket!(bucket_name)
-        bucket = Aws::S3::Bucket.new(bucket_name, client: @client)
+        bucket = Aws::S3::Bucket.new(bucket_name, client: client)
         raise "Bucket '#{bucket_name}' not found" unless bucket.exists?
 
         return bucket
       end
+    end
+
+    private
+
+    def client
+      @client ||= Aws::S3::Client.new
     end
   end
 end

--- a/fastlane/spec/helper/s3_client_helper_spec.rb
+++ b/fastlane/spec/helper/s3_client_helper_spec.rb
@@ -1,0 +1,34 @@
+describe Fastlane::Helper::S3ClientHelper do
+  subject { described_class.new }
+
+  describe '#find_bucket!' do
+    before { class_double('Aws::S3::Bucket', new: bucket).as_stubbed_const }
+
+    context 'when bucket found' do
+      let(:bucket) { instance_double('Aws::S3::Bucket', exists?: true) }
+
+      it 'returns bucket' do
+        expect(subject.find_bucket!('foo')).to eq(bucket)
+      end
+    end
+
+    context 'when bucket not found' do
+      let(:bucket) { instance_double('Aws::S3::Bucket', exists?: false) }
+
+      it 'raises error' do
+        expect { subject.find_bucket!('foo') }.to raise_error("Bucket 'foo' not found")
+      end
+    end
+  end
+
+  describe '#delete_file' do
+    it 'deletes s3 object' do
+      object = instance_double('Aws::S3::Object', delete: true)
+      bucket = instance_double('Aws::S3::Bucket', object: object)
+
+      expect(subject).to receive(:find_bucket!).and_return(bucket)
+      expect(object).to receive(:delete)
+      subject.delete_file('foo', 'bar')
+    end
+  end
+end

--- a/match/spec/storage/s3_storage_spec.rb
+++ b/match/spec/storage/s3_storage_spec.rb
@@ -1,7 +1,7 @@
 describe Match do
   describe Match::Storage::S3Storage do
     subject { described_class.new(s3_region: nil, s3_access_key: nil, s3_secret_access_key: nil, s3_bucket: 'foobar') }
-    let(:working_directory) { '/var/folders/px/abcdefghijklmnop/T/d20181026-96528-1av4gge'}
+    let(:working_directory) { '/var/folders/px/abcdefghijklmnop/T/d20181026-96528-1av4gge' }
 
     before do
       allow(subject).to receive(:working_directory).and_return(working_directory)

--- a/match/spec/storage/s3_storage_spec.rb
+++ b/match/spec/storage/s3_storage_spec.rb
@@ -1,0 +1,73 @@
+describe Match do
+  describe Match::Storage::S3Storage do
+    subject { described_class.new(s3_region: nil, s3_access_key: nil, s3_secret_access_key: nil, s3_bucket: 'foobar') }
+    let(:working_directory) { '/var/folders/px/abcdefghijklmnop/T/d20181026-96528-1av4gge'}
+
+    before do
+      allow(subject).to receive(:working_directory).and_return(working_directory)
+      allow(subject).to receive(:s3_client).and_return(s3_client)
+    end
+
+    describe '#upload_files' do
+      let(:files_to_upload) do
+        [
+          "#{working_directory}/ABCDEFG/certs/development/ABCDEFG.cer",
+          "#{working_directory}/ABCDEFG/certs/development/ABCDEFG.p12"
+        ]
+      end
+      let(:s3_client) { double(upload_file: true) }
+      let!(:file) { class_double('File', read: 'body').as_stubbed_const }
+
+      it 'reads the correct files from local storage' do
+        files_to_upload.each do |file_name|
+          expect(file).to receive(:read).with(file_name)
+        end
+
+        subject.upload_files(files_to_upload: files_to_upload)
+      end
+
+      it 'uploads files to the correct path in remote storage' do
+        expect(s3_client).to receive(:upload_file).with('foobar', 'ABCDEFG/certs/development/ABCDEFG.cer', 'body', 'private')
+        expect(s3_client).to receive(:upload_file).with('foobar', 'ABCDEFG/certs/development/ABCDEFG.p12', 'body', 'private')
+        subject.upload_files(files_to_upload: files_to_upload)
+      end
+    end
+
+    describe '#delete_files' do
+      let(:files_to_upload) do
+        [
+          "#{working_directory}/ABCDEFG/certs/development/ABCDEFG.cer",
+          "#{working_directory}/ABCDEFG/certs/development/ABCDEFG.p12"
+        ]
+      end
+      let(:s3_client) { double(delete_file: true) }
+
+      it 'deletes files with correct paths' do
+        expect(s3_client).to receive(:delete_file).with('foobar', 'ABCDEFG/certs/development/ABCDEFG.cer')
+        expect(s3_client).to receive(:delete_file).with('foobar', 'ABCDEFG/certs/development/ABCDEFG.p12')
+
+        subject.delete_files(files_to_delete: files_to_upload)
+      end
+    end
+
+    describe '#download' do
+      let(:files_to_download) do
+        [
+          instance_double('Aws::S3::Object', key: 'ABCDEFG/certs/development/ABCDEFG.cer', download_file: true),
+          instance_double('Aws::S3::Object', key: 'ABCDEFG/certs/development/ABCDEFG.p12', download_file: true)
+        ]
+      end
+      let(:s3_client) { instance_double('Fastlane::Helper::S3ClientHelper', find_bucket!: double(objects: files_to_download)) }
+
+      before { class_double('FileUtils', mkdir_p: true).as_stubbed_const }
+
+      it 'downloads to correct working directory' do
+        files_to_download.each do |file_object|
+          expect(file_object).to receive(:download_file).with("#{working_directory}/#{file_object.key}")
+        end
+
+        subject.download
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
* When using S3 as storage for `match`, error occurs when calling command `match nuke <env>`

* When downloading files, the file path is split using delimiter string `s3.amazonaws.com` which fails when the url specifies a region i.e. `s3.us-east-1.amazonaws.com`
As a result, match thinks there are no files in s3 and tries to recreate certificates. This fails when `readonly: true`, and it also creates Profile-Cert mismatch when `readonly: false`

<!-- If it fixes an open issue, please link to the issue here. -->
#### Github Issues:
[match nuke fails with deleting from S3](https://github.com/fastlane/fastlane/issues/16216)
[match always creates new certificates for appstore, fails on readonly [XCode 11]](https://github.com/fastlane/fastlane/issues/16210)
### Description
<!-- Describe your changes in detail. -->
Uses correct `bucket_name` variable in `helper/s3_client_helper.rb`
Use `object.key` instead of parsing `public_url` in `S3Storage`
For `delete_files` in `S3Storage`, passes prefixed working directory

<!-- Please describe in detail how you tested your changes. -->
Adds `spec/helper/s3_client_helper_spec.rb`
Adds `match/spec/storage/s3_storage_spec.rb`
Added tests for methods `#find_bucket!` and `#delete_file` for integration and behavior
Since `delete_file` is called per-file, opted to use `bucket.object(key)` vs `bucket.objects[key]`

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
* `bundle exec rspec`
* Tested locally on machine against local fastlane setup - was able to successfully run `match nuke development`
* Tested locally on machine against local fastlane setup - was able to successfully run `match development` and `match development --readonly true`

<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
