### PR TITLE
[fastlane-core] Require rubyzip >= 2.0.0

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -84,7 +84,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('json', '< 3.0.0') # Because sometimes it's just not installed
   spec.add_dependency('mini_magick', '>= 4.9.4', '< 5.0.0') # To open, edit and export PSD files
   spec.add_dependency('multi_xml', '~> 0.5')
-  spec.add_dependency('rubyzip', '>= 1.3.0', '< 2.0.0') # fix swift/ipa in gym
+  spec.add_dependency('rubyzip', '>= 2.0.0', '< 3.0.0') # fix swift/ipa in gym
   spec.add_dependency('security', '= 0.1.3') # macOS Keychain manager, a dead project, no updates expected
   spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3')
   spec.add_dependency('dotenv', '>= 2.1.1', '< 3.0.0')

--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -37,7 +37,6 @@ module FastlaneCore
 
     def self.fetch_info_plist_file(path)
       UI.user_error!("Could not find file at path '#{path}'") unless File.exist?(path)
-      Zip.validate_entry_sizes = true # https://github.com/rubyzip/rubyzip/releases/tag/v2.0.0
       Zip::File.open(path, "rb") do |zipfile|
         file = zipfile.glob('**/Payload/*.app/Info.plist').first
         return nil unless file


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

2.x fixes some bugs and also supports only Ruby 2.4 and above, like fastlane. `Zip.validate_entry_sizes = true` was removed because it's the default in rubyzip 2.x.

https://github.com/rubyzip/rubyzip/blob/v2.3.0/rubyzip.gemspec#L23
https://github.com/rubyzip/rubyzip/blob/v2.3.0/Changelog.md

https://github.com/rubyzip/rubyzip/blob/v2.3.0/Changelog.md#130-2019-09-25
https://github.com/fastlane/fastlane/blob/2.150.0.rc1/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb#L40

Edit:
Related PRs:
https://github.com/fastlane/fastlane/pull/16072
https://github.com/fastlane/fastlane/pull/15970

### Description

The only direct usage of `rubyzip` I could find was in `ipa_file_analyzer.rb`, I did not find any usage that should break with this change.

### Testing Steps

Ran all specs and especially the `ipd_file_analyzer_specs.rb`, which pass with `rubyzip` 2.3.
