### PR TITLE
[Fastlane.swift] Fix function hanging with error from command

### DIFF
--- a/fastlane/swift/SocketClient.swift
+++ b/fastlane/swift/SocketClient.swift
@@ -118,6 +118,7 @@ class SocketClient: NSObject {
     public func send(rubyCommand: RubyCommandable) {
         verbose(message: "sending: \(rubyCommand.json)")
         send(string: rubyCommand.json)
+        writeSemaphore.signal()
     }
     
     public func sendComplete() {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
As raised in #16677 the new version of Fastlane.swift hang when certain error clauses converged at the same time between the Ruby and the Swift part. This PR aims to address it.
