### PR TITLE
[scan] Fix test result parser issue with disable_xcpretty

### DIFF
--- a/scan/lib/scan/test_result_parser.rb
+++ b/scan/lib/scan/test_result_parser.rb
@@ -3,6 +3,13 @@ require_relative 'module'
 module Scan
   class TestResultParser
     def parse_result(output)
+      unless output
+        return {
+            tests: 0,
+            failures: 0
+        }
+      end
+
       # e.g. ...<testsuites tests='2' failures='1'>...
       matched = output.scan(/<testsuites\b(?=[^<>]*\s+tests='(\d+)')(?=[^<>]*\s+failures='(\d+)')[^<>]+>/)
 
@@ -10,13 +17,13 @@ module Scan
         tests = matched[0][0].to_i
         failures = matched[0][1].to_i
 
-        return {
+        {
           tests: tests,
           failures: failures
         }
       else
         UI.error("Couldn't parse the number of tests from the output")
-        return {
+        {
           tests: 0,
           failures: 0
         }

--- a/scan/spec/test_result_parser_spec.rb
+++ b/scan/spec/test_result_parser_spec.rb
@@ -64,5 +64,15 @@ describe Scan do
         failures: 1
       )
     end
+
+    it "returns early if the xcodebuild output is nil" do
+      output = nil
+
+      result = Scan::TestResultParser.new.parse_result(output)
+      expect(result).to eq(
+        tests: 0,
+        failures: 0
+      )
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes regression issue https://github.com/fastlane/fastlane/issues/16480 introduced by https://github.com/fastlane/fastlane/pull/16375 when using `scan` with both `only_testing` and `disable_xcpretty`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Skip test result parsing if xcodebuild output is nil (due to `disable_xcpretty`).

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Tested `scan` locally using both `only_testing` and `disable_xcpretty`.