### PR TITLE
Adding --port setter to socket_server

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -159,7 +159,7 @@ module Fastlane
           server = Fastlane::SocketServer.new(
             command_executor: command_executor,
             connection_timeout: connection_timeout,
-            stay_alive: stay_alive, 
+            stay_alive: stay_alive,
             port: port
           )
           result = server.start

--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -141,10 +141,12 @@ module Fastlane
         c.description = 'Starts local socket server and enables only a single local connection'
         c.option('-s', '--stay_alive', 'Keeps socket server up even after error or disconnects, requires CTRL-C to kill.')
         c.option('-c seconds', '--connection_timeout', 'Sets connection established timeout')
+        c.option('-p port', '--port', "Sets the port on localhost for the socket connection")
         c.action do |args, options|
           default_connection_timeout = 5
           stay_alive = options.stay_alive || false
           connection_timeout = options.connection_timeout || default_connection_timeout
+          port = options.port || 2000
 
           if stay_alive && options.connection_timeout.nil?
             UI.important("stay_alive is set, but the connection timeout is not, this will give you #{default_connection_timeout} seconds to (re)connect")
@@ -157,7 +159,8 @@ module Fastlane
           server = Fastlane::SocketServer.new(
             command_executor: command_executor,
             connection_timeout: connection_timeout,
-            stay_alive: stay_alive
+            stay_alive: stay_alive, 
+            port: port
           )
           result = server.start
           UI.success("Result: #{result}") if result


### PR DESCRIPTION


### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Right now, except for swift lanes, one cannot (without additional ruby code) run multiple fastlane socket server sessions. This would be really nice for parallelization, as well as for environments where localhost:2000 is otherwise spoken for. 

### Description
The `start_server` action gains an additional, optional parameter: `-p port`.  This option (documented in the action itself) sets the port on localhost on which to mount the socket server. Takes four lines of code. 

### Testing Steps
```bash
fastlane action start_server -p 2001 &
nc localhost 2001
``` 
Happy connecting!

**NB** This change just adds three lines of code - it's a small change to open up a lot of power.  