### PR TITLE
Version bump to 2.154.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,87 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-</tr>
-<tr>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
 <img src='https://github.com/lacostej.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
@@ -122,31 +46,75 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='daniel-jankowski'>
 <a href='https://github.com/mollyIV'>
 <img src='https://github.com/mollyIV.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+</tr>
+<tr>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+</tr>
+<tr>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
 </td>
 <td id='joshua-liebowitz'>
 <a href='https://github.com/taquitos'>
@@ -162,11 +130,43 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+</tr>
+<tr>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
 </td>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Danielle Tomlinson",
-                        "Fumiya Nakamura",
-                        "Maksym Grebenets",
+  spec.authors       = ["Joshua Liebowitz",
+                        "Jorge Revuelta H",
+                        "Aaron Brager",
+                        "Stefan Natchev",
+                        "Daniel Jankowski",
                         "Kohki Miki",
+                        "Fumiya Nakamura",
+                        "Iulian Onofrei",
+                        "Felix Krause",
+                        "Josh Holtz",
+                        "Jimmy Dee",
+                        "Olivier Halligon",
+                        "Helmut Januschka",
+                        "Jan Piotrowski",
                         "Luka Mirosevic",
                         "Manu Wallner",
-                        "Joshua Liebowitz",
-                        "Olivier Halligon",
                         "Matthew Ellis",
                         "Max Ott",
-                        "Josh Holtz",
-                        "Helmut Januschka",
-                        "Daniel Jankowski",
-                        "Jorge Revuelta H",
-                        "Jimmy Dee",
-                        "Felix Krause",
-                        "Aaron Brager",
-                        "Iulian Onofrei",
-                        "Jan Piotrowski",
-                        "Stefan Natchev",
                         "Jérôme Lacoste",
-                        "Andrew McBurney"]
+                        "Danielle Tomlinson",
+                        "Andrew McBurney",
+                        "Maksym Grebenets"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.153.1'.freeze
+  VERSION = '2.154.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -14,4 +14,4 @@ class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.153.1
+// Generated with fastlane 2.154.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -245,4 +245,4 @@ extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.27]
+// FastlaneRunnerAPIVersion [0.9.28]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1442,6 +1442,7 @@ func captureAndroidScreenshots(androidHome: String? = nil,
    - clearPreviousScreenshots: Enabling this option will automatically clear previously generated screenshots before running snapshot
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - eraseSimulator: Enabling this option will automatically erase the simulator before running the application
+   - headless: Enabling this option will prevent displaying the simulator window
    - overrideStatusBar: Enabling this option wil automatically override the status bar to show 9:41 AM, full battery, and full reception
    - localizeSimulator: Enabling this option will configure the Simulator's system language
    - darkMode: Enabling this option will configure the Simulator to be in dark mode (false for light, true for dark)
@@ -1485,6 +1486,7 @@ func captureIosScreenshots(workspace: String? = nil,
                            clearPreviousScreenshots: Bool = false,
                            reinstallApp: Bool = false,
                            eraseSimulator: Bool = false,
+                           headless: Bool = true,
                            overrideStatusBar: Bool = false,
                            localizeSimulator: Bool = false,
                            darkMode: Bool? = nil,
@@ -1527,6 +1529,7 @@ func captureIosScreenshots(workspace: String? = nil,
                                                                                                            RubyCommand.Argument(name: "clear_previous_screenshots", value: clearPreviousScreenshots),
                                                                                                            RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                                            RubyCommand.Argument(name: "erase_simulator", value: eraseSimulator),
+                                                                                                           RubyCommand.Argument(name: "headless", value: headless),
                                                                                                            RubyCommand.Argument(name: "override_status_bar", value: overrideStatusBar),
                                                                                                            RubyCommand.Argument(name: "localize_simulator", value: localizeSimulator),
                                                                                                            RubyCommand.Argument(name: "dark_mode", value: darkMode),
@@ -1576,6 +1579,7 @@ func captureIosScreenshots(workspace: String? = nil,
    - clearPreviousScreenshots: Enabling this option will automatically clear previously generated screenshots before running snapshot
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - eraseSimulator: Enabling this option will automatically erase the simulator before running the application
+   - headless: Enabling this option will prevent displaying the simulator window
    - overrideStatusBar: Enabling this option wil automatically override the status bar to show 9:41 AM, full battery, and full reception
    - localizeSimulator: Enabling this option will configure the Simulator's system language
    - darkMode: Enabling this option will configure the Simulator to be in dark mode (false for light, true for dark)
@@ -1619,6 +1623,7 @@ func captureScreenshots(workspace: String? = nil,
                         clearPreviousScreenshots: Bool = false,
                         reinstallApp: Bool = false,
                         eraseSimulator: Bool = false,
+                        headless: Bool = true,
                         overrideStatusBar: Bool = false,
                         localizeSimulator: Bool = false,
                         darkMode: Bool? = nil,
@@ -1661,6 +1666,7 @@ func captureScreenshots(workspace: String? = nil,
                                                                                                        RubyCommand.Argument(name: "clear_previous_screenshots", value: clearPreviousScreenshots),
                                                                                                        RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                                        RubyCommand.Argument(name: "erase_simulator", value: eraseSimulator),
+                                                                                                       RubyCommand.Argument(name: "headless", value: headless),
                                                                                                        RubyCommand.Argument(name: "override_status_bar", value: overrideStatusBar),
                                                                                                        RubyCommand.Argument(name: "localize_simulator", value: localizeSimulator),
                                                                                                        RubyCommand.Argument(name: "dark_mode", value: darkMode),
@@ -1699,6 +1705,7 @@ func captureScreenshots(workspace: String? = nil,
    - dependencies: Carthage dependencies to update, build or bootstrap
    - useSsh: Use SSH for downloading GitHub repositories
    - useSubmodules: Add dependencies as Git submodules
+   - useNetrc: Use .netrc for downloading frameworks
    - useBinaries: Check out dependency repositories even when prebuilt frameworks exist
    - noCheckout: When bootstrapping Carthage do not checkout
    - noBuild: When bootstrapping Carthage do not build
@@ -1720,6 +1727,7 @@ func carthage(command: String = "bootstrap",
               dependencies: [String] = [],
               useSsh: Bool? = nil,
               useSubmodules: Bool? = nil,
+              useNetrc: Bool? = nil,
               useBinaries: Bool? = nil,
               noCheckout: Bool? = nil,
               noBuild: Bool? = nil,
@@ -1740,6 +1748,7 @@ func carthage(command: String = "bootstrap",
                                                                                             RubyCommand.Argument(name: "dependencies", value: dependencies),
                                                                                             RubyCommand.Argument(name: "use_ssh", value: useSsh),
                                                                                             RubyCommand.Argument(name: "use_submodules", value: useSubmodules),
+                                                                                            RubyCommand.Argument(name: "use_netrc", value: useNetrc),
                                                                                             RubyCommand.Argument(name: "use_binaries", value: useBinaries),
                                                                                             RubyCommand.Argument(name: "no_checkout", value: noCheckout),
                                                                                             RubyCommand.Argument(name: "no_build", value: noBuild),
@@ -3558,10 +3567,14 @@ func gitCommit(path: Any,
 /**
  Executes a simple git pull command
 
- - parameter onlyTags: Simply pull the tags, and not bring new commits to the current branch from the remote
+ - parameters:
+   - onlyTags: Simply pull the tags, and not bring new commits to the current branch from the remote
+   - rebase: Rebase on top of the remote branch instead of merge
  */
-func gitPull(onlyTags: Bool = false) {
-    let command = RubyCommand(commandID: "", methodName: "git_pull", className: nil, args: [RubyCommand.Argument(name: "only_tags", value: onlyTags)])
+func gitPull(onlyTags: Bool = false,
+             rebase: Bool = false) {
+    let command = RubyCommand(commandID: "", methodName: "git_pull", className: nil, args: [RubyCommand.Argument(name: "only_tags", value: onlyTags),
+                                                                                            RubyCommand.Argument(name: "rebase", value: rebase)])
     _ = runner.executeCommand(command)
 }
 
@@ -4555,6 +4568,7 @@ func makeChangelogFromJenkins(fallbackChangelog: String = "",
    - cloneBranchDirectly: Clone just the branch specified, instead of the whole repo. This requires that the branch already exists. Otherwise the command will fail
    - gitBasicAuthorization: Use a basic authorization header to access the git repo (e.g.: access via HTTPS, GitHub Actions, etc), usually a string in Base64
    - gitBearerAuthorization: Use a bearer authorization header to access the git repo (e.g.: access to an Azure Devops repository), usually a string in Base64
+   - gitPrivateKey: Use a private key to access the git repo (e.g.: access to GitHub repository via Deploy keys), usually a id_rsa named file or the contents hereof
    - googleCloudBucketName: Name of the Google Cloud Storage bucket to use
    - googleCloudKeysFile: Path to the gc_keys.json file
    - googleCloudProjectId: ID of the Google Cloud project to use for authentication
@@ -4596,6 +4610,7 @@ func match(type: Any = matchfile.type,
            cloneBranchDirectly: Bool = matchfile.cloneBranchDirectly,
            gitBasicAuthorization: Any? = matchfile.gitBasicAuthorization,
            gitBearerAuthorization: Any? = matchfile.gitBearerAuthorization,
+           gitPrivateKey: Any? = matchfile.gitPrivateKey,
            googleCloudBucketName: Any? = matchfile.googleCloudBucketName,
            googleCloudKeysFile: Any? = matchfile.googleCloudKeysFile,
            googleCloudProjectId: Any? = matchfile.googleCloudProjectId,
@@ -4634,6 +4649,7 @@ func match(type: Any = matchfile.type,
                                                                                          RubyCommand.Argument(name: "clone_branch_directly", value: cloneBranchDirectly),
                                                                                          RubyCommand.Argument(name: "git_basic_authorization", value: gitBasicAuthorization),
                                                                                          RubyCommand.Argument(name: "git_bearer_authorization", value: gitBearerAuthorization),
+                                                                                         RubyCommand.Argument(name: "git_private_key", value: gitPrivateKey),
                                                                                          RubyCommand.Argument(name: "google_cloud_bucket_name", value: googleCloudBucketName),
                                                                                          RubyCommand.Argument(name: "google_cloud_keys_file", value: googleCloudKeysFile),
                                                                                          RubyCommand.Argument(name: "google_cloud_project_id", value: googleCloudProjectId),
@@ -5038,7 +5054,7 @@ func pem(development: Bool = false,
    - betaAppDescription: Provide the 'Beta App Description' when uploading a new build
    - betaAppFeedbackEmail: Provide the beta app email when uploading a new build
    - localizedBuildInfo: Localized beta app test info for what's new
-   - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
+   - changelog: Provide the 'What to Test' text when uploading a new build
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
    - skipWaitingForBuildProcessing: If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
@@ -6870,6 +6886,7 @@ func slather(buildDirectory: String? = nil,
    - clearPreviousScreenshots: Enabling this option will automatically clear previously generated screenshots before running snapshot
    - reinstallApp: Enabling this option will automatically uninstall the application before running it
    - eraseSimulator: Enabling this option will automatically erase the simulator before running the application
+   - headless: Enabling this option will prevent displaying the simulator window
    - overrideStatusBar: Enabling this option wil automatically override the status bar to show 9:41 AM, full battery, and full reception
    - localizeSimulator: Enabling this option will configure the Simulator's system language
    - darkMode: Enabling this option will configure the Simulator to be in dark mode (false for light, true for dark)
@@ -6913,6 +6930,7 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
               clearPreviousScreenshots: Bool = snapshotfile.clearPreviousScreenshots,
               reinstallApp: Bool = snapshotfile.reinstallApp,
               eraseSimulator: Bool = snapshotfile.eraseSimulator,
+              headless: Bool = snapshotfile.headless,
               overrideStatusBar: Bool = snapshotfile.overrideStatusBar,
               localizeSimulator: Bool = snapshotfile.localizeSimulator,
               darkMode: Bool? = snapshotfile.darkMode,
@@ -6955,6 +6973,7 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
                                                                                             RubyCommand.Argument(name: "clear_previous_screenshots", value: clearPreviousScreenshots),
                                                                                             RubyCommand.Argument(name: "reinstall_app", value: reinstallApp),
                                                                                             RubyCommand.Argument(name: "erase_simulator", value: eraseSimulator),
+                                                                                            RubyCommand.Argument(name: "headless", value: headless),
                                                                                             RubyCommand.Argument(name: "override_status_bar", value: overrideStatusBar),
                                                                                             RubyCommand.Argument(name: "localize_simulator", value: localizeSimulator),
                                                                                             RubyCommand.Argument(name: "dark_mode", value: darkMode),
@@ -7353,6 +7372,7 @@ func swiftlint(mode: Any = "lint",
    - cloneBranchDirectly: Clone just the branch specified, instead of the whole repo. This requires that the branch already exists. Otherwise the command will fail
    - gitBasicAuthorization: Use a basic authorization header to access the git repo (e.g.: access via HTTPS, GitHub Actions, etc), usually a string in Base64
    - gitBearerAuthorization: Use a bearer authorization header to access the git repo (e.g.: access to an Azure Devops repository), usually a string in Base64
+   - gitPrivateKey: Use a private key to access the git repo (e.g.: access to GitHub repository via Deploy keys), usually a id_rsa named file or the contents hereof
    - googleCloudBucketName: Name of the Google Cloud Storage bucket to use
    - googleCloudKeysFile: Path to the gc_keys.json file
    - googleCloudProjectId: ID of the Google Cloud project to use for authentication
@@ -7394,6 +7414,7 @@ func syncCodeSigning(type: String = "development",
                      cloneBranchDirectly: Bool = false,
                      gitBasicAuthorization: String? = nil,
                      gitBearerAuthorization: String? = nil,
+                     gitPrivateKey: String? = nil,
                      googleCloudBucketName: String? = nil,
                      googleCloudKeysFile: String? = nil,
                      googleCloudProjectId: String? = nil,
@@ -7432,6 +7453,7 @@ func syncCodeSigning(type: String = "development",
                                                                                                      RubyCommand.Argument(name: "clone_branch_directly", value: cloneBranchDirectly),
                                                                                                      RubyCommand.Argument(name: "git_basic_authorization", value: gitBasicAuthorization),
                                                                                                      RubyCommand.Argument(name: "git_bearer_authorization", value: gitBearerAuthorization),
+                                                                                                     RubyCommand.Argument(name: "git_private_key", value: gitPrivateKey),
                                                                                                      RubyCommand.Argument(name: "google_cloud_bucket_name", value: googleCloudBucketName),
                                                                                                      RubyCommand.Argument(name: "google_cloud_keys_file", value: googleCloudKeysFile),
                                                                                                      RubyCommand.Argument(name: "google_cloud_project_id", value: googleCloudProjectId),
@@ -7535,7 +7557,7 @@ func testfairy(apiKey: String,
    - betaAppDescription: Provide the 'Beta App Description' when uploading a new build
    - betaAppFeedbackEmail: Provide the beta app email when uploading a new build
    - localizedBuildInfo: Localized beta app test info for what's new
-   - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
+   - changelog: Provide the 'What to Test' text when uploading a new build
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
    - skipWaitingForBuildProcessing: If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
@@ -8453,7 +8475,7 @@ func uploadToPlayStoreInternalAppSharing(packageName: String,
    - betaAppDescription: Provide the 'Beta App Description' when uploading a new build
    - betaAppFeedbackEmail: Provide the beta app email when uploading a new build
    - localizedBuildInfo: Localized beta app test info for what's new
-   - changelog: Provide the 'What to Test' text when uploading a new build. `skip_waiting_for_build_processing: false` is required to set the changelog
+   - changelog: Provide the 'What to Test' text when uploading a new build
    - skipSubmission: Skip the distributing action of pilot and only upload the ipa file
    - skipWaitingForBuildProcessing: If set to true, the `distribute_external` option won't work and no build will be distributed to testers. (You might want to use this option if you are using this action on CI and have to pay for 'minutes used' on your CI plan). If set to `true` and a changelog is provided, it will partially wait for the build to appear on AppStore Connect so the changelog can be set, and skip the remaining processing steps
    - updateBuildInfoOnUpload: **DEPRECATED!** Update build info immediately after validation. This is deprecated and will be removed in a future release. App Store Connect no longer supports setting build info until after build processing has completed, which is when build info is updated by default
@@ -8989,4 +9011,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.80]
+// FastlaneRunnerAPIVersion [0.9.81]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -14,4 +14,4 @@ class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.153.1
+// Generated with fastlane 2.154.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -181,4 +181,4 @@ extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.30]
+// FastlaneRunnerAPIVersion [0.9.31]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -14,4 +14,4 @@ class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.153.1
+// Generated with fastlane 2.154.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -53,6 +53,9 @@ protocol MatchfileProtocol: class {
     /// Use a bearer authorization header to access the git repo (e.g.: access to an Azure Devops repository), usually a string in Base64
     var gitBearerAuthorization: String? { get }
 
+    /// Use a private key to access the git repo (e.g.: access to GitHub repository via Deploy keys), usually a id_rsa named file or the contents hereof
+    var gitPrivateKey: String? { get }
+
     /// Name of the Google Cloud Storage bucket to use
     var googleCloudBucketName: String? { get }
 
@@ -133,6 +136,7 @@ extension MatchfileProtocol {
     var cloneBranchDirectly: Bool { return false }
     var gitBasicAuthorization: String? { return nil }
     var gitBearerAuthorization: String? { return nil }
+    var gitPrivateKey: String? { return nil }
     var googleCloudBucketName: String? { return nil }
     var googleCloudKeysFile: String? { return nil }
     var googleCloudProjectId: String? { return nil }
@@ -157,4 +161,4 @@ extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.24]
+// FastlaneRunnerAPIVersion [0.9.25]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -14,4 +14,4 @@ class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.153.1
+// Generated with fastlane 2.154.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -33,4 +33,4 @@ extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.23]
+// FastlaneRunnerAPIVersion [0.9.24]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -14,4 +14,4 @@ class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.153.1
+// Generated with fastlane 2.154.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -257,4 +257,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.35]
+// FastlaneRunnerAPIVersion [0.9.36]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -14,4 +14,4 @@ class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.153.1
+// Generated with fastlane 2.154.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -93,4 +93,4 @@ extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.25]
+// FastlaneRunnerAPIVersion [0.9.26]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -14,4 +14,4 @@ class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.153.1
+// Generated with fastlane 2.154.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -44,6 +44,9 @@ protocol SnapshotfileProtocol: class {
     /// Enabling this option will automatically erase the simulator before running the application
     var eraseSimulator: Bool { get }
 
+    /// Enabling this option will prevent displaying the simulator window
+    var headless: Bool { get }
+
     /// Enabling this option wil automatically override the status bar to show 9:41 AM, full battery, and full reception
     var overrideStatusBar: Bool { get }
 
@@ -142,6 +145,7 @@ extension SnapshotfileProtocol {
     var clearPreviousScreenshots: Bool { return false }
     var reinstallApp: Bool { return false }
     var eraseSimulator: Bool { return false }
+    var headless: Bool { return true }
     var overrideStatusBar: Bool { return false }
     var localizeSimulator: Bool { return false }
     var darkMode: Bool? { return nil }
@@ -173,4 +177,4 @@ extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.19]
+// FastlaneRunnerAPIVersion [0.9.20]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.153.1':**

* [match] fix failing tests from merge (#16968) via Josh Holtz
* [deliver] Fixed filename for review information of AppStoreConnect (#16963) via はるふ
* [match] add git private key support for match (#16457) via Morten Bøgh
* [fastlane] adds git_pull rebase option (#16592) via Benjamin Borowski
* [deliver] fixed crash on running 'deliver download_metadata' (#16964) via はるふ
* [gym] iOS Export Options "Destination" Handling (#16609) via DomenicBianchi01
* [frameit] look for title.strings in parent folders (#16630) via Robert Sasak
* [spaceship] add shortcuts for getting current pending release and current in revi… (#16808) via Addison Brickey
* [snapshot] add headless option (#16863) via Andreas Ganske
* [docs] update docs to reflect you can set changelog while still skipping full processing (#16934) via Alex Benoit
* [fastlane_core] update the simulator device state (#16936) via Lyndsey Ferguson
* [action] add --use-netrc option to carthage action (#16942) via Tatsuya Tanaka
* [docs] updated match encryption documentation to prevent further confusion when trying to debug/decrypt the match managed and encrypted certificates/profiles (#16948) via Adriaan Duz
* [spaceship ]fix: infinite retry of with_asc_retry (#16953) via Valerio Castelli
* [pilot] remove < from pilot changelog (#16933) via Alex Benoit
