### PR TITLE
[create_keychain] Populate KEYCHAIN_NAME to lane variables upon creation of keychain

### DIFF
--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -26,13 +26,14 @@ module Fastlane
 
         if !exists?(keychain_path)
           commands << Fastlane::Actions.sh("security create-keychain -p #{escaped_password} #{keychain_path}", log: false)
-          Actions.lane_context[Actions::SharedValues::KEYCHAIN_PATH] = keychain_path
         elsif params[:require_create]
           UI.abort_with_message!("`require_create` option passed, but found keychain '#{keychain_path}', failing create_keychain action")
         else
           UI.important("Found keychain '#{keychain_path}', creation skipped")
           UI.important("If creating a new Keychain DB is required please set the `require_create` option true to cause the action to fail")
         end
+
+        Actions.lane_context[Actions::SharedValues::KEYCHAIN_PATH] = keychain_path
 
         if params[:default_keychain]
           # if there is no default keychain - setting the original will fail - silent this error
@@ -94,7 +95,7 @@ module Fastlane
       def self.output
         [
           ['ORIGINAL_DEFAULT_KEYCHAIN', 'The path to the default keychain'],
-          ['KEYCHAIN_PATH', 'The path of the newly created keychain']
+          ['KEYCHAIN_PATH', 'The path of the keychain']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -4,6 +4,7 @@ module Fastlane
   module Actions
     module SharedValues
       ORIGINAL_DEFAULT_KEYCHAIN = :ORIGINAL_DEFAULT_KEYCHAIN
+      KEYCHAIN_NAME = :KEYCHAIN_NAME
     end
 
     class CreateKeychainAction < Action
@@ -50,6 +51,8 @@ module Fastlane
         command << " #{keychain_path}"
 
         commands << Fastlane::Actions.sh(command, log: false)
+
+        Actions.lane_context[Actions::SharedValues::KEYCHAIN_NAME] = keychain_path.split('/').last
 
         if params[:add_to_search_list]
           keychains = list_keychains

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -94,7 +94,8 @@ module Fastlane
 
       def self.output
         [
-          ['ORIGINAL_DEFAULT_KEYCHAIN', 'The path to the default keychain']
+          ['ORIGINAL_DEFAULT_KEYCHAIN', 'The path to the default keychain'],
+          ['KEYCHAIN_NAME', 'The name of the created keychain']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -4,7 +4,7 @@ module Fastlane
   module Actions
     module SharedValues
       ORIGINAL_DEFAULT_KEYCHAIN = :ORIGINAL_DEFAULT_KEYCHAIN
-      KEYCHAIN_NAME = :KEYCHAIN_NAME
+      KEYCHAIN_PATH = :KEYCHAIN_PATH
     end
 
     class CreateKeychainAction < Action
@@ -26,6 +26,7 @@ module Fastlane
 
         if !exists?(keychain_path)
           commands << Fastlane::Actions.sh("security create-keychain -p #{escaped_password} #{keychain_path}", log: false)
+          Actions.lane_context[Actions::SharedValues::KEYCHAIN_PATH] = keychain_path
         elsif params[:require_create]
           UI.abort_with_message!("`require_create` option passed, but found keychain '#{keychain_path}', failing create_keychain action")
         else
@@ -51,8 +52,6 @@ module Fastlane
         command << " #{keychain_path}"
 
         commands << Fastlane::Actions.sh(command, log: false)
-
-        Actions.lane_context[Actions::SharedValues::KEYCHAIN_NAME] = keychain_path.split('/').last
 
         if params[:add_to_search_list]
           keychains = list_keychains
@@ -95,7 +94,7 @@ module Fastlane
       def self.output
         [
           ['ORIGINAL_DEFAULT_KEYCHAIN', 'The path to the default keychain'],
-          ['KEYCHAIN_NAME', 'The name of the created keychain']
+          ['KEYCHAIN_PATH', 'The path of the newly created keychain'],
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -94,7 +94,7 @@ module Fastlane
       def self.output
         [
           ['ORIGINAL_DEFAULT_KEYCHAIN', 'The path to the default keychain'],
-          ['KEYCHAIN_PATH', 'The path of the newly created keychain'],
+          ['KEYCHAIN_PATH', 'The path of the newly created keychain']
         ]
       end
 

--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -1,205 +1,217 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Create keychain Integration" do
-      it "works with name and password, when keychain doesn't exist" do
-        allow(Fastlane::Actions::CreateKeychainAction).to receive(:list_keychains).and_return(
-          # first time
-          [File.expand_path('~/Library/Keychains/login.keychain-db')],
-          # after creation
-          [File.expand_path('~/Library/Keychains/login.keychain-db'), File.expand_path('~/Library/Keychains/test.keychain')]
-        )
+      context "with name and password options" do
+        it "works when keychain doesn't exist" do
+          allow(Fastlane::Actions::CreateKeychainAction).to receive(:list_keychains).and_return(
+            # first time
+            [File.expand_path('~/Library/Keychains/login.keychain-db')],
+            # after creation
+            [File.expand_path('~/Library/Keychains/login.keychain-db'), File.expand_path('~/Library/Keychains/test.keychain')]
+          )
 
-        allow(Fastlane::Actions::CreateKeychainAction).to receive(:resolved_keychain_path).and_return(
-          nil,
-          File.expand_path('~/Library/Keychains/test.keychain')
-        )
+          allow(Fastlane::Actions::CreateKeychainAction).to receive(:resolved_keychain_path).and_return(
+            nil,
+            File.expand_path('~/Library/Keychains/test.keychain')
+          )
 
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-          })
-        end").runner.execute(:test)
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: 'testpassword',
+            })
+          end").runner.execute(:test)
 
-        expect(result.size).to eq(3)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+          expect(result.size).to eq(3)
+          expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
 
-        expect(result[1]).to start_with('security set-keychain-settings')
-        expect(result[1]).to include('-t 300')
-        expect(result[1]).to_not(include('-l'))
-        expect(result[1]).to_not(include('-u'))
-        expect(result[1]).to include('~/Library/Keychains/test.keychain')
-        expect(result[2]).to start_with("security list-keychains -s")
-        expect(result[2]).to end_with(File.expand_path('~/Library/Keychains/test.keychain').to_s)
+          expect(result[1]).to start_with('security set-keychain-settings')
+          expect(result[1]).to include('-t 300')
+          expect(result[1]).to_not(include('-l'))
+          expect(result[1]).to_not(include('-u'))
+          expect(result[1]).to include('~/Library/Keychains/test.keychain')
+          expect(result[2]).to start_with("security list-keychains -s")
+          expect(result[2]).to end_with(File.expand_path('~/Library/Keychains/test.keychain').to_s)
+        end
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
+        it "work when keychain already exist" do
+          allow(Fastlane::Actions::CreateKeychainAction).to receive(:list_keychains).and_return(
+            [File.expand_path('~/Library/Keychains/login.keychain-db'), File.expand_path('~/Library/Keychains/test.keychain')]
+          )
+
+          allow(Fastlane::Actions::CreateKeychainAction).to receive(:resolved_keychain_path).and_return(
+            File.expand_path('~/Library/Keychains/test.keychain')
+          )
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: 'testpassword',
+            })
+          end").runner.execute(:test)
+
+          expect(result.size).to eq(1)
+          expect(result[0]).to start_with('security set-keychain-settings')
+          expect(result[0]).to include('-t 300')
+          expect(result[0]).to_not(include('-l'))
+          expect(result[0]).to_not(include('-u'))
+          expect(result[0]).to include('~/Library/Keychains/test.keychain')
+        end
+
+        it "works with a password that contain spaces or `\"`" do
+          password = "\"test password\""
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: '#{password}',
+            })
+          end").runner.execute(:test)
+
+          expect(result.size).to eq(3)
+          expect(result[0]).to eq(%(security create-keychain -p #{password.shellescape} ~/Library/Keychains/test.keychain))
+        end
+
+        it "works with keychain-settings" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: 'testpassword',
+              timeout: 600,
+              lock_when_sleeps: true,
+              lock_after_timeout: true,
+            })
+          end").runner.execute(:test)
+
+          expect(result.size).to eq(3)
+          expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+
+          expect(result[1]).to start_with('security set-keychain-settings')
+          expect(result[1]).to include('-t 600')
+          expect(result[1]).to include('-l')
+          expect(result[1]).to include('-u')
+          expect(result[1]).to include('~/Library/Keychains/test.keychain')
+        end
+
+        it "works with default_keychain" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: 'testpassword',
+              default_keychain: true,
+            })
+          end").runner.execute(:test)
+
+          expect(result.size).to eq(4)
+          expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+
+          expect(result[1]).to eq('security default-keychain -s ~/Library/Keychains/test.keychain')
+
+          expect(result[2]).to start_with('security set-keychain-settings')
+          expect(result[2]).to include('-t 300')
+          expect(result[2]).to_not(include('-l'))
+          expect(result[2]).to_not(include('-u'))
+          expect(result[2]).to include('~/Library/Keychains/test.keychain')
+        end
+
+        it "works with unlock" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: 'testpassword',
+              unlock: true,
+            })
+          end").runner.execute(:test)
+
+          expect(result.size).to eq(4)
+          expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+
+          expect(result[1]).to eq('security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain')
+
+          expect(result[2]).to start_with('security set-keychain-settings')
+          expect(result[2]).to include('-t 300')
+          expect(result[2]).to_not(include('-l'))
+          expect(result[2]).to_not(include('-u'))
+          expect(result[2]).to include('~/Library/Keychains/test.keychain')
+        end
+
+        it "works with all params" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: 'testpassword',
+              default_keychain: true,
+              unlock: true,
+              timeout: 600,
+              lock_when_sleeps: true,
+              lock_after_timeout: true,
+              add_to_search_list: false,
+            })
+          end").runner.execute(:test)
+
+          expect(result.size).to eq(4)
+          expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+
+          expect(result[1]).to eq('security default-keychain -s ~/Library/Keychains/test.keychain')
+          expect(result[2]).to eq('security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain')
+
+          expect(result[3]).to start_with('security set-keychain-settings')
+          expect(result[3]).to include('-t 600')
+          expect(result[3]).to include('-l')
+          expect(result[3]).to include('-u')
+          expect(result[3]).to include('~/Library/Keychains/test.keychain')
+        end
+
+        it "sets the correct keychain path" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: 'testpassword',
+              default_keychain: true,
+            })
+          end").runner.execute(:test)
+
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_PATH]).to eq('~/Library/Keychains/test.keychain')
+        end
       end
 
-      it "works with name and password, when keychain already exist" do
-        allow(Fastlane::Actions::CreateKeychainAction).to receive(:list_keychains).and_return(
-          [File.expand_path('~/Library/Keychains/login.keychain-db'), File.expand_path('~/Library/Keychains/test.keychain')]
-        )
+      context "with path and password options" do
+        it "successfully creates the keychain" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              path: '/tmp/test.keychain',
+              password: 'testpassword',
+              default_keychain: true,
+              unlock: true,
+              timeout: 600,
+              lock_when_sleeps: true,
+              lock_after_timeout: true,
+              add_to_search_list: false,
+            })
+          end").runner.execute(:test)
+          expect(result.size).to eq(4)
+          expect(result[0]).to eq('security create-keychain -p testpassword /tmp/test.keychain')
 
-        allow(Fastlane::Actions::CreateKeychainAction).to receive(:resolved_keychain_path).and_return(
-          File.expand_path('~/Library/Keychains/test.keychain')
-        )
+          expect(result[1]).to eq('security default-keychain -s /tmp/test.keychain')
+          expect(result[2]).to eq('security unlock-keychain -p testpassword /tmp/test.keychain')
 
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-          })
-        end").runner.execute(:test)
+          expect(result[3]).to start_with('security set-keychain-settings')
+          expect(result[3]).to include('-t 600')
+          expect(result[3]).to include('-l')
+          expect(result[3]).to include('-u')
+          expect(result[3]).to include('/tmp/test.keychain')
+        end
 
-        expect(result.size).to eq(1)
-        expect(result[0]).to start_with('security set-keychain-settings')
-        expect(result[0]).to include('-t 300')
-        expect(result[0]).to_not(include('-l'))
-        expect(result[0]).to_not(include('-u'))
-        expect(result[0]).to include('~/Library/Keychains/test.keychain')
+        it "sets the correct keychain path" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              path: '/tmp/test.keychain',
+              password: 'testpassword',
+              default_keychain: true,
+            })
+          end").runner.execute(:test)
 
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
-      end
-
-      it "works with name and password that contain spaces or `\"`" do
-        password = "\"test password\""
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: '#{password}',
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq(3)
-        expect(result[0]).to eq(%(security create-keychain -p #{password.shellescape} ~/Library/Keychains/test.keychain))
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
-      end
-
-      it "works with keychain-settings and name and password" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-            timeout: 600,
-            lock_when_sleeps: true,
-            lock_after_timeout: true,
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq(3)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
-
-        expect(result[1]).to start_with('security set-keychain-settings')
-        expect(result[1]).to include('-t 600')
-        expect(result[1]).to include('-l')
-        expect(result[1]).to include('-u')
-        expect(result[1]).to include('~/Library/Keychains/test.keychain')
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
-      end
-
-      it "works with default_keychain and name and password" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-            default_keychain: true,
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq(4)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
-
-        expect(result[1]).to eq('security default-keychain -s ~/Library/Keychains/test.keychain')
-
-        expect(result[2]).to start_with('security set-keychain-settings')
-        expect(result[2]).to include('-t 300')
-        expect(result[2]).to_not(include('-l'))
-        expect(result[2]).to_not(include('-u'))
-        expect(result[2]).to include('~/Library/Keychains/test.keychain')
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
-      end
-
-      it "works with unlock and name and password" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-            unlock: true,
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq(4)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
-
-        expect(result[1]).to eq('security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain')
-
-        expect(result[2]).to start_with('security set-keychain-settings')
-        expect(result[2]).to include('-t 300')
-        expect(result[2]).to_not(include('-l'))
-        expect(result[2]).to_not(include('-u'))
-        expect(result[2]).to include('~/Library/Keychains/test.keychain')
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
-      end
-
-      it "works with :path param" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            path: '/tmp/test.keychain',
-            password: 'testpassword',
-            default_keychain: true,
-            unlock: true,
-            timeout: 600,
-            lock_when_sleeps: true,
-            lock_after_timeout: true,
-            add_to_search_list: false,
-          })
-        end").runner.execute(:test)
-        expect(result.size).to eq(4)
-        expect(result[0]).to eq('security create-keychain -p testpassword /tmp/test.keychain')
-
-        expect(result[1]).to eq('security default-keychain -s /tmp/test.keychain')
-        expect(result[2]).to eq('security unlock-keychain -p testpassword /tmp/test.keychain')
-
-        expect(result[3]).to start_with('security set-keychain-settings')
-        expect(result[3]).to include('-t 600')
-        expect(result[3]).to include('-l')
-        expect(result[3]).to include('-u')
-        expect(result[3]).to include('/tmp/test.keychain')
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
-      end
-
-      it "works with all params" do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          create_keychain ({
-            name: 'test.keychain',
-            password: 'testpassword',
-            default_keychain: true,
-            unlock: true,
-            timeout: 600,
-            lock_when_sleeps: true,
-            lock_after_timeout: true,
-            add_to_search_list: false,
-          })
-        end").runner.execute(:test)
-
-        expect(result.size).to eq(4)
-        expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
-
-        expect(result[1]).to eq('security default-keychain -s ~/Library/Keychains/test.keychain')
-        expect(result[2]).to eq('security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain')
-
-        expect(result[3]).to start_with('security set-keychain-settings')
-        expect(result[3]).to include('-t 600')
-        expect(result[3]).to include('-l')
-        expect(result[3]).to include('-u')
-        expect(result[3]).to include('~/Library/Keychains/test.keychain')
-
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_PATH]).to eq('/tmp/test.keychain')
+        end
       end
     end
   end

--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -31,6 +31,8 @@ describe Fastlane do
         expect(result[1]).to include('~/Library/Keychains/test.keychain')
         expect(result[2]).to start_with("security list-keychains -s")
         expect(result[2]).to end_with(File.expand_path('~/Library/Keychains/test.keychain').to_s)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
       end
 
       it "works with name and password, when keychain already exist" do
@@ -55,6 +57,8 @@ describe Fastlane do
         expect(result[0]).to_not(include('-l'))
         expect(result[0]).to_not(include('-u'))
         expect(result[0]).to include('~/Library/Keychains/test.keychain')
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
       end
 
       it "works with name and password that contain spaces or `\"`" do
@@ -68,6 +72,8 @@ describe Fastlane do
 
         expect(result.size).to eq(3)
         expect(result[0]).to eq(%(security create-keychain -p #{password.shellescape} ~/Library/Keychains/test.keychain))
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
       end
 
       it "works with keychain-settings and name and password" do
@@ -89,6 +95,8 @@ describe Fastlane do
         expect(result[1]).to include('-l')
         expect(result[1]).to include('-u')
         expect(result[1]).to include('~/Library/Keychains/test.keychain')
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
       end
 
       it "works with default_keychain and name and password" do
@@ -110,6 +118,8 @@ describe Fastlane do
         expect(result[2]).to_not(include('-l'))
         expect(result[2]).to_not(include('-u'))
         expect(result[2]).to include('~/Library/Keychains/test.keychain')
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
       end
 
       it "works with unlock and name and password" do
@@ -131,6 +141,8 @@ describe Fastlane do
         expect(result[2]).to_not(include('-l'))
         expect(result[2]).to_not(include('-u'))
         expect(result[2]).to include('~/Library/Keychains/test.keychain')
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
       end
 
       it "works with :path param" do
@@ -157,6 +169,8 @@ describe Fastlane do
         expect(result[3]).to include('-l')
         expect(result[3]).to include('-u')
         expect(result[3]).to include('/tmp/test.keychain')
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
       end
 
       it "works with all params" do
@@ -184,6 +198,8 @@ describe Fastlane do
         expect(result[3]).to include('-l')
         expect(result[3]).to include('-u')
         expect(result[3]).to include('~/Library/Keychains/test.keychain')
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::KEYCHAIN_NAME]).to eq('test.keychain')
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change populates the share lane variable `KEYCHAIN_NAME` so you can use it in subsequent actions such as `import_certificate`. Closes https://github.com/fastlane/fastlane/discussions/16906

### Description
I am not sure if we want to support the use-case where a user passes `foo/bar.keychain` as keychain name. Currently do `keychain_path.split('/').last` to get the keychain name and support both `:name` or `:path` options, but not tied to this implementation.