### PR TITLE
[spaceship] fix infinite retry of with_asc_retry

### DIFF
--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -129,7 +129,6 @@ module Spaceship
         tries = 1 if Object.const_defined?("SpecHelper")
         response = yield
 
-        tries -= 1
         status = response.status if response
 
         if [500, 504].include?(status)
@@ -139,6 +138,7 @@ module Spaceship
 
         return response
       rescue => error
+        tries -= 1
         puts(error) if Spaceship::Globals.verbose?
         if tries.zero?
           return response


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The previous implementation of `with_asc_retry` decremented the number of attempts only after a response from the yield block. However, if the yield block raised an unhandled exception, the execution jumped straight to the rescue block without decrementing the number of retry attempts. This led to an infinite loop of retries.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
The fix moves the `tries -= 1` instruction at the beginning of the rescue block. The block is always entered upon a 500 or 504 response from the yield block thanks to the manually raised exception, so the previous behaviour is preserved; however, the number of retries will now be properly decremented also in case of unhandled exceptions raised within the yield block.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
We've verified the fix by deploying the change in production on our business infrastructure, and it has indeed solved the infinite retry issue we were experiencing. We've also run `bundle exec rspec` to verify that existing tests are still valid.