### PR TITLE
[screengrab] handle permission denied during screengrab `adb pull`

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -51,7 +51,8 @@ module FastlaneCore
         begin
           status = FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
             command_stdout.each do |l|
-              line = l.chomp.delete_prefix("\r")
+              line = l.chomp
+              line = line[1..-1] if line[0] == "\r"
               output << line
 
               next unless print_all

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -51,7 +51,7 @@ module FastlaneCore
         begin
           status = FastlaneCore::FastlanePty.spawn(command) do |command_stdout, command_stdin, pid|
             command_stdout.each do |l|
-              line = l.chomp
+              line = l.chomp.delete_prefix("\r")
               output << line
 
               next unless print_all

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -41,7 +41,7 @@ describe FastlaneCore do
         fake_std_in = [
           "Shopping list:\n",
           "  - Milk\n",
-          "  - Bread\n",
+          "\r  - Bread\n",
           "  - Muffins\n"
         ]
 

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -299,9 +299,17 @@ module Screengrab
         device_screenshots_paths.each do |device_path|
           if_device_path_exists(@config[:app_package_name], device_serial, device_path) do |path|
             next unless path.include?(locale)
-            run_adb_command("-s #{device_serial} pull #{path} #{tempdir}",
-                            print_all: false,
-                            print_command: true)
+            out = run_adb_command("-s #{device_serial} pull #{path} #{tempdir}",
+                                  print_all: false,
+                                  print_command: true,
+                                  raise_errors: false)
+            if out =~ /Permission denied/
+              dir = File.dirname(path)
+              base = File.basename(path)
+              run_adb_command("-s #{device_serial} shell run-as #{@config[:app_package_name]} 'tar -cC #{dir} #{base}' | tar -xvC #{tempdir}",
+                              print_all: false,
+                              print_command: true)
+            end
           end
         end
 
@@ -381,16 +389,26 @@ module Screengrab
       packages.split("\n").map { |package| package.gsub("package:", "") }
     end
 
-    def run_adb_command(command, print_all: false, print_command: false)
+    def run_adb_command(command, print_all: false, print_command: false, raise_errors: true)
       adb_path = @android_env.adb_path.chomp("adb")
       adb_host = @config[:adb_host]
       host = adb_host.nil? ? '' : "-H #{adb_host} "
-      output = @executor.execute(command: adb_path + "adb " + host + command,
-                                 print_all: print_all,
-                                 print_command: print_command) || ''
+      output = ''
+      begin
+        errout = nil
+        cmdout = @executor.execute(command: adb_path + "adb " + host + command,
+                                  print_all: print_all,
+                                  print_command: print_command,
+                                  error: raise_errors ? nil : lambda{|out,status| errout = out }) || ''
+        output = errout || cmdout
+      rescue => ex
+        if raise_errors
+          raise ex
+        end
+      end
       output.lines.reject do |line|
-        # Debug/Warning output from ADB}
-        line.start_with?('adb: ')
+        # Debug/Warning output from ADB
+        line.start_with?('adb: ') && !line.start_with?('adb: error: ')
       end.join('') # Lines retain their newline chars
     end
 

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -399,7 +399,7 @@ module Screengrab
         cmdout = @executor.execute(command: adb_path + "adb " + host + command,
                                   print_all: print_all,
                                   print_command: print_command,
-                                  error: raise_errors ? nil : -> { |out, status| errout = out }) || ''
+                                  error: raise_errors ? nil : proc { |out, status| errout = out }) || ''
         output = errout || cmdout
       rescue => ex
         if raise_errors

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -399,7 +399,7 @@ module Screengrab
         cmdout = @executor.execute(command: adb_path + "adb " + host + command,
                                   print_all: print_all,
                                   print_command: print_command,
-                                  error: raise_errors ? nil : lambda{|out,status| errout = out }) || ''
+                                  error: raise_errors ? nil : -> { |out, status| errout = out }) || ''
         output = errout || cmdout
       rescue => ex
         if raise_errors


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Using an API 28 Android TV emulator, `adb pull` fails with Permission denied:

>INFO [2020-08-27 10:55:04.12]: ▸ adb: error: failed to stat remote object '/data/data/com.getchannels.app.debug/files/com.getchannels.app.debug/screengrab/en-US/images/screenshots': Permission denied

### Description
Catch the permission denied error and fallback to `adb run-as`
