### PR TITLE
[spaceship] Support get uninstalls and opt-in rates of app analytics

### DIFF
--- a/spaceship/docs/AppStoreConnect.md
+++ b/spaceship/docs/AppStoreConnect.md
@@ -358,7 +358,7 @@ impressions = analytics.app_impressions  # => Array of dates representing raw da
 sales = analytics.app_sales              # => Array of dates representing raw data for each day
 
 # Get paying users
-users = analytics.paying_users           # => Array of dates representing raw data for each day
+users = analytics.app_paying_users       # => Array of dates representing raw data for each day
 
 # Get in app purchases
 iap = analytics.app_in_app_purchases     # => Array of dates representing raw data for each day
@@ -374,6 +374,12 @@ devices = analytics.app_active_devices   # => Array of dates representing raw da
 
 # Get crashes
 crashes = analytics.app_crashes          # => Array of dates representing raw data for each day
+
+# Get app uninstalls
+crashes = analytics.app_uninstalls       # => Array of dates representing raw data for each day
+
+# Get Rolling 30 day opt-in rate history for app
+crashes = analytics.app_optin_rates      # => Array of dates representing raw data for each day
 ```
 
 ## License

--- a/spaceship/lib/spaceship/tunes/app_analytics.rb
+++ b/spaceship/lib/spaceship/tunes/app_analytics.rb
@@ -89,6 +89,20 @@ module Spaceship
         app_crashes_interval(start_t, end_t)
       end
 
+      # Usage / Uninstalls
+      def app_uninstalls
+        start_t, end_t = time_last_7_days
+
+        app_uninstalls_interval(start_t, end_t)
+      end
+
+      # About App Analytics Data / Opt-in Rate
+      def app_optin_rates
+        start_t, end_t = time_last_7_days
+
+        app_optin_rates_interval(start_t, end_t)
+      end
+
       def app_measure_interval(start_t, end_t, measure, view_by = nil)
         client.time_series_analytics([apple_id], [measure], start_t, end_t, "DAY", view_by)
       end
@@ -135,6 +149,14 @@ module Spaceship
 
       def app_crashes_interval(start_t, end_t, view_by = nil)
         client.time_series_analytics([apple_id], ['crashes'], start_t, end_t, "DAY", view_by)
+      end
+
+      def app_uninstalls_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['uninstalls'], start_t, end_t, "DAY", view_by)
+      end
+
+      def app_optin_rates_interval(start_t, end_t, view_by = nil)
+        client.time_series_analytics([apple_id], ['optin'], start_t, end_t, "DAY", view_by)
       end
 
       def time_last_7_days


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Getting app uninstalls from App Analytics is missing on Spaceship.

### Description
Added `app_uninstalls` and `app_optin_rates` on analytics.

### Testing Steps
Personally added below code to `Rakefile` to test

```rb
task(:debug) do
  require 'spaceship'

  Spaceship::Tunes.login("test@example.com", "password") # use your own test account
  app = Spaceship::Tunes::Application.find("com.test.app")

  analytics = app.analytics
  print("Uninstalls:\n")
  print(analytics.app_uninstalls)
  print("\n\nOpt-in Rates:\n")
  print(analytics.app_optin_rates)
end
```
```
Uninstalls:
{"size"=>1, "results"=>[{"adamId"=>"123456", "meetsThreshold"=>true, "group"=>nil, "data"=>[{"date"=>"2020-06-08T00:00:00Z", "uninstalls"=>1.0}, {"date"=>"2020-06-09T00:00:00Z", "uninstalls"=>2.0}, {"date"=>"2020-06-10T00:00:00Z", "uninstalls"=>3.0}, {"date"=>"2020-06-11T00:00:00Z", "uninstalls"=>4.0}, {"date"=>"2020-06-12T00:00:00Z", "uninstalls"=>5.0}, {"date"=>"2020-06-13T00:00:00Z", "uninstalls"=>6.0}, {"date"=>"2020-06-14T00:00:00Z", "uninstalls"=>7.0}, {"date"=>"2020-06-15T00:00:00Z", "uninstalls"=>8.0}], "totals"=>{"value"=>45.0, "type"=>"COUNT", "key"=>"uninstalls"}}]}

Opt-in Rates:
{"size"=>1, "results"=>[{"adamId"=>"123456", "meetsThreshold"=>true, "group"=>nil, "data"=>[{"date"=>"2020-06-08T00:00:00Z", "optin"=>0.1}, {"date"=>"2020-06-09T00:00:00Z", "optin"=>0.2}, {"date"=>"2020-06-10T00:00:00Z", "optin"=>0.3}, {"date"=>"2020-06-11T00:00:00Z", "optin"=>0.4}, {"date"=>"2020-06-12T00:00:00Z", "optin"=>0.5}, {"date"=>"2020-06-13T00:00:00Z", "optin"=>0.6}, {"date"=>"2020-06-14T00:00:00Z", "optin"=>0.7}, {"date"=>"2020-06-15T00:00:00Z", "optin"=>0.8}], "totals"=>{"value"=>4.5, "type"=>"COUNT", "key"=>"optin"}}]}
```