### PR TITLE
[match] Updated match documentation to with hashing algorithm option

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -488,14 +488,14 @@ _match_ stores the certificate (`.cer`) and the private key (`.p12`) files separ
 Decrypt your cert found in `certs/<type>/<unique-id>.cer` as a pem file:
 
 ```no-highlight
-openssl aes-256-cbc -k "<password>" -in "certs/<type>/<unique-id>.cer" -out "cert.der" -a -d
+openssl aes-256-cbc -k "<password>" -in "certs/<type>/<unique-id>.cer" -out "cert.der" -a -d -md [md5|sha256]
 openssl x509 -inform der -in cert.der -out cert.pem
 ```
 
 Decrypt your private key found in `certs/<type>/<unique-id>.p12` as a pem file:
 
 ```no-highlight
-openssl aes-256-cbc -k "<password>" -in "certs/distribution/<unique-id>.p12" -out "key.pem" -a -d
+openssl aes-256-cbc -k "<password>" -in "certs/distribution/<unique-id>.p12" -out "key.pem" -a -d -md [md5|sha256]
 ```
 
 Generate an encrypted p12 file with the same or new password:


### PR DESCRIPTION
🔑

Updated match encryption documentation to prevent further confusion when trying to debug/decrypt the _match_ managed and encrypted certificates/profiles.

As stated in the `match/lib/match/encryption/openssl.rb:110/138` the default behavior of openssl has changed with regards to the password hashing algorithm. The openssl default is now `sha256` where _match_ is still encrypting with a `MD5` password hashing algorithm.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. <--

### Motivation and Context
The fact that openssl changed their default password hashing algorithm from `md5` to the more cryptographically secure `sha256` has led to numerous hours of debugging match source-code and confusion as to why I couldn't successfully decrypt the _match_ managed certificates and profiles. To mitigate this for my future self and possibly others I'd like to add this hint to the documentation.

### Description
Added a hint to the match Manual Decrypt section: `fastlane/lib/fastlane/actions/docs/sync_code_signing.md`

### Testing Steps
Just try to decrypt a _match_ managed certificate/profile with the right password and right/wrong hashing algorithm
