### PR TITLE
[Ruby 2.7] Fix deprecated warnings

### DIFF
--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -26,7 +26,7 @@ module Fastlane
         # Login
         credentials = JSON.parse(json_key_data)
         callback_uri = 'https://fastlane.github.io/managed_google_play-callback/callback.html'
-        uri = "https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{credentials['client_email']}&continueUrl=#{URI.escape(callback_uri)}"
+        uri = "https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{credentials['client_email']}&continueUrl=#{URI.encode_www_form_component(callback_uri)}"
 
         UI.message("To obtain publishing rights for custom apps on Managed Play Store, open the following URL and log in:")
         UI.message("")

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -307,10 +307,10 @@ module Fastlane
           export_options[:teamID] = CredentialsManager::AppfileConfig.try_fetch_value(:team_id) if !export_options[:teamID] && CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
           export_options[:onDemandResourcesAssetPacksBaseURL] = URI.escape(export_options[:onDemandResourcesAssetPacksBaseURL]) if export_options[:onDemandResourcesAssetPacksBaseURL]
           if export_options[:manifest]
-            export_options[:manifest][:appURL] = URI.escape(export_options[:manifest][:appURL]) if export_options[:manifest][:appURL]
-            export_options[:manifest][:displayImageURL] = URI.escape(export_options[:manifest][:displayImageURL]) if export_options[:manifest][:displayImageURL]
-            export_options[:manifest][:fullSizeImageURL] = URI.escape(export_options[:manifest][:fullSizeImageURL]) if export_options[:manifest][:fullSizeImageURL]
-            export_options[:manifest][:assetPackManifestURL] = URI.escape(export_options[:manifest][:assetPackManifestURL]) if export_options[:manifest][:assetPackManifestURL]
+            export_options[:manifest][:appURL] = URI.encode_www_form_component(export_options[:manifest][:appURL]) if export_options[:manifest][:appURL]
+            export_options[:manifest][:displayImageURL] = URI.encode_www_form_component(export_options[:manifest][:displayImageURL]) if export_options[:manifest][:displayImageURL]
+            export_options[:manifest][:fullSizeImageURL] = URI.encode_www_form_component(export_options[:manifest][:fullSizeImageURL]) if export_options[:manifest][:fullSizeImageURL]
+            export_options[:manifest][:assetPackManifestURL] = URI.encode_www_form_component(export_options[:manifest][:assetPackManifestURL]) if export_options[:manifest][:assetPackManifestURL]
           end
 
           # Saves options to plist

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -215,7 +215,7 @@ module Fastlane
       # Bundler.with_clean_env solves this problem by resetting Bundler state before the
       # exec'd call gets merged into this process.
 
-      Bundler.with_clean_env do
+      Bundler.with_original_env do
         yield if block_given?
       end
     end

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -159,7 +159,7 @@ module Fastlane
       require 'json'
       url = "https://rubygems.org/api/v1/gems/#{gem_name}.json"
       begin
-        JSON.parse(open(url).read)
+        JSON.parse(::OpenURI.open_uri(url).read)
       rescue
         nil
       end

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -159,7 +159,7 @@ module Fastlane
       require 'json'
       url = "https://rubygems.org/api/v1/gems/#{gem_name}.json"
       begin
-        JSON.parse(::OpenURI.open_uri(url).read)
+        JSON.parse(URI.open(url).read)
       rescue
         nil
       end

--- a/fastlane/spec/actions_specs/get_managed_play_store_publishing_rights_spec.rb
+++ b/fastlane/spec/actions_specs/get_managed_play_store_publishing_rights_spec.rb
@@ -21,7 +21,7 @@ describe Fastlane do
         it "found file" do
           expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'").once
           expect(UI).to receive(:input).with(anything).and_return(json_key_path)
-          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https://fastlane.github.io/managed_google_play-callback/callback.html")
+          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
 
           Fastlane::FastFile.new.parse("lane :test do
             get_managed_play_store_publishing_rights()
@@ -31,7 +31,7 @@ describe Fastlane do
 
       describe "with options" do
         it "with :json_key" do
-          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https://fastlane.github.io/managed_google_play-callback/callback.html")
+          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
 
           Fastlane::FastFile.new.parse("lane :test do
             get_managed_play_store_publishing_rights(
@@ -41,7 +41,7 @@ describe Fastlane do
         end
 
         it "with :json_key_data" do
-          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https://fastlane.github.io/managed_google_play-callback/callback.html")
+          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
 
           Fastlane::FastFile.new.parse("lane :test do
             get_managed_play_store_publishing_rights(


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Ruby 2.7.1 is out for some time and it would be nice to have proper support.
Relies on Ruby 2.7 tests from https://github.com/fastlane/fastlane/pull/16407

### Description
- Fix URL.encode for URLs via query encoding

### Testing Steps

