### PR TITLE
Rubocop: Enable linter for FastlaneCore::ConfigItem `is_string` in all files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -294,11 +294,7 @@ CrossPlatform/ForkUsage:
 
 Lint/IsStringUsage:
   Include:
-    - 'cert/**/*'
-    - 'gym/**/*'
-    - 'match/**/*'
-    - 'screengrab/**/*'
-    - 'supply/**/*'
+    - '**/*'
 
 # ( ) for method calls
 Style/MethodCallWithArgsParentheses:


### PR DESCRIPTION
We have a linter that checks for the deprecated `is_string` in options, but it is only enabled for some of our tools and actions.

This PR enables it for all our code.

Starting point is:
> 1151 files inspected, 628 offenses detected

## TODO

- [ ] Adapt changes from https://github.com/fastlane/fastlane/pull/13816
- [ ] Fix all the rest