### PR TITLE
[action] Add support to exclude files from sonar qube analysis

### DIFF
--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -16,6 +16,7 @@ module Fastlane
         sonar_scanner_args << "-Dsonar.projectName=\"#{params[:project_name]}\"" if params[:project_name]
         sonar_scanner_args << "-Dsonar.projectVersion=\"#{params[:project_version]}\"" if params[:project_version]
         sonar_scanner_args << "-Dsonar.sources=\"#{params[:sources_path]}\"" if params[:sources_path]
+        sonar_scanner_args << "-Dsonar.exclusions=\"#{params[:exclusions]}\"" if params[:exclusions]
         sonar_scanner_args << "-Dsonar.language=\"#{params[:project_language]}\"" if params[:project_language]
         sonar_scanner_args << "-Dsonar.sourceEncoding=\"#{params[:source_encoding]}\"" if params[:source_encoding]
         sonar_scanner_args << "-Dsonar.login=\"#{params[:sonar_login]}\"" if params[:sonar_login]
@@ -80,6 +81,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :sources_path,
                                        env_name: "FL_SONAR_RUNNER_SOURCES_PATH",
                                        description: "Comma-separated paths to directories containing source files. Must either be specified here or inside the sonar project configuration file",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :exclusions,
+                                       env_name: "FL_SONAR_RUNNER_EXCLUSIONS",
+                                       description: "Comma-separated paths to directories to be excluded from the analysis",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :project_language,
                                        env_name: "FL_SONAR_RUNNER_PROJECT_LANGUAGE",

--- a/fastlane/spec/actions_specs/sonar_spec.rb
+++ b/fastlane/spec/actions_specs/sonar_spec.rb
@@ -35,6 +35,7 @@ describe Fastlane do
             project_name: 'project-name',
             project_version: '1.0.0',
             sources_path: '/Sources',
+            exclusions: '/Sources/Excluded',
             project_language: 'ruby',
             source_encoding: 'utf-8',
             sonar_login: 'sonar-login',
@@ -53,6 +54,7 @@ describe Fastlane do
                     -Dsonar.projectName=\"project-name\"
                     -Dsonar.projectVersion=\"1.0.0\"
                     -Dsonar.sources=\"/Sources\"
+                    -Dsonar.exclusions=\"/Sources/Excluded\"
                     -Dsonar.language=\"ruby\"
                     -Dsonar.sourceEncoding=\"utf-8\"
                     -Dsonar.login=\"sonar-login\"

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -7157,6 +7157,7 @@ func snapshot(workspace: Any? = snapshotfile.workspace,
    - projectName: The name of the project that gets displayed on the sonar report page. Must either be specified here or inside the sonar project configuration file
    - projectVersion: The project's version that gets displayed on the sonar report page. Must either be specified here or inside the sonar project configuration file
    - sourcesPath: Comma-separated paths to directories containing source files. Must either be specified here or inside the sonar project configuration file
+   - exclusions: Comma-separated paths to directories to be excluded from the analysis
    - projectLanguage: Language key, e.g. objc
    - sourceEncoding: Used encoding of source files, e.g., UTF-8
    - sonarRunnerArgs: Pass additional arguments to sonar-scanner. Be sure to provide the arguments with a leading `-D` e.g. FL_SONAR_RUNNER_ARGS="-Dsonar.verbose=true"
@@ -7178,6 +7179,7 @@ func sonar(projectConfigurationPath: String? = nil,
            projectName: String? = nil,
            projectVersion: String? = nil,
            sourcesPath: String? = nil,
+           exclusions: String? = nil,
            projectLanguage: String? = nil,
            sourceEncoding: String? = nil,
            sonarRunnerArgs: String? = nil,
@@ -7194,6 +7196,7 @@ func sonar(projectConfigurationPath: String? = nil,
                                                                                          RubyCommand.Argument(name: "project_name", value: projectName),
                                                                                          RubyCommand.Argument(name: "project_version", value: projectVersion),
                                                                                          RubyCommand.Argument(name: "sources_path", value: sourcesPath),
+                                                                                         RubyCommand.Argument(name: "exclusions", value: exclusions),
                                                                                          RubyCommand.Argument(name: "project_language", value: projectLanguage),
                                                                                          RubyCommand.Argument(name: "source_encoding", value: sourceEncoding),
                                                                                          RubyCommand.Argument(name: "sonar_runner_args", value: sonarRunnerArgs),


### PR DESCRIPTION
Sonar scanner supports excluding paths from being processed to narrow down the scope of the analysis.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When running the sonar scanner it is common to provide path to the sources directories and then narrow down the scope of the analysis by passing a list of directories to be excluded. This is explained in the official documentation https://docs.sonarqube.org/latest/project-administration/narrowing-the-focus/

Currently this is not supported by the sonar action, so if you want to exclude files from the sonar analysis you are forced to use the sonar.properties file.

This pull request adds the possibility of specify the directories or files to be ignored directly from fastlane rather than having to work with the properties file. This way a developer can have the sonar scanning functionality in one single file rather than split in different files.

### Description
I have added a new parameter called exclusions to the sonar action. I chose this name since the name of the sonar configuration parameter is sonar.exclusions.
I updated the tests for the action to take the new parameter into account.

I also updated Fastlane.swift to include this new parameter.

I have a repository that is using sonar scanner. I updated my Gemfile to use my local updated version of fastlane, and run the lane passing the exclusions parameter. Then I checked in the terminal output and in sonar qube interface that the files had been excluded correctly.