### PR TITLE
Version bump to 2.148.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='daniel-jankowski'>
 <a href='https://github.com/mollyIV'>
@@ -64,8 +52,90 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
 </tr>
 <tr>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+</tr>
+<tr>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+</tr>
+<tr>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
 <td id='jimmy-dee'>
 <a href='https://github.com/jdee'>
 <img src='https://github.com/jdee.png?size=140'>
@@ -78,101 +148,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-</tr>
-<tr>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-</tr>
-<tr>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
 <td id='andrew-mcburney'>
 <a href='https://github.com/armcburney'>
 <img src='https://github.com/armcburney.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
-</tr>
-<tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
 <img src='https://github.com/AliSoftware.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+</tr>
+<tr>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Josh Holtz",
-                        "Joshua Liebowitz",
-                        "Felix Krause",
-                        "Iulian Onofrei",
-                        "Stefan Natchev",
-                        "Fumiya Nakamura",
-                        "Jorge Revuelta H",
-                        "Helmut Januschka",
-                        "Manu Wallner",
+  spec.authors       = ["Matthew Ellis",
                         "Olivier Halligon",
-                        "Danielle Tomlinson",
-                        "Jérôme Lacoste",
-                        "Matthew Ellis",
-                        "Max Ott",
-                        "Aaron Brager",
-                        "Luka Mirosevic",
-                        "Andrew McBurney",
-                        "Maksym Grebenets",
-                        "Daniel Jankowski",
-                        "Jan Piotrowski",
                         "Kohki Miki",
-                        "Jimmy Dee"]
+                        "Danielle Tomlinson",
+                        "Maksym Grebenets",
+                        "Helmut Januschka",
+                        "Daniel Jankowski",
+                        "Max Ott",
+                        "Stefan Natchev",
+                        "Jimmy Dee",
+                        "Luka Mirosevic",
+                        "Jan Piotrowski",
+                        "Andrew McBurney",
+                        "Aaron Brager",
+                        "Josh Holtz",
+                        "Jérôme Lacoste",
+                        "Fumiya Nakamura",
+                        "Manu Wallner",
+                        "Joshua Liebowitz",
+                        "Iulian Onofrei",
+                        "Jorge Revuelta H",
+                        "Felix Krause"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.147.0'.freeze
+  VERSION = '2.148.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.147.0
+// Generated with fastlane 2.148.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1465,6 +1465,8 @@ func captureAndroidScreenshots(androidHome: String? = nil,
    - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
    - testplan: The testplan associated with the scheme that should be used for testing
+   - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
+   - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
 */
 func captureIosScreenshots(workspace: String? = nil,
                            project: String? = nil,
@@ -1503,7 +1505,9 @@ func captureIosScreenshots(workspace: String? = nil,
                            concurrentSimulators: Bool = true,
                            disableSlideToType: Bool = false,
                            clonedSourcePackagesPath: String? = nil,
-                           testplan: String? = nil) {
+                           testplan: String? = nil,
+                           onlyTesting: Any? = nil,
+                           skipTesting: Any? = nil) {
   let command = RubyCommand(commandID: "", methodName: "capture_ios_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                          RubyCommand.Argument(name: "project", value: project),
                                                                                                          RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -1541,7 +1545,9 @@ func captureIosScreenshots(workspace: String? = nil,
                                                                                                          RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
                                                                                                          RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
                                                                                                          RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
-                                                                                                         RubyCommand.Argument(name: "testplan", value: testplan)])
+                                                                                                         RubyCommand.Argument(name: "testplan", value: testplan),
+                                                                                                         RubyCommand.Argument(name: "only_testing", value: onlyTesting),
+                                                                                                         RubyCommand.Argument(name: "skip_testing", value: skipTesting)])
   _ = runner.executeCommand(command)
 }
 
@@ -1587,6 +1593,8 @@ func captureIosScreenshots(workspace: String? = nil,
    - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
    - testplan: The testplan associated with the scheme that should be used for testing
+   - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
+   - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
 */
 func captureScreenshots(workspace: String? = nil,
                         project: String? = nil,
@@ -1625,7 +1633,9 @@ func captureScreenshots(workspace: String? = nil,
                         concurrentSimulators: Bool = true,
                         disableSlideToType: Bool = false,
                         clonedSourcePackagesPath: String? = nil,
-                        testplan: String? = nil) {
+                        testplan: String? = nil,
+                        onlyTesting: Any? = nil,
+                        skipTesting: Any? = nil) {
   let command = RubyCommand(commandID: "", methodName: "capture_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                      RubyCommand.Argument(name: "project", value: project),
                                                                                                      RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -1663,7 +1673,9 @@ func captureScreenshots(workspace: String? = nil,
                                                                                                      RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
                                                                                                      RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
                                                                                                      RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
-                                                                                                     RubyCommand.Argument(name: "testplan", value: testplan)])
+                                                                                                     RubyCommand.Argument(name: "testplan", value: testplan),
+                                                                                                     RubyCommand.Argument(name: "only_testing", value: onlyTesting),
+                                                                                                     RubyCommand.Argument(name: "skip_testing", value: skipTesting)])
   _ = runner.executeCommand(command)
 }
 
@@ -2149,10 +2161,6 @@ func copyArtifacts(keepOriginal: Bool = true,
    - notifications: Crashlytics notification option (true/false)
    - debug: Crashlytics debug option (true/false)
 
- Crashlytics Beta has been deprecated and replaced with Firebase App Distribution.
- Beta will continue working until May 4, 2020.
- Check out the [Firebase App Distribution docs](https://github.com/fastlane/fastlane-plugin-firebase_app_distribution) to get started.
- 
  Additionally, you can specify `notes`, `emails`, `groups` and `notifications`.
  Distributing to Groups: When using the `groups` parameter, it's important to use the group **alias** names for each group you'd like to distribute to. A group's alias can be found in the web UI. If you're viewing the Beta page, you can open the groups dialog by clicking the 'Manage Groups' button.
  This action uses the `submit` binary provided by the Crashlytics framework. If the binary is not found in its usual path, you'll need to specify the path manually by using the `crashlytics_path` option.
@@ -3353,6 +3361,7 @@ func getManagedPlayStorePublishingRights(jsonKey: String? = nil,
    - platform: Set the provisioning profile's platform (i.e. ios, tvos)
    - readonly: Only fetch existing profile, don't generate new ones
    - templateName: The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
+   - failOnNameTaken: Should the command fail if it was about to create a duplicate of an existing provisioning profile. It can happen due to issues on Apple Developer Portal, when profile to be recreated was not properly deleted first
 
  - returns: The UUID of the profile sigh just fetched/generated
 
@@ -3377,7 +3386,8 @@ func getProvisioningProfile(adhoc: Bool = false,
                             skipCertificateVerification: Bool = false,
                             platform: Any = "ios",
                             readonly: Bool = false,
-                            templateName: String? = nil) {
+                            templateName: String? = nil,
+                            failOnNameTaken: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "get_provisioning_profile", className: nil, args: [RubyCommand.Argument(name: "adhoc", value: adhoc),
                                                                                                           RubyCommand.Argument(name: "developer_id", value: developerId),
                                                                                                           RubyCommand.Argument(name: "development", value: development),
@@ -3397,7 +3407,8 @@ func getProvisioningProfile(adhoc: Bool = false,
                                                                                                           RubyCommand.Argument(name: "skip_certificate_verification", value: skipCertificateVerification),
                                                                                                           RubyCommand.Argument(name: "platform", value: platform),
                                                                                                           RubyCommand.Argument(name: "readonly", value: readonly),
-                                                                                                          RubyCommand.Argument(name: "template_name", value: templateName)])
+                                                                                                          RubyCommand.Argument(name: "template_name", value: templateName),
+                                                                                                          RubyCommand.Argument(name: "fail_on_name_taken", value: failOnNameTaken)])
   _ = runner.executeCommand(command)
 }
 
@@ -4509,6 +4520,7 @@ func makeChangelogFromJenkins(fallbackChangelog: String = "",
    - platform: Set the provisioning profile's platform to work with (i.e. ios, tvos, macos)
    - templateName: The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
    - profileName: A custom name for the provisioning profile. This will replace the default provisioning profile name if specified
+   - failOnNameTaken: Should the command fail if it was about to create a duplicate of an existing provisioning profile. It can happen due to issues on Apple Developer Portal, when profile to be recreated was not properly deleted first
    - outputPath: Path in which to export certificates, key and profile
    - verbose: Print out extra information and all commands
 
@@ -4548,6 +4560,7 @@ func match(type: Any = matchfile.type,
            platform: Any = matchfile.platform,
            templateName: Any? = matchfile.templateName,
            profileName: Any? = matchfile.profileName,
+           failOnNameTaken: Bool = matchfile.failOnNameTaken,
            outputPath: Any? = matchfile.outputPath,
            verbose: Bool = matchfile.verbose) {
   let command = RubyCommand(commandID: "", methodName: "match", className: nil, args: [RubyCommand.Argument(name: "type", value: type),
@@ -4584,6 +4597,7 @@ func match(type: Any = matchfile.type,
                                                                                        RubyCommand.Argument(name: "platform", value: platform),
                                                                                        RubyCommand.Argument(name: "template_name", value: templateName),
                                                                                        RubyCommand.Argument(name: "profile_name", value: profileName),
+                                                                                       RubyCommand.Argument(name: "fail_on_name_taken", value: failOnNameTaken),
                                                                                        RubyCommand.Argument(name: "output_path", value: outputPath),
                                                                                        RubyCommand.Argument(name: "verbose", value: verbose)])
   _ = runner.executeCommand(command)
@@ -4979,6 +4993,7 @@ func pem(development: Bool = false,
    - notifyExternalTesters: Should notify external testers?
    - appVersion: The version number of the application build to distribute. If the version number is not specified, then the most recent build uploaded to TestFlight will be distributed. If specified, the most recent build for the version number will be distributed
    - buildNumber: The build number of the application build to distribute. If the build number is not specified, the most recent build is distributed
+   - expirePreviousBuilds: Should expire previous builds?
    - firstName: The tester's first name
    - lastName: The tester's last name
    - email: The tester's email
@@ -5015,6 +5030,7 @@ func pilot(username: String,
            notifyExternalTesters: Bool = true,
            appVersion: String? = nil,
            buildNumber: String? = nil,
+           expirePreviousBuilds: Bool = false,
            firstName: String? = nil,
            lastName: String? = nil,
            email: String? = nil,
@@ -5047,6 +5063,7 @@ func pilot(username: String,
                                                                                        RubyCommand.Argument(name: "notify_external_testers", value: notifyExternalTesters),
                                                                                        RubyCommand.Argument(name: "app_version", value: appVersion),
                                                                                        RubyCommand.Argument(name: "build_number", value: buildNumber),
+                                                                                       RubyCommand.Argument(name: "expire_previous_builds", value: expirePreviousBuilds),
                                                                                        RubyCommand.Argument(name: "first_name", value: firstName),
                                                                                        RubyCommand.Argument(name: "last_name", value: lastName),
                                                                                        RubyCommand.Argument(name: "email", value: email),
@@ -5678,6 +5695,8 @@ func rubyVersion() {
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
    - testplan: The testplan associated with the scheme that should be used for testing
+   - onlyTestConfigurations: Array of strings matching test plan configurations to run
+   - skipTestConfigurations: Array of strings matching test plan configurations to skip
    - xctestrun: Run tests using the provided `.xctestrun` file
    - toolchain: The toolchain that should be used for building the application (e.g. `com.apple.dt.toolchain.Swift_2_3, org.swift.30p620160816a`)
    - clean: Should the project be cleaned before building it?
@@ -5742,6 +5761,8 @@ func runTests(workspace: String? = nil,
               onlyTesting: Any? = nil,
               skipTesting: Any? = nil,
               testplan: String? = nil,
+              onlyTestConfigurations: Any? = nil,
+              skipTestConfigurations: Any? = nil,
               xctestrun: String? = nil,
               toolchain: Any? = nil,
               clean: Bool = false,
@@ -5803,6 +5824,8 @@ func runTests(workspace: String? = nil,
                                                                                            RubyCommand.Argument(name: "only_testing", value: onlyTesting),
                                                                                            RubyCommand.Argument(name: "skip_testing", value: skipTesting),
                                                                                            RubyCommand.Argument(name: "testplan", value: testplan),
+                                                                                           RubyCommand.Argument(name: "only_test_configurations", value: onlyTestConfigurations),
+                                                                                           RubyCommand.Argument(name: "skip_test_configurations", value: skipTestConfigurations),
                                                                                            RubyCommand.Argument(name: "xctestrun", value: xctestrun),
                                                                                            RubyCommand.Argument(name: "toolchain", value: toolchain),
                                                                                            RubyCommand.Argument(name: "clean", value: clean),
@@ -5945,6 +5968,8 @@ func say(text: Any,
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
    - testplan: The testplan associated with the scheme that should be used for testing
+   - onlyTestConfigurations: Array of strings matching test plan configurations to run
+   - skipTestConfigurations: Array of strings matching test plan configurations to skip
    - xctestrun: Run tests using the provided `.xctestrun` file
    - toolchain: The toolchain that should be used for building the application (e.g. `com.apple.dt.toolchain.Swift_2_3, org.swift.30p620160816a`)
    - clean: Should the project be cleaned before building it?
@@ -6009,6 +6034,8 @@ func scan(workspace: Any? = scanfile.workspace,
           onlyTesting: Any? = scanfile.onlyTesting,
           skipTesting: Any? = scanfile.skipTesting,
           testplan: Any? = scanfile.testplan,
+          onlyTestConfigurations: Any? = scanfile.onlyTestConfigurations,
+          skipTestConfigurations: Any? = scanfile.skipTestConfigurations,
           xctestrun: Any? = scanfile.xctestrun,
           toolchain: Any? = scanfile.toolchain,
           clean: Bool = scanfile.clean,
@@ -6070,6 +6097,8 @@ func scan(workspace: Any? = scanfile.workspace,
                                                                                       RubyCommand.Argument(name: "only_testing", value: onlyTesting),
                                                                                       RubyCommand.Argument(name: "skip_testing", value: skipTesting),
                                                                                       RubyCommand.Argument(name: "testplan", value: testplan),
+                                                                                      RubyCommand.Argument(name: "only_test_configurations", value: onlyTestConfigurations),
+                                                                                      RubyCommand.Argument(name: "skip_test_configurations", value: skipTestConfigurations),
                                                                                       RubyCommand.Argument(name: "xctestrun", value: xctestrun),
                                                                                       RubyCommand.Argument(name: "toolchain", value: toolchain),
                                                                                       RubyCommand.Argument(name: "clean", value: clean),
@@ -6510,6 +6539,7 @@ func setupTravis(force: Bool = false) {
    - platform: Set the provisioning profile's platform (i.e. ios, tvos)
    - readonly: Only fetch existing profile, don't generate new ones
    - templateName: The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
+   - failOnNameTaken: Should the command fail if it was about to create a duplicate of an existing provisioning profile. It can happen due to issues on Apple Developer Portal, when profile to be recreated was not properly deleted first
 
  - returns: The UUID of the profile sigh just fetched/generated
 
@@ -6534,7 +6564,8 @@ func sigh(adhoc: Bool = false,
           skipCertificateVerification: Bool = false,
           platform: Any = "ios",
           readonly: Bool = false,
-          templateName: String? = nil) {
+          templateName: String? = nil,
+          failOnNameTaken: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "sigh", className: nil, args: [RubyCommand.Argument(name: "adhoc", value: adhoc),
                                                                                       RubyCommand.Argument(name: "developer_id", value: developerId),
                                                                                       RubyCommand.Argument(name: "development", value: development),
@@ -6554,7 +6585,8 @@ func sigh(adhoc: Bool = false,
                                                                                       RubyCommand.Argument(name: "skip_certificate_verification", value: skipCertificateVerification),
                                                                                       RubyCommand.Argument(name: "platform", value: platform),
                                                                                       RubyCommand.Argument(name: "readonly", value: readonly),
-                                                                                      RubyCommand.Argument(name: "template_name", value: templateName)])
+                                                                                      RubyCommand.Argument(name: "template_name", value: templateName),
+                                                                                      RubyCommand.Argument(name: "fail_on_name_taken", value: failOnNameTaken)])
   _ = runner.executeCommand(command)
 }
 
@@ -6795,6 +6827,8 @@ func slather(buildDirectory: String? = nil,
    - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
    - testplan: The testplan associated with the scheme that should be used for testing
+   - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
+   - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
 */
 func snapshot(workspace: Any? = snapshotfile.workspace,
               project: Any? = snapshotfile.project,
@@ -6833,7 +6867,9 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
               concurrentSimulators: Bool = snapshotfile.concurrentSimulators,
               disableSlideToType: Bool = snapshotfile.disableSlideToType,
               clonedSourcePackagesPath: Any? = snapshotfile.clonedSourcePackagesPath,
-              testplan: Any? = snapshotfile.testplan) {
+              testplan: Any? = snapshotfile.testplan,
+              onlyTesting: Any? = snapshotfile.onlyTesting,
+              skipTesting: Any? = snapshotfile.skipTesting) {
   let command = RubyCommand(commandID: "", methodName: "snapshot", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                           RubyCommand.Argument(name: "project", value: project),
                                                                                           RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -6871,7 +6907,9 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
                                                                                           RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
                                                                                           RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
                                                                                           RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
-                                                                                          RubyCommand.Argument(name: "testplan", value: testplan)])
+                                                                                          RubyCommand.Argument(name: "testplan", value: testplan),
+                                                                                          RubyCommand.Argument(name: "only_testing", value: onlyTesting),
+                                                                                          RubyCommand.Argument(name: "skip_testing", value: skipTesting)])
   _ = runner.executeCommand(command)
 }
 
@@ -7087,6 +7125,7 @@ func ssh(username: String,
    - timeout: Timeout for read, open, and send (in seconds)
    - deactivateOnPromote: **DEPRECATED!** Google Play does this automatically now - When promoting to a new track, deactivate the binary in the origin track
    - versionCodesToRetain: An array of version codes to retain when publishing a new APK
+   - inAppUpdatePriority: In-app update priority for all the newly added apks in the release. Can take values between [0,5]
    - obbMainReferencesVersion: References version of 'main' expansion file
    - obbMainFileSize: Size of 'main' expansion file in bytes
    - obbPatchReferencesVersion: References version of 'patch' expansion file
@@ -7124,6 +7163,7 @@ func supply(packageName: String,
             timeout: Int = 300,
             deactivateOnPromote: Bool = true,
             versionCodesToRetain: [String]? = nil,
+            inAppUpdatePriority: Int? = nil,
             obbMainReferencesVersion: String? = nil,
             obbMainFileSize: String? = nil,
             obbPatchReferencesVersion: String? = nil,
@@ -7158,6 +7198,7 @@ func supply(packageName: String,
                                                                                         RubyCommand.Argument(name: "timeout", value: timeout),
                                                                                         RubyCommand.Argument(name: "deactivate_on_promote", value: deactivateOnPromote),
                                                                                         RubyCommand.Argument(name: "version_codes_to_retain", value: versionCodesToRetain),
+                                                                                        RubyCommand.Argument(name: "in_app_update_priority", value: inAppUpdatePriority),
                                                                                         RubyCommand.Argument(name: "obb_main_references_version", value: obbMainReferencesVersion),
                                                                                         RubyCommand.Argument(name: "obb_main_file_size", value: obbMainFileSize),
                                                                                         RubyCommand.Argument(name: "obb_patch_references_version", value: obbPatchReferencesVersion),
@@ -7253,6 +7294,7 @@ func swiftlint(mode: Any = "lint",
    - platform: Set the provisioning profile's platform to work with (i.e. ios, tvos, macos)
    - templateName: The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
    - profileName: A custom name for the provisioning profile. This will replace the default provisioning profile name if specified
+   - failOnNameTaken: Should the command fail if it was about to create a duplicate of an existing provisioning profile. It can happen due to issues on Apple Developer Portal, when profile to be recreated was not properly deleted first
    - outputPath: Path in which to export certificates, key and profile
    - verbose: Print out extra information and all commands
 
@@ -7292,6 +7334,7 @@ func syncCodeSigning(type: String = "development",
                      platform: String = "ios",
                      templateName: String? = nil,
                      profileName: String? = nil,
+                     failOnNameTaken: Bool = false,
                      outputPath: String? = nil,
                      verbose: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "sync_code_signing", className: nil, args: [RubyCommand.Argument(name: "type", value: type),
@@ -7328,6 +7371,7 @@ func syncCodeSigning(type: String = "development",
                                                                                                    RubyCommand.Argument(name: "platform", value: platform),
                                                                                                    RubyCommand.Argument(name: "template_name", value: templateName),
                                                                                                    RubyCommand.Argument(name: "profile_name", value: profileName),
+                                                                                                   RubyCommand.Argument(name: "fail_on_name_taken", value: failOnNameTaken),
                                                                                                    RubyCommand.Argument(name: "output_path", value: outputPath),
                                                                                                    RubyCommand.Argument(name: "verbose", value: verbose)])
   _ = runner.executeCommand(command)
@@ -7422,6 +7466,7 @@ func testfairy(apiKey: String,
    - notifyExternalTesters: Should notify external testers?
    - appVersion: The version number of the application build to distribute. If the version number is not specified, then the most recent build uploaded to TestFlight will be distributed. If specified, the most recent build for the version number will be distributed
    - buildNumber: The build number of the application build to distribute. If the build number is not specified, the most recent build is distributed
+   - expirePreviousBuilds: Should expire previous builds?
    - firstName: The tester's first name
    - lastName: The tester's last name
    - email: The tester's email
@@ -7458,6 +7503,7 @@ func testflight(username: String,
                 notifyExternalTesters: Bool = true,
                 appVersion: String? = nil,
                 buildNumber: String? = nil,
+                expirePreviousBuilds: Bool = false,
                 firstName: String? = nil,
                 lastName: String? = nil,
                 email: String? = nil,
@@ -7490,6 +7536,7 @@ func testflight(username: String,
                                                                                             RubyCommand.Argument(name: "notify_external_testers", value: notifyExternalTesters),
                                                                                             RubyCommand.Argument(name: "app_version", value: appVersion),
                                                                                             RubyCommand.Argument(name: "build_number", value: buildNumber),
+                                                                                            RubyCommand.Argument(name: "expire_previous_builds", value: expirePreviousBuilds),
                                                                                             RubyCommand.Argument(name: "first_name", value: firstName),
                                                                                             RubyCommand.Argument(name: "last_name", value: lastName),
                                                                                             RubyCommand.Argument(name: "email", value: email),
@@ -8187,6 +8234,7 @@ func uploadToAppStore(username: String,
    - timeout: Timeout for read, open, and send (in seconds)
    - deactivateOnPromote: **DEPRECATED!** Google Play does this automatically now - When promoting to a new track, deactivate the binary in the origin track
    - versionCodesToRetain: An array of version codes to retain when publishing a new APK
+   - inAppUpdatePriority: In-app update priority for all the newly added apks in the release. Can take values between [0,5]
    - obbMainReferencesVersion: References version of 'main' expansion file
    - obbMainFileSize: Size of 'main' expansion file in bytes
    - obbPatchReferencesVersion: References version of 'patch' expansion file
@@ -8224,6 +8272,7 @@ func uploadToPlayStore(packageName: String,
                        timeout: Int = 300,
                        deactivateOnPromote: Bool = true,
                        versionCodesToRetain: [String]? = nil,
+                       inAppUpdatePriority: Int? = nil,
                        obbMainReferencesVersion: String? = nil,
                        obbMainFileSize: String? = nil,
                        obbPatchReferencesVersion: String? = nil,
@@ -8258,6 +8307,7 @@ func uploadToPlayStore(packageName: String,
                                                                                                       RubyCommand.Argument(name: "timeout", value: timeout),
                                                                                                       RubyCommand.Argument(name: "deactivate_on_promote", value: deactivateOnPromote),
                                                                                                       RubyCommand.Argument(name: "version_codes_to_retain", value: versionCodesToRetain),
+                                                                                                      RubyCommand.Argument(name: "in_app_update_priority", value: inAppUpdatePriority),
                                                                                                       RubyCommand.Argument(name: "obb_main_references_version", value: obbMainReferencesVersion),
                                                                                                       RubyCommand.Argument(name: "obb_main_file_size", value: obbMainFileSize),
                                                                                                       RubyCommand.Argument(name: "obb_patch_references_version", value: obbPatchReferencesVersion),
@@ -8328,6 +8378,7 @@ func uploadToPlayStoreInternalAppSharing(packageName: String,
    - notifyExternalTesters: Should notify external testers?
    - appVersion: The version number of the application build to distribute. If the version number is not specified, then the most recent build uploaded to TestFlight will be distributed. If specified, the most recent build for the version number will be distributed
    - buildNumber: The build number of the application build to distribute. If the build number is not specified, the most recent build is distributed
+   - expirePreviousBuilds: Should expire previous builds?
    - firstName: The tester's first name
    - lastName: The tester's last name
    - email: The tester's email
@@ -8364,6 +8415,7 @@ func uploadToTestflight(username: String,
                         notifyExternalTesters: Bool = true,
                         appVersion: String? = nil,
                         buildNumber: String? = nil,
+                        expirePreviousBuilds: Bool = false,
                         firstName: String? = nil,
                         lastName: String? = nil,
                         email: String? = nil,
@@ -8396,6 +8448,7 @@ func uploadToTestflight(username: String,
                                                                                                       RubyCommand.Argument(name: "notify_external_testers", value: notifyExternalTesters),
                                                                                                       RubyCommand.Argument(name: "app_version", value: appVersion),
                                                                                                       RubyCommand.Argument(name: "build_number", value: buildNumber),
+                                                                                                      RubyCommand.Argument(name: "expire_previous_builds", value: expirePreviousBuilds),
                                                                                                       RubyCommand.Argument(name: "first_name", value: firstName),
                                                                                                       RubyCommand.Argument(name: "last_name", value: lastName),
                                                                                                       RubyCommand.Argument(name: "email", value: email),
@@ -8850,4 +8903,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.75]
+// FastlaneRunnerAPIVersion [0.9.76]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.147.0
+// Generated with fastlane 2.148.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.147.0
+// Generated with fastlane 2.148.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -102,6 +102,9 @@ protocol MatchfileProtocol: class {
   /// A custom name for the provisioning profile. This will replace the default provisioning profile name if specified
   var profileName: String? { get }
 
+  /// Should the command fail if it was about to create a duplicate of an existing provisioning profile. It can happen due to issues on Apple Developer Portal, when profile to be recreated was not properly deleted first
+  var failOnNameTaken: Bool { get }
+
   /// Path in which to export certificates, key and profile
   var outputPath: String? { get }
 
@@ -144,10 +147,11 @@ extension MatchfileProtocol {
   var platform: String { return "ios" }
   var templateName: String? { return nil }
   var profileName: String? { return nil }
+  var failOnNameTaken: Bool { return false }
   var outputPath: String? { return nil }
   var verbose: Bool { return false }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.16]
+// FastlaneRunnerAPIVersion [0.9.17]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.147.0
+// Generated with fastlane 2.148.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.147.0
+// Generated with fastlane 2.148.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -45,6 +45,12 @@ protocol ScanfileProtocol: class {
   /// The testplan associated with the scheme that should be used for testing
   var testplan: String? { get }
 
+  /// Array of strings matching test plan configurations to run
+  var onlyTestConfigurations: String? { get }
+
+  /// Array of strings matching test plan configurations to skip
+  var skipTestConfigurations: String? { get }
+
   /// Run tests using the provided `.xctestrun` file
   var xctestrun: String? { get }
 
@@ -200,6 +206,8 @@ extension ScanfileProtocol {
   var onlyTesting: String? { return nil }
   var skipTesting: String? { return nil }
   var testplan: String? { return nil }
+  var onlyTestConfigurations: String? { return nil }
+  var skipTestConfigurations: String? { return nil }
   var xctestrun: String? { return nil }
   var toolchain: String? { return nil }
   var clean: Bool { return false }
@@ -250,4 +258,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.28]
+// FastlaneRunnerAPIVersion [0.9.29]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.147.0
+// Generated with fastlane 2.148.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.147.0
+// Generated with fastlane 2.148.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -113,6 +113,12 @@ protocol SnapshotfileProtocol: class {
 
   /// The testplan associated with the scheme that should be used for testing
   var testplan: String? { get }
+
+  /// Array of strings matching Test Bundle/Test Suite/Test Cases to run
+  var onlyTesting: String? { get }
+
+  /// Array of strings matching Test Bundle/Test Suite/Test Cases to skip
+  var skipTesting: String? { get }
 }
 
 extension SnapshotfileProtocol {
@@ -154,8 +160,10 @@ extension SnapshotfileProtocol {
   var disableSlideToType: Bool { return false }
   var clonedSourcePackagesPath: String? { return nil }
   var testplan: String? { return nil }
+  var onlyTesting: String? { return nil }
+  var skipTesting: String? { return nil }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.8]
+// FastlaneRunnerAPIVersion [0.9.9]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.147.0':**

* [deliver] add fix for app_version and build_number matching (#16091) via onurpolattimur
* [fastlane] load additional .env files from within CLIToolsDistributor (#16096) via Liam Nichols
* [match] improve match macOS support (#16456) via Davide De Rosa
* [gym] move AppStoreInfo.plist to build output directory if generated … (#16133) via Ashton Williams
* [actions] push_to_git_remote - raise an error if get current branch failed (#16141) via Jierong Li
* [deliver] fix crash when metadata_path is outside of the fastlane path (#16146) via Bruno Virlet
* [Fastlane.swift] add options to beforeAll (#16220) via Niil Öhlin
* [supply] added `in_app_update_priority` option to set the InAppUpdatePriority … (#16452) via jomisj
* [Ruby 2.7] fix deprecated warnings (#16409) via Jakub Kašpar
* [snapshot] fix warning in SnapshotHelper.swift (#16244) via Cédric Luthi
* [sigh][match] add :fail_on_name_taken in sigh, use in match (#16281) via Michal Laskowski
* [snapshot] erase simulator only when erase_simulator is true (#16299) via Theodore Gonzalez
* [spaceship][pilot] expire TestFlight Builds (#16332) via Steven Sherry
* [gym] add info on passing plist into export_options on gym (#16345) via Bahadır Öncel
* [doc][crashlytics] remove duplicated deprecation message (#16363) via JAEHYUN OH
* [scan] add `only_test_configurations` and `skip_test_configurations` options for use with test plans (#16367) via Rob Nadin
* [snapshot] add -only-testing and -skip-testing options from scan (#16312) via Jean Mainguy
* [screengrab] adding locales in all the paths where screenshots could be saved (#16370) via Nicolas Brosy
* [action] upload_symbols_to_crashlytics include Path Suggested by Carthage Instructions (#16401) via Stefan Herold
* [action] dd missing env_names to swiftlint action (#16445) via Tóth Balázs
