### PR TITLE
[match] prompt for keychain password to set partition list for certificates to disable xcode prompt for password on sign

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -416,5 +416,22 @@ module FastlaneCore
       UI.deprecated("Helper.log is deprecated. Use `UI` class instead")
       UI.current.log
     end
+
+    def self.ask_password(message: "Passphrase: ", confirm: nil)
+      raise "This code should only run in interactive mode" unless UI.interactive?
+
+      loop do
+        password = UI.password(message)
+        if confirm
+          password2 = UI.password("Type passphrase again: ")
+          if password == password2
+            return password
+          end
+        else
+          return password
+        end
+        UI.error("Passphrases differ. Try again")
+      end
+    end
   end
 end

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -20,6 +20,7 @@ module FastlaneCore
 
         # Set partition list only if success since it can be a time consuming process if a lot of keys are installed
         if thrd.value.success?
+          keychain_password ||= resolve_keychain_password(keychain_path)
           set_partition_list(path, keychain_path, keychain_password: keychain_password, output: output)
         else
           # Output verbose if file is already installed since not an error otherwise we will show the whole error
@@ -34,37 +35,6 @@ module FastlaneCore
     end
 
     def self.set_partition_list(path, keychain_path, keychain_password: nil, output: FastlaneCore::Globals.verbose?)
-      keychain_name = File.basename(keychain_path, ".*")
-      server = server_name(keychain_name)
-
-      # https://github.com/fastlane/fastlane/issues/14196
-      # Keychain password is needed to set the partition list to
-      # prevent Xcode from prompting dialog for keychain password when signing
-      # 1. Uses password if given
-      # 2. Uses keychain password from login keychain if found
-      # 3. Prompts user for keychain password and stores it in login keychain for user later
-      if keychain_password.nil?
-        # Attempt to find password in keychain for keychain
-        item = Security::InternetPassword.find(server: server)
-        if item
-          keychain_password = item.password
-          UI.important("Using keychain password from keychain item #{server} in #{keychain_path}")
-        end
-
-        if keychain_password.nil?
-          if UI.interactive?
-            UI.important("Enter the password for #{keychain_path}")
-            UI.important("This passphrase will be stored in your local keychain with the name #{server} and used in future runs")
-            UI.important("This prompt can be avoided by specifying the 'keychain_password' option or 'MATCH_KEYCHAIN_PASSWORD' environment variable")
-            keychain_password = FastlaneCore::Helper.ask_password(message: "Password for #{keychain_name} keychain: ", confirm: true)
-            Security::InternetPassword.add(server, "", keychain_password)
-          else
-            UI.important("Keychain password for #{keychain_path} was not specified and not found in your keychain. Specify the 'keychain_password' option to prevent the UI permission popup when code signing")
-            keychain_password = ""
-          end
-        end
-      end
-
       # When security supports partition lists, also add the partition IDs
       # See https://openradar.appspot.com/28524119
       if Helper.backticks('security -h | grep set-key-partition-list', print: false).length > 0
@@ -85,7 +55,8 @@ module FastlaneCore
 
             # Inform user when no/wrong password was used as its needed to prevent UI permission popup from Xcode when signing
             if err.include?("SecKeychainItemSetAccessWithPassword")
-              Security::InternetPassword.delete(server: server)
+              keychain_name = File.basename(keychain_path, ".*")
+              Security::InternetPassword.delete(server: server_name(keychain_name))
 
               UI.important("")
               UI.important("Could not configure imported keychain item (certificate) to prevent UI permission popup when code signing\n" \
@@ -105,6 +76,38 @@ module FastlaneCore
         Helper.hide_loading_indicator
 
       end
+    end
+
+    # https://github.com/fastlane/fastlane/issues/14196
+    # Keychain password is needed to set the partition list to
+    # prevent Xcode from prompting dialog for keychain password when signing
+    # 1. Uses keychain password from login keychain if found
+    # 2. Prompts user for keychain password and stores it in login keychain for user later
+    def self.resolve_keychain_password(keychain_path)
+      keychain_name = File.basename(keychain_path, ".*")
+      server = server_name(keychain_name)
+
+      # Attempt to find password in keychain for keychain
+      item = Security::InternetPassword.find(server: server)
+      if item
+        keychain_password = item.password
+        UI.important("Using keychain password from keychain item #{server} in #{keychain_path}")
+      end
+
+      if keychain_password.nil?
+        if UI.interactive?
+          UI.important("Enter the password for #{keychain_path}")
+          UI.important("This passphrase will be stored in your local keychain with the name #{server} and used in future runs")
+          UI.important("This prompt can be avoided by specifying the 'keychain_password' option or 'MATCH_KEYCHAIN_PASSWORD' environment variable")
+          keychain_password = FastlaneCore::Helper.ask_password(message: "Password for #{keychain_name} keychain: ", confirm: true)
+          Security::InternetPassword.add(server, "", keychain_password)
+        else
+          UI.important("Keychain password for #{keychain_path} was not specified and not found in your keychain. Specify the 'keychain_password' option to prevent the UI permission popup when code signing")
+          keychain_password = ""
+        end
+      end
+
+      return keychain_password
     end
 
     # server name used for accessing the macOS keychain

--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -16,7 +16,7 @@ module Match
 
       ensure_ui_interactive
 
-      to = ChangePassword.ask_password(message: "New passphrase for Git Repo: ", confirm: true)
+      to = FastlaneCore::Helper.ask_password(message: "New passphrase for Git Repo: ", confirm: true)
 
       # Choose the right storage and encryption implementations
       storage = Storage.for_mode(params[:storage_mode], {
@@ -42,23 +42,6 @@ module Match
       message = "[fastlane] Changed passphrase"
       files_to_commit = encryption.encrypt_files
       storage.save_changes!(files_to_commit: files_to_commit, custom_message: message)
-    end
-
-    # This method is called from both here, and from `openssl.rb`
-    def self.ask_password(message: "Passphrase for Match storage: ", confirm: nil)
-      ensure_ui_interactive
-      loop do
-        password = UI.password(message)
-        if confirm
-          password2 = UI.password("Type passphrase again: ")
-          if password == password2
-            return password
-          end
-        else
-          return password
-        end
-        UI.error("Passphrases differ. Try again")
-      end
     end
 
     def self.ensure_ui_interactive

--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -99,7 +99,7 @@ module Match
             UI.important("Enter the passphrase that should be used to encrypt/decrypt your certificates")
             UI.important("This passphrase is specific per repository and will be stored in your local keychain")
             UI.important("Make sure to remember the password, as you'll need it when you run match on a different machine")
-            password = ChangePassword.ask_password(confirm: true)
+            password = FastlaneCore::Helper.ask_password(message: "Passphrase for Match storage: ", confirm: true)
             store_password(password)
           end
         end

--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -4,7 +4,7 @@ require_relative 'module'
 
 module Match
   class Utils
-    def self.import(item_path, keychain, password: "")
+    def self.import(item_path, keychain, password: nil)
       keychain_path = FastlaneCore::Helper.keychain_path(keychain)
       FastlaneCore::KeychainImporter.import_file(item_path, keychain_path, keychain_password: password, output: FastlaneCore::Globals.verbose?)
     end

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -1,6 +1,14 @@
 describe Match do
   describe Match::Utils do
+    let(:thread) { double }
+
     before(:each) do
+      value = double
+      allow(value).to receive(:success?).and_return(true)
+      allow(thread).to receive(:value).and_return(value)
+
+      allow(Security::InternetPassword).to receive(:find).and_return(nil)
+
       allow(FastlaneCore::Helper).to receive(:backticks).with('security -h | grep set-key-partition-list', print: false).and_return('    set-key-partition-list               Set the partition list of a key.')
     end
 
@@ -9,17 +17,17 @@ describe Match do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
+        expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
-        allow(Open3).to receive(:popen3).with(expected_command)
-        allow(Open3).to receive(:popen3).with(allowed_command)
+        expect(Open3).to receive(:popen3).with(expected_command).and_yield("", "", "", thread)
+        expect(Open3).to receive(:popen3).with(expected_partition_command)
 
-        Match::Utils.import('item.path', 'login.keychain')
+        Match::Utils.import('item.path', 'login.keychain', password: '')
       end
 
       it 'treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path' do
@@ -28,17 +36,17 @@ describe Match do
         expected_command = "security import item.path -k '#{keychain}' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{keychain} 1> /dev/null"
+        expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{keychain} 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with(keychain).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with('item.path').and_return(true)
 
-        allow(Open3).to receive(:popen3).with(expected_command)
-        allow(Open3).to receive(:popen3).with(allowed_command)
+        expect(Open3).to receive(:popen3).with(expected_command).and_yield("", "", "", thread)
+        expect(Open3).to receive(:popen3).with(expected_partition_command)
 
-        Match::Utils.import('item.path', keychain)
+        Match::Utils.import('item.path', keychain, password: '')
       end
 
       it 'shows a user error if the keychain path cannot be resolved' do
@@ -53,17 +61,63 @@ describe Match do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        allowed_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db 1> /dev/null"
+        expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)
         allow(File).to receive(:exist?).and_return(false)
         expect(File).to receive(:exist?).with("item.path").and_return(true)
 
-        allow(Open3).to receive(:popen3).with(expected_command)
-        allow(Open3).to receive(:popen3).with(allowed_command)
+        expect(Open3).to receive(:popen3).with(expected_command).and_yield("", "", "", thread)
+        expect(Open3).to receive(:popen3).with(expected_partition_command)
 
         Match::Utils.import('item.path', "login.keychain")
+      end
+
+      describe "keychain_password" do
+        it 'prompts for keychain password when none given and not in keychain' do
+          expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
+
+          # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
+          expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{'user_entered'.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
+
+          allow(Security::InternetPassword).to receive(:find).and_return(nil)
+          allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
+
+          expect(FastlaneCore::Helper).to receive(:ask_password).and_return('user_entered')
+          expect(Security::InternetPassword).to receive(:add).with('fastlane_keychain_login', anything, 'user_entered')
+
+          allow(File).to receive(:file?).and_return(false)
+          expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
+          allow(File).to receive(:exist?).and_return(false)
+          expect(File).to receive(:exist?).with('item.path').and_return(true)
+
+          expect(Open3).to receive(:popen3).with(expected_command).and_yield("", "", "", thread)
+          expect(Open3).to receive(:popen3).with(expected_partition_command)
+
+          Match::Utils.import('item.path', 'login.keychain')
+        end
+
+        it 'find keychain password in keychain when none given' do
+          expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
+
+          # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
+          expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{'from_keychain'.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
+
+          item = double
+          allow(item).to receive(:password).and_return('from_keychain')
+          allow(Security::InternetPassword).to receive(:find).and_return(item)
+
+          allow(File).to receive(:file?).and_return(false)
+          expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
+          allow(File).to receive(:exist?).and_return(false)
+          expect(File).to receive(:exist?).with('item.path').and_return(true)
+
+          expect(Open3).to receive(:popen3).with(expected_command).and_yield("", "", "", thread)
+          expect(Open3).to receive(:popen3).with(expected_partition_command)
+
+          Match::Utils.import('item.path', 'login.keychain')
+        end
       end
     end
 


### PR DESCRIPTION
### Motivation and Context
Fixes #14196
Entering the keychain password used for certificate signing (usually login) required storing the keychain password in an environment variable or passing it in via options which was pretty insure. This will allow for a prompt of the password and store the password for the keychain in the keychain to use later.

### Description
1. Uses password if given
2. Uses keychain password from login keychain if found
3. Prompts user for keychain password and stores it in login keychain for user later

Also fixed broken match tests that were using `allow` instead of `expect` for some `Open3` commands. The `Open3` command weren’t getting mocked properly so the inside was never getting executed which means not all of the things were getting tested properly 🤷‍♂️ 

### Testing Steps
1. Nuke all existing certs
2. Run match
  - Will prompt for keychain password
3. Look in Keychain Access for `fastlane_keychain_<keychain_name>` entry
4. Nuke all certs again
5. Run match again
  - There won’t be any prompt
