### PR TITLE
[upload_symbols_to_crashlytics] Include Path Suggested by Carthage Instructions

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -130,7 +130,7 @@ module Fastlane
       end
 
       def self.find_binary_path(params)
-        params[:binary_path] ||= (Dir["/Applications/Fabric.app/**/upload-symbols"] + Dir["./Pods/Fabric/upload-symbols"] + Dir["./Pods/FirebaseCrashlytics/upload-symbols"]).last
+        params[:binary_path] ||= (Dir["/Applications/Fabric.app/**/upload-symbols"] + Dir["./Pods/Fabric/upload-symbols"] + Dir["./scripts/upload-symbols"] + Dir["./Pods/FirebaseCrashlytics/upload-symbols"]).last
         UI.user_error!("Failed to find Fabric's upload_symbols binary at /Applications/Fabric.app/**/upload-symbols or ./Pods/**/upload-symbols. Please specify the location of the binary explicitly by using the binary_path option") unless params[:binary_path]
 
         params[:binary_path] = File.expand_path(params[:binary_path])


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation 
I use Carthage and the upload_symbols command is not found since it is not packaged with the framework for [some reasons](https://github.com/firebase/firebase-ios-sdk/issues/4720). So I think it is a good idea to add the path suggested in the [docs](https://github.com/firebase/firebase-ios-sdk/blob/master/Carthage.md) to the search paths. This way fastlane can automatically find the executable.

### Description
Includes the [FirebaseCrashlytics upload_symbols directory suggested by the fastlane docs regarding integration with Carthage](https://github.com/firebase/firebase-ios-sdk/blob/master/Carthage.md). This one is preferred over the Fabric installation.