### PR TITLE
[docs] supply/upload_to_play_store - update the quick-start requirement to setup supply correctly

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -49,7 +49,7 @@ The previous p12 configuration is still currently supported.
 
 ## Quick Start
 
-> Before use `supply` correctly to connect with PlayStore, you'll need setup your app manually first, uploading an only build to PlayStore, at least. Take a look into [fastane/fastlane#14686](https://github.com/fastlane/fastlane/issues/14686) to have a better understanding
+> Before use supply correctly to connect with PlayStore, you'll need setup your app manually first, uploading an only build to PlayStore, at least. Take a look into [fastane/fastlane#14686](https://github.com/fastlane/fastlane/issues/14686) to have a better understanding
 
 - `cd [your_project_folder]`
 - `fastlane supply init`

--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -49,7 +49,7 @@ The previous p12 configuration is still currently supported.
 
 ## Quick Start
 
-> Before use _supply_ correctly to connect with PlayStore, you'll need setup your app manually first, uploading an only build to PlayStore, at least. Take a look into [fastane/fastlane#14686](https://github.com/fastlane/fastlane/issues/14686) to have a better understanding
+> Before using _supply_ to connect to Google Play Store, you'll need to set up your app manually first by uploading at least one build to Google Play Store. See [fastane/fastlane#14686](https://github.com/fastlane/fastlane/issues/14686) for more info.
 
 - `cd [your_project_folder]`
 - `fastlane supply init`

--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -49,6 +49,8 @@ The previous p12 configuration is still currently supported.
 
 ## Quick Start
 
+> Before use `supply` correctly to connect with PlayStore, you'll need setup your app manually first, uploading an only build to PlayStore, at least. Take a look into [fastane/fastlane#14686](https://github.com/fastlane/fastlane/issues/14686) to have a better understanding
+
 - `cd [your_project_folder]`
 - `fastlane supply init`
 - Make changes to the downloaded metadata, add images, screenshots and/or an APK

--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -49,7 +49,7 @@ The previous p12 configuration is still currently supported.
 
 ## Quick Start
 
-> Before use supply correctly to connect with PlayStore, you'll need setup your app manually first, uploading an only build to PlayStore, at least. Take a look into [fastane/fastlane#14686](https://github.com/fastlane/fastlane/issues/14686) to have a better understanding
+> Before use _supply_ correctly to connect with PlayStore, you'll need setup your app manually first, uploading an only build to PlayStore, at least. Take a look into [fastane/fastlane#14686](https://github.com/fastlane/fastlane/issues/14686) to have a better understanding
 
 - `cd [your_project_folder]`
 - `fastlane supply init`


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

According to https://github.com/fastlane/fastlane/issues/14686 which was closed by inactivity, we should update the supply documentation to have the missing step to setup supply correctly and connect it with PlayStore without having errors.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Added to the quick-start section on upload to PlayStore documentation what is needed to do before trying to use supply.

**There are other places still missing this described step?**

By the way, there's not another way to upload a build to PlayStore on `supply init`? it wouldn't be possible at all?

### ~~Testing Steps~~
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
