### PR TITLE
[sigh] fix issue with dev development devices

### DIFF
--- a/sigh/spec/spec_helper.rb
+++ b/sigh/spec/spec_helper.rb
@@ -10,6 +10,10 @@ def sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: n
   allow(certificate).to receive(:id).and_return("id")
   allow(certificate).to receive(:certificate_content).and_return(Base64.encode64("cert content"))
 
+  device = "device"
+  allow(device).to receive(:id).and_return(1)
+  allow(Spaceship::ConnectAPI::Device).to receive(:all).and_return([device])
+
   bundle_ids = all_app_identifiers.map do |id|
     Spaceship::ConnectAPI::BundleId.new("123", {
       identifier: id,

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -65,10 +65,10 @@ module Spaceship
                 end
               },
               devices: {
-                data: (devices || []).map do |certificate|
+                data: (devices || []).map do |device|
                   {
                     type: "devices",
-                    id: devices
+                    id: device
                   }
                 end
               }


### PR DESCRIPTION
### Motivation and Context
Fixes #17008

### Description
- `certificates_to_use` now always returns an array
  - artifact from legacy API allowing either array or single id
- gets devices properly 🤷‍♂️ 