### PR TITLE
[actions] fix window tests for app_store_connect_api_key

### DIFF
--- a/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
@@ -50,6 +50,9 @@ describe Fastlane do
           in_house: true
         }
 
+        # Remove \r for windows tests
+        hash[:key] = hash[:key].gsub('\r', '')
+
         expect(result).to eq(hash)
       end
 

--- a/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
@@ -30,7 +30,7 @@ describe Fastlane do
       end
 
       it "with key_content" do
-        key_content = File.binread(fake_api_key_p8_path).gsub('\r', '')
+        key_content = File.binread(fake_api_key_p8_path).gsub("\r", '')
 
         result = Fastlane::FastFile.new.parse("lane :test do
           app_store_connect_api_key(

--- a/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
@@ -30,7 +30,7 @@ describe Fastlane do
       end
 
       it "with key_content" do
-        key_content = File.binread(fake_api_key_p8_path)
+        key_content = File.binread(fake_api_key_p8_path).gsub('\r', '')
 
         result = Fastlane::FastFile.new.parse("lane :test do
           app_store_connect_api_key(
@@ -49,9 +49,6 @@ describe Fastlane do
           duration: 200,
           in_house: true
         }
-
-        # Remove \r for windows tests
-        hash[:key] = hash[:key].gsub('\r', '')
 
         expect(result).to eq(hash)
       end


### PR DESCRIPTION
### Motivation and Context
Windows tests broken because `\r\`

### Description
Ignore `\r`
