### PR TITLE
[fastlane] replace blank? with to_s.empty?

### DIFF
--- a/fastlane/lib/fastlane/helper/s3_client_helper.rb
+++ b/fastlane/lib/fastlane/helper/s3_client_helper.rb
@@ -66,7 +66,7 @@ module Fastlane
       end
 
       def create_credentials
-        return nil if access_key.blank? || secret_access_key.blank?
+        return nil if access_key.to_s.empty? || secret_access_key.to_s.empty?
 
         Aws::Credentials.new(
           access_key,


### PR DESCRIPTION
### Motivation and Context
Error while running `fastlane validate_repo`

### Description
`blank?` isn’t a thing so use `to_s.empty?` instead

