### PR TITLE
[spm] Adds disable_sandbox parameter

### DIFF
--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -8,6 +8,7 @@ module Fastlane
         cmd << "--build-path #{params[:build_path]}" if params[:build_path]
         cmd << "--package-path #{params[:package_path]}" if params[:package_path]
         cmd << "--configuration #{params[:configuration]}" if params[:configuration]
+        cmd << "--disable-sandbox" if params[:disable_sandbox]
         cmd << "--verbose" if params[:verbose]
         cmd << params[:command] if package_commands.include?(params[:command])
         if params[:xcconfig]
@@ -63,6 +64,12 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Please pass a valid configuration: (debug|release)") unless valid_configurations.include?(value)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :disable_sandbox,
+                                       env_name: "FL_SPM_DISABLE_SANDBOX",
+                                       description: "Disable using the sandbox when executing subprocesses",
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :xcpretty_output,
                                        env_name: "FL_SPM_XCPRETTY_OUTPUT",
                                        description: "Specifies the output type for xcpretty. eg. 'test', or 'simple'",

--- a/fastlane/spec/actions_specs/spm_spec.rb
+++ b/fastlane/spec/actions_specs/spm_spec.rb
@@ -133,6 +133,22 @@ describe Fastlane do
           end.to raise_error("Please pass a valid configuration: (debug|release)")
         end
 
+        it "adds disable-sandbox flag to command if disable_sandbox is set to true" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(disable_sandbox: true)
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift build --disable-sandbox")
+        end
+
+        it "doesn't add a disable-sandbox flag to command if disable_sandbox is set to false" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+              spm(disable_sandbox: false)
+            end").runner.execute(:test)
+
+          expect(result).to eq("swift build")
+        end
+
         it "works with no parameters" do
           expect do
             Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adds `disable_sandbox` as an optional parameter to the `spm` action.
It also closes #16601.

### Description
I added the `disable_sandbox` as an optional parameter to the `SpmAction`.

Also, I added a unit test in `spm_spec` to ensure that `--disable-sandbox` flag is added to `spm` command. Another unit test checks if `disable_sandbox` is set to false by default.

### Testing Steps
I tested it locally with a Swift package by running a lane which uses `spm` action with new option:
```
spm(command: "build", disable_sandbox: true)
``` 
The lane was executed with no failures and it called `swift build --disable-sandbox` command.
