### PR TITLE
[action] erb uses ErbTemplateHelper and adds trim mode

### DIFF
--- a/fastlane/lib/fastlane/actions/erb.rb
+++ b/fastlane/lib/fastlane/actions/erb.rb
@@ -3,7 +3,10 @@ module Fastlane
     class ErbAction < Action
       def self.run(params)
         template = File.read(params[:template])
-        result =   ERB.new(template).result(OpenStruct.new(params[:placeholders]).instance_eval { binding })
+        trim_mode = params[:trim_mode]
+
+        result = Fastlane::ErbTemplateHelper.render(template, params[:placeholders], trim_mode)
+
         File.open(params[:destination], 'w') { |file| file.write(result) } if params[:destination]
         UI.message("Successfully parsed template: '#{params[:template]}' and rendered output to: #{params[:destination]}") if params[:destination]
         result
@@ -45,7 +48,12 @@ module Fastlane
                                        description: "Placeholders given as a hash",
                                        default_value: {},
                                        is_string: false,
-                                       type: Hash)
+                                       type: Hash),
+          FastlaneCore::ConfigItem.new(key: :trim_mode,
+                                       short_option: "-t",
+                                       env_name: "FL_ERB_TRIM_MODE",
+                                       description: "Trim mode applied to the ERB",
+                                       optional: true)
 
         ]
       end


### PR DESCRIPTION
### Motivation and Context
Fixes #16869
cc: @jschnare

### Description
I actually needed this today so I made the change 😊 

- Now uses `ErbTemplateHelper`
- Adds `trim_mode`
  - Defaults to `nil`
  - Example use is `“-“`

### Testing Steps

```rb
lane :do_thing do
  erb(                                                                                                                                                
    template: "fastlane/README.md.erb",                                                                                                               
    destination: "README.md",                                                                                                                         
    placeholders: {                                                                                                                                   
      things: [“stuff”]
    },                                                                                                                                                
    trim_mode: "-"                                                                                                                                    
  )  
end
```

```erb
<%- if things.size.empty? -%>
<h1>Hey</h1>
<%- end -%>
```
