### PR TITLE
[gym] safer logic getting last 5 lines of logs

### DIFF
--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -143,7 +143,7 @@ module Gym
         # `xcodebuild` doesn't properly mark lines as failure reason or important information
         # so we assume that the last few lines show the error message that's relevant
         # (at least that's what was correct during testing)
-        log_content = File.read(log_path).split("\n")[-5..-1]
+        log_content = File.read(log_path).split("\n").last(5)
         log_content.each do |row|
           UI.command_output(row)
         end


### PR DESCRIPTION
If the log file contains less than 5 lines, `log_content` is nil, and the following `each` fails.

I just had a case where the log file only contained one line, `Command line invocation:` (probably due to some other error, but fixing this issue will make it easier to identify the root cause).

Fixes #13959.