### PR TITLE
[2.150.0][deliver] fix category deleting when not specified

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -201,41 +201,70 @@ module Deliver
         secondary_first_sub_category = options[:secondary_first_sub_category].to_s.strip
         secondary_second_sub_category = options[:secondary_second_sub_category].to_s.strip
 
+        mapped_values = {}
+
         # Only update primary and secondar category if explicitly set
         unless primary_category.empty?
-          category_id_map[:primary_category_id] = Spaceship::ConnectAPI::AppCategory.map_category_from_itc(
+          mapped = Spaceship::ConnectAPI::AppCategory.map_category_from_itc(
             primary_category
           )
+
+          mapped_values[primary_category] = mapped
+          category_id_map[:primary_category_id] = mapped
         end
         unless secondary_category.empty?
-          category_id_map[:secondary_category_id] = Spaceship::ConnectAPI::AppCategory.map_category_from_itc(
+          mapped = Spaceship::ConnectAPI::AppCategory.map_category_from_itc(
             secondary_category
           )
+
+          mapped_values[secondary_category] = mapped
+          category_id_map[:secondary_category_id] = mapped
         end
 
         # Only set if primary category is going to be set
         unless primary_category.empty?
-          category_id_map[:primary_subcategory_one_id] = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
+          mapped = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
             primary_first_sub_category
           )
+
+          mapped_values[primary_first_sub_category] = mapped
+          category_id_map[:primary_subcategory_one_id] = mapped
         end
         unless primary_category.empty?
-          category_id_map[:primary_subcategory_two_id] = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
+          mapped = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
             primary_second_sub_category
           )
+
+          mapped_values[primary_second_sub_category] = mapped
+          category_id_map[:primary_subcategory_two_id] = mapped
         end
 
         # Only set if secondary category is going to be set
         unless secondary_category.empty?
-          category_id_map[:secondary_subcategory_one_id] = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
+          mapped = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
             secondary_first_sub_category
           )
+
+          mapped_values[secondary_first_sub_category] = mapped
+          category_id_map[:secondary_subcategory_one_id] = mapped
         end
         unless secondary_category.empty?
-          category_id_map[:secondary_subcategory_two_id] = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
+          mapped = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
             secondary_second_sub_category
           )
+
+          mapped_values[secondary_second_sub_category] = mapped
+          category_id_map[:secondary_subcategory_two_id] = mapped
         end
+
+        # Print deprecation warnings if category was mapped
+        has_mapped_values = false
+        mapped_values.each do |k, v|
+          next if k.nil? || v.nil?
+          has_mapped_values = true
+          UI.deprecated("'#{k}' from iTunesConnect as been deprecated. Please replace with '#{v}'")
+        end
+        UI.deprecated("You can find more info at http://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values
 
         app_info.update_categories(category_id_map: category_id_map)
       end

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -192,26 +192,52 @@ module Deliver
       # Update categories
       app_info = app.fetch_edit_app_info
       if app_info
-        app_info.update_categories(
-          primary_category_id: Spaceship::ConnectAPI::AppCategory.map_category_from_itc(
-            options[:primary_category].to_s.strip
-          ),
-          secondary_category_id: Spaceship::ConnectAPI::AppCategory.map_category_from_itc(
-            options[:secondary_category].to_s.strip
-          ),
-          primary_subcategory_one_id: Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
-            options[:primary_first_sub_category].to_s.strip
-          ),
-          primary_subcategory_two_id: Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
-            options[:primary_second_sub_category].to_s.strip
-          ),
-          secondary_subcategory_one_id: Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
-            options[:secondary_first_sub_category].to_s.strip
-          ),
-          secondary_subcategory_two_id: Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
-            options[:secondary_second_sub_category].to_s.strip
+        category_id_map = {}
+
+        primary_category = options[:primary_category].to_s.strip
+        secondary_category = options[:secondary_category].to_s.strip
+        primary_first_sub_category = options[:primary_first_sub_category].to_s.strip
+        primary_second_sub_category = options[:primary_second_sub_category].to_s.strip
+        secondary_first_sub_category = options[:secondary_first_sub_category].to_s.strip
+        secondary_second_sub_category = options[:secondary_second_sub_category].to_s.strip
+
+        # Only update primary and secondar category if explicitly set
+        unless primary_category.empty?
+          category_id_map[:primary_category_id] = Spaceship::ConnectAPI::AppCategory.map_category_from_itc(
+            primary_category
           )
-        )
+        end
+        unless secondary_category.empty?
+          category_id_map[:secondary_category_id] = Spaceship::ConnectAPI::AppCategory.map_category_from_itc(
+            secondary_category
+          )
+        end
+
+        # Only set if primary category is going to be set
+        unless primary_category.empty?
+          category_id_map[:primary_subcategory_one_id] = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
+            primary_first_sub_category
+          )
+        end
+        unless primary_category.empty?
+          category_id_map[:primary_subcategory_two_id] = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
+            primary_second_sub_category
+          )
+        end
+
+        # Only set if secondary category is going to be set
+        unless secondary_category.empty?
+          category_id_map[:secondary_subcategory_one_id] = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
+            secondary_first_sub_category
+          )
+        end
+        unless secondary_category.empty?
+          category_id_map[:secondary_subcategory_two_id] = Spaceship::ConnectAPI::AppCategory.map_subcategory_from_itc(
+            secondary_second_sub_category
+          )
+        end
+
+        app_info.update_categories(category_id_map: category_id_map)
       end
 
       # Update phased release

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -494,33 +494,32 @@ Key | Editable While Live | Directory | Filename
 
 ### Available Categories
 
-You can always prefix the category using `MZGenre.` (e.g. `MZGenre.Book`). _deliver_ supports both notations.
-
-- `Book`
-- `Business`
-- `Apps.Catalogs`
-- `Education`
-- `Entertainment`
-- `Finance`
-- `Apps.Food_Drink`
-- `Games`
-- `Healthcare_Fitness`
-- `Lifestyle`
-- `Medical`
-- `Music`
-- `Navigation`
-- `News`
-- `Apps.Newsstand`
-- `Photography`
-- `Productivity`
-- `Reference`
-- `Apps.Shopping`
-- `SocialNetworking`
-- `Sports`
-- `Stickers`
-- `Travel`
-- `Utilities`
-- `Weather`
+- `FOOD_AND_DRINK`
+- `BUSINESS`
+- `EDUCATION`
+- `SOCIAL_NETWORKING`
+- `BOOKS`
+- `SPORTS`
+- `FINANCE`
+- `REFERENCE`
+- `GRAPHICS_AND_DESIGN`
+- `DEVELOPER_TOOLS`
+- `HEALTH_AND_FITNESS`
+- `MUSIC`
+- `WEATHER`
+- `TRAVEL`
+- `ENTERTAINMENT`
+- `STICKERS`
+- `GAMES`
+- `LIFESTYLE`
+- `MEDICAL`
+- `MAGAZINES_AND_NEWSPAPERS`
+- `UTILITIES`
+- `SHOPPING`
+- `PRODUCTIVITY`
+- `NEWS`
+- `PHOTO_AND_VIDEO`
+- `NAVIGATION`
 
 ### Available Game Subcategories
 
@@ -543,54 +542,40 @@ You can always prefix the category using `MZGenre.` (e.g. `MZGenre.Book`). _deli
 - `MZGenre.Trivia`
 - `MZGenre.Word`
 
-### Available Magazines & Newspapers Subcategories
-
-- `MZGenre.Apps.Arts_Photography`
-- `MZGenre.Apps.Automotive`
-- `MZGenre.Apps.Brides_Weddings`
-- `MZGenre.Apps.Business_Investing`
-- `MZGenre.Apps.Childrens_Magazines`
-- `MZGenre.Apps.Computers_Internet`
-- `MZGenre.Apps.Cooking_Food_Drink`
-- `MZGenre.Apps.Crafts_Hobbies`
-- `MZGenre.Apps.Electronics_Audio`
-- `MZGenre.Apps.Entertainment`
-- `MZGenre.Apps.Fashion_Style`
-- `MZGenre.Apps.Health_Mind_Body`
-- `MZGenre.Apps.History`
-- `MZGenre.Apps.Home_Garden`
-- `MZGenre.Apps.Literary_Magazines_Journals`
-- `MZGenre.Apps.Mens_Interest`
-- `MZGenre.Apps.Movies_Music`
-- `MZGenre.Apps.News_Politics`
-- `MZGenre.Apps.Outdoors_Nature`
-- `MZGenre.Apps.Parenting_Family`
-- `MZGenre.Apps.Pets`
-- `MZGenre.Apps.Professional_Trade`
-- `MZGenre.Apps.Regional_News`
-- `MZGenre.Apps.Science`
-- `MZGenre.Apps.Sports_Leisure`
-- `MZGenre.Apps.Teens`
-- `MZGenre.Apps.Travel_Regional`
-- `MZGenre.Apps.Womens_Interest`
+- `GAMES_SPORTS`
+- `GAMES_WORD`
+- `GAMES_MUSIC`
+- `GAMES_ADVENTURE`
+- `GAMES_ACTION`
+- `GAMES_ROLE_PLAYING`
+- `GAMES_CASUAL`
+- `GAMES_BOARD`
+- `GAMES_TRIVIA`
+- `GAMES_CARD`
+- `GAMES_PUZZLE`
+- `GAMES_CASINO`
+- `GAMES_STRATEGY`
+- `GAMES_SIMULATION`
+- `GAMES_RACING`
+- `GAMES_FAMILY`
 
 ### Available Stickers Subcategories
 
-- `MZGenre.Apps.Stickers.Animals`
-- `MZGenre.Apps.Stickers.Art`
-- `MZGenre.Apps.Stickers.BirthdaysAndCelebrations`
-- `MZGenre.Apps.Stickers.Celebrities`
-- `MZGenre.Apps.Stickers.Characters`
-- `MZGenre.Apps.Stickers.FoodAndDrink`
-- `MZGenre.Apps.Stickers.Emotions`
-- `MZGenre.Apps.Stickers.Fashion`
-- `MZGenre.Apps.Stickers.Games`
-- `MZGenre.Apps.Stickers.KidsAndFamily`
-- `MZGenre.Apps.Stickers.MoviesAndTV`
-- `MZGenre.Apps.Stickers.Music`
-- `MZGenre.Apps.Stickers.People`
-- `MZGenre.Apps.Stickers.Places`
-- `MZGenre.Apps.Stickers.Sports`
+- `STICKERS_PLACES_AND_OBJECTS`
+- `STICKERS_EMOJI_AND_EXPRESSIONS`
+- `STICKERS_CELEBRATIONS`
+- `STICKERS_CELEBRITIES`
+- `STICKERS_MOVIES_AND_TV`
+- `STICKERS_SPORTS_AND_ACTIVITIES`
+- `STICKERS_EATING_AND_DRINKING`
+- `STICKERS_CHARACTERS`
+- `STICKERS_ANIMALS`
+- `STICKERS_FASHION`
+- `STICKERS_ART`
+- `STICKERS_GAMING`
+- `STICKERS_KIDS_AND_FAMILY`
+- `STICKERS_PEOPLE`
+- `STICKERS_MUSIC`
 
 ### Available age rating groups
 

--- a/spaceship/lib/spaceship/connect_api/models/app_info.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_info.rb
@@ -38,19 +38,11 @@ module Spaceship
       #
 
       def update(filter: {}, includes: nil, limit: nil, sort: nil)
-        Spaceship::ConnectAPI.patch_app_info(app_info_id: id)
+        Spaceship::ConnectAPI.patch_app_info(app_info_id: id).first
       end
 
-      def update_categories(primary_category_id: nil, secondary_category_id: nil, primary_subcategory_one_id: nil, primary_subcategory_two_id: nil, secondary_subcategory_one_id: nil, secondary_subcategory_two_id: nil)
-        Spaceship::ConnectAPI.patch_app_info_categories(
-          app_info_id: id,
-          primary_category_id: primary_category_id,
-          secondary_category_id: secondary_category_id,
-          primary_subcategory_one_id: primary_subcategory_one_id,
-          primary_subcategory_two_id: primary_subcategory_two_id,
-          secondary_subcategory_one_id: secondary_subcategory_one_id,
-          secondary_subcategory_two_id: secondary_subcategory_two_id
-        )
+      def update_categories(category_id_map: nil)
+        Spaceship::ConnectAPI.patch_app_info_categories(app_info_id: id, category_id_map: category_id_map).first
       end
 
       def delete!(filter: {}, includes: nil, limit: nil, sort: nil)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -324,10 +324,12 @@ module Spaceship
       end
 
       #
+      # Adding the key will create/update (if value) or delete if nil
+      # Not including a key will leave as is
       # category_id_map: {
-      #   primary_category_id: nil,
-      #   primary_subcategory_one_id: nil,
-      #   primary_subcategory_two_id: nil,
+      #   primary_category_id: "GAMES",
+      #   primary_subcategory_one_id: "PUZZLE",
+      #   primary_subcategory_two_id: "STRATEGY",
       #   secondary_category_id: nil,
       #   secondary_subcategory_one_id: nil,
       #   secondary_subcategory_two_id: nil
@@ -344,36 +346,42 @@ module Spaceship
 
         relationships = {}
 
+        # Only update if key is included (otherwise category will be removed)
         if category_id_map.include?(:primary_category_id)
           relationships[:primaryCategory] = {
             data: primary_category_id ? { type: "appCategories", id: primary_category_id } : nil
           }
         end
 
+        # Only update if key is included (otherwise category will be removed)
         if category_id_map.include?(:primary_subcategory_one_id)
           relationships[:primarySubcategoryOne] = {
             data: primary_subcategory_one_id ? { type: "appCategories", id: primary_subcategory_one_id } : nil
           }
         end
 
+        # Only update if key is included (otherwise category will be removed)
         if category_id_map.include?(:primary_subcategory_two_id)
           relationships[:primarySubcategoryTwo] = {
             data: primary_subcategory_two_id ? { type: "appCategories", id: primary_subcategory_two_id } : nil
           }
         end
 
+        # Only update if key is included (otherwise category will be removed)
         if category_id_map.include?(:secondary_category_id)
           relationships[:secondaryCategory] = {
             data: secondary_category_id ? { type: "appCategories", id: secondary_category_id } : nil
           }
         end
 
+        # Only update if key is included (otherwise category will be removed)
         if category_id_map.include?(:secondary_subcategory_one_id)
           relationships[:secondarySubcategoryOne] = {
             data: secondary_subcategory_one_id ? { type: "appCategories", id: secondary_subcategory_one_id } : nil
           }
         end
 
+        # Only update if key is included (otherwise category will be removed)
         if category_id_map.include?(:secondary_subcategory_two_id)
           relationships[:secondarySubcategoryTwo] = {
             data: secondary_subcategory_two_id ? { type: "appCategories", id: secondary_subcategory_two_id } : nil

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -323,27 +323,62 @@ module Spaceship
         Client.instance.patch("appInfos/#{app_info_id}", body)
       end
 
-      def patch_app_info_categories(app_info_id: nil, primary_category_id: nil, secondary_category_id: nil, primary_subcategory_one_id: nil, primary_subcategory_two_id: nil, secondary_subcategory_one_id: nil, secondary_subcategory_two_id: nil)
-        relationships = {
-          primaryCategory: {
+      #
+      # category_id_map: {
+      #   primary_category_id: nil,
+      #   primary_subcategory_one_id: nil,
+      #   primary_subcategory_two_id: nil,
+      #   secondary_category_id: nil,
+      #   secondary_subcategory_one_id: nil,
+      #   secondary_subcategory_two_id: nil
+      # }
+      #
+      def patch_app_info_categories(app_info_id: nil, category_id_map: nil)
+        category_id_map ||= {}
+        primary_category_id = category_id_map[:primary_category_id]
+        primary_subcategory_one_id = category_id_map[:primary_subcategory_one_id]
+        primary_subcategory_two_id = category_id_map[:primary_subcategory_two_id]
+        secondary_category_id = category_id_map[:secondary_category_id]
+        secondary_subcategory_one_id = category_id_map[:secondary_subcategory_one_id]
+        secondary_subcategory_two_id = category_id_map[:secondary_subcategory_two_id]
+
+        relationships = {}
+
+        if category_id_map.include?(:primary_category_id)
+          relationships[:primaryCategory] = {
             data: primary_category_id ? { type: "appCategories", id: primary_category_id } : nil
-          },
-          secondaryCategory: {
-            data: secondary_category_id ? { type: "appCategories", id: secondary_category_id } : nil
-          },
-          primarySubcategoryOne: {
+          }
+        end
+
+        if category_id_map.include?(:primary_subcategory_one_id)
+          relationships[:primarySubcategoryOne] = {
             data: primary_subcategory_one_id ? { type: "appCategories", id: primary_subcategory_one_id } : nil
-          },
-          primarySubcategoryTwo: {
+          }
+        end
+
+        if category_id_map.include?(:primary_subcategory_two_id)
+          relationships[:primarySubcategoryTwo] = {
             data: primary_subcategory_two_id ? { type: "appCategories", id: primary_subcategory_two_id } : nil
-          },
-          secondarySubcategoryOne: {
+          }
+        end
+
+        if category_id_map.include?(:secondary_category_id)
+          relationships[:secondaryCategory] = {
+            data: secondary_category_id ? { type: "appCategories", id: secondary_category_id } : nil
+          }
+        end
+
+        if category_id_map.include?(:secondary_subcategory_one_id)
+          relationships[:secondarySubcategoryOne] = {
             data: secondary_subcategory_one_id ? { type: "appCategories", id: secondary_subcategory_one_id } : nil
-          },
-          secondarySubcategoryTwo: {
+          }
+        end
+
+        if category_id_map.include?(:secondary_subcategory_two_id)
+          relationships[:secondarySubcategoryTwo] = {
             data: secondary_subcategory_two_id ? { type: "appCategories", id: secondary_subcategory_two_id } : nil
           }
-        }
+        end
 
         data = {
           type: "appInfos",


### PR DESCRIPTION
### Motivation and Context
Fixes https://github.com/fastlane/fastlane/issues/16621#issuecomment-647143129

### Description
- Only update category 1 (and its sub categories) when category 1 is explicitly specified 
- Only update category 2 (and its sub categories) when category 2 is explicitly specified 

```sh
[12:21:25]: 'MZGenre.Games' from iTunesConnect as been deprecated. Please replace with 'GAMES'
[12:21:25]: 'Travel' from iTunesConnect as been deprecated. Please replace with 'TRAVEL'
[12:21:25]: 'MZGenre.Puzzle' from iTunesConnect as been deprecated. Please replace with 'GAMES_PUZZLE'
[12:21:25]: 'MZGenre.Simulation' from iTunesConnect as been deprecated. Please replace with 'GAMES_SIMULATION'
[12:21:25]: You can find more info at http://docs.fastlane.tools/actions/deliver/#reference
```