### PR TITLE
[action] add synchronous option to pod_push

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -51,6 +51,10 @@ module Fastlane
           command << "--use-modular-headers"
         end
 
+        if params[:synchronous]
+          command << "--synchronous"
+        end
+
         result = Actions.sh(command.join(' '))
         UI.success("Successfully pushed Podspec ⬆️ ")
         return result
@@ -127,7 +131,12 @@ module Fastlane
                                        description: "Use modular headers option during validation",
                                        optional: true,
                                        type: Boolean,
-                                       env_name: "FL_POD_PUSH_USE_MODULAR_HEADERS")
+                                       env_name: "FL_POD_PUSH_USE_MODULAR_HEADERS"),
+          FastlaneCore::ConfigItem.new(key: :synchronous,
+                                       description: "If validation depends on other recently pushed pods, synchronize",
+                                       optional: true,
+                                       type: Boolean,
+                                       env_name: "FL_POD_PUSH_SYNCHRONOUS")
         ]
       end
 

--- a/fastlane/spec/actions_specs/pod_push_spec.rb
+++ b/fastlane/spec/actions_specs/pod_push_spec.rb
@@ -91,6 +91,14 @@ describe Fastlane do
           end
         end
       end
+
+      it "generates the correct pod push command with the synchronous parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_push(synchronous: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod trunk push --synchronous")
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Updating the pod_push action with a recently-added option. 
--synchronous assists developers when deploying multiple interdependent pods to Trunk
CocoaPods PR for context: https://github.com/CocoaPods/cocoapods-trunk/pull/147

### Description
<!-- Describe your changes in detail. -->
Added code to append the option when `synchronous: true` is passed as a param to the `pod_push` action.
Augmented the `available_options` array for the action with the requisite details about the param.

<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
Added a test for this option to pod_push_spec.rb
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
