### PR TITLE
[match] delete the correct files when working with multiple teams on S3

### DIFF
--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -41,7 +41,8 @@ module Match
         s3_region: params[:s3_region].to_s,
         s3_access_key: params[:s3_access_key].to_s,
         s3_secret_access_key: params[:s3_secret_access_key].to_s,
-        s3_bucket: params[:s3_bucket].to_s
+        s3_bucket: params[:s3_bucket].to_s,
+        team_id: params[:team_id]
       })
       self.storage.download
 
@@ -141,15 +142,15 @@ module Match
       certs = []
       keys = []
       cert_types.each do |ct|
-        certs += Dir[File.join(self.storage.working_directory, "**", ct.to_s, "*.cer")]
-        keys += Dir[File.join(self.storage.working_directory, "**", ct.to_s, "*.p12")]
+        certs += self.storage.list_files(file_name: ct.to_s, file_ext: "cer")
+        keys += self.storage.list_files(file_name: ct.to_s, file_ext: "p12")
       end
 
       # Finds all the iOS and macOS profofiles in the file storage
       profiles = []
       prov_types.each do |prov_type|
-        profiles += Dir[File.join(self.storage.working_directory, "**", prov_type.to_s, "*.mobileprovision")]
-        profiles += Dir[File.join(self.storage.working_directory, "**", prov_type.to_s, "*.provisionprofile")]
+        profiles += self.storage.list_files(file_name: prov_type.to_s, file_ext: "mobileprovision")
+        profiles += self.storage.list_files(file_name: prov_type.to_s, file_ext: "provisionprofile")
       end
 
       self.files = certs + keys + profiles

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -152,6 +152,10 @@ module Match
         return "git_url(\"#{url}\")"
       end
 
+      def list_files(file_name: "", file_ext: "")
+        Dir[File.join(working_directory, "**", file_name, "*.#{file_ext}")]
+      end
+
       private
 
       # Create and checkout an specific branch in the git repo

--- a/match/lib/match/storage/google_cloud_storage.rb
+++ b/match/lib/match/storage/google_cloud_storage.rb
@@ -180,6 +180,10 @@ module Match
         false
       end
 
+      def list_files(file_name: "", file_ext: "")
+        Dir[File.join(working_directory, self.team_id, "**", file_name, "*.#{file_ext}")]
+      end
+
       def generate_matchfile_content
         return "google_cloud_bucket_name(\"#{self.bucket_name}\")"
       end

--- a/match/lib/match/storage/interface.rb
+++ b/match/lib/match/storage/interface.rb
@@ -96,6 +96,10 @@ module Match
         not_implemented(__method__)
       end
 
+      def list_files(file_name: "", file_ext: "")
+        not_implemented(__method__)
+      end
+
       # Implement this for the `fastlane match init` command
       # This method must return the content of the Matchfile
       # that should be generated

--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -139,6 +139,10 @@ module Match
         false
       end
 
+      def list_files(file_name: "", file_ext: "")
+        Dir[File.join(working_directory, self.team_id, "**", file_name, "*.#{file_ext}")]
+      end
+
       # Implement this for the `fastlane match init` command
       # This method must return the content of the Matchfile
       # that should be generated


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
It fixes the bug https://github.com/fastlane/fastlane/issues/16532

### Description
According to documentation S3 and Google Cloud storage saves the files starting with `team_id`. Git storage uses branches to distinguish between teams. The fix was to correct the way each storage list files to delete. I've tested it on S3 and Git using multiple teams and it works.

### Testing Steps
* To test it you need to have an account with multiple teams.
* Then you need to use `match` to generate profiles and certificates. You don't need to create each type, one type is enough to test the fix (for ex. development).
* You need to `match` for Git and S3 (or Google Cloud)
* Then you need to `nuke` it. Previously when you nuke S3 account, it will delete all files no matter what team you give. 
* Expected behaviour is to nuke only files in the team you provided. This pull request fixes it.
