### PR TITLE
[match] Add `s3_object_prefix` option to match's S3Storage.

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -186,6 +186,10 @@ module Match
                                      env_name: "MATCH_S3_BUCKET",
                                      description: "Name of the S3 bucket",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :s3_object_prefix,
+                                     env_name: "MATCH_S3_OBJECT_PREFIX",
+                                     description: "Prefix to be used on all objects uploaded to S3",
+                                     optional: true),
 
         # Keychain
         FastlaneCore::ConfigItem.new(key: :keychain_name,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -50,6 +50,7 @@ module Match
         s3_access_key: params[:s3_access_key].to_s,
         s3_secret_access_key: params[:s3_secret_access_key].to_s,
         s3_bucket: params[:s3_bucket].to_s,
+        s3_object_prefix: params[:s3_object_prefix],
         readonly: params[:readonly],
         username: params[:readonly] ? nil : params[:username], # only pass username if not readonly
         team_id: params[:team_id],

--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -167,7 +167,7 @@ module Match
       end
 
       def strip_s3_object_prefix(object_path)
-        object_path.gsub(s3_object_prefix, "")
+        object_path.gsub(/^#{s3_object_prefix}/, "")
       end
 
       def sanitize_file_name(file_name)

--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -14,6 +14,7 @@ module Match
       attr_reader :s3_bucket
       attr_reader :s3_region
       attr_reader :s3_client
+      attr_reader :s3_object_prefix
       attr_reader :readonly
       attr_reader :username
       attr_reader :team_id
@@ -24,6 +25,7 @@ module Match
         s3_access_key = params[:s3_access_key]
         s3_secret_access_key = params[:s3_secret_access_key]
         s3_bucket = params[:s3_bucket]
+        s3_object_prefix = params[:s3_object_prefix]
 
         if params[:git_url].to_s.length > 0
           UI.important("Looks like you still define a `git_url` somewhere, even though")
@@ -37,6 +39,7 @@ module Match
           s3_access_key: s3_access_key,
           s3_secret_access_key: s3_secret_access_key,
           s3_bucket: s3_bucket,
+          s3_object_prefix: s3_object_prefix,
           readonly: params[:readonly],
           username: params[:username],
           team_id: params[:team_id],
@@ -48,6 +51,7 @@ module Match
                      s3_access_key: nil,
                      s3_secret_access_key: nil,
                      s3_bucket: nil,
+                     s3_object_prefix: nil,
                      readonly: nil,
                      username: nil,
                      team_id: nil,
@@ -55,6 +59,7 @@ module Match
         @s3_bucket = s3_bucket
         @s3_region = s3_region
         @s3_client = Fastlane::Helper::S3ClientHelper.new(access_key: s3_access_key, secret_access_key: s3_secret_access_key, region: s3_region)
+        @s3_object_prefix = s3_object_prefix.to_s
         @readonly = readonly
         @username = username
         @team_id = team_id
@@ -88,8 +93,10 @@ module Match
         # No existing working directory, creating a new one now
         self.working_directory = Dir.mktmpdir
 
-        s3_client.find_bucket!(s3_bucket).objects.each do |object|
-          file_path = object.key # :team_id/path/to/file
+        s3_client.find_bucket!(s3_bucket).objects(prefix: s3_object_prefix).each do |object|
+          file_path = strip_s3_object_prefix(object.key) # :s3_object_prefix:team_id/path/to/file
+
+          # strip s3_prefix from file_path
           download_path = File.join(self.working_directory, file_path)
 
           FileUtils.mkdir_p(File.expand_path("..", download_path))
@@ -113,12 +120,11 @@ module Match
 
         files_to_upload.each do |file_name|
           # Go from
-          #   "/var/folders/px/bz2kts9n69g8crgv4jpjh6b40000gn/T/d20181026-96528-1av4gge/profiles/development/Development_me.mobileprovision"
+          #   "/var/folders/px/bz2kts9n69g8crgv4jpjh6b40000gn/T/d20181026-96528-1av4gge/:team_id/profiles/development/Development_me.mobileprovision"
           # to
-          #   "profiles/development/Development_me.mobileprovision"
+          #   ":s3_object_prefix:team_id/profiles/development/Development_me.mobileprovision"
           #
-
-          target_path = sanitize_file_name(file_name)
+          target_path = s3_object_path(file_name)
           UI.verbose("Uploading '#{target_path}' to S3 Storage...")
 
           body = File.read(file_name)
@@ -130,7 +136,8 @@ module Match
 
       def delete_files(files_to_delete: [], custom_message: nil)
         files_to_delete.each do |file_name|
-          target_path = sanitize_file_name(file_name)
+          target_path = s3_object_path(file_name)
+          UI.verbose("Deleting '#{target_path}' from S3 Storage...")
           s3_client.delete_file(s3_bucket, target_path)
         end
       end
@@ -151,6 +158,17 @@ module Match
       end
 
       private
+
+      def s3_object_path(file_name)
+        santized = sanitize_file_name(file_name)
+        return santized if santized.start_with?(s3_object_prefix)
+
+        s3_object_prefix + santized
+      end
+
+      def strip_s3_object_prefix(object_path)
+        object_path.gsub(s3_object_prefix, "")
+      end
 
       def sanitize_file_name(file_name)
         file_name.gsub(self.working_directory + "/", "")

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -38,31 +38,7 @@ describe Match do
           destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
           fake_storage = "fake_storage"
-          expect(Match::Storage::GitStorage).to receive(:configure).with(
-            git_url: git_url,
-            shallow_clone: true,
-            skip_docs: false,
-            git_branch: "master",
-            git_full_name: nil,
-            git_user_email: nil,
-            clone_branch_directly: false,
-            git_basic_authorization: nil,
-            git_bearer_authorization: nil,
-            type: config[:type],
-            generate_apple_certs: generate_apple_certs,
-            platform: config[:platform],
-            google_cloud_bucket_name: "",
-            google_cloud_keys_file: "",
-            google_cloud_project_id: "",
-            s3_region: "",
-            s3_access_key: "",
-            s3_secret_access_key: "",
-            s3_bucket: "",
-            readonly: false,
-            username: values[:username],
-            team_id: nil,
-            team_name: nil
-          ).and_return(fake_storage)
+          expect(Match::Storage).to receive(:for_mode).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
           expect(fake_storage).to receive(:clear_changes).and_return(nil)
@@ -119,31 +95,7 @@ describe Match do
           key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
 
           fake_storage = "fake_storage"
-          expect(Match::Storage::GitStorage).to receive(:configure).with(
-            git_url: git_url,
-            shallow_clone: false,
-            skip_docs: false,
-            git_branch: "master",
-            git_full_name: nil,
-            git_user_email: nil,
-            clone_branch_directly: false,
-            git_basic_authorization: nil,
-            git_bearer_authorization: nil,
-            type: config[:type],
-            generate_apple_certs: generate_apple_certs,
-            platform: config[:platform],
-            google_cloud_bucket_name: "",
-            google_cloud_keys_file: "",
-            google_cloud_project_id: "",
-            s3_region: "",
-            s3_access_key: "",
-            s3_secret_access_key: "",
-            s3_bucket: "",
-            readonly: false,
-            username: values[:username],
-            team_id: nil,
-            team_name: nil
-          ).and_return(fake_storage)
+          expect(Match::Storage).to receive(:for_mode).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
           expect(fake_storage).to receive(:clear_changes).and_return(nil)
@@ -199,31 +151,7 @@ describe Match do
           key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
 
           fake_storage = "fake_storage"
-          expect(Match::Storage::GitStorage).to receive(:configure).with(
-            git_url: git_url,
-            shallow_clone: false,
-            skip_docs: false,
-            git_branch: "master",
-            git_full_name: nil,
-            git_user_email: nil,
-            clone_branch_directly: false,
-            git_basic_authorization: nil,
-            git_bearer_authorization: nil,
-            type: config[:type],
-            generate_apple_certs: generate_apple_certs,
-            platform: config[:platform],
-            google_cloud_bucket_name: "",
-            google_cloud_keys_file: "",
-            google_cloud_project_id: "",
-            s3_region: "",
-            s3_access_key: "",
-            s3_secret_access_key: "",
-            s3_bucket: "",
-            readonly: false,
-            username: values[:username],
-            team_id: nil,
-            team_name: nil
-          ).and_return(fake_storage)
+          expect(Match::Storage).to receive(:for_mode).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
           expect(fake_storage).to receive(:clear_changes).and_return(nil)
@@ -265,31 +193,7 @@ describe Match do
           destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
           fake_storage = "fake_storage"
-          expect(Match::Storage::GitStorage).to receive(:configure).with(
-            git_url: git_url,
-            shallow_clone: true,
-            skip_docs: false,
-            git_branch: "master",
-            git_full_name: nil,
-            git_user_email: nil,
-            clone_branch_directly: false,
-            git_basic_authorization: nil,
-            git_bearer_authorization: nil,
-            type: config[:type],
-            generate_apple_certs: generate_apple_certs,
-            platform: config[:platform],
-            google_cloud_bucket_name: "",
-            google_cloud_keys_file: "",
-            google_cloud_project_id: "",
-            s3_region: "",
-            s3_access_key: "",
-            s3_secret_access_key: "",
-            s3_bucket: "",
-            readonly: false,
-            username: values[:username],
-            team_id: nil,
-            team_name: nil
-          ).and_return(fake_storage)
+          expect(Match::Storage).to receive(:for_mode).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
           expect(fake_storage).to receive(:clear_changes).and_return(nil)

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -38,7 +38,32 @@ describe Match do
           destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
           fake_storage = "fake_storage"
-          expect(Match::Storage).to receive(:for_mode).and_return(fake_storage)
+          expect(Match::Storage::GitStorage).to receive(:configure).with(
+            git_url: git_url,
+            shallow_clone: true,
+            skip_docs: false,
+            git_branch: "master",
+            git_full_name: nil,
+            git_user_email: nil,
+            clone_branch_directly: false,
+            git_basic_authorization: nil,
+            git_bearer_authorization: nil,
+            type: config[:type],
+            generate_apple_certs: generate_apple_certs,
+            platform: config[:platform],
+            google_cloud_bucket_name: "",
+            google_cloud_keys_file: "",
+            google_cloud_project_id: "",
+            s3_region: "",
+            s3_access_key: "",
+            s3_secret_access_key: "",
+            s3_bucket: "",
+            s3_object_prefix: nil,
+            readonly: false,
+            username: values[:username],
+            team_id: nil,
+            team_name: nil
+          ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
           expect(fake_storage).to receive(:clear_changes).and_return(nil)
@@ -95,7 +120,32 @@ describe Match do
           key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
 
           fake_storage = "fake_storage"
-          expect(Match::Storage).to receive(:for_mode).and_return(fake_storage)
+          expect(Match::Storage::GitStorage).to receive(:configure).with(
+            git_url: git_url,
+            shallow_clone: false,
+            skip_docs: false,
+            git_branch: "master",
+            git_full_name: nil,
+            git_user_email: nil,
+            clone_branch_directly: false,
+            git_basic_authorization: nil,
+            git_bearer_authorization: nil,
+            type: config[:type],
+            generate_apple_certs: generate_apple_certs,
+            platform: config[:platform],
+            google_cloud_bucket_name: "",
+            google_cloud_keys_file: "",
+            google_cloud_project_id: "",
+            s3_region: "",
+            s3_access_key: "",
+            s3_secret_access_key: "",
+            s3_bucket: "",
+            s3_object_prefix: nil,
+            readonly: false,
+            username: values[:username],
+            team_id: nil,
+            team_name: nil
+          ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
           expect(fake_storage).to receive(:clear_changes).and_return(nil)
@@ -151,7 +201,32 @@ describe Match do
           key_path = "./match/spec/fixtures/existing/certs/distribution/E7P4EE896K.p12"
 
           fake_storage = "fake_storage"
-          expect(Match::Storage).to receive(:for_mode).and_return(fake_storage)
+          expect(Match::Storage::GitStorage).to receive(:configure).with(
+            git_url: git_url,
+            shallow_clone: false,
+            skip_docs: false,
+            git_branch: "master",
+            git_full_name: nil,
+            git_user_email: nil,
+            clone_branch_directly: false,
+            git_basic_authorization: nil,
+            git_bearer_authorization: nil,
+            type: config[:type],
+            generate_apple_certs: generate_apple_certs,
+            platform: config[:platform],
+            google_cloud_bucket_name: "",
+            google_cloud_keys_file: "",
+            google_cloud_project_id: "",
+            s3_region: "",
+            s3_access_key: "",
+            s3_secret_access_key: "",
+            s3_bucket: "",
+            s3_object_prefix: nil,
+            readonly: false,
+            username: values[:username],
+            team_id: nil,
+            team_name: nil
+          ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
           expect(fake_storage).to receive(:clear_changes).and_return(nil)
@@ -193,7 +268,32 @@ describe Match do
           destination = File.expand_path("~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision")
 
           fake_storage = "fake_storage"
-          expect(Match::Storage).to receive(:for_mode).and_return(fake_storage)
+          expect(Match::Storage::GitStorage).to receive(:configure).with(
+            git_url: git_url,
+            shallow_clone: true,
+            skip_docs: false,
+            git_branch: "master",
+            git_full_name: nil,
+            git_user_email: nil,
+            clone_branch_directly: false,
+            git_basic_authorization: nil,
+            git_bearer_authorization: nil,
+            type: config[:type],
+            generate_apple_certs: generate_apple_certs,
+            platform: config[:platform],
+            google_cloud_bucket_name: "",
+            google_cloud_keys_file: "",
+            google_cloud_project_id: "",
+            s3_region: "",
+            s3_access_key: "",
+            s3_secret_access_key: "",
+            s3_bucket: "",
+            s3_object_prefix: nil,
+            readonly: false,
+            username: values[:username],
+            team_id: nil,
+            team_name: nil
+          ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
           expect(fake_storage).to receive(:clear_changes).and_return(nil)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Wanted to use the Match S3 storage option but realized that it would take over the bucket I had planned to use. With a prefix, I'd be able to keep android/ios codesign assets in the same bucket but partitioned off correctly.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This adds the `s3_object_prefix` (`MATCH_S3_OBJECT_PREFIX` envvar) as an available option. This can be used to help partition match in an existing bucket.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I've added RSpec examples for the areas that were updated. Also updated what seemed to be an odd stub mechanism in the runner spec as I did not expect tests to fail because this new optional option was not present.

I also switched over to use this updated option locally and was able to import my existing certificates/profiles into the expected s3 structure.

