### PR TITLE
[produce] support creating multiple platforms on App Store Connect

### DIFF
--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -59,7 +59,7 @@ module Produce
         app = Spaceship.app.create!(bundle_id: app_identifier,
                                          name: app_name,
                                          enable_services: enable_services,
-                                         mac: Produce.config[:platform] == "osx")
+                                         mac: platform == "osx")
 
         if app.name != Produce.config[:app_name]
           UI.important("Your app name includes non-ASCII characters, which are not supported by the Apple Developer Portal.")
@@ -122,8 +122,17 @@ module Produce
 
     private
 
+    def platform
+      # This was added to support creation of multiple platforms
+      # Produce::ItunesConnect can take an array of platforms to create for App Store Connect
+      # but the Developer Center is now platform agnostic so we choose any platform here
+      #
+      # Platform won't be needed at all in the future when this is change over to use Spaceship::ConnectAPI
+      (Produce.config[:platforms] || []).first || Produce.config[:platform]
+    end
+
     def app_exists?
-      Spaceship.app.find(app_identifier, mac: Produce.config[:platform] == "osx") != nil
+      Spaceship.app.find(app_identifier, mac: platform == "osx") != nil
     end
 
     def login

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -58,14 +58,16 @@ module Produce
         end
 
         UI.success("Successfully created new app '#{Produce.config[:app_name]}' on App Store Connect with ID #{application.apple_id}")
-
-        return Spaceship::Tunes::Application.find(@full_bundle_identifier, mac: platforms.first == "osx").apple_id
       end
 
-      return Spaceship::Tunes::Application.find(@full_bundle_identifier, mac: Produce.config[:platform] == "osx").apple_id
+      return Spaceship::Tunes::Application.find(@full_bundle_identifier, mac: platform == "osx").apple_id
     end
 
     private
+
+    def platform
+      (Produce.config[:platforms] || []).first || Produce.config[:platform]
+    end
 
     def fetch_application
       Spaceship::Tunes::Application.find(@full_bundle_identifier)

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -23,6 +23,8 @@ module Produce
       else
         UI.success("Creating new app '#{Produce.config[:app_name]}' on App Store Connect")
 
+        platforms = Produce.config[:platforms] || [Produce.config[:platform]]
+
         Produce.config[:bundle_identifier_suffix] = '' unless wildcard_bundle?
         generated_app = Spaceship::Tunes::Application.create!(name: Produce.config[:app_name],
                                                               primary_language: language,
@@ -30,7 +32,7 @@ module Produce
                                                               bundle_id: app_identifier,
                                                               bundle_id_suffix: Produce.config[:bundle_identifier_suffix],
                                                               company_name: Produce.config[:company_name],
-                                                              platform: Produce.config[:platform],
+                                                              platforms: platforms,
                                                               itunes_connect_users: Produce.config[:itc_users])
 
         UI.crash!("Something went wrong when creating the new app on iTC") if generated_app["adamId"].to_s.empty?
@@ -51,9 +53,13 @@ module Produce
         UI.crash!("Something went wrong when creating the new app - it's not listed in the App's list") unless application
 
         UI.message("Ensuring version number")
-        application.ensure_version!(Produce.config[:app_version], platform: Produce.config[:platform]) if Produce.config[:app_version]
+        platforms.each do |platform|
+          application.ensure_version!(Produce.config[:app_version], platform: platform) if Produce.config[:app_version]
+        end
 
         UI.success("Successfully created new app '#{Produce.config[:app_name]}' on App Store Connect with ID #{application.apple_id}")
+
+        return Spaceship::Tunes::Application.find(@full_bundle_identifier, mac: platforms.first == "osx").apple_id
       end
 
       return Spaceship::Tunes::Application.find(@full_bundle_identifier, mac: Produce.config[:platform] == "osx").apple_id

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -50,10 +50,22 @@ module Produce
                                      short_option: "-j",
                                      env_name: "PRODUCE_PLATFORM",
                                      description: "The platform to use (optional)",
+                                     conflicting_options: [:platforms],
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
                                                      UI.user_error!("The platform can only be ios or osx") unless %('ios', 'osx').include?(value)
+                                                   end),
+        FastlaneCore::ConfigItem.new(key: :platforms,
+                                     short_option: "-J",
+                                     env_name: "PRODUCE_PLATFORMS",
+                                     description: "The platforms to use (optional)",
+                                     conflicting_options: [:platform],
+                                     optional: true,
+                                     type: Array,
+                                     verify_block: proc do |values|
+                                                     types = %w(ios osx)
+                                                     UI.user_error!("The platform can only be #{types}") unless (values - types).empty?
                                                    end),
         FastlaneCore::ConfigItem.new(key: :language,
                                      short_option: "-m",

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -91,7 +91,7 @@ module Spaceship
         # @param platform (String): Platform one of (ios,osx)
         #  should it be an ios or an osx app
 
-        def create!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil, itunes_connect_users: nil)
+        def create!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil, platforms: nil, itunes_connect_users: nil)
           puts("The `version` parameter is deprecated. Use `ensure_version!` method instead") if version
           client.create_application!(name: name,
                          primary_language: primary_language,
@@ -100,6 +100,7 @@ module Spaceship
                                 bundle_id_suffix: bundle_id_suffix,
                                 company_name: company_name,
                                     platform: platform,
+                                    platforms: platforms,
                                     itunes_connect_users: itunes_connect_users)
         end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -286,7 +286,7 @@ module Spaceship
     # @param sku (String): A unique ID for your app that is not visible on the App Store.
     # @param bundle_id (String): The bundle ID must match the one you used in Xcode. It
     #   can't be changed after you submit your first build.
-    def create_application!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil, itunes_connect_users: nil)
+    def create_application!(name: nil, primary_language: nil, version: nil, sku: nil, bundle_id: nil, bundle_id_suffix: nil, company_name: nil, platform: nil, platforms: nil, itunes_connect_users: nil)
       puts("The `version` parameter is deprecated. Use `Spaceship::Tunes::Application.ensure_version!` method instead") if version
 
       # First, we need to fetch the data from Apple, which we then modify with the user's values
@@ -307,7 +307,7 @@ module Spaceship
       data['enabledPlatformsForCreation'] = { value: [platform] }
 
       data['initialPlatform'] = platform
-      data['enabledPlatformsForCreation'] = { value: [platform] }
+      data['enabledPlatformsForCreation'] = { value: platforms || [platform] }
 
       unless itunes_connect_users.nil?
         data['iTunesConnectUsers']['grantedAllUsers'] = false


### PR DESCRIPTION
### Motivation and Context
Open up `produce` to create an app in App Store Connect on multiple platforms. This will probably be used often for universal and Catalyst apps

### Description
- added new `:platforms` option to `produce`
  - conflicts with `:platform` (only one allowed)
- `Produce::DeveloperCenter`
  - Takes first platform in `:platforms` option
  - Apps in the Developer Center don’t actually have a platform anymore so it doesn’t matter
    - _Eventually_ this needs to get replaced with `Spaceship::ConnectAPI`
- `Produce::ItunesConnect`
  - Passes array of platforms to create to spaceship
  - Iterates over platforms to make sure they exist

### Testing Steps
```ruby
produce(
  platforms: [“ios”, “osx”]
)
```