### PR TITLE
[spaceship] retry file uploader and poll app preview to set frame

### DIFF
--- a/spaceship/lib/spaceship/connect_api/file_uploader.rb
+++ b/spaceship/lib/spaceship/connect_api/file_uploader.rb
@@ -30,7 +30,7 @@ module Spaceship
           offset = upload_operation["offset"]
           length = upload_operation["length"]
 
-          puts("Uploading app preview file (part #{index + 1})...") if Spaceship::Globals.verbose?
+          puts("Uploading file (part #{index + 1})...") if Spaceship::Globals.verbose?
           with_retry do
             client.send(
               upload_operation["method"].downcase,
@@ -40,7 +40,7 @@ module Spaceship
             )
           end
         end
-        puts("Uploading app preview complete!") if Spaceship::Globals.verbose?
+        puts("Uploading complete!") if Spaceship::Globals.verbose?
       end
 
       def self.with_retry(tries = 5, &_block)

--- a/spaceship/lib/spaceship/connect_api/file_uploader.rb
+++ b/spaceship/lib/spaceship/connect_api/file_uploader.rb
@@ -58,7 +58,7 @@ module Spaceship
       rescue => error
         puts(error) if Spaceship::Globals.verbose?
         if tries.zero?
-          return response
+          raise "Failed to upload file after retries... Received #{response.status}"
         else
           retry
         end

--- a/spaceship/lib/spaceship/connect_api/file_uploader.rb
+++ b/spaceship/lib/spaceship/connect_api/file_uploader.rb
@@ -2,10 +2,12 @@ require 'faraday' # HTTP Client
 require 'faraday-cookie_jar'
 require 'faraday_middleware'
 
+require 'spaceship/globals'
+
 module Spaceship
   class ConnectAPI
     module FileUploader
-      def self.upload(upload_operation, payload)
+      def self.upload(upload_operations, bytes)
         # {
         #   "method": "PUT",
         #   "url": "https://some-url-apple-gives-us",
@@ -19,17 +21,47 @@ module Spaceship
         #   ]
         # }
 
-        headers = {}
-        upload_operation["requestHeaders"].each do |hash|
-          headers[hash["name"]] = hash["value"]
+        upload_operations.each_with_index do |upload_operation, index|
+          headers = {}
+          upload_operation["requestHeaders"].each do |hash|
+            headers[hash["name"]] = hash["value"]
+          end
+
+          offset = upload_operation["offset"]
+          length = upload_operation["length"]
+
+          puts("Uploading app preview file (part #{index + 1})...") if Spaceship::Globals.verbose?
+          with_retry do
+            client.send(
+              upload_operation["method"].downcase,
+              upload_operation["url"],
+              bytes[offset, length],
+              headers
+            )
+          end
+        end
+        puts("Uploading app preview complete!") if Spaceship::Globals.verbose?
+      end
+
+      def self.with_retry(tries = 5, &_block)
+        tries = 1 if Object.const_defined?("SpecHelper")
+        response = yield
+
+        tries -= 1
+
+        unless (200...300).cover?(response.status)
+          msg = "Received status of #{response.status}! Retrying after 3 seconds (remaining: #{tries})..."
+          raise msg
         end
 
-        client.send(
-          upload_operation["method"].downcase,
-          upload_operation["url"],
-          payload,
-          headers
-        )
+        return response
+      rescue => error
+        puts(error) if Spaceship::Globals.verbose?
+        if tries.zero?
+          return response
+        else
+          retry
+        end
       end
 
       def self.client

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -95,7 +95,7 @@ module Spaceship
           return value if new_value.nil?
           return new_value
         else
-          return LEGACY_RATING_VALUE_ITC_MAP[value]
+          return LEGACY_RATING_VALUE_ITC_MAP[value] || value
         end
 
         return value

--- a/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
@@ -63,8 +63,8 @@ module Spaceship
         return resp.to_models
       end
 
-      def upload_preview(path: nil)
-        return Spaceship::ConnectAPI::AppPreview.create(app_preview_set_id: id, path: path)
+      def upload_preview(path: nil, frame_time_code: nil)
+        return Spaceship::ConnectAPI::AppPreview.create(app_preview_set_id: id, path: path, frame_time_code: frame_time_code)
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/app_review_attachment.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_review_attachment.rb
@@ -41,14 +41,17 @@ module Spaceship
           fileName: filename
         }
 
+        # Create placeholder
         post_resp = Spaceship::ConnectAPI.post_app_review_attachment(
           app_store_review_detail_id: app_store_review_detail_id,
           attributes: post_attributes
         ).to_models.first
 
+        # Upload the file
         upload_operations = post_resp.upload_operations
         Spaceship::ConnectAPI::FileUploader.upload(upload_operations, bytes)
 
+        # Update file uploading complete
         patch_attributes = {
           uploaded: true,
           sourceFileChecksum: Digest::MD5.hexdigest(bytes)

--- a/spaceship/lib/spaceship/connect_api/models/app_review_attachment.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_review_attachment.rb
@@ -42,13 +42,13 @@ module Spaceship
         }
 
         # Create placeholder
-        post_resp = Spaceship::ConnectAPI.post_app_review_attachment(
+        attachment = Spaceship::ConnectAPI.post_app_review_attachment(
           app_store_review_detail_id: app_store_review_detail_id,
           attributes: post_attributes
         ).to_models.first
 
         # Upload the file
-        upload_operations = post_resp.upload_operations
+        upload_operations = attachment.upload_operations
         Spaceship::ConnectAPI::FileUploader.upload(upload_operations, bytes)
 
         # Update file uploading complete
@@ -58,7 +58,7 @@ module Spaceship
         }
 
         Spaceship::ConnectAPI.patch_app_review_attachment(
-          app_review_attachment_id: post_resp.id,
+          app_review_attachment_id: attachment.id,
           attributes: patch_attributes
         ).to_models.first
       end

--- a/spaceship/lib/spaceship/connect_api/models/app_review_attachment.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_review_attachment.rb
@@ -1,4 +1,7 @@
 require_relative '../model'
+require_relative '../file_uploader'
+require 'digest/md5'
+
 module Spaceship
   class ConnectAPI
     class AppReviewAttachment
@@ -31,46 +34,30 @@ module Spaceship
 
         filename = File.basename(path)
         filesize = File.size(path)
-        payload = File.binread(path)
+        bytes = File.binread(path)
 
         post_attributes = {
           fileSize: filesize,
           fileName: filename
         }
 
-        post_resp = Spaceship::ConnectAPI.post_app_review_attachment(app_store_review_detail_id: app_store_review_detail_id, attributes: post_attributes).to_models.first
+        post_resp = Spaceship::ConnectAPI.post_app_review_attachment(
+          app_store_review_detail_id: app_store_review_detail_id,
+          attributes: post_attributes
+        ).to_models.first
 
-        # {
-        #   "method": "PUT",
-        #   "url": "https://some-url-apple-gives-us",
-        #   "length": 57365,
-        #   "offset": 0,
-        #   "requestHeaders": [
-        #     {
-        #       "name": "Content-Type",
-        #       "value": "image/png"
-        #     }
-        #   ]
-        # }
-        upload_operation = post_resp.upload_operations.first
-
-        headers = {}
-        upload_operation["requestHeaders"].each do |hash|
-          headers[hash["name"]] = hash["value"]
-        end
-
-        Faraday.put(
-          upload_operation["url"],
-          payload,
-          headers
-        )
+        upload_operations = post_resp.upload_operations
+        Spaceship::ConnectAPI::FileUploader.upload(upload_operations, bytes)
 
         patch_attributes = {
           uploaded: true,
-          sourceFileChecksum: "checksum-holder"
+          sourceFileChecksum: Digest::MD5.hexdigest(bytes)
         }
 
-        Spaceship::ConnectAPI.patch_app_review_attachment(app_review_attachment_id: post_resp.id, attributes: patch_attributes).to_models.first
+        Spaceship::ConnectAPI.patch_app_review_attachment(
+          app_review_attachment_id: post_resp.id,
+          attributes: patch_attributes
+        ).to_models.first
       end
 
       def delete!(filter: {}, includes: nil, limit: nil, sort: nil)

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
@@ -48,14 +48,17 @@ module Spaceship
           fileName: filename
         }
 
+        # Create placeholder
         post_resp = Spaceship::ConnectAPI.post_app_screenshot(
           app_screenshot_set_id: app_screenshot_set_id,
           attributes: post_attributes
         ).to_models.first
 
+        # Upload the file
         upload_operations = post_resp.upload_operations
         Spaceship::ConnectAPI::FileUploader.upload(upload_operations, bytes)
 
+        # Update file uploading complete
         patch_attributes = {
           uploaded: true,
           sourceFileChecksum: Digest::MD5.hexdigest(bytes)

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
@@ -1,6 +1,8 @@
 require_relative '../model'
 require_relative '../file_uploader'
 
+require 'digest/md5'
+
 module Spaceship
   class ConnectAPI
     class AppScreenshot
@@ -14,36 +16,6 @@ module Spaceship
       attr_accessor :upload_operations
       attr_accessor :asset_delivery_state
       attr_accessor :uploaded
-
-      # "fileSize": 92542,
-      #   "fileName": "ftl_3241d62418767c0aa9b889b020c4f8db_45455763d4aaf7b18ee0045bc787f3de.png",
-      #   "sourceFileChecksum": "c237fd7852ed8f9285d16d9a28d2ec25",
-      #   "imageAsset": {
-      #     "templateUrl": "https://is4-ssl.mzstatic.com/image/thumb/Purple113/v4/61/18/68/61186886-b234-5bd0-1f4a-563124f18511/pr_source.png/{w}x{h}bb.{f}",
-      #     "width": 2048,
-      #     "height": 2732
-      #   },
-      #   "assetToken": "Purple113/v4/61/18/68/61186886-b234-5bd0-1f4a-563124f18511/pr_source.png",
-      #   "assetType": "SortedJ99ScreenShot",
-      #   "uploadOperations": null,
-      #   "assetDeliveryState": {
-      #     "errors": [],
-      #     "warnings": null,
-      #     "state": "COMPLETE"
-      #   },
-      #   "uploaded": null
-
-      # "assetDeliveryState": {
-      #   "errors": [],
-      #   "warnings": null,
-      #   "state": "AWAITING_UPLOAD"
-      # },
-
-      # "assetDeliveryState": {
-      #   "errors": [],
-      #   "warnings": null,
-      #   "state": "UPLOAD_COMPLETE"
-      # },
 
       attr_mapping({
         "fileName" => "file_name",
@@ -69,24 +41,30 @@ module Spaceship
 
         filename = File.basename(path)
         filesize = File.size(path)
-        payload = File.binread(path)
+        bytes = File.binread(path)
 
         post_attributes = {
           fileSize: filesize,
           fileName: filename
         }
 
-        post_resp = Spaceship::ConnectAPI.post_app_screenshot(app_screenshot_set_id: app_screenshot_set_id, attributes: post_attributes).to_models.first
+        post_resp = Spaceship::ConnectAPI.post_app_screenshot(
+          app_screenshot_set_id: app_screenshot_set_id,
+          attributes: post_attributes
+        ).to_models.first
 
-        upload_operation = post_resp.upload_operations.first
-        Spaceship::ConnectAPI::FileUploader.upload(upload_operation, payload)
+        upload_operations = post_resp.upload_operations
+        Spaceship::ConnectAPI::FileUploader.upload(upload_operations, bytes)
 
         patch_attributes = {
           uploaded: true,
-          sourceFileChecksum: "checksum-holder"
+          sourceFileChecksum: Digest::MD5.hexdigest(bytes)
         }
 
-        Spaceship::ConnectAPI.patch_app_screenshot(app_screenshot_id: post_resp.id, attributes: patch_attributes).to_models.first
+        Spaceship::ConnectAPI.patch_app_screenshot(
+          app_screenshot_id: post_resp.id,
+          attributes: patch_attributes
+        ).to_models.first
       end
 
       def delete!(filter: {}, includes: nil, limit: nil, sort: nil)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -188,6 +188,11 @@ module Spaceship
       # appPreview
       #
 
+      def get_app_preview(app_preview_id: nil)
+        params = Client.instance.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
+        Client.instance.get("appPreviews/#{app_preview_id}", params)
+      end
+
       def post_app_preview(app_preview_set_id: nil, attributes: {})
         body = {
           data: {

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -343,6 +343,11 @@ module Spaceship
       # appScreenshots
       #
 
+      def get_app_screenshot(app_screenshot_id: nil)
+        params = Client.instance.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
+        Client.instance.get("appScreenshots/#{app_screenshot_id}", params)
+      end
+
       def post_app_screenshot(app_screenshot_set_id: nil, attributes: {})
         body = {
           data: {


### PR DESCRIPTION
### Motivation and Context
Fixes https://github.com/fastlane/fastlane/pull/16640#issuecomment-649762454

### Description
- Poll app preview to set frame (will only poll for app preview completion if frame time set)
- Retry failed file uploader
- Handle multi part file uploader
- Use file uploader on review attachment

#### Output if `--verbose` is used

```
Uploading app preview file (part 1)...
Uploading app preview file (part 2)...
Uploading app preview file (part 3)...
Uploading app preview file (part 4)...
Uploading app preview file (part 5)...
Uploading app preview complete!
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Waiting 30 seconds before checking status of processing...
Preview processing complete!
Updated preview frame time code!
```