### PR TITLE
[pilot] Strip Unicode 13 emoji

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,7 +97,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('google-api-client', '>= 0.37.0', '< 0.39.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
 
-  spec.add_dependency('emoji_regex', '>= 0.1', '< 2.0') # Used to scan for Emoji in the changelog
+  spec.add_dependency('emoji_regex', '>= 0.1', '< 4.0') # Used to scan for Emoji in the changelog
 
   spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used for S3 storage in fastlane match
 

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -26,7 +26,7 @@ describe "Build Manager" do
 
   describe ".sanitize_changelog" do
     it "removes emoji" do
-      changelog = "I'm 🦇B🏧an!"
+      changelog = "I'm 🦇B🏧an🪴!"
       changelog = Pilot::BuildManager.sanitize_changelog(changelog)
       expect(changelog).to eq("I'm Ban!")
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`emoji_regex` 3.0.0 adds support for Unicode 13 emoji. These would otherwise not be stripped.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Makes it possible to update to `emoji_regex` 3.0 to strip the latest emoji.

There's also an alternative gem called `unicode-emoji` which is interesting because it features more regular expressions, but also because starting with [Ruby 2.5](https://github.com/janlelis/unicode-emoji/commit/743418f591783f47b6c033c65f25cdd105ab4ec5) it uses Ruby's built-in emoji-regex if the unicode version matches.

However, officially it only supports Ruby 2.5 and above, but the tests for Ruby 2.4 [still pass](https://travis-ci.org/github/janlelis/unicode-emoji/builds/697752468).

No action to be taken here, but since `emoji_regex` does not [specify](https://github.com/ticky/ruby-emoji-regex/blob/v3.0.0/emoji_regex.gemspec) or [test](https://travis-ci.org/github/ticky/ruby-emoji-regex/builds/680335378) any Ruby versions but the one defined in `.ruby-version`, I thought I'd mention it here.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

The adopted test was failing with the current version of the `master` branch, but is not failing anymore after updating `emoji_regex`. The emoji added is the one of the [potted plant](https://emojipedia.org/potted-plant/), no reason other than it was added in Unicode 13. I can of course exchange it for any other emoji [added in Unicode 13](https://www.unicode.org/emoji/charts-13.0/emoji-released.html).