### PR TITLE
Clarify Sigh Arg Conflicts Error Messages

### DIFF
--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -16,7 +16,7 @@ module Sigh
                                      default_value: false,
                                      conflicting_options: [:developer_id, :development],
                                      conflict_block: proc do |option|
-                                       UI.user_error!("You can't enable both :#{option.key} and :adhoc")
+                                       UI.user_error!("You can't pass arguments for both :#{option.key} and :adhoc")
                                      end),
         FastlaneCore::ConfigItem.new(key: :developer_id,
                                      env_name: "SIGH_DEVELOPER_ID",
@@ -25,7 +25,7 @@ module Sigh
                                      default_value: false,
                                      conflicting_options: [:adhoc, :development],
                                      conflict_block: proc do |option|
-                                       UI.user_error!("You can't enable both :#{option.key} and :developer_id")
+                                       UI.user_error!("You can't pass arguments for both :#{option.key} and :developer_id")
                                      end),
         FastlaneCore::ConfigItem.new(key: :development,
                                      env_name: "SIGH_DEVELOPMENT",
@@ -34,7 +34,7 @@ module Sigh
                                      default_value: false,
                                      conflicting_options: [:adhoc, :developer_id],
                                      conflict_block: proc do |option|
-                                       UI.user_error!("You can't enable both :#{option.key} and :development")
+                                       UI.user_error!("You can't pass arguments for both :#{option.key} and :development")
                                      end),
         FastlaneCore::ConfigItem.new(key: :skip_install,
                                      env_name: "SIGH_SKIP_INSTALL",
@@ -147,7 +147,7 @@ module Sigh
                                      default_value: false,
                                      conflicting_options: [:force],
                                      conflict_block: proc do |value|
-                                       UI.user_error!("You can't enable both :force and :readonly")
+                                       UI.user_error!("You can't pass arguments for both :force and :readonly")
                                      end),
         FastlaneCore::ConfigItem.new(key: :template_name,
                                      env_name: "SIGH_PROVISIONING_PROFILE_TEMPLATE_NAME",


### PR DESCRIPTION
Sigh propegates an error if the user passes in two arguments that sigh
perceives as being mutually exlusive. For example, if the user passes
both an :adhoc and a :development arg, it will fail.

The error message that it currently propegates however states that "You can't enable both
:development and :adhoc".

This is problematic because the word "enable" suggests that the two
boolean arguments can't both be true when in reality sigh will still
error if given values of "false" and "false" or "false" and "true".

This commit thus removes the word "enable" and clarifies that the problem is
caused by mutually exclusive arguments.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
