### PR TITLE
[fastlane] Explain multi_xml dependency

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -83,7 +83,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('highline', '>= 1.7.2', '< 2.0.0') # user inputs (e.g. passwords)
   spec.add_dependency('json', '< 3.0.0') # Because sometimes it's just not installed
   spec.add_dependency('mini_magick', '>= 4.9.4', '< 5.0.0') # To open, edit and export PSD files
-  spec.add_dependency('multi_xml', '~> 0.5')
+  spec.add_dependency('multi_xml', '~> 0.5') # Used indirectly by spaceship client via faraday_middleware
   spec.add_dependency('rubyzip', '>= 1.3.0', '< 2.0.0') # fix swift/ipa in gym
   spec.add_dependency('security', '= 0.1.3') # macOS Keychain manager, a dead project, no updates expected
   spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`faraday_middleware` is being used to parse XML responses in the spaceship client. Indirectly, this requires `multi_xml` as a dependency.

https://github.com/lostisland/faraday_middleware#dependencies
https://github.com/fastlane/fastlane/blob/2.150.0.rc1/spaceship/lib/spaceship/client.rb#L208

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Explain `multi_xml` dependency

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Ran the tests and they ran through. Let's hope the same is true on CI.