### PR TITLE
[fastlane_core] escape xcrun itmstransporter password for special characters

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -249,10 +249,11 @@ module FastlaneCore
     def build_upload_command(username, password, source = "/tmp", provider_short_name = "")
       if Helper.mac? && Helper.xcode_at_least?(11)
         [
+          "ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}",
           'xcrun iTMSTransporter',
           '-m upload',
           "-u #{username.shellescape}",
-          "-p #{password.shellescape}",
+          "-p @env:ITMS_TRANSPORTER_PASSWORD",
           "-f #{source.shellescape}",
           additional_upload_parameters, # that's here, because the user might overwrite the -t option
           '-k 100000',
@@ -285,10 +286,11 @@ module FastlaneCore
     def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "")
       if Helper.mac? && Helper.xcode_at_least?(11)
         [
+          "ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}",
           'xcrun iTMSTransporter',
           '-m lookupMetadata',
           "-u #{username.shellescape}",
-          "-p #{password.shellescape}",
+          "-p @env:ITMS_TRANSPORTER_PASSWORD",
           "-apple_id #{apple_id.shellescape}",
           "-destination #{destination.shellescape}",
           ("-itc_provider #{provider_short_name}" unless provider_short_name.to_s.empty?),
@@ -319,10 +321,11 @@ module FastlaneCore
     def build_provider_ids_command(username, password)
       if Helper.mac? && Helper.xcode_at_least?(11)
         [
+          "ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}",
           'xcrun iTMSTransporter',
           '-m provider',
           "-u #{username.shellescape}",
-          "-p #{password.shellescape}",
+          "-p @env:ITMS_TRANSPORTER_PASSWORD",
           '2>&1' # cause stderr to be written to stdout
         ].compact.join(' ')
       else

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -164,10 +164,11 @@ describe FastlaneCore do
 
     def xcrun_upload_command(provider_short_name: nil, transporter: nil)
       [
+        "ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}",
         "xcrun iTMSTransporter",
         "-m upload",
         "-u #{email.shellescape}",
-        "-p #{password.shellescape}",
+        "-p @env:ITMS_TRANSPORTER_PASSWORD",
         "-f /tmp/my.app.id.itmsp",
         (transporter.to_s if transporter),
         "-k 100000",
@@ -178,10 +179,11 @@ describe FastlaneCore do
 
     def xcrun_download_command(provider_short_name = nil)
       [
+        "ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}",
         "xcrun iTMSTransporter",
         '-m lookupMetadata',
         "-u #{email.shellescape}",
-        "-p #{password.shellescape}",
+        "-p @env:ITMS_TRANSPORTER_PASSWORD",
         '-apple_id my.app.id',
         '-destination /tmp',
         ("-itc_provider #{provider_short_name}" if provider_short_name),


### PR DESCRIPTION
### Motivation and Context
Fixes #16777

### Description
- Sets `ITMS_TRANSPORTER_PASSWORD` variable before `xcrun iTMSTransporter` 
- Uses `-p @env:ITMS_TRANSPORTER_PASSWORD` to tell `iTMSTransporter` to look at the env
- Found doc on `@env` at https://help.apple.com/itc/transporteruserguide/en.lproj/static.html
![Screen Shot 2020-07-08 at 12 34 23 PM](https://user-images.githubusercontent.com/401294/86951609-5d2f2200-c117-11ea-91c4-cc93b7cfab18.png)

