### PR TITLE
[frameit] add font_size parameter

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -135,7 +135,7 @@ The general parameters are defined in the `default` key and can be:
 | `show_complete_frame` | Specifies whether _frameit_ should shrink the device frame so that it is completely shown in the framed screenshot. If it is false, clipping of the device frame might occur at the bottom (when `title_below_image` is `false`) or top (when `title_below_image` is `true`) of the framed screenshot. | `false` |
 | `padding` | The content of the framed screenshot will be resized to match the specified `padding` around all edges. The vertical padding is also applied between the text and the top or bottom (depending on `title_below_image`) of the device frame. <p> There are 3 different options of specyfying the padding: <p> 1. Default: An integer value that defines both horizontal and vertical padding in pixels. <br> 2. A string that defines (different) padding values in pixels for horizontal and vertical padding. The syntax is `"<horizontal>x<vertical>"`, e.g. `"30x60"`. <br> 3. A string that defines (different) padding values in percentage for horizontal and vertical padding. The syntax is `"<horizontal>%x<vertical>%"`, e.g. `"5%x10%"`. <br> **Note:** The percentage is calculated from the smallest image dimension (height or width). <p> A combination of option 2 and 3 is possible, e.g. `"5%x40"`. | `50` |
 | `interline_spacing` | Specifies whether _frameit_ should add or subtract this many pixels between the individual lines of text. This only applies to a multi-line `title` and/or `keyword` to expand or squash together the individual lines of text. | `0` |
-| `font_scale_factor` | Specifies whether _frameit_ should increase or decrease the font size of the text. | `0.1` |
+| `font_scale_factor` | Specifies whether _frameit_ should increase or decrease the font size of the text. Is ignored for `keyword` or `title`, if `font_size` is specified. | `0.1` |
 | `frame` | Overrides the color of the frame to be used. (Valid values are `BLACK`, `WHITE`, `GOLD` and `ROSE_GOLD`) | NA |
 | `title_min_height` | Specifies a height always reserved for the title. Value can be a percentage of the height or an absolute value. The device will be placed below (or above) this area. Convenient to ensure the device top (or bottom) will be consistently placed at the same height on the different screenshots. | NA |
 | `use_platform` | Overrides the platform used for the screenshot. Valid values are `IOS`, `ANDROID` and `ANY`. | `IOS` |
@@ -163,6 +163,7 @@ The `keyword` and `title` parameters are both used in `default` and `data`. They
 |-----|-------------|---------------|
 | `color` | The font color for the text. Specify a hex/html color code. | `#000000` (black) |
 | `font` | The font family for the text. Specify the (relative) path to the font file (e.g. an OpenType Font). | The default `imagemagick` font, which is system dependent. |
+| `font_size` | The font size for the text specified in points. If not specified or `0`, font will be scaled automatically to fit the available space. _frameit_ still shrinks the text, if it would not fit. | NA |
 | `text` | The text that should be used for the `keyword` or `title`. <p> Note: If you want to use localised text, use [`.strings` files](#strings-files). | NA |
 
 ### Example
@@ -176,6 +177,7 @@ The `keyword` and `title` parameters are both used in `default` and `data`. They
     },
     "title": {
       "font": "./fonts/MyFont-Th.otf",
+      "font_size": 128,
       "color": "#545454"
     },
     "background": "./background.jpg",

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -298,7 +298,7 @@ module Frameit
       resize_text(keyword)
 
       vertical_padding = vertical_frame_padding # assign padding to variable
-      spacing_between_title_and_keyword = (actual_font_size / 2)
+      spacing_between_title_and_keyword = (actual_font_size('keyword') / 2)
       title_left_space = (background.width / 2.0 - title.width / 2.0).round
       keyword_left_space = (background.width / 2.0 - keyword.width / 2.0).round
 
@@ -359,7 +359,7 @@ module Frameit
       vertical_padding = vertical_frame_padding # assign padding to variable
       left_space = (background.width / 2.0 - sum_width / 2.0).round
 
-      self.space_to_device += actual_font_size + vertical_padding
+      self.space_to_device += actual_font_size('title') + vertical_padding
 
       if title_below_image
         title_top = background.height - effective_text_height / 2 - title.height / 2
@@ -385,7 +385,10 @@ module Frameit
       background
     end
 
-    def actual_font_size
+    def actual_font_size(key)
+      font_size = @config[key.to_s]['font_size']
+      return font_size if !font_size.nil? && font_size > 0
+
       font_scale_factor = @config['font_scale_factor'] || 0.1
       UI.user_error!("Parameter 'font_scale_factor' can not be 0. Please provide a value larger than 0.0 (default = 0.1).") if font_scale_factor == 0.0
       [@image.width * font_scale_factor].max.round
@@ -393,7 +396,7 @@ module Frameit
 
     # The space between the keyword and the title
     def keyword_padding
-      (actual_font_size / 3.0).round
+      (actual_font_size('keyword') / 3.0).round
     end
 
     # This will build up to 2 individual images with the title and optional keyword, which will then be added to the real image
@@ -427,7 +430,7 @@ module Frameit
         text_image.combine_options do |i|
           i.font(current_font) if current_font
           i.gravity("Center")
-          i.pointsize(actual_font_size)
+          i.pointsize(actual_font_size(key))
           i.draw("text 0,0 '#{text}'")
           i.interline_spacing(interline_spacing) if interline_spacing
           i.fill(@config[key.to_s]['color'])


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

_frameit_ scales the `keyword` and `title` automatically per screenshot to fit the available size above or below the device. This is a good approach for simple screenshots, but lacks a **consistent** and **unified appearance** across the screenshots.

Specifying a fixed `font_size` for keyword and title (separately) gives users of _frameit_ the ability to fix the font size and keep it consistent across screenshots.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This PR introdocudes a new parameter `font_size` for the `keyword` and `title` parameters. Instead of calculating the `actual_font_size` from the available space everywhere, it now checks for the `font_size` and returns it if specified and  `font_size  > 0`. This way, we keep the old behavior intact.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Specifiy a `font_size` in either the `default` config in your `Framefile.json` or for a single screenshot config for the `title` or `keyword`. Frameit should use this font size when generating the framed screenshots.