### PR TITLE
[deliver][spaceship] choose highest edit version, retry on 500, submit without app version

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -96,6 +96,12 @@ module Deliver
     end
 
     def upload_screenshots(screenshots_per_language, localizations)
+      # Check if should wait for processing
+      wait_for_processing = !FastlaneCore::Env.truthy?("DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING")
+      if wait_for_processing
+        UI.important("Set environment variable DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING=true to skip waiting for screenshots to process")
+      end
+
       # Upload screenshots
       indized = {} # per language and device type
 
@@ -166,8 +172,6 @@ module Deliver
           else
             indized[localization.locale][set.screenshot_display_type][:count] += 1
             UI.message("Uploading '#{screenshot.path}'...")
-
-            wait_for_processing = !FastlaneCore::Env.truthy?("DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING")
             set.upload_screenshot(path: screenshot.path, wait_for_processing: wait_for_processing)
           end
         end

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -6,7 +6,7 @@ module FastlaneCore
   class BuildWatcher
     class << self
       # @return The build we waited for. This method will always return a build
-      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, app_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false, return_when_build_appears: false, return_spaceship_testflight_build: true)
+      def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, app_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false, return_when_build_appears: false, return_spaceship_testflight_build: true, select_latest: false)
         # Warn about train_version being removed in the future
         if train_version
           UI.deprecated(":train_version is no longer a used argument on FastlaneCore::BuildWatcher. Please use :app_version instead.")
@@ -23,7 +23,7 @@ module FastlaneCore
 
         showed_info = false
         loop do
-          matched_build = matching_build(watched_app_version: app_version, watched_build_version: build_version, app_id: app_id, platform: platform)
+          matched_build = matching_build(watched_app_version: app_version, watched_build_version: build_version, app_id: app_id, platform: platform, select_latest: select_latest)
 
           if matched_build.nil? && !showed_info
             UI.important("Read more information on why this build isn't showing up yet - https://github.com/fastlane/fastlane/issues/14997")
@@ -55,7 +55,7 @@ module FastlaneCore
         return version.instance_of?(String) ? version.split('.').map { |s| s.to_i.to_s }.join('.') : version
       end
 
-      def matching_build(watched_app_version: nil, watched_build_version: nil, app_id: nil, platform: nil)
+      def matching_build(watched_app_version: nil, watched_build_version: nil, app_id: nil, platform: nil, select_latest: false)
         # Get build deliveries (newly uploaded processing builds)
         watched_app_version = remove_version_leading_zeros(version: watched_app_version)
         watched_build_version = remove_version_leading_zeros(version: watched_build_version)
@@ -69,7 +69,7 @@ module FastlaneCore
 
         # Raise error if more than 1 build is returned
         # This should never happen but need to inform the user if it does
-        if matched_builds.size > 1
+        if matched_builds.size > 1 && !select_latest
           error_builds = matched_builds.map do |build|
             "#{build.app_version}(#{build.version}) for #{build.platform} - #{build.processing_state}"
           end.join("\n")

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -133,7 +133,7 @@ module Spaceship
         tries -= 1
         status = response.status if response
 
-        if [504].include?(status)
+        if [500, 504].include?(status)
           msg = "Timeout received! Retrying after 3 seconds (remaining: #{tries})..."
           raise msg
         end

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -154,7 +154,11 @@ module Spaceship
           ].join(","),
           platform: platform
         }
-        return get_app_store_versions(filter: filter, includes: includes).first
+
+        # Get the latest version
+        return get_app_store_versions(filter: filter, includes: includes)
+               .sort_by { |v| Gem::Version.new(v.version_string) }
+               .last
       end
 
       def get_app_store_versions(filter: {}, includes: nil, limit: nil, sort: nil)


### PR DESCRIPTION
### Motivation and Context
- Fixes #16665
- Fixes #16700
- Fixes #16663

### Description
- `get_edit_app_store_version ` just grabbed the first one version
  - now it will grab the highest version
- `Spaceship::ConnectAPI` will also retry on 500
- `deliver` will look for latest edit version and submit that if no app version or build version is passed
