### PR TITLE
[spaceship] Retry request when Developer Portal responds with a 403 status code

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -870,7 +870,7 @@ module Spaceship
         if resp_hash[:status] == 403
           msg = "Access forbidden"
           logger.warn(msg)
-          raise AccessForbiddenError.new, "Access Forbidden"
+          raise AccessForbiddenError.new, msg
         end
 
         return response

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -54,6 +54,7 @@ module Spaceship
     GatewayTimeoutError = Spaceship::GatewayTimeoutError
     InternalServerError = Spaceship::InternalServerError
     BadGatewayError = Spaceship::BadGatewayError
+    AccessForbiddenError = Spaceship::AccessForbiddenError
 
     def self.hostname
       raise "You must implement self.hostname"
@@ -628,7 +629,8 @@ module Spaceship
         Faraday::TimeoutError,
         BadGatewayError,
         AppleTimeoutError,
-        GatewayTimeoutError => ex
+        GatewayTimeoutError,
+        AccessForbiddenError => ex
       tries -= 1
       unless tries.zero?
         msg = "Timeout received: '#{ex.class}', '#{ex.message}'. Retrying after 3 seconds (remaining: #{tries})..."
@@ -863,6 +865,12 @@ module Spaceship
 
         if response.body.to_s.include?("<h3>Bad Gateway</h3>")
           raise BadGatewayError.new, "Apple 502 detected - this might be temporary server error, try again later"
+        end
+
+        if resp_hash[:status] == 403
+          msg = "Access forbidden"
+          logger.warn(msg)
+          raise AccessForbiddenError.new, "Access Forbidden"
         end
 
         return response

--- a/spaceship/lib/spaceship/errors.rb
+++ b/spaceship/lib/spaceship/errors.rb
@@ -76,4 +76,7 @@ module Spaceship
 
   # Raised when 504 is received from App Store Connect
   class GatewayTimeoutError < BasicPreferredInfoError; end
+
+  # Raised when 403 is received from portal request
+  class AccessForbiddenError < BasicPreferredInfoError; end
 end

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -95,7 +95,7 @@ describe Spaceship::Client do
     end
 
     it "raises Spaceship::AccessForbiddenError" do
-      stub_client_request(Spaceship::AccessForbiddenError, 6, 406, "<html>Access Denied - In Read</html>")
+      stub_client_request(Spaceship::AccessForbiddenError, 6, 403, "<html>Access Denied - In Read</html>")
 
       expect do
         subject.req_home

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -93,6 +93,22 @@ describe Spaceship::Client do
         subject.req_home
       end.to raise_error(Spaceship::ProgramLicenseAgreementUpdated)
     end
+
+    it "raises Spaceship::AccessForbiddenError" do
+      stub_client_request(Spaceship::AccessForbiddenError, 6, 406, "<html>Access Denied - In Read</html>")
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::AccessForbiddenError)
+    end
+
+    it "raises Spaceship::ProgramLicenseAgreementUpdated" do
+      stub_client_request(Spaceship::ProgramLicenseAgreementUpdated, 6, 200, "Program License Agreement")
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::ProgramLicenseAgreementUpdated)
+    end
   end
 
   describe 'retry' do
@@ -102,7 +118,79 @@ describe Spaceship::Client do
       Faraday::ParsingError,
       Spaceship::BadGatewayError,
       Spaceship::InternalServerError,
-      Spaceship::GatewayTimeoutError
+      Spaceship::GatewayTimeoutError,
+      Spaceship::AccessForbiddenError
+    ].each do |thrown|
+      it "re-raises when retry limit reached throwing #{thrown}" do
+        stub_client_request(thrown, 6, 200, nil)
+
+        expect do
+          subject.req_home
+        end.to raise_error(thrown)
+      end
+
+      it "retries when #{thrown} error raised" do
+        stub_client_request(thrown, 2, 200, default_body)
+
+        expect(subject.req_home.body).to eq(default_body)
+      end
+    end
+
+    it "raises AppleTimeoutError when response contains '302 Found'" do
+      ClientStubbing.stub_connection_timeout_302
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::Client::AppleTimeoutError)
+    end
+
+    it "raises BadGatewayError when response contains 'Bad Gateway'" do
+      body = <<BODY
+      <!DOCTYPE html>
+<html lang="en">
+<head>
+    <style>
+        body {
+            font-family: "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
+            font-size: 15px;
+            font-weight: 200;
+            line-height: 20px;
+            color: #4c4c4c;
+            text-align: center;
+        }
+
+        .section {
+            margin-top: 50px;
+        }
+    </style>
+</head>
+<body>
+<div class="section">
+    <h1>&#63743;</h1>
+
+    <h3>Bad Gateway</h3>
+    <p>Correlation Key: XXXXXXXXXXXXXXXXXXXX</p>
+</div>
+</body>
+</html>
+BODY
+      stub_client_retry_auth(502, 1, 200, body)
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::Client::BadGatewayError)
+    end
+  end
+
+  describe 'retry' do
+    [
+      Faraday::TimeoutError,
+      Faraday::ConnectionFailed,
+      Faraday::ParsingError,
+      Spaceship::BadGatewayError,
+      Spaceship::InternalServerError,
+      Spaceship::GatewayTimeoutError,
+      Spaceship::AccessForbiddenError
     ].each do |thrown|
       it "re-raises when retry limit reached throwing #{thrown}" do
         stub_client_request(thrown, 6, 200, nil)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
To fix the [Issue 16430](https://github.com/fastlane/fastlane/issues/16430)
We started to see this happen a few weeks ago. Sometimes, requests done to the developer portal fail. If we retry a few times, the error goes away.  When requests fail, the Developer Portal response has a **403** status code  and this body.:
```html
<HEAD>
  <TITLE>Access Denied</TITLE>
</HEAD>
<BODY BGCOLOR="white" FGCOLOR="black">
  <H1>Access Denied</H1>
  <HR>
  <FONT FACE="Helvetica,Arial"><B>
Description: You are not allowed to access the document you requested.
  </B></FONT>
  <HR>
 </BODY>
```
### Description
1. I've added a new Error called `SpaceshipError::AccessForbiddenError` that is raised in the `send_request` method of `Spaceship::Client` when the status code of the response is `403`. 
2. I've modified the `with_retries` method in `Spaceship::Client` to retry when the `AccessForbidden` error is raised.
3. I've used my fork in my project and verified that the error I described wasn't present anymore. Since the error is intermittent, I leaved my project to run every 30 mins for a day. Before my change that test made my project to fail several times per day.
4. I've also added a unit test to verify that the new Error is raised in the presence of a 403 status code and modified the existing unit test to verify that the request is retried if the Error is raised.

### Testing Steps

In my project, the call that failed more often was the one done to the endpoint `https://developer.apple.com/services-account/<account>/account/ios/identifiers/getAppIdDetail.action` triggered by using the method `Spaceship::PortalClient::details_for_app`. Since the request to the endpoint doesn't fail all the times, the only way to reproduce it is to run a script that uses that method during a long period of time.