### PR TITLE
[deliver] use utc for autoreleasdate

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -330,10 +330,6 @@ module Deliver
       seconds_in_hour = 60 * 60
       time_in_s_to_hour = (time_in_s / seconds_in_hour).to_i * seconds_in_hour
 
-      # Remove minute offset if timezone has minute offset
-      minute_offset = Time.now.utc_offset % seconds_in_hour
-      time_in_s_to_hour -= minute_offset
-
       return Time.at(time_in_s_to_hour).utc.strftime("%Y-%m-%dT%H:%M:%S%:z")
     end
 


### PR DESCRIPTION
### Motivation and Context
Fixes https://github.com/fastlane/fastlane/pull/16640#issuecomment-653755768

### Description
Removing fancy time math and just using utc
