### PR TITLE
[screengrab] pass adb_path into AdbHelper

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -82,7 +82,7 @@ module Screengrab
     end
 
     def select_device
-      adb = Fastlane::Helper::AdbHelper.new(adb_host: @config[:adb_host])
+      adb = Fastlane::Helper::AdbHelper.new(adb_path: @android_env.adb_path, adb_host: @config[:adb_host])
       devices = adb.load_all_devices
 
       UI.user_error!('There are no connected and authorized devices or emulators') if devices.empty?

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -250,7 +250,8 @@ describe Screengrab::Runner do
       mock_helper = double('mock helper')
       device = Fastlane::Helper::AdbDevice.new(serial: 'e1dbf228')
 
-      expect(Fastlane::Helper::AdbHelper).to receive(:new).with(adb_host: 'device_farm').and_return(mock_helper)
+      expect(mock_android_environment).to receive(:adb_path).and_return("adb")
+      expect(Fastlane::Helper::AdbHelper).to receive(:new).with(adb_path: 'adb', adb_host: 'device_farm').and_return(mock_helper)
       expect(mock_helper).to receive(:load_all_devices).and_return([device])
 
       expect(@runner.select_device).to eq('e1dbf228')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
If ANDROID_HOME is not set, `AdbHelper` fails even though other parts of screengrab know where to run adb from

### Description
Passing through the computed adb_path into AdbHelper

### Testing Steps
Ran `fastlane screengrab` with and without this change