### PR TITLE
[spaceship] reorder app screenshots in AppScreenshotSet

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
@@ -120,6 +120,12 @@ module Spaceship
       def upload_screenshot(path: nil, wait_for_processing: true)
         return Spaceship::ConnectAPI::AppScreenshot.create(app_screenshot_set_id: id, path: path, wait_for_processing: wait_for_processing)
       end
+
+      def reorder_screenshots(app_screenshot_ids: nil)
+        Spaceship::ConnectAPI.patch_app_screenshot_set_screenshots(app_screenshot_set_id: id, app_screenshot_ids: app_screenshot_ids)
+
+        return Spaceship::ConnectAPI.get_app_screenshot_set(app_screenshot_set_id: id, includes: "appScreenshots").first
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -323,6 +323,11 @@ module Spaceship
         Client.instance.get("appScreenshotSets", params)
       end
 
+      def get_app_screenshot_set(app_screenshot_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+        params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+        Client.instance.get("appScreenshotSets/#{app_screenshot_set_id}", params)
+      end
+
       def post_app_screenshot_set(app_store_version_localization_id: nil, attributes: {})
         body = {
           data: {
@@ -340,6 +345,21 @@ module Spaceship
         }
 
         Client.instance.post("appScreenshotSets", body)
+      end
+
+      def patch_app_screenshot_set_screenshots(app_screenshot_set_id: nil, app_screenshot_ids: nil)
+        app_screenshot_ids ||= []
+
+        body = {
+          data: app_screenshot_ids.map do |app_screenshot_id|
+            {
+              type: "appScreenshots",
+              id: app_screenshot_id
+            }
+          end
+        }
+
+        Client.instance.patch("appScreenshotSets/#{app_screenshot_set_id}/relationships/appScreenshots", body)
       end
 
       #


### PR DESCRIPTION
### Motivation and Context
Fixes https://github.com/fastlane/fastlane/issues/16708

### Description
- Added `reorder_screenshots(app_screenshot_ids: ids)` to `Spaceship::ConnectAPI::AppScreenshotSet`

### Testing Steps

```rb
lane :reorder_screenshots do
  require 'spaceship'

  # Login
  Spaceship::Tunes.login("email@email.com")
  Spaceship::Tunes.select_team(team_name: "Team Name")

  # Get app
  app = Spaceship::ConnectAPI::App.find("com.bundle.id")

  # Get screenshot sets
  versions = app.get_edit_app_store_version(platform: Spaceship::ConnectAPI::Platform::IOS)
  localizations = versions.get_app_store_version_localizations

  screenshot_sets = localizations.map do |localization|
    localization.get_app_screenshot_sets
  end.flatten

  # Prompt for reorder behavior
  reverse = false
  alphabetical = false
  if UI.confirm("Reverse order?")
    reverse = true
  elsif UI.confirm("Alphabetical order? (from original file name)")
    alphabetical = true
  end

  # Apply reorder to all screenshot sets
  screenshot_sets.each do |set|
    screenshots = set.app_screenshots
    next if screenshots.empty?

    screenshots.reverse! if reverse
    screenshots.sort_by!(&:file_name) if alphabetical

    set.reorder_screenshots(app_screenshot_ids: screenshots.map(&:id))
  end
end
```

cc: @bolom 