### PR TITLE
[deliver][submit][regression] Fix issue: Deliver failed to select IDFA agreement, if app uses IDFA

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -125,6 +125,7 @@ module Deliver
           "    add_id_info_tracks_action: true,",
           "    add_id_info_limits_tracking: true",
           "  }",
+          "Note: If application uses IDFA, deliver automatically set the mandatory \"add_id_info_limits_tracking\" value to \"true\" always (agreement)",
           "  Example CLI:",
           "    --submission_information \"{\\\"add_id_info_uses_idfa\\\": false}\""
         ].join("\n")
@@ -141,7 +142,8 @@ module Deliver
         end
       elsif uses_idfa == true
         attributes = {
-          honorsLimitedAdTracking: !!submission_information[:add_id_info_limits_tracking],
+          # Application uses IDFA, before sending for submission limitsTracking key in the request JSON must be set to true (agreement).
+          honorsLimitedAdTracking: true,
           servesAds: !!submission_information[:add_id_info_serves_ads],
           attributesAppInstallationToPreviousAd: !!submission_information[:add_id_info_tracks_install],
           attributesActionWithPreviousAd: !!submission_information[:add_id_info_tracks_action]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Earlier (before 2.150.x version), Fastlane(spaceship) always **automatically** select the IDFA agreement, if any app uses IDFA.
- More details: in the below-attached screenshot.

### Description
- After 2.150.x release (new AppStore API migration release), Fastlane(deliver) needs **DEPRECATED** parameter `add_id_info_limits_tracking: true` inside the submission information to select the IDFA agreement. 🤷🏻‍♂️
- If application uses IDFA then Fastlane(deliver) `must select` the mandatory agreement checkbox automatically. 😈

### Testing Steps
Run `deliver` **without** passing `add_id_info_limits_tracking` submission_information.
```ruby
deliver(
  username: "xxxx@xxxx.nl",
  app_identifier: "xxxx-app_identifier",
  app_version: 1.0,
  skip_screenshots: true,
  force: true,
  submit_for_review: true,
  submission_information: {
      add_id_info_uses_idfa: true,
      add_id_info_serves_ads: false,
      add_id_info_tracks_action: true,
      add_id_info_tracks_install: true
  }
)
```

#### More details (about this issue)
Found this issue, when my release pipeline was failed to submit for Apple-review, last week :(
Because I am not sending `deprecated` add_id_info_limits_tracking parameter inside submission_information details.
.
.
<img width="1246" alt="Screenshot 2020-07-10 at 17 47 26 copy" src="https://user-images.githubusercontent.com/5364500/87256921-0323b900-c497-11ea-84ed-7b6a2fc7283e.png">


#### Pre 2.150.x implementation
<img width="902" alt="spaceship-document" src="https://user-images.githubusercontent.com/5364500/87256968-5d247e80-c497-11ea-8cc9-77eae5d0c4e1.png">
