### PR TITLE
[spaceship] add shortcuts for getting current pending release and current in review app store version

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -181,6 +181,24 @@ module Spaceship
                .last
       end
 
+      def get_in_review_app_store_version(platform: nil, includes: nil)
+        platform ||= Spaceship::ConnectAPI::Platform::IOS
+        filter = {
+          appStoreState: [Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::IN_REVIEW].join(","),
+          platform: platform
+        }
+        return get_app_store_versions(filter: filter, includes: includes).first
+      end
+
+      def get_pending_release_app_store_version(platform: nil, includes: nil)
+        platform ||= Spaceship::ConnectAPI::Platform::IOS
+        filter = {
+          appStoreState: [Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::PENDING_DEVELOPER_RELEASE].join(","),
+          platform: platform
+        }
+        return get_app_store_versions(filter: filter, includes: includes).first
+      end
+
       def get_app_store_versions(filter: {}, includes: nil, limit: nil, sort: nil)
         resps = Spaceship::ConnectAPI.get_app_store_versions(app_id: id, filter: filter, includes: includes, limit: limit, sort: sort).all_pages
         return resps.flat_map(&:to_models)

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -155,7 +155,7 @@ module Spaceship
       def get_live_app_store_version(platform: nil, includes: nil)
         platform ||= Spaceship::ConnectAPI::Platform::IOS
         filter = {
-          appStoreState: [Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::READY_FOR_SALE].join(","),
+          appStoreState: Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::READY_FOR_SALE,
           platform: platform
         }
         return get_app_store_versions(filter: filter, includes: includes).first
@@ -184,7 +184,7 @@ module Spaceship
       def get_in_review_app_store_version(platform: nil, includes: nil)
         platform ||= Spaceship::ConnectAPI::Platform::IOS
         filter = {
-          appStoreState: [Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::IN_REVIEW].join(","),
+          appStoreState: Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::IN_REVIEW,
           platform: platform
         }
         return get_app_store_versions(filter: filter, includes: includes).first
@@ -193,7 +193,7 @@ module Spaceship
       def get_pending_release_app_store_version(platform: nil, includes: nil)
         platform ||= Spaceship::ConnectAPI::Platform::IOS
         filter = {
-          appStoreState: [Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::PENDING_DEVELOPER_RELEASE].join(","),
+          appStoreState: Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::PENDING_DEVELOPER_RELEASE,
           platform: platform
         }
         return get_app_store_versions(filter: filter, includes: includes).first


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This adds short cuts for getting the app store version which is In Review via `get_in_review_app_store_version`, and Pending Developer Release via `get_pending_release_app_store_version`. This way I don't have to remember the filters when looking these versions up.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
This adds short cuts for getting the app store version which is In Review via `get_in_review_app_store_version`, and Pending Developer Release via `get_pending_release_app_store_version`.
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
