### PR TITLE
[snapshot] add disable_xcpretty option from scan

### DIFF
--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -757,5 +757,23 @@ describe Scan do
         end
       end
     end
+
+    context "disable_xcpretty" do
+      it "does not include xcpretty in the pipe command when true", requires_xcode: true do
+        options = { disable_xcpretty: true, project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0" }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = @test_command_generator.generate
+        expect(result.last).to_not(include("| xcpretty "))
+      end
+
+      it "includes xcpretty in the pipe command when false", requires_xcode: true do
+        options = { disable_xcpretty: false, project: "./scan/examples/standard/app.xcodeproj", sdk: "9.0" }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+        result = @test_command_generator.generate
+        expect(result.last).to include("| xcpretty ")
+      end
+    end
   end
 end

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -263,7 +263,12 @@ module Snapshot
                                      is_string: false,
                                      verify_block: proc do |value|
                                        verify_type('skip_testing', [Array, String], value)
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :disable_xcpretty,
+                                     env_name: "SNAPSHOT_DISABLE_XCPRETTY",
+                                     description: "Disable xcpretty formatting of build",
+                                     type: Boolean,
+                                     optional: true)
       ]
     end
   end

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -16,20 +16,25 @@ module Snapshot
         parts += build_settings
         parts += actions
         parts += suffix
-        parts += pipe(language: language, locale: locale, log_path: log_path)
+        parts += pipe(log_path: log_path)
 
         return parts
       end
 
-      def pipe(language: nil, locale: nil, log_path: nil)
+      def pipe(log_path: nil)
         tee_command = ['tee']
         tee_command << '-a' if log_path && File.exist?(log_path)
         tee_command << log_path.shellescape if log_path
 
+        pipe = ["| #{tee_command.join(' ')}"]
+        if Snapshot.config[:disable_xcpretty]
+          return pipe
+        end
+
         xcpretty = "xcpretty #{Snapshot.config[:xcpretty_args]}"
         xcpretty << "--no-color" if Helper.colors_disabled?
 
-        return ["| #{tee_command.join(' ')} | #{xcpretty}"]
+        return pipe << "| #{xcpretty}"
       end
 
       def destination(devices)

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -180,7 +180,8 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee /path/to/logs | xcpretty "
+              "| tee /path/to/logs",
+              "| xcpretty "
             ]
           )
         end
@@ -208,7 +209,8 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee /path/to/logs | xcpretty "
+              "| tee /path/to/logs",
+              "| xcpretty "
             ]
           )
         end
@@ -235,7 +237,8 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee /path/to/logs | xcpretty "
+              "| tee /path/to/logs",
+              "| xcpretty "
             ]
           )
         end
@@ -309,6 +312,22 @@ describe Snapshot do
           expect(command.join('')).not_to(include("-skip-testing:TestBundleC"))
         end
       end
+
+      context "disable_xcpretty" do
+        it "does not include xcpretty in the pipe command when true", requires_xcode: true do
+          configure(options.merge(disable_xcpretty: true))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to_not(include("| xcpretty "))
+        end
+
+        it "includes xcpretty in the pipe command when false", requires_xcode: true do
+          configure(options.merge(disable_xcpretty: false))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to include("| xcpretty ")
+        end
+      end
     end
 
     describe "Valid macOS Configuration" do
@@ -334,7 +353,8 @@ describe Snapshot do
             "FASTLANE_SNAPSHOT=YES",
             :build,
             :test,
-            "| tee /path/to/logs | xcpretty "
+            "| tee /path/to/logs",
+            "| xcpretty "
           ]
         )
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Brings existing option `disable_xcpretty` from scan to snapshot.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Added option `disable_xcpretty` to snapshot and unit tests.
