### PR TITLE
[scan] Add `only_test_configurations` and `skip_test_configurations` options for use with test plans

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -45,6 +45,9 @@ module Scan
       coerce_to_array_of_strings(:only_testing)
       coerce_to_array_of_strings(:skip_testing)
 
+      coerce_to_array_of_strings(:only_test_configurations)
+      coerce_to_array_of_strings(:skip_test_configurations)
+
       return config
     end
 

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -123,12 +123,30 @@ module Scan
                                        verify_type('skip_testing', [Array, String], value)
                                      end),
 
-        # other test options
+        # test plans to run
         FastlaneCore::ConfigItem.new(key: :testplan,
                                      env_name: "SCAN_TESTPLAN",
                                      description: "The testplan associated with the scheme that should be used for testing",
                                      is_string: true,
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :only_test_configurations,
+                                     env_name: "SCAN_ONLY_TEST_CONFIGURATIONS",
+                                     description: "Array of strings matching test plan configurations to run",
+                                     optional: true,
+                                     is_string: false,
+                                     verify_block: proc do |value|
+                                       verify_type('only_test_configurations', [Array, String], value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :skip_test_configurations,
+                                     env_name: "SCAN_SKIP_TEST_CONFIGURATIONS",
+                                     description: "Array of strings matching test plan configurations to skip",
+                                     optional: true,
+                                     is_string: false,
+                                     verify_block: proc do |value|
+                                       verify_type('skip_test_configurations', [Array, String], value)
+                                     end),
+
+        # other test options
         FastlaneCore::ConfigItem.new(key: :xctestrun,
                                      short_option: "-X",
                                      env_name: "SCAN_XCTESTRUN",

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -47,6 +47,11 @@ module Scan
       options << "-enableThreadSanitizer #{config[:thread_sanitizer] ? 'YES' : 'NO'}" unless config[:thread_sanitizer].nil?
       if FastlaneCore::Helper.xcode_at_least?(11)
         options << "-testPlan '#{config[:testplan]}'" if config[:testplan]
+
+        # detect_values will ensure that these values are present as Arrays if
+        # they are present at all
+        options += config[:only_test_configurations].map { |name| "-only-test-configuration '#{name}'" } if config[:only_test_configurations]
+        options += config[:skip_test_configurations].map { |name| "-skip-test-configuration '#{name}'" } if config[:skip_test_configurations]
       end
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -64,6 +64,33 @@ describe Scan do
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         expect(Scan.config[:skip_testing]).to eq(["Bundle/SuiteA", "Bundle/SuiteB"])
       end
+
+      it "coerces only_test_configurations to be an array", requires_xcodebuild: true do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          only_test_configurations: "ConfigurationA"
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        expect(Scan.config[:only_test_configurations]).to eq(["ConfigurationA"])
+      end
+
+      it "coerces skip_test_configurations to be an array", requires_xcodebuild: true do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          skip_test_configurations: "ConfigurationA,ConfigurationB"
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        expect(Scan.config[:skip_test_configurations]).to eq(["ConfigurationA", "ConfigurationB"])
+      end
+
+      it "leaves skip_test_configurations as an array", requires_xcodebuild: true do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          skip_test_configurations: ["ConfigurationA", "ConfigurationB"]
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        expect(Scan.config[:skip_test_configurations]).to eq(["ConfigurationA", "ConfigurationB"])
+      end
     end
   end
 end

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -649,5 +649,113 @@ describe Scan do
         expect(result).to include("-testPlan simple") if FastlaneCore::Helper.xcode_at_least?(11)
       end
     end
+
+    describe "Test plan configuration example" do
+      it "only tests the test configuration specified in only_test_configurations when the input is an array", requires_xcodebuild: true do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          testplan: "simple",
+          only_test_configurations: %w(TestConfigurationA TestConfigurationB)
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = @test_command_generator.generate
+
+        if FastlaneCore::Helper.xcode_at_least?(11)
+          expect(result).to start_with([
+                                         "set -o pipefail &&",
+                                         "env NSUnbufferedIO=YES xcodebuild",
+                                         "-scheme app",
+                                         "-project ./scan/examples/standard/app.xcodeproj",
+                                         "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                         "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                         "-testPlan 'simple'",
+                                         "-only-test-configuration 'TestConfigurationA'",
+                                         "-only-test-configuration 'TestConfigurationB'",
+                                         :build,
+                                         :test
+                                       ])
+        end
+      end
+
+      it "only tests the test configuration specified in only_test_configurations when the input is a string", requires_xcodebuild: true do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          testplan: "simple",
+          only_test_configurations: 'TestConfigurationA'
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = @test_command_generator.generate
+
+        if FastlaneCore::Helper.xcode_at_least?(11)
+          expect(result).to start_with([
+                                         "set -o pipefail &&",
+                                         "env NSUnbufferedIO=YES xcodebuild",
+                                         "-scheme app",
+                                         "-project ./scan/examples/standard/app.xcodeproj",
+                                         "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                         "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                         "-testPlan 'simple'",
+                                         "-only-test-configuration 'TestConfigurationA'",
+                                         :build,
+                                         :test
+                                       ])
+        end
+      end
+
+      it "does not test the test configuration specified in skip_test_configurations when the input is an array", requires_xcodebuild: true do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          testplan: "simple",
+          skip_test_configurations: %w(TestConfigurationA TestConfigurationB)
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = @test_command_generator.generate
+
+        if FastlaneCore::Helper.xcode_at_least?(11)
+          expect(result).to start_with([
+                                         "set -o pipefail &&",
+                                         "env NSUnbufferedIO=YES xcodebuild",
+                                         "-scheme app",
+                                         "-project ./scan/examples/standard/app.xcodeproj",
+                                         "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                         "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                         "-testPlan 'simple'",
+                                         "-skip-test-configuration 'TestConfigurationA'",
+                                         "-skip-test-configuration 'TestConfigurationB'",
+                                         :build,
+                                         :test
+                                       ])
+        end
+      end
+
+      it "does not test the test configuration specified in skip_test_configurations when the input is a string", requires_xcodebuild: true do
+        options = {
+          project: "./scan/examples/standard/app.xcodeproj",
+          testplan: "simple",
+          skip_test_configurations: "TestConfigurationA"
+        }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = @test_command_generator.generate
+
+        if FastlaneCore::Helper.xcode_at_least?(11)
+          expect(result).to start_with([
+                                         "set -o pipefail &&",
+                                         "env NSUnbufferedIO=YES xcodebuild",
+                                         "-scheme app",
+                                         "-project ./scan/examples/standard/app.xcodeproj",
+                                         "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                         "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                         "-testPlan 'simple'",
+                                         "-skip-test-configuration 'TestConfigurationA'",
+                                         :build,
+                                         :test
+                                       ])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR builds upon the test plan support added in #16043 by introducing options for `-only-test-configuration` and `-skip-test-configuration` so that individual test configurations of a test plan can be run or skipped.

### Description
The new options work similar to the existing `only_testing` and `skip_testing` options so they can take either a string or an array of configurations and will be mapped accordingly if multiple configurations are specified e.g.:
```
xcodebuild test \
  -project 'app.xcodeproj' \
  -testPlan 'simple' \
  -only-test-configuration 'foo' \
  -only-test-configuration 'bar' \
  -skip-test-configuration 'baz'
```

### Testing Steps
I've added unit tests that covers all of the new functionality.
