### PR TITLE
[gemspec] Remove public_suffix version constraint

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -67,8 +67,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('multipart-post', '~> 2.0.0') # Needed for uploading builds to appetize
   spec.add_dependency('word_wrap', '~> 1.0.0') # to add line breaks for tables with long strings
 
-  spec.add_dependency('public_suffix', '~> 2.0.0') # https://github.com/fastlane/fastlane/issues/10162
-
   # TTY dependencies
   spec.add_dependency('tty-screen', '>= 0.6.3', '< 1.0.0') # detect the terminal width
   spec.add_dependency('tty-spinner', '>= 0.8.0', '< 1.0.0') # loading indicators


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Description

Was added in https://github.com/fastlane/fastlane/pull/10168 because
newer versions of public_suffix didn't support all Ruby versions that
fastlane did. However fastlane now requires Ruby 2.4 or above while
public_suffix supports 2.3 and higher.

https://github.com/fastlane/fastlane/pull/16408
https://github.com/weppos/publicsuffix-ruby/blob/v4.0.5/CHANGELOG.md#400