### PR TITLE
[deliver] fetches app with Spaceship::ConnectAPI

### DIFF
--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -40,6 +40,7 @@ module Deliver
       res
     end
 
+    # rubocop:disable Metrics/PerceivedComplexity
     def run
       program :name, 'deliver'
       program :version, Fastlane::VERSION
@@ -171,7 +172,7 @@ module Deliver
           v = app.get_latest_app_store_version(platform: platform)
           if options[:app_version].to_s.length > 0
             v = app.get_live_app_store_version(platform: platform) if v.version_string != options[:app_version]
-            if v.version_string != options[:app_version]
+            if v.nil? || v.version_string != options[:app_version]
               raise "Neither the current nor live version match specified app_version \"#{options[:app_version]}\""
             end
           end

--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -166,15 +166,17 @@ module Deliver
           return 0 unless res
 
           require 'deliver/setup'
-          v = options[:app].latest_version
+          app = options[:app]
+          platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
+          v = app.get_latest_app_store_version(platform: platform)
           if options[:app_version].to_s.length > 0
-            v = options[:app].live_version if v.version != options[:app_version]
-            if v.version != options[:app_version]
+            v = app.get_live_app_store_version(platform: platform) if v.version_string != options[:app_version]
+            if v.version_string != options[:app_version]
               raise "Neither the current nor live version match specified app_version \"#{options[:app_version]}\""
             end
           end
 
-          Deliver::Setup.new.generate_metadata_files(v, path)
+          Deliver::Setup.new.generate_metadata_files(app, v, path)
         end
       end
 

--- a/deliver/lib/deliver/detect_values.rb
+++ b/deliver/lib/deliver/detect_values.rb
@@ -36,9 +36,15 @@ module Deliver
     end
 
     def find_app(options)
-      search_by = options[:app_identifier]
-      search_by = options[:app] if search_by.to_s.length == 0
-      app = Spaceship::Tunes::Application.find(search_by, mac: options[:platform] == "osx")
+      app_identifier = options[:app_identifier]
+      app_id = options[:app] if app_identifier.to_s.empty?
+
+      if !app_identifier.to_s.empty?
+        app = Spaceship::ConnectAPI::App.find(app_identifier)
+      elsif !app_id.kind_of?(Spaceship::ConnectAPI::App) && !app_id.to_s.empty?
+        app = Spaceship::ConnectAPI::App.get(app_id: app_id)
+      end
+
       if app
         options[:app] = app
       else

--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -14,9 +14,7 @@ module Deliver
     end
 
     def self.download(options, folder_path)
-      legacy_app = options[:app]
-      app_id = legacy_app.apple_id
-      app = Spaceship::ConnectAPI::App.get(app_id: app_id)
+      app = options[:app]
 
       platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
       if options[:use_live_version]

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -91,9 +91,7 @@ module Deliver
       app_version = options[:app_version]
       UI.message("Making sure the latest version on App Store Connect matches '#{app_version}'...")
 
-      legacy_app = options[:app]
-      app_id = legacy_app.apple_id
-      app = Spaceship::ConnectAPI::App.get(app_id: app_id)
+      app = options[:app]
 
       platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
       changed = app.ensure_version!(app_version, platform: platform)
@@ -142,14 +140,14 @@ module Deliver
 
       if upload_ipa
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
-          app_id: options[:app].apple_id,
+          app_id: options[:app].id,
           ipa_path: options[:ipa],
           package_path: "/tmp",
           platform: options[:platform]
         )
       elsif upload_pkg
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
-          app_id: options[:app].apple_id,
+          app_id: options[:app].id,
           pkg_path: options[:pkg],
           package_path: "/tmp",
           platform: options[:platform]
@@ -157,15 +155,12 @@ module Deliver
       end
 
       transporter = transporter_for_selected_team
-      result = transporter.upload(options[:app].apple_id, package_path)
+      result = transporter.upload(options[:app].id, package_path)
       UI.user_error!("Could not upload binary to App Store Connect. Check out the error above", show_github_issues: true) unless result
     end
 
     def reject_version_if_possible
-      legacy_app = options[:app]
-      app_id = legacy_app.apple_id
-      app = Spaceship::ConnectAPI::App.get(app_id: app_id)
-
+      app = options[:app]
       platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
       if app.reject_version_if_possible!(platform: platform)
         UI.success("Successfully rejected previous version!")

--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -41,11 +41,12 @@ module Deliver
     # and screenshots folders
     def generate_deliver_file(deliver_path, options)
       app = options[:app]
-      legacy_app = Spaceship::Tunes::Application.find(app.id, mac: options[:platform] == "osx")
-      v = legacy_app.latest_version
+
+      platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
+      v = app.get_latest_app_store_version(platform: platform)
 
       metadata_path = options[:metadata_path] || File.join(deliver_path, 'metadata')
-      generate_metadata_files(v, metadata_path)
+      generate_metadata_files(app, v, metadata_path)
 
       # Generate the final Deliverfile here
       return File.read(deliverfile_path)
@@ -59,7 +60,44 @@ module Deliver
       end
     end
 
-    def generate_metadata_files(v, path)
+    def generate_metadata_files(app, version, path)
+      # App info localizations
+      app_info = app.fetch_live_app_info || app.fetch_edit_app_info
+      app_info_localizations = app_info.get_app_info_localizations
+      app_info_localizations.each do |localization|
+        language = localization.locale
+
+        UploadMetadata::LOCALISED_APP_VALUES.each do |file_key, attribute_name|
+          content = localization.send(attribute_name) || ""
+          content += "\n"
+
+          resulting_path = File.join(path, language, "#{file_key}.txt")
+          FileUtils.mkdir_p(File.expand_path('..', resulting_path))
+          File.write(resulting_path, content)
+
+          UI.message("Writing to '#{resulting_path}'")
+        end
+      end
+
+      # Version localizations
+      version_localizations = version.get_app_store_version_localizations
+      version_localizations.each do |localization|
+        language = localization.locale
+
+        UploadMetadata::LOCALISED_VERSION_VALUES.each do |file_key, attribute_name|
+          content = localization.send(attribute_name) || ""
+          content += "\n"
+
+          resulting_path = File.join(path, language, "#{file_key}.txt")
+          FileUtils.mkdir_p(File.expand_path('..', resulting_path))
+          File.write(resulting_path, content)
+
+          UI.message("Writing to '#{resulting_path}'")
+        end
+      end
+    end
+
+    def generate_metadata_files_old(v, path)
       app_details = v.application.details
 
       # All the localised metadata

--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -95,6 +95,53 @@ module Deliver
           UI.message("Writing to '#{resulting_path}'")
         end
       end
+
+      # App info (categories)
+      UploadMetadata::NON_LOCALISED_APP_VALUES.each do |file_key, attribute_name|
+        category = app_info.send(attribute_name)
+
+        content = category ? category.id.to_s : ""
+        content += "\n"
+
+        resulting_path = File.join(path, "#{file_key}.txt")
+        FileUtils.mkdir_p(File.expand_path('..', resulting_path))
+        File.write(resulting_path, content)
+
+        UI.message("Writing to '#{resulting_path}'")
+      end
+
+      # Version
+      UploadMetadata::NON_LOCALISED_VERSION_VALUES.each do |file_key, attribute_name|
+        content = version.send(attribute_name) || ""
+        content += "\n"
+
+        resulting_path = File.join(path, "#{file_key}.txt")
+        FileUtils.mkdir_p(File.expand_path('..', resulting_path))
+        File.write(resulting_path, content)
+
+        UI.message("Writing to '#{resulting_path}'")
+      end
+
+      # Review information
+      app_store_review_detail = begin
+                                  version.fetch_app_store_review_detail
+                                rescue => error
+                                  nil
+                                end # errors if doesn't exist
+      UploadMetadata::REVIEW_INFORMATION_VALUES.each do |file_key, attribute_name|
+        content = app_store_review_detail.send(attribute_name) || ""
+        content += "\n"
+
+        base_dir = File.join(path, UploadMetadata::REVIEW_INFORMATION_DIR)
+        FileUtils.mkdir_p(base_dir)
+
+        file_key = UploadMetadata::REVIEW_INFORMATION_VALUES_LEGACY.key(file_key)
+
+        resulting_path = File.join(base_dir, "#{file_key}.txt")
+        File.write(resulting_path, content)
+
+        UI.message("Writing to '#{resulting_path}'")
+      end
     end
 
     def generate_metadata_files_old(v, path)

--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -68,7 +68,7 @@ module Deliver
         language = localization.locale
 
         UploadMetadata::LOCALISED_APP_VALUES.each do |file_key, attribute_name|
-          content = localization.send(attribute_name) || ""
+          content = localization.send(attribute_name.to_slug) || ""
           content += "\n"
 
           resulting_path = File.join(path, language, "#{file_key}.txt")
@@ -125,19 +125,22 @@ module Deliver
       # Review information
       app_store_review_detail = begin
                                   version.fetch_app_store_review_detail
-                                rescue => error
+                                rescue
                                   nil
                                 end # errors if doesn't exist
       UploadMetadata::REVIEW_INFORMATION_VALUES.each do |file_key, attribute_name|
-        content = app_store_review_detail.send(attribute_name) || ""
+        if app_store_review_detail
+          content = app_store_review_detail.send(attribute_name)
+        else
+          content = ""
+        end
         content += "\n"
-
-        base_dir = File.join(path, UploadMetadata::REVIEW_INFORMATION_DIR)
-        FileUtils.mkdir_p(base_dir)
 
         file_key = UploadMetadata::REVIEW_INFORMATION_VALUES_LEGACY.key(file_key)
 
+        base_dir = File.join(path, UploadMetadata::REVIEW_INFORMATION_DIR)
         resulting_path = File.join(base_dir, "#{file_key}.txt")
+        FileUtils.mkdir_p(File.expand_path('..', resulting_path))
         File.write(resulting_path, content)
 
         UI.message("Writing to '#{resulting_path}'")

--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -40,7 +40,10 @@ module Deliver
     # This method takes care of creating a new 'deliver' folder, containing the app metadata
     # and screenshots folders
     def generate_deliver_file(deliver_path, options)
-      v = options[:app].latest_version
+      app = options[:app]
+      legacy_app = Spaceship::Tunes::Application.find(app.id, mac: options[:platform] == "osx")
+      v = legacy_app.latest_version
+
       metadata_path = options[:metadata_path] || File.join(deliver_path, 'metadata')
       generate_metadata_files(v, metadata_path)
 

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -7,9 +7,7 @@ require 'fastlane_core/pkg_file_analyser'
 module Deliver
   class SubmitForReview
     def submit!(options)
-      legacy_app = options[:app]
-      app_id = legacy_app.apple_id
-      app = Spaceship::ConnectAPI::App.get(app_id: app_id)
+      app = options[:app]
 
       platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
       version = app.get_edit_app_store_version(platform: platform)

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -8,10 +8,10 @@ module Deliver
     LOCALISED_VERSION_VALUES = {
       description: "description",
       keywords: "keywords",
-      release_notes: "whatsNew",
-      support_url: "supportUrl",
-      marketing_url: "marketingUrl",
-      promotional_text: "promotionalText"
+      release_notes: "whats_new",
+      support_url: "support_url",
+      marketing_url: "marketing_url",
+      promotional_text: "promotional_text"
     }
 
     # Everything attached to the version but not being localised
@@ -23,8 +23,8 @@ module Deliver
     LOCALISED_APP_VALUES = {
       name: "name",
       subtitle: "subtitle",
-      privacy_url: "privacyPolicyUrl",
-      apple_tv_privacy_policy: "privacyPolicyText"
+      privacy_url: "privacy_policy_url",
+      apple_tv_privacy_policy: "privacy_policy_text"
     }
 
     # Non localized app details values
@@ -48,12 +48,12 @@ module Deliver
       review_notes: :notes
     }
     REVIEW_INFORMATION_VALUES = {
-      first_name: "contactFirstName",
-      last_name: "contactLastName",
-      phone_number: "contactPhone",
-      email_address: "contactEmail",
-      demo_user: "demoAccountName",
-      demo_password: "demoAccountPassword",
+      first_name: "contact_first_name",
+      last_name: "contact_last_name",
+      phone_number: "contact_phone",
+      email_address: "contact_email",
+      demo_user: "demo_account_name",
+      demo_password: "demo_account_password",
       notes: "notes"
     }
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -28,9 +28,14 @@ module Deliver
     }
 
     # Non localized app details values
-    NON_LOCALISED_APP_VALUES = [:primary_category, :secondary_category,
-                                :primary_first_sub_category, :primary_second_sub_category,
-                                :secondary_first_sub_category, :secondary_second_sub_category]
+    NON_LOCALISED_APP_VALUES = {
+      primary_category: :primary_category,
+      secondary_category: :secondary_category,
+      primary_first_sub_category: :primary_subcategory_one,
+      primary_second_sub_category: :primary_subcategory_two,
+      secondary_first_sub_category: :secondary_subcategory_one,
+      secondary_second_sub_category: :secondary_subcategory_two
+    }
 
     # Review information values
     REVIEW_INFORMATION_VALUES_LEGACY = {
@@ -493,7 +498,7 @@ module Deliver
       end
 
       # Load non localised data
-      (NON_LOCALISED_VERSION_VALUES.keys + NON_LOCALISED_APP_VALUES).each do |key|
+      (NON_LOCALISED_VERSION_VALUES.keys + NON_LOCALISED_APP_VALUES.keys).each do |key|
         path = File.join(options[:metadata_path], "#{key}.txt")
         next unless File.exist?(path)
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -74,9 +74,7 @@ module Deliver
     def upload(options)
       return if options[:skip_metadata]
 
-      legacy_app = options[:app]
-      app_id = legacy_app.apple_id
-      app = Spaceship::ConnectAPI::App.get(app_id: app_id)
+      app = options[:app]
 
       platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
 

--- a/deliver/lib/deliver/upload_price_tier.rb
+++ b/deliver/lib/deliver/upload_price_tier.rb
@@ -9,9 +9,7 @@ module Deliver
 
       price_tier = options[:price_tier].to_s
 
-      legacy_app = options[:app]
-      app_id = legacy_app.apple_id
-      app = Spaceship::ConnectAPI::App.get(app_id: app_id)
+      app = options[:app]
 
       attributes = {}
       territory_ids = []

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -12,9 +12,7 @@ module Deliver
       return if options[:skip_screenshots]
       return if options[:edit_live]
 
-      legacy_app = options[:app]
-      app_id = legacy_app.apple_id
-      app = Spaceship::ConnectAPI::App.get(app_id: app_id)
+      app = options[:app]
 
       platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
       version = app.get_edit_app_store_version(platform: platform)

--- a/deliver/spec/commands_generator_spec.rb
+++ b/deliver/spec/commands_generator_spec.rb
@@ -196,6 +196,11 @@ describe Deliver::CommandsGenerator do
   end
 
   describe ":download_metadata option handling" do
+    let(:latest_version) do
+      double('version',
+             version_string: "1.0.0")
+    end
+
     it "can use the app_identifier flag from tool options" do
       stub_commander_runner_args(['download_metadata', '--description', 'My description', '--app_identifier', 'abcd', '-m', 'metadata/path', '--force'])
 
@@ -207,7 +212,7 @@ describe Deliver::CommandsGenerator do
       })
 
       fake_app = "fake_app"
-      expect(fake_app).to receive(:latest_version).and_return('1.0.0')
+      expect(fake_app).to receive(:get_latest_app_store_version).and_return(latest_version)
 
       expect(Deliver::Runner).to receive(:new) do |actual_options|
         expect(expected_options._values).to eq(actual_options._values)
@@ -217,8 +222,9 @@ describe Deliver::CommandsGenerator do
 
       fake_setup = "fake_setup"
       expect(Deliver::Setup).to receive(:new).and_return(fake_setup)
-      expect(fake_setup).to receive(:generate_metadata_files) do |version, metadata_path|
-        expect(version).to eq('1.0.0')
+      expect(fake_setup).to receive(:generate_metadata_files) do |app, version, metadata_path|
+        expect(app).to eq(fake_app)
+        expect(version).to eq(latest_version)
         expect(metadata_path).to eq('metadata/path')
       end
 

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -38,7 +38,7 @@ describe Deliver::Runner do
       ipa: 'ACME.ipa',
       app_identifier: 'com.acme.acme',
       app_version: '1.0.7',
-      app: double('app', { apple_id: 'YI8C2AS' }),
+      app: double('app', { id: 'YI8C2AS' }),
       platform: 'ios'
     }
   end

--- a/deliver/spec/setup_spec.rb
+++ b/deliver/spec/setup_spec.rb
@@ -10,12 +10,12 @@ describe Deliver do
         let(:app) { double('app') }
         let(:app_info) do
           double('app_info',
-                 primary_category: nil,
-                 primary_subcategory_one: nil,
-                 primary_subcategory_two: nil,
-                 secondary_category: nil,
-                 secondary_subcategory_one: nil,
-                 secondary_subcategory_two: nil)
+                 primary_category: double('primary_category', id: 'cat1'),
+                 primary_subcategory_one: double('primary_subcategory_one', id: 'cat1sub1'),
+                 primary_subcategory_two: double('primary_subcategory_two', id: 'cat1sub2'),
+                 secondary_category: double('secondary_category', id: 'cat2'),
+                 secondary_subcategory_one: double('secondary_subcategory_one', id: 'cat2sub1'),
+                 secondary_subcategory_two: double('secondary_subcategory_two', id: 'cat2sub2'))
         end
         let(:app_info_localization_en) do
           double('app_info_localization_en',
@@ -61,6 +61,12 @@ describe Deliver do
         it 'generates metadata' do
           map = {
             "copyright" => "2020 fastlane",
+            "primary_category" => "cat1",
+            "secondary_category" => "cat2",
+            "primary_first_sub_category" => "cat1sub1",
+            "primary_second_sub_category" => "cat1sub2",
+            "secondary_first_sub_category" => "cat2sub1",
+            "secondary_second_sub_category" => "cat2sub2",
 
             "en-US/description" => "description en",
             "en-US/keywords" => "app version en",

--- a/deliver/spec/setup_spec.rb
+++ b/deliver/spec/setup_spec.rb
@@ -2,51 +2,88 @@ require 'deliver/setup'
 
 describe Deliver do
   describe Deliver::Setup do
-    it "properly downloads existing metadata" do
-#      app = "app"
-#      version = "version"
-#      allow(Spaceship::Application).to receive(:find).and_return(app)
-#      expect(app).to receive(:latest_version).and_return(version)
-#      expect(version).to receive(:name).and_return("name")
-#
-#      options = {
-#        app_identifier: "tools.fastlane.app",
-#        username: "flapple@krausefx.com",
-#      }
-#      Deliver::Runner.new(options) # to login
-#      Deliver::Setup.new.run(options)
-    end
-
     describe '#generate_metadata_files' do
       context 'with review_information' do
-        let(:version) do
-          double('version',
-            review_first_name: 'John',
-            review_last_name: 'Smith',
-            review_phone_number: '+819012345678',
-            review_email: 'deliver@example.com',
-            review_demo_user: 'user',
-            review_demo_password: 'password',
-            review_notes: 'This is a note')
-        end
-        let(:application) { double('application') }
         let(:setup) { Deliver::Setup.new }
         let(:tempdir) { Dir.mktmpdir }
-        before do
-          allow(version).to receive_message_chain('application.details').and_return(application)
-          allow(version).to receive_message_chain('description.languages').and_return([])
-          allow(version).to receive_message_chain('large_app_icon.asset_token').and_return(nil)
-          allow(version).to receive_message_chain('watch_app_icon.asset_token').and_return(nil)
-          stub_const('Deliver::UploadMetadata::NON_LOCALISED_VERSION_VALUES', {})
-          stub_const('Deliver::UploadMetadata::NON_LOCALISED_APP_VALUES', [])
-          stub_const('Deliver::UploadMetadata::TRADE_REPRESENTATIVE_CONTACT_INFORMATION_VALUES', {})
+
+        let(:app) { double('app') }
+        let(:app_info) do
+          double('app_info',
+                 primary_category: nil,
+                 primary_subcategory_one: nil,
+                 primary_subcategory_two: nil,
+                 secondary_category: nil,
+                 secondary_subcategory_one: nil,
+                 secondary_subcategory_two: nil)
+        end
+        let(:app_info_localization_en) do
+          double('app_info_localization_en',
+                 locale: "en-US",
+                 name: "fastlane",
+                 subtitle: "the fastest lane",
+                 privacy_policy_url: "https://fastlane.tools/privacy/en",
+                 privacy_policy_text: "fastlane privacy en")
+        end
+        let(:version) do
+          double('version',
+                 copyright: "2020 fastlane")
+        end
+        let(:version_localization_en) do
+          double('version',
+                 description: "description en",
+                 locale: "en-US",
+                 keywords: "app version en",
+                 marketing_url: "https://fastlane.tools/en",
+                 promotional_text: "promotional text en",
+                 support_url: "https://fastlane.tools/support/en",
+                 whats_new: "whats new en")
+        end
+        let(:app_review_detail) do
+          double('app_review_detail',
+                 contact_first_name: 'John',
+                 contact_last_name: 'Smith',
+                 contact_phone: '+819012345678',
+                 contact_email: 'deliver@example.com',
+                 demo_account_name: 'user',
+                 demo_account_password: 'password',
+                 notes: 'This is a note')
         end
 
-        it 'generates review information' do
-          setup.generate_metadata_files(version, tempdir)
-          base_dir = File.join(tempdir, 'review_information')
-          %w(first_name last_name phone_number email_address demo_user demo_password notes).each do |filename|
-            expect(File.exist?(File.join(base_dir, "#{filename}.txt"))).to be_truthy
+        before do
+          allow(app).to receive(:fetch_live_app_info).and_return(app_info)
+          allow(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
+
+          allow(version).to receive(:get_app_store_version_localizations).and_return([version_localization_en])
+          allow(version).to receive(:fetch_app_store_review_detail).and_return(app_review_detail)
+        end
+
+        it 'generates metadata' do
+          map = {
+            "copyright" => "2020 fastlane",
+
+            "en-US/description" => "description en",
+            "en-US/keywords" => "app version en",
+            "en-US/release_notes" => "whats new en",
+            "en-US/support_url" => "https://fastlane.tools/support/en",
+            "en-US/marketing_url" => "https://fastlane.tools/en",
+            "en-US/promotional_text" => "promotional text en",
+
+            "review_information/review_first_name" => "John",
+            "review_information/review_last_name" => "Smith",
+            "review_information/review_phone_number" => "+819012345678",
+            "review_information/review_email" => "deliver@example.com",
+            "review_information/review_demo_user" => "user",
+            "review_information/review_demo_password" => "password",
+            "review_information/review_notes" => "This is a note"
+          }
+
+          setup.generate_metadata_files(app, version, tempdir)
+          base_dir = File.join(tempdir)
+          map.each do |filename, value|
+            path = File.join(base_dir, "#{filename}.txt")
+            expect(File.exist?(path)).to be_truthy
+            expect(File.read(path).strip).to eq(value)
           end
         end
 

--- a/deliver/spec/setup_spec.rb
+++ b/deliver/spec/setup_spec.rb
@@ -1,97 +1,59 @@
 require 'deliver/setup'
 
-# describe Deliver do
-#   describe Deliver::Setup do
-#     it "properly downloads existing metadata" do
-#       # app = "app"
-#       # version = "version"
-#       # allow(Spaceship::Application).to receive(:find).and_return(app)
-#       # expect(app).to receive(:latest_version).and_return(version)
-#       # expect(version).to receive(:name).and_return("name")
+describe Deliver do
+  describe Deliver::Setup do
+    it "properly downloads existing metadata" do
+#      app = "app"
+#      version = "version"
+#      allow(Spaceship::Application).to receive(:find).and_return(app)
+#      expect(app).to receive(:latest_version).and_return(version)
+#      expect(version).to receive(:name).and_return("name")
+#
+#      options = {
+#        app_identifier: "tools.fastlane.app",
+#        username: "flapple@krausefx.com",
+#      }
+#      Deliver::Runner.new(options) # to login
+#      Deliver::Setup.new.run(options)
+    end
 
-#       # options = {
-#       #   app_identifier: "tools.fastlane.app",
-#       #   username: "flapple@krausefx.com",
-#       # }
-#       # Deliver::Runner.new(options) # to login
-#       # Deliver::Setup.new.run(options)
-#     end
+    describe '#generate_metadata_files' do
+      context 'with review_information' do
+        let(:version) do
+          double('version',
+            review_first_name: 'John',
+            review_last_name: 'Smith',
+            review_phone_number: '+819012345678',
+            review_email: 'deliver@example.com',
+            review_demo_user: 'user',
+            review_demo_password: 'password',
+            review_notes: 'This is a note')
+        end
+        let(:application) { double('application') }
+        let(:setup) { Deliver::Setup.new }
+        let(:tempdir) { Dir.mktmpdir }
+        before do
+          allow(version).to receive_message_chain('application.details').and_return(application)
+          allow(version).to receive_message_chain('description.languages').and_return([])
+          allow(version).to receive_message_chain('large_app_icon.asset_token').and_return(nil)
+          allow(version).to receive_message_chain('watch_app_icon.asset_token').and_return(nil)
+          stub_const('Deliver::UploadMetadata::NON_LOCALISED_VERSION_VALUES', {})
+          stub_const('Deliver::UploadMetadata::NON_LOCALISED_APP_VALUES', [])
+          stub_const('Deliver::UploadMetadata::TRADE_REPRESENTATIVE_CONTACT_INFORMATION_VALUES', {})
+        end
 
-#     describe '#generate_metadata_files' do
-#       context 'with review_information' do
-#         let(:version) do
-#           double('version',
-#                  review_first_name: 'John',
-#                  review_last_name: 'Smith',
-#                  review_phone_number: '+819012345678',
-#                  review_email: 'deliver@example.com',
-#                  review_demo_user: 'user',
-#                  review_demo_password: 'password',
-#                  review_notes: 'This is a note')
-#         end
-#         let(:application) { double('application') }
-#         let(:setup) { Deliver::Setup.new }
-#         let(:tempdir) { Dir.mktmpdir }
-#         before do
-#           allow(version).to receive_message_chain('application.details').and_return(application)
-#           allow(version).to receive_message_chain('description.languages').and_return([])
-#           allow(version).to receive_message_chain('large_app_icon.asset_token').and_return(nil)
-#           allow(version).to receive_message_chain('watch_app_icon.asset_token').and_return(nil)
-#           stub_const('Deliver::UploadMetadata::NON_LOCALISED_VERSION_VALUES', [])
-#           stub_const('Deliver::UploadMetadata::NON_LOCALISED_APP_VALUES', [])
-#           stub_const('Deliver::UploadMetadata::TRADE_REPRESENTATIVE_CONTACT_INFORMATION_VALUES', {})
-#         end
+        it 'generates review information' do
+          setup.generate_metadata_files(version, tempdir)
+          base_dir = File.join(tempdir, 'review_information')
+          %w(first_name last_name phone_number email_address demo_user demo_password notes).each do |filename|
+            expect(File.exist?(File.join(base_dir, "#{filename}.txt"))).to be_truthy
+          end
+        end
 
-#         it 'generates review information' do
-#           setup.generate_metadata_files(version, tempdir)
-#           base_dir = File.join(tempdir, 'review_information')
-#           %w(first_name last_name phone_number email_address demo_user demo_password notes).each do |filename|
-#             expect(File.exist?(File.join(base_dir, "#{filename}.txt"))).to be_truthy
-#           end
-#         end
-
-#         after do
-#           FileUtils.remove_entry_secure(tempdir)
-#         end
-#       end
-#       context 'with trade_representative_contact_information' do
-#         let(:version) do
-#           double('version',
-#                  trade_representative_trade_name: 'John Smith',
-#                  trade_representative_first_name: 'John',
-#                  trade_representative_last_name: 'Smith',
-#                  trade_representative_address_line_1: '1 Infinite Loop',
-#                  trade_representative_address_line_2: '',
-#                  trade_representative_address_line_3: '',
-#                  trade_representative_city_name: 'Cupertino',
-#                  trade_representative_state: 'California',
-#                  trade_representative_country: 'United States',
-#                  trade_representative_postal_code: '95014',
-#                  trade_representative_phone_number: '+819012345678',
-#                  trade_representative_email: 'deliver@example.com',
-#                  trade_representative_is_displayed_on_app_store: 'false')
-#         end
-#         let(:application) { double('application') }
-#         let(:setup) { Deliver::Setup.new }
-#         let(:tempdir) { Dir.mktmpdir }
-#         before do
-#           allow(version).to receive_message_chain('application.details').and_return(application)
-#           allow(version).to receive_message_chain('description.languages').and_return([])
-#           allow(version).to receive_message_chain('large_app_icon.asset_token').and_return(nil)
-#           allow(version).to receive_message_chain('watch_app_icon.asset_token').and_return(nil)
-#           stub_const('Deliver::UploadMetadata::NON_LOCALISED_VERSION_VALUES', [])
-#           stub_const('Deliver::UploadMetadata::NON_LOCALISED_APP_VALUES', [])
-#           stub_const('Deliver::UploadMetadata::REVIEW_INFORMATION_VALUES', {})
-#         end
-
-#         it 'generates trade representative contact information' do
-#           setup.generate_metadata_files(version, tempdir)
-#           base_dir = File.join(tempdir, 'trade_representative_contact_information')
-#           %w(trade_name first_name last_name address_line1 city_name state country postal_code phone_number email_address is_displayed_on_app_store).each do |filename|
-#             expect(File.exist?(File.join(base_dir, "#{filename}.txt"))).to be_truthy
-#           end
-#         end
-#       end
-#     end
-#   end
-# end
+        after do
+          FileUtils.remove_entry_secure(tempdir)
+        end
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -471,7 +471,7 @@ _deliver_ allows for metadata to be set through `.txt` files in the metadata fol
 
 Key | Editable While Live | Directory | Filename
 ----|--------|--------|--------
-<%- (Deliver::UploadMetadata::NON_LOCALISED_VERSION_VALUES.keys + Deliver::UploadMetadata::NON_LOCALISED_APP_VALUES).each do |value| -%>
+<%- (Deliver::UploadMetadata::NON_LOCALISED_VERSION_VALUES.keys + Deliver::UploadMetadata::NON_LOCALISED_APP_VALUES.keys).each do |value| -%>
   `<%= value %>` | <%= Deliver::UploadMetadata::NON_LOCALISED_LIVE_VALUES.include?(value) ? 'Yes' : 'No' %> | `<metadata_path>` | `<%= value %>.txt`
 <%- end %>
 

--- a/spaceship/lib/spaceship/connect_api/model.rb
+++ b/spaceship/lib/spaceship/connect_api/model.rb
@@ -8,6 +8,7 @@ module Spaceship
       end
 
       attr_accessor :id
+      attr_accessor :reverse_attr_map
 
       def initialize(id, attributes)
         self.id = id
@@ -29,6 +30,7 @@ module Spaceship
       # Creates alias for :minOsVersion to :min_os_version
       #
       def attr_mapping(attr_map)
+        self.reverse_attr_map ||= attr_map.invert
         attr_map.each do |key, value|
           # Actual
           reader = value.to_sym
@@ -47,6 +49,14 @@ module Spaceship
           # Alias the API response name to attribute name
           alias_method(key_reader, reader)
           alias_method(key_writer, writer)
+        end
+      end
+
+      def reverse_attr_mapping(attributes)
+        return nil if attributes.nil?
+        attributes.each_with_object({}) do |(k, v), memo|
+          key = self.class.reverse_attr_map[k] || k
+          memo[key] = v
         end
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -77,6 +77,21 @@ module Spaceship
       #
       # App Info
       #
+      
+      def fetch_live_app_info(includes: Spaceship::ConnectAPI::AppInfo::ESSENTIAL_INCLUDES)
+        states = [
+          Spaceship::ConnectAPI::AppInfo::AppStoreState::READY_FOR_SALE,
+          Spaceship::ConnectAPI::AppInfo::AppStoreState::PENDING_DEVELOPER_RELEASE,
+          Spaceship::ConnectAPI::AppInfo::AppStoreState::PROCESSING_FOR_APP_STORE,
+          Spaceship::ConnectAPI::AppInfo::AppStoreState::IN_REVIEW
+        ]
+
+        filter = { app: id }
+        resp = Spaceship::ConnectAPI.get_app_infos(filter: filter, includes: includes)
+        return resp.to_models.select do |model|
+          states.include?(model.app_store_state)
+        end.first
+      end
 
       def fetch_edit_app_info(includes: Spaceship::ConnectAPI::AppInfo::ESSENTIAL_INCLUDES)
         states = [
@@ -150,6 +165,18 @@ module Spaceship
 
           return true
         end
+      end
+
+      def get_latest_app_store_version(platform: nil, includes: nil)
+        platform ||= Spaceship::ConnectAPI::Platform::IOS
+        filter = {
+          platform: platform
+        }
+
+        # Get the latest version
+        return get_app_store_versions(filter: filter, includes: includes)
+               .sort_by { |v| Gem::Version.new(v.version_string) }
+               .last
       end
 
       def get_live_app_store_version(platform: nil, includes: nil)

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -71,13 +71,14 @@ module Spaceship
       end
 
       def update(attributes: nil, app_price_tier_id: nil, territory_ids: nil)
+        attributes = reverse_attr_mapping(attributes)
         return Spaceship::ConnectAPI.patch_app(app_id: id, attributes: attributes, app_price_tier_id: app_price_tier_id, territory_ids: territory_ids)
       end
 
       #
       # App Info
       #
-      
+
       def fetch_live_app_info(includes: Spaceship::ConnectAPI::AppInfo::ESSENTIAL_INCLUDES)
         states = [
           Spaceship::ConnectAPI::AppInfo::AppStoreState::READY_FOR_SALE,

--- a/spaceship/lib/spaceship/connect_api/models/app_info_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_info_localization.rb
@@ -27,6 +27,7 @@ module Spaceship
       #
 
       def update(attributes: nil)
+        attributes = reverse_attr_mapping(attributes)
         Spaceship::ConnectAPI.patch_app_info_localization(app_info_localization_id: id, attributes: attributes)
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -85,6 +85,7 @@ module Spaceship
       end
 
       def update(attributes: nil)
+        attributes = reverse_attr_mapping(attributes)
         return Spaceship::ConnectAPI.patch_app_store_version(app_store_version_id: id, attributes: attributes).first
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
@@ -45,6 +45,7 @@ module Spaceship
       end
 
       def update(attributes: nil)
+        attributes = reverse_attr_mapping(attributes)
         Spaceship::ConnectAPI.patch_app_store_version_localization(app_store_version_localization_id: id, attributes: attributes)
       end
 


### PR DESCRIPTION
### Motivation and Context
Fixes #16823

### Description
- Replaces `Spaceship::Tunes::Application.find` with `Spaceship::ConnectAPI` equivalents
- Rewrote `Deliver::Setup` to use `Spaceship::ConnectAPI`
- Uncommented `deliver/setup_spec.rb`