### PR TITLE
[screengrab] Wait for device to reconnect after adb root

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -64,6 +64,7 @@ module Screengrab
       # Root is needed to access device paths at /data
       if @config[:use_adb_root]
         run_adb_command("-s #{device_serial} root", print_all: false, print_command: true)
+        run_adb_command("-s #{device_serial} wait-for-device", print_all: false, print_command: true)
       end
 
       clear_device_previous_screenshots(@config[:app_package_name], device_serial, device_screenshots_paths)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] ~I've updated the documentation if necessary.~

### Motivation and Context

Every time I tried to run `screengrab` with the `use_adb_root: true`, it ends up failing and exiting with exit code 255, not being able to install the APK onto the emulator.

In practice, it starts by booting the emulator, then switches the emulator to root mode, then the rest of the workflow errors saying the device/emulator is not connected anymore.

The error especially happens at the step when screengrab is trying to install the APK, with a `failed to get feature set` error:

```
[20:49:45]: Installing app APK
[20:49:45]: $ /Users/olivier/Library/Android/sdk/platform-tools/adb -s emulator-5554 install -t -r /Users/olivier/Documents/Dev/a8c/WordPress-Android/WordPress/build/outputs/apk/vanilla/debug/org.wordpress.android-vanilla-debug.apk
[20:49:45]: ▸ Performing Push Install
[20:49:45]: ▸ adb: error: failed to get feature set: device offline
Performing Push Install
adb: error: failed to get feature set: device offline
[20:49:45]: Exit status: 255
```

Sometimes the clue about the fact that the device went offline is visible a couple of lines before the installation step even:
```
[20:23:03]: $ /Users/olivier/Library/Android/sdk/platform-tools/adb -s emulator-5554 shell echo \$EXTERNAL_STORAGE
[20:23:03]: ▸ /sdcard
[20:23:03]: $ /Users/olivier/Library/Android/sdk/platform-tools/adb -s emulator-5554 root
[20:23:03]: Cleaning screenshots on device
adb: device offline
[20:23:03]: Exit status: 1
adb: device offline
[20:23:03]: Exit status: 1
adb: device offline
[20:23:03]: Exit status: 1
adb: device offline
[20:23:03]: Exit status: 1
adb: device offline
[20:23:03]: Exit status: 1
adb: device offline
[20:23:03]: Exit status: 1
adb: device offline
[20:23:03]: Exit status: 1
adb: device offline
[20:23:03]: Exit status: 1
adb: device offline
[20:23:03]: Exit status: 1
```

This happens while I see the emulator being launched properly on my Mac; so it's not a matter of the device/emulator not actually existing. In fact:

* If I try to manually run the `adb -s emulator-5554 install …` command myself immediately after screengrab tried and failed with code 255, the install succeeds. This led me to conclude that the emulator only goes into a disconnected state for just a couple of seconds, before connecting back to the adb server, and this short disconnection window is very likely caused by the transition of the device into root.
* If I set `use_adb_root: false`, the installation of the APK on the emulator doesn't fail anymore (but then I have permission issues to get the screenshots from `/data/…` later, of course)

\cc @loremattei @oguzkocer

### Description

I've added a call to `adb wait-for-device` right after the `adb root` command is executed by the runner to ensure we wait for the device to reconnect after having switched to root.

This single line finally eliminated the constant `exit with code 255` error I got over and over while trying to run screengrab on my machine and project (I've lost countless hours to that one trying to figure out what I was doing wrong on my config 😓 and of course as always, bugs with most time lost ends up being solved by the simplest fixes…)

### Testing Steps

* You can try running any lane invoking `screengrab(use_adb_root: true)` on an Android project
* If you want a specific project to test it on, you can try cloning [this one](https://github.com/wordpress-mobile/WordPress-Android) then run the `bundle exec fastlane android screenshots` lane in it.