### PR TITLE
[produce][spaceship] add users to app when created

### DIFF
--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -43,7 +43,8 @@ module Produce
           sku: Produce.config[:sku].to_s,
           primary_locale: language,
           bundle_id: app_identifier,
-          platforms: platforms
+          platforms: platforms,
+          company_name: Produce.config[:company_name]
         )
 
         application = fetch_application

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -54,14 +54,15 @@ module Spaceship
         end
       end
 
-      def self.create(name: nil, version_string: nil, sku: nil, primary_locale: nil, bundle_id: nil, platforms: nil)
+      def self.create(name: nil, version_string: nil, sku: nil, primary_locale: nil, bundle_id: nil, platforms: nil, company_name: nil)
         Spaceship::ConnectAPI.post_app(
           name: name,
           version_string: version_string,
           sku: sku,
           primary_locale: primary_locale,
           bundle_id: bundle_id,
-          platforms: platforms
+          platforms: platforms,
+          company_name: company_name
         )
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -231,6 +231,16 @@ module Spaceship
         ).all_pages
         return resps.flat_map(&:to_models).first
       end
+
+      #
+      # Users
+      #
+
+      def add_users(user_ids: nil)
+        user_ids.each do |user_id|
+          Spaceship::ConnectAPI.add_user_visible_apps(user_id: user_id, app_ids: [id])
+        end
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/user.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user.rb
@@ -39,7 +39,8 @@ module Spaceship
       #
 
       def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
-        return Spaceship::ConnectAPI.get_users(filter: filter, includes: includes)
+        resps = Spaceship::ConnectAPI.get_users(filter: filter, includes: includes).all_pages
+        return resps.flat_map(&:to_models)
       end
 
       def self.find(email: nil, includes: nil)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -28,7 +28,7 @@ module Spaceship
       # app
       #
 
-      def post_app(name: nil, version_string: nil, sku: nil, primary_locale: nil, bundle_id: nil, platforms: nil)
+      def post_app(name: nil, version_string: nil, sku: nil, primary_locale: nil, bundle_id: nil, platforms: nil, company_name: nil)
         included = []
         included << {
           type: "appInfos",
@@ -103,14 +103,17 @@ module Spaceship
           }
         }
 
+        app_attributes = {
+          sku: sku,
+          primaryLocale: primary_locale,
+          bundleId: bundle_id
+        }
+        app_attributes[:companyName] = company_name if company_name
+
         body = {
           data: {
             type: "apps",
-            attributes: {
-              sku: sku,
-              primaryLocale: primary_locale,
-              bundleId: bundle_id
-            },
+            attributes: app_attributes,
             relationships: relationships
           },
           included: included

--- a/spaceship/lib/spaceship/connect_api/users/users.rb
+++ b/spaceship/lib/spaceship/connect_api/users/users.rb
@@ -11,6 +11,19 @@ module Spaceship
         params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
         Client.instance.get("users", params)
       end
+
+      def add_user_visible_apps(user_id: nil, app_ids: nil)
+        body = {
+          data: app_ids.map do |app_id|
+            {
+              type: "apps",
+              id: app_id
+            }
+          end
+        }
+
+        Client.instance.post("users/#{user_id}/relationships/visibleApps", body)
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
Adds back in ability to add users to app created with produce with `:itc_users`

### Testing Steps
```sh
fastlane produce create -u "me@joshholtz.com" -l "Josh Holtz" -p "Josh Holtz" -a "com.joshholtz.wwdc20.test11" -q "Josh WWDC20 Test 11" -y "JOSH_WWDC20_TEST_11" -J "ios" -m "English"
```
