### PR TITLE
[action] fix formatting syntax error on commit_version_bump

### DIFF
--- a/fastlane/lib/fastlane/actions/commit_version_bump.rb
+++ b/fastlane/lib/fastlane/actions/commit_version_bump.rb
@@ -220,7 +220,7 @@ module Fastlane
           'commit_version_bump',
           'commit_version_bump(
             message: "Version Bump",                    # create a commit with a custom message
-            xcodeproj: "./path/to/MyProject.xcodeproj", # optional, if you have multiple Xcode project files, you must specify your main project here
+            xcodeproj: "./path/to/MyProject.xcodeproj"  # optional, if you have multiple Xcode project files, you must specify your main project here
           )',
           'commit_version_bump(
             settings: true # Include Settings.bundle/Root.plist


### PR DESCRIPTION
The extra comma will throw a syntax error, the user will receive the following error:-

i/interface.rb:141:in `user_error!': [!] Syntax error in your Fastfile on line: Fastfile:: syntax error, unexpected ',', expecting => (FastlaneCore::Interface::FastlaneError)
...codeproj= "./MyProject.xcodeproj",

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
