### PR TITLE
[deliver] set default ITMSTransporter transport flag to blank #16749

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -149,14 +149,22 @@ module FastlaneCore
     end
 
     def additional_upload_parameters
-      # Workaround because the traditional transporter broke on 1st March 2018
-      # More information https://github.com/fastlane/fastlane/issues/11958
-      # As there was no communication from Apple, we don't know if this is a temporary
-      # server outage, or something they changed without giving a heads-up
-      if ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"].to_s.length == 0
-        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV,Signiant"
+      # As Apple recommends in Transporter User Guide we shouldn't specify the -t transport parameter
+      # and instead allow Transporter to use automatic transport discovery
+      # to determine the best transport mode for packages.
+      # It became crucial after WWDC 2020 as it leaded to "Broken pipe (Write failed)" exception
+      # More information https://github.com/fastlane/fastlane/issues/16749
+      env_deliver_additional_params = ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"]
+      if env_deliver_additional_params.nil?
+        return nil
       end
-      return ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"]
+
+      deliver_additional_params = env_deliver_additional_params.to_s.strip
+      if !deliver_additional_params.include?("-t ")
+        UI.user_error!("Invalid transport parameter")
+      else
+        return deliver_additional_params
+      end
     end
   end
 

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -155,7 +155,7 @@ module FastlaneCore
       # It became crucial after WWDC 2020 as it leaded to "Broken pipe (Write failed)" exception
       # More information https://github.com/fastlane/fastlane/issues/16749
       env_deliver_additional_params = ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"]
-      if env_deliver_additional_params.nil?
+      if env_deliver_additional_params.to_s.empty?
         return nil
       end
 

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -6,7 +6,7 @@ describe FastlaneCore do
   let(:email) { 'fabric.devtools@gmail.com' }
 
   describe FastlaneCore::ItunesTransporter do
-    def shell_upload_command(provider_short_name = nil)
+    def shell_upload_command(provider_short_name: nil, transporter: nil)
       escaped_password = password.shellescape
       unless FastlaneCore::Helper.windows?
         escaped_password = escaped_password.gsub("\\'") do
@@ -20,7 +20,7 @@ describe FastlaneCore do
         "-u #{email.shellescape}",
         "-p #{escaped_password}",
         "-f \"/tmp/my.app.id.itmsp\"",
-        "-t DAV,Signiant",
+        (transporter.to_s if transporter),
         "-k 100000",
         ("-WONoPause true" if FastlaneCore::Helper.windows?),
         ("-itc_provider #{provider_short_name}" if provider_short_name)
@@ -55,7 +55,7 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def java_upload_command(provider_short_name = nil)
+    def java_upload_command(provider_short_name: nil, transporter: nil)
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
@@ -71,7 +71,7 @@ describe FastlaneCore do
         "-u #{email.shellescape}",
         "-p #{password.shellescape}",
         "-f /tmp/my.app.id.itmsp",
-        "-t DAV,Signiant",
+        (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
@@ -119,7 +119,7 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def java_upload_command_9(provider_short_name = nil)
+    def java_upload_command_9(provider_short_name: nil, transporter: nil)
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
@@ -134,7 +134,7 @@ describe FastlaneCore do
         "-u #{email.shellescape}",
         "-p #{password.shellescape}",
         "-f /tmp/my.app.id.itmsp",
-        "-t DAV,Signiant",
+        (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
@@ -162,14 +162,14 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def xcrun_upload_command(provider_short_name = nil)
+    def xcrun_upload_command(provider_short_name: nil, transporter: nil)
       [
         "xcrun iTMSTransporter",
         "-m upload",
         "-u #{email.shellescape}",
         "-p #{password.shellescape}",
         "-f /tmp/my.app.id.itmsp",
-        "-t DAV,Signiant",
+        (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
@@ -205,6 +205,17 @@ describe FastlaneCore do
           end
         end
 
+        describe "upload command generation with DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS set" do
+          before(:each) { ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV,Signiant" }
+
+          it 'generates a call to java directly' do
+            transporter = FastlaneCore::ItunesTransporter.new(email, password)
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(transporter: "-t DAV,Signiant"))
+          end
+
+          after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
+        end
+
         describe "download command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password)
@@ -224,7 +235,7 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd1234')
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command('abcd1234'))
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(provider_short_name: 'abcd1234'))
           end
         end
 
@@ -247,7 +258,7 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true, 'abcd1234')
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command('abcd1234'))
+            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(provider_short_name: 'abcd1234'))
           end
         end
 
@@ -357,6 +368,17 @@ describe FastlaneCore do
         end
       end
 
+      describe "upload command generation with DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS set" do
+        before(:each) { ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV,Signiant" }
+
+        it 'generates a call to java directly' do
+          transporter = FastlaneCore::ItunesTransporter.new(email, password)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(transporter: "-t DAV,Signiant"))
+        end
+
+        after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
+      end
+
       describe "download command generation" do
         it 'generates a call to the shell script' do
           transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
@@ -387,6 +409,17 @@ describe FastlaneCore do
         end
       end
 
+      describe "upload command generation with DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS set" do
+        before(:each) { ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV,Signiant" }
+
+        it 'generates a call to java directly' do
+          transporter = FastlaneCore::ItunesTransporter.new(email, password)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9(transporter: "-t DAV,Signiant"))
+        end
+
+        after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
+      end
+
       describe "download command generation" do
         it 'generates a call to java directly' do
           transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
@@ -408,6 +441,17 @@ describe FastlaneCore do
           transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
           expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
         end
+      end
+
+      describe "upload command generation with DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS set" do
+        before(:each) { ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV,Signiant" }
+
+        it 'generates a call to java directly' do
+          transporter = FastlaneCore::ItunesTransporter.new(email, password)
+          expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant"))
+        end
+
+        after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
       end
 
       describe "download command generation" do
@@ -439,6 +483,26 @@ describe FastlaneCore do
       end
 
       after(:each) { ENV.delete("FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT") }
+    end
+
+    describe "with `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` set to wrong value" do
+      it 'failed to generate command for upload with lack of space' do
+        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-tDAV,Signiant"
+        transporter = FastlaneCore::ItunesTransporter.new(email, password)
+        expect do
+          transporter.upload('my.app.id', '/tmp')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+
+      it 'failed to generate command for upload with incorrect value' do
+        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-x DAV,Signiant"
+        transporter = FastlaneCore::ItunesTransporter.new(email, password)
+        expect do
+          transporter.upload('my.app.id', '/tmp')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+
+      after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
     end
 
     describe "with no special configuration" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
It solves issue https://github.com/fastlane/fastlane/issues/16749 

### Description
According to [Apple's Transporter User Guide 2.0 documentation](https://help.apple.com/itc/transporteruserguide/#/apdATD1E1288-D1E1A1303-D1E1288A1126) Apple recommends to not  specify transport option and let the tool to determine the best transport mode for packages. It is also visible in the comments, in the mentioned issue that setting this parameter to empty string, fix the issue.

### Testing Steps
Try to use deliver or pilot to send build to TestFlight without `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` ENV variable being set.
