### PR TITLE
[pilot] Update docs to reflect setting changelog while still skipping processing

### DIFF
--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -122,7 +122,7 @@ module Pilot
                                      short_option: "-w",
                                      optional: true,
                                      env_name: "PILOT_CHANGELOG",
-                                     description: "Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog"),
+                                     description: "Provide the 'What to Test' text when uploading a new build"),
         FastlaneCore::ConfigItem.new(key: :skip_submission,
                                      short_option: "-s",
                                      env_name: "PILOT_SKIP_SUBMISSION",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Thanks to https://github.com/fastlane/fastlane/pull/15617, you can now upload a changelog while skipping the full time needed to process the build. This is also described here https://github.com/fastlane/fastlane/blob/master/pilot/lib/pilot/options.rb#L137

### Description
This PR updated the documentation of the `changelog` option to reflect this change.
