### PR TITLE
Run spaceauth and get FASTLANE_SESSION on CI without UI.interactive

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -140,10 +140,7 @@ module Spaceship
         should_request_code = !sms_automatically_sent(response) && (!ENV["SPACESHIP_2FA_SMS_CODE"] || ENV["SPACESHIP_2FA_SMS_CODE"].empty?)
         code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length, should_request_code)
-
-        # raise "aaa2 body: #{body}"
       elsif sms_automatically_sent(response) # sms fallback, code was automatically sent
-        raise "aaa3"
         fallback_number = response.body["trustedPhoneNumbers"].first
         phone_number = fallback_number["numberWithDialCode"]
         phone_id = fallback_number["id"]
@@ -151,11 +148,9 @@ module Spaceship
         code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length, false)
       elsif sms_fallback(response) # sms fallback but code wasn't sent bec > 1 phone number
-        raise "aaa4"
         code_type = 'phone'
         body = request_two_factor_code_from_phone_choose(response.body["trustedPhoneNumbers"], code_length)
       else
-        raise "aaa5"
         puts("(Input `sms` to escape this prompt and select a trusted phone number to send the code as a text message)")
         puts("")
         puts("(You can also set the environment variable `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` to automate this)")

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -125,7 +125,6 @@ module Spaceship
 
       puts("")
       env_2fa_sms_default_phone_number = ENV["SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER"]
-      env_2fa_sms_code = ENV["SPACESHIP_2FA_SMS_CODE"]
 
       if env_2fa_sms_default_phone_number
         raise Tunes::Error.new, "Environment variable SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER is set, but empty." if env_2fa_sms_default_phone_number.empty?
@@ -138,7 +137,7 @@ module Spaceship
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
         # don't request sms if no trusted devices and env default is the only trusted number,
         # code was automatically sent
-        should_request_code = !sms_automatically_sent(response) && !env_2fa_sms_code
+        should_request_code = !sms_automatically_sent(response) && (!ENV["SPACESHIP_2FA_SMS_CODE"] || ENV["SPACESHIP_2FA_SMS_CODE"].empty?)
         code_type = 'phone'
         body = request_two_factor_code_from_phone(phone_id, phone_number, code_length, should_request_code)
 
@@ -314,7 +313,7 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
         puts("Successfully requested text message to #{phone_number}")
       end
 
-      if ENV["SPACESHIP_2FA_SMS_CODE"]
+      if ENV["SPACESHIP_2FA_SMS_CODE"] && !ENV["SPACESHIP_2FA_SMS_CODE"].empty?
         code = ENV["SPACESHIP_2FA_SMS_CODE"]
       else 
         code = ask_for_2fa_code("Please enter the #{code_length} digit code you received at #{phone_number}:")

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -1,5 +1,6 @@
 require_relative 'globals'
 require_relative 'tunes/tunes_client'
+require_relative 'fastlane_core/ui/ui'
 
 module Spaceship
   class Client
@@ -310,7 +311,7 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
 
       if ENV["SPACESHIP_2FA_SMS_CODE"] && !ENV["SPACESHIP_2FA_SMS_CODE"].empty?
         code = ENV["SPACESHIP_2FA_SMS_CODE"]
-      else 
+      else
         code = ask_for_2fa_code("Please enter the #{code_length} digit code you received at #{phone_number}:")
       end
 

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -1,6 +1,6 @@
 require_relative 'globals'
 require_relative 'tunes/tunes_client'
-require_relative 'fastlane_core/ui/ui'
+require_relative 'helper'
 
 module Spaceship
   class Client

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -1,6 +1,6 @@
 require_relative 'globals'
 require_relative 'tunes/tunes_client'
-require_relative 'helper'
+require 'fastlane_core/ui/ui'
 
 module Spaceship
   class Client


### PR DESCRIPTION
🔑
# Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary. - **Nope**, beacasue I don't believe the `SPACESHIP_2FA_SMS_CODE` is a final solution.

### Motivation and Context
#17012

### Description
This is just a POC to demonstrate it can work. I believe that code shouldn't be merged 😃.
There is a space to improvement and If you agree with my concept I'd be grateful if someone with better knowledge about Fastlane architecture and Ruby will take it over.

### Testing Steps
I put some description in the #17012, but generally the code was not tested.