### PR TITLE
[deliver] Update fakefs to 1.2.x

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -116,7 +116,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rubocop-require_tools', '>= 0.1.2')
   spec.add_development_dependency('rb-readline') # https://github.com/deivid-rodriguez/byebug/issues/289#issuecomment-251383465
   spec.add_development_dependency('rest-client', '>= 1.8.0')
-  spec.add_development_dependency('fakefs', '~> 0.8.1')
+  spec.add_development_dependency('fakefs', '~> 1.2.1')
   spec.add_development_dependency('sinatra', '~> 2.0.8') # Used for mock servers
   spec.add_development_dependency('xcov', '~> 1.4.1') # Used for xcov's parameters generation: https://github.com/fastlane/fastlane/pull/12416
   spec.add_development_dependency('climate_control', '~> 0.2.0')


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Update to a release that is considered stable and fixes some Ruby 2.7 warnings.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

1.x marked that it's considered stable. New releases also removed Ruby 2.7 warnings which should help with running fastlane on 2.7.

https://github.com/fakefs/fakefs/blob/master/CHANGELOG.md
https://github.com/fastlane/fastlane/issues/16342

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I did not test the commented out specs here:
https://github.com/fastlane/fastlane/blob/fastlane/2.151.1/deliver/spec/upload_screenshots_spec.rb

Unrelated to this PR, but should these maybe the [properly skipped](https://relishapp.com/rspec/rspec-core/v/3-8/docs/pending-and-skipped-examples/skip-examples) so it's more explicit that there is a file which is not actually run?