### PR TITLE
[pilot] add new distribute_only option (similar to 'fastlane pilot distribute' command)

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -5,15 +5,23 @@ module Fastlane
         require 'pilot'
         require 'pilot/options'
 
+        distribute_only = values[:distribute_only]
+
         changelog = Actions.lane_context[SharedValues::FL_CHANGELOG]
         values[:changelog] ||= changelog if changelog
 
-        values[:ipa] ||= Actions.lane_context[SharedValues::IPA_OUTPUT_PATH]
-        values[:ipa] = File.expand_path(values[:ipa]) if values[:ipa]
+        unless distribute_only
+          values[:ipa] ||= Actions.lane_context[SharedValues::IPA_OUTPUT_PATH]
+          values[:ipa] = File.expand_path(values[:ipa]) if values[:ipa]
+        end
 
         return values if Helper.test?
 
-        Pilot::BuildManager.new.upload(values) # we already have the finished config
+        if distribute_only
+          Pilot::BuildManager.new.distribute(values) # we already have the finished config
+        else
+          Pilot::BuildManager.new.upload(values) # we already have the finished config
+        end
       end
 
       #####################################################

--- a/fastlane/spec/actions_specs/pilot_spec.rb
+++ b/fastlane/spec/actions_specs/pilot_spec.rb
@@ -21,6 +21,22 @@ describe Fastlane do
         expect(values[:changelog]).to eq('custom changelog')
       end
 
+      it "defaults distribute_only to false" do
+        values = Fastlane::FastFile.new.parse("lane :test do
+          pilot
+        end").runner.execute(:test)
+
+        expect(values[:distribute_only]).to eq(false)
+      end
+
+      it "allows setting of distribute_only to true" do
+        values = Fastlane::FastFile.new.parse("lane :test do
+          pilot(distribute_only: true)
+        end").runner.execute(:test)
+
+        expect(values[:distribute_only]).to eq(true)
+      end
+
       describe "Test `apple_id` parameter" do
         it "raises an error if `apple_id` is set to email address" do
           expect do

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -146,6 +146,12 @@ module Pilot
                                      default_value: false),
 
         # distribution
+        FastlaneCore::ConfigItem.new(key: :distribute_only,
+                                     short_option: "-D",
+                                     env_name: "PILOT_DISTRIBUTE_ONLY",
+                                     description: "Distribute a previously uploaded build (equivalent to the `fastlane pilot distribute` command)",
+                                     default_value: false,
+                                     type: Boolean),
         FastlaneCore::ConfigItem.new(key: :uses_non_exempt_encryption,
                                      short_option: "-X",
                                      env_name: "PILOT_USES_NON_EXEMPT_ENCRYPTION",


### PR DESCRIPTION
### Motivation and Context
Fixes #16815

### Description
- The `Fastfile` should have the equivalent of `fastlane pilot distribute`.
  - Added a new option called `distribute_only` which takes a boolean
  - Slightly modifies the pilot action to call `distribute` method instead of `upload` method if `distribute_only: true`

### Testing Steps

```rb
lane :distribute do                                                                                                                                 
  pilot(                                                                                                                                            
    app_identifier: "com.your.bundle",                                                                                               
    app_version: "0.1.0",                                                                                                                           
    build_number: "123456",                                                                                                                     

    distribute_external: true,                                                                                                                      
    groups: "Dude",                                                                                                                                                                                                                                           
    distribute_only: true                                                                                                                           
  )                                                                                                                                                 
end

```
