### PR TITLE
[fastlane] fix directory change on nested actions

### DIFF
--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -216,7 +216,9 @@ module Fastlane
     end
 
     def execute_action(method_sym, class_ref, arguments, custom_dir: nil, from_action: false)
-      if custom_dir.nil?
+      if from_action == true
+        custom_dir = "." # We preserve the directory from where the previous action was called from
+      elsif custom_dir.nil?
         custom_dir ||= "." if Helper.test?
         custom_dir ||= ".."
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #16145. There's an issue when calling an action from `other_action` where it takes as a root directory the fastlane one instead than the project root.

I upload a small project that describes the issue (thanks to its original author) and I hope the issue gets fixed!
[pwd.zip](https://github.com/fastlane/fastlane/files/4941928/pwd.zip)
