### PR TITLE
[deliver] Fixed filename for review information of AppStoreConnect

### DIFF
--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -136,8 +136,6 @@ module Deliver
         end
         content += "\n"
 
-        file_key = UploadMetadata::REVIEW_INFORMATION_VALUES_LEGACY.key(file_key)
-
         base_dir = File.join(path, UploadMetadata::REVIEW_INFORMATION_DIR)
         resulting_path = File.join(base_dir, "#{file_key}.txt")
         FileUtils.mkdir_p(File.expand_path('..', resulting_path))

--- a/deliver/spec/setup_spec.rb
+++ b/deliver/spec/setup_spec.rb
@@ -75,20 +75,20 @@ describe Deliver do
             "en-US/marketing_url" => "https://fastlane.tools/en",
             "en-US/promotional_text" => "promotional text en",
 
-            "review_information/review_first_name" => "John",
-            "review_information/review_last_name" => "Smith",
-            "review_information/review_phone_number" => "+819012345678",
-            "review_information/review_email" => "deliver@example.com",
-            "review_information/review_demo_user" => "user",
-            "review_information/review_demo_password" => "password",
-            "review_information/review_notes" => "This is a note"
+            "review_information/first_name" => "John",
+            "review_information/last_name" => "Smith",
+            "review_information/phone_number" => "+819012345678",
+            "review_information/email_address" => "deliver@example.com",
+            "review_information/demo_user" => "user",
+            "review_information/demo_password" => "password",
+            "review_information/notes" => "This is a note"
           }
 
           setup.generate_metadata_files(app, version, tempdir)
           base_dir = File.join(tempdir)
           map.each do |filename, value|
             path = File.join(base_dir, "#{filename}.txt")
-            expect(File.exist?(path)).to be_truthy
+            expect(File.exist?(path)).to be_truthy, " for #{path}"
             expect(File.read(path).strip).to eq(value)
           end
         end

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -488,7 +488,7 @@ Key | Editable While Live | Directory | Filename
 Key | Editable While Live | Directory | Filename
 ----|--------|--------|--------
 <%- Deliver::UploadMetadata::REVIEW_INFORMATION_VALUES_LEGACY.each do |key, value| -%>
-  `<%= value %>` | Yes | `<metadata_path>/<%= Deliver::UploadMetadata::REVIEW_INFORMATION_DIR %>` | `<%= value %>.txt`
+  `<%= value %>` | Yes | `<metadata_path>/<%= Deliver::UploadMetadata::REVIEW_INFORMATION_DIR %>` | `<%= key %>.txt`
 <%- end %>
 
 ## Reference

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -485,10 +485,10 @@ Key | Editable While Live | Directory | Filename
 
 ### Review Information Metadata
 
-Key | Editable While Live | Directory | Filename
-----|--------|--------|--------
+Key | Editable While Live | Directory | Filename | Deprecated Filename
+----|--------|--------|--------|--------
 <%- Deliver::UploadMetadata::REVIEW_INFORMATION_VALUES_LEGACY.each do |key, value| -%>
-  `<%= value %>` | Yes | `<metadata_path>/<%= Deliver::UploadMetadata::REVIEW_INFORMATION_DIR %>` | `<%= key %>.txt`
+  `<%= value %>` | Yes | `<metadata_path>/<%= Deliver::UploadMetadata::REVIEW_INFORMATION_DIR %>` | `<%= value %>.txt` | `<%= key %>.txt`
 <%- end %>
 
 ## Reference


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

As for [`upload_to_app_store` docs](https://docs.fastlane.tools/actions/upload_to_app_store/#review-information-metadata), I guess filename for "Review Information Metadata" is wrong.

<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->

I changed filename for doc to match the implementation.

Since we use key of `UploadMetadata::REVIEW_INFORMATION_VALUES_LEGACY` for its filename here.
https://github.com/fastlane/fastlane/blob/a68011c570bd429e91d5adeb1c363a0dce49ec82/deliver/lib/deliver/setup.rb#L142

<!-- Please describe in detail how you tested your changes. -->

I'm not sure which is wrong, generate path or docs.
If I have to change generate function instead, I'll implement it.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
