### PR TITLE
[fastlane] Fix S3ClientHelper side effects

### DIFF
--- a/fastlane/lib/fastlane/helper/s3_client_helper.rb
+++ b/fastlane/lib/fastlane/helper/s3_client_helper.rb
@@ -3,7 +3,6 @@ require 'aws-sdk-s3'
 module Fastlane
   module Helper
     class S3ClientHelper
-
       attr_reader :region
 
       def initialize(region: ENV['AWS_REGION'])
@@ -53,7 +52,6 @@ module Fastlane
       def client
         @client ||= Aws::S3::Client.new(region: region)
       end
-
     end
   end
 end

--- a/fastlane/lib/fastlane/helper/s3_client_helper.rb
+++ b/fastlane/lib/fastlane/helper/s3_client_helper.rb
@@ -5,8 +5,9 @@ module Fastlane
     class S3ClientHelper
       attr_reader :region
 
-      def initialize(region: ENV['AWS_REGION'])
+      def initialize(region: ENV['AWS_REGION'], s3_client: nil)
         @region = region
+        @client = s3_client
       end
 
       def list_buckets

--- a/fastlane/lib/fastlane/helper/s3_client_helper.rb
+++ b/fastlane/lib/fastlane/helper/s3_client_helper.rb
@@ -54,6 +54,8 @@ module Fastlane
 
       private
 
+      attr_reader :secret_access_key
+
       def client
         @client ||= Aws::S3::Client.new(
           {
@@ -64,11 +66,11 @@ module Fastlane
       end
 
       def create_credentials
-        return nil if access_key.nil? || @secret_access_key.nil?
+        return nil if access_key.nil? || secret_access_key.nil?
 
         Aws::Credentials.new(
           access_key,
-          @secret_access_key
+          secret_access_key
         )
       end
     end

--- a/fastlane/lib/fastlane/helper/s3_client_helper.rb
+++ b/fastlane/lib/fastlane/helper/s3_client_helper.rb
@@ -3,10 +3,14 @@ require 'aws-sdk-s3'
 module Fastlane
   module Helper
     class S3ClientHelper
+      attr_reader :access_key
       attr_reader :region
 
-      def initialize(region: ENV['AWS_REGION'], s3_client: nil)
+      def initialize(access_key: nil, secret_access_key: nil, region: nil, s3_client: nil)
+        @access_key = access_key
+        @secret_access_key = secret_access_key
         @region = region
+
         @client = s3_client
       end
 
@@ -51,7 +55,21 @@ module Fastlane
       private
 
       def client
-        @client ||= Aws::S3::Client.new(region: region)
+        @client ||= Aws::S3::Client.new(
+          {
+            region: region,
+            credentials: create_credentials
+          }.compact
+        )
+      end
+
+      def create_credentials
+        return nil if access_key.nil? || @secret_access_key.nil?
+
+        Aws::Credentials.new(
+          access_key,
+          @secret_access_key
+        )
       end
     end
   end

--- a/fastlane/lib/fastlane/helper/s3_client_helper.rb
+++ b/fastlane/lib/fastlane/helper/s3_client_helper.rb
@@ -3,14 +3,11 @@ require 'aws-sdk-s3'
 module Fastlane
   module Helper
     class S3ClientHelper
-      attr_reader :client
 
-      def initialize(access_key: nil, secret_access_key: nil, region: nil)
-        creds = Aws::Credentials.new(access_key, secret_access_key)
-        Aws.config.update(
-          region: region,
-          credentials: creds
-        )
+      attr_reader :region
+
+      def initialize(region: ENV['AWS_REGION'])
+        @region = region
       end
 
       def list_buckets
@@ -50,12 +47,13 @@ module Fastlane
 
         return bucket
       end
-    end
 
-    private
+      private
 
-    def client
-      @client ||= Aws::S3::Client.new
+      def client
+        @client ||= Aws::S3::Client.new(region: region)
+      end
+
     end
   end
 end

--- a/fastlane/spec/helper/s3_client_helper_spec.rb
+++ b/fastlane/spec/helper/s3_client_helper_spec.rb
@@ -1,5 +1,5 @@
 describe Fastlane::Helper::S3ClientHelper do
-  subject { described_class.new }
+  subject { described_class.new(s3_client: instance_double('Aws::S3::Client')) }
 
   describe '#find_bucket!' do
     before { class_double('Aws::S3::Bucket', new: bucket).as_stubbed_const }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When testing the changes in https://github.com/fastlane/fastlane/pull/16682 I found that my authentication was not working because the S3ClientHelper was overwriting the Aws config I expected. This change will remove that side-effect and allow the caller to dictate what AWS credentials should be used.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Updates the S3ClientHelper to remove the access_key/secret initializer parameters. Removes the call to `Aws.config.update`. Instead, passes the remaining `region` parameter to the S3 client when initializing that.

Also cleans up some confusing code in the file. The `client` method was defined as private outside of the S3ClientHelper class. The S3ClientHelper then had a public `attr_reader :client` that allowed the underlying client to leak out. This has been updated such that there is a private `client` method that is not accessible outside the helper class as I believe the intention is to always use the interface defined by the helper.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Updated the necessary call sites in match's S3Storage and specs. Specs for the S3ClientHelper continue to pass.
