### PR TITLE
[upload_symbols_to_crashlytics] add support for debug flag

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -56,6 +56,9 @@ module Fastlane
         UI.message("Uploading '#{path}'...")
         command = []
         command << File.expand_path(params[:binary_path]).shellescape
+        if params[:debug]
+          command << "-d"
+        end
         if params[:app_id]
           command << "-ai #{params[:app_id].shellescape}"
         elsif params[:gsp_path]
@@ -68,7 +71,7 @@ module Fastlane
         begin
           command_to_execute = command.join(" ")
           UI.verbose("upload_dsym using command: #{command_to_execute}")
-          Actions.sh(command_to_execute, log: false)
+          Actions.sh(command_to_execute, log: params[:debug])
         rescue => ex
           UI.error(ex.to_s) # it fails, however we don't want to fail everything just for this
         end
@@ -189,7 +192,12 @@ module Fastlane
                                        verify_block: proc do |value|
                                          min_threads = 1
                                          UI.user_error!("Too few threads (#{value}) minimum number of threads: #{min_threads}") unless value >= min_threads
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :debug,
+                                       env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_DEBUG",
+                                       description: "Enable debug mode for upload-symbols",
+                                       type: Boolean,
+                                       default_value: false)
         ]
       end
 

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -100,7 +100,7 @@ describe Fastlane do
         command << "-p tvos"
         command << File.expand_path(File.join("fastlane", dsym_path)).shellescape
 
-        expect(Fastlane::Actions).to receive(:sh).with(command.join(" "), log: false)
+        expect(Fastlane::Actions).to receive(:sh).with(command.join(" "), log: true)
 
         Fastlane::FastFile.new.parse("lane :test do
           upload_symbols_to_crashlytics(

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -88,6 +88,29 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "uploads dSYM files with platform and debug params" do
+        dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
+        binary_path = './spec/fixtures/screenshots/screenshot1.png'
+        gsp_path = './spec/fixtures/plist/GoogleService-Info.plist'
+
+        command = []
+        command << File.expand_path(File.join("fastlane", binary_path)).shellescape
+        command << "-d"
+        command << "-gsp #{File.expand_path(File.join('fastlane', gsp_path)).shellescape}"
+        command << "-p tvos"
+        command << File.expand_path(File.join("fastlane", dsym_path)).shellescape
+
+        expect(Fastlane::Actions).to receive(:sh).with(command.join(" "), log: false)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          upload_symbols_to_crashlytics(
+            dsym_path: 'fastlane/#{dsym_path}',
+            binary_path: 'fastlane/#{binary_path}',
+            platform: 'appletvos',
+            debug: true)
+        end").runner.execute(:test)
+      end
+
       it "raises exception if no api access is given" do
         allow(Fastlane::Actions::UploadSymbolsToCrashlyticsAction).to receive(:find_gsp_path).and_return(nil)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Make it easier to diagnose problems for `upload-symbols`, particularly in CI environments. Here's an issue I ran into with our pipeline that turned out to be a network proxy configuration problem.
![image](https://user-images.githubusercontent.com/676185/86497311-0fd93c00-bd36-11ea-908f-9704fb2957d9.png)


### Description
- Added a `debug` flag for `upload_symbols_to_crashlytics` with default: false
- When debug is enabled, log `upload-symbols` output by default
- Added test case that covers the new `debug` argument and a previously untested path for the `platform` config value

### Testing Steps
I tested this locally and the cryptic message from above turned into this on my local machine
![image](https://user-images.githubusercontent.com/676185/86497722-9d695b80-bd37-11ea-8f31-7d5cd913aeb9.png)
