### PR TITLE
[spaceship] remove xml parser from Spaceship::ConnectAPI::FileUploader

### DIFF
--- a/spaceship/lib/spaceship/connect_api/file_uploader.rb
+++ b/spaceship/lib/spaceship/connect_api/file_uploader.rb
@@ -74,7 +74,6 @@ module Spaceship
 
         @client ||= Faraday.new(options) do |c|
           c.response(:json, content_type: /\bjson$/)
-          c.response(:xml, content_type: /\bxml$/)
           c.response(:plist, content_type: /\bplist$/)
           c.adapter(Faraday.default_adapter)
 


### PR DESCRIPTION
### Motivation and Context
Fails up upload files with left over xml parser that was removed in previous PR

### Description
Removes unused XML parser
