### PR TITLE
Allow newer rake versions

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -104,7 +104,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used for S3 storage in fastlane match
 
   # Development only
-  spec.add_development_dependency('rake', '< 12')
+  spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec', '~> 3.5.0')
   spec.add_development_dependency('rspec_junit_formatter', '~> 0.2.3')
   spec.add_development_dependency('pry')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

rake was constrained to `< 12` because of an issue with rspec `< 3.5`.
Since rspec is now at 3.5.x, we can allow newer rake versions.

There's also a CVE in rake < 12.3.3.

https://github.com/fastlane/fastlane/pull/7464
https://github.com/ruby/rake/issues/116
https://github.com/ruby/rake/issues/133
https://github.com/rspec/rspec-core/issues/2205
https://github.com/advisories/GHSA-jppv-gw3r-w3q8

### Description

Removed the version constraint and did not put another, just like with the pry dependencies.
Other gems in this monorepo do not have versions constraints on rake either, nor does the plugin template.

### Testing Steps

Tried to run as many rake tasks locally as I could.
