### PR TITLE
[spaceship] Update sinatra to 2.x (uses rack 2.x)

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -117,7 +117,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rb-readline') # https://github.com/deivid-rodriguez/byebug/issues/289#issuecomment-251383465
   spec.add_development_dependency('rest-client', '>= 1.8.0')
   spec.add_development_dependency('fakefs', '~> 0.8.1')
-  spec.add_development_dependency('sinatra', '~> 1.4.8')
+  spec.add_development_dependency('sinatra', '~> 2.0.8') # Used for mock servers
   spec.add_development_dependency('xcov', '~> 1.4.1') # Used for xcov's parameters generation: https://github.com/fastlane/fastlane/pull/12416
   spec.add_development_dependency('climate_control', '~> 0.2.0')
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The sinatra usage in this project is easy enough that it didn't need any changes when updating. While being on the latest release should be reason enough, there is one nice thing implicitly done here (not shown since no `Gemfile.lock` is being committed), is that `rack` is now also at `~> 2.0`, which receives updates and security fixes (although most were backported to 1.6.x).

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

No real description, but some CHANGELOG.md files to see what changed.

https://github.com/sinatra/sinatra/blob/master/CHANGELOG.md
https://github.com/rack/rack/blob/master/CHANGELOG.md

Example of a backported CVE fix.
https://nvd.nist.gov/vuln/detail/CVE-2019-16782
