### PR TITLE
[spaceship] Remove multi_xml dependency

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -83,7 +83,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('highline', '>= 1.7.2', '< 2.0.0') # user inputs (e.g. passwords)
   spec.add_dependency('json', '< 3.0.0') # Because sometimes it's just not installed
   spec.add_dependency('mini_magick', '>= 4.9.4', '< 5.0.0') # To open, edit and export PSD files
-  spec.add_dependency('multi_xml', '~> 0.5')
   spec.add_dependency('rubyzip', '>= 2.0.0', '< 3.0.0') # fix swift/ipa in gym
   spec.add_dependency('security', '= 0.1.3') # macOS Keychain manager, a dead project, no updates expected
   spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3')

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -205,7 +205,6 @@ module Spaceship
       @cookie = cookie || HTTP::CookieJar.new
       @client = Faraday.new(self.class.hostname, options) do |c|
         c.response(:json, content_type: /\bjson$/)
-        c.response(:xml, content_type: /\bxml$/)
         c.response(:plist, content_type: /\bplist$/)
         c.use(:cookie_jar, jar: @cookie)
         c.use(FaradayMiddleware::RelsMiddleware)

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -28,7 +28,6 @@ module Spaceship
 
           @client = Faraday.new(hostname, options) do |c|
             c.response(:json, content_type: /\bjson$/)
-            c.response(:xml, content_type: /\bxml$/)
             c.response(:plist, content_type: /\bplist$/)
             c.use(FaradayMiddleware::RelsMiddleware)
             c.adapter(Faraday.default_adapter)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I believe `multi_xml` is not needed. This PR is what #16664 should have been. Thanks to the feedback by @janpio I took another look.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This was an optional dependency for `faraday_middleware` when parsing XML responses. As far as I can tell, and from what is being tested with [fixtures](https://github.com/fastlane/fastlane/tree/master/spaceship/spec/portal/fixtures), that used to be the case but is not any longer, using the App Store Connect API.

There is a custom plist middleware, but that one is in fastlane itself and does not make use of `multi_xml`. I believe it's used by `#provisioning_profiles_via_xcode_api`.

https://github.com/fastlane/fastlane/blob/2.150.0.rc4/spaceship/lib/spaceship/portal/portal_client.rb#L653-L674
https://github.com/fastlane/fastlane/blob/2.150.0.rc4/spaceship/lib/spaceship/helper/plist_middleware.rb

The client was introduced in https://github.com/fastlane/fastlane/pull/14888.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Ran the tests, worked. :)
