### PR TITLE
[spaceship] waiting_for_review is editable (ish)

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -145,7 +145,8 @@ module Spaceship
             Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::PREPARE_FOR_SUBMISSION,
             Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::DEVELOPER_REJECTED,
             Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::REJECTED,
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::METADATA_REJECTED
+            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::METADATA_REJECTED,
+            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::WAITING_FOR_REVIEW
           ].join(","),
           platform: platform
         }

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -82,7 +82,8 @@ module Spaceship
           Spaceship::ConnectAPI::AppInfo::AppStoreState::PREPARE_FOR_SUBMISSION,
           Spaceship::ConnectAPI::AppInfo::AppStoreState::DEVELOPER_REJECTED,
           Spaceship::ConnectAPI::AppInfo::AppStoreState::REJECTED,
-          Spaceship::ConnectAPI::AppInfo::AppStoreState::METADATA_REJECTED
+          Spaceship::ConnectAPI::AppInfo::AppStoreState::METADATA_REJECTED,
+          Spaceship::ConnectAPI::AppInfo::AppStoreState::WAITING_FOR_REVIEW
         ]
 
         resp = Spaceship::ConnectAPI.get_app_infos(app_id: id)


### PR DESCRIPTION
### Motivation and Context
App information is editable when in a “Waiting for review” state which is highly possible if your app supports multiple platforms

### Description
Just add in “waiting for review”

### Testing Steps

Updated `Gemfile` and run `bundle update fastlane`

```rb

gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-2.150.0-waiting_for_review-is-editable-ish”
```
