### PR TITLE
[deliver] update app version before localization to prevent invalid state

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -176,6 +176,7 @@ module Deliver
       non_localized_version_attributes['releaseType'] = release_type
 
       # Update app store version
+      # This needs to happen before updating localizations (https://openradar.appspot.com/radar?id=4925914991296512)
       UI.message("Uploading metadata to App Store Connect for version")
       version.update(attributes: non_localized_version_attributes)
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -175,6 +175,10 @@ module Deliver
                      end
       non_localized_version_attributes['releaseType'] = release_type
 
+      # Update app store version
+      UI.message("Uploading metadata to App Store Connect for version")
+      version.update(attributes: non_localized_version_attributes)
+
       # Update app store version localizations
       app_store_version_localizations.each do |app_store_version_localization|
         attributes = localized_version_attributes_by_locale[app_store_version_localization.locale]
@@ -192,10 +196,6 @@ module Deliver
           app_info_localization.update(attributes: attributes)
         end
       end
-
-      # Update app store version
-      UI.message("Uploading metadata to App Store Connect for version")
-      version.update(attributes: non_localized_version_attributes)
 
       # Update categories
       app_info = app.fetch_edit_app_info


### PR DESCRIPTION
### Motivation and Context
Fixes #16679
(Hopefully 🤞 )

### Description
When running update meta, there is a bad API response of invalid state when trying to update release type and copyright. These update perfectly fine when the endpoints are hit directly on their own. There might be some sort of internal processing state when localized info was updated before this that was causing this issue. This _might_ fix it.

### How to test

Update `Gemfile` to below and run `bundle update fastlane` or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-deliver-update-app-version-before-localizations"
```
