### PR TITLE
[gym] make error messages more clear with IPAs and PKGs cannot be found

### DIFF
--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -127,6 +127,14 @@ module Gym
         UI.build_failure!("Archive invalid")
       end
 
+      def handle_empty_ipa
+        UI.build_failure!("IPA invalid")
+      end
+
+      def handle_empty_pkg
+        UI.build_failure!("PKG invalid")
+      end
+
       private
 
       # Just to make things easier

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -75,7 +75,7 @@ module Gym
           Gym.cache[:ipa_path] = File.join(temporary_output_path, "#{Gym.config[:output_name]}.ipa")
           FileUtils.cp(path, Gym.cache[:ipa_path]) unless File.expand_path(path).casecmp(File.expand_path(Gym.cache[:ipa_path]).downcase).zero?
         else
-          ErrorHandler.handle_empty_archive unless path
+          ErrorHandler.handle_empty_ipa unless path
         end
 
         Gym.cache[:ipa_path]
@@ -99,7 +99,7 @@ module Gym
           Gym.cache[:pkg_path] = File.join(temporary_output_path, "#{Gym.config[:output_name]}.pkg")
           FileUtils.cp(path, Gym.cache[:pkg_path]) unless File.expand_path(path).casecmp(File.expand_path(Gym.cache[:pkg_path]).downcase).zero?
         else
-          ErrorHandler.handle_empty_archive unless path
+          ErrorHandler.handle_empty_pkg unless path
         end
 
         Gym.cache[:pkg_path]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The purpose of this change is to make it easier to debug certain failure situations. Currently, fastlane emits the same error code in three different situations:

1. [When an `xcarchive` cannot be found](https://github.com/fastlane/fastlane/blob/master/gym/lib/gym/runner.rb#L143)
1. [When an `IPA` cannot be found](https://github.com/fastlane/fastlane/blob/master/gym/lib/gym/generators/package_command_generator_xcode7.rb#L78)
1. [When a `PKG` cannot be found](https://github.com/fastlane/fastlane/blob/master/gym/lib/gym/generators/package_command_generator_xcode7.rb#L102)

Since each of these failure situations has the same error message it is difficult to debug the failure by scanning the code.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
These changes provide different error messages when an `IPA` or `PKG` cannot be found.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Ran `bundle exec fastlane test` and manually verified the changes in my local environment against the errors I was seeing.