### PR TITLE
[Fastlane.swift] [snapshot] Fix html_template default value

### DIFF
--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -156,7 +156,6 @@ module Snapshot
                                      env_name: 'SNAPSHOT_HTML_TEMPLATE',
                                      short_option: "-e",
                                      description: "A path to screenshots.html template",
-                                     default_value: File.join(Snapshot::ROOT, "lib", "snapshot/page.html.erb"),
                                      optional: true),
 
         # Everything around building

--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -5,6 +5,14 @@ module Snapshot
     require 'erb'
     require 'fastimage'
 
+    def html_path
+      if Snapshot.config[:html_template]
+        Snapshot.config[:html_template]
+      else
+        File.join(Snapshot::ROOT, "lib", "snapshot/page.html.erb")
+      end
+    end
+
     def generate
       UI.message("Generating HTML Report")
 
@@ -36,7 +44,6 @@ module Snapshot
         end
       end
 
-      html_path = Snapshot.config[:html_template]
       html = ERB.new(File.read(html_path)).result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
 
       export_path = "#{screens_path}/screenshots.html"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix for issue https://github.com/fastlane/fastlane/issues/16563.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Removes the `html_template` option default value and return it at runtime instead.