### PR TITLE
[Ruby 2.7] Allow Faraday 1.0.0 and Faraday-middleware 1.0.0 with Ruby 2.7 fixes, fix base Ruby 2.3 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,12 @@ jobs:
       xcode: '11.4.0'
     environment:
       _RUBY_VERSION: '2.6'
+  'Execute tests on macOS (Xcode 11.4.0, Ruby 2.7)':
+    <<: *tests_macos
+    macos:
+      xcode: '11.4.0'
+    environment:
+      _RUBY_VERSION: '2.7'
 
   'Execute tests on Ubuntu':
     environment:
@@ -221,7 +227,7 @@ jobs:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     docker:
-      - image: circleci/ruby:2.3
+      - image: circleci/ruby:2.4
     shell: /bin/bash --login -eo pipefail
     steps:
       - *cache_restore_git
@@ -244,6 +250,7 @@ workflows:
       - 'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)'
       - 'Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)'
       - 'Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)'
+      - 'Execute tests on macOS (Xcode 11.4.0, Ruby 2.7)'
       - 'Execute tests on Ubuntu'
 
       - "Validate Fastlane.swift Generation"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,12 +118,6 @@ jobs:
       xcode: '11.4.0'
     environment:
       _RUBY_VERSION: '2.6'
-  'Execute tests on macOS (Xcode 11.4.0, Ruby 2.7)':
-    <<: *tests_macos
-    macos:
-      xcode: '11.4.0'
-    environment:
-      _RUBY_VERSION: '2.7'
 
   'Execute tests on Ubuntu':
     environment:
@@ -250,7 +244,6 @@ workflows:
       - 'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)'
       - 'Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)'
       - 'Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)'
-      - 'Execute tests on macOS (Xcode 11.4.0, Ruby 2.7)'
       - 'Execute tests on Ubuntu'
 
       - "Validate Fastlane.swift Generation"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,14 +56,14 @@ aliases:
 version: 2
 
 jobs:
-  'Execute tests on macOS (Xcode 9.4.1, Ruby 2.3)': &tests_macos  # define alias
+  'Execute tests on macOS (Xcode 9.4.1, Ruby 2.4)': &tests_macos  # define alias
     macos:
       xcode: '9.4.1'
     environment:
       CIRCLE_TEST_REPORTS: '~/test-reports'
       LC_ALL: 'en_US.UTF-8'
       LANG: 'en_US.UTF-8'
-      _RUBY_VERSION: '2.3'
+      _RUBY_VERSION: '2.4'
     shell: '/bin/bash --login -eo pipefail'
     steps:
       - *cache_restore_git
@@ -246,7 +246,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - 'Execute tests on macOS (Xcode 9.4.1, Ruby 2.3)'
+      - 'Execute tests on macOS (Xcode 9.4.1, Ruby 2.4)'
       - 'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)'
       - 'Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)'
       - 'Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)'

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -78,8 +78,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency('commander-fastlane', '>= 4.4.6', '< 5.0.0') # CLI parser
   spec.add_dependency('excon', '>= 0.71.0', '< 1.0.0') # Great HTTP Client
   spec.add_dependency('faraday-cookie_jar', '~> 0.0.6')
-  spec.add_dependency('faraday', '~> 0.17') # Used for deploygate, hockey and testfairy actions
-  spec.add_dependency('faraday_middleware', '~> 0.13.1') # same as faraday
+  spec.add_dependency('faraday', '>= 0.17', '< 2.0') # Used for deploygate, hockey and testfairy actions
+  spec.add_dependency('faraday_middleware', '>= 0.13.1', '< 2.0') # Same as faraday
   spec.add_dependency('fastimage', '>= 2.1.0', '< 3.0.0') # fetch the image sizes from the screenshots
   spec.add_dependency('gh_inspector', '>= 1.1.2', '< 2.0.0') # search for issues on GitHub when something goes wrong
   spec.add_dependency('highline', '>= 1.7.2', '< 2.0.0') # user inputs (e.g. passwords)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
- partially fixes https://github.com/fastlane/fastlane/issues/16342
- partially fixes https://github.com/fastlane/fastlane/issues/15856
- fixes https://github.com/fastlane/fastlane/issues/16339

### Description
Allow Faraday 1.0.0 as first final stable release with Ruby 2.7 fixes included. We still allow older version for users with older Ruby.

### Testing
- update `Execute modules load up tests` to Ruby 2.4 (should be higher?)
- remove tests for Ruby 2.3 - there should be support for Ruby 2.0 for example but there are no tests for this. All PRs are failing on this and I think we should drop version 2.3 completely and keep supporting only Ruby maintained versions that are not at EOL - https://www.ruby-lang.org/en/downloads/branches/