### PR TITLE
[action] cocoapods: replace clean -> clean_install in example

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -156,7 +156,7 @@ module Fastlane
         [
           'cocoapods',
           'cocoapods(
-            clean: true,
+            clean_install: true,
             podfile: "./CustomPodfile"
           )'
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`clean` in `cocoapods` actions is marked as deprecated

### Description
From available_options:
```
         FastlaneCore::ConfigItem.new(key: :clean,
                                       env_name: "FL_COCOAPODS_CLEAN",
                                       description: "(Option renamed as clean_install) Remove SCM directories",
                                       deprecated: true,
                                       is_string: false,
                                       default_value: true)
```