### PR TITLE
[deliver] fix deliver download screenshot file extension

### DIFF
--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -32,12 +32,12 @@ module Deliver
         screenshot_sets = localization.get_app_screenshot_sets
         screenshot_sets.each do |screenshot_set|
           screenshot_set.app_screenshots.each_with_index do |screenshot, index|
-            url = screenshot.image_asset_url
-            next if url.nil?
-
             file_name = [index, screenshot_set.screenshot_display_type, index].join("_")
-            original_file_extension = File.basename(screenshot.file_name)
+            original_file_extension = File.extname(screenshot.file_name).strip.downcase[1..-1]
             file_name += "." + original_file_extension
+
+            url = screenshot.image_asset_url(type: original_file_extension)
+            next if url.nil?
 
             language = localization.locale
 

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -92,14 +92,27 @@ module Deliver
         localizations = version.get_app_store_version_localizations
       end
 
-      upload_screenshots(screenshots_per_language, localizations)
+      upload_screenshots(screenshots_per_language, localizations, options)
     end
 
-    def upload_screenshots(screenshots_per_language, localizations)
+    def upload_screenshots(screenshots_per_language, localizations, options)
       # Check if should wait for processing
-      wait_for_processing = !FastlaneCore::Env.truthy?("DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING")
+      # Default to waiting if submitting for review (since needed for submission)
+      # Otherwise use enviroment variable
+      if ENV["DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING"].nil?
+        wait_for_processing = options[:submit_for_review]
+        UI.verbose("Setting wait_for_processing from ':submit_for_review' option")
+      else
+        UI.verbose("Setting wait_for_processing from 'DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING' environment variable")
+        wait_for_processing = !FastlaneCore::Env.truthy?("DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING")
+      end
+
       if wait_for_processing
-        UI.important("Set environment variable DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING=true to skip waiting for screenshots to process")
+        UI.important("Will wait for screenshot image processing")
+        UI.important("Set env DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING=true to skip waiting for screenshots to process")
+      else
+        UI.important("Skipping the wait for screenshot image processing (which may affect submission)")
+        UI.important("Set env DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING=false to skip waiting for screenshots to process")
       end
 
       # Upload screenshots


### PR DESCRIPTION
### Motivation and Context
Fixes issue reported by @changusmc (https://github.com/fastlane/fastlane/issues/16639#issuecomment-652478085)

### Description
- Extension file grabbing code was bad
  - Replaced with proper way to get extension

### Testing Steps

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-2.150.0-fix-deliver-download-extension"
```
