### PR TITLE
[spaceship] allow modify is_opted_in_to_distribute_ios_app_on_mac_app_store on Spaceship::ConnectAPI:App

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -10,6 +10,7 @@ module Spaceship
       attr_accessor :bundle_id
       attr_accessor :sku
       attr_accessor :primary_locale
+      attr_accessor :is_opted_in_to_distribute_ios_app_on_mac_app_store
       attr_accessor :removed
       attr_accessor :is_aag
       attr_accessor :available_in_new_territories
@@ -26,6 +27,7 @@ module Spaceship
         "bundleId" => "bundle_id",
         "sku" => "sku",
         "primaryLocale" => "primary_locale",
+        "isOptedInToDistributeIosAppOnMacAppStore" => "is_opted_in_to_distribute_ios_app_on_mac_app_store",
         "removed" => "removed",
         "isAAG" => "is_aag",
         "availableInNewTerritories" => "available_in_new_territories",


### PR DESCRIPTION
### Motivation and Context
Fixes #16868
cc @reishka @squallstar

### Description
Allows updating of `is_opted_in_to_distribute_ios_app_on_mac_app_store` on `Spaceship::ConnectAPI::App`

### Testing Steps

```rb
lane :ios_as_mac do
  require 'spaceship'

  Spaceship::Tunes.login("your@email.com")
  Spaceship::Tunes.select_team(team_name: "Your Team Name")

  app = Spaceship::ConnectAPI::App.find("com.your.bundle.id")
  app.update(attributes: {
    is_opted_in_to_distribute_ios_app_on_mac_app_store: false
  })
end
```
