### PR TITLE
[spaceship] added Spaceship::ConnectAPI::SandboxTester

### DIFF
--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -50,6 +50,7 @@ require 'spaceship/connect_api/models/app_store_version_phased_release'
 require 'spaceship/connect_api/models/app_store_version'
 require 'spaceship/connect_api/models/idfa_declaration'
 require 'spaceship/connect_api/models/reset_ratings_request'
+require 'spaceship/connect_api/models/sandbox_tester'
 require 'spaceship/connect_api/models/territory'
 
 module Spaceship

--- a/spaceship/lib/spaceship/connect_api/models/sandbox_tester.rb
+++ b/spaceship/lib/spaceship/connect_api/models/sandbox_tester.rb
@@ -1,0 +1,64 @@
+require_relative '../model'
+module Spaceship
+  class ConnectAPI
+    class SandboxTester
+      include Spaceship::ConnectAPI::Model
+
+      attr_accessor :first_name
+      attr_accessor :last_name
+      attr_accessor :email
+      attr_accessor :password
+      attr_accessor :confirm_password
+      attr_accessor :secret_question
+      attr_accessor :secret_answer
+      attr_accessor :birth_date # 1980-03-01
+      attr_accessor :app_store_territory
+      attr_accessor :apple_pay_compatible
+
+      attr_mapping({
+        "firstName" => "first_name",
+        "lastName" => "last_name",
+        "email" => "email",
+        "password" => "password",
+        "confirmPassword" => "confirm_password",
+        "secretQuestion" => "secret_question",
+        "secretAnswer" => "secret_answer",
+        "birthDate" => "birth_date",
+        "appStoreTerritory" => "app_store_territory",
+        "applePayCompatible" => "apple_pay_compatible"
+      })
+
+      def self.type
+        return "sandboxTesters"
+      end
+
+      #
+      # API
+      #
+
+      def self.all(filter: {}, includes: nil, limit: 2000, sort: nil)
+        resps = Spaceship::ConnectAPI.get_sandbox_testers(filter: filter, includes: includes).all_pages
+        return resps.flat_map(&:to_models)
+      end
+
+      def self.create(first_name: nil, last_name: nil, email: nil, password: nil, confirm_password: nil, secret_question: nil, secret_answer: nil, birth_date: nil, app_store_territory: nil)
+        attributes = {
+          firstName: first_name,
+          lastName: last_name,
+          email: email,
+          password: password,
+          confirmPassword: confirm_password,
+          secretQuestion: secret_question,
+          secretAnswer: secret_answer,
+          birthDate: birth_date,
+          appStoreTerritory: app_store_territory
+        }
+        return Spaceship::ConnectAPI.post_sandbox_tester(attributes: attributes).first
+      end
+
+      def delete!
+        Spaceship::ConnectAPI.delete_sandbox_tester(sandbox_tester_id: id)
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -847,6 +847,31 @@ module Spaceship
       end
 
       #
+      # sandboxTesters
+      #
+
+      def get_sandbox_testers(filter: nil, includes: nil, limit: nil, sort: nil)
+        params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+        Client.instance.get("sandboxTesters", params)
+      end
+
+      def post_sandbox_tester(attributes: {})
+        body = {
+          data: {
+            type: "sandboxTesters",
+            attributes: attributes
+          }
+        }
+
+        Client.instance.post("sandboxTesters", body)
+      end
+
+      def delete_sandbox_tester(sandbox_tester_id: nil)
+        params = Client.instance.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
+        Client.instance.delete("sandboxTesters/#{sandbox_tester_id}", params)
+      end
+
+      #
       # territories
       #
 


### PR DESCRIPTION
### Motivation and Context
Fixes #16739
For @polok 

### Description
Added `Spaceship::ConnectAPI::SandboxTester`

### Testing Steps

#### List and delete
```rb
lane :test_testers do
  require 'pp'
  require 'spaceship'

  Spaceship::Tunes.login(email)
  Spaceship::Tunes.select_team(team_name: team_name)

  testers = Spaceship::ConnectAPI::SandboxTester.all
  pp testers

  testers.each do |tester|
    if UI.confirm("Delete #{tester.email}?")
      tester.delete!
    end
  end
end
```

#### Create
```rb
lane :create_testers do
  require 'pp'
  require 'spaceship'

  Spaceship::Tunes.login(email)
  Spaceship::Tunes.select_team(team_name: team_name)

  tester = Spaceship::ConnectAPI::SandboxTester.create(
    first_name: "Test",
    last_name: "Three",
    email: "testThree@someemail.com",
    password: "Test0101",
    confirm_password: "Test0101",
    secret_question: "Question",
    secret_answer: "Answer",
    birth_date: "1980-03-01",
    app_store_territory: "USA"
  )
  pp tester
end
```