### PR TITLE
[snapshot] Add `suppress_xcode_output` option

### DIFF
--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -278,6 +278,11 @@ module Snapshot
                                      env_name: "SNAPSHOT_DISABLE_XCPRETTY",
                                      description: "Disable xcpretty formatting of build",
                                      type: Boolean,
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :suppress_xcode_output,
+                                     env_name: "SNAPSHOT_SUPPRESS_XCODE_OUTPUT",
+                                     description: "Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path",
+                                     type: Boolean,
                                      optional: true)
       ]
     end

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -34,7 +34,7 @@ module Snapshot
         xcpretty = "xcpretty #{Snapshot.config[:xcpretty_args]}"
         xcpretty << "--no-color" if Helper.colors_disabled?
         pipe << "| #{xcpretty}"
-        pipe << " > /dev/null" if Snapshot.config[:suppress_xcode_output]
+        pipe << "> /dev/null" if Snapshot.config[:suppress_xcode_output]
         return pipe
       end
 

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -34,7 +34,7 @@ module Snapshot
         xcpretty = "xcpretty #{Snapshot.config[:xcpretty_args]}"
         xcpretty << "--no-color" if Helper.colors_disabled?
         pipe << "| #{xcpretty}"
-        pipe << "> /dev/null" if Snapshot.config[:suppress_xcode_output]
+        pipe << " > /dev/null" if Snapshot.config[:suppress_xcode_output]
         return pipe
       end
 

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -33,8 +33,9 @@ module Snapshot
 
         xcpretty = "xcpretty #{Snapshot.config[:xcpretty_args]}"
         xcpretty << "--no-color" if Helper.colors_disabled?
-
-        return pipe << "| #{xcpretty}"
+        pipe << "| #{xcpretty}"
+        pipe << "> /dev/null" if Snapshot.config[:suppress_xcode_output]
+        return pipe
       end
 
       def destination(devices)

--- a/snapshot/lib/snapshot/test_command_generator_xcode_8.rb
+++ b/snapshot/lib/snapshot/test_command_generator_xcode_8.rb
@@ -24,7 +24,10 @@ module Snapshot
 
       def pipe(device_type, language, locale)
         log_path = xcodebuild_log_path(device_type: device_type, language: language, locale: locale)
-        return ["| tee #{log_path.shellescape} | xcpretty #{Snapshot.config[:xcpretty_args]}"]
+        pipe = "| tee #{log_path.shellescape} "
+        pipe << "| xcpretty #{Snapshot.config[:xcpretty_args]}"
+        pipe << "> /dev/null" if Snapshot.config[:suppress_xcode_output]
+        return [pipe]
       end
 
       def destination(device_name)

--- a/snapshot/lib/snapshot/test_command_generator_xcode_8.rb
+++ b/snapshot/lib/snapshot/test_command_generator_xcode_8.rb
@@ -26,7 +26,7 @@ module Snapshot
         log_path = xcodebuild_log_path(device_type: device_type, language: language, locale: locale)
         pipe = "| tee #{log_path.shellescape} "
         pipe << "| xcpretty #{Snapshot.config[:xcpretty_args]}"
-        pipe << "> /dev/null" if Snapshot.config[:suppress_xcode_output]
+        pipe << " > /dev/null" if Snapshot.config[:suppress_xcode_output]
         return [pipe]
       end
 

--- a/snapshot/lib/snapshot/test_command_generator_xcode_8.rb
+++ b/snapshot/lib/snapshot/test_command_generator_xcode_8.rb
@@ -24,10 +24,10 @@ module Snapshot
 
       def pipe(device_type, language, locale)
         log_path = xcodebuild_log_path(device_type: device_type, language: language, locale: locale)
-        pipe = "| tee #{log_path.shellescape} "
+        pipe = ["| tee #{log_path.shellescape}"]
         pipe << "| xcpretty #{Snapshot.config[:xcpretty_args]}"
-        pipe << " > /dev/null" if Snapshot.config[:suppress_xcode_output]
-        return [pipe]
+        pipe << "> /dev/null" if Snapshot.config[:suppress_xcode_output]
+        return pipe
       end
 
       def destination(device_name)

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -328,6 +328,22 @@ describe Snapshot do
           expect(command.join('')).to include("| xcpretty ")
         end
       end
+
+      context "suppress_xcode_output" do
+        it "includes /dev/null in the pipe command when true", requires_xcode: true do
+          configure(options.merge(suppress_xcode_output: true))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to include("> /dev/null")
+        end
+
+        it "does not include /dev/null in the pipe command when false", requires_xcode: true do
+          configure(options.merge(suppress_xcode_output: false))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to_not(include("> /dev/null"))
+        end
+      end
     end
 
     describe "Valid macOS Configuration" do

--- a/snapshot/spec/test_command_generator_xcode_8_spec.rb
+++ b/snapshot/spec/test_command_generator_xcode_8_spec.rb
@@ -199,6 +199,22 @@ describe Snapshot do
         end
       end
 
+      context "disable_xcpretty" do
+        it "does not include xcpretty in the pipe command when true", requires_xcode: true do
+          configure(options.merge(disable_xcpretty: true))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to_not(include("| xcpretty "))
+        end
+
+        it "includes xcpretty in the pipe command when false", requires_xcode: true do
+          configure(options.merge(disable_xcpretty: false))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to include("| xcpretty ")
+        end
+      end
+
       context "suppress_xcode_output" do
         it "includes /dev/null in the pipe command when true", requires_xcode: true do
           configure(options.merge(suppress_xcode_output: true))

--- a/snapshot/spec/test_command_generator_xcode_8_spec.rb
+++ b/snapshot/spec/test_command_generator_xcode_8_spec.rb
@@ -198,6 +198,22 @@ describe Snapshot do
           expect(command.join('')).to include("-derivedDataPath 'fake/derived/path'")
         end
       end
+
+      context "suppress_xcode_output" do
+        it "includes /dev/null in the pipe command when true", requires_xcode: true do
+          configure(options.merge(suppress_xcode_output: true))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to include("> /dev/null")
+        end
+
+        it "does not include /dev/null in the pipe command when false", requires_xcode: true do
+          configure(options.merge(suppress_xcode_output: false))
+
+          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+          expect(command.join('')).to_not(include("> /dev/null"))
+        end
+      end
     end
 
     describe "Valid macOS Configuration" do


### PR DESCRIPTION
🔑 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Thanks to the `You can do this` label, this PR resolves #16792 🚀 

### Description

This change is quite simple actually, it simply adds a `suppress_xcode_output` to `snapshot` action, similar to the analogous argument in `scan` and `gym`.

### Testing Steps

`bundle exec fastlane snapshot --suppress_xcode_output=true`