### PR TITLE
[deliver] fix for reverse attribute mapping for app store review detail

### DIFF
--- a/spaceship/lib/spaceship/connect_api/model.rb
+++ b/spaceship/lib/spaceship/connect_api/model.rb
@@ -30,7 +30,7 @@ module Spaceship
       # Creates alias for :minOsVersion to :min_os_version
       #
       def attr_mapping(attr_map)
-        self.reverse_attr_map ||= attr_map.invert
+        self.reverse_attr_map ||= attr_map.invert.each_with_object({}) { |(k, v), memo| memo[k.to_sym] = v; }
         attr_map.each do |key, value|
           # Actual
           reader = value.to_sym
@@ -54,8 +54,12 @@ module Spaceship
 
       def reverse_attr_mapping(attributes)
         return nil if attributes.nil?
+
+        # allows for getting map from either an instance or class execution
+        map = self.reverse_attr_map || self.class.reverse_attr_map
+
         attributes.each_with_object({}) do |(k, v), memo|
-          key = self.class.reverse_attr_map[k] || k
+          key = map[k.to_sym] || k.to_sym
           memo[key] = v
         end
       end

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -1,4 +1,5 @@
 require_relative '../model'
+require_relative './app_store_review_detail'
 require_relative './app_store_version_localization'
 
 module Spaceship
@@ -119,6 +120,7 @@ module Spaceship
       #
 
       def create_app_store_review_detail(attributes: nil)
+        attributes = Spaceship::ConnectAPI::AppStoreReviewDetail.reverse_attr_mapping(attributes)
         resp = Spaceship::ConnectAPI.post_app_store_review_detail(app_store_version_id: id, attributes: attributes)
         return resp.to_models.first
       end

--- a/spaceship/spec/connect_api/models/app_store_version_spec.rb
+++ b/spaceship/spec/connect_api/models/app_store_version_spec.rb
@@ -1,0 +1,39 @@
+describe Spaceship::ConnectAPI::AppStoreVersion do
+  before { Spaceship::Tunes.login }
+
+  describe "AppStoreVersion object" do
+    describe "reverse maps attributes" do
+      let(:app_store_version) { Spaceship::ConnectAPI::AppStoreVersion.new('id', {}) }
+      let(:attribute_attributes) do
+        {
+          contact_first_name: "",
+          contact_last_name: "",
+          contact_phone: "",
+          contact_email: "",
+          demo_account_name: "",
+          demo_account_password: "",
+          demo_account_required: "",
+          notes: ""
+        }
+      end
+
+      it "maps attributes names to API names" do
+        resp = double
+        allow(resp).to receive(:to_models).and_return([])
+
+        expect(Spaceship::ConnectAPI).to receive(:post_app_store_review_detail).with(app_store_version_id: 'id', attributes: {
+          "contactFirstName" => "",
+          "contactLastName" => "",
+          "contactPhone" => "",
+          "contactEmail" => "",
+          "demoAccountName" => "",
+          "demoAccountPassword" => "",
+          "demoAccountRequired" => "",
+          "notes" => ""
+        }).and_return(resp)
+
+        app_store_version.create_app_store_review_detail(attributes: attribute_attributes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation and Context
Fixes #16928 

### Description
- Attributes where not getting mapped to the proper App Store Connect format when creating App Store Review Detail
  - Ex: `contact_first_name` => `contactFirstName`
