### PR TITLE
[deliver] warn about mapped/deprecated age rating values

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -264,7 +264,7 @@ module Deliver
           has_mapped_values = true
           UI.deprecated("Category '#{k}' from iTunesConnect as been deprecated. Please replace with '#{v}'")
         end
-        UI.deprecated("You can find more info at http://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values
+        UI.deprecated("You can find more info at https://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values
 
         app_info.update_categories(category_id_map: category_id_map)
       end

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -262,7 +262,7 @@ module Deliver
         mapped_values.each do |k, v|
           next if k.nil? || v.nil?
           has_mapped_values = true
-          UI.deprecated("'#{k}' from iTunesConnect as been deprecated. Please replace with '#{v}'")
+          UI.deprecated("Category '#{k}' from iTunesConnect as been deprecated. Please replace with '#{v}'")
         end
         UI.deprecated("You can find more info at http://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values
 
@@ -572,12 +572,26 @@ module Deliver
       UI.message("Setting the app's age rating...")
 
       # Maping from legacy ITC values to App Store Connect Values
+      mapped_values = {}
       attributes = {}
       json.each do |k, v|
         new_key = Spaceship::ConnectAPI::AgeRatingDeclaration.map_key_from_itc(k)
         new_value = Spaceship::ConnectAPI::AgeRatingDeclaration.map_value_from_itc(new_key, v)
+
+        mapped_values[k] = new_key
+        mapped_values[v] = new_value
+
         attributes[new_key] = new_value
       end
+
+      # Print deprecation warnings if category was mapped
+      has_mapped_values = false
+      mapped_values.each do |k, v|
+        next if k.nil? || v.nil?
+        has_mapped_values = true
+        UI.deprecated("Age rating '#{k}' from iTunesConnect as been deprecated. Please replace with '#{v}'")
+      end
+      UI.deprecated("You can find more info at http://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values
 
       age_rating_delcaration = version.fetch_age_rating_declaration
       age_rating_delcaration.update(attributes: attributes)

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -261,6 +261,7 @@ module Deliver
         has_mapped_values = false
         mapped_values.each do |k, v|
           next if k.nil? || v.nil?
+          next if k == v
           has_mapped_values = true
           UI.deprecated("Category '#{k}' from iTunesConnect as been deprecated. Please replace with '#{v}'")
         end
@@ -588,10 +589,11 @@ module Deliver
       has_mapped_values = false
       mapped_values.each do |k, v|
         next if k.nil? || v.nil?
+        next if k == v
         has_mapped_values = true
         UI.deprecated("Age rating '#{k}' from iTunesConnect as been deprecated. Please replace with '#{v}'")
       end
-      UI.deprecated("You can find more info at http://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values
+      UI.deprecated("You can find more info at https://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values
 
       age_rating_delcaration = version.fetch_age_rating_declaration
       age_rating_delcaration.update(attributes: attributes)

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -587,26 +587,30 @@ Key | Editable While Live | Directory | Filename
 - 1: Infrequent/Mild
 - 2: Frequent/Intense
 
+- `NONE`
+- `INFREQUENT_OR_MILD`
+- `FREQUENT_OR_INTENSE`
+
 **Keys**
 
-- `CARTOON_FANTASY_VIOLENCE`
-- `REALISTIC_VIOLENCE`
-- `PROLONGED_GRAPHIC_SADISTIC_REALISTIC_VIOLENCE`
-- `PROFANITY_CRUDE_HUMOR`
-- `MATURE_SUGGESTIVE`
-- `HORROR`
-- `MEDICAL_TREATMENT_INFO`
-- `ALCOHOL_TOBACCO_DRUGS`
-- `GAMBLING`
-- `SEXUAL_CONTENT_NUDITY`
-- `GRAPHIC_SEXUAL_CONTENT_NUDITY`
+- `violenceCartoonOrFantasy`
+- `violenceRealistic`
+- `violenceRealisticProlongedGraphicOrSadistic`
+- `profanityOrCrudeHumor`
+- `matureOrSuggestiveThemes`
+- `horrorOrFearThemes`
+- `medicalOrTreatmentInformation`
+- `alcoholTobaccoOrDrugUseOrReferences`
+- `gamblingSimulated`
+- `sexualContentOrNudity`
+- `sexualContentGraphicAndNudity`
 
 #### Boolean
 
 **Keys**
 
-- `UNRESTRICTED_WEB_ACCESS`
-- `GAMBLING_CONTESTS`
+- `unrestrictedWebAccess`
+- `gamblingAndContests`
 </details>
 
 <br />

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -91,10 +91,14 @@ module Spaceship
 
       def self.map_value_from_itc(key, value)
         if ["gamblingAndContests", "unrestrictedWebAccess"].include?(key)
-          return LEGACY_BOOLEAN_VALUE_ITC_MAP[value]
+          new_value = LEGACY_BOOLEAN_VALUE_ITC_MAP[value]
+          return value if new_value.nil?
+          return new_value
         else
           return LEGACY_RATING_VALUE_ITC_MAP[value]
         end
+
+        return value
       end
 
       #


### PR DESCRIPTION
### Motivation and Context 
Similar to https://github.com/fastlane/fastlane/pull/16652

### Description

```sh
[12:58:27]: Age rating 'REALISTIC_VIOLENCE' from iTunesConnect as been deprecated. Please replace with 'violenceRealistic'
[12:58:27]: Age rating 'PROLONGED_GRAPHIC_SADISTIC_REALISTIC_VIOLENCE' from iTunesConnect as been deprecated. Please replace with 'violenceRealisticProlongedGraphicOrSadistic'
[12:58:27]: Age rating 'PROFANITY_CRUDE_HUMOR' from iTunesConnect as been deprecated. Please replace with 'profanityOrCrudeHumor'
[12:58:27]: Age rating 'MATURE_SUGGESTIVE' from iTunesConnect as been deprecated. Please replace with 'matureOrSuggestiveThemes'
[12:58:27]: Age rating 'HORROR' from iTunesConnect as been deprecated. Please replace with 'horrorOrFearThemes'
[12:58:27]: Age rating 'MEDICAL_TREATMENT_INFO' from iTunesConnect as been deprecated. Please replace with 'medicalOrTreatmentInformation'
[12:58:27]: Age rating 'ALCOHOL_TOBACCO_DRUGS' from iTunesConnect as been deprecated. Please replace with 'alcoholTobaccoOrDrugUseOrReferences'
[12:58:27]: Age rating 'GAMBLING' from iTunesConnect as been deprecated. Please replace with 'gamblingSimulated'
[12:58:27]: Age rating 'SEXUAL_CONTENT_NUDITY' from iTunesConnect as been deprecated. Please replace with 'sexualContentOrNudity'
[12:58:27]: Age rating 'GRAPHIC_SEXUAL_CONTENT_NUDITY' from iTunesConnect as been deprecated. Please replace with 'sexualContentGraphicAndNudity'
[12:58:27]: Age rating 'UNRESTRICTED_WEB_ACCESS' from iTunesConnect as been deprecated. Please replace with 'unrestrictedWebAccess'
[12:58:27]: Age rating 'GAMBLING_CONTESTS' from iTunesConnect as been deprecated. Please replace with 'gamblingAndContests'
[12:58:27]: You can find more info at http://docs.fastlane.tools/actions/deliver/#reference
```
