### PR TITLE
[fastlane_core] fix: paths with spaces fail

### DIFF
--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -113,7 +113,7 @@ module FastlaneCore
           else
             # `security` only works on Mac, fallback to `openssl`
             # via https://stackoverflow.com/a/14379814/252627
-            decoded = `openssl smime -inform der -verify -noverify -in "#{path}" 2> #{err}`
+            decoded = `openssl smime -inform der -verify -noverify -in #{path.shellescape} 2> #{err}`
           end
           UI.error("Failure to decode #{path}. Exit: #{$?.exitstatus}: #{File.read(err)}") if $?.exitstatus != 0
           decoded

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -113,7 +113,7 @@ module FastlaneCore
           else
             # `security` only works on Mac, fallback to `openssl`
             # via https://stackoverflow.com/a/14379814/252627
-            decoded = `openssl smime -inform der -verify -noverify -in #{path} 2> #{err}`
+            decoded = `openssl smime -inform der -verify -noverify -in "#{path}" 2> #{err}`
           end
           UI.error("Failure to decode #{path}. Exit: #{$?.exitstatus}: #{File.read(err)}") if $?.exitstatus != 0
           decoded


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If the path has a space in it (for example `C:/Users/User Name/AppData/Local/Temp/....`), the command would ignore anything after the space, thus exiting with
```Can't open C:/Users/User for reading, No such file or directory```

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
The only change is wrapping the path in quotes.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I personally didn't test - because it requires creating a new user on Windows that has a home directory with a space in it, however this came up on the NativeScript discord by someone having trouble with it (screenshot submitted by a community member)

![image](https://user-images.githubusercontent.com/879060/85208833-b0d9f700-b333-11ea-9c49-0f3478541a66.png)
