### PR TITLE
[spaceship] use created_date for fetching latest app store version

### DIFF
--- a/snapshot/spec/test_command_generator_xcode_8_spec.rb
+++ b/snapshot/spec/test_command_generator_xcode_8_spec.rb
@@ -136,7 +136,8 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone\\ 6-en.log")} | xcpretty "
+              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone\\ 6-en.log")}",
+              "| xcpretty "
             ]
           )
         end
@@ -159,7 +160,8 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests-iPhone\\ 6-en.log')} | xcpretty "
+              "| tee #{File.expand_path('~/Library/Logs/snapshot/Example-ExampleUITests-iPhone\\ 6-en.log')}",
+              "| xcpretty "
             ]
           )
         end
@@ -181,7 +183,8 @@ describe Snapshot do
               "FASTLANE_SNAPSHOT=YES",
               :build,
               :test,
-              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-Apple\\ TV\\ 1080p-en.log")} | xcpretty "
+              "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-Apple\\ TV\\ 1080p-en.log")}",
+              "| xcpretty "
             ]
           )
         end
@@ -250,7 +253,8 @@ describe Snapshot do
             "FASTLANE_SNAPSHOT=YES",
             :build,
             :test,
-            "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/ExampleMacOS-ExampleMacOS-Mac-en.log")} | xcpretty "
+            "| tee #{File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/ExampleMacOS-ExampleMacOS-Mac-en.log")}",
+            "| xcpretty "
           ]
         )
       end

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -188,7 +188,7 @@ module Spaceship
 
         # Get the latest version
         return get_app_store_versions(filter: filter, includes: includes)
-               .sort_by { |v| Gem::Version.new(v.version_string) }
+               .sort_by { |v| Date.parse(v.created_date) }
                .last
       end
 


### PR DESCRIPTION
### Motivation and Context
Downloading metadata from `deliver` was experiencing weird behavior when trying to find the "latest" version when based off of version string. Version string format can change (if dev wants it to) so sorting was inconsistent.

### Description
Uses `created_date` instead