### PR TITLE
[download_dsyms ] Add option to pass `build_number` as an integer

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -22,7 +22,7 @@ module Fastlane
 
         # Process options
         version = params[:version]
-        build_number = params[:build_number]
+        build_number = params[:build_number]&.to_s
         platform = params[:platform]
         output_directory = params[:output_directory]
         wait_for_dsym_processing = params[:wait_for_dsym_processing]
@@ -258,7 +258,8 @@ module Fastlane
                                        short_option: "-b",
                                        env_name: "DOWNLOAD_DSYMS_BUILD_NUMBER",
                                        description: "The app build_number for dSYMs you wish to download",
-                                       optional: true),
+                                       optional: true,
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :min_version,
                                        short_option: "-m",
                                        env_name: "DOWNLOAD_DSYMS_MIN_VERSION",
@@ -308,6 +309,7 @@ module Fastlane
         [
           'download_dsyms',
           'download_dsyms(version: "1.0.0", build_number: "345")',
+          'download_dsyms(version: "1.0.1", build_number: 42)',
           'download_dsyms(version: "live")',
           'download_dsyms(min_version: "1.2.3")'
         ]

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -22,7 +22,7 @@ module Fastlane
 
         # Process options
         version = params[:version]
-        build_number = params[:build_number]&.to_s
+        build_number = params[:build_number].to_s if params[:build_number]
         platform = params[:platform]
         output_directory = params[:output_directory]
         wait_for_dsym_processing = params[:wait_for_dsym_processing]

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -22,7 +22,7 @@ module Fastlane
 
         # Process options
         version = params[:version]
-        build_number = params[:build_number].to_s if params[:build_number]
+        build_number = params[:build_number].to_s unless params[:build_number].nil?
         platform = params[:platform]
         output_directory = params[:output_directory]
         wait_for_dsym_processing = params[:wait_for_dsym_processing]

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -72,6 +72,17 @@ describe Fastlane do
         end
       end
 
+      context 'when build_number is an integer' do
+        it 'downloads the correct dsyms' do
+          expect(app).to receive(:tunes_all_builds_for_train).and_return([build2])
+          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build2.build_version, nil)
+          Fastlane::FastFile.new.parse("lane :test do
+              download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: '2.0.0', build_number: 2)
+          end").runner.execute(:test)
+        end
+      end
+
       context 'when version is latest' do
         before do
           # latest


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
https://github.com/fastlane/fastlane/issues/16599

### Description
This change allows passing a `build_number` that can be either a `String` or an `Integer`. This is more in line with `increment_build_number` that has the same behaviour.
