### PR TITLE
Add --use-netrc option to carthage action

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -20,6 +20,7 @@ module Fastlane
         cmd << "--output #{params[:output]}" if params[:output]
         cmd << "--use-ssh" if params[:use_ssh]
         cmd << "--use-submodules" if params[:use_submodules]
+        cmd << "--use-netrc" if params[:use_netrc]
         cmd << "--no-use-binaries" if params[:use_binaries] == false
         cmd << "--no-checkout" if params[:no_checkout] == true
         cmd << "--no-build" if params[:no_build] == true
@@ -86,6 +87,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :use_submodules,
                                        env_name: "FL_CARTHAGE_USE_SUBMODULES",
                                        description: "Add dependencies as Git submodules",
+                                       is_string: false,
+                                       type: Boolean,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :use_netrc,
+                                       env_name: "FL_CARTHAGE_USE_NETRC",
+                                       description: "Use .netrc for downloading frameworks",
                                        is_string: false,
                                        type: Boolean,
                                        optional: true),

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -101,6 +101,26 @@ describe Fastlane do
         expect(result).to eq("carthage bootstrap")
       end
 
+      it "adds use-netrc flag to command if use_netrc is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              use_netrc: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap --use-netrc")
+      end
+
+      it "doesn't add a use-netrc flag to command if use_netrc is set to false" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              use_netrc: false
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage bootstrap")
+      end
+
       it "adds no-use-binaries flag to command if use_binaries is set to false" do
         result = Fastlane::FastFile.new.parse("lane :test do
             carthage(


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Carthage has `--use-netrc` option. (https://github.com/Carthage/Carthage/pull/2774)
But the carthage action is not supported for the option.

### Description
I added `use-netrc` option to carthage action.
And I added the test.

### Testing Steps
I tried the option locally. It was successful.
```ruby
carthage(platform: 'iOS', use_netrc: true)
```
```
[13:17:41]: ----------------------
[13:17:41]: --- Step: carthage ---
[13:17:41]: ----------------------
[13:17:41]: $ carthage bootstrap --use-netrc --platform iOS
```