### PR TITLE
[deliver] verify all screenshot deleted successfully and wait for screenshots to appear on failure

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -26,51 +26,7 @@ module Deliver
       localizations = version.get_app_store_version_localizations
 
       if options[:overwrite_screenshots]
-        # Get localizations on version
-        localizations.each do |localization|
-          # Only delete screenshots if trying to upload
-          next unless screenshots_per_language.keys.include?(localization.locale)
-
-          # Iterate over all screenshots for each set and delete
-          screenshot_sets = localization.get_app_screenshot_sets
-
-          # Multi threading delete on single localization
-          threads = []
-          errors = []
-
-          screenshot_sets.each do |screenshot_set|
-            UI.message("Removing all previously uploaded screenshots for '#{localization.locale}' '#{screenshot_set.screenshot_display_type}'...")
-            screenshot_set.app_screenshots.each do |screenshot|
-              UI.verbose("Deleting screenshot - #{localization.locale} #{screenshot_set.screenshot_display_type} #{screenshot.id}")
-              threads << Thread.new do
-                begin
-                  screenshot.delete!
-                  UI.verbose("Deleted screenshot - #{localization.locale} #{screenshot_set.screenshot_display_type} #{screenshot.id}")
-                rescue => error
-                  UI.verbose("Failed to delete screenshot - #{localization.locale} #{screenshot_set.screenshot_display_type} #{screenshot.id}")
-                  errors << error
-                end
-              end
-            end
-          end
-
-          sleep(1) # Feels bad but sleeping a bit to let the threads catchup
-
-          unless threads.empty?
-            Helper.show_loading_indicator("Waiting for screenshots to be deleted for '#{localization.locale}'... (might be slow)") unless FastlaneCore::Globals.verbose?
-            threads.each(&:join)
-            Helper.hide_loading_indicator unless FastlaneCore::Globals.verbose?
-          end
-
-          # Crash if any errors happen while deleting
-          errors.each do |error|
-            UI.error(error.message)
-          end
-        end
-
-        # Verify all screenshots have been deleted
-        # Sometimes API requests will fail but screenshots will still be deleted
-        verify_no_screenshots!(localizations)
+        delete_screenshots(localizations, screenshots_per_language)
       end
 
       # Finding languages to enable
@@ -97,7 +53,68 @@ module Deliver
       upload_screenshots(screenshots_per_language, localizations, options)
     end
 
-    def verify_no_screenshots!(localizations)
+    def delete_screenshots(localizations, screenshots_per_language, tries: 5)
+      tries -= 1
+
+      # Get localizations on version
+      localizations.each do |localization|
+        # Only delete screenshots if trying to upload
+        next unless screenshots_per_language.keys.include?(localization.locale)
+
+        # Iterate over all screenshots for each set and delete
+        screenshot_sets = localization.get_app_screenshot_sets
+
+        # Multi threading delete on single localization
+        threads = []
+        errors = []
+
+        screenshot_sets.each do |screenshot_set|
+          UI.message("Removing all previously uploaded screenshots for '#{localization.locale}' '#{screenshot_set.screenshot_display_type}'...")
+          screenshot_set.app_screenshots.each do |screenshot|
+            UI.verbose("Deleting screenshot - #{localization.locale} #{screenshot_set.screenshot_display_type} #{screenshot.id}")
+            threads << Thread.new do
+              begin
+                screenshot.delete!
+                UI.verbose("Deleted screenshot - #{localization.locale} #{screenshot_set.screenshot_display_type} #{screenshot.id}")
+              rescue => error
+                UI.verbose("Failed to delete screenshot - #{localization.locale} #{screenshot_set.screenshot_display_type} #{screenshot.id}")
+                errors << error
+              end
+            end
+          end
+        end
+
+        sleep(1) # Feels bad but sleeping a bit to let the threads catchup
+
+        unless threads.empty?
+          Helper.show_loading_indicator("Waiting for screenshots to be deleted for '#{localization.locale}'... (might be slow)") unless FastlaneCore::Globals.verbose?
+          threads.each(&:join)
+          Helper.hide_loading_indicator unless FastlaneCore::Globals.verbose?
+        end
+
+        # Crash if any errors happen while deleting
+        errors.each do |error|
+          UI.error(error.message)
+        end
+      end
+
+      # Verify all screenshots have been deleted
+      # Sometimes API requests will fail but screenshots will still be deleted
+      count = count_screenshots(localizations)
+      UI.important("Number of screenshots not deleted: #{count}")
+      if count > 0
+        if tries.zero?
+          UI.user_error!("Failed verification of all screenshots deleted... #{count} screenshot(s) still exist")
+        else
+          UI.error("Failed to delete all screenshots... Tries remaining: #{tries}")
+          delete_screenshots(localizations, screenshots_per_language, tries: tries)
+        end
+      end
+        
+      UI.message("Successfully deleted all screenshots")
+    end
+
+    def count_screenshots(localizations)
       count = 0
       localizations.each do |localization|
         screenshot_sets = localization.get_app_screenshot_sets
@@ -106,11 +123,7 @@ module Deliver
         end
       end
 
-      if count > 0
-        UI.user_error!("Failed verification of all screenshots deleted... #{count} screenshot(s) still exist")
-      else
-        UI.message("Successfully deleted all screenshots")
-      end
+      return count
     end
 
     def upload_screenshots(screenshots_per_language, localizations, options)

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -109,9 +109,9 @@ module Deliver
           UI.error("Failed to delete all screenshots... Tries remaining: #{tries}")
           delete_screenshots(localizations, screenshots_per_language, tries: tries)
         end
+      else
+        UI.message("Successfully deleted all screenshots")
       end
-        
-      UI.message("Successfully deleted all screenshots")
     end
 
     def count_screenshots(localizations)

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -67,6 +67,10 @@ module Deliver
             UI.error(error.message)
           end
         end
+
+        # Verify all screenshots have been deleted
+        # Sometimes API requests will fail but screenshots will still be deleted
+        verify_no_screenshots!(localizations)
       end
 
       # Finding languages to enable
@@ -91,6 +95,22 @@ module Deliver
       end
 
       upload_screenshots(screenshots_per_language, localizations, options)
+    end
+
+    def verify_no_screenshots!(localizations)
+      count = 0
+      localizations.each do |localization|
+        screenshot_sets = localization.get_app_screenshot_sets
+        screenshot_sets.each do |screenshot_set|
+          count += screenshot_set.app_screenshots.size
+        end
+      end
+
+      if count > 0
+        UI.user_error!("Failed verification of all screenshots deleted... #{count} screenshot(s) still exist")
+      else
+        UI.message("Successfully deleted all screenshots")
+      end
     end
 
     def upload_screenshots(screenshots_per_language, localizations, options)

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -88,8 +88,8 @@ module Spaceship
         handle_response(response)
       end
 
-      def post(url_or_path, body)
-        response = with_asc_retry do
+      def post(url_or_path, body, tries: 5)
+        response = with_asc_retry(tries) do
           request(:post) do |req|
             req.url(url_or_path)
             req.body = body.to_json

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -106,6 +106,7 @@ module Spaceship
       #
 
       def update(attributes: nil)
+        attributes = reverse_attr_mapping(attributes)
         Spaceship::ConnectAPI.patch_age_rating_declaration(age_rating_declaration_id: id, attributes: attributes)
       end
     end

--- a/spaceship/lib/spaceship/connect_api/models/app_info.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_info.rb
@@ -65,7 +65,6 @@ module Spaceship
       #
 
       def update(filter: {}, includes: nil, limit: nil, sort: nil)
-        attributes = reverse_attr_mapping(attributes)
         Spaceship::ConnectAPI.patch_app_info(app_info_id: id).first
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_info.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_info.rb
@@ -65,6 +65,7 @@ module Spaceship
       #
 
       def update(filter: {}, includes: nil, limit: nil, sort: nil)
+        attributes = reverse_attr_mapping(attributes)
         Spaceship::ConnectAPI.patch_app_info(app_info_id: id).first
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_preview.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview.rb
@@ -119,6 +119,7 @@ module Spaceship
       end
 
       def update(attributes: nil)
+        attributes = reverse_attr_mapping(attributes)
         Spaceship::ConnectAPI.patch_app_preview(app_preview_id: id, attributes: attributes).first
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
@@ -108,6 +108,8 @@ module Spaceship
           # https://github.com/fastlane/fastlane/pull/16842
           time = Time.now.to_i
 
+          timeout_minutes = (ENV["SPACESHIP_SCREENSHOT_UPLOAD_TIMEOUT"] || 20).to_i
+
           loop do
             puts("Waiting for screenshot to appear before uploading...")
             sleep(30)
@@ -123,7 +125,7 @@ module Spaceship
             break if screenshot
 
             time_diff = Time.now.to_i - time
-            raise error if time_diff >= (60 * 6)
+            raise error if time_diff >= (60 * timeout_minutes)
           end
         end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_store_review_detail.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_review_detail.rb
@@ -39,6 +39,7 @@ module Spaceship
       #
 
       def update(attributes: nil)
+        attributes = reverse_attr_mapping(attributes)
         return Spaceship::ConnectAPI.patch_app_store_review_detail(app_store_review_detail_id: id, attributes: attributes)
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -130,6 +130,7 @@ module Spaceship
       end
 
       def update(attributes: nil)
+        attributes = reverse_attr_mapping(attributes)
         return Spaceship::ConnectAPI.patch_builds(build_id: id, attributes: attributes).first
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/idfa_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/idfa_declaration.rb
@@ -29,6 +29,7 @@ module Spaceship
       #
 
       def update(attributes: nil)
+        attributes = reverse_attr_mapping(attributes)
         Spaceship::ConnectAPI.patch_idfa_declaration(idfa_declaration_id: id, attributes: attributes)
       end
 

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -411,7 +411,7 @@ module Spaceship
           }
         }
 
-        Client.instance.post("appScreenshots", body)
+        Client.instance.post("appScreenshots", body, tries: 1)
       end
 
       def patch_app_screenshot(app_screenshot_id: nil, attributes: {})


### PR DESCRIPTION
### Motivation and Context
Reports of some screenshot deletion errors from @changusmc

### Description
- `deliver` will now verify that all screenshots have been deleted when `overwrite_screenshot: true` before uploading screenshots
- Removed retries on `POST` for `Spaceship::ConnectAPI`
  - Failed `POST`s were actually having database transactions go through which caused a bunch of blank screenshots
- Failed screenshot creations will now poll for them to appear

### How to test

Update `Gemfile` and run `bundle update fastlane` or `bundle udpdate`

```rb
gem “fastlane”, :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-deliver-verify-all-screenshots-deleted"
```