### PR TITLE
ci: Fix Homebrew + Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
+            brew update
             brew untap caskroom/versions || true
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
       - checkout
       - *cache_save_git
       - *cache_restore_bundler
+      - *cache_restore_homebrew
       - *set_ruby
       - run:
           name: debug | ruby version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ jobs:
       - checkout
       - *cache_save_git
       - *cache_restore_bundler
-      - *cache_restore_homebrew
       - *set_ruby
       - run:
           name: debug | ruby version


### PR DESCRIPTION
With this, Homebrew should really use the correct Ruby version.

Fix #16536