### PR TITLE
Version bump to 2.147.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,43 +34,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-</tr>
-<tr>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
@@ -78,55 +52,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-</tr>
-<tr>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
 <img src='https://github.com/lmirosevic.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
 </tr>
 <tr>
@@ -142,23 +78,55 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+</tr>
+<tr>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
 <img src='https://github.com/KrauseFx.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 </tr>
 <tr>
@@ -168,11 +136,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+</tr>
+<tr>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Jérôme Lacoste",
+  spec.authors       = ["Josh Holtz",
+                        "Joshua Liebowitz",
+                        "Felix Krause",
                         "Iulian Onofrei",
-                        "Luka Mirosevic",
-                        "Matthew Ellis",
+                        "Stefan Natchev",
+                        "Fumiya Nakamura",
+                        "Jorge Revuelta H",
                         "Helmut Januschka",
                         "Manu Wallner",
                         "Olivier Halligon",
+                        "Danielle Tomlinson",
+                        "Jérôme Lacoste",
+                        "Matthew Ellis",
+                        "Max Ott",
                         "Aaron Brager",
+                        "Luka Mirosevic",
+                        "Andrew McBurney",
+                        "Maksym Grebenets",
+                        "Daniel Jankowski",
                         "Jan Piotrowski",
                         "Kohki Miki",
-                        "Maksym Grebenets",
-                        "Felix Krause",
-                        "Josh Holtz",
-                        "Max Ott",
-                        "Danielle Tomlinson",
-                        "Daniel Jankowski",
-                        "Jimmy Dee",
-                        "Fumiya Nakamura",
-                        "Andrew McBurney",
-                        "Stefan Natchev",
-                        "Joshua Liebowitz",
-                        "Jorge Revuelta H"]
+                        "Jimmy Dee"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.146.1'.freeze
+  VERSION = '2.147.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.146.1
+// Generated with fastlane 2.147.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1442,6 +1442,7 @@ func captureAndroidScreenshots(androidHome: String? = nil,
    - clearPreviousScreenshots: Enabling this option will automatically clear previously generated screenshots before running snapshot
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - eraseSimulator: Enabling this option will automatically erase the simulator before running the application
+   - overrideStatusBar: Enabling this option wil automatically override the status bar to show 9:41 AM, full battery, and full reception
    - localizeSimulator: Enabling this option will configure the Simulator's system language
    - darkMode: Enabling this option will configure the Simulator to be in dark mode (false for light, true for dark)
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
@@ -1463,6 +1464,7 @@ func captureAndroidScreenshots(androidHome: String? = nil,
    - concurrentSimulators: Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
    - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - testplan: The testplan associated with the scheme that should be used for testing
 */
 func captureIosScreenshots(workspace: String? = nil,
                            project: String? = nil,
@@ -1479,6 +1481,7 @@ func captureIosScreenshots(workspace: String? = nil,
                            clearPreviousScreenshots: Bool = false,
                            reinstallApp: Bool = false,
                            eraseSimulator: Bool = false,
+                           overrideStatusBar: Bool = false,
                            localizeSimulator: Bool = false,
                            darkMode: Bool? = nil,
                            appIdentifier: String? = nil,
@@ -1499,7 +1502,8 @@ func captureIosScreenshots(workspace: String? = nil,
                            namespaceLogFiles: Any? = nil,
                            concurrentSimulators: Bool = true,
                            disableSlideToType: Bool = false,
-                           clonedSourcePackagesPath: String? = nil) {
+                           clonedSourcePackagesPath: String? = nil,
+                           testplan: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "capture_ios_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                          RubyCommand.Argument(name: "project", value: project),
                                                                                                          RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -1515,6 +1519,7 @@ func captureIosScreenshots(workspace: String? = nil,
                                                                                                          RubyCommand.Argument(name: "clear_previous_screenshots", value: clearPreviousScreenshots),
                                                                                                          RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                                          RubyCommand.Argument(name: "erase_simulator", value: eraseSimulator),
+                                                                                                         RubyCommand.Argument(name: "override_status_bar", value: overrideStatusBar),
                                                                                                          RubyCommand.Argument(name: "localize_simulator", value: localizeSimulator),
                                                                                                          RubyCommand.Argument(name: "dark_mode", value: darkMode),
                                                                                                          RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
@@ -1535,7 +1540,8 @@ func captureIosScreenshots(workspace: String? = nil,
                                                                                                          RubyCommand.Argument(name: "namespace_log_files", value: namespaceLogFiles),
                                                                                                          RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
                                                                                                          RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
-                                                                                                         RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
+                                                                                                         RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                                         RubyCommand.Argument(name: "testplan", value: testplan)])
   _ = runner.executeCommand(command)
 }
 
@@ -1558,6 +1564,7 @@ func captureIosScreenshots(workspace: String? = nil,
    - clearPreviousScreenshots: Enabling this option will automatically clear previously generated screenshots before running snapshot
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - eraseSimulator: Enabling this option will automatically erase the simulator before running the application
+   - overrideStatusBar: Enabling this option wil automatically override the status bar to show 9:41 AM, full battery, and full reception
    - localizeSimulator: Enabling this option will configure the Simulator's system language
    - darkMode: Enabling this option will configure the Simulator to be in dark mode (false for light, true for dark)
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
@@ -1579,6 +1586,7 @@ func captureIosScreenshots(workspace: String? = nil,
    - concurrentSimulators: Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
    - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - testplan: The testplan associated with the scheme that should be used for testing
 */
 func captureScreenshots(workspace: String? = nil,
                         project: String? = nil,
@@ -1595,6 +1603,7 @@ func captureScreenshots(workspace: String? = nil,
                         clearPreviousScreenshots: Bool = false,
                         reinstallApp: Bool = false,
                         eraseSimulator: Bool = false,
+                        overrideStatusBar: Bool = false,
                         localizeSimulator: Bool = false,
                         darkMode: Bool? = nil,
                         appIdentifier: String? = nil,
@@ -1615,7 +1624,8 @@ func captureScreenshots(workspace: String? = nil,
                         namespaceLogFiles: Any? = nil,
                         concurrentSimulators: Bool = true,
                         disableSlideToType: Bool = false,
-                        clonedSourcePackagesPath: String? = nil) {
+                        clonedSourcePackagesPath: String? = nil,
+                        testplan: String? = nil) {
   let command = RubyCommand(commandID: "", methodName: "capture_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                      RubyCommand.Argument(name: "project", value: project),
                                                                                                      RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -1631,6 +1641,7 @@ func captureScreenshots(workspace: String? = nil,
                                                                                                      RubyCommand.Argument(name: "clear_previous_screenshots", value: clearPreviousScreenshots),
                                                                                                      RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                                      RubyCommand.Argument(name: "erase_simulator", value: eraseSimulator),
+                                                                                                     RubyCommand.Argument(name: "override_status_bar", value: overrideStatusBar),
                                                                                                      RubyCommand.Argument(name: "localize_simulator", value: localizeSimulator),
                                                                                                      RubyCommand.Argument(name: "dark_mode", value: darkMode),
                                                                                                      RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
@@ -1651,7 +1662,8 @@ func captureScreenshots(workspace: String? = nil,
                                                                                                      RubyCommand.Argument(name: "namespace_log_files", value: namespaceLogFiles),
                                                                                                      RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
                                                                                                      RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
-                                                                                                     RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
+                                                                                                     RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                                     RubyCommand.Argument(name: "testplan", value: testplan)])
   _ = runner.executeCommand(command)
 }
 
@@ -3004,7 +3016,7 @@ func flock(message: String,
    - forceOrientationBlock: [Advanced] A block to customize your screenshots' device orientation
    - debugMode: Output debug information in framed screenshots
    - resume: Resume frameit instead of reprocessing all screenshots
-   - usePlatform: Choose a platform, the valid options are IOS, ANDROID and ANY (IOS is default to ensure backward compatibility)
+   - usePlatform: Choose a platform, the valid options are IOS, ANDROID and ANY (default is either general platform defined in the fastfile or IOS to ensure backward compatibility)
    - path: The path to the directory containing the screenshots
 
  Uses [frameit](https://docs.fastlane.tools/actions/frameit/) to prepare perfect screenshots for the App Store, your website, QA or emails.
@@ -3066,7 +3078,7 @@ func frameScreenshots(white: Bool? = nil,
    - forceOrientationBlock: [Advanced] A block to customize your screenshots' device orientation
    - debugMode: Output debug information in framed screenshots
    - resume: Resume frameit instead of reprocessing all screenshots
-   - usePlatform: Choose a platform, the valid options are IOS, ANDROID and ANY (IOS is default to ensure backward compatibility)
+   - usePlatform: Choose a platform, the valid options are IOS, ANDROID and ANY (default is either general platform defined in the fastfile or IOS to ensure backward compatibility)
    - path: The path to the directory containing the screenshots
 
  Uses [frameit](https://docs.fastlane.tools/actions/frameit/) to prepare perfect screenshots for the App Store, your website, QA or emails.
@@ -4496,6 +4508,7 @@ func makeChangelogFromJenkins(fallbackChangelog: String = "",
    - skipDocs: Skip generation of a README.md for the created git repository
    - platform: Set the provisioning profile's platform to work with (i.e. ios, tvos, macos)
    - templateName: The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
+   - profileName: A custom name for the provisioning profile. This will replace the default provisioning profile name if specified
    - outputPath: Path in which to export certificates, key and profile
    - verbose: Print out extra information and all commands
 
@@ -4534,6 +4547,7 @@ func match(type: Any = matchfile.type,
            skipDocs: Bool = matchfile.skipDocs,
            platform: Any = matchfile.platform,
            templateName: Any? = matchfile.templateName,
+           profileName: Any? = matchfile.profileName,
            outputPath: Any? = matchfile.outputPath,
            verbose: Bool = matchfile.verbose) {
   let command = RubyCommand(commandID: "", methodName: "match", className: nil, args: [RubyCommand.Argument(name: "type", value: type),
@@ -4569,6 +4583,7 @@ func match(type: Any = matchfile.type,
                                                                                        RubyCommand.Argument(name: "skip_docs", value: skipDocs),
                                                                                        RubyCommand.Argument(name: "platform", value: platform),
                                                                                        RubyCommand.Argument(name: "template_name", value: templateName),
+                                                                                       RubyCommand.Argument(name: "profile_name", value: profileName),
                                                                                        RubyCommand.Argument(name: "output_path", value: outputPath),
                                                                                        RubyCommand.Argument(name: "verbose", value: verbose)])
   _ = runner.executeCommand(command)
@@ -5670,8 +5685,9 @@ func rubyVersion() {
    - addressSanitizer: Should the address sanitizer be turned on?
    - threadSanitizer: Should the thread sanitizer be turned on?
    - openReport: Should the HTML report be opened when tests are completed?
+   - disableXcpretty: Disable xcpretty formatting of build, similar to `output_style='raw'` but this will also skip the test results table
    - outputDirectory: The directory in which all reports will be stored
-   - outputStyle: Define how the output should look like. Valid values are: standard, basic, rspec, or raw (disables xcpretty)
+   - outputStyle: Define how the output should look like. Valid values are: standard, basic, rspec, or raw (disables xcpretty during xcodebuild)
    - outputTypes: Comma separated list of the output types (e.g. html, junit, json-compilation-database)
    - outputFiles: Comma separated list of the output files, corresponding to the types provided by :output_types (order should match). If specifying an output type of json-compilation-database with :use_clang_report_name enabled, that option will take precedence
    - buildlogPath: The directory where to store the raw log
@@ -5733,6 +5749,7 @@ func runTests(workspace: String? = nil,
               addressSanitizer: Bool? = nil,
               threadSanitizer: Bool? = nil,
               openReport: Bool = false,
+              disableXcpretty: Bool? = nil,
               outputDirectory: String = "./test_output",
               outputStyle: String? = nil,
               outputTypes: String = "html,junit",
@@ -5793,6 +5810,7 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "address_sanitizer", value: addressSanitizer),
                                                                                            RubyCommand.Argument(name: "thread_sanitizer", value: threadSanitizer),
                                                                                            RubyCommand.Argument(name: "open_report", value: openReport),
+                                                                                           RubyCommand.Argument(name: "disable_xcpretty", value: disableXcpretty),
                                                                                            RubyCommand.Argument(name: "output_directory", value: outputDirectory),
                                                                                            RubyCommand.Argument(name: "output_style", value: outputStyle),
                                                                                            RubyCommand.Argument(name: "output_types", value: outputTypes),
@@ -5934,8 +5952,9 @@ func say(text: Any,
    - addressSanitizer: Should the address sanitizer be turned on?
    - threadSanitizer: Should the thread sanitizer be turned on?
    - openReport: Should the HTML report be opened when tests are completed?
+   - disableXcpretty: Disable xcpretty formatting of build, similar to `output_style='raw'` but this will also skip the test results table
    - outputDirectory: The directory in which all reports will be stored
-   - outputStyle: Define how the output should look like. Valid values are: standard, basic, rspec, or raw (disables xcpretty)
+   - outputStyle: Define how the output should look like. Valid values are: standard, basic, rspec, or raw (disables xcpretty during xcodebuild)
    - outputTypes: Comma separated list of the output types (e.g. html, junit, json-compilation-database)
    - outputFiles: Comma separated list of the output files, corresponding to the types provided by :output_types (order should match). If specifying an output type of json-compilation-database with :use_clang_report_name enabled, that option will take precedence
    - buildlogPath: The directory where to store the raw log
@@ -5997,6 +6016,7 @@ func scan(workspace: Any? = scanfile.workspace,
           addressSanitizer: Bool? = scanfile.addressSanitizer,
           threadSanitizer: Bool? = scanfile.threadSanitizer,
           openReport: Bool = scanfile.openReport,
+          disableXcpretty: Bool? = scanfile.disableXcpretty,
           outputDirectory: Any = scanfile.outputDirectory,
           outputStyle: Any? = scanfile.outputStyle,
           outputTypes: Any = scanfile.outputTypes,
@@ -6057,6 +6077,7 @@ func scan(workspace: Any? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "address_sanitizer", value: addressSanitizer),
                                                                                       RubyCommand.Argument(name: "thread_sanitizer", value: threadSanitizer),
                                                                                       RubyCommand.Argument(name: "open_report", value: openReport),
+                                                                                      RubyCommand.Argument(name: "disable_xcpretty", value: disableXcpretty),
                                                                                       RubyCommand.Argument(name: "output_directory", value: outputDirectory),
                                                                                       RubyCommand.Argument(name: "output_style", value: outputStyle),
                                                                                       RubyCommand.Argument(name: "output_types", value: outputTypes),
@@ -6751,6 +6772,7 @@ func slather(buildDirectory: String? = nil,
    - clearPreviousScreenshots: Enabling this option will automatically clear previously generated screenshots before running snapshot
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - eraseSimulator: Enabling this option will automatically erase the simulator before running the application
+   - overrideStatusBar: Enabling this option wil automatically override the status bar to show 9:41 AM, full battery, and full reception
    - localizeSimulator: Enabling this option will configure the Simulator's system language
    - darkMode: Enabling this option will configure the Simulator to be in dark mode (false for light, true for dark)
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
@@ -6772,6 +6794,7 @@ func slather(buildDirectory: String? = nil,
    - concurrentSimulators: Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
    - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - testplan: The testplan associated with the scheme that should be used for testing
 */
 func snapshot(workspace: Any? = snapshotfile.workspace,
               project: Any? = snapshotfile.project,
@@ -6788,6 +6811,7 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
               clearPreviousScreenshots: Bool = snapshotfile.clearPreviousScreenshots,
               reinstallApp: Bool = snapshotfile.reinstallApp,
               eraseSimulator: Bool = snapshotfile.eraseSimulator,
+              overrideStatusBar: Bool = snapshotfile.overrideStatusBar,
               localizeSimulator: Bool = snapshotfile.localizeSimulator,
               darkMode: Bool? = snapshotfile.darkMode,
               appIdentifier: Any? = snapshotfile.appIdentifier,
@@ -6808,7 +6832,8 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
               namespaceLogFiles: Any? = snapshotfile.namespaceLogFiles,
               concurrentSimulators: Bool = snapshotfile.concurrentSimulators,
               disableSlideToType: Bool = snapshotfile.disableSlideToType,
-              clonedSourcePackagesPath: Any? = snapshotfile.clonedSourcePackagesPath) {
+              clonedSourcePackagesPath: Any? = snapshotfile.clonedSourcePackagesPath,
+              testplan: Any? = snapshotfile.testplan) {
   let command = RubyCommand(commandID: "", methodName: "snapshot", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                           RubyCommand.Argument(name: "project", value: project),
                                                                                           RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -6824,6 +6849,7 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
                                                                                           RubyCommand.Argument(name: "clear_previous_screenshots", value: clearPreviousScreenshots),
                                                                                           RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                           RubyCommand.Argument(name: "erase_simulator", value: eraseSimulator),
+                                                                                          RubyCommand.Argument(name: "override_status_bar", value: overrideStatusBar),
                                                                                           RubyCommand.Argument(name: "localize_simulator", value: localizeSimulator),
                                                                                           RubyCommand.Argument(name: "dark_mode", value: darkMode),
                                                                                           RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
@@ -6844,7 +6870,8 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
                                                                                           RubyCommand.Argument(name: "namespace_log_files", value: namespaceLogFiles),
                                                                                           RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
                                                                                           RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
-                                                                                          RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath)])
+                                                                                          RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                          RubyCommand.Argument(name: "testplan", value: testplan)])
   _ = runner.executeCommand(command)
 }
 
@@ -7225,6 +7252,7 @@ func swiftlint(mode: Any = "lint",
    - skipDocs: Skip generation of a README.md for the created git repository
    - platform: Set the provisioning profile's platform to work with (i.e. ios, tvos, macos)
    - templateName: The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
+   - profileName: A custom name for the provisioning profile. This will replace the default provisioning profile name if specified
    - outputPath: Path in which to export certificates, key and profile
    - verbose: Print out extra information and all commands
 
@@ -7263,6 +7291,7 @@ func syncCodeSigning(type: String = "development",
                      skipDocs: Bool = false,
                      platform: String = "ios",
                      templateName: String? = nil,
+                     profileName: String? = nil,
                      outputPath: String? = nil,
                      verbose: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "sync_code_signing", className: nil, args: [RubyCommand.Argument(name: "type", value: type),
@@ -7298,6 +7327,7 @@ func syncCodeSigning(type: String = "development",
                                                                                                    RubyCommand.Argument(name: "skip_docs", value: skipDocs),
                                                                                                    RubyCommand.Argument(name: "platform", value: platform),
                                                                                                    RubyCommand.Argument(name: "template_name", value: templateName),
+                                                                                                   RubyCommand.Argument(name: "profile_name", value: profileName),
                                                                                                    RubyCommand.Argument(name: "output_path", value: outputPath),
                                                                                                    RubyCommand.Argument(name: "verbose", value: verbose)])
   _ = runner.executeCommand(command)
@@ -8820,4 +8850,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.74]
+// FastlaneRunnerAPIVersion [0.9.75]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.146.1
+// Generated with fastlane 2.147.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.146.1
+// Generated with fastlane 2.147.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -99,6 +99,9 @@ protocol MatchfileProtocol: class {
   /// The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
   var templateName: String? { get }
 
+  /// A custom name for the provisioning profile. This will replace the default provisioning profile name if specified
+  var profileName: String? { get }
+
   /// Path in which to export certificates, key and profile
   var outputPath: String? { get }
 
@@ -140,10 +143,11 @@ extension MatchfileProtocol {
   var skipDocs: Bool { return false }
   var platform: String { return "ios" }
   var templateName: String? { return nil }
+  var profileName: String? { return nil }
   var outputPath: String? { return nil }
   var verbose: Bool { return false }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.15]
+// FastlaneRunnerAPIVersion [0.9.16]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.146.1
+// Generated with fastlane 2.147.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.146.1
+// Generated with fastlane 2.147.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -66,10 +66,13 @@ protocol ScanfileProtocol: class {
   /// Should the HTML report be opened when tests are completed?
   var openReport: Bool { get }
 
+  /// Disable xcpretty formatting of build, similar to `output_style='raw'` but this will also skip the test results table
+  var disableXcpretty: Bool? { get }
+
   /// The directory in which all reports will be stored
   var outputDirectory: String { get }
 
-  /// Define how the output should look like. Valid values are: standard, basic, rspec, or raw (disables xcpretty)
+  /// Define how the output should look like. Valid values are: standard, basic, rspec, or raw (disables xcpretty during xcodebuild)
   var outputStyle: String? { get }
 
   /// Comma separated list of the output types (e.g. html, junit, json-compilation-database)
@@ -204,6 +207,7 @@ extension ScanfileProtocol {
   var addressSanitizer: Bool? { return nil }
   var threadSanitizer: Bool? { return nil }
   var openReport: Bool { return false }
+  var disableXcpretty: Bool? { return nil }
   var outputDirectory: String { return "./test_output" }
   var outputStyle: String? { return nil }
   var outputTypes: String { return "html,junit" }
@@ -246,4 +250,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.27]
+// FastlaneRunnerAPIVersion [0.9.28]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.146.1
+// Generated with fastlane 2.147.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.146.1
+// Generated with fastlane 2.147.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -45,6 +45,9 @@ protocol SnapshotfileProtocol: class {
   /// Enabling this option will automatically erase the simulator before running the application
   var eraseSimulator: Bool { get }
 
+  /// Enabling this option wil automatically override the status bar to show 9:41 AM, full battery, and full reception
+  var overrideStatusBar: Bool { get }
+
   /// Enabling this option will configure the Simulator's system language
   var localizeSimulator: Bool { get }
 
@@ -107,6 +110,9 @@ protocol SnapshotfileProtocol: class {
 
   /// Sets a custom path for Swift Package Manager dependencies
   var clonedSourcePackagesPath: String? { get }
+
+  /// The testplan associated with the scheme that should be used for testing
+  var testplan: String? { get }
 }
 
 extension SnapshotfileProtocol {
@@ -125,6 +131,7 @@ extension SnapshotfileProtocol {
   var clearPreviousScreenshots: Bool { return false }
   var reinstallApp: Bool { return false }
   var eraseSimulator: Bool { return false }
+  var overrideStatusBar: Bool { return false }
   var localizeSimulator: Bool { return false }
   var darkMode: Bool? { return nil }
   var appIdentifier: String? { return nil }
@@ -146,8 +153,9 @@ extension SnapshotfileProtocol {
   var concurrentSimulators: Bool { return true }
   var disableSlideToType: Bool { return false }
   var clonedSourcePackagesPath: String? { return nil }
+  var testplan: String? { return nil }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.7]
+// FastlaneRunnerAPIVersion [0.9.8]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.146.1':**

* [action] updating TestFairy action, based upon documentation and endpoint test. (#16425) via cdm2012
* [frameit] automatically determine platform from fastfile (#16428) via Miloš Černilovský
* [snapshot] add override_status_bar option (#16419) via Bouke van der Bijl
* [action] fix shellescape in set_pod_key (#16421) via Arnaud Dorgans
* [spaceship] add to_json for ConnectAPI models (#16422) via Theodore Dubois
* [frameit] add iPad Pro 12.9 4th generation (#16444) via Bouke van der Bijl
* [match] prompt for keychain password to set partition list for certificates to disable xcode prompt for password on sign (#16448) via Josh Holtz
* [action] cocoapods: replace clean -> clean_install in example (#16435) via Marcin Stepnowski
* [fastlane] drop Ruby 2.0, 2.1, 2.2 and 2.3 from gemspec (#16408) via Jakub Kašpar
* [scan] add disable_xcpretty option that skips it post-xcodebuild too (#16375) via Marcelo Gobetti
* [verify_xcode] add entry with TeamIdentifier=APPLECOMPUTER (#16395) via Teameh
* [Fastlane.swift] adding --port setter to socket_server (#16381) via Ray Deck
* [spaceship] fix error "can't modify frozen String" (#16403) via bill2004158
* [git_branch] adding AppCenter for ENV variable check (#16404) via matemoln
* [match] profile name parameter to specify your own provisioning profile name (#16386) via Josh Slebodnik
* [Ruby 2.7] allow Faraday 1.0.0 and Faraday-middleware 1.0.0 with Ruby 2.7 fixes, fix base Ruby 2.3 tests (#16399) via Jakub Kašpar
* [spaceship] add retrieve-create of iap shared secret to Spaceship::Tunes (#16326) via Michael Galperin
* [frameit] change framefile.json load path to support Screengrab and Supply (#16306) via Wellington Avelino dos Santos
* [fastlane] remove trailing spaces from custom_action_template file (#16366) via Akira Fukunaga
* [snapshot] add -testPlan option from scan (#16350) via Jean Mainguy
