### PR TITLE
[sigh] fix for sending up template_name to ASC API

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -172,7 +172,8 @@ module Sigh
         profile_type: profile_type,
         bundle_id_id: bundle_id.id,
         certificate_ids: certificates_to_use.map(&:id),
-        device_ids: devices_to_use.map(&:id)
+        device_ids: devices_to_use.map(&:id),
+        template_name: Sigh.config[:template_name]
       )
 
       profile

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -69,14 +69,15 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.create(name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil)
+      def self.create(name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
         resp = Spaceship::ConnectAPI.post_profiles(
           bundle_id_id: bundle_id_id,
           certificates: certificate_ids,
           devices: device_ids,
           attributes: {
             name: name,
-            profileType: profile_type
+            profileType: profile_type,
+            templateName: template_name
           }
         )
         return resp.to_models.first


### PR DESCRIPTION
### Motivation and Context
Fixes #17017

### Description
- Send `templateName` to API 🤷‍♂️ 

### Testing Steps

#### Use this branch

Update `Gemfile` and run `bundle update fastlane` or `bundle udpdate`

```rb
gem “fastlane”, :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-sigh-template_name"
```

#### Sigh

##### CLI

```sh
$ fastlane sigh development --username "your@email.com" --team_id "TEAM_ID" --platform ios --app_identifier "com.your.bundle" --template_name "Exposure Notification with Logging Support for TEAM_ID (Dev) iOS Dev"
```

##### Fastfile

```rb
lane :your_lane do
  sigh(
    username: "your@email.com",
    app_identifier: "com.your.bundle",
    team_id: "TEAM_ID",
    template_name: "Exposure Notification with Logging Support for TEAM_ID (Dev) iOS Dev"
  )
end
```

#### Match

After your match storage is initialized...

##### CLI

```sh
$ fastlane match development --username "your@email.com" --team_id "TEAM_ID" --platform ios --app_identifier "com.your.bundle" --template_name "Exposure Notification with Logging Support for TEAM_ID (Dev) iOS Dev"
```

##### Fastfile

```rb
lane :your_lane do
  match(
    username: "your@email.com",
    app_identifier: "com.your.bundle",
    team_id: "TEAM_ID",
    template_name: "Exposure Notification with Logging Support for TEAM_ID (Dev) iOS Dev"
  )
end
```