### PR TITLE
[deliver] add platform to reject_if_possible and fix order to happen before meta

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -110,7 +110,7 @@ module Spaceship
       # App Store Versions
       #
 
-      def reject_version_if_possible!
+      def reject_version_if_possible!(platform: nil)
         platform ||= Spaceship::ConnectAPI::Platform::IOS
         filter = {
           appStoreState: [


### PR DESCRIPTION
### Motivation and Context
- `deliver`'s `reject_if_possible` only did iOS
- `reject_if_possible` needs to happen before meta data (screenshots can't be modified)

### Description
See motivation 😊 
