### PR TITLE
[screengrab] adding locales in all the paths where screenshots could be saved

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -57,7 +57,7 @@ module Screengrab
       device_serial = select_device
 
       device_screenshots_paths = [
-        determine_external_screenshots_path(device_serial),
+        determine_external_screenshots_path(device_serial, @config[:locales]),
         determine_internal_screenshots_paths(@config[:app_package_name], @config[:locales])
       ].flatten
 
@@ -130,7 +130,7 @@ module Screengrab
       Dir.glob(File.join(output_directory, '**', device_type, '*.png'), File::FNM_CASEFOLD)
     end
 
-    def determine_external_screenshots_path(device_serial)
+    def determine_external_screenshots_path(device_serial, locales)
       # macOS evaluates $foo in `echo $foo` before executing the command,
       # Windows doesn't - hence the double backslash vs. single backslash
       command = Helper.windows? ? "shell echo \$EXTERNAL_STORAGE " : "shell echo \\$EXTERNAL_STORAGE"
@@ -138,22 +138,23 @@ module Screengrab
                                            print_all: true,
                                            print_command: true)
       device_ext_storage = device_ext_storage.strip
-      File.join(device_ext_storage, @config[:app_package_name], 'screengrab')
+      return locales.map do |locale|
+        File.join(device_ext_storage, @config[:app_package_name], 'screengrab', locale, "images", "screenshots")
+      end.flatten
     end
 
     def determine_internal_screenshots_paths(app_package_name, locales)
-      locale_paths = locales.map do |locale|
+      return locales.map do |locale|
         [
           "/data/user/0/#{app_package_name}/files/#{app_package_name}/screengrab/#{locale}/images/screenshots",
 
           # https://github.com/fastlane/fastlane/issues/15653#issuecomment-578541663
-          "/data/data/#{app_package_name}/files/#{app_package_name}/screengrab/#{locale}/images/screenshots"
+          "/data/data/#{app_package_name}/files/#{app_package_name}/screengrab/#{locale}/images/screenshots",
+          
+          "/data/data/#{app_package_name}/app_screengrab/#{locale}/images/screenshots",
+          "/data/data/#{app_package_name}/screengrab/#{locale}/images/screenshots"
         ]
       end.flatten
-
-      return ["/data/data/#{app_package_name}/app_screengrab"] +
-             ["/data/data/#{app_package_name}/screengrab"] +
-             locale_paths
     end
 
     def clear_device_previous_screenshots(device_serial, device_screenshots_paths)

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -150,7 +150,7 @@ module Screengrab
 
           # https://github.com/fastlane/fastlane/issues/15653#issuecomment-578541663
           "/data/data/#{app_package_name}/files/#{app_package_name}/screengrab/#{locale}/images/screenshots",
-          
+
           "/data/data/#{app_package_name}/app_screengrab/#{locale}/images/screenshots",
           "/data/data/#{app_package_name}/screengrab/#{locale}/images/screenshots"
         ]


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
This purpose of this PR is to fix an issue reported here #16209 

### Description
The version 2.143.0 of fastlane  introduce a regression by adding a new filter while pulling screenshots.
The following line: `next unless path.include?(locale)` added in the method `pull_screenshots_from_device` requires to provide the locale in the path. But they were not provided for all the paths (external and internal) eg: (`"/data/data/#{app_package_name}/app_screengrab"` and `"/data/data/#{app_package_name}/screengrab"`)

The fix applied here is about adding locales in all the paths where screenshots could be saved

### Testing Steps
Run Screengrab on different versions of android at least api 22 and 28