### PR TITLE
Update AppStoreConnect.md - Adds missing quote to issuer_id param value

### DIFF
--- a/spaceship/docs/AppStoreConnect.md
+++ b/spaceship/docs/AppStoreConnect.md
@@ -28,7 +28,7 @@ In general the classes are pre-fixed with the `ConnectAPI` module. If you want t
 
 token = Spaceship::ConnectAPI::Token.create(
   key_id: 'the-key-id',
-  issuer_id: 'the-issuer-id,
+  issuer_id: 'the-issuer-id',
   filepath:  File.absolute_path("../AuthKey_the-key-id.p8")
 )
 


### PR DESCRIPTION
Adds missing quote to issuer_id param value

### Motivation and Context
Copied and pasted a couple of times without realizing immediately that the quote was missing :)

### Description
Simple documentation fix to allow copy/paste from the readme

