### PR TITLE
[deliver] make uploading and deleting screenshots more efficient

### DIFF
--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -1,0 +1,83 @@
+module Deliver
+  # This is a convinient class that enumerates app store connect's screenshots in various degrees.
+  class AppScreenshotIterator
+    # @param localizations [Array<Spaceship::ConnectAPI::AppStoreVersionLocalization>]
+    def initialize(localizations)
+      @localizations = localizations
+    end
+
+    # Iterate app_screenshot_set over localizations
+    #
+    # @yield [localization, app_screenshot_set]
+    # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreVersionLocalization] localization
+    # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreScreenshotSet] app_screenshot_set
+    def each_app_screenshot_set(&block)
+      return enum_for(__method__) unless block_given?
+
+      @localizations.each do |localization|
+        localization.get_app_screenshot_sets.each do |app_screenshot_set|
+          yield(localization, app_screenshot_set)
+        end
+      end
+    end
+
+    # Iterate app_screenshot over localizations and app_screenshot_sets
+    #
+    # @yield [localization, app_screenshot_set, app_screenshot]
+    # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreVersionLocalization] localization
+    # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreScreenshotSet] app_screenshot_set
+    # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreScreenshot] app_screenshot
+    def each_app_screenshot(&block)
+      return enum_for(__method__) unless block_given?
+
+      each_app_screenshot_set do |localization, app_screenshot_set|
+        app_screenshot_set.app_screenshots.each do |app_screenshot|
+          yield(localization, app_screenshot_set, app_screenshot)
+        end
+      end
+    end
+
+    # Iterate given local app_screenshot over localizations and app_screenshot_sets with index within each app_screenshot_set
+    #
+    # @param screenshots_per_language [Hash<String, Array<Deliver::AppScreenshot>]
+    # @yield [localization, app_screenshot_set, app_screenshot, index]
+    # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreVersionLocalization] localization
+    # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreScreenshotSet] app_screenshot_set
+    # @yieldparam [optional, Deliver::AppScreenshot] screenshot
+    # @yieldparam [optional, Integer] index a number reperesents which position the screenshot will be
+    def each_local_screenshot(screenshots_per_language, &block)
+      return enum_for(__method__, screenshots_per_language) unless block_given?
+
+      # Iterate over all the screenshots per language and display_type
+      # and then enqueue them to worker one by one if it's not duplciated on App Store Connect
+      screenshots_per_language.map { |language, screenshots_for_language|
+        localization = @localizations.find { |l| l.locale == language }
+        [localization, screenshots_for_language]
+      }.reject { |localization, _|
+        localization.nil?
+      }.each do |localization, screenshots_for_language|
+        iterate_over_screenshots_per_language(localization, screenshots_for_language, &block)
+      end
+    end
+
+    private
+
+    def iterate_over_screenshots_per_language(localization, screenshots_for_language, &block)
+      app_screenshot_sets_per_display_type = localization.get_app_screenshot_sets.map { |set| [set.screenshot_display_type, set] }.to_h
+      screenshots_per_display_type = screenshots_for_language.reject { |screenshot| screenshot.device_type.nil? }.group_by(&:device_type)
+
+      screenshots_per_display_type.each do |display_type, screenshots|
+        # Create AppScreenshotSet for given display_type if it doesn't exsit
+        app_screenshot_set = app_screenshot_sets_per_display_type[display_type]
+        app_screenshot_set ||= localization.create_app_screenshot_set(attributes: { screenshotDisplayType: display_type })
+        iterate_over_screenshots_per_display_type(localization, app_screenshot_set, screenshots, &block)
+      end
+    end
+
+    def iterate_over_screenshots_per_display_type(localization, app_screenshot_set, screenshots, &block)
+      screenshots.each.with_index do |screenshot, index|
+        yield(localization, app_screenshot_set, screenshot, index)
+      end
+    end
+  end
+end

--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -1,7 +1,7 @@
 module Deliver
   # This is a convinient class that enumerates app store connect's screenshots in various degrees.
   class AppScreenshotIterator
-    NUMBER_OF_THREADS = Helper.test? ? 1 : 10
+    NUMBER_OF_THREADS = Helper.test? ? 1 : [ENV.fetch("DELIVER_NUMBER_OF_THREADS", 10).to_i, 10].min
 
     # @param localizations [Array<Spaceship::ConnectAPI::AppStoreVersionLocalization>]
     def initialize(localizations)

--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -50,12 +50,12 @@ module Deliver
 
       # Iterate over all the screenshots per language and display_type
       # and then enqueue them to worker one by one if it's not duplciated on App Store Connect
-      screenshots_per_language.map { |language, screenshots_for_language|
+      screenshots_per_language.map do |language, screenshots_for_language|
         localization = @localizations.find { |l| l.locale == language }
         [localization, screenshots_for_language]
-      }.reject { |localization, _|
+      end.reject do |localization, _|
         localization.nil?
-      }.each do |localization, screenshots_for_language|
+      end.each do |localization, screenshots_for_language|
         iterate_over_screenshots_per_language(localization, screenshots_for_language, &block)
       end
     end

--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -17,7 +17,8 @@ module Deliver
       return enum_for(__method__) unless block_given?
 
       # Collect app_screenshot_sets from localizations in parallel but
-      # save the number of threads used at a time with using `lazy` and `force` controls
+      # limit the number of threads working at a time with using `lazy` and `force` controls
+      # to not attack App Store Connect
       results = @localizations.each_slice(NUMBER_OF_THREADS).lazy.map do |localizations|
         localizations.map do |localization|
           Thread.new do

--- a/deliver/lib/deliver/queue_worker.rb
+++ b/deliver/lib/deliver/queue_worker.rb
@@ -49,12 +49,12 @@ module Deliver
     def wait_for_complete
       wait_thread = Thread.new do
         loop do
-          sleep(1)
-
           if @queue.empty?
             @queue.close
             break
           end
+
+          sleep(1)
         end
       end
 

--- a/deliver/lib/deliver/queue_worker.rb
+++ b/deliver/lib/deliver/queue_worker.rb
@@ -1,0 +1,64 @@
+require 'thread'
+
+module Deliver
+  # This dispatches jobs to worker threads and make it work in parallel.
+  # It's suitable for I/O bounds works and not for CPU bounds works.
+  # Use this when you have all the items that you'll process in advance.
+  # Simply enqueue them to this and call `QueueWorker#start`.
+  class QueueWorker
+    # @param concurrency (Numeric) - A number of threads to be created
+    # @param block (Proc) - A task you want to execute with enqueued items
+    def initialize(concurrency, &block)
+      @concurrency = concurrency
+      @block = block
+      @queue = Queue.new
+    end
+
+    # @param job (Object) - An arbitary object that keeps parameters
+    def enqueue(job)
+      @queue.push(job)
+    end
+
+    # Call this after you enqueuned all the jobs you want to process
+    # This method blocks current thread until all the enqueued jobs are processed
+    def start
+      threads = []
+      @concurrency.times do
+        threads << Thread.new do
+          while running? && !empty?
+            job = @queue.pop
+            @block.call(job) if job
+          end
+        end
+      end
+
+      wait_for_complete
+      threads.each(&:join)
+    end
+
+    private
+
+    def running?
+      !@queue.closed?
+    end
+
+    def empty?
+      @queue.empty?
+    end
+
+    def wait_for_complete
+      wait_thread = Thread.new do
+        loop do
+          sleep(1)
+
+          if @queue.empty?
+            @queue.close
+            break
+          end
+        end
+      end
+
+      wait_thread.join
+    end
+  end
+end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -190,7 +190,7 @@ module Deliver
           iterator.each_app_screenshot do |_, _, app_screenshot|
             app_screenshot.delete! unless app_screenshot.complete?
           end
-          upload_screenshots(screenshots_per_language, localizations, tries: tries)
+          upload_screenshots(localizations, screenshots_per_language, tries: tries)
         end
       end
     end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -85,7 +85,7 @@ module Deliver
       iterator = AppScreenshotIterator.new(localizations)
       iterator.each_app_screenshot do |localization, app_screenshot_set, app_screenshot|
         # Only delete screenshots if trying to upload
-        # next unless screenshots_per_language.keys.include?(localization.locale)
+        next unless screenshots_per_language.keys.include?(localization.locale)
 
         UI.verbose("Queued delete sceeenshot job for #{localization.locale} #{app_screenshot_set.screenshot_display_type} #{app_screenshot.id}")
         worker.enqueue(DeleteScreenshotJob.new(app_screenshot, localization, app_screenshot_set))

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -13,7 +13,7 @@ module Deliver
     DeleteScreenshotJob = Struct.new(:app_screenshot, :localization, :app_screenshot_set)
     UploadScreenshotJob = Struct.new(:app_screenshot_set, :path)
 
-    NUMBER_OF_THREADS = Helper.test? ? 1 : 10
+    NUMBER_OF_THREADS = Helper.test? ? 1 : [ENV.fetch("DELIVER_NUMBER_OF_THREADS", 10).to_i, 10].min
 
     def upload(options, screenshots)
       return if options[:skip_screenshots]

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -59,7 +59,7 @@ module Deliver
 
       upload_screenshots(screenshots_per_language, localizations, options)
 
-      Helper.show_loading_indicator("Reodering screenshots uploaded...")
+      Helper.show_loading_indicator("Reordering screenshots uploaded...")
       # Wait for records created asynchronusly
       sleep(3)
       clean_up_screenshots(localizations)

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -151,7 +151,9 @@ module Deliver
 
       UI.verbose('Uploading jobs are completed')
 
+      Helper.show_loading_indicator("Waiting for all the screenshots processed...")
       states = wait_for_complete(iterator)
+      Helper.hide_loading_indicator
       retry_upload_screenshots_if_needed(iterator, states, number_of_screenshots, tries, localizations, screenshots_per_language)
 
       UI.message("Successfully uploaded all screenshots")

--- a/deliver/spec/app_screenshot_iterator_spec.rb
+++ b/deliver/spec/app_screenshot_iterator_spec.rb
@@ -102,7 +102,7 @@ describe Deliver::AppScreenshotIterator do
       end
     end
 
-    context 'when local screenshots are mutiple within an app_screenshot_set' do
+    context 'when local screenshots are multiple within an app_screenshot_set' do
       it 'should give index incremented on each' do
         app_screenshot_set1 = double('Spaceship::ConnectAPI::AppScreenshotSet',
                                      app_screenshots: [],

--- a/deliver/spec/app_screenshot_iterator_spec.rb
+++ b/deliver/spec/app_screenshot_iterator_spec.rb
@@ -1,0 +1,134 @@
+require 'deliver/app_screenshot_iterator'
+require 'spaceship/connect_api/models/app_screenshot_set'
+
+describe Deliver::AppScreenshotIterator do
+  describe "#each_app_screenshot_set" do
+    context 'when screenshot is empty' do
+      it 'should iterates nothing' do
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [])
+        # Test the result with enumerator returned
+        expect(described_class.new([localization]).each_app_screenshot_set.to_a).to be_empty
+      end
+    end
+
+    context 'when a localization has an app_screenshot_set' do
+      it 'should iterates app_screenshot_set with corresponding localization' do
+        app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet')
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [app_screenshot_set])
+        expect(described_class.new([localization]).each_app_screenshot_set.to_a).to eq([[localization, app_screenshot_set]])
+      end
+    end
+
+    context 'when localizations have multiple app_screenshot_sets' do
+      it 'should iterates app_screenshot_set with corresponding localization' do
+        app_screenshot_set1 = double('Spaceship::ConnectAPI::AppScreenshotSet')
+        app_screenshot_set2 = double('Spaceship::ConnectAPI::AppScreenshotSet')
+        app_screenshot_set3 = double('Spaceship::ConnectAPI::AppScreenshotSet')
+        app_screenshot_set4 = double('Spaceship::ConnectAPI::AppScreenshotSet')
+        localization1 = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [app_screenshot_set1, app_screenshot_set2])
+        localization2 = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [app_screenshot_set3, app_screenshot_set4])
+
+        expect(described_class.new([localization1, localization2]).each_app_screenshot_set.to_a)
+          .to eq([[localization1, app_screenshot_set1], [localization1, app_screenshot_set2], [localization2, app_screenshot_set3], [localization2, app_screenshot_set4]])
+      end
+    end
+  end
+
+  describe "#each_app_screenshot" do
+    context 'when screenshot is empty' do
+      it 'should iterates nothing' do
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [])
+        expect(described_class.new([localization]).each_app_screenshot.to_a).to be_empty
+      end
+    end
+
+    context 'when a localization has an app_screenshot_set' do
+      it 'should iterates app_screenshot_set with corresponding localization' do
+        app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet', app_screenshots: [])
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [app_screenshot_set])
+        expect(described_class.new([localization]).each_app_screenshot.to_a).to be_empty
+      end
+    end
+
+    context 'when localizations have multiple app_screenshot_sets which have an app_screenshot' do
+      it 'should iterates app_screenshot with corresponding localization and app_screenshot_set' do
+        app_screenshot1 = double('Spaceship::ConnectAPI::AppScreenshot')
+        app_screenshot2 = double('Spaceship::ConnectAPI::AppScreenshot')
+        app_screenshot3 = double('Spaceship::ConnectAPI::AppScreenshot')
+        app_screenshot4 = double('Spaceship::ConnectAPI::AppScreenshot')
+
+        app_screenshot_set1 = double('Spaceship::ConnectAPI::AppScreenshotSet', app_screenshots: [app_screenshot1])
+        app_screenshot_set2 = double('Spaceship::ConnectAPI::AppScreenshotSet', app_screenshots: [app_screenshot2])
+        app_screenshot_set3 = double('Spaceship::ConnectAPI::AppScreenshotSet', app_screenshots: [app_screenshot3])
+        app_screenshot_set4 = double('Spaceship::ConnectAPI::AppScreenshotSet', app_screenshots: [app_screenshot4])
+
+        localization1 = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [app_screenshot_set1, app_screenshot_set2])
+        localization2 = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [app_screenshot_set3, app_screenshot_set4])
+
+        actual = described_class.new([localization1, localization2]).each_app_screenshot.to_a
+        expect(actual).to eq([[localization1, app_screenshot_set1, app_screenshot1], [localization1, app_screenshot_set2, app_screenshot2],
+                              [localization2, app_screenshot_set3, app_screenshot3], [localization2, app_screenshot_set4, app_screenshot4]])
+      end
+    end
+  end
+
+  describe '#each_local_screenshot' do
+    context 'when screenshot is empty' do
+      it 'should iterates nothing' do
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [], locale: ['en-US'])
+        screenshots_per_language = { 'en-US' => [] }
+        expect(described_class.new([localization]).each_local_screenshot(screenshots_per_language).to_a).to be_empty
+      end
+    end
+
+    context 'when locale doens\'t match the one for given local screenshots' do
+      it 'should iterates nothing' do
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization', get_app_screenshot_sets: [], locale: ['fr-FR'])
+        screenshots_per_language = { 'en-US' => [] }
+        expect(described_class.new([localization]).each_local_screenshot(screenshots_per_language).to_a).to be_empty
+      end
+    end
+
+    context 'when a localization has an app_screenshot_set' do
+      it 'should iterates app_screenshot_set with corresponding localization' do
+        app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
+                                    app_screenshots: [],
+                                    screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization',
+                              get_app_screenshot_sets: [app_screenshot_set],
+                              locale: 'en-US')
+        screenshots_per_language = { 'en-US' => [] }
+        expect(described_class.new([localization]).each_local_screenshot(screenshots_per_language).to_a).to be_empty
+      end
+    end
+
+    context 'when local screenshots are mutiple within an app_screenshot_set' do
+      it 'should give index incremented on each' do
+        app_screenshot_set1 = double('Spaceship::ConnectAPI::AppScreenshotSet',
+                                     app_screenshots: [],
+                                     screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        app_screenshot_set2 = double('Spaceship::ConnectAPI::AppScreenshotSet',
+                                     app_screenshots: [],
+                                     screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+
+        localization1 = double('Spaceship::ConnectAPI::AppStoreVersionLocalization',
+                               get_app_screenshot_sets: [app_screenshot_set1],
+                               locale: 'en-US')
+        localization2 = double('Spaceship::ConnectAPI::AppStoreVersionLocalization',
+                               get_app_screenshot_sets: [app_screenshot_set2],
+                               locale: 'fr-FR')
+
+        screenshot1 = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        screenshot2 = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        screenshot3 = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        screenshot4 = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+
+        screenshots_per_language = { 'en-US' => [screenshot1, screenshot2], 'fr-FR' => [screenshot3, screenshot4] }
+
+        actual = described_class.new([localization1, localization2]).each_local_screenshot(screenshots_per_language).to_a
+        expect(actual).to eq([[localization1, app_screenshot_set1, screenshot1, 0], [localization1, app_screenshot_set1, screenshot2, 1],
+                              [localization2, app_screenshot_set2, screenshot3, 0], [localization2, app_screenshot_set2, screenshot4, 1]])
+      end
+    end
+  end
+end

--- a/deliver/spec/queue_worker_spec.rb
+++ b/deliver/spec/queue_worker_spec.rb
@@ -1,0 +1,39 @@
+require 'deliver/queue_worker'
+
+describe Deliver::QueueWorker do
+  describe '#enqueue' do
+    subject { described_class.new(1) { |_| } }
+
+    it 'should accepet any object' do
+      expect { subject.enqueue(1) }.not_to(raise_error)
+      expect { subject.enqueue('aaa') }.not_to(raise_error)
+      expect { subject.enqueue([1,2,3]) }.not_to(raise_error)
+      expect { subject.enqueue(Object.new) }.not_to(raise_error)
+    end
+  end
+
+  describe '#start' do
+    it 'should dispatch enqueued items to given block in FIFO order' do
+      dispatched_jobs = []
+
+      subject = described_class.new(1) do |job|
+        dispatched_jobs << job
+      end
+
+      subject.enqueue(1)
+      subject.enqueue('aaa')
+      subject.start
+
+      expect(dispatched_jobs).to eq([1, 'aaa'])
+    end
+
+    it 'should not be reused once it\'s started' do
+      subject = described_class.new(1) { |_| }
+
+      subject.enqueue(1)
+      subject.start
+
+      expect { subject.enqueue(2) }.to raise_error(ClosedQueueError)
+    end
+  end
+end

--- a/deliver/spec/queue_worker_spec.rb
+++ b/deliver/spec/queue_worker_spec.rb
@@ -7,7 +7,7 @@ describe Deliver::QueueWorker do
     it 'should accepet any object' do
       expect { subject.enqueue(1) }.not_to(raise_error)
       expect { subject.enqueue('aaa') }.not_to(raise_error)
-      expect { subject.enqueue([1,2,3]) }.not_to(raise_error)
+      expect { subject.enqueue([1, 2, 3]) }.not_to(raise_error)
       expect { subject.enqueue(Object.new) }.not_to(raise_error)
     end
   end

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -228,7 +228,7 @@ describe Deliver::UploadScreenshots do
   end
 
   describe '#clean_up_screenshots' do
-    def make_app_screenshot(id:, file_name:, is_complete: true)
+    def make_app_screenshot(id: nil, file_name: nil, is_complete: true)
       app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot', id: id, file_name: file_name)
       # `complete?` needed to be mocked by this way since Rubocop using 2.0 parser can't handle `{ 'complete?':  false }` format
       allow(app_screenshot).to receive(:complete?).and_return(is_complete)

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -248,7 +248,7 @@ describe Deliver::UploadScreenshots do
         iterator = Deliver::AppScreenshotIterator.new([localization])
 
         expect(::Kernel).to_not(receive(:sleep))
-        subject.wait_for_complete(iterator)
+        expect(subject.wait_for_complete(iterator)).to eq('COMPLETE' => 1)
       end
     end
 
@@ -265,7 +265,7 @@ describe Deliver::UploadScreenshots do
 
         expect_any_instance_of(Object).to receive(:sleep).with(kind_of(Numeric)).once
         expect(app_screenshot).to receive(:asset_delivery_state).and_return({ 'state' => 'UPLOAD_COMPLETE' }, { 'state' => 'COMPLETE' })
-        subject.wait_for_complete(iterator)
+        expect(subject.wait_for_complete(iterator)).to eq('COMPLETE' => 1)
       end
     end
   end

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -227,26 +227,12 @@ describe Deliver::UploadScreenshots do
     end
   end
 
-  describe '#clean_up_screenshots' do
+  describe '#sort_screenshots' do
     def make_app_screenshot(id: nil, file_name: nil, is_complete: true)
       app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot', id: id, file_name: file_name)
       # `complete?` needed to be mocked by this way since Rubocop using 2.0 parser can't handle `{ 'complete?':  false }` format
       allow(app_screenshot).to receive(:complete?).and_return(is_complete)
       app_screenshot
-    end
-
-    context 'when localization has incomplete screenshots uploaded' do
-      it 'should delete screenshot' do
-        app_screenshot = make_app_screenshot(id: 'some-id', file_name: '6.5_1.jpg', is_complete: false)
-        app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
-                                    screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55,
-                                    app_screenshots: [app_screenshot])
-        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization',
-                              locale: 'en-US',
-                              get_app_screenshot_sets: [app_screenshot_set])
-        expect(app_screenshot).to receive(:delete!)
-        described_class.new.clean_up_screenshots([localization])
-      end
     end
 
     context 'when localization has screenshots uploaded in wrong order' do
@@ -261,7 +247,7 @@ describe Deliver::UploadScreenshots do
                               locale: 'en-US',
                               get_app_screenshot_sets: [app_screenshot_set])
         expect(app_screenshot_set).to receive(:reorder_screenshots).with(app_screenshot_ids: ['1', '2', '3'])
-        described_class.new.clean_up_screenshots([localization])
+        described_class.new.sort_screenshots([localization])
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

(The amount of LoC changed in this PR might be too big. Let me know if this is acceptable size😅)

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

First of all, thank you for all the hard works in the support of new App Store Connect API, @joshdholtz.
It's been amazingly working on our project 👏 

However, we've also observed a significant performance degression in app-submission at the same time lately.
It is already noted by another person here.  https://github.com/fastlane/fastlane/issues/16924

Looking at the current code, deleting screenshot in `deliver` is already using multiple threads, but uploading part doesn't use it. I suppose this is due to uploaded screenshots need to be sorted in the correct order but parallelisation may break it as App Store Connect would put them in FIFO order.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I introduced two new components to make things easier;

1. `Deliver::AppScreenshotIterator` to simplify common operations to iterate screenshots through all the localisations
2. `Deliver::QueueWorker` to simplify multi-threading model or even make it more efficient in some cases

At first, `Deliver::AppScreenshotIterator` gives you convenient accesses to individual screenshot object. I expect that this is going to improve the readability of `Deliver::UploadScreenshots` as nesting will be 1-level for common iterative procedures.

```ruby
# Before
localizations.each do |localization|
  localization.get_app_screenshot_sets.each do |screenshot_set|
    screenshot_set.app_screenshots.each do |screenshot|
      screenshot.delete!
    end
  end
end

# After
iterator = AppScreenshotIterator.new(localizations)
iterator.each_app_screenshot do |localization, app_screenshot_set, app_screenshot|
  app_screenshot.delete!
end
```

Secondly, `Deliver::QueueWorker` abstracts how a task works in parallel against a large number of inputs. Unlike simple multi-threading that you have to remember or learn how multi-thread works on Ruby, it lets you write the job queue or thread-pool model seamlessly. That model works better than the current approach that creates threads and waits for deletions on single localisation. Let's say most requests succeed in a short time but the rest of them fall into retrying or unresponsive. While the current pattern has to wait for the completion of the all the requests including such slow ones, thread pool model can just let it keep on running and take next job on available threads without having to wait unnecessarily. I actually observed such cases until a few days ago. It might have been a temporary issue App Store Connect has but the thread pool model just works well in general.

```ruby
# Initialise it with a block. This is single-use object for a task.
worker = QueueWorker.new(NUMBER_OF_THREADS) do |job|
  job[:app_screenshot].delete!
end

app_screenshot_set.app_screenshots.each do |app_screenshot|
  # Enqueue parameters with arbitary type for the block
  worker.enqueue(app_screenshot: app_screenshot)
end

# Wait until enqueued jobs are all consumed
worker.start
```

With those components that I introduced, both deleting and uploading screenshots now works on top of them without changing existing essential logic. I also added an additional step to the end of the uploading process, which removes some of the intermediate state entries that block "submit for review" and re-orders screenshots in the natural order by Ruby's sort. That is needed because multi-threading uploads won't guarantee the order of requests arriving at App Store Connect API servers. As far as I'm aware, App Store Connect API put received screenshots in the list in FIFO order and the way `Spaceship::ConnectAPI::AppScreenshotSet` specifies the position requires its screenshots to be all "COMPLETED". It doesn't work out while multiple requests are inflight.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I've covered everything I added by unit tests.
You can test this with a real project having many screenshots and this code bit below.

```ruby
upload_to_app_store(
  skip_binary_upload: true,
  skip_metadata: true,
  overwrite_screenshot: true,
  run_precheck_before_submit: false,
)
```

To check whether you get the error "There are still screenshot uploads in progress.", you can open App Store Connect console and press "Submit to Review" to see if the message will appears.

##### Rough benchmark

<details>

There's no statistical comparison because I'm seeing App Store Connect's response time is quite varied depending on their condition😅 
Today I got very stable results that all the uploading completes less than 10 secs. I saw some requests could be over 1 or 2 mins before but didn't see that today 😅 

So I tested `upload_to_app_store` with ^ above section's options. We have 385 images to be uploaded (but 4 skipped due to exceeding the limit of 10 in each screenshot set 🙈 )

```
% du -sh fastlane/screenshots
 90M	fastlane/screenshots 
% ls fastlane/screenshots/**/*.{png,jpg} | wc -l
     385
```

With 2.154.0 (19m25.106s)
```
+------+------------------------------------------+-------------+
|                       fastlane summary                        |
+------+------------------------------------------+-------------+
| Step | Action                                   | Time (in s) |
+------+------------------------------------------+-------------+
| 1    | default_platform                         | 0           |
| 2    | Switch to map_environment_variables lane | 0           |
| 3    | is_ci                                    | 0           |
| 4    | xcversion                                | 1           |
| 5    | setup_jenkins                            | 0           |
| 6    | Switch to reset_temporary_keychain lane  | 0           |
| 7    | delete_keychain                          | 0           |
| 8    | create_keychain                          | 0           |
| 9    | ensure_git_status_clean                  | 0           |
| 10   | Switch to sync_metadata lane             | 0           |
| 11   | upload_to_app_store                      | 1159        |
| 12   | git                                      | 0           |
+------+------------------------------------------+-------------+

[18:46:51]: fastlane.tools just saved you 19 minutes! 🎉

#######################################################################
# fastlane 2.154.0 is available. You are on 2.153.1.
# You should use the latest version.
# Please update using `bundle update fastlane`.
# To see what's new, open https://github.com/fastlane/fastlane/releases.
#######################################################################

real	19m25.106s
user	0m11.365s
sys	0m3.687s
Finished: SUCCESS
```

With my branch (3m20.148s)
```
+------+------------------------------------------+-------------+
|                       fastlane summary                        |
+------+------------------------------------------+-------------+
| Step | Action                                   | Time (in s) |
+------+------------------------------------------+-------------+
| 1    | default_platform                         | 0           |
| 2    | Switch to map_environment_variables lane | 0           |
| 3    | is_ci                                    | 0           |
| 4    | xcversion                                | 1           |
| 5    | setup_jenkins                            | 0           |
| 6    | Switch to reset_temporary_keychain lane  | 0           |
| 7    | delete_keychain                          | 0           |
| 8    | create_keychain                          | 0           |
| 9    | ensure_git_status_clean                  | 0           |
| 10   | Switch to sync_metadata lane             | 0           |
| 11   | upload_to_app_store                      | 195         |
| 12   | git                                      | 0           |
+------+------------------------------------------+-------------+

[18:01:18]: fastlane.tools finished successfully 🎉

real	3m20.148s
user	0m10.324s
sys	0m3.450s
Finished: SUCCESS
```

So even in the least efficient case for `QueueWorker` itself (but the best condition on App Store Connect) where the current approach also just works with mostly the same performance, it's roughly 6 times faster than the current thanks to multi-threading for uploading.

</details>
