### PR TITLE
[scan] Add disable_xcpretty option that skips it post-xcodebuild too

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -180,6 +180,11 @@ module Scan
                                      description: "Should the HTML report be opened when tests are completed?",
                                      is_string: false,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :disable_xcpretty,
+                                     env_name: "SCAN_DISABLE_XCPRETTY",
+                                     description: "Disable xcpretty formatting of build, similar to `output_style='raw'` but this will also skip the test results table",
+                                     type: Boolean,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :output_directory,
                                      short_option: "-o",
                                      env_name: "SCAN_OUTPUT_DIRECTORY",
@@ -191,7 +196,7 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :output_style,
                                      short_option: "-b",
                                      env_name: "SCAN_OUTPUT_STYLE",
-                                     description: "Define how the output should look like. Valid values are: standard, basic, rspec, or raw (disables xcpretty)",
+                                     description: "Define how the output should look like. Valid values are: standard, basic, rspec, or raw (disables xcpretty during xcodebuild)",
                                      optional: true,
                                      verify_block: proc do |value|
                                        UI.user_error!("Invalid output_style #{value}") unless ['standard', 'basic', 'rspec', 'raw'].include?(value)

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -148,6 +148,8 @@ module Scan
     end
 
     def test_results
+      return if Scan.config[:disable_xcpretty]
+
       temp_junit_report = Scan.cache[:temp_junit_report]
       return File.read(temp_junit_report) if temp_junit_report && File.file?(temp_junit_report)
 

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -85,7 +85,7 @@ module Scan
     def pipe
       pipe = ["| tee '#{xcodebuild_log_path}'"]
 
-      if Scan.config[:output_style] == 'raw'
+      if Scan.config[:disable_xcpretty] || Scan.config[:output_style] == 'raw'
         return pipe
       end
 

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -105,6 +105,21 @@ describe Scan do
           expect(Scan.cache[:temp_junit_report]).to_not(eq('/var/folders/non_existent_file.junit'))
         end
       end
+
+      describe "with scan option :disable_xcpretty set to true" do
+        it "does not generate a temp junit report", requires_xcodebuild: true do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            output_directory: '/tmp/scan_results',
+            project: './scan/examples/standard/app.xcodeproj',
+            include_simulator_logs: false,
+            disable_xcpretty: true
+          })
+
+          Scan.cache[:temp_junit_report] = '/var/folders/non_existent_file.junit'
+          expect(@scan.test_results).to(be_nil)
+          expect(Scan.cache[:temp_junit_report]).to(eq('/var/folders/non_existent_file.junit'))
+        end
+      end
     end
 
     describe "#zip_build_products" do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Closes #16372 - see issue for motivation and context
