### PR TITLE
Added support for Slather's SonarQube option

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Actions
     class SlatherAction < Action
-      # https://github.com/SlatherOrg/slather/blob/v2.4.2/lib/slather/command/coverage_command.rb
+      # https://github.com/SlatherOrg/slather/blob/v2.4.9/lib/slather/command/coverage_command.rb
       ARGS_MAP = {
           travis: '--travis',
           travis_pro: '--travispro',
@@ -14,6 +14,7 @@ module Fastlane
           simple_output: '--simple-output',
           gutter_json: '--gutter-json',
           cobertura_xml: '--cobertura-xml',
+          sonarqube_xml: '--sonarqube-xml',
           llvm_cov: '--llvm-cov',
           html: '--html',
           show: '--show',
@@ -210,6 +211,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :cobertura_xml,
                                        env_name: "FL_SLATHER_COBERTURA_XML_ENABLED",
                                        description: "Tell slather that it should output results as Cobertura XML format",
+                                       is_string: false,
+                                       type: Boolean,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :sonarqube_xml,
+                                       env_name: "FL_SLATHER_SONARQUBE_XML_ENABLED",
+                                       description: "Tell slather that it should output results as SonarQube Generic XML format",
                                        is_string: false,
                                        type: Boolean,
                                        optional: true),

--- a/fastlane/spec/actions_specs/slather_spec.rb
+++ b/fastlane/spec/actions_specs/slather_spec.rb
@@ -22,6 +22,7 @@ describe Fastlane do
             simple_output: true,
             gutter_json: true,
             cobertura_xml: true,
+            sonarqube_xml: true,
             llvm_cov: true,
             html: true,
             show: true,
@@ -50,6 +51,7 @@ describe Fastlane do
                     --simple-output
                     --gutter-json
                     --cobertura-xml
+                    --sonarqube-xml
                     --llvm-cov
                     --html
                     --show
@@ -90,6 +92,7 @@ describe Fastlane do
             simple_output: true,
             gutter_json: true,
             cobertura_xml: true,
+            sonarqube_xml: true,
             llvm_cov: true,
             html: true,
             show: true,
@@ -113,6 +116,7 @@ describe Fastlane do
                     --simple-output
                     --gutter-json
                     --cobertura-xml
+                    --sonarqube-xml
                     --llvm-cov
                     --html
                     --show

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -6707,6 +6707,7 @@ func slackTrainStart(distance: Int = 5,
    - simpleOutput: Tell slather that it should output results to the terminal
    - gutterJson: Tell slather that it should output results as Gutter JSON format
    - coberturaXml: Tell slather that it should output results as Cobertura XML format
+   - sonarQubeXml: Tell slather that it should output results as SonarQube Generic XML format
    - llvmCov: Tell slather that it should output results as llvm-cov show format
    - html: Tell slather that it should output results as static HTML pages
    - show: Tell slather that it should open static html pages automatically
@@ -6740,6 +6741,7 @@ func slather(buildDirectory: String? = nil,
              simpleOutput: Bool? = nil,
              gutterJson: Bool? = nil,
              coberturaXml: Bool? = nil,
+             sonarQubeXml: Bool? = nil,
              llvmCov: Any? = nil,
              html: Bool? = nil,
              show: Bool = false,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
Issue #16498

### Description
I'm adding support to Slather's SonarQube new option SlatherOrg/slather#456.
I tested with unit test and running a lean using a real project.

### Testing Steps
1. Install master/last version of [Slather](https://github.com/SlatherOrg/slather), including SlatherOrg/slather#456
2. Having a project/workspace with Unit Tests, and a lane similar to this, run `fastlane metrics`
```
fastlane_version "2.95.0"
default_platform :ios
platform :ios do

  desc "Sonar Metrics"
  lane :metrics do

    run_tests(
      scheme: "<scheme>",
      configuration: "Debug",
      deployment_target_version: '11',
      app_name: "",
      devices: ["iPhone 11"],
      code_coverage: true,
      fail_build: false,
      output_types: '',
      output_style: 'raw',
      xcargs: '-quiet -resultBundleVersion 3 COMPILER_INDEX_STORE_ENABLE=NO',
      result_bundle: true,
      output_directory: "derivedData"
    )

    slather(
      scheme: "<scheme>",
      sonarqube_xml: true,
      build_directory: "derivedData",
      output_directory: "sonar-reports",
      proj: "<project>.xcodeproj",
      workspace: "<workspace>.xcworkspace"
    )

    # sonar
    
  end
end
```
3. Fastlane's Slather Action will run with this command: `slather coverage --sonarqube-xml --build-directory derivedData --output-directory sonar-reports --scheme <scheme> --workspace ios-<workspace>.xcworkspace <project>.xcodeproj`
4. File `sonar-reports/sonarqube-generic-coverage.xml` will be generated, ready to be sent with `sonar` Action.
