### PR TITLE
Version bump to 2.157.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,81 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
 <img src='https://github.com/minuscorp.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+</tr>
+<tr>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+</tr>
+<tr>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
@@ -52,12 +122,6 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
 <td id='fumiya-nakamura'>
 <a href='https://github.com/nafu'>
 <img src='https://github.com/nafu.png?size=140'>
@@ -66,93 +130,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-</tr>
-<tr>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
 <td id='matthew-ellis'>
 <a href='https://github.com/matthewellis'>
@@ -160,19 +142,37 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
 </tr>
 <tr>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Aaron Brager",
+  spec.authors       = ["Josh Holtz",
+                        "Daniel Jankowski",
+                        "Jimmy Dee",
+                        "Olivier Halligon",
+                        "Jorge Revuelta H",
+                        "Helmut Januschka",
+                        "Jérôme Lacoste",
+                        "Felix Krause",
+                        "Iulian Onofrei",
+                        "Matthew Ellis",
+                        "Aaron Brager",
+                        "Danielle Tomlinson",
+                        "Manu Wallner",
+                        "Andrew McBurney",
+                        "Max Ott",
                         "Luka Mirosevic",
                         "Maksym Grebenets",
-                        "Jorge Revuelta H",
-                        "Manu Wallner",
-                        "Stefan Natchev",
-                        "Andrew McBurney",
-                        "Matthew Ellis",
-                        "Josh Holtz",
-                        "Max Ott",
-                        "Iulian Onofrei",
-                        "Joshua Liebowitz",
-                        "Jimmy Dee",
-                        "Daniel Jankowski",
-                        "Jan Piotrowski",
                         "Kohki Miki",
-                        "Jérôme Lacoste",
-                        "Fumiya Nakamura",
-                        "Olivier Halligon",
-                        "Felix Krause",
-                        "Danielle Tomlinson",
-                        "Helmut Januschka"]
+                        "Jan Piotrowski",
+                        "Stefan Natchev",
+                        "Joshua Liebowitz",
+                        "Fumiya Nakamura"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.156.1'.freeze
+  VERSION = '2.157.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -14,4 +14,4 @@ class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.156.1
+// Generated with fastlane 2.157.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -245,4 +245,4 @@ extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.34]
+// FastlaneRunnerAPIVersion [0.9.35]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -128,6 +128,35 @@ func appStoreBuildNumber(initialBuildNumber: Any,
 }
 
 /**
+ Load the App Store Connect API token to use in other fastlane tools and actions
+
+ - parameters:
+   - keyId: The key ID
+   - issuerId: The issuer ID
+   - keyFilepath: The path to the key p8 file
+   - keyContent: The content of the key p8 file
+   - duration: The token session duration
+   - inHouse: Is App Store or Enterprise (in house) team? App Store Connect API cannot not determine this on its own (yet)
+
+ Load the App Store Connect API token to use in other fastlane tools and actions
+ */
+func appStoreConnectApiKey(keyId: String,
+                           issuerId: String,
+                           keyFilepath: String? = nil,
+                           keyContent: String? = nil,
+                           duration: Int? = nil,
+                           inHouse: Bool? = nil)
+{
+    let command = RubyCommand(commandID: "", methodName: "app_store_connect_api_key", className: nil, args: [RubyCommand.Argument(name: "key_id", value: keyId),
+                                                                                                             RubyCommand.Argument(name: "issuer_id", value: issuerId),
+                                                                                                             RubyCommand.Argument(name: "key_filepath", value: keyFilepath),
+                                                                                                             RubyCommand.Argument(name: "key_content", value: keyContent),
+                                                                                                             RubyCommand.Argument(name: "duration", value: duration),
+                                                                                                             RubyCommand.Argument(name: "in_house", value: inHouse)])
+    _ = runner.executeCommand(command)
+}
+
+/**
  Upload your app to [Appaloosa Store](https://www.appaloosa-store.com/)
 
  - parameters:
@@ -5149,6 +5178,8 @@ func pem(development: Bool = false,
  Alias for the `upload_to_testflight` action
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API key JSON file
+   - apiKey: Path to your App Store Connect API key JSON file
    - username: Your Apple ID Username
    - appIdentifier: The bundle identifier of the app to upload or manage testers (optional)
    - appPlatform: The platform to use (optional)
@@ -5187,7 +5218,9 @@ func pem(development: Bool = false,
  More details can be found on https://docs.fastlane.tools/actions/pilot/.
  This integration will only do the TestFlight upload.
  */
-func pilot(username: String,
+func pilot(apiKeyPath: String? = nil,
+           apiKey: [String: Any]? = nil,
+           username: String,
            appIdentifier: String? = nil,
            appPlatform: String = "ios",
            appleId: String? = nil,
@@ -5222,7 +5255,9 @@ func pilot(username: String,
            waitForUploadedBuild: Bool = false,
            rejectBuildWaitingForReview: Bool = false)
 {
-    let command = RubyCommand(commandID: "", methodName: "pilot", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
+    let command = RubyCommand(commandID: "", methodName: "pilot", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                         RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                         RubyCommand.Argument(name: "username", value: username),
                                                                                          RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                          RubyCommand.Argument(name: "app_platform", value: appPlatform),
                                                                                          RubyCommand.Argument(name: "apple_id", value: appleId),
@@ -7237,6 +7272,16 @@ func spaceshipLogs(latest: Bool = true,
 }
 
 /**
+ Print out Spaceship stats from this session (number of request to each domain)
+
+ - parameter printRequestLogs: Print all URLs requested
+ */
+func spaceshipStats(printRequestLogs: Bool = false) {
+    let command = RubyCommand(commandID: "", methodName: "spaceship_stats", className: nil, args: [RubyCommand.Argument(name: "print_request_logs", value: printRequestLogs)])
+    _ = runner.executeCommand(command)
+}
+
+/**
  Upload dSYM file to [Splunk MINT](https://mint.splunk.com/)
 
  - parameters:
@@ -7708,6 +7753,8 @@ func testfairy(apiKey: String,
  Alias for the `upload_to_testflight` action
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API key JSON file
+   - apiKey: Path to your App Store Connect API key JSON file
    - username: Your Apple ID Username
    - appIdentifier: The bundle identifier of the app to upload or manage testers (optional)
    - appPlatform: The platform to use (optional)
@@ -7746,7 +7793,9 @@ func testfairy(apiKey: String,
  More details can be found on https://docs.fastlane.tools/actions/pilot/.
  This integration will only do the TestFlight upload.
  */
-func testflight(username: String,
+func testflight(apiKeyPath: String? = nil,
+                apiKey: [String: Any]? = nil,
+                username: String,
                 appIdentifier: String? = nil,
                 appPlatform: String = "ios",
                 appleId: String? = nil,
@@ -7781,7 +7830,9 @@ func testflight(username: String,
                 waitForUploadedBuild: Bool = false,
                 rejectBuildWaitingForReview: Bool = false)
 {
-    let command = RubyCommand(commandID: "", methodName: "testflight", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
+    let command = RubyCommand(commandID: "", methodName: "testflight", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                              RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                              RubyCommand.Argument(name: "username", value: username),
                                                                                               RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                               RubyCommand.Argument(name: "app_platform", value: appPlatform),
                                                                                               RubyCommand.Argument(name: "apple_id", value: appleId),
@@ -8651,6 +8702,8 @@ func uploadToPlayStoreInternalAppSharing(packageName: String,
  Upload new binary to App Store Connect for TestFlight beta testing (via _pilot_)
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API key JSON file
+   - apiKey: Path to your App Store Connect API key JSON file
    - username: Your Apple ID Username
    - appIdentifier: The bundle identifier of the app to upload or manage testers (optional)
    - appPlatform: The platform to use (optional)
@@ -8689,7 +8742,9 @@ func uploadToPlayStoreInternalAppSharing(packageName: String,
  More details can be found on https://docs.fastlane.tools/actions/pilot/.
  This integration will only do the TestFlight upload.
  */
-func uploadToTestflight(username: String,
+func uploadToTestflight(apiKeyPath: String? = nil,
+                        apiKey: [String: Any]? = nil,
+                        username: String,
                         appIdentifier: String? = nil,
                         appPlatform: String = "ios",
                         appleId: String? = nil,
@@ -8724,7 +8779,9 @@ func uploadToTestflight(username: String,
                         waitForUploadedBuild: Bool = false,
                         rejectBuildWaitingForReview: Bool = false)
 {
-    let command = RubyCommand(commandID: "", methodName: "upload_to_testflight", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
+    let command = RubyCommand(commandID: "", methodName: "upload_to_testflight", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                        RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                                        RubyCommand.Argument(name: "username", value: username),
                                                                                                         RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                                         RubyCommand.Argument(name: "app_platform", value: appPlatform),
                                                                                                         RubyCommand.Argument(name: "apple_id", value: appleId),
@@ -9061,7 +9118,7 @@ func xcov(workspace: String? = nil,
           coverallsServiceJobId: String? = nil,
           coverallsRepoToken: String? = nil,
           xcconfig: String? = nil,
-          ideFoundationPath: String = "/Applications/Xcode-11.5.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+          ideFoundationPath: String = "/Applications/Xcode-12.beta.5.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
           legacySupport: Bool = false)
 {
     let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
@@ -9207,4 +9264,4 @@ let snapshotfile: Snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.87]
+// FastlaneRunnerAPIVersion [0.9.88]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -14,4 +14,4 @@ class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.156.1
+// Generated with fastlane 2.157.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -181,4 +181,4 @@ extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.37]
+// FastlaneRunnerAPIVersion [0.9.38]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -14,4 +14,4 @@ class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.156.1
+// Generated with fastlane 2.157.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -165,4 +165,4 @@ extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.31]
+// FastlaneRunnerAPIVersion [0.9.32]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -14,4 +14,4 @@ class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.156.1
+// Generated with fastlane 2.157.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -33,4 +33,4 @@ extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.30]
+// FastlaneRunnerAPIVersion [0.9.31]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -14,4 +14,4 @@ class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.156.1
+// Generated with fastlane 2.157.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -257,4 +257,4 @@ extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.42]
+// FastlaneRunnerAPIVersion [0.9.43]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -14,4 +14,4 @@ class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.156.1
+// Generated with fastlane 2.157.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -93,4 +93,4 @@ extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.32]
+// FastlaneRunnerAPIVersion [0.9.33]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -14,4 +14,4 @@ class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.156.1
+// Generated with fastlane 2.157.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -181,4 +181,4 @@ extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.26]
+// FastlaneRunnerAPIVersion [0.9.27]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.156.1':**

* [deliver] improve screenshot uploading verification (#17060) via Satoshi Namai
* [docs] supply/upload_to_play_store - update the quick-start requirement to setup supply correctly (#17057) via Renato Benkendorf
* [screengrab] Wait for device to reconnect after adb root (#17077) via Olivier Halligon
* [action] fix formatting syntax error on commit_version_bump (#17092) via Sandeep M
* [gym] safer logic getting last 5 lines of logs (#17096) via Christian Schmidt
* [pilot][spaceship][action] set ASC API key in pilot, new app_store_connect_api_key action, and spaceship fixes for both of those (#17061) via Josh Holtz
* [spaceship] improve multiple sessions and multiple auth types (#17042) via Josh Holtz
* [action] Add support to exclude files from sonar qube analysis (#17049) via David Cacenabes
