### PR TITLE
[deliver][spaceship] wait for screenshots to be completed after processing and download properly formatted screenshots and error on processing error

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -166,7 +166,9 @@ module Deliver
           else
             indized[localization.locale][set.screenshot_display_type][:count] += 1
             UI.message("Uploading '#{screenshot.path}'...")
-            set.upload_screenshot(path: screenshot.path)
+
+            wait_for_processing = !FastlaneCore::Env.truthy?("DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING")
+            set.upload_screenshot(path: screenshot.path, wait_for_processing: wait_for_processing)
           end
         end
       end

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
@@ -39,7 +39,23 @@ module Spaceship
         APP_WATCH_SERIES_3 = "APP_WATCH_SERIES_3"
         APP_WATCH_SERIES_4 = "APP_WATCH_SERIES_4"
 
+        APP_APPLE_TV = "APP_APPLE_TV"
+
         APP_DESKTOP = "APP_DESKTOP"
+
+        ALL_IMESSAGE = [
+          IMESSAGE_APP_IPHONE_40,
+          IMESSAGE_APP_IPHONE_47,
+          IMESSAGE_APP_IPHONE_55,
+          IMESSAGE_APP_IPHONE_58,
+          IMESSAGE_APP_IPHONE_65,
+
+          IMESSAGE_APP_IPAD_97,
+          IMESSAGE_APP_IPAD_105,
+          IMESSAGE_APP_IPAD_PRO_129,
+          IMESSAGE_APP_IPAD_PRO_3GEN_11,
+          IMESSAGE_APP_IPAD_PRO_3GEN_129
+        ]
 
         ALL = [
           APP_IPHONE_35,
@@ -84,6 +100,14 @@ module Spaceship
         return "appScreenshotSets"
       end
 
+      def apple_tv?
+        DisplayType::APP_APPLE_TV == screenshot_display_type
+      end
+
+      def imessage?
+        DisplayType::ALL_IMESSAGE.include?(screenshot_display_type)
+      end
+
       #
       # API
       #
@@ -93,8 +117,8 @@ module Spaceship
         return resp.to_models
       end
 
-      def upload_screenshot(path: nil)
-        return Spaceship::ConnectAPI::AppScreenshot.create(app_screenshot_set_id: id, path: path)
+      def upload_screenshot(path: nil, wait_for_processing: true)
+        return Spaceship::ConnectAPI::AppScreenshot.create(app_screenshot_set_id: id, path: path, wait_for_processing: wait_for_processing)
       end
     end
   end


### PR DESCRIPTION
### Motivation and Context
Fixes https://github.com/fastlane/fastlane/issues/16639#issuecomment-651824456
Fixes issue @changusmc was seeing with download screenshots

### Description
- `deliver` - waits for screenshots to finish processing before moving on
  - can be skipped with `DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING=1`
- `deliver` fails when error during screenshot processing
  - like wrong image type or colorspace or something
- `deliver` download screenshots now uses new API and downloads PNG
  - but doesn't download source(uploaded) image because we don't have that ability
  - opened radar for it - https://openradar.appspot.com/radar?id=4980344105205760
