### PR TITLE
[actions] update `danger` to 8, lock faraday to <1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source("https://rubygems.org")
 
 gem "xcode-install", ">= 2.2.1" # needed for running xcode-install related tests
 
-gem "danger", ">= 4.2.1", "< 5.0.0"
-gem "danger-junit", ">= 0.7.3", "< 1.0.0"
+gem "danger", "~> 8.0"
+gem "danger-junit", "~> 1.0"
 
 gemspec(path: ".")
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -76,7 +76,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency('commander-fastlane', '>= 4.4.6', '< 5.0.0') # CLI parser
   spec.add_dependency('excon', '>= 0.71.0', '< 1.0.0') # Great HTTP Client
   spec.add_dependency('faraday-cookie_jar', '~> 0.0.6')
-  spec.add_dependency('faraday', '>= 0.17', '< 2.0') # Used for deploygate, hockey and testfairy actions
+  # The faraday gem is used for deploygate, hockey and testfairy actions.
+  # Locked under 1.0 until webmock 3.6.0 can be used to handle empty array
+  # parameters https://github.com/bblimke/webmock/blob/master/CHANGELOG.md#360,
+  # probably.
+  spec.add_dependency('faraday', '>= 0.17', '< 1.0')
   spec.add_dependency('faraday_middleware', '>= 0.13.1', '< 2.0') # Same as faraday
   spec.add_dependency('fastimage', '>= 2.1.0', '< 3.0.0') # fetch the image sizes from the screenshots
   spec.add_dependency('gh_inspector', '>= 1.1.2', '< 2.0.0') # search for issues on GitHub when something goes wrong


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The reason to update was that it was holding other dependencies back, like `kramdown` or `faraday`. Also it was behind several major versions.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

`danger` 8 supports Ruby 2.4+, like fastlane. The range could of course include `danger` 4 up to 8, but since it's a development dependency, it can be as high as we want it.

Talking about `faraday`, ironically it had to be locked to less than 1 because of two failing test cases with `faraday` 1.x. Specifically these two:
`rspec ./spaceship/spec/portal/enterprise_spec.rb:21`
`rspec ./spaceship/spec/portal/portal_client_spec.rb:286`

I believe at least one of them is caused by `webmock` in combination with `faraday` and empty arrays as parameters. See also the changelog of `webmock` for version 3.6, which supposedly fixes this. However I haven't tried since this would entail updating `webmock`.

The `faraday` dependency was initially loosened in a PR, however to no `Gemfile.lock` being committed, it probably remained largely unnoticed that another dependency (`danger`) was holding it back.


https://github.com/danger/danger/blob/v8.0.2/CHANGELOG.md#800
https://github.com/bblimke/webmock/blob/v3.8.3/CHANGELOG.md#360
https://github.com/fastlane/fastlane/pull/16399
https://github.com/fastlane/fastlane/pull/8135

Further reading about committing a `Gemfile.lock` file:
https://bundler.io/blog/2018/01/17/making-gem-development-a-little-better.html

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I didn't really see breaking changes in `danger`'s changelog, so I guess we'll see how the danger bot reacts.