### PR TITLE
[spaceship] add requester fields Spaceship::ConnectAPI::Certificate

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -10,6 +10,9 @@ module Spaceship
       attr_accessor :platform
       attr_accessor :serial_number
       attr_accessor :certificate_type
+      attr_accessor :requester_email
+      attr_accessor :requester_first_name
+      attr_accessor :requester_last_name
 
       attr_mapping({
         "certificateContent" => "certificate_content",
@@ -18,7 +21,10 @@ module Spaceship
         "name" => "name",
         "platform" => "platform",
         "serialNumber" => "serial_number",
-        "certificateType" => "certificate_type"
+        "certificateType" => "certificate_type",
+        "requesterEmail" => "requester_email",
+        "requesterFirstName" => "requester_first_name",
+        "requesterLastName" => "requester_last_name"
       })
 
       module CertificateType
@@ -35,6 +41,10 @@ module Spaceship
 
       def self.type
         return "certificates"
+      end
+
+      def valid?
+        Time.parse(expiration_date) > Time.now
       end
 
       #

--- a/spaceship/spec/connect_api/models/certificate_spec.rb
+++ b/spaceship/spec/connect_api/models/certificate_spec.rb
@@ -19,6 +19,32 @@ describe Spaceship::ConnectAPI::Certificate do
       expect(model.platform).to eq("IOS")
       expect(model.serial_number).to eq("F5A44933E05F97D")
       expect(model.certificate_type).to eq("IOS_DEVELOPMENT")
+      expect(model.requester_email).to eq("email@email.com")
+      expect(model.requester_first_name).to eq("Josh")
+      expect(model.requester_last_name).to eq("Holtz")
+    end
+  end
+
+  describe '#valid?' do
+    let!(:certificate) do
+      certificates_response = JSON.parse File.read(File.join('spaceship', 'spec', 'connect_api', 'fixtures', 'provisioning', 'certificates.json'))
+      model = Spaceship::ConnectAPI::Models.parse(certificates_response).first
+    end
+
+    context 'with past exiration_date' do
+      before { certificate.expiration_date = "1999-02-01T20:50:34.000+0000" }
+
+      it 'should be invalid' do
+        expect(certificate.valid?).to eq(false)
+      end
+    end
+
+    context 'with a future exiration_date' do
+      before { certificate.expiration_date = "9999-02-01T20:50:34.000+0000" }
+
+      it 'should be valid' do
+        expect(certificate.valid?).to eq(true)
+      end
     end
   end
 end

--- a/spaceship/spec/connect_api/models/certificate_spec.rb
+++ b/spaceship/spec/connect_api/models/certificate_spec.rb
@@ -27,7 +27,7 @@ describe Spaceship::ConnectAPI::Certificate do
 
   describe '#valid?' do
     let!(:certificate) do
-      certificates_response = JSON.parse File.read(File.join('spaceship', 'spec', 'connect_api', 'fixtures', 'provisioning', 'certificates.json'))
+      certificates_response = JSON.parse(File.read(File.join('spaceship', 'spec', 'connect_api', 'fixtures', 'provisioning', 'certificates.json')))
       model = Spaceship::ConnectAPI::Models.parse(certificates_response).first
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Needed to tell which distribution certificates were created by my user in a client's account. The owner for all distribution certificates is always the organization owner. The requester information (email, first and last name) are who actually created the certificate.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
Adds the fields `requester_email`, `requester_first_name` and `requester_last_name`  to `Spaceship::ConnectAPI::Certificate` model. This uses the direct developer portal web api which includes the requester fields. The `Spaceship::Portal::Certificate` uses a different api and does not includes these.
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
