### PR TITLE
[gym] Fix typo in `installer_cert_name` description

### DIFF
--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -60,7 +60,7 @@ protocol GymfileProtocol: class {
   /// Platform to build when using a Catalyst enabled app. Valid values are: ios, macos
   var catalystPlatform: String? { get }
 
-  /// Full name of 3rd Party Mac Developer Installer or Deveoper ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
+  /// Full name of 3rd Party Mac Developer Installer or Developer ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
   var installerCertName: String? { get }
 
   /// The directory in which the archive should be stored in

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -155,7 +155,7 @@ module Gym
                                      end),
         FastlaneCore::ConfigItem.new(key: :installer_cert_name,
                                      env_name: "GYM_INSTALLER_CERT_NAME",
-                                     description: "Full name of 3rd Party Mac Developer Installer or Deveoper ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`",
+                                     description: "Full name of 3rd Party Mac Developer Installer or Developer ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`",
                                      type: String,
                                      optional: true),
         # Very optional


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There was a typo in the documentation for Gym.

### Description
This fixes the typo.