### PR TITLE
[fastlane_core] Update the simulator device state

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -206,7 +206,7 @@ module FastlaneCore
 
         UI.message("Booting #{self}")
 
-        `xcrun simctl boot #{self.udid}`
+        `xcrun simctl boot #{self.udid} 2>/dev/null`
         self.state = 'Booted'
       end
 
@@ -216,7 +216,7 @@ module FastlaneCore
         return if self.state != 'Booted'
 
         UI.message("Shutting down #{self.udid}")
-        `xcrun simctl shutdown #{self.udid}`
+        `xcrun simctl shutdown #{self.udid} 2>/dev/null`
         self.state = 'Shutdown'
       end
 

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -202,17 +202,22 @@ module FastlaneCore
       def boot
         return unless is_simulator
         return unless os_type == "iOS"
+        return if self.state == 'Booted'
 
         UI.message("Booting #{self}")
-        `xcrun simctl boot #{self.udid}` unless self.state == "Booted"
+
+        `xcrun simctl boot #{self.udid}`
+        self.state = 'Booted'
       end
 
       def shutdown
         return unless is_simulator
         return unless os_type == "iOS"
+        return if self.state != 'Booted'
 
         UI.message("Shutting down #{self.udid}")
-        `xcrun simctl shutdown #{self.udid}` if self.state == "Booted"
+        `xcrun simctl shutdown #{self.udid}`
+        self.state = 'Shutdown'
       end
 
       def reset


### PR DESCRIPTION
When booting, or shutting down, we save the new state.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When interacting with the simulator devices, the `:state` value can be left in an old state. Code that relies on a device being booted, for example, may fail if the `shutdown` method was called and the state was not updated.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Change the state for the device when booting or shutting down.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I tested locally to ensure that when a device is booted from shutdown state, it boots, otherwise, it does not boot. The same way around for shutting down a device.