### PR TITLE
[spaceship] get app info categories easier

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -78,7 +78,7 @@ module Spaceship
       # App Info
       #
 
-      def fetch_edit_app_info
+      def fetch_edit_app_info(includes: Spaceship::ConnectAPI::AppInfo::ESSENTIAL_INCLUDES)
         states = [
           Spaceship::ConnectAPI::AppInfo::AppStoreState::PREPARE_FOR_SUBMISSION,
           Spaceship::ConnectAPI::AppInfo::AppStoreState::DEVELOPER_REJECTED,
@@ -89,7 +89,7 @@ module Spaceship
         ]
 
         filter = { app: id }
-        resp = Spaceship::ConnectAPI.get_app_infos(filter: filter)
+        resp = Spaceship::ConnectAPI.get_app_infos(filter: filter, includes: includes)
         return resp.to_models.select do |model|
           states.include?(model.app_store_state)
         end.first

--- a/spaceship/lib/spaceship/connect_api/models/app_info.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_info.rb
@@ -9,6 +9,13 @@ module Spaceship
       attr_accessor :brazil_age_rating
       attr_accessor :kids_age_band
 
+      attr_accessor :primary_category
+      attr_accessor :primary_subcategory_one
+      attr_accessor :primary_subcategory_two
+      attr_accessor :secondary_category
+      attr_accessor :secondary_subcategory_one
+      attr_accessor :secondary_subcategory_two
+
       module AppStoreState
         READY_FOR_SALE = "READY_FOR_SALE"
         PROCESSING_FOR_APP_STORE = "PROCESSING_FOR_APP_STORE"
@@ -30,8 +37,24 @@ module Spaceship
         "appStoreState" => "app_store_state",
         "appStoreAgeRating" => "app_store_age_rating",
         "brazilAgeRating" => "brazil_age_rating",
-        "kidsAgeBand" => "kids_age_band"
+        "kidsAgeBand" => "kids_age_band",
+
+        "primaryCategory" => "primary_category",
+        "primarySubcategoryOne" => "primary_subcategory_one",
+        "primarySubcategoryTwo" => "primary_subcategory_two",
+        "secondaryCategory" => "secondary_category",
+        "secondarySubcategoryOne" => "secondary_subcategory_one",
+        "secondarySubcategoryTwo" => "secondary_subcategory_two"
       })
+
+      ESSENTIAL_INCLUDES = [
+        "primaryCategory",
+        "primarySubcategoryOne",
+        "primarySubcategoryTwo",
+        "secondaryCategory",
+        "secondarySubcategoryOne",
+        "secondarySubcategoryTwo"
+      ].join(",")
 
       def self.type
         return "appInfos"


### PR DESCRIPTION
### Motivation and Context
Fixes https://github.com/fastlane/fastlane/issues/16649#issuecomment-653571128 mentioned by @squallstar 

### Description
- Adds relationships for all categories on app info
- Adds essential includes when fetching app info to also get categories

### Testing Steps

```rb
lane :test do
  require 'pp'
  require 'spaceship'

  Spaceship::Tunes.login(email)
  Spaceship::Tunes.select_team(team_name: team_name)

  # Gets app
  app = Spaceship::ConnectAPI::App.find(bundle_id)

  # Gets app info and includes relationships to all categories
  app_info = app.fetch_edit_app_info

  puts "PRIMARY"
  pp app_info.primary_category
  puts "\nPRIMARY SUB 1"
  pp app_info.primary_subcategory_one
  puts "\nPRIMARY SUB 2"
  pp app_info.primary_subcategory_one
  puts "\SECONDARY"
  pp app_info.secondary_category
  puts "\SECONDARY SUB 1"
  pp app_info.secondary_subcategory_one
  puts "\SECONDARY SUB 2"
  pp app_info.secondary_subcategory_one
end
```