### PR TITLE
[match] Fix Google Cloud Storage Crash When No Fastfile Is Being Used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ rspec_logs.json
 test_output/
 .DS_STORE
 .keys
-*.swp 
+*.swp
 
 ## Specific to Android
 .gradle/

--- a/match/lib/match/storage/google_cloud_storage.rb
+++ b/match/lib/match/storage/google_cloud_storage.rb
@@ -213,7 +213,7 @@ module Match
 
         return DEFAULT_KEYS_FILE_NAME if File.exist?(DEFAULT_KEYS_FILE_NAME)
 
-        fastlane_folder_gc_keys_path = File.join(FastlaneCore::FastlaneFolder.path, DEFAULT_KEYS_FILE_NAME)
+        fastlane_folder_gc_keys_path = File.join(FastlaneCore::FastlaneFolder.path || Dir.pwd, DEFAULT_KEYS_FILE_NAME)
         return fastlane_folder_gc_keys_path if File.exist?(fastlane_folder_gc_keys_path)
 
         if google_cloud_project_id.to_s.length > 0


### PR DESCRIPTION
🔑 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Thanks to the `You can do this` label, this PR resolves #16836  🚀 

### Description

Prior to this PR, the line in match/lib/match/storage/google_cloud_storage.rb would output

```
TypeError: [!] no implicit conversion of nil into String
```
In a scenario where no Fastfile is being used (i.e. the command is executed entirely from CLI, which's often the case when using `match`).

### Testing Steps

Execute the following command with no Fastfile in your environment.

```
 bundle exec fastlane match development\
        --app_identifier {id}\
        --storage_mode google_cloud\
        --google_cloud_bucket_name {bucket_name}\
        --google_cloud_project_id {project_id}\
        --team_id {team_id}\
        --username {email@domain.com}
```
