### PR TITLE
[match] Always checkout the specified branch as master may not be the default branch

### DIFF
--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -113,7 +113,7 @@ module Match
           UI.user_error!("Error cloning repo, make sure you have access to it '#{self.git_url}'")
         end
 
-        checkout_branch unless self.branch == "master"
+        checkout_branch
       end
 
       def human_readable_description

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -16,18 +16,22 @@ describe Match do
         path = Dir.mktmpdir # to have access to the actual path
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+        git_branch = "master"
         shallow_clone = true
-        command = "git clone #{git_url.shellescape} #{path.shellescape} --depth 1 --no-single-branch"
-        to_params = {
-          command: command,
-          print_all: nil,
-          print_command: nil
-        }
 
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(to_params).
-          and_return(nil)
+        expected_commands = [
+          "git clone #{git_url.shellescape} #{path.shellescape} --depth 1 --no-single-branch",
+          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
+          "git checkout --orphan #{git_branch}",
+          "git reset --hard"
+        ]
+        expected_commands.each do |command|
+          expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
+            command: command,
+            print_all: nil,
+            print_command: nil
+          }).and_return("")
+        end
 
         storage = Match::Storage::GitStorage.new(
           git_url: git_url,
@@ -43,18 +47,22 @@ describe Match do
         path = Dir.mktmpdir # to have access to the actual path
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+        git_branch = "master"
         shallow_clone = false
-        command = "git clone #{git_url.shellescape} #{path.shellescape}"
-        to_params = {
-          command: command,
-          print_all: nil,
-          print_command: nil
-        }
-
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(to_params).
-          and_return(nil)
+        
+        expected_commands = [
+          "git clone #{git_url.shellescape} #{path.shellescape}",
+          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
+          "git checkout --orphan #{git_branch}",
+          "git reset --hard"
+        ]
+        expected_commands.each do |command|
+          expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
+            command: command,
+            print_all: nil,
+            print_command: nil
+          }).and_return("")
+        end
 
         storage = Match::Storage::GitStorage.new(
           git_url: git_url,
@@ -104,6 +112,7 @@ describe Match do
         path = Dir.mktmpdir # to have access to the actual path
         expect(Dir).to receive(:mktmpdir).and_return(path)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+        git_branch = "master"
         random_file = "random_file"
 
         storage = Match::Storage::GitStorage.new(
@@ -115,11 +124,14 @@ describe Match do
         )
 
         expected_commands = [
+          "git clone #{git_url.shellescape} #{path.shellescape}",
+          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
+          "git checkout --orphan #{git_branch}",
+          "git reset --hard",
           "git add #{random_file}",
           "git add match_version.txt",
           "git commit -m " + '[fastlane] Updated appstore and platform ios'.shellescape,
-          "git push origin master",
-          "git clone #{git_url.shellescape} #{path.shellescape}"
+          "git push origin #{git_branch}"
         ]
 
         expected_commands.each do |command|

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -49,7 +49,7 @@ describe Match do
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         git_branch = "master"
         shallow_clone = false
-        
+
         expected_commands = [
           "git clone #{git_url.shellescape} #{path.shellescape}",
           "git --no-pager branch --list origin/#{git_branch} --no-color -r",


### PR DESCRIPTION
… branch.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As described in #16475 `master` is not guaranteed to be the default branch and then `match` fails to work.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I have changed the `git_storage.rb` such that the branch specified is always checked out.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
