### PR TITLE
Version bump to 2.150.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
 <td id='joshua-liebowitz'>
 <a href='https://github.com/taquitos'>
 <img src='https://github.com/taquitos.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
@@ -58,11 +52,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
 </td>
 </tr>
 <tr>
@@ -72,55 +72,23 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-</tr>
-<tr>
 <td id='jimmy-dee'>
 <a href='https://github.com/jdee'>
 <img src='https://github.com/jdee.png?size=140'>
 </a>
 <h4 align='center'>Jimmy Dee</h4>
 </td>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
@@ -130,29 +98,55 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+</tr>
+<tr>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='fumiya-nakamura'>
 <a href='https://github.com/nafu'>
@@ -160,19 +154,25 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
 </tr>
 <tr>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
 <img src='https://github.com/giginet.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Manu Wallner",
-                        "Danielle Tomlinson",
-                        "Matthew Ellis",
-                        "Stefan Natchev",
+  spec.authors       = ["Andrew McBurney",
                         "Jimmy Dee",
-                        "Kohki Miki",
-                        "Jorge Revuelta H",
-                        "Daniel Jankowski",
-                        "Jérôme Lacoste",
-                        "Andrew McBurney",
-                        "Max Ott",
-                        "Iulian Onofrei",
-                        "Helmut Januschka",
+                        "Matthew Ellis",
                         "Jan Piotrowski",
-                        "Luka Mirosevic",
-                        "Felix Krause",
-                        "Fumiya Nakamura",
-                        "Olivier Halligon",
-                        "Maksym Grebenets",
                         "Aaron Brager",
+                        "Helmut Januschka",
                         "Josh Holtz",
-                        "Joshua Liebowitz"]
+                        "Daniel Jankowski",
+                        "Manu Wallner",
+                        "Kohki Miki",
+                        "Luka Mirosevic",
+                        "Max Ott",
+                        "Jorge Revuelta H",
+                        "Danielle Tomlinson",
+                        "Stefan Natchev",
+                        "Fumiya Nakamura",
+                        "Iulian Onofrei",
+                        "Joshua Liebowitz",
+                        "Jérôme Lacoste",
+                        "Maksym Grebenets",
+                        "Olivier Halligon",
+                        "Felix Krause"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.149.1'.freeze
+  VERSION = '2.150.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.149.1
+// Generated with fastlane 2.150.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -76,7 +76,7 @@ protocol DeliverfileProtocol: class {
   var appRatingConfigPath: String? { get }
 
   /// Extra information for the submission (e.g. compliance specifications, IDFA settings)
-  var submissionInformation: String? { get }
+  var submissionInformation: [String : Any]? { get }
 
   /// The ID of your App Store Connect team if you're in multiple teams
   var teamId: String? { get }
@@ -99,13 +99,13 @@ protocol DeliverfileProtocol: class {
   /// The default precheck rule level unless otherwise configured
   var precheckDefaultRuleLevel: String { get }
 
-  /// An array of localized metadata items to upload individually by language so that errors can be identified. E.g. ['name', 'keywords', 'description']. Note: slow
+  /// **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - An array of localized metadata items to upload individually by language so that errors can be identified. E.g. ['name', 'keywords', 'description']. Note: slow
   var individualMetadataItems: [String] { get }
 
-  /// Metadata: The path to the app icon
+  /// **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - Metadata: The path to the app icon
   var appIcon: String? { get }
 
-  /// Metadata: The path to the Apple Watch app icon
+  /// **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - Metadata: The path to the Apple Watch app icon
   var appleWatchAppIcon: String? { get }
 
   /// Metadata: The copyright notice
@@ -207,7 +207,7 @@ extension DeliverfileProtocol {
   var resetRatings: Bool { return false }
   var priceTier: String? { return nil }
   var appRatingConfigPath: String? { return nil }
-  var submissionInformation: String? { return nil }
+  var submissionInformation: [String : Any]? { return nil }
   var teamId: String? { return nil }
   var teamName: String? { return nil }
   var devPortalTeamId: String? { return nil }
@@ -246,4 +246,4 @@ extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.19]
+// FastlaneRunnerAPIVersion [0.9.20]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -455,9 +455,9 @@ func appledoc(input: Any,
    - itcProvider: The provider short name to be used with the iTMSTransporter to identify your team. This value will override the automatically detected provider short name. To get provider short name run `pathToXcode.app/Contents/Applications/Application\ Loader.app/Contents/itms/bin/iTMSTransporter -m provider -u 'USERNAME' -p 'PASSWORD' -account_type itunes_connect -v off`. The short names of providers should be listed in the second column
    - runPrecheckBeforeSubmit: Run precheck before submitting to app review
    - precheckDefaultRuleLevel: The default precheck rule level unless otherwise configured
-   - individualMetadataItems: An array of localized metadata items to upload individually by language so that errors can be identified. E.g. ['name', 'keywords', 'description']. Note: slow
-   - appIcon: Metadata: The path to the app icon
-   - appleWatchAppIcon: Metadata: The path to the Apple Watch app icon
+   - individualMetadataItems: **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - An array of localized metadata items to upload individually by language so that errors can be identified. E.g. ['name', 'keywords', 'description']. Note: slow
+   - appIcon: **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - Metadata: The path to the app icon
+   - appleWatchAppIcon: **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - Metadata: The path to the Apple Watch app icon
    - copyright: Metadata: The copyright notice
    - primaryCategory: Metadata: The english name of the primary category (e.g. `Business`, `Books`)
    - secondaryCategory: Metadata: The english name of the secondary category (e.g. `Business`, `Books`)
@@ -515,7 +515,7 @@ func appstore(username: String,
               resetRatings: Bool = false,
               priceTier: Any? = nil,
               appRatingConfigPath: String? = nil,
-              submissionInformation: Any? = nil,
+              submissionInformation: [String : Any]? = nil,
               teamId: Any? = nil,
               teamName: String? = nil,
               devPortalTeamId: String? = nil,
@@ -2248,7 +2248,7 @@ func createAppOnManagedPlayStore(jsonKey: String? = nil,
    - sku: SKU Number (e.g. '1234')
    - platform: The platform to use (optional)
    - platforms: The platforms to use (optional)
-   - language: Primary Language (e.g. 'English', 'German')
+   - language: Primary Language (e.g. 'en-US', 'fr-FR')
    - companyName: The name of your company. Only required if it's the first app you create
    - skipItc: Skip the creation of the app on App Store Connect
    - itcUsers: Array of App Store Connect users. If provided, you can limit access to this newly created app for users with the App Manager, Developer, Marketer or Sales roles
@@ -2505,9 +2505,9 @@ func deleteKeychain(name: String? = nil,
    - itcProvider: The provider short name to be used with the iTMSTransporter to identify your team. This value will override the automatically detected provider short name. To get provider short name run `pathToXcode.app/Contents/Applications/Application\ Loader.app/Contents/itms/bin/iTMSTransporter -m provider -u 'USERNAME' -p 'PASSWORD' -account_type itunes_connect -v off`. The short names of providers should be listed in the second column
    - runPrecheckBeforeSubmit: Run precheck before submitting to app review
    - precheckDefaultRuleLevel: The default precheck rule level unless otherwise configured
-   - individualMetadataItems: An array of localized metadata items to upload individually by language so that errors can be identified. E.g. ['name', 'keywords', 'description']. Note: slow
-   - appIcon: Metadata: The path to the app icon
-   - appleWatchAppIcon: Metadata: The path to the Apple Watch app icon
+   - individualMetadataItems: **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - An array of localized metadata items to upload individually by language so that errors can be identified. E.g. ['name', 'keywords', 'description']. Note: slow
+   - appIcon: **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - Metadata: The path to the app icon
+   - appleWatchAppIcon: **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - Metadata: The path to the Apple Watch app icon
    - copyright: Metadata: The copyright notice
    - primaryCategory: Metadata: The english name of the primary category (e.g. `Business`, `Books`)
    - secondaryCategory: Metadata: The english name of the secondary category (e.g. `Business`, `Books`)
@@ -2565,7 +2565,7 @@ func deliver(username: Any = deliverfile.username,
              resetRatings: Bool = deliverfile.resetRatings,
              priceTier: Any? = deliverfile.priceTier,
              appRatingConfigPath: Any? = deliverfile.appRatingConfigPath,
-             submissionInformation: Any? = deliverfile.submissionInformation,
+             submissionInformation: [String : Any]? = deliverfile.submissionInformation,
              teamId: Any? = deliverfile.teamId,
              teamName: Any? = deliverfile.teamName,
              devPortalTeamId: Any? = deliverfile.devPortalTeamId,
@@ -2799,7 +2799,7 @@ func downloadDsyms(username: String,
 func downloadFromPlayStore(packageName: String,
                            versionName: String? = nil,
                            track: String = "production",
-                           metadataPath: String? = nil,
+                           metadataPath: String = "./metadata",
                            key: String? = nil,
                            issuer: String? = nil,
                            jsonKey: String? = nil,
@@ -5343,7 +5343,7 @@ func println(message: String? = nil) {
    - sku: SKU Number (e.g. '1234')
    - platform: The platform to use (optional)
    - platforms: The platforms to use (optional)
-   - language: Primary Language (e.g. 'English', 'German')
+   - language: Primary Language (e.g. 'en-US', 'fr-FR')
    - companyName: The name of your company. Only required if it's the first app you create
    - skipItc: Skip the creation of the app on App Store Connect
    - itcUsers: Array of App Store Connect users. If provided, you can limit access to this newly created app for users with the App Manager, Developer, Marketer or Sales roles
@@ -7097,6 +7097,7 @@ func splunkmint(dsym: String? = nil,
    - packagePath: Change working directory before any other operation
    - xcconfig: Use xcconfig file to override swift package generate-xcodeproj defaults
    - configuration: Build with configuration (debug|release) [default: debug]
+   - disableSandbox: Disable using the sandbox when executing subprocesses
    - xcprettyOutput: Specifies the output type for xcpretty. eg. 'test', or 'simple'
    - xcprettyArgs: Pass in xcpretty additional command line arguments (e.g. '--test --no-color' or '--tap --no-utf'), requires xcpretty_output to be specified also
    - verbose: Increase verbosity of informational output
@@ -7106,6 +7107,7 @@ func spm(command: String = "build",
          packagePath: String? = nil,
          xcconfig: String? = nil,
          configuration: String? = nil,
+         disableSandbox: Bool = false,
          xcprettyOutput: String? = nil,
          xcprettyArgs: String? = nil,
          verbose: Bool = false) {
@@ -7114,6 +7116,7 @@ func spm(command: String = "build",
                                                                                      RubyCommand.Argument(name: "package_path", value: packagePath),
                                                                                      RubyCommand.Argument(name: "xcconfig", value: xcconfig),
                                                                                      RubyCommand.Argument(name: "configuration", value: configuration),
+                                                                                     RubyCommand.Argument(name: "disable_sandbox", value: disableSandbox),
                                                                                      RubyCommand.Argument(name: "xcpretty_output", value: xcprettyOutput),
                                                                                      RubyCommand.Argument(name: "xcpretty_args", value: xcprettyArgs),
                                                                                      RubyCommand.Argument(name: "verbose", value: verbose)])
@@ -7196,7 +7199,7 @@ func supply(packageName: String,
             releaseStatus: String = "completed",
             track: String = "production",
             rollout: String? = nil,
-            metadataPath: String? = nil,
+            metadataPath: String = "./metadata",
             key: String? = nil,
             issuer: String? = nil,
             jsonKey: String? = nil,
@@ -8099,9 +8102,9 @@ func uploadSymbolsToSentry(apiHost: String = "https://app.getsentry.com/api/0",
    - itcProvider: The provider short name to be used with the iTMSTransporter to identify your team. This value will override the automatically detected provider short name. To get provider short name run `pathToXcode.app/Contents/Applications/Application\ Loader.app/Contents/itms/bin/iTMSTransporter -m provider -u 'USERNAME' -p 'PASSWORD' -account_type itunes_connect -v off`. The short names of providers should be listed in the second column
    - runPrecheckBeforeSubmit: Run precheck before submitting to app review
    - precheckDefaultRuleLevel: The default precheck rule level unless otherwise configured
-   - individualMetadataItems: An array of localized metadata items to upload individually by language so that errors can be identified. E.g. ['name', 'keywords', 'description']. Note: slow
-   - appIcon: Metadata: The path to the app icon
-   - appleWatchAppIcon: Metadata: The path to the Apple Watch app icon
+   - individualMetadataItems: **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - An array of localized metadata items to upload individually by language so that errors can be identified. E.g. ['name', 'keywords', 'description']. Note: slow
+   - appIcon: **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - Metadata: The path to the app icon
+   - appleWatchAppIcon: **DEPRECATED!** Removed after the migration to the new App Store Connect API in June 2020 - Metadata: The path to the Apple Watch app icon
    - copyright: Metadata: The copyright notice
    - primaryCategory: Metadata: The english name of the primary category (e.g. `Business`, `Books`)
    - secondaryCategory: Metadata: The english name of the secondary category (e.g. `Business`, `Books`)
@@ -8159,7 +8162,7 @@ func uploadToAppStore(username: String,
                       resetRatings: Bool = false,
                       priceTier: Any? = nil,
                       appRatingConfigPath: String? = nil,
-                      submissionInformation: Any? = nil,
+                      submissionInformation: [String : Any]? = nil,
                       teamId: Any? = nil,
                       teamName: String? = nil,
                       devPortalTeamId: String? = nil,
@@ -8305,7 +8308,7 @@ func uploadToPlayStore(packageName: String,
                        releaseStatus: String = "completed",
                        track: String = "production",
                        rollout: String? = nil,
-                       metadataPath: String? = nil,
+                       metadataPath: String = "./metadata",
                        key: String? = nil,
                        issuer: String? = nil,
                        jsonKey: String? = nil,
@@ -8815,7 +8818,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode-11.5.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false) {
   let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                       RubyCommand.Argument(name: "project", value: project),
@@ -8960,4 +8963,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.71]
+// FastlaneRunnerAPIVersion [0.9.72]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.149.1
+// Generated with fastlane 2.150.0

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.149.1
+// Generated with fastlane 2.150.0

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.149.1
+// Generated with fastlane 2.150.0

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.149.1
+// Generated with fastlane 2.150.0

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.149.1
+// Generated with fastlane 2.150.0

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.149.1
+// Generated with fastlane 2.150.0


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.149.1':**

*  [deliver][produce][spaceship] Update to use new App Store Connect API endpoints (#16640) via Josh Holtz
* [Fastlane.swift] Increase default command timeout (#16675) via Jean Mainguy
* [Fastlane.swift] Fix function hanging with error from command (#16692) via Jorge
* [fastlane-core] Require rubyzip >= 2.0.0 (#16660) via Anton Rieder
* [pilot] Strip Unicode 13 emoji (#16662) via Anton Rieder
* [fastlane_core] fix: paths with spaces fail (#16636) via Igor Randjelovic
* [spm] Adds disable_sandbox parameter (#16602) via Michał Matoga
* [Fastlane.swift] Fix swift function nesting (#16578) via Jorge
* [fastlane] remove blacklist and whitelist references (#16583) via Josh Holtz
* [snapshot] Remove double word (#16572) via Morten Bjerg Gregersen
* [gemspec] Remove public_suffix version constraint (#16569) via Anton Rieder
* [actions] add action google_play_track_release_names (#15961) via Rob Aldred
* [actions] download_dsyms - add explicit proxy specification for dsyms file downloading in case when 'http_proxy' env variable was specified (#16434) via zhelanov
* [actions] update upload_symbols_to_crashlytics.rb (#16551) via Dmitry
* [Fastlane.swift] [snapshot] Fix html_template default value (#16564) via Jean Mainguy
