### PR TITLE
Version bump to 2.151.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
@@ -64,13 +46,95 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
 </tr>
 <tr>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+</tr>
+<tr>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+</tr>
+<tr>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 <td id='daniel-jankowski'>
 <a href='https://github.com/mollyIV'>
@@ -84,95 +148,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+</tr>
+<tr>
 <td id='maksym-grebenets'>
 <a href='https://github.com/mgrebenets'>
 <img src='https://github.com/mgrebenets.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-</tr>
-<tr>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-</tr>
-<tr>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-</tr>
-<tr>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Max Ott",
-                        "Helmut Januschka",
-                        "Aaron Brager",
-                        "Felix Krause",
-                        "Andrew McBurney",
-                        "Matthew Ellis",
-                        "Josh Holtz",
-                        "Joshua Liebowitz",
-                        "Maksym Grebenets",
-                        "Jérôme Lacoste",
-                        "Jorge Revuelta H",
+  spec.authors       = ["Matthew Ellis",
                         "Iulian Onofrei",
+                        "Andrew McBurney",
+                        "Stefan Natchev",
+                        "Fumiya Nakamura",
+                        "Luka Mirosevic",
                         "Jimmy Dee",
                         "Manu Wallner",
-                        "Fumiya Nakamura",
                         "Daniel Jankowski",
-                        "Jan Piotrowski",
+                        "Aaron Brager",
                         "Danielle Tomlinson",
+                        "Maksym Grebenets",
+                        "Jan Piotrowski",
+                        "Josh Holtz",
+                        "Jérôme Lacoste",
+                        "Joshua Liebowitz",
+                        "Helmut Januschka",
                         "Olivier Halligon",
                         "Kohki Miki",
-                        "Stefan Natchev",
-                        "Luka Mirosevic"]
+                        "Max Ott",
+                        "Jorge Revuelta H",
+                        "Felix Krause"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.150.3'.freeze
+  VERSION = '2.151.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -14,4 +14,4 @@ class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.150.3
+// Generated with fastlane 2.151.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -60,7 +60,7 @@ protocol DeliverfileProtocol: class {
     var automaticRelease: Bool { get }
 
     /// Date in milliseconds for automatically releasing on pending approval (Can not be used together with `automatic_release`)
-    var autoReleaseDate: String? { get }
+    var autoReleaseDate: Int? { get }
 
     /// Enable the phased release feature of iTC
     var phasedRelease: Bool { get }
@@ -201,7 +201,7 @@ extension DeliverfileProtocol {
     var submitForReview: Bool { return false }
     var rejectIfPossible: Bool { return false }
     var automaticRelease: Bool { return false }
-    var autoReleaseDate: String? { return nil }
+    var autoReleaseDate: Int? { return nil }
     var phasedRelease: Bool { return false }
     var resetRatings: Bool { return false }
     var priceTier: String? { return nil }
@@ -245,4 +245,4 @@ extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.21]
+// FastlaneRunnerAPIVersion [0.9.22]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -510,7 +510,7 @@ func appstore(username: String,
               submitForReview: Bool = false,
               rejectIfPossible: Bool = false,
               automaticRelease: Bool = false,
-              autoReleaseDate: Any? = nil,
+              autoReleaseDate: Int? = nil,
               phasedRelease: Bool = false,
               resetRatings: Bool = false,
               priceTier: Any? = nil,
@@ -2560,7 +2560,7 @@ func deliver(username: Any = deliverfile.username,
              submitForReview: Bool = deliverfile.submitForReview,
              rejectIfPossible: Bool = deliverfile.rejectIfPossible,
              automaticRelease: Bool = deliverfile.automaticRelease,
-             autoReleaseDate: Any? = deliverfile.autoReleaseDate,
+             autoReleaseDate: Int? = deliverfile.autoReleaseDate,
              phasedRelease: Bool = deliverfile.phasedRelease,
              resetRatings: Bool = deliverfile.resetRatings,
              priceTier: Any? = deliverfile.priceTier,
@@ -4559,6 +4559,7 @@ func makeChangelogFromJenkins(fallbackChangelog: String = "",
    - s3AccessKey: S3 access key
    - s3SecretAccessKey: S3 secret access key
    - s3Bucket: Name of the S3 bucket
+   - s3ObjectPrefix: Prefix to be used on all objects uploaded to S3
    - keychainName: Keychain the items should be imported to
    - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
    - force: Renew the provisioning profiles every time you run match
@@ -4599,6 +4600,7 @@ func match(type: Any = matchfile.type,
            s3AccessKey: Any? = matchfile.s3AccessKey,
            s3SecretAccessKey: Any? = matchfile.s3SecretAccessKey,
            s3Bucket: Any? = matchfile.s3Bucket,
+           s3ObjectPrefix: Any? = matchfile.s3ObjectPrefix,
            keychainName: Any = matchfile.keychainName,
            keychainPassword: Any? = matchfile.keychainPassword,
            force: Bool = matchfile.force,
@@ -4636,6 +4638,7 @@ func match(type: Any = matchfile.type,
                                                                                          RubyCommand.Argument(name: "s3_access_key", value: s3AccessKey),
                                                                                          RubyCommand.Argument(name: "s3_secret_access_key", value: s3SecretAccessKey),
                                                                                          RubyCommand.Argument(name: "s3_bucket", value: s3Bucket),
+                                                                                         RubyCommand.Argument(name: "s3_object_prefix", value: s3ObjectPrefix),
                                                                                          RubyCommand.Argument(name: "keychain_name", value: keychainName),
                                                                                          RubyCommand.Argument(name: "keychain_password", value: keychainPassword),
                                                                                          RubyCommand.Argument(name: "force", value: force),
@@ -5633,7 +5636,7 @@ func resetSimulatorContents(ios: [String]? = nil,
    - shortVersion: Short version string to force resigned ipa to use (`CFBundleShortVersionString`)
    - bundleVersion: Bundle version to force resigned ipa to use (`CFBundleVersion`)
    - bundleId: Set new bundle ID during resign (`CFBundleIdentifier`)
-   - useAppEntitlements: Extract app bundle codesigning entitlements and combine with entitlements from new provisionin profile
+   - useAppEntitlements: Extract app bundle codesigning entitlements and combine with entitlements from new provisioning profile
    - keychainPath: Provide a path to a keychain file that should be used by `/usr/bin/codesign`
  */
 func resign(ipa: String,
@@ -7351,6 +7354,7 @@ func swiftlint(mode: Any = "lint",
    - s3AccessKey: S3 access key
    - s3SecretAccessKey: S3 secret access key
    - s3Bucket: Name of the S3 bucket
+   - s3ObjectPrefix: Prefix to be used on all objects uploaded to S3
    - keychainName: Keychain the items should be imported to
    - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
    - force: Renew the provisioning profiles every time you run match
@@ -7391,6 +7395,7 @@ func syncCodeSigning(type: String = "development",
                      s3AccessKey: String? = nil,
                      s3SecretAccessKey: String? = nil,
                      s3Bucket: String? = nil,
+                     s3ObjectPrefix: String? = nil,
                      keychainName: String = "login.keychain",
                      keychainPassword: String? = nil,
                      force: Bool = false,
@@ -7428,6 +7433,7 @@ func syncCodeSigning(type: String = "development",
                                                                                                      RubyCommand.Argument(name: "s3_access_key", value: s3AccessKey),
                                                                                                      RubyCommand.Argument(name: "s3_secret_access_key", value: s3SecretAccessKey),
                                                                                                      RubyCommand.Argument(name: "s3_bucket", value: s3Bucket),
+                                                                                                     RubyCommand.Argument(name: "s3_object_prefix", value: s3ObjectPrefix),
                                                                                                      RubyCommand.Argument(name: "keychain_name", value: keychainName),
                                                                                                      RubyCommand.Argument(name: "keychain_password", value: keychainPassword),
                                                                                                      RubyCommand.Argument(name: "force", value: force),
@@ -8166,7 +8172,7 @@ func uploadToAppStore(username: String,
                       submitForReview: Bool = false,
                       rejectIfPossible: Bool = false,
                       automaticRelease: Bool = false,
-                      autoReleaseDate: Any? = nil,
+                      autoReleaseDate: Int? = nil,
                       phasedRelease: Bool = false,
                       resetRatings: Bool = false,
                       priceTier: Any? = nil,
@@ -8827,7 +8833,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode-11.4.1.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode-11.5.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false) {
     let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                         RubyCommand.Argument(name: "project", value: project),
@@ -8971,4 +8977,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.74]
+// FastlaneRunnerAPIVersion [0.9.75]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -14,4 +14,4 @@ class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.150.3
+// Generated with fastlane 2.151.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -181,4 +181,4 @@ extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.24]
+// FastlaneRunnerAPIVersion [0.9.25]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -14,4 +14,4 @@ class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.150.3
+// Generated with fastlane 2.151.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -74,6 +74,9 @@ protocol MatchfileProtocol: class {
     /// Name of the S3 bucket
     var s3Bucket: String? { get }
 
+    /// Prefix to be used on all objects uploaded to S3
+    var s3ObjectPrefix: String? { get }
+
     /// Keychain the items should be imported to
     var keychainName: String { get }
 
@@ -137,6 +140,7 @@ extension MatchfileProtocol {
     var s3AccessKey: String? { return nil }
     var s3SecretAccessKey: String? { return nil }
     var s3Bucket: String? { return nil }
+    var s3ObjectPrefix: String? { return nil }
     var keychainName: String { return "login.keychain" }
     var keychainPassword: String? { return nil }
     var force: Bool { return false }
@@ -153,4 +157,4 @@ extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.18]
+// FastlaneRunnerAPIVersion [0.9.19]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -14,4 +14,4 @@ class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.150.3
+// Generated with fastlane 2.151.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -33,4 +33,4 @@ extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.17]
+// FastlaneRunnerAPIVersion [0.9.18]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -14,4 +14,4 @@ class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.150.3
+// Generated with fastlane 2.151.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -257,4 +257,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.29]
+// FastlaneRunnerAPIVersion [0.9.30]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -14,4 +14,4 @@ class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.150.3
+// Generated with fastlane 2.151.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -93,4 +93,4 @@ extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.19]
+// FastlaneRunnerAPIVersion [0.9.20]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -14,4 +14,4 @@ class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.150.3
+// Generated with fastlane 2.151.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -173,4 +173,4 @@ extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.13]
+// FastlaneRunnerAPIVersion [0.9.14]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.150.3':**

* [fastlane_core] strip upload param env before checking (#16783) via Josh Holtz
* [deliver] set default ITMSTransporter transport flag to blank #16749 (#16774) via Krzysztof Romanowski
* [action] add retry to notarize when request uuid isn't ready (#16782) via Josh Holtz
* [match] always checkout the specified branch as master may not be the default branch (#16622) via Morten Bøgh
* [spaceship] loosen jwt dependency (#16778) via Anton Rieder
* [spaceship] update sinatra to 2.x (uses rack 2.x) (#16776) via Anton Rieder
* [fastlane] Fix S3ClientHelper side effects (#16687) via Austin Treat Emmons
* [deliver] set type of auto release date to integer (#16767) via Josh Holtz
* [action] run setup_keychain on macOS environments only (#16733) via Sean Reinhardt
* [match] add `s3_object_prefix` option to match's S3Storage. (#16682) via Austin Treat Emmons
* [sigh][resign] fix typo in resign.rb (#16705) via Eduardo Pelitti
* [fastlane] extend socket failure payload (#16632) via Ray Deck
* [sigh][resign] OnDemandResources (#16669) via steven 'haji' hajducko
* [fastlane] change the `brew cask install fastlane` in any output to `brew install fastlane` (#16670) via Steven Conaway
* [Fastlane.swift] add formatter to Fastlane.swift (#16693) via Jorge
* [pilot] update docs to include App Store Connect roles (#16766) via Josh Holtz
* [spaceship] remove multi_xml dependency (#16697) via Anton Rieder
* [spaceship] remove babosa fix (#16699) via Anton Rieder
* [deliver] fix typo: delcaration => declaration (#16756) via Koen Punt
* [action] upload_symbols_to_crashlytics - add support for debug flag (#16745) via Yang Su
* [action] add synchronous option to pod_push (#16698) via Ivan Artemiev
