### PR TITLE
run setup_keychain on macOS environments only

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_ci.rb
@@ -29,6 +29,11 @@ module Fastlane
           return
         end
 
+        unless Helper.operating_system == 'macOS'
+          UI.message("Skipping Keychain setup on non-macOS CI Agent")
+          return
+        end
+
         keychain_name = "fastlane_tmp_keychain"
         ENV["MATCH_KEYCHAIN_NAME"] = keychain_name
         ENV["MATCH_KEYCHAIN_PASSWORD"] = ""

--- a/fastlane/lib/fastlane/actions/setup_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_ci.rb
@@ -24,13 +24,13 @@ module Fastlane
       end
 
       def self.setup_keychain
-        unless ENV["MATCH_KEYCHAIN_NAME"].nil?
-          UI.message("Skipping Keychain setup as a keychain was already specified")
+        unless Helper.mac?
+          UI.message("Skipping Keychain setup on non-macOS CI Agent")
           return
         end
 
-        unless Helper.operating_system == 'macOS'
-          UI.message("Skipping Keychain setup on non-macOS CI Agent")
+        unless ENV["MATCH_KEYCHAIN_NAME"].nil?
+          UI.message("Skipping Keychain setup as a keychain was already specified")
           return
         end
 

--- a/fastlane/lib/fastlane/actions/setup_circle_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_circle_ci.rb
@@ -41,7 +41,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include?(platform)
+        true
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/setup_travis.rb
+++ b/fastlane/lib/fastlane/actions/setup_travis.rb
@@ -40,7 +40,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include?(platform)
+        true
       end
 
       def self.example_code

--- a/fastlane/spec/actions_specs/setup_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_ci_spec.rb
@@ -1,6 +1,5 @@
 describe Fastlane do
   describe Fastlane::Actions::SetupCiAction do
-    is_macos_env = RUBY_PLATFORM.downcase.include?("darwin")
     describe "#run" do
       context "when it should run" do
         before do
@@ -8,28 +7,45 @@ describe Fastlane do
           allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
         end
 
-        it "calls setup_keychain after setup_output_paths if :provider is set to circleci on Mac Agents" do
-          if is_macos_env
+        describe "calls setup_keychain after setup_output_paths if :provider is set to circleci on Mac Agents" do
+          it "runs on Mac" do
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+
             # Message is asserted in reverse order, hence output of setup_output_paths is expected last
             expect(Fastlane::UI).to receive(:message).with("Enabling match readonly mode.")
             expect(Fastlane::UI).to receive(:message).with("Creating temporary keychain: \"fastlane_tmp_keychain\".")
             expect(Fastlane::UI).to receive(:message).with("Skipping Log Path setup as FL_OUTPUT_DIR is unset")
-          else
+
+            described_class.run(provider: "circleci")
+          end
+
+          it "skips on linux" do
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
+
             expect(Fastlane::UI).to receive(:message).with("Skipping Log Path setup as FL_OUTPUT_DIR is unset")
             expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup on non-macOS CI Agent")
+
+            described_class.run(provider: "circleci")
           end
-          described_class.run(provider: "circleci")
         end
 
-        it "calls setup_keychain if no provider is be detected on Mac Agents" do
-          if is_macos_env
+        describe "calls setup_keychain if no provider is be detected on Mac Agents" do
+          it "runs on Mac" do
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+
             expect(Fastlane::UI).to receive(:message).with("Enabling match readonly mode.")
             expect(Fastlane::UI).to receive(:message).with("Creating temporary keychain: \"fastlane_tmp_keychain\".")
-          else
-            expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup on non-macOS CI Agent")
+
+            described_class.run(force: true)
           end
 
-          described_class.run(force: true)
+          it "skips on linux" do
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
+
+            expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup on non-macOS CI Agent")
+
+            described_class.run(force: true)
+          end
         end
       end
     end
@@ -104,11 +120,12 @@ describe Fastlane do
         end
       end
 
-      if is_macos_env
-        describe "Setting up the environment" do
+      describe "Setting up the environment" do
+        context "when operating system is macOS" do
           before do
             stub_const("ENV", {})
             allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
           end
 
           it "sets the MATCH_KEYCHAIN_NAME env var" do
@@ -126,9 +143,12 @@ describe Fastlane do
             expect(ENV["MATCH_READONLY"]).to eql("true")
           end
         end
-      else
+
         context "when operating system is not macOS" do
           it "skips the setup process" do
+            stub_const("ENV", {})
+            allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
             expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup on non-macOS CI Agent")
             described_class.setup_keychain
           end

--- a/fastlane/spec/actions_specs/setup_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_ci_spec.rb
@@ -115,43 +115,42 @@ describe Fastlane do
       context "when MATCH_KEYCHAIN_NAME is set" do
         it "skips the setup process" do
           stub_const("ENV", { "MATCH_KEYCHAIN_NAME" => "anything" })
+          allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
           expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup as a keychain was already specified")
           described_class.setup_keychain
         end
       end
 
-      describe "Setting up the environment" do
-        context "when operating system is macOS" do
-          before do
-            stub_const("ENV", {})
-            allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
-            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
-          end
-
-          it "sets the MATCH_KEYCHAIN_NAME env var" do
-            described_class.setup_keychain
-            expect(ENV["MATCH_KEYCHAIN_NAME"]).to eql("fastlane_tmp_keychain")
-          end
-
-          it "sets the MATCH_KEYCHAIN_PASSWORD env var" do
-            described_class.setup_keychain
-            expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eql("")
-          end
-
-          it "sets the MATCH_READONLY env var" do
-            described_class.setup_keychain
-            expect(ENV["MATCH_READONLY"]).to eql("true")
-          end
+      context "when operating system is macOS" do
+        before do
+          stub_const("ENV", {})
+          allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
+          allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         end
 
-        context "when operating system is not macOS" do
-          it "skips the setup process" do
-            stub_const("ENV", {})
-            allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
-            allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
-            expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup on non-macOS CI Agent")
-            described_class.setup_keychain
-          end
+        it "sets the MATCH_KEYCHAIN_NAME env var" do
+          described_class.setup_keychain
+          expect(ENV["MATCH_KEYCHAIN_NAME"]).to eql("fastlane_tmp_keychain")
+        end
+
+        it "sets the MATCH_KEYCHAIN_PASSWORD env var" do
+          described_class.setup_keychain
+          expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eql("")
+        end
+
+        it "sets the MATCH_READONLY env var" do
+          described_class.setup_keychain
+          expect(ENV["MATCH_READONLY"]).to eql("true")
+        end
+      end
+
+      context "when operating system is not macOS" do
+        it "skips the setup process" do
+          stub_const("ENV", {})
+          allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
+          allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
+          expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup on non-macOS CI Agent")
+          described_class.setup_keychain
         end
       end
     end

--- a/fastlane/spec/actions_specs/setup_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_ci_spec.rb
@@ -95,6 +95,14 @@ describe Fastlane do
         end
       end
 
+      context "when operating system is not macOS" do
+        it "skips the setup process" do
+          expect(Fastlane::Helper).to receive(:operating_system).and_return('Linux')
+          expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup on non-macOS CI Agent")
+          described_class.setup_keychain
+        end
+      end
+
       describe "Setting up the environment" do
         before do
           stub_const("ENV", {})

--- a/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
@@ -2,6 +2,21 @@ describe Fastlane do
   describe Fastlane::Actions::SetupCircleCiAction do
     describe "Setup CircleCi Integration" do
       let(:tmp_keychain_name) { "fastlane_tmp_keychain" }
+      is_macos_env = RUBY_PLATFORM.downcase.include?("darwin")
+      expected_test_result = is_macos_env ? 'works on MacOS Environment' : 'skips outside MacOS Environment'
+
+      def check_keychain_nil
+        expect(ENV["MATCH_KEYCHAIN_NAME"]).to be_nil
+        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to be_nil
+        expect(ENV["MATCH_READONLY"]).to be_nil
+      end
+
+      def check_keychain_created
+        expect(ENV["MATCH_KEYCHAIN_NAME"]).to eq(tmp_keychain_name)
+        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eq("")
+        expect(ENV["MATCH_READONLY"]).to eq("true")
+      end
+
       it "doesn't work outside CI" do
         stub_const("ENV", {})
 
@@ -11,12 +26,10 @@ describe Fastlane do
           setup_circle_ci
         end").runner.execute(:test)
 
-        expect(ENV["MATCH_KEYCHAIN_NAME"]).to be_nil
-        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to be_nil
-        expect(ENV["MATCH_READONLY"]).to be_nil
+        check_keychain_nil
       end
 
-      it "works when forced" do
+      it "#{expected_test_result} when forced" do
         stub_const("ENV", {})
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -25,23 +38,27 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(ENV["MATCH_KEYCHAIN_NAME"]).to eq(tmp_keychain_name)
-        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eq("")
-        expect(ENV["MATCH_READONLY"]).to eq("true")
+        if is_macos_env
+          check_keychain_created
+        else
+          check_keychain_nil
+        end
       end
 
-      it "works inside CI" do
-        expect(Fastlane::Actions::CreateKeychainAction).to receive(:run).with(
-          {
-            name: tmp_keychain_name,
-            default_keychain: true,
-            unlock: true,
-            timeout: 3600,
-            lock_when_sleeps: true,
-            password: "",
-            add_to_search_list: true
-          }
-        )
+      it "#{expected_test_result} inside CI" do
+        if is_macos_env
+          expect(Fastlane::Actions::CreateKeychainAction).to receive(:run).with(
+            {
+                name: tmp_keychain_name,
+                default_keychain: true,
+                unlock: true,
+                timeout: 3600,
+                lock_when_sleeps: true,
+                password: "",
+                add_to_search_list: true
+            }
+          )
+        end
 
         stub_const("ENV", { "FL_SETUP_CIRCLECI_FORCE" => "true" })
 
@@ -49,9 +66,11 @@ describe Fastlane do
           setup_circle_ci
         end").runner.execute(:test)
 
-        expect(ENV["MATCH_KEYCHAIN_NAME"]).to eq(tmp_keychain_name)
-        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eq("")
-        expect(ENV["MATCH_READONLY"]).to eq("true")
+        if is_macos_env
+          check_keychain_created
+        else
+          check_keychain_nil
+        end
       end
     end
   end

--- a/fastlane/spec/actions_specs/setup_travis_spec.rb
+++ b/fastlane/spec/actions_specs/setup_travis_spec.rb
@@ -2,8 +2,6 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Setup Travis Integration" do
       let(:tmp_keychain_name) { "fastlane_tmp_keychain" }
-      is_macos_env = RUBY_PLATFORM.downcase.include?("darwin")
-      expected_test_result = is_macos_env ? 'works on MacOS Environment' : 'skips outside MacOS Environment'
 
       def check_keychain_nil
         expect(ENV["MATCH_KEYCHAIN_NAME"]).to be_nil
@@ -18,6 +16,7 @@ describe Fastlane do
       end
 
       it "doesn't work outside CI" do
+        allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         stub_const("ENV", {})
 
         expect(UI).to receive(:message).with("Not running on CI, skipping CI setup")
@@ -29,7 +28,21 @@ describe Fastlane do
         check_keychain_nil
       end
 
-      it "#{expected_test_result} when forced" do
+      it "skips outside macOS CI agent" do
+        allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
+        stub_const("ENV", { "TRAVIS" => "true" })
+
+        expect(UI).to receive(:message).with("Skipping Keychain setup on non-macOS CI Agent")
+
+        Fastlane::FastFile.new.parse("lane :test do
+          setup_travis
+        end").runner.execute(:test)
+
+        check_keychain_nil
+      end
+
+      it "works on MacOS Environment when forced" do
+        allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         stub_const("ENV", {})
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -38,17 +51,13 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        if is_macos_env
-          check_keychain_created
-        else
-          check_keychain_nil
-        end
+        check_keychain_created
       end
 
-      it "#{expected_test_result} inside CI" do
-        if is_macos_env
-          expect(Fastlane::Actions::CreateKeychainAction).to receive(:run).with(
-            {
+      it "works on MacOS Environment inside CI" do
+        allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+        expect(Fastlane::Actions::CreateKeychainAction).to receive(:run).with(
+          {
               name: tmp_keychain_name,
               default_keychain: true,
               unlock: true,
@@ -56,9 +65,8 @@ describe Fastlane do
               lock_when_sleeps: true,
               password: "",
               add_to_search_list: true
-            }
-          )
-        end
+          }
+        )
 
         stub_const("ENV", { "TRAVIS" => "true" })
 
@@ -66,11 +74,7 @@ describe Fastlane do
           setup_travis
         end").runner.execute(:test)
 
-        if is_macos_env
-          check_keychain_created
-        else
-          check_keychain_nil
-        end
+        check_keychain_created
       end
     end
   end

--- a/fastlane/spec/actions_specs/setup_travis_spec.rb
+++ b/fastlane/spec/actions_specs/setup_travis_spec.rb
@@ -2,6 +2,21 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Setup Travis Integration" do
       let(:tmp_keychain_name) { "fastlane_tmp_keychain" }
+      is_macos_env = RUBY_PLATFORM.downcase.include?("darwin")
+      expected_test_result = is_macos_env ? 'works on MacOS Environment' : 'skips outside MacOS Environment'
+
+      def check_keychain_nil
+        expect(ENV["MATCH_KEYCHAIN_NAME"]).to be_nil
+        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to be_nil
+        expect(ENV["MATCH_READONLY"]).to be_nil
+      end
+
+      def check_keychain_created
+        expect(ENV["MATCH_KEYCHAIN_NAME"]).to eq(tmp_keychain_name)
+        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eq("")
+        expect(ENV["MATCH_READONLY"]).to eq("true")
+      end
+
       it "doesn't work outside CI" do
         stub_const("ENV", {})
 
@@ -11,12 +26,10 @@ describe Fastlane do
           setup_travis
         end").runner.execute(:test)
 
-        expect(ENV["MATCH_KEYCHAIN_NAME"]).to be_nil
-        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to be_nil
-        expect(ENV["MATCH_READONLY"]).to be_nil
+        check_keychain_nil
       end
 
-      it "works when forced" do
+      it "#{expected_test_result} when forced" do
         stub_const("ENV", {})
 
         Fastlane::FastFile.new.parse("lane :test do
@@ -25,23 +38,27 @@ describe Fastlane do
           )
         end").runner.execute(:test)
 
-        expect(ENV["MATCH_KEYCHAIN_NAME"]).to eq(tmp_keychain_name)
-        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eq("")
-        expect(ENV["MATCH_READONLY"]).to eq("true")
+        if is_macos_env
+          check_keychain_created
+        else
+          check_keychain_nil
+        end
       end
 
-      it "works inside CI" do
-        expect(Fastlane::Actions::CreateKeychainAction).to receive(:run).with(
-          {
-            name: tmp_keychain_name,
-            default_keychain: true,
-            unlock: true,
-            timeout: 3600,
-            lock_when_sleeps: true,
-            password: "",
-            add_to_search_list: true
-          }
-        )
+      it "#{expected_test_result} inside CI" do
+        if is_macos_env
+          expect(Fastlane::Actions::CreateKeychainAction).to receive(:run).with(
+            {
+              name: tmp_keychain_name,
+              default_keychain: true,
+              unlock: true,
+              timeout: 3600,
+              lock_when_sleeps: true,
+              password: "",
+              add_to_search_list: true
+            }
+          )
+        end
 
         stub_const("ENV", { "TRAVIS" => "true" })
 
@@ -49,9 +66,11 @@ describe Fastlane do
           setup_travis
         end").runner.execute(:test)
 
-        expect(ENV["MATCH_KEYCHAIN_NAME"]).to eq(tmp_keychain_name)
-        expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eq("")
-        expect(ENV["MATCH_READONLY"]).to eq("true")
+        if is_macos_env
+          check_keychain_created
+        else
+          check_keychain_nil
+        end
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`setup_travis` fails on the Linux CI agents in the setup_keychain action, throwing an error and failing the task.
To run Travis CI lanes on Mac and Linux agents, `setup_travis` must be conditionally run.

Since that action only applies to a macOS environment, it could be updated to skip the setup_keychain step on non macOS agents.
🔑
### Description
Exit early out of `setup_keychain` in the `setup_ci` action on non mac-OS envoronments, logging a message that it was skipped.

### Testing Steps
- Run `setup_ci` on a macOS agent without any change in behavior.
- Run `setup_ci` on a linux agent and see that it no longer fails, and logs "Skipping Keychain setup on non-macOS CI Agent"