### PR TITLE
[spaceship][fastlane_core] run iTMSTransporter with `xcrun` if Xcode 11 or up

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -239,64 +239,101 @@ module FastlaneCore
   # escaping problems in its accompanying shell script.
   class JavaTransporterExecutor < TransporterExecutor
     def build_upload_command(username, password, source = "/tmp", provider_short_name = "")
-      [
-        Helper.transporter_java_executable_path.shellescape,
-        "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
-        '-XX:NewSize=2m',
-        '-Xms32m',
-        '-Xmx1024m',
-        '-Xms1024m',
-        '-Djava.awt.headless=true',
-        '-Dsun.net.http.retryPost=false',
-        java_code_option,
-        '-m upload',
-        "-u #{username.shellescape}",
-        "-p #{password.shellescape}",
-        "-f #{source.shellescape}",
-        additional_upload_parameters, # that's here, because the user might overwrite the -t option
-        '-k 100000',
-        ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?),
-        '2>&1' # cause stderr to be written to stdout
-      ].compact.join(' ') # compact gets rid of the possibly nil ENV value
+      if Helper.mac? && Helper.xcode_at_least?(11)
+        [
+          'xcrun iTMSTransporter',
+          '-m upload',
+          "-u #{username.shellescape}",
+          "-p #{password.shellescape}",
+          "-f #{source.shellescape}",
+          additional_upload_parameters, # that's here, because the user might overwrite the -t option
+          '-k 100000',
+          ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?),
+          '2>&1' # cause stderr to be written to stdout
+        ].compact.join(' ') # compact gets rid of the possibly nil ENV value
+      else
+        [
+          Helper.transporter_java_executable_path.shellescape,
+          "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
+          '-XX:NewSize=2m',
+          '-Xms32m',
+          '-Xmx1024m',
+          '-Xms1024m',
+          '-Djava.awt.headless=true',
+          '-Dsun.net.http.retryPost=false',
+          java_code_option,
+          '-m upload',
+          "-u #{username.shellescape}",
+          "-p #{password.shellescape}",
+          "-f #{source.shellescape}",
+          additional_upload_parameters, # that's here, because the user might overwrite the -t option
+          '-k 100000',
+          ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?),
+          '2>&1' # cause stderr to be written to stdout
+        ].compact.join(' ') # compact gets rid of the possibly nil ENV value
+      end
     end
 
     def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "")
-      [
-        Helper.transporter_java_executable_path.shellescape,
-        "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
-        '-XX:NewSize=2m',
-        '-Xms32m',
-        '-Xmx1024m',
-        '-Xms1024m',
-        '-Djava.awt.headless=true',
-        '-Dsun.net.http.retryPost=false',
-        java_code_option,
-        '-m lookupMetadata',
-        "-u #{username.shellescape}",
-        "-p #{password.shellescape}",
-        "-apple_id #{apple_id.shellescape}",
-        "-destination #{destination.shellescape}",
-        ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?),
-        '2>&1' # cause stderr to be written to stdout
-      ].compact.join(' ')
+      if Helper.mac? && Helper.xcode_at_least?(11)
+        [
+          'xcrun iTMSTransporter',
+          '-m lookupMetadata',
+          "-u #{username.shellescape}",
+          "-p #{password.shellescape}",
+          "-apple_id #{apple_id.shellescape}",
+          "-destination #{destination.shellescape}",
+          ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?),
+          '2>&1' # cause stderr to be written to stdout
+        ].compact.join(' ')
+      else
+        [
+          Helper.transporter_java_executable_path.shellescape,
+          "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
+          '-XX:NewSize=2m',
+          '-Xms32m',
+          '-Xmx1024m',
+          '-Xms1024m',
+          '-Djava.awt.headless=true',
+          '-Dsun.net.http.retryPost=false',
+          java_code_option,
+          '-m lookupMetadata',
+          "-u #{username.shellescape}",
+          "-p #{password.shellescape}",
+          "-apple_id #{apple_id.shellescape}",
+          "-destination #{destination.shellescape}",
+          ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?),
+          '2>&1' # cause stderr to be written to stdout
+        ].compact.join(' ')
+      end
     end
 
     def build_provider_ids_command(username, password)
-      [
-        Helper.transporter_java_executable_path.shellescape,
-        "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
-        '-XX:NewSize=2m',
-        '-Xms32m',
-        '-Xmx1024m',
-        '-Xms1024m',
-        '-Djava.awt.headless=true',
-        '-Dsun.net.http.retryPost=false',
-        java_code_option,
-        '-m provider',
-        "-u #{username.shellescape}",
-        "-p #{password.shellescape}",
-        '2>&1' # cause stderr to be written to stdout
-      ].compact.join(' ')
+      if Helper.mac? && Helper.xcode_at_least?(11)
+        [
+          'xcrun iTMSTransporter',
+          '-m provider',
+          "-u #{username.shellescape}",
+          "-p #{password.shellescape}",
+          '2>&1' # cause stderr to be written to stdout
+        ].compact.join(' ')
+      else
+        [
+          Helper.transporter_java_executable_path.shellescape,
+          "-Djava.ext.dirs=#{Helper.transporter_java_ext_dir.shellescape}",
+          '-XX:NewSize=2m',
+          '-Xms32m',
+          '-Xmx1024m',
+          '-Xms1024m',
+          '-Djava.awt.headless=true',
+          '-Dsun.net.http.retryPost=false',
+          java_code_option,
+          '-m provider',
+          "-u #{username.shellescape}",
+          "-p #{password.shellescape}",
+          '2>&1' # cause stderr to be written to stdout
+        ].compact.join(' ')
+      end
     end
 
     def java_code_option

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -83,7 +83,8 @@ module Spaceship
           Spaceship::ConnectAPI::AppInfo::AppStoreState::DEVELOPER_REJECTED,
           Spaceship::ConnectAPI::AppInfo::AppStoreState::REJECTED,
           Spaceship::ConnectAPI::AppInfo::AppStoreState::METADATA_REJECTED,
-          Spaceship::ConnectAPI::AppInfo::AppStoreState::WAITING_FOR_REVIEW
+          Spaceship::ConnectAPI::AppInfo::AppStoreState::WAITING_FOR_REVIEW,
+          Spaceship::ConnectAPI::AppInfo::AppStoreState::INVALID_BINARY
         ]
 
         resp = Spaceship::ConnectAPI.get_app_infos(app_id: id)
@@ -146,7 +147,8 @@ module Spaceship
             Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::DEVELOPER_REJECTED,
             Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::REJECTED,
             Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::METADATA_REJECTED,
-            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::WAITING_FOR_REVIEW
+            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::WAITING_FOR_REVIEW,
+            Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::INVALID_BINARY
           ].join(","),
           platform: platform
         }

--- a/spaceship/lib/spaceship/connect_api/models/app_info.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_info.rb
@@ -16,6 +16,7 @@ module Spaceship
         REJECTED = "REJECTED"
         PREPARE_FOR_SUBMISSION = "PREPARE_FOR_SUBMISSION"
         METADATA_REJECTED = "METADATA_REJECTED"
+        INVALID_BINARY = "INVALID_BINARY"
       end
 
       module AppStoreAgeRating

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -26,6 +26,7 @@ module Spaceship
         REJECTED = "REJECTED"
         PREPARE_FOR_SUBMISSION = "PREPARE_FOR_SUBMISSION"
         METADATA_REJECTED = "METADATA_REJECTED"
+        INVALID_BINARY = "INVALID_BINARY"
       end
 
       module ReleaseType


### PR DESCRIPTION
# Motivation and Context
Fixes https://github.com/fastlane/fastlane/issues/15323

- Started receiving error of `Transporter error: Could not create the Java Virtual Machine`

### Description
- use `xcrun iTMSTransporter` if Xcode 11 or up
- fixes issues that if not using correct version of Java which `iTMSTransporter` needs (I think)
  - `xcrun` is in charge of the environment
