### PR TITLE
[fastlane] ignore vendor debug check when running tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,14 +26,15 @@ desc "Verifies source code is in a good state"
 lane :lint_source do
   # Verifying that no debug code is in the code base
   #
-  ensure_no_debug_code(text: "binding.pry", extension: ".rb", exclude: "playground.rb", exclude_dirs: ["\.bundle"]) # debugging code
-  ensure_no_debug_code(text: "# TODO", extension: ".rb", exclude_dirs: ["\.bundle"]) # TODOs
-  ensure_no_debug_code(text: "now: ", extension: ".rb", exclude_dirs: ["\.bundle"]) # rspec focus
-  ensure_no_debug_code(text: "<<<<<<<", extension: ".rb", exclude_dirs: ["\.bundle"]) # Merge conflict
+  exclude_dirs = ["\.bundle", "*/vendor/bundle"]
+  ensure_no_debug_code(text: "binding.pry", extension: ".rb", exclude: "playground.rb", exclude_dirs: exclude_dirs) # debugging code
+  ensure_no_debug_code(text: "# TODO", extension: ".rb", exclude_dirs: exclude_dirs) # TODOs
+  ensure_no_debug_code(text: "now: ", extension: ".rb", exclude_dirs: exclude_dirs) # rspec focus
+  ensure_no_debug_code(text: "<<<<<<<", extension: ".rb", exclude_dirs: exclude_dirs) # Merge conflict
 
   # spaceship and credentials_manager don't have access to fastlane_core
-  ensure_no_debug_code(text: " UI\\.", path: "spaceship/lib", extension: ".rb", exclude_dirs: ["\.bundle"])
-  ensure_no_debug_code(text: " UI\\.", path: "credentials_manager/lib", extension: ".rb", exclude_dirs: ["\.bundle"])
+  ensure_no_debug_code(text: " UI\\.", path: "spaceship/lib", extension: ".rb", exclude_dirs: exclude_dirs)
+  ensure_no_debug_code(text: " UI\\.", path: "credentials_manager/lib", extension: ".rb", exclude_dirs: exclude_dirs)
 
   rubocop(step_name: 'policekeeping_the_code_with_rubocop')
 

--- a/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_no_debug_code_spec.rb
@@ -69,7 +69,7 @@ describe Fastlane do
         expect(result).to eq("grep -RE 'pry' '#{File.absolute_path('./')}' --exclude-dir #{directory.shellescape}")
       end
 
-      it "handles the exclude_dirs parameter with multiple  elements correctly" do
+      it "handles the exclude_dirs parameter with multiple elements correctly" do
         result = Fastlane::FastFile.new.parse("lane :test do
           ensure_no_debug_code(text: 'pry', path: '.', exclude_dirs: ['.bundle', 'Packages/'])
         end").runner.execute(:test)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

When running a system that does not have a ruby manager like rbenv, you often cannot bundle without sudo. This leads to bundler recommending that you bundle with a path like `vendor/bundle` (which is the default recommendation).

If you do this fastlane tests fail checking for TODOS, binding.pry and other debug code because they exist in your working directory for gem dependencies.

This change skips that folder when checking for debug code.

### Description

Adds `*/vendor/bundle` to the `--exclude-dir` parameter of the grep command that is searching for these strings

### Testing Steps

Checkout a fresh fastlane repo
Run `bundle install --path vendor/bundle`
Run fastlane tests: `bundle exec fastlane test`
