### PR TITLE
[fastlane] update fastlane logo default in actions

### DIFF
--- a/fastlane/lib/assets/s3_html_template.erb
+++ b/fastlane/lib/assets/s3_html_template.erb
@@ -72,7 +72,7 @@
     <p id="footnote">
       This is a beta version and is not meant to share with the public.
     </p>
-    <img src="https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane_medium.png" id="fastlaneLogo" />
+    <img src="https://fastlane.tools/assets/img/fastlane_icon.png" id="fastlaneLogo" />
   </body>
 
   <script type='text/javascript'>

--- a/fastlane/lib/fastlane/actions/hipchat.rb
+++ b/fastlane/lib/fastlane/actions/hipchat.rb
@@ -25,7 +25,7 @@ module Fastlane
 
         message = options[:message]
         if (message_format == "html") && (options[:include_html_header] == true)
-          message = "<table><tr><td><img src='https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png' width='50' height='50'></td><td>#{message[0..9999]}</td></tr></table>"
+          message = "<table><tr><td><img src='https://fastlane.tools/assets/img/fastlane_icon.png' width='50' height='50'></td><td>#{message[0..9999]}</td></tr></table>"
         end
 
         if api_version.to_i == 1

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -105,7 +105,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :icon_url,
                                        env_name: "FL_SLACK_ICON_URL",
                                        description: "Overrides the webhook's image property if use_webhook_configured_username_and_icon is false",
-                                       default_value: "https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png",
+                                       default_value: "https://fastlane.tools/assets/img/fastlane_icon.png",
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :payload,

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -398,7 +398,7 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :slack_icon_url,
                                      env_name: "SCAN_SLACK_ICON_URL",
                                      description: "Overrides the webhook's image property if slack_use_webhook_configured_username_and_icon is false",
-                                     default_value: "https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png",
+                                     default_value: "https://fastlane.tools/assets/img/fastlane_icon.png",
                                      is_string: true,
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :skip_slack,

--- a/scan/spec/slack_poster_spec.rb
+++ b/scan/spec/slack_poster_spec.rb
@@ -87,7 +87,7 @@ describe Scan::SlackPoster do
           channel: nil,
           slack_url: 'https://slack/hook/url',
           username: 'fastlane',
-          icon_url: 'https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png',
+          icon_url: 'https://fastlane.tools/assets/img/fastlane_icon.png',
           attachment_properties: {
             fields: [
               {


### PR DESCRIPTION
### Motivation and Context
Fixes #16552

### Description
Moving default logo from S3 to fastlane website (hosted on GitHub)
