### PR TITLE
[action] fix set_changelog

### DIFF
--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -9,16 +9,18 @@ module Fastlane
         Spaceship::Tunes.select_team
         UI.message("Login successful")
 
-        app = Spaceship::Application.find(params[:app_identifier]) || Spaceship::Application.find(params[:app_identifier], mac: true)
+        app = Spaceship::ConnectAPI::App.find(params[:app_identifier])
         UI.user_error!("Couldn't find app with identifier #{params[:app_identifier]}") if app.nil?
 
         version_number = params[:version]
-        platform = params[:platform]
+        platform = Spaceship::ConnectAPI::Platform.map(params[:platform])
+
         unless version_number
           # Automatically fetch the latest version
           UI.message("Fetching the latest version for this app")
-          if app.edit_version(platform: platform) && app.edit_version(platform: platform).version
-            version_number = app.edit_version(platform: platform).version
+          edit_version = app.get_edit_app_store_version(platform: platform)
+          if edit_version
+            version_number = edit_version.version_string
           else
             UI.message("You have to specify a new version number: ")
             version_number = STDIN.gets.strip
@@ -42,31 +44,32 @@ module Fastlane
 
         UI.important("Going to update the changelog to:\n\n#{changelog}\n\n")
 
-        if (v = app.edit_version(platform: platform))
-          if v.version != version_number
+        edit_version = app.get_edit_app_store_version(platform: platform)
+        if edit_version
+          if edit_version.version_string != version_number
             # Version is already there, make sure it matches the one we want to create
-            UI.message("Changing existing version number from '#{v.version}' to '#{version_number}'")
-            v.version = version_number
-            v.save!
+            UI.message("Changing existing version number from '#{edit_version.version_string}' to '#{version_number}'")
+            edit_version = edit_version.update(attributes: {
+              versionString: version_number
+            })
           else
-            UI.message("Updating changelog for existing version #{v.version}")
+            UI.message("Updating changelog for existing version #{edit_version.version_string}")
           end
         else
           UI.message("Creating the new version: #{version_number}")
-          app.create_version!(version_number)
-          app = Spaceship::Application.find(params[:app_identifier]) # Replace with .reload method once available
-          v = app.edit_version(platform: platform)
+          attributes = { versionString: version_number, platform: platform }
+          edit_version = Spaceship::ConnectAPI.post_app_store_version(app_id: app.id, attributes: attributes).first
         end
 
-        v.release_notes.languages.each do |lang|
-          v.release_notes[lang] = changelog
+        localizations = edit_version.get_app_store_version_localizations
+        localizations.each do |localization|
+          UI.message("Updating changelog for the '#{localization.locale}'")
+          localization.update(attributes: {
+            whatsNew: changelog
+          })
         end
 
-        UI.message("Found and updated changelog for the following languages: #{v.release_notes.languages.join(', ')}")
-        UI.message("Uploading changes to App Store Connect...")
-        v.save!
-
-        UI.success("👼  Successfully pushed the new changelog to #{v.url}")
+        UI.success("👼  Successfully pushed the new changelog to for #{edit_version.version_string}")
       end
 
       def self.default_changelog_path

--- a/fastlane/spec/actions_specs/set_changelog_spec.rb
+++ b/fastlane/spec/actions_specs/set_changelog_spec.rb
@@ -19,7 +19,7 @@ describe Fastlane do
         it 'raises a Fastlane error' do
           allow(Spaceship::Tunes).to receive(:login).and_return(true)
           allow(Spaceship::Tunes).to receive(:select_team).and_return(true)
-          allow(Spaceship::Application).to receive(:find).and_return(nil)
+          allow(Spaceship::ConnectAPI::App).to receive(:find).and_return(nil)
 
           expect { Fastlane::FastFile.new.parse(validPlatform_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|


### PR DESCRIPTION
### Motivation and Context
Fixes https://github.com/fastlane/fastlane/issues/16639#issuecomment-647661174

### Description
- `set_changelog` now uses `Spaceship::ConnectAPI` stuff
