### PR TITLE
[deliver] improve screenshot uploading verification

### DIFF
--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -13,14 +13,14 @@ module Deliver
     # @yield [localization, app_screenshot_set]
     # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreVersionLocalization] localization
     # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreScreenshotSet] app_screenshot_set
-    def each_app_screenshot_set(&block)
-      return enum_for(__method__) unless block_given?
+    def each_app_screenshot_set(localizations = @localizations, &block)
+      return enum_for(__method__, localizations) unless block_given?
 
       # Collect app_screenshot_sets from localizations in parallel but
       # limit the number of threads working at a time with using `lazy` and `force` controls
       # to not attack App Store Connect
-      results = @localizations.each_slice(NUMBER_OF_THREADS).lazy.map do |localizations|
-        localizations.map do |localization|
+      results = localizations.each_slice(NUMBER_OF_THREADS).lazy.map do |localizations_grouped|
+        localizations_grouped.map do |localization|
           Thread.new do
             [localization, localization.get_app_screenshot_sets]
           end
@@ -63,35 +63,32 @@ module Deliver
     def each_local_screenshot(screenshots_per_language, &block)
       return enum_for(__method__, screenshots_per_language) unless block_given?
 
-      # Iterate over all the screenshots per language and display_type
-      # and then enqueue them to worker one by one if it's not duplciated on App Store Connect
-      screenshots_per_language.map do |language, screenshots_for_language|
-        localization = @localizations.find { |l| l.locale == language }
-        [localization, screenshots_for_language]
-      end.reject do |localization, _|
-        localization.nil?
-      end.each do |localization, screenshots_for_language|
-        iterate_over_screenshots_per_language(localization, screenshots_for_language, &block)
+      # filter unnecessary localizations
+      supported_localizations = @localizations.reject { |l| screenshots_per_language[l.locale].nil? }
+
+      # build a hash that can access app_screenshot_set corresponding to given locale and display_type
+      # via parallelized each_app_screenshot_set to gain performance
+      app_screenshot_set_per_locale_and_display_type = each_app_screenshot_set(supported_localizations)
+                                                       .each_with_object({}) do |(localization, app_screenshot_set), hash|
+        hash[localization.locale] ||= {}
+        hash[localization.locale][app_screenshot_set.screenshot_display_type] = app_screenshot_set
       end
-    end
 
-    private
+      # iterate over screenshots per localization
+      screenshots_per_language.each do |language, screenshots_for_language|
+        localization = supported_localizations.find { |l| l.locale == language }
+        screenshots_per_display_type = screenshots_for_language.reject { |screenshot| screenshot.device_type.nil? }.group_by(&:device_type)
 
-    def iterate_over_screenshots_per_language(localization, screenshots_for_language, &block)
-      app_screenshot_sets_per_display_type = localization.get_app_screenshot_sets.map { |set| [set.screenshot_display_type, set] }.to_h
-      screenshots_per_display_type = screenshots_for_language.reject { |screenshot| screenshot.device_type.nil? }.group_by(&:device_type)
+        screenshots_per_display_type.each do |display_type, screenshots|
+          # create AppScreenshotSet for given display_type if it doesn't exsit
+          app_screenshot_set = app_screenshot_set_per_locale_and_display_type[language][display_type]
+          app_screenshot_set ||= localization.create_app_screenshot_set(attributes: { screenshotDisplayType: display_type })
 
-      screenshots_per_display_type.each do |display_type, screenshots|
-        # Create AppScreenshotSet for given display_type if it doesn't exsit
-        app_screenshot_set = app_screenshot_sets_per_display_type[display_type]
-        app_screenshot_set ||= localization.create_app_screenshot_set(attributes: { screenshotDisplayType: display_type })
-        iterate_over_screenshots_per_display_type(localization, app_screenshot_set, screenshots, &block)
-      end
-    end
-
-    def iterate_over_screenshots_per_display_type(localization, app_screenshot_set, screenshots, &block)
-      screenshots.each.with_index do |screenshot, index|
-        yield(localization, app_screenshot_set, screenshot, index)
+          # iterate over screenshots per display size with index
+          screenshots.each.with_index do |screenshot, index|
+            yield(localization, app_screenshot_set, screenshot, index)
+          end
+        end
       end
     end
   end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -180,19 +180,18 @@ module Deliver
     def retry_upload_screenshots_if_needed(iterator, states, number_of_screenshots, tries, localizations, screenshots_per_language)
       is_failure = states.fetch("FAILED", 0) > 0
       is_missing_screenshot = !screenshots_per_language.empty? && !verify_local_screenshots_are_uploaded(iterator, screenshots_per_language)
+      return unless is_failure || is_missing_screenshot
 
-      if is_failure || is_missing_screenshot
-        if tries.zero?
-          incomplete_screenshot_count = states.reject { |k, v| k == 'COMPLETE' }.reduce(0) { |sum, (k, v)| sum + v }
-          UI.user_error!("Failed verification of all screenshots uploaded... #{incomplete_screenshot_count} incomplete screenshot(s) still exist")
-        else
-          UI.error("Failed to upload all screenshots... Tries remaining: #{tries}")
-          # Delete bad entries before retry
-          iterator.each_app_screenshot do |_, _, app_screenshot|
-            app_screenshot.delete! unless app_screenshot.complete?
-          end
-          upload_screenshots(localizations, screenshots_per_language, tries: tries)
+      if tries.zero?
+        incomplete_screenshot_count = states.reject { |k, v| k == 'COMPLETE' }.reduce(0) { |sum, (k, v)| sum + v }
+        UI.user_error!("Failed verification of all screenshots uploaded... #{incomplete_screenshot_count} incomplete screenshot(s) still exist")
+      else
+        UI.error("Failed to upload all screenshots... Tries remaining: #{tries}")
+        # Delete bad entries before retry
+        iterator.each_app_screenshot do |_, _, app_screenshot|
+          app_screenshot.delete! unless app_screenshot.complete?
         end
+        upload_screenshots(localizations, screenshots_per_language, tries: tries)
       end
     end
 

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -202,12 +202,13 @@ module Deliver
     def verify_local_screenshots_are_uploaded(iterator, screenshots_per_language)
       # Check if local screenshots' checksum exist on App Store Connect
       checksum_to_app_screenshot = iterator.each_app_screenshot.map { |_, _, app_screenshot| [app_screenshot.source_file_checksum, app_screenshot] }.to_h
-      missing_local_screenshots = iterator.each_local_screenshot(screenshots_per_language).select do |_, _, local_screenshot|
+
+      missing_local_screenshots = iterator.each_local_screenshot(screenshots_per_language).select do |_, _, local_screenshot, index|
         checksum = UploadScreenshots.calculate_checksum(local_screenshot.path)
-        checksum_to_app_screenshot[checksum].nil?
+        checksum_to_app_screenshot[checksum].nil? && index < 10 # if index is more than 10, it's skipped
       end
 
-      missing_local_screenshots.each do |_, _, screenshot|
+      missing_local_screenshots.each do |_, _, screenshot, _|
         UI.error("#{screenshot.path} is missing on App Store Connect.")
       end
 

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -183,6 +183,9 @@ module Deliver
       return unless is_failure || is_missing_screenshot
 
       if tries.zero?
+        iterator.each_app_screenshot.select { |_, _, app_screenshot| app_screenshot.error? }.each do |localization, _, app_screenshot|
+          UI.error("#{app_screenshot.file_name} for #{localization.locale} has error(s) - #{app_screenshot.error_messages.join(', ')}")
+        end
         incomplete_screenshot_count = states.reject { |k, v| k == 'COMPLETE' }.reduce(0) { |sum, (k, v)| sum + v }
         UI.user_error!("Failed verification of all screenshots uploaded... #{incomplete_screenshot_count} incomplete screenshot(s) still exist")
       else

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -332,7 +332,7 @@ describe Deliver::UploadScreenshots do
 
     context 'when one of the screenshots is FAILD state and tries reamins non zero' do
       it 'should retry upload_screenshots' do
-        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot', 'complete?' => false)
+        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot', 'complete?' => false, 'error?' => true)
         app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
                                     screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55,
                                     app_screenshots: [app_screenshot])
@@ -350,7 +350,7 @@ describe Deliver::UploadScreenshots do
 
     context 'when given number_of_screenshots doesn\'t match numbers in states in total' do
       it 'should retry upload_screenshots' do
-        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot', 'complete?' => true)
+        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot', 'complete?' => true, 'error?' => false)
         app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
                                     screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55,
                                     app_screenshots: [app_screenshot])
@@ -367,7 +367,11 @@ describe Deliver::UploadScreenshots do
 
     context 'when retry count left is 0' do
       it 'should raise error' do
-        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot', 'complete?' => true)
+        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot',
+                                'complete?' => false,
+                                'error?' => true,
+                                file_name: '5.5_1.jpg',
+                                error_messages: ['error_message'])
         app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
                                     screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55,
                                     app_screenshots: [app_screenshot])


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Since #16972, there is a bug report that its bug was caused by that change #17047. I think the original issue reported on #17047 was resolved by #17051 but I found another issue reported within #17047 where you can't pass the verification when your local screenshots are out of sync with ones on App Store Connect. 

To reproduce the issue you can start with an app that has no screenshots on App Store Connect and follow these steps.

1. Upload a screenshot manually, which doesn't exist on your local to be uploaded, to any localization and display type on App Store Connect
2. Run `deliver` with below options

```ruby
upload_to_app_store(
  overwrite_screenshots: false, # default value but just to be explicit
  skip_metadata: true,
  skip_binary_upload: true,
  run_precheck_before_submit: false,
)
```

You'll get errors like this and end up with seeing ` Failed verification of all screenshots uploaded... 0 incomplete screenshot(s) still exist` message.

<details>

```
INFO [2020-08-17 11:10:01.48]: Making sure the latest version on App Store Connect matches '10.3.0'...
INFO [2020-08-17 11:10:01.85]: '10.3.0' is the latest version on App Store Connect
WARN [2020-08-17 11:10:06.10]: Will begin uploading snapshots for '10.3.0' on App Store Connect
INFO [2020-08-17 11:10:06.10]: Starting with the upload of screenshots...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_1.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_2.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_3.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_4.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_5.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_6.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_1.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_2.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_3.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_4.jpg'...
INFO [2020-08-17 11:10:07.79]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_5.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_6.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_1.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_2.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_3.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_4.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_5.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_6.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_1.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_2.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_3.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_4.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_5.jpg'...
INFO [2020-08-17 11:10:07.80]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_6.jpg'...
DEBUG [2020-08-17 11:10:07.83]: Uploading jobs are completed
[✔] Waiting for all the screenshots processed...
ERROR [2020-08-17 11:10:09.03]: Failed to upload all screenshots... Tries remaining: 4
///
// omit................
//
ERROR [2020-08-17 11:10:18.94]: Failed to upload all screenshots... Tries remaining: 1
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_1.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_2.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_3.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_4.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_5.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/12.9-2_6.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_1.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_2.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_3.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_4.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_5.jpg'...
INFO [2020-08-17 11:10:20.83]: Previous uploaded. Skipping './fastlane/screenshots/en-US/5.5_6.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_1.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_2.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_3.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_4.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_5.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/6.5_6.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_1.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_2.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_3.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_4.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_5.jpg'...
INFO [2020-08-17 11:10:20.84]: Previous uploaded. Skipping './fastlane/screenshots/en-US/iPad Pro (12.9-inch) (3rd generation)_6.jpg'...
DEBUG [2020-08-17 11:10:20.84]: Uploading jobs are completed
[✔] Waiting for all the screenshots processed...
ERROR [2020-08-17 11:10:22.65]: Failed verification of all screenshots uploaded... 0 incomplete screenshot(s) still exist
```

</details>

This fails 😞 because [the verification logic](https://github.com/fastlane/fastlane/blob/master/deliver/lib/deliver/upload_screenshots.rb#L182) uses number comparison to determine whether all the local screenshots are uploaded. If a screenshot lives on App Store Connect, which doesn't exist locally to be uploaded, it's going to create the discrepancy between App Store Connect and local. 

### Description

Due to the issue that I described above, I decided to rewrite the verification not to rely on numbers and instead rely on exactly checking all checksums of local screenshots. It takes more code but it's going to be 100% accurate. https://github.com/fastlane/fastlane/commit/f9375558f120c38e3ca4d764ab6179f1032c632e

There is also a user-friendly improvement that shows error details when `deliver` fails due to screenshot uploading.  https://github.com/fastlane/fastlane/commit/e884d1c1755c30f323da3e04551ab4fd03489d9d
With this error handling, fastlane users will understand if it's their problem or fastlane's problem.

They'll see error messages like below. (I wonder if  Apple could have given us more human-readable message like shown on App Store Connect through `Spaceship::ConnectAPI::AppScreenshot#asset_delivery_state` 🤔 as it currently gives exactly the same string on both `code` and `description` 😅  )

```
[✔] Waiting for all the screenshots processed...
ERROR [2020-08-17 11:40:18.90]: ./fastlane/screenshots/en-US/5.5_1.png is missing on App Store Connect.
ERROR [2020-08-17 11:40:20.64]: 5.5_1.png for en-US has error(s) - IMAGE_BAD_FILE_EXTENSION - IMAGE_BAD_FILE_EXTENSION
```

Finally, I made a tweak https://github.com/fastlane/fastlane/pull/17060/commits/674b498ee60c2fe6d5019548fac4bedf6691baaa to gain more performance on `Deliver::AppScreenshotIterator#each_local_screenshot` by leveraging existing `each_app_screenshot_set` using multi threads. This mitigates the slowness within `verify_local_screenshots_are_uploaded` newly added. (In my project, this improved `each_local_screenshot` taking from 9-11 secs to 1-2 secs)

### Testing Steps

This is already mentioned on "Motivation and Context" section. You can confirm the issue with v2.156.1 first and then can confirm it's resolved by this PR with the same env.