### PR TITLE
[deliver] Fix language detection for HtmlGenerator

### DIFF
--- a/deliver/lib/deliver/html_generator.rb
+++ b/deliver/lib/deliver/html_generator.rb
@@ -51,7 +51,12 @@ module Deliver
       @app_name ||= options[:app].name
 
       @languages = options[:description].keys if options[:description]
-      @languages ||= options[:app].latest_version.description.languages
+      @languages ||= begin
+        platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
+        version = options[:app].get_edit_app_store_version(platform: platform)
+
+        version.get_app_store_version_localizations.collect(&:locale)
+      end
 
       html_path = File.join(Deliver::ROOT, "lib/assets/summary.html.erb")
       html = ERB.new(File.read(html_path)).result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system

--- a/deliver/lib/deliver/html_generator.rb
+++ b/deliver/lib/deliver/html_generator.rb
@@ -1,3 +1,5 @@
+require 'spaceship'
+
 require_relative 'module'
 
 module Deliver


### PR DESCRIPTION
`#latest_version` method doesn't exist and thus languages could not be detected.
Use `#get_edit_app_store_version` instead to get available locales.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
If no locales were given in `description` option, previously an error would be raised:

```
#<NoMethodError: undefined method `latest_version' for #<Spaceship::ConnectAPI::App:0x00007fcd57899078>>
/.../fastlane-2.154.0/deliver/lib/deliver/html_generator.rb:54:in `render'
``` 

This PR fixes the issue.