### PR TITLE
[deliver] updated docs on how to use submission and fix for submission information when using CLI

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -59,6 +59,8 @@ module Deliver
 
     def update_export_compliance(options, app, build)
       submission_information = options[:submission_information] || {}
+      submission_information = submission_information.collect { |k, v| [k.to_sym, v] }.to_h
+
       uses_encryption = submission_information[:export_compliance_uses_encryption]
 
       if build.uses_non_exempt_encryption.nil?
@@ -70,6 +72,8 @@ module Deliver
             "Add information to the :submission_information option...",
             "  Docs: http://docs.fastlane.tools/actions/deliver/#compliance-and-idfa-settings",
             "  Example: submission_information: { export_compliance_uses_encryption: false }",
+            "  Example CLI:",
+            "    --submission_information \"{\\\"export_compliance_uses_encryption\\\": false}\"",
             "This can also be set in your Info.plist with key 'ITSAppUsesNonExemptEncryption'"
           ].join("\n")
           UI.user_error!(message)
@@ -85,6 +89,8 @@ module Deliver
 
     def update_idfa(options, app, version)
       submission_information = options[:submission_information] || {}
+      submission_information = submission_information.collect { |k, v| [k.to_sym, v] }.to_h
+
       uses_idfa = submission_information[:add_id_info_uses_idfa]
 
       idfa_declaration = begin
@@ -115,7 +121,9 @@ module Deliver
           "    add_id_info_serves_ads: false,",
           "    add_id_info_uses_idfa: false,",
           "    add_id_info_tracks_install: false",
-          "  }"
+          "  }",
+          "  Example CLI:",
+          "    --submission_information \"{\\\"add_id_info_uses_idfa\\\": false}\""
         ].join("\n")
         UI.user_error!(message)
       end
@@ -151,6 +159,7 @@ module Deliver
 
     def update_submission_information(options, app)
       submission_information = options[:submission_information] || {}
+      submission_information = submission_information.collect { |k, v| [k.to_sym, v] }.to_h
 
       content_rights = submission_information[:content_rights_contains_third_party_content]
 

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -435,6 +435,10 @@ Omit `build_number` to let _fastlane_ automatically select the latest build numb
 
 Use the `submission_information` parameter for additional submission specifiers, including compliance and IDFA settings. Look at the Spaceship's [`app_submission.rb`](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/tunes/app_submission.rb) file for options. See [this example](https://github.com/artsy/eigen/blob/faa02e2746194d8d7c11899474de9c517435eca4/fastlane/Fastfile#L131-L149).
 
+```no-highlight
+fastlane deliver submit_build --build_number 830 --submission_information "{\"export_compliance_uses_encryption\": false, \"add_id_info_uses_idfa\": false }"
+```
+
 # Credentials
 
 A detailed description about how your credentials are handled is available in a [credentials_manager](https://github.com/fastlane/fastlane/tree/master/credentials_manager).


### PR DESCRIPTION
### Motivation and Context
Fixes #16701
Fixes #16674

### Description
- Looks for keys as string or symbol in `submission_information` hash
- Adds information on how to use submission information on CLI
  - When info is needed when when running deliver
  - Also added to the docs

### Testing Steps

Add to `Gemfile` and run `bundle update fastlane`

```rb

gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-2.150.0-deliver-submission-information-improvements"

```
