### PR TITLE
[deliver] Fixed crash on running 'deliver download_metadata'

### DIFF
--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -130,7 +130,7 @@ module Deliver
                                 end # errors if doesn't exist
       UploadMetadata::REVIEW_INFORMATION_VALUES.each do |file_key, attribute_name|
         if app_store_review_detail
-          content = app_store_review_detail.send(attribute_name)
+          content = app_store_review_detail.send(attribute_name) || ""
         else
           content = ""
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

If we run `fastlane deliver download_metadata` with empty content, it crashes and the process will be interrupted.

<!-- If it fixes an open issue, please link to the issue here. -->

closes #16949 

### Description
<!-- Describe your changes in detail. -->

I use default string for nil.

<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
