### PR TITLE
[WIP][pilot] improve/correct error message on beta submit

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -372,8 +372,12 @@ module Pilot
       if options[:groups] || options[:distribute_external]
         if uploaded_build.ready_for_beta_submission?
           uploaded_build.post_beta_app_review_submission
-        else
+        elsif uploaded_build.waiting_for_beta_review?
           UI.message("Build #{uploaded_build.app_version} - #{uploaded_build.version} already submitted for review")
+        elsif uploaded_build.beta_approved?
+          UI.message("Build #{uploaded_build.app_version} - #{uploaded_build.version} already approved for beta testing")
+        else
+          UI.user_error!("Build #{uploaded_build.app_version} - #{uploaded_build.version} is not in a submittable state: #{uploaded_build.external_build_state}")
         end
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -87,6 +87,21 @@ module Spaceship
         return build_beta_detail.ready_for_beta_submission?
       end
 
+      def waiting_for_beta_review?
+        raise "No build_beta_detail included" unless build_beta_detail
+        return build_beta_detail.waiting_for_beta_review?
+      end
+
+      def beta_approved?
+        raise "No build_beta_detail included" unless build_beta_detail
+        return build_beta_detail.beta_approved?
+      end
+
+      def external_build_state
+        raise "No build_beta_detail included" unless build_beta_detail
+        return build_beta_detail.external_build_state
+      end
+
       # This is here temporarily until the removal of Spaceship::TestFlight
       def to_testflight_build
         h = {

--- a/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
@@ -56,6 +56,14 @@ module Spaceship
       def ready_for_beta_submission?
         return external_build_state == ExternalState::READY_FOR_BETA_SUBMISSION
       end
+
+      def waiting_for_beta_review?
+        return [ExternalState::WAITING_FOR_BETA_REVIEW, ExternalState::IN_BETA_TESTING].include?(external_build_state)
+      end
+
+      def beta_approved?
+        return external_build_state == ExternalState::BETA_APPROVED
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation and Context
Had a report of `pilot` beta submission saying "already submitted for review" when not submitted. Looks like error handling and message output needed to be better.

### Description
- `uploaded_build.ready_for_beta_submission?` didn't necessarily mean it was already submitted
- Doing separate check for "waiting for review" and "beta approved"
- Throwing user error if other state and showing the state error

### Testing

Update `Gemfile` to 👇 and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-pilot-improve-beta-submit-error"
```
