### PR TITLE
[fastlane] fix overly strong substitution of “action” for plugin/actions with the phrase “action” in it

### DIFF
--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -176,7 +176,7 @@ module Fastlane
         # them as broken actions in the table, regardless of platform specification
         next if platform && action.respond_to?(:is_supported?) && !action.is_supported?(platform.to_sym)
 
-        name = symbol.to_s.gsub('Action', '').fastlane_underscore
+        name = symbol.to_s.delete_suffix('Action').fastlane_underscore
         yield(action, name)
       end
     end

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -176,7 +176,7 @@ module Fastlane
         # them as broken actions in the table, regardless of platform specification
         next if platform && action.respond_to?(:is_supported?) && !action.is_supported?(platform.to_sym)
 
-        name = symbol.to_s.delete_suffix('Action').fastlane_underscore
+        name = symbol.to_s.gsub(/Action$/, '').fastlane_underscore
         yield(action, name)
       end
     end

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -375,7 +375,7 @@ module Fastlane
       references = Fastlane.const_get(module_name).all_classes.collect do |path|
         next unless File.dirname(path).include?("/actions") # we only want to match actions
 
-        File.basename(path).gsub("_action", "").gsub(".rb", "").to_sym # the _action is optional
+        File.basename(path).gsub(".rb", "").delete_suffix("_action").to_sym # the _action is optional
       end
       references.compact!
 

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -375,7 +375,7 @@ module Fastlane
       references = Fastlane.const_get(module_name).all_classes.collect do |path|
         next unless File.dirname(path).include?("/actions") # we only want to match actions
 
-        File.basename(path).gsub(".rb", "").delete_suffix("_action").to_sym # the _action is optional
+        File.basename(path).gsub(".rb", "").gsub(/_action$/, '').to_sym # the _action is optional
       end
       references.compact!
 


### PR DESCRIPTION
### Motivation and Context
An action named `GithubActionAction` would be seen just as `github` when calling `fastlane action` or `fastlane action <action_name>`

### Description
Use `gsub` for replacing `_action` and `Action` at the end of the action/plugin name
