### PR TITLE
[notarize] Add parameter to select if compressed package should be removed

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -7,6 +7,7 @@ module Fastlane
         try_early_stapling = params[:try_early_stapling]
         print_log = params[:print_log]
         verbose = params[:verbose]
+        remove_compressed_package = params[:remove_compressed_package]
 
         # Compress and read bundle identifier only for .app bundle.
         compressed_package_path = nil
@@ -44,7 +45,7 @@ module Fastlane
           log: verbose
         )
 
-        FileUtils.rm_rf(compressed_package_path) if compressed_package_path
+        FileUtils.rm_rf(compressed_package_path) if compressed_package_path && remove_compressed_package
 
         notarization_upload_plist = Plist.parse_xml(notarization_upload_response)
         notarization_request_id = notarization_upload_plist['notarization-upload']['RequestUUID']
@@ -167,6 +168,12 @@ module Fastlane
                                        description: 'Whether to log requests',
                                        optional: true,
                                        default_value: false,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :remove_compressed_package,
+                                       env_name: 'FL_REMOVE_COMPRESSED_PACKAGE',
+                                       description: 'Whether to remove generated compressed package',
+                                       optional: true,
+                                       default_value: true,
                                        type: Boolean)
         ]
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Was not able to distribute my zipped up app after notarization, as notarize removes the zip file it generates, which is being notarized as well.

### Description
The problem is that notarize creates a zip file that is sent to the notarization service. The zip file is then also notarized.
```
{
  "logFormatVersion": 1,
  "jobId": "48e1bb69-e2aa-47ec-8c82-adc340aaa88a",
  "status": "Accepted",
  "statusSummary": "Ready for distribution",
  "statusCode": 0,
  "archiveFilename": "AppName.app.zip",
  "uploadDate": "2020-04-30T18:23:09Z",
  "sha256": "1d88ea6a1af6ad82fa7c23b49e81da4cfaaace1637a2df26819f9b91158b6d68",
```

Then, notarize removes the zip file. If a new zip file is then created to distribute the app, it fails notarization (at least on macOS 10.15.4)

This PR provides a new configuration parameter that can be used to prevent the zip file from being removed. This notarized zip file can then be used for distribution.

I tried setting the flag to true and to false, and it behaves as expected.
Also, I set the default to "true" so notarize will continue to work the same way unless the parameter is set to false.

Regarding documentation, I documented the parameter in the code by adding it to the available options. Not sure what other documentation might be required for this small change.

### Testing Steps
- Set the parameter `remove_compressed_package` to `false`
- Run notarize 
- Verify that the generated zip file is not removed.
