### PR TITLE
[snapshot] Add -testPlan option from scan

### DIFF
--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -646,7 +646,7 @@ describe Scan do
         log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
 
         result = @test_command_generator.generate
-        expect(result).to include("-testPlan simple") if FastlaneCore::Helper.xcode_at_least?(10)
+        expect(result).to include("-testPlan simple") if FastlaneCore::Helper.xcode_at_least?(11)
       end
     end
   end

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -232,6 +232,11 @@ module Snapshot
                                      env_name: "SNAPSHOT_CLONED_SOURCE_PACKAGES_PATH",
                                      description: "Sets a custom path for Swift Package Manager dependencies",
                                      type: String,
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :testplan,
+                                     env_name: "SNAPSHOT_TESTPLAN",
+                                     description: "The testplan associated with the scheme that should be used for testing",
+                                     is_string: true,
                                      optional: true)
       ]
     end

--- a/snapshot/lib/snapshot/test_command_generator_base.rb
+++ b/snapshot/lib/snapshot/test_command_generator_base.rb
@@ -26,6 +26,9 @@ module Snapshot
         options << "-sdk '#{config[:sdk]}'" if config[:sdk]
         options << "-derivedDataPath '#{derived_data_path}'"
         options << "-resultBundlePath '#{result_bundle_path}'" if result_bundle_path
+        if FastlaneCore::Helper.xcode_at_least?(11)
+          options << "-testPlan '#{config[:testplan]}'" if config[:testplan]
+        end
         options << config[:xcargs] if config[:xcargs]
         return options
       end

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -264,6 +264,15 @@ describe Snapshot do
           expect(command.join('')).not_to(include("build test"))
         end
       end
+
+      context 'test-plan' do
+        it 'adds the testplan to the xcodebuild command', requires_xcode: true do
+          configure(options.merge(testplan: 'simple'))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to include("-testPlan 'simple'") if FastlaneCore::Helper.xcode_at_least?(11)
+        end
+      end
     end
 
     describe "Valid macOS Configuration" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

To allow more flexibility on which tests to run while capturing screenshots, we need to leverage the `-testPlan` options that already exists in `scan`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This change brings the option `-testPlan` from scan to `snapshot`.
The `snapshot` implementation is extremely similar, if not identical, to the `scan` implementation.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I have tested this change in my project and I was able to create a retrying mechanism, that only do so with failing tests.