### PR TITLE
[spaceship] Add to_json for ConnectAPI models

### DIFF
--- a/spaceship/lib/spaceship/connect_api/model.rb
+++ b/spaceship/lib/spaceship/connect_api/model.rb
@@ -25,7 +25,7 @@ module Spaceship
       # Example:
       # { "minOsVersion" => "min_os_version" }
       #
-      # Creates attr_write and attr_reader for :min_os_version
+      # Creates attr_write and attr_/Users/tbodt/Developer/projects/fastlane/spaceship/spec/connect_api/models/model_spec.rb/Users/tbodt/Developer/projects/fastlane/spaceship/spec/connect_api/models/model_spec.rbreader for :min_os_version
       # Creates alias for :minOsVersion to :min_os_version
       #
       def attr_mapping(attr_map)
@@ -48,6 +48,12 @@ module Spaceship
           alias_method(key_reader, reader)
           alias_method(key_writer, writer)
         end
+      end
+
+      def to_json(*options)
+        instance_variables.map do |var|
+          [var.to_s[1..-1], instance_variable_get(var)]
+        end.to_h.to_json(*options)
       end
     end
 

--- a/spaceship/lib/spaceship/connect_api/model.rb
+++ b/spaceship/lib/spaceship/connect_api/model.rb
@@ -25,7 +25,7 @@ module Spaceship
       # Example:
       # { "minOsVersion" => "min_os_version" }
       #
-      # Creates attr_write and attr_/Users/tbodt/Developer/projects/fastlane/spaceship/spec/connect_api/models/model_spec.rb/Users/tbodt/Developer/projects/fastlane/spaceship/spec/connect_api/models/model_spec.rbreader for :min_os_version
+      # Creates attr_write and attr_reader for :min_os_version
       # Creates alias for :minOsVersion to :min_os_version
       #
       def attr_mapping(attr_map)

--- a/spaceship/spec/connect_api/model_spec.rb
+++ b/spaceship/spec/connect_api/model_spec.rb
@@ -1,0 +1,23 @@
+require 'json'
+
+describe Spaceship::ConnectAPI::Model do
+  it "#to_json" do
+    class TestModel
+      include Spaceship::ConnectAPI::Model
+
+      attr_accessor :foo
+      attr_accessor :foo_bar
+
+      attr_mapping({
+        "fooBar" => "foo_bar"
+      })
+    end
+
+    test = TestModel.new("id", { foo: "foo", foo_bar: "foo_bar" })
+    expect(JSON.parse(test.to_json)).to eq({
+      "id" => "id",
+      "foo" => "foo",
+      "foo_bar" => "foo_bar"
+    })
+  end
+end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I wanted to write a script that dumps out the list of beta testers as JSON, but the ConnectAPI models didn't have to_json implemented, so I implemented it.

### Description
Added a to_json method to ConnectAPI models that returns its attributes in JSON.

### Testing Steps
bundle exec rspec spaceship/spec/connect_api/model_spec.rb
