### PR TITLE
Version bump to 2.150.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,29 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
@@ -52,17 +64,69 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
+</tr>
+<tr>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+</tr>
+<tr>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
 <img src='https://github.com/joshdholtz.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
 </td>
 </tr>
 <tr>
@@ -78,31 +142,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
 <td id='jimmy-dee'>
 <a href='https://github.com/jdee'>
 <img src='https://github.com/jdee.png?size=140'>
 </a>
 <h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-</tr>
-<tr>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
 <td id='jan-piotrowski'>
 <a href='https://github.com/janpio'>
@@ -110,69 +160,19 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+</tr>
+<tr>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
 <img src='https://github.com/AliSoftware.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
-</tr>
-<tr>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-</tr>
-<tr>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Andrew McBurney",
-                        "Jimmy Dee",
-                        "Matthew Ellis",
-                        "Jan Piotrowski",
-                        "Aaron Brager",
-                        "Helmut Januschka",
-                        "Josh Holtz",
-                        "Daniel Jankowski",
-                        "Manu Wallner",
-                        "Kohki Miki",
+  spec.authors       = ["Joshua Liebowitz",
                         "Luka Mirosevic",
-                        "Max Ott",
+                        "Kohki Miki",
+                        "Aaron Brager",
+                        "Matthew Ellis",
+                        "Jimmy Dee",
                         "Jorge Revuelta H",
-                        "Danielle Tomlinson",
-                        "Stefan Natchev",
+                        "Manu Wallner",
+                        "Josh Holtz",
                         "Fumiya Nakamura",
-                        "Iulian Onofrei",
-                        "Joshua Liebowitz",
-                        "Jérôme Lacoste",
                         "Maksym Grebenets",
+                        "Jan Piotrowski",
+                        "Daniel Jankowski",
                         "Olivier Halligon",
-                        "Felix Krause"]
+                        "Max Ott",
+                        "Felix Krause",
+                        "Iulian Onofrei",
+                        "Danielle Tomlinson",
+                        "Jérôme Lacoste",
+                        "Andrew McBurney",
+                        "Helmut Januschka",
+                        "Stefan Natchev"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.150.0'.freeze
+  VERSION = '2.150.1'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -18,4 +18,4 @@ class Deliverfile: DeliverfileProtocol {
 
 
 
-// Generated with fastlane 2.150.0
+// Generated with fastlane 2.150.1

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -18,4 +18,4 @@ class Gymfile: GymfileProtocol {
 
 
 
-// Generated with fastlane 2.150.0
+// Generated with fastlane 2.150.1

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -18,4 +18,4 @@ class Matchfile: MatchfileProtocol {
 
 
 
-// Generated with fastlane 2.150.0
+// Generated with fastlane 2.150.1

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -18,4 +18,4 @@ class Precheckfile: PrecheckfileProtocol {
 
 
 
-// Generated with fastlane 2.150.0
+// Generated with fastlane 2.150.1

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -18,4 +18,4 @@ class Scanfile: ScanfileProtocol {
 
 
 
-// Generated with fastlane 2.150.0
+// Generated with fastlane 2.150.1

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -18,4 +18,4 @@ class Screengrabfile: ScreengrabfileProtocol {
 
 
 
-// Generated with fastlane 2.150.0
+// Generated with fastlane 2.150.1

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -18,4 +18,4 @@ class Snapshotfile: SnapshotfileProtocol {
 
 
 
-// Generated with fastlane 2.150.0
+// Generated with fastlane 2.150.1


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.150.0':**

* [spaceship] rename model to appStoreViewAttachments (#16730) via Josh Holtz
