### PR TITLE
Version bump to 2.156.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,29 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/endocrimes'>
 <img src='https://github.com/endocrimes.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
@@ -66,49 +66,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-</tr>
-<tr>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
@@ -116,25 +78,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-</tr>
-<tr>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
@@ -142,37 +96,83 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
+</tr>
+<tr>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+</tr>
+<tr>
 <td id='jimmy-dee'>
 <a href='https://github.com/jdee'>
 <img src='https://github.com/jdee.png?size=140'>
 </a>
 <h4 align='center'>Jimmy Dee</h4>
 </td>
-</tr>
-<tr>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
 <td id='maksym-grebenets'>
 <a href='https://github.com/mgrebenets'>
 <img src='https://github.com/mgrebenets.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
+</tr>
+<tr>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Jimmy Dee",
-                        "Helmut Januschka",
-                        "Felix Krause",
-                        "Stefan Natchev",
-                        "Daniel Jankowski",
-                        "Fumiya Nakamura",
-                        "Kohki Miki",
-                        "Josh Holtz",
-                        "Jorge Revuelta H",
-                        "Matthew Ellis",
+  spec.authors       = ["Luka Mirosevic",
                         "Max Ott",
-                        "Maksym Grebenets",
-                        "Luka Mirosevic",
-                        "Manu Wallner",
-                        "Aaron Brager",
-                        "Andrew McBurney",
+                        "Fumiya Nakamura",
                         "Danielle Tomlinson",
-                        "Jan Piotrowski",
+                        "Jimmy Dee",
                         "Iulian Onofrei",
+                        "Matthew Ellis",
+                        "Stefan Natchev",
+                        "Andrew McBurney",
+                        "Manu Wallner",
+                        "Jorge Revuelta H",
+                        "Olivier Halligon",
+                        "Felix Krause",
+                        "Jan Piotrowski",
+                        "Helmut Januschka",
                         "Joshua Liebowitz",
-                        "Jérôme Lacoste",
-                        "Olivier Halligon"]
+                        "Aaron Brager",
+                        "Kohki Miki",
+                        "Maksym Grebenets",
+                        "Daniel Jankowski",
+                        "Josh Holtz",
+                        "Jérôme Lacoste"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.155.3'.freeze
+  VERSION = '2.156.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -14,4 +14,4 @@ class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.155.3
+// Generated with fastlane 2.156.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -245,4 +245,4 @@ extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.32]
+// FastlaneRunnerAPIVersion [0.9.33]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -9204,4 +9204,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.85]
+// FastlaneRunnerAPIVersion [0.9.86]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -14,4 +14,4 @@ class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.155.3
+// Generated with fastlane 2.156.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -181,4 +181,4 @@ extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.35]
+// FastlaneRunnerAPIVersion [0.9.36]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -14,4 +14,4 @@ class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.155.3
+// Generated with fastlane 2.156.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -165,4 +165,4 @@ extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.29]
+// FastlaneRunnerAPIVersion [0.9.30]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -14,4 +14,4 @@ class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.155.3
+// Generated with fastlane 2.156.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -33,4 +33,4 @@ extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.28]
+// FastlaneRunnerAPIVersion [0.9.29]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -14,4 +14,4 @@ class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.155.3
+// Generated with fastlane 2.156.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -257,4 +257,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.40]
+// FastlaneRunnerAPIVersion [0.9.41]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -14,4 +14,4 @@ class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.155.3
+// Generated with fastlane 2.156.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -93,4 +93,4 @@ extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.30]
+// FastlaneRunnerAPIVersion [0.9.31]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -14,4 +14,4 @@ class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.155.3
+// Generated with fastlane 2.156.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -181,4 +181,4 @@ extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.24]
+// FastlaneRunnerAPIVersion [0.9.25]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.155.3':**

* [deliver] make uploading and deleting screenshots more efficient (#16972) via Satoshi Namai
* [gym][scan] xcodebuild -resolvePackageDependencies missing -derivedDataPath (#16986) via Adriaan Duz
* [screengrab] changed adb commands that were having permission errors to use run-as syntax (#17006) via Greg Billetdeaux
