### PR TITLE
[spaceship] upload screenshots and previews to specific position

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app_preview.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview.rb
@@ -54,7 +54,7 @@ module Spaceship
       # @param app_preview_set_id The AppPreviewSet id
       # @param path The path of the file
       # @param frame_time_code The time code for the preview still frame (ex: "00:00:07:01")
-      def self.create(app_preview_set_id: nil, path: nil, frame_time_code: nil)
+      def self.create(app_preview_set_id: nil, path: nil, wait_for_processing: true, frame_time_code: nil)
         require 'faraday'
 
         filename = File.basename(path)
@@ -95,7 +95,8 @@ module Spaceship
         end
 
         # Poll for video processing completion to set still frame time
-        unless frame_time_code.nil?
+        wait_for_processing = true unless frame_time_code.nil?
+        if wait_for_processing
           loop do
             unless preview.video_url.nil?
               puts("Preview processing complete!") if Spaceship::Globals.verbose?

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -241,6 +241,11 @@ module Spaceship
         Client.instance.get("appPreviewSets", params)
       end
 
+      def get_app_preview_set(app_preview_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+        params = Client.instance.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+        Client.instance.get("appPreviewSets/#{app_preview_set_id}", params)
+      end
+
       def post_app_preview_set(app_store_version_localization_id: nil, attributes: {})
         body = {
           data: {
@@ -258,6 +263,21 @@ module Spaceship
         }
 
         Client.instance.post("appPreviewSets", body)
+      end
+
+      def patch_app_preview_set_previews(app_preview_set_id: nil, app_preview_ids: nil)
+        app_preview_ids ||= []
+
+        body = {
+          data: app_preview_ids.map do |app_preview_id|
+            {
+              type: "appPreviews",
+              id: app_preview_id
+            }
+          end
+        }
+
+        Client.instance.patch("appPreviewSets/#{app_preview_set_id}/relationships/appPreviews", body)
       end
 
       #


### PR DESCRIPTION
### Motivation and Context
Fixes #16708
For @bolom 

### Description
1. Uploads screenshot/preview
2. If position is given (index of 0)
    1. Fetch all screenshot/previews for the set
    2. Get ordered list of all ids
    3. Remove newly uploaded id
    4. Place newly uploaded screenshot/preview id at specific position
    5. Send reorder request

#### Screenshot
```rb
screenshot_set.upload_screenshot(path: path, wait_for_processing: true, position: position)
```

#### Position
```rb
preview_set.upload_preview(path: path, wait_for_processing: true, position: position, frame_time_code: frame_time_code)
```
