### PR TITLE
[pilot] remove < characters from TestFlight changelogs

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -281,8 +281,17 @@ module Pilot
       changelog
     end
 
+    def self.strip_less_than_sign(changelog)
+      if changelog && changelog.include?("<")
+        changelog.delete!("<")
+        UI.important("Less than signs (<) have been removed from the changelog, since they're not allowed by Apple.")
+      end
+      changelog
+    end
+
     def self.sanitize_changelog(changelog)
       changelog = strip_emoji(changelog)
+      changelog = strip_less_than_sign(changelog)
       truncate_changelog(changelog)
     end
 

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -30,9 +30,14 @@ describe "Build Manager" do
       changelog = Pilot::BuildManager.sanitize_changelog(changelog)
       expect(changelog).to eq("I'm Ban!")
     end
-    it "removes emoji before truncating" do
+    it "removes less than symbols" do
+      changelog = "I'm <script>man<<!"
+      changelog = Pilot::BuildManager.sanitize_changelog(changelog)
+      expect(changelog).to eq("I'm script>man!")
+    end
+    it "removes prohibited symbols before truncating" do
       changelog = File.read("./pilot/spec/fixtures/build_manager/changelog_long")
-      changelog = "🎉🎉🎉#{changelog}"
+      changelog = "🎉<🎉<🎉#{changelog}🎉<🎉<🎉"
       changelog = Pilot::BuildManager.sanitize_changelog(changelog)
       expect(changelog).to eq(File.read("./pilot/spec/fixtures/build_manager/changelog_long_truncated"))
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
TestFlight rejects changelogs with `<` characters in them.

<img width="1254" alt="Screenshot 2020-07-24 at 22 11 07" src="https://user-images.githubusercontent.com/16181471/88438520-d1004880-ce00-11ea-8386-5200b0cebdbf.png">

Fixes https://github.com/fastlane/fastlane/issues/16932

### Description
Add an additional sanitize step for the changelog when distributing the build via TestFlight.

### Testing Steps
Please make sure this is the case for you as well at the client level.