### PR TITLE
[deliver] fix upload_screenshots when not using upload_to_app_store for screenshots

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -179,7 +179,8 @@ module Deliver
     # Verify all screenshots states on App Store Connect are okay
     def retry_upload_screenshots_if_needed(iterator, states, number_of_screenshots, tries, localizations, screenshots_per_language)
       is_failure = states.fetch("FAILED", 0) > 0
-      is_missing_screenshot = states.reduce(0) { |sum, (k, v)| sum + v } != number_of_screenshots
+      is_missing_screenshot = states.reduce(0) { |sum, (k, v)| sum + v } != number_of_screenshots && !screenshots_per_language.empty?
+
       if is_failure || is_missing_screenshot
         if tries.zero?
           incomplete_screenshot_count = states.reject { |k, v| k == 'COMPLETE' }.reduce(0) { |sum, (k, v)| sum + v }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Since this PR #16972, `deliver` has updated its logic to handle screenshot uploading and deleting. Some users reported a regression that it fails in case they don't use `deliver` for screenshot uploading but don't set `skip_screenshots: false`.  

https://github.com/fastlane/fastlane/issues/17047

I actually didn't take account of this case while working on #16927.

### Description

The error happens because of the logic to verify the completion of uploading by checking whether the number of screenshots to be uploaded matches the number of screenshots correctly uploaded on App Store Connect. 

In the reported case, the number of screenshots to be uploaded is always **0** but the number of screenshots correctly uploaded on App Store Connect can be as many as they have on it. So that comparison will never succeed.

Fortunately, we've got a given parameter `screenshots_per_language` to check screenshots to be uploaded. I could simply add `!screenshots_per_language.empty?`  to check if it's missing screenshot to upload.

https://github.com/fastlane/fastlane/blob/6413734cbbde7ba2d0d1961ed11fb27475b7bf6a/deliver/lib/deliver/upload_screenshots.rb#L179-L183

### Testing Steps

Added a unit test case. 

To reproduce the problem quickly, at first you need to set up a project that has no screenshots directory to be uploaded. (You can just delete the existing directory.) And then call `upload_to_app_store` with following options.

```ruby
upload_to_app_store(
  overwrite_screenshots: false,
  skip_binary_upload: true,
  skip_metadata: true,
  run_precheck_before_submit: false,
)
``` 
