### PR TITLE
[sigh] Resign OnDemandResources

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -69,6 +69,9 @@
 # new features March 2019
 # 1. two more fixes for only creating the archived-expanded-entitlements.xcent file if the version of Xcode < 9.3 as Xcode 10 does not create it.
 #
+# new features June 2020
+# 1. enable (re)signing of OnDemandResources when ipa has been built for the appstore
+#
 
 # Logging functions
 

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -528,6 +528,21 @@ function resign {
         PlistBuddy -c "Set :CFBundleVersion $BUNDLE_VERSION" "$APP_PATH/Info.plist"
     fi
 
+    # Check for and resign OnDemandResource folders
+    ODR_DIR="$(dirname $APP_PATH)/OnDemandResources"
+    if [ -d "$ODR_DIR" ]; then
+        for assetpack in "$ODR_DIR"/*
+        do
+            if [[ "$assetpack" == *.assetpack ]]; then
+                rm -rf $assetpack/_CodeSignature
+                /usr/bin/codesign ${VERBOSE} ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$assetpack"
+                checkStatus
+            else
+                log "Ignoring non-assetpack: $assetpack"
+            fi
+        done
+    fi
+
     # Check for and resign any embedded frameworks (new feature for iOS 8 and above apps)
     FRAMEWORKS_DIR="$APP_PATH/Frameworks"
     if [ -d "$FRAMEWORKS_DIR" ]; then


### PR DESCRIPTION
Allows sigh to resign OnDemandResource assetpacks

fixes #16668

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

We have teams that create/sign IPAs with development provisioning profiles and then we centrally sign with fastlane before deploying to the store.  They would like to start using ODR's, however, when we resign, these ODR's are not being (re)signed.

### Description

Detects if an ODR folder is within the Payload folder, if so, removes any codesignature's from each pack and resigns each pack.

### Testing Steps

Modified a local installation of fastlane with these changes and ran an IPA with ODR through it.  IPA came out successfully signed.