### PR TITLE
[match] improve match macOS support

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -4,7 +4,7 @@
 
 ###### Easily sync your certificates and profiles across your team
 
-A new approach to iOS code signing: Share one code signing identity across your development team to simplify your codesigning setup and prevent code signing issues.
+A new approach to iOS and macOS code signing: Share one code signing identity across your development team to simplify your codesigning setup and prevent code signing issues.
 
 _match_ is the implementation of the [codesigning.guide concept](https://codesigning.guide). _match_ creates all required certificates & provisioning profiles and stores them in a separate git repository, Google Cloud, or Amazon S3. Every team member with access to the selected storage can use those credentials for code signing. _match_ also automatically repairs broken and expired credentials. It's the easiest way to share signing credentials across teams
 
@@ -49,7 +49,7 @@ For more information about the concept, visit [codesigning.guide](https://codesi
 
 |          |  match  |
 |----------|---------|
-🔄  | Automatically sync your iOS keys and profiles across all your team members using git
+🔄  | Automatically sync your iOS and macOS keys and profiles across all your team members using git
 📦  | Handle all the heavy lifting of creating and storing your certificates and profiles
 💻  | Setup codesigning on a new machine in under a minute
 🎯 | Designed to work with apps with multiple targets and bundle identifiers

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -83,7 +83,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -10,6 +10,16 @@ module Fastlane
         require 'match'
 
         params.load_configuration_file("Matchfile")
+
+        # fall back to lane platform when missing from configuration
+        if params.config_file_options[:platform].nil?
+          if lane_context[SharedValues::PLATFORM_NAME] == :mac
+            params.set(:platform, "macos")
+          else
+            params.set(:platform, "ios")
+          end
+        end
+
         Match::Runner.new.run(params)
 
         define_profile_type(params)

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -10,16 +10,6 @@ module Fastlane
         require 'match'
 
         params.load_configuration_file("Matchfile")
-
-        # fall back to lane platform when missing from configuration
-        if params.config_file_options[:platform].nil?
-          if lane_context[SharedValues::PLATFORM_NAME] == :mac
-            params.set(:platform, "macos")
-          else
-            params.set(:platform, "ios")
-          end
-        end
-
         Match::Runner.new.run(params)
 
         define_profile_type(params)

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -1,4 +1,5 @@
 require 'fastlane_core/configuration/config_item'
+require 'fastlane/helper/lane_helper'
 require 'credentials_manager/appfile_config'
 require_relative 'module'
 
@@ -8,6 +9,15 @@ module Match
     def self.append_option(option)
       self.available_options # to ensure we created the initial `@available_options` array
       @available_options << option
+    end
+
+    def self.default_platform
+      case Fastlane::Helper::LaneHelper.current_platform.to_s
+      when "mac"
+        "macos"
+      else
+        "ios"
+      end
     end
 
     def self.available_options
@@ -215,7 +225,8 @@ module Match
                                      short_option: '-o',
                                      env_name: "MATCH_PLATFORM",
                                      description: "Set the provisioning profile's platform to work with (i.e. ios, tvos, macos)",
-                                     default_value: "ios",
+                                     default_value: default_platform,
+                                     default_value_dynamic: true,
                                      verify_block: proc do |value|
                                        value = value.to_s
                                        pt = %w(tvos ios macos)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

NOTE: I unchecked `bundle exec rspec` but the very same tests also fail on `master` (unrelated to this PR).

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a warning with `match(platform: "macos")` and default `match` platform to lane context platform.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Firstly, fix a warning when using `match` with `platform = macos` parameter:

    Action 'match' isn't known to support operating system 'mac'.

caused by an incomplete condition in `is_supported`.

Second addition is a bit of a stretch, as it's my first PR and I tried my best to comply with the overall architecture.

I see `ConfigItem` has no knowledge of the lane context (specific to actions), so I thought of setting a default match `platform` according to the platform set in lane context. `Matchfile` takes over as usual, but at the very least this is a more sensible setting than hardcoded `ios` when no platform is specified. An invocation of `match` without arguments would now work in a `mac` lane.

Along the way, I added tiny bits of doc about macOS support. I guess `cert` also supports it, but I'm not 100% sure so I didn't alter anything about it.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->