### PR TITLE
Version bump to 2.149.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,119 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
 <img src='https://github.com/AliSoftware.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-</tr>
-<tr>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-</tr>
-<tr>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-</tr>
-<tr>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
 <td id='jimmy-dee'>
 <a href='https://github.com/jdee'>
@@ -160,19 +52,127 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
 </tr>
 <tr>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+</tr>
+<tr>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+</tr>
+<tr>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
 <img src='https://github.com/minuscorp.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+</tr>
+<tr>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Jan Piotrowski",
-                        "Aaron Brager",
-                        "Stefan Natchev",
+  spec.authors       = ["Kohki Miki",
                         "Andrew McBurney",
-                        "Olivier Halligon",
-                        "Danielle Tomlinson",
-                        "Jimmy Dee",
-                        "Joshua Liebowitz",
-                        "Felix Krause",
+                        "Jan Piotrowski",
                         "Iulian Onofrei",
+                        "Luka Mirosevic",
+                        "Jimmy Dee",
+                        "Josh Holtz",
                         "Max Ott",
+                        "Matthew Ellis",
+                        "Felix Krause",
+                        "Olivier Halligon",
+                        "Stefan Natchev",
+                        "Helmut Januschka",
                         "Maksym Grebenets",
                         "Manu Wallner",
-                        "Jorge Revuelta H",
+                        "Aaron Brager",
                         "Fumiya Nakamura",
-                        "Matthew Ellis",
                         "Daniel Jankowski",
-                        "Helmut Januschka",
-                        "Josh Holtz",
-                        "Jérôme Lacoste",
-                        "Luka Mirosevic",
-                        "Kohki Miki"]
+                        "Danielle Tomlinson",
+                        "Jorge Revuelta H",
+                        "Joshua Liebowitz",
+                        "Jérôme Lacoste"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.148.1'.freeze
+  VERSION = '2.149.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.148.1
+// Generated with fastlane 2.149.0

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -894,7 +894,7 @@ func buildAndroidApp(task: String? = nil,
    - skipArchive: After building, don't archive, effectively not including -archivePath param
    - skipCodesigning: Build without codesigning
    - catalystPlatform: Platform to build when using a Catalyst enabled app. Valid values are: ios, macos
-   - installerCertName: Full name of 3rd Party Mac Developer Installer or Deveoper ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
+   - installerCertName: Full name of 3rd Party Mac Developer Installer or Developer ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
    - buildPath: The directory in which the archive should be stored in
    - archivePath: The path to the created archive
    - derivedDataPath: The directory where built products and other derived data will go
@@ -1171,7 +1171,7 @@ func buildIosApp(workspace: String? = nil,
    - skipBuildArchive: Export ipa from previously built xcarchive. Uses archive_path as source
    - skipArchive: After building, don't archive, effectively not including -archivePath param
    - skipCodesigning: Build without codesigning
-   - installerCertName: Full name of 3rd Party Mac Developer Installer or Deveoper ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
+   - installerCertName: Full name of 3rd Party Mac Developer Installer or Developer ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
    - buildPath: The directory in which the archive should be stored in
    - archivePath: The path to the created archive
    - derivedDataPath: The directory where built products and other derived data will go
@@ -1448,6 +1448,7 @@ func captureAndroidScreenshots(androidHome: String? = nil,
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
    - addPhotos: A list of photos that should be added to the simulator before running the application
    - addVideos: A list of videos that should be added to the simulator before running the application
+   - htmlTemplate: A path to screenshots.html template
    - buildlogPath: The directory where to store the build log
    - clean: Should the project be cleaned before building it?
    - testWithoutBuilding: Test without building, requires a derived data path
@@ -1467,6 +1468,7 @@ func captureAndroidScreenshots(androidHome: String? = nil,
    - testplan: The testplan associated with the scheme that should be used for testing
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
+   - disableXcpretty: Disable xcpretty formatting of build
 */
 func captureIosScreenshots(workspace: String? = nil,
                            project: String? = nil,
@@ -1489,6 +1491,7 @@ func captureIosScreenshots(workspace: String? = nil,
                            appIdentifier: String? = nil,
                            addPhotos: [String]? = nil,
                            addVideos: [String]? = nil,
+                           htmlTemplate: String = "/Users/josh/Projects/fastlane/fastlane/snapshot/lib/snapshot/page.html.erb",
                            buildlogPath: String = "~/Library/Logs/snapshot",
                            clean: Bool = false,
                            testWithoutBuilding: Bool? = nil,
@@ -1507,7 +1510,8 @@ func captureIosScreenshots(workspace: String? = nil,
                            clonedSourcePackagesPath: String? = nil,
                            testplan: String? = nil,
                            onlyTesting: Any? = nil,
-                           skipTesting: Any? = nil) {
+                           skipTesting: Any? = nil,
+                           disableXcpretty: Bool? = nil) {
   let command = RubyCommand(commandID: "", methodName: "capture_ios_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                          RubyCommand.Argument(name: "project", value: project),
                                                                                                          RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -1529,6 +1533,7 @@ func captureIosScreenshots(workspace: String? = nil,
                                                                                                          RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                                          RubyCommand.Argument(name: "add_photos", value: addPhotos),
                                                                                                          RubyCommand.Argument(name: "add_videos", value: addVideos),
+                                                                                                         RubyCommand.Argument(name: "html_template", value: htmlTemplate),
                                                                                                          RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
                                                                                                          RubyCommand.Argument(name: "clean", value: clean),
                                                                                                          RubyCommand.Argument(name: "test_without_building", value: testWithoutBuilding),
@@ -1547,7 +1552,8 @@ func captureIosScreenshots(workspace: String? = nil,
                                                                                                          RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
                                                                                                          RubyCommand.Argument(name: "testplan", value: testplan),
                                                                                                          RubyCommand.Argument(name: "only_testing", value: onlyTesting),
-                                                                                                         RubyCommand.Argument(name: "skip_testing", value: skipTesting)])
+                                                                                                         RubyCommand.Argument(name: "skip_testing", value: skipTesting),
+                                                                                                         RubyCommand.Argument(name: "disable_xcpretty", value: disableXcpretty)])
   _ = runner.executeCommand(command)
 }
 
@@ -1576,6 +1582,7 @@ func captureIosScreenshots(workspace: String? = nil,
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
    - addPhotos: A list of photos that should be added to the simulator before running the application
    - addVideos: A list of videos that should be added to the simulator before running the application
+   - htmlTemplate: A path to screenshots.html template
    - buildlogPath: The directory where to store the build log
    - clean: Should the project be cleaned before building it?
    - testWithoutBuilding: Test without building, requires a derived data path
@@ -1595,6 +1602,7 @@ func captureIosScreenshots(workspace: String? = nil,
    - testplan: The testplan associated with the scheme that should be used for testing
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
+   - disableXcpretty: Disable xcpretty formatting of build
 */
 func captureScreenshots(workspace: String? = nil,
                         project: String? = nil,
@@ -1617,6 +1625,7 @@ func captureScreenshots(workspace: String? = nil,
                         appIdentifier: String? = nil,
                         addPhotos: [String]? = nil,
                         addVideos: [String]? = nil,
+                        htmlTemplate: String = "/Users/josh/Projects/fastlane/fastlane/snapshot/lib/snapshot/page.html.erb",
                         buildlogPath: String = "~/Library/Logs/snapshot",
                         clean: Bool = false,
                         testWithoutBuilding: Bool? = nil,
@@ -1635,7 +1644,8 @@ func captureScreenshots(workspace: String? = nil,
                         clonedSourcePackagesPath: String? = nil,
                         testplan: String? = nil,
                         onlyTesting: Any? = nil,
-                        skipTesting: Any? = nil) {
+                        skipTesting: Any? = nil,
+                        disableXcpretty: Bool? = nil) {
   let command = RubyCommand(commandID: "", methodName: "capture_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                      RubyCommand.Argument(name: "project", value: project),
                                                                                                      RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -1657,6 +1667,7 @@ func captureScreenshots(workspace: String? = nil,
                                                                                                      RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                                      RubyCommand.Argument(name: "add_photos", value: addPhotos),
                                                                                                      RubyCommand.Argument(name: "add_videos", value: addVideos),
+                                                                                                     RubyCommand.Argument(name: "html_template", value: htmlTemplate),
                                                                                                      RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
                                                                                                      RubyCommand.Argument(name: "clean", value: clean),
                                                                                                      RubyCommand.Argument(name: "test_without_building", value: testWithoutBuilding),
@@ -1675,7 +1686,8 @@ func captureScreenshots(workspace: String? = nil,
                                                                                                      RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
                                                                                                      RubyCommand.Argument(name: "testplan", value: testplan),
                                                                                                      RubyCommand.Argument(name: "only_testing", value: onlyTesting),
-                                                                                                     RubyCommand.Argument(name: "skip_testing", value: skipTesting)])
+                                                                                                     RubyCommand.Argument(name: "skip_testing", value: skipTesting),
+                                                                                                     RubyCommand.Argument(name: "disable_xcpretty", value: disableXcpretty)])
   _ = runner.executeCommand(command)
 }
 
@@ -3735,7 +3747,7 @@ func gradle(task: String? = nil,
    - skipArchive: After building, don't archive, effectively not including -archivePath param
    - skipCodesigning: Build without codesigning
    - catalystPlatform: Platform to build when using a Catalyst enabled app. Valid values are: ios, macos
-   - installerCertName: Full name of 3rd Party Mac Developer Installer or Deveoper ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
+   - installerCertName: Full name of 3rd Party Mac Developer Installer or Developer ID Installer certificate. Example: `3rd Party Mac Developer Installer: Your Company (ABC1234XWYZ)`
    - buildPath: The directory in which the archive should be stored in
    - archivePath: The path to the created archive
    - derivedDataPath: The directory where built products and other derived data will go
@@ -5801,7 +5813,7 @@ func runTests(workspace: String? = nil,
               slackMessage: String? = nil,
               slackUseWebhookConfiguredUsernameAndIcon: Bool = false,
               slackUsername: String = "fastlane",
-              slackIconUrl: String = "https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png",
+              slackIconUrl: String = "https://fastlane.tools/assets/img/fastlane_icon.png",
               skipSlack: Bool = false,
               slackOnlyOnFailure: Bool = false,
               destination: Any? = nil,
@@ -6626,7 +6638,7 @@ func slack(message: String? = nil,
            useWebhookConfiguredUsernameAndIcon: Bool = false,
            slackUrl: String,
            username: String = "fastlane",
-           iconUrl: String = "https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png",
+           iconUrl: String = "https://fastlane.tools/assets/img/fastlane_icon.png",
            payload: [String : Any] = [:],
            defaultPayloads: [String]? = nil,
            attachmentProperties: [String : Any] = [:],
@@ -6707,7 +6719,7 @@ func slackTrainStart(distance: Int = 5,
    - simpleOutput: Tell slather that it should output results to the terminal
    - gutterJson: Tell slather that it should output results as Gutter JSON format
    - coberturaXml: Tell slather that it should output results as Cobertura XML format
-   - sonarQubeXml: Tell slather that it should output results as SonarQube Generic XML format
+   - sonarqubeXml: Tell slather that it should output results as SonarQube Generic XML format
    - llvmCov: Tell slather that it should output results as llvm-cov show format
    - html: Tell slather that it should output results as static HTML pages
    - show: Tell slather that it should open static html pages automatically
@@ -6741,7 +6753,7 @@ func slather(buildDirectory: String? = nil,
              simpleOutput: Bool? = nil,
              gutterJson: Bool? = nil,
              coberturaXml: Bool? = nil,
-             sonarQubeXml: Bool? = nil,
+             sonarqubeXml: Bool? = nil,
              llvmCov: Any? = nil,
              html: Bool? = nil,
              show: Bool = false,
@@ -6771,6 +6783,7 @@ func slather(buildDirectory: String? = nil,
                                                                                          RubyCommand.Argument(name: "simple_output", value: simpleOutput),
                                                                                          RubyCommand.Argument(name: "gutter_json", value: gutterJson),
                                                                                          RubyCommand.Argument(name: "cobertura_xml", value: coberturaXml),
+                                                                                         RubyCommand.Argument(name: "sonarqube_xml", value: sonarqubeXml),
                                                                                          RubyCommand.Argument(name: "llvm_cov", value: llvmCov),
                                                                                          RubyCommand.Argument(name: "html", value: html),
                                                                                          RubyCommand.Argument(name: "show", value: show),
@@ -6812,6 +6825,7 @@ func slather(buildDirectory: String? = nil,
    - appIdentifier: The bundle identifier of the app to uninstall (only needed when enabling reinstall_app)
    - addPhotos: A list of photos that should be added to the simulator before running the application
    - addVideos: A list of videos that should be added to the simulator before running the application
+   - htmlTemplate: A path to screenshots.html template
    - buildlogPath: The directory where to store the build log
    - clean: Should the project be cleaned before building it?
    - testWithoutBuilding: Test without building, requires a derived data path
@@ -6831,6 +6845,7 @@ func slather(buildDirectory: String? = nil,
    - testplan: The testplan associated with the scheme that should be used for testing
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
+   - disableXcpretty: Disable xcpretty formatting of build
 */
 func snapshot(workspace: Any? = snapshotfile.workspace,
               project: Any? = snapshotfile.project,
@@ -6853,6 +6868,7 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
               appIdentifier: Any? = snapshotfile.appIdentifier,
               addPhotos: [String]? = snapshotfile.addPhotos,
               addVideos: [String]? = snapshotfile.addVideos,
+              htmlTemplate: Any = snapshotfile.htmlTemplate,
               buildlogPath: Any = snapshotfile.buildlogPath,
               clean: Bool = snapshotfile.clean,
               testWithoutBuilding: Bool? = snapshotfile.testWithoutBuilding,
@@ -6871,7 +6887,8 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
               clonedSourcePackagesPath: Any? = snapshotfile.clonedSourcePackagesPath,
               testplan: Any? = snapshotfile.testplan,
               onlyTesting: Any? = snapshotfile.onlyTesting,
-              skipTesting: Any? = snapshotfile.skipTesting) {
+              skipTesting: Any? = snapshotfile.skipTesting,
+              disableXcpretty: Bool? = snapshotfile.disableXcpretty) {
   let command = RubyCommand(commandID: "", methodName: "snapshot", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                           RubyCommand.Argument(name: "project", value: project),
                                                                                           RubyCommand.Argument(name: "xcargs", value: xcargs),
@@ -6893,6 +6910,7 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
                                                                                           RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                           RubyCommand.Argument(name: "add_photos", value: addPhotos),
                                                                                           RubyCommand.Argument(name: "add_videos", value: addVideos),
+                                                                                          RubyCommand.Argument(name: "html_template", value: htmlTemplate),
                                                                                           RubyCommand.Argument(name: "buildlog_path", value: buildlogPath),
                                                                                           RubyCommand.Argument(name: "clean", value: clean),
                                                                                           RubyCommand.Argument(name: "test_without_building", value: testWithoutBuilding),
@@ -6911,7 +6929,8 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
                                                                                           RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
                                                                                           RubyCommand.Argument(name: "testplan", value: testplan),
                                                                                           RubyCommand.Argument(name: "only_testing", value: onlyTesting),
-                                                                                          RubyCommand.Argument(name: "skip_testing", value: skipTesting)])
+                                                                                          RubyCommand.Argument(name: "skip_testing", value: skipTesting),
+                                                                                          RubyCommand.Argument(name: "disable_xcpretty", value: disableXcpretty)])
   _ = runner.executeCommand(command)
 }
 
@@ -8744,7 +8763,7 @@ func xcov(workspace: String? = nil,
           htmlReport: Bool = true,
           markdownReport: Bool = false,
           jsonReport: Bool = false,
-          minimumCoveragePercentage: Int = 0,
+          minimumCoveragePercentage: Float = 0,
           slackUrl: String? = nil,
           slackChannel: String? = nil,
           skipSlack: Bool = false,
@@ -8760,7 +8779,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode-11.4.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode-11.5.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -8905,4 +8924,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.76]
+// FastlaneRunnerAPIVersion [0.9.77]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.148.1
+// Generated with fastlane 2.149.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.148.1
+// Generated with fastlane 2.149.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.148.1
+// Generated with fastlane 2.149.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.148.1
+// Generated with fastlane 2.149.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -246,7 +246,7 @@ extension ScanfileProtocol {
   var slackMessage: String? { return nil }
   var slackUseWebhookConfiguredUsernameAndIcon: Bool { return false }
   var slackUsername: String { return "fastlane" }
-  var slackIconUrl: String { return "https://s3-eu-west-1.amazonaws.com/fastlane.tools/fastlane.png" }
+  var slackIconUrl: String { return "https://fastlane.tools/assets/img/fastlane_icon.png" }
   var skipSlack: Bool { return false }
   var slackOnlyOnFailure: Bool { return false }
   var destination: String? { return nil }
@@ -258,4 +258,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.29]
+// FastlaneRunnerAPIVersion [0.9.30]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.148.1
+// Generated with fastlane 2.149.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.148.1
+// Generated with fastlane 2.149.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -63,6 +63,9 @@ protocol SnapshotfileProtocol: class {
   /// A list of videos that should be added to the simulator before running the application
   var addVideos: [String]? { get }
 
+  /// A path to screenshots.html template
+  var htmlTemplate: String { get }
+
   /// The directory where to store the build log
   var buildlogPath: String { get }
 
@@ -119,6 +122,9 @@ protocol SnapshotfileProtocol: class {
 
   /// Array of strings matching Test Bundle/Test Suite/Test Cases to skip
   var skipTesting: String? { get }
+
+  /// Disable xcpretty formatting of build
+  var disableXcpretty: Bool? { get }
 }
 
 extension SnapshotfileProtocol {
@@ -143,6 +149,7 @@ extension SnapshotfileProtocol {
   var appIdentifier: String? { return nil }
   var addPhotos: [String]? { return nil }
   var addVideos: [String]? { return nil }
+  var htmlTemplate: String { return "/Users/josh/Projects/fastlane/fastlane/snapshot/lib/snapshot/page.html.erb" }
   var buildlogPath: String { return "~/Library/Logs/snapshot" }
   var clean: Bool { return false }
   var testWithoutBuilding: Bool? { return nil }
@@ -162,8 +169,9 @@ extension SnapshotfileProtocol {
   var testplan: String? { return nil }
   var onlyTesting: String? { return nil }
   var skipTesting: String? { return nil }
+  var disableXcpretty: Bool? { return nil }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.9]
+// FastlaneRunnerAPIVersion [0.9.10]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.148.1':**

* [fastlane] update fastlane logo default in actions (#16556) via Josh Holtz
* [match] delete the correct files when working with multiple teams on S3 (#16542) via Krzysztof Romanowski
* [Fastlane.swift] add support for Float and Double variables that can be 0 initialized. (#16512) via Jorge
* [upload_symbols_to_crashlytics] fix `gsp_path` parameter will not expand when use with `api_token` parameter. (#16477) via r-plus
* [fastlane] allow newer rake versions (#16522) via Anton Rieder
* [fastlane_core] add -derivedDataPath when SwiftPM dependencies resolving (#16534) via sudachi808
* [screengrab] Improved screengrab documentation for use with kotlin (#16476) via Thorsten Knöller
* [spaceship] retry request when Developer Portal responds with a 403 status code (#16478) via Erick Camacho
* [ci] output ruby version directly after setting via Jan Piotrowski
* [gym] fix typo in `installer_cert_name` description (#16517) via Morten Bjerg Gregersen
* [deliver] fix app_screenshot comments (#16503) via Jan Piotrowski
* [snapshot] add disable_xcpretty option from scan (#16466) via Jean Mainguy
* [GH Actions] enable lock action (#16446) via Daniel Jankowski
* [snapshot] specify custom path for erb (#15349) via Nikolay Derkach
* [pilot] changelog bytesize truncate tests (#14485) via Albert
* [ci] fix ruby selection (#16507) via Jan Piotrowski
* [action] added support for Slather's SonarQube option (#16500) via Alberto Salas
* [scan] fix test result parser issue with disable_xcpretty (#16481) via Jean Mainguy
