### PR TITLE
[deliver] Implement parallel screenshot downloads

### DIFF
--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -28,42 +28,49 @@ module Deliver
       end
 
       localizations = version.get_app_store_version_localizations
+      threads = []
       localizations.each do |localization|
-        screenshot_sets = localization.get_app_screenshot_sets
-        screenshot_sets.each do |screenshot_set|
-          screenshot_set.app_screenshots.each_with_index do |screenshot, index|
-            file_name = [index, screenshot_set.screenshot_display_type, index].join("_")
-            original_file_extension = File.extname(screenshot.file_name).strip.downcase[1..-1]
-            file_name += "." + original_file_extension
+        threads << Thread.new do
+          download_screenshots(folder_path, localization)
+        end
+      end
+      threads.each(&:join)
+    end
 
-            url = screenshot.image_asset_url(type: original_file_extension)
-            next if url.nil?
+    def self.download_screenshots(folder_path, localization)
+      language = localization.locale
+      screenshot_sets = localization.get_app_screenshot_sets
+      screenshot_sets.each do |screenshot_set|
+        screenshot_set.app_screenshots.each_with_index do |screenshot, index|
+          file_name = [index, screenshot_set.screenshot_display_type, index].join("_")
+          original_file_extension = File.extname(screenshot.file_name).strip.downcase[1..-1]
+          file_name += "." + original_file_extension
 
-            language = localization.locale
+          url = screenshot.image_asset_url(type: original_file_extension)
+          next if url.nil?
 
-            UI.message("Downloading existing screenshot '#{file_name}' for language '#{language}'")
+          UI.message("Downloading existing screenshot '#{file_name}' for language '#{language}'")
 
-            # If the screen shot is for an appleTV we need to store it in a way that we'll know it's an appleTV
-            # screen shot later as the screen size is the same as an iPhone 6 Plus in landscape.
-            if screenshot_set.apple_tv?
-              containing_folder = File.join(folder_path, "appleTV", language)
-            else
-              containing_folder = File.join(folder_path, language)
-            end
-
-            if screenshot_set.imessage?
-              containing_folder = File.join(folder_path, "iMessage", language)
-            end
-
-            begin
-              FileUtils.mkdir_p(containing_folder)
-            rescue
-              # if it's already there
-            end
-
-            path = File.join(containing_folder, file_name)
-            File.binwrite(path, open(url).read)
+          # If the screen shot is for an appleTV we need to store it in a way that we'll know it's an appleTV
+          # screen shot later as the screen size is the same as an iPhone 6 Plus in landscape.
+          if screenshot_set.apple_tv?
+            containing_folder = File.join(folder_path, "appleTV", language)
+          else
+            containing_folder = File.join(folder_path, language)
           end
+
+          if screenshot_set.imessage?
+            containing_folder = File.join(folder_path, "iMessage", language)
+          end
+
+          begin
+            FileUtils.mkdir_p(containing_folder)
+          rescue
+            # if it's already there
+          end
+
+          path = File.join(containing_folder, file_name)
+          File.binwrite(path, open(url).read)
         end
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I am working on an application that supports many languages. Therefore, loading and unloading screenshots for all of them takes a lot of time. To get started, I would like to add a parallel download of screenshots. I know that Fastlane is not designed for parallel operations, but in this case I think this is a suitable solution.

### Description
I added the creation of a thread for downloading screenshots for each language, this should be the optimal solution (the optimal number of threads and file descriptors) and should not create collisions.

### Testing Steps
Execute `fastlane deliver download_screenshots` on the current release version of Fastlane and on version from the current branch.

Averaged local measurement results:
Hardware: MacBook Pro (15-inch, 2019) 2.4 GHz Intel Core i9 32 GB 2400 MHz DDR4
Input: 31 language * 4 devices * 9 screenshots = 1116 images 421.6 MB
Connection: WiFi 46.9 Mbps

**Result before: ~ 375s**
**Result after: ~ 99s**
