### PR TITLE
[gym][scan] xcodebuild -resolvePackageDependencies missing -derivedDataPath

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -320,7 +320,7 @@ module FastlaneCore
       proj << "-scheme #{options[:scheme].shellescape}" if options[:scheme]
       proj << "-project #{options[:project].shellescape}" if options[:project]
       proj << "-configuration #{options[:configuration].shellescape}" if options[:configuration]
-      proj << "-derivedDataPath '#{options[:derived_data_path]}'" if options[:derived_data_path]
+      proj << "-derivedDataPath #{options[:derived_data_path].shellescape}" if options[:derived_data_path]
       proj << "-xcconfig #{options[:xcconfig].shellescape}" if options[:xcconfig]
 
       if FastlaneCore::Helper.xcode_at_least?('11.0') && options[:cloned_source_packages_path]

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -320,6 +320,7 @@ module FastlaneCore
       proj << "-scheme #{options[:scheme].shellescape}" if options[:scheme]
       proj << "-project #{options[:project].shellescape}" if options[:project]
       proj << "-configuration #{options[:configuration].shellescape}" if options[:configuration]
+      proj << "-derivedDataPath '#{options[:derived_data_path]}'" if options[:derived_data_path]
       proj << "-xcconfig #{options[:xcconfig].shellescape}" if options[:xcconfig]
 
       if FastlaneCore::Helper.xcode_at_least?('11.0') && options[:cloned_source_packages_path]

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -482,6 +482,17 @@ describe FastlaneCore do
       end
     end
 
+    describe "xcodebuild derived_data_path" do
+      it 'generates an xcodebuild -showBuildSettings command that includes derived_data_path if provided in options', requires_xcode: true do
+        project = FastlaneCore::Project.new({
+          project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+          derived_data_path: "./special/path/DerivedData"
+        })
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -derivedDataPath ./special/path/DerivedData"
+        expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+      end
+    end
+
     describe 'xcodebuild_xcconfig option', requires_xcode: true do
       it 'generates an xcodebuild -showBuildSettings command without xcconfig by default' do
         project = FastlaneCore::Project.new({ project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" })

--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -38,7 +38,6 @@ module Gym
         options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
         options << "-destination '#{config[:destination]}'" if config[:destination]
         options << "-archivePath #{archive_path.shellescape}" unless config[:skip_archive]
-        options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
         options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
         options << config[:xcargs] if config[:xcargs]
         options << "OTHER_SWIFT_FLAGS=\"-Xfrontend -debug-time-function-bodies\"" if config[:analyze_build_time]

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -183,7 +183,7 @@ describe Gym do
                                "xcodebuild",
                                "-scheme Example",
                                "-project ./gym/examples/standard/Example.xcodeproj",
-                               "-derivedDataPath '/tmp/my/derived_data'",
+                               "-derivedDataPath /tmp/my/derived_data",
                                "-destination 'generic/platform=iOS'",
                                "-archivePath #{Gym::BuildCommandGenerator.archive_path.shellescape}",
                                :archive,

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -168,11 +168,12 @@ describe Gym do
     end
 
     describe "Derived Data Example" do
-      before do
+      before(:each) do
         options = { project: "./gym/examples/standard/Example.xcodeproj", derived_data_path: "/tmp/my/derived_data", scheme: 'Example' }
-        Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+        config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+        @project = FastlaneCore::Project.new(config)
+        allow(Gym).to receive(:project).and_return(@project)
       end
-
       it "uses the correct build command with the example project", requires_xcodebuild: true do
         log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 
@@ -182,9 +183,9 @@ describe Gym do
                                "xcodebuild",
                                "-scheme Example",
                                "-project ./gym/examples/standard/Example.xcodeproj",
+                               "-derivedDataPath '/tmp/my/derived_data'",
                                "-destination 'generic/platform=iOS'",
                                "-archivePath #{Gym::BuildCommandGenerator.archive_path.shellescape}",
-                               "-derivedDataPath '/tmp/my/derived_data'",
                                :archive,
                                "| tee #{log_path.shellescape}",
                                "| xcpretty"

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -35,8 +35,8 @@ module Scan
       options << "-sdk '#{config[:sdk]}'" if config[:sdk]
       options << destination # generated in `detect_values`
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
-      if config[:derived_data_path] && !options.include?("-derivedDataPath '#{config[:derived_data_path]}'")
-        options << "-derivedDataPath '#{config[:derived_data_path]}'"
+      if config[:derived_data_path] && !options.include?("-derivedDataPath #{config[:derived_data_path].shellescape}")
+        options << "-derivedDataPath #{config[:derived_data_path].shellescape}"
       end
       options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
       if FastlaneCore::Helper.xcode_at_least?(10)

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -35,7 +35,9 @@ module Scan
       options << "-sdk '#{config[:sdk]}'" if config[:sdk]
       options << destination # generated in `detect_values`
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
-      options << "-derivedDataPath '#{config[:derived_data_path]}'" if config[:derived_data_path]
+      if config[:derived_data_path] && !options.include?("-derivedDataPath '#{config[:derived_data_path]}'")
+        options << "-derivedDataPath '#{config[:derived_data_path]}'"
+      end
       options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
       if FastlaneCore::Helper.xcode_at_least?(10)
         options << "-parallel-testing-worker-count #{config[:concurrent_workers]}" if config[:concurrent_workers]

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -114,7 +114,7 @@ describe Scan do
                                        "-sdk '9.0'",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                        "-toolchain 'com.apple.dt.toolchain.Swift_2_3'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        :build,
                                        :test
                                      ])
@@ -136,7 +136,7 @@ describe Scan do
                                      "-project ./scan/examples/standard/app.xcodeproj",
                                      "-sdk '9.0'",
                                      "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                     "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                     "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                      "DEBUG=1 BUNDLE_NAME=Example\\ App",
                                      :build,
                                      :test
@@ -175,7 +175,7 @@ describe Scan do
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        :build,
                                        :test
                                      ])
@@ -221,7 +221,7 @@ describe Scan do
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                       "-derivedDataPath '/tmp/my/derived_data'",
+                                       "-derivedDataPath /tmp/my/derived_data",
                                        :build,
                                        :test
                                      ])
@@ -321,7 +321,7 @@ describe Scan do
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        "-resultBundlePath './fastlane/test_output/app.test_result'",
                                        :build,
                                        :test
@@ -342,7 +342,7 @@ describe Scan do
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        "-resultBundlePath './fastlane/test_output/app.xcresult'",
                                        :build,
                                        :test
@@ -366,7 +366,7 @@ describe Scan do
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        '-only-testing:TestBundleA/TestSuiteB',
                                        '-only-testing:TestBundleC',
                                        :build,
@@ -389,7 +389,7 @@ describe Scan do
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        '-only-testing:TestBundleA/TestSuiteB',
                                        :build,
                                        :test
@@ -411,7 +411,7 @@ describe Scan do
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        '-skip-testing:TestBundleA/TestSuiteB',
                                        '-skip-testing:TestBundleC',
                                        :build,
@@ -434,7 +434,7 @@ describe Scan do
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        '-skip-testing:TestBundleA/TestSuiteB',
                                        :build,
                                        :test
@@ -454,7 +454,7 @@ describe Scan do
                                      "-project ./scan/examples/standard/app.xcodeproj",
                                      # expect the single highest versioned iOS simulator device available with matching name
                                      "-destination 'platform=iOS Simulator,id=021A465B-A294-4D9E-AD07-6BDC8E186343'",
-                                     "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                     "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                      :build,
                                      :test
                                    ])
@@ -487,7 +487,7 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        "build-for-testing"
                                      ])
       end
@@ -501,7 +501,7 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        "test-without-building"
                                      ])
       end
@@ -526,7 +526,7 @@ describe Scan do
                                        "env NSUnbufferedIO=YES xcodebuild",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        "-xctestrun '/folder/mytests.xctestrun'",
                                        "test-without-building"
                                      ])
@@ -549,7 +549,7 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' " \
                                        "-destination 'platform=iOS Simulator,name=iPad Air 2,OS=9.2'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        :build,
                                        :test
                                      ])
@@ -570,7 +570,7 @@ describe Scan do
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=70E1E92F-A292-4980-BC3C-7770C5EEFCFD' " \
                                        "-destination 'platform=iOS Simulator,id=DD134998-177F-47DA-99FA-D549D9305476'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        :build,
                                        :test
                                      ])
@@ -590,7 +590,7 @@ describe Scan do
                                        "-scheme app",
                                        "-project ./scan/examples/standard/app.xcodeproj",
                                        "-destination 'platform=iOS Simulator,id=9905A018-9DC9-4DD8-BA14-B0B000CC8622'",
-                                       "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                       "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                        :build,
                                        :test
                                      ])
@@ -668,7 +668,7 @@ describe Scan do
                                          "-scheme app",
                                          "-project ./scan/examples/standard/app.xcodeproj",
                                          "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                         "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                         "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                          "-testPlan 'simple'",
                                          "-only-test-configuration 'TestConfigurationA'",
                                          "-only-test-configuration 'TestConfigurationB'",
@@ -695,7 +695,7 @@ describe Scan do
                                          "-scheme app",
                                          "-project ./scan/examples/standard/app.xcodeproj",
                                          "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                         "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                         "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                          "-testPlan 'simple'",
                                          "-only-test-configuration 'TestConfigurationA'",
                                          :build,
@@ -721,7 +721,7 @@ describe Scan do
                                          "-scheme app",
                                          "-project ./scan/examples/standard/app.xcodeproj",
                                          "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                         "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                         "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                          "-testPlan 'simple'",
                                          "-skip-test-configuration 'TestConfigurationA'",
                                          "-skip-test-configuration 'TestConfigurationB'",
@@ -748,7 +748,7 @@ describe Scan do
                                          "-scheme app",
                                          "-project ./scan/examples/standard/app.xcodeproj",
                                          "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                         "-derivedDataPath '#{Scan.config[:derived_data_path]}'",
+                                         "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                          "-testPlan 'simple'",
                                          "-skip-test-configuration 'TestConfigurationA'",
                                          :build,

--- a/snapshot/lib/snapshot/test_command_generator_base.rb
+++ b/snapshot/lib/snapshot/test_command_generator_base.rb
@@ -24,7 +24,9 @@ module Snapshot
         options = []
         options += project_path_array
         options << "-sdk '#{config[:sdk]}'" if config[:sdk]
-        options << "-derivedDataPath '#{derived_data_path}'"
+        if derived_data_path && !options.include?("-derivedDataPath #{derived_data_path.shellescape}")
+          options << "-derivedDataPath #{derived_data_path.shellescape}"
+        end
         options << "-resultBundlePath '#{result_bundle_path}'" if result_bundle_path
         if FastlaneCore::Helper.xcode_at_least?(11)
           options << "-testPlan '#{config[:testplan]}'" if config[:testplan]

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -175,7 +175,7 @@ describe Snapshot do
               "xcodebuild",
               "-scheme ExampleUITests",
               "-project ./snapshot/example/Example.xcodeproj",
-              "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+              "-derivedDataPath /tmp/path/to/snapshot_derived",
               "-destination 'platform=iOS Simulator,name=#{name},OS=#{ios}'",
               "FASTLANE_SNAPSHOT=YES",
               :build,
@@ -203,7 +203,7 @@ describe Snapshot do
               "xcodebuild",
               "-scheme ExampleUITests",
               "-project ./snapshot/example/Example.xcodeproj",
-              "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+              "-derivedDataPath /tmp/path/to/snapshot_derived",
               "-only-testing:TestBundle/TestSuite/Screenshots",
               "-destination 'platform=iOS Simulator,name=#{name},OS=#{ios}'",
               "FASTLANE_SNAPSHOT=YES",
@@ -232,7 +232,7 @@ describe Snapshot do
               "xcodebuild",
               "-scheme ExampleUITests",
               "-project ./snapshot/example/Example.xcodeproj",
-              "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+              "-derivedDataPath /tmp/path/to/snapshot_derived",
               "-destination 'platform=tvOS Simulator,name=#{name},OS=#{os}'",
               "FASTLANE_SNAPSHOT=YES",
               :build,
@@ -252,7 +252,7 @@ describe Snapshot do
         it 'uses the fixed derivedDataPath if given', requires_xcode: true do
           expect(Dir).not_to(receive(:mktmpdir))
           command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("-derivedDataPath 'fake/derived/path'")
+          expect(command.join('')).to include("-derivedDataPath fake/derived/path")
         end
       end
 
@@ -364,7 +364,7 @@ describe Snapshot do
             "xcodebuild",
             "-scheme ExampleMacOS",
             "-project ./snapshot/example/Example.xcodeproj",
-            "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+            "-derivedDataPath /tmp/path/to/snapshot_derived",
             "-destination 'platform=macOS'",
             "FASTLANE_SNAPSHOT=YES",
             :build,

--- a/snapshot/spec/test_command_generator_xcode_8_spec.rb
+++ b/snapshot/spec/test_command_generator_xcode_8_spec.rb
@@ -131,7 +131,7 @@ describe Snapshot do
               "xcodebuild",
               "-scheme ExampleUITests",
               "-project ./snapshot/example/Example.xcodeproj",
-              "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+              "-derivedDataPath /tmp/path/to/snapshot_derived",
               "-destination 'platform=iOS Simulator,id=#{id},OS=#{ios}'",
               "FASTLANE_SNAPSHOT=YES",
               :build,
@@ -154,7 +154,7 @@ describe Snapshot do
               "xcodebuild",
               "-scheme ExampleUITests",
               "-project ./snapshot/example/Example.xcodeproj",
-              "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+              "-derivedDataPath /tmp/path/to/snapshot_derived",
               "-only-testing:TestBundle/TestSuite/Screenshots",
               "-destination 'platform=iOS Simulator,id=#{id},OS=#{ios}'",
               "FASTLANE_SNAPSHOT=YES",
@@ -178,7 +178,7 @@ describe Snapshot do
               "xcodebuild",
               "-scheme ExampleUITests",
               "-project ./snapshot/example/Example.xcodeproj",
-              "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+              "-derivedDataPath /tmp/path/to/snapshot_derived",
               "-destination 'platform=tvOS Simulator,id=#{id},OS=#{os}'",
               "FASTLANE_SNAPSHOT=YES",
               :build,
@@ -198,7 +198,7 @@ describe Snapshot do
         it 'uses the fixed derivedDataPath if given', requires_xcode: true do
           expect(Dir).not_to(receive(:mktmpdir))
           command = Snapshot::TestCommandGeneratorXcode8.generate(device_type: "iPhone 6", language: "en", locale: nil)
-          expect(command.join('')).to include("-derivedDataPath 'fake/derived/path'")
+          expect(command.join('')).to include("-derivedDataPath fake/derived/path")
         end
       end
 
@@ -248,7 +248,7 @@ describe Snapshot do
             "xcodebuild",
             "-scheme ExampleMacOS",
             "-project ./snapshot/example/Example.xcodeproj",
-            "-derivedDataPath '/tmp/path/to/snapshot_derived'",
+            "-derivedDataPath /tmp/path/to/snapshot_derived",
             "-destination 'platform=macOS'",
             "FASTLANE_SNAPSHOT=YES",
             :build,


### PR DESCRIPTION
🔑 

Added `-derivedDataPath` parameter to xcodebuild when `derived_data_path` is set in options and or `SCAN_DERIVED_DATA_PATH` or `GYM_DERIVED_DATA_PATH` env are set.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When adding SPM dependencies to your Xcode project the checkout repositories are cached within the `DerivedData` folder of your current project. However when building/testing your project with `fastlane gym/scan` the derived data path setting is not propagated to the `xcodebuild -resolvePackageDependencies` step. This can lead to confusion and bugs when adding/removing/updating said dependencies.

### Description
Added the `derivedDataPath` step to `Project` and skip setting/overwriting this parameter in `Scan` and `Gym`.

### Testing Steps
Just run a `fastlane scan [derived_data_path:your_path]` and/or `fastlane gym [derived_data_path:your_path]` on your project that **has** SPM dependencies (managed by Xcodeproj) and see that the `xcodebuild -resolvePackageDependencies` step has propagated the derivedDataPath when either `derived_data_path` is passed to gym/scan as an argument. Or respectively `SCAN_DERIVED_DATA_PATH` or `GYM_DERIVED_DATA_PATH` env are set.
