### PR TITLE
[action] set_pod_key: remove shellescape of params

### DIFF
--- a/fastlane/lib/fastlane/actions/set_pod_key.rb
+++ b/fastlane/lib/fastlane/actions/set_pod_key.rb
@@ -8,9 +8,9 @@ module Fastlane
         cmd << ['bundle exec'] if params[:use_bundle_exec] && shell_out_should_use_bundle_exec?
         cmd << ['pod keys set']
 
-        cmd << ["\"#{params[:key].shellescape}\""]
-        cmd << ["\"#{params[:value].shellescape}\""]
-        cmd << ["\"#{params[:project].shellescape}\""] if params[:project]
+        cmd << ["\"#{params[:key]}\""]
+        cmd << ["\"#{params[:value]}\""]
+        cmd << ["\"#{params[:project]}\""] if params[:project]
 
         Actions.sh(cmd.join(' '))
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I use cocoapods-keys to store API keys but using `set_pod_key` action automatically escapes the provided parameters.
So each time I provide an API key that contains escapable characters, the API key becomes malformed.

### Description
Remove shellescape

### Testing Steps
Before:
```ruby
set_pod_key(key: "PublicKey", value: "XXXX|XXXX", project: "Y")
set_pod_key(key: "ApiKey", value: "XX/nXX==-XX", project: "Y")
```
![Capture d’écran 2020-05-04 à 14 44 37_censored](https://user-images.githubusercontent.com/10015557/80969872-977bfa80-8e1a-11ea-966d-07e98fa95b33.jpg)

After:
```ruby
set_pod_key(key: "PublicKey", value: "XXXX|XXXX", project: "Y")
set_pod_key(key: "ApiKey", value: "XX/nXX==-XX", project: "Y")
```
![Capture d’écran 2020-05-04 à 14 43 45_censored](https://user-images.githubusercontent.com/10015557/80969846-8c28cf00-8e1a-11ea-8e71-e8dd7182c7a1.jpg)