### PR TITLE
[spaceship] separate portal team id and tunes team id

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -27,7 +27,7 @@ module Deliver
 
     def login
       UI.message("Login to App Store Connect (#{options[:username]})")
-      Spaceship::ConnectAPI.login(options[:username])
+      Spaceship::ConnectAPI.login(options[:username], nil, use_portal: true, use_tunes: true)
       Spaceship::ConnectAPI.select_team
       UI.message("Login successful")
     end

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -27,7 +27,7 @@ module Deliver
 
     def login
       UI.message("Login to App Store Connect (#{options[:username]})")
-      Spaceship::ConnectAPI.login(options[:username], nil, use_portal: true, use_tunes: true)
+      Spaceship::ConnectAPI.login(options[:username], nil, use_portal: false, use_tunes: true)
       Spaceship::ConnectAPI.select_team
       UI.message("Login successful")
     end

--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -5,7 +5,7 @@ module Fastlane
         require 'spaceship'
 
         UI.message("Login to App Store Connect (#{params[:username]})")
-        Spaceship::ConnectAPI.login(params[:username])
+        Spaceship::ConnectAPI.login(params[:username], use_portal: false, use_tunes: true)
         Spaceship::ConnectAPI.select_team
         UI.message("Login successful")
 

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -24,7 +24,8 @@ module Pilot
         config[:username] ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
         UI.message("Login to App Store Connect (#{config[:username]})")
-        Spaceship::ConnectAPI.login(config[:username], team_id: config[:team_id], team_name: config[:team_name])
+        Spaceship::ConnectAPI.login(config[:username], use_portal: false, use_tunes: true)
+        Spaceship::ConnectAPI.select_team(tunes_team_id: config[:team_id], team_name: config[:team_name])
         UI.message("Login successful")
       end
     end

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -9,7 +9,7 @@ module Produce
       @full_bundle_identifier = app_identifier
       @full_bundle_identifier.gsub!('*', Produce.config[:bundle_identifier_suffix].to_s) if wildcard_bundle?
 
-      Spaceship::ConnectAPI.login(Produce.config[:username], nil)
+      Spaceship::ConnectAPI.login(Produce.config[:username], nil, use_portal: false, use_tunes: true)
       Spaceship::ConnectAPI.client.select_team
 
       create_new_app

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -18,7 +18,7 @@ module Sigh
                                              title: "Summary for sigh #{Fastlane::VERSION}")
 
       UI.message("Starting login with user '#{Sigh.config[:username]}'")
-      Spaceship::ConnectAPI.login(Sigh.config[:username], nil)
+      Spaceship::ConnectAPI.login(Sigh.config[:username], nil, use_portal: true, use_tunes: false)
       Spaceship::ConnectAPI.select_team
       UI.message("Successfully logged in")
 

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -38,20 +38,23 @@ module Spaceship
       #
       # @param user (String) (optional): The username (usually the email address)
       # @param password (String) (optional): The password
-      # @param team_id (String) (optional): The team id
+      # @param portal_team_id (String) (optional): The team id
+      # @param tunes_team_id (String) (optional): The team id
       # @param team_name (String) (optional): The team name
       #
       # @raise InvalidUserCredentialsError: raised if authentication failed
       #
       # @return (Spaceship::ConnectAPI::Client) The client the login method was called for
-      def self.login(user = nil, password = nil, team_id: nil, team_name: nil)
-        tunes_client = TunesClient.login(user, password)
-        portal_client = PortalClient.login(user, password)
+      def self.login(user = nil, password = nil, use_portal: true, use_tunes: true, portal_team_id: nil, tunes_team_id: nil, team_name: nil)
+        portal_client = PortalClient.login(user, password) if use_portal
+        tunes_client = TunesClient.login(user, password) if use_tunes
 
         # The clients will automatically select the first team if none is given
-        if !team_id.nil? || !team_name.nil?
-          tunes_client.select_team(team_id: team_id, team_name: team_name)
-          portal_client.select_team(team_id: team_id, team_name: team_name)
+        if portal_client && (!portal_team_id.nil? || !team_name.nil?)
+          portal_client.select_team(team_id: portal_team_id, team_name: team_name)
+        end
+        if tunes_client && (!tunes_team_id.nil? || !team_name.nil?)
+          tunes_client.select_team(team_id: tunes_team_id, team_name: team_name)
         end
 
         return ConnectAPI::Client.new(tunes_client: tunes_client, portal_client: portal_client)
@@ -104,9 +107,9 @@ module Spaceship
         end
       end
 
-      def select_team(team_id: nil, team_name: nil)
-        @tunes_client.select_team(team_id: team_id, team_name: team_name)
-        @portal_client.select_team(team_id: team_id, team_name: team_name)
+      def select_team(portal_team_id: nil, tunes_team_id: nil, team_name: nil)
+        @portal_client.select_team(team_id: portal_team_id, team_name: team_name) unless @portal_client.nil?
+        @tunes_client.select_team(team_id: tunes_team_id, team_name: team_name) unless @tunes_client.nil?
 
         # Updating the tunes and portal clients requires resetting
         # of the clients in the API modules

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -38,8 +38,10 @@ module Spaceship
       #
       # @param user (String) (optional): The username (usually the email address)
       # @param password (String) (optional): The password
-      # @param portal_team_id (String) (optional): The team id
-      # @param tunes_team_id (String) (optional): The team id
+      # @param use_portal (Boolean) (optional): Whether to log in to Spaceship::Portal or not
+      # @param use_tunes (Boolean) (optional): Whether to log in to Spaceship::Tunes or not
+      # @param portal_team_id (String) (optional): The Spaceship::Portal team id
+      # @param tunes_team_id (String) (optional): The Spaceship::Tunes team id
       # @param team_name (String) (optional): The team name
       #
       # @raise InvalidUserCredentialsError: raised if authentication failed

--- a/spaceship/lib/spaceship/connect_api/spaceship.rb
+++ b/spaceship/lib/spaceship/connect_api/spaceship.rb
@@ -68,14 +68,15 @@ module Spaceship
       #
       # @param user (String) (optional): The username (usually the email address)
       # @param password (String) (optional): The password
-      # @param team_id (String) (optional): The team id
+      # @param portal_team_id (String) (optional): The team id
+      # @param tunes_team_id (String) (optional): The team id
       # @param team_name (String) (optional): The team name
       #
       # @raise InvalidUserCredentialsError: raised if authentication failed
       #
       # @return (Spaceship::ConnectAPI::Client) The client the login method was called for
-      def login(user = nil, password = nil, team_id: nil, team_name: nil)
-        @client = ConnectAPI::Client.login(user, password, team_id: team_id, team_name: team_name)
+      def login(user = nil, password = nil, use_portal: true, use_tunes: true, portal_team_id: nil, tunes_team_id: nil, team_name: nil)
+        @client = ConnectAPI::Client.login(user, password, use_portal: use_portal, use_tunes: use_tunes, portal_team_id: portal_team_id, tunes_team_id: tunes_team_id, team_name: team_name)
       end
 
       # Open up the team selection for the user (if necessary).
@@ -85,9 +86,9 @@ module Spaceship
       #
       # @param team_id (String) (optional): The ID of an App Store Connect team
       # @param team_name (String) (optional): The name of an App Store Connect team
-      def select_team(team_id: nil, team_name: nil)
+      def select_team(portal_team_id: nil, tunes_team_id: nil, team_name: nil)
         return if client.nil?
-        client.select_team(team_id: team_id, team_name: team_name)
+        client.select_team(portal_team_id: portal_team_id, tunes_team_id: tunes_team_id, team_name: team_name)
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/spaceship.rb
+++ b/spaceship/lib/spaceship/connect_api/spaceship.rb
@@ -68,8 +68,10 @@ module Spaceship
       #
       # @param user (String) (optional): The username (usually the email address)
       # @param password (String) (optional): The password
-      # @param portal_team_id (String) (optional): The team id
-      # @param tunes_team_id (String) (optional): The team id
+      # @param use_portal (Boolean) (optional): Whether to log in to Spaceship::Portal or not
+      # @param use_tunes (Boolean) (optional): Whether to log in to Spaceship::Tunes or not
+      # @param portal_team_id (String) (optional): The Spaceship::Portal team id
+      # @param tunes_team_id (String) (optional): The Spaceship::Tunes team id
       # @param team_name (String) (optional): The team name
       #
       # @raise InvalidUserCredentialsError: raised if authentication failed
@@ -84,7 +86,8 @@ module Spaceship
       # If the user is in multiple teams, a team selection is shown.
       # The user can then select a team by entering the number
       #
-      # @param team_id (String) (optional): The ID of an App Store Connect team
+      # @param portal_team_id (String) (optional): The Spaceship::Portal team id
+      # @param tunes_team_id (String) (optional): The Spaceship::Tunes team id
       # @param team_name (String) (optional): The name of an App Store Connect team
       def select_team(portal_team_id: nil, tunes_team_id: nil, team_name: nil)
         return if client.nil?

--- a/spaceship/spec/connect_api/spaceship_spec.rb
+++ b/spaceship/spec/connect_api/spaceship_spec.rb
@@ -66,16 +66,42 @@ describe Spaceship::ConnectAPI do
         expect(client).to eq(Spaceship::ConnectAPI.client)
       end
 
-      it '#login' do
-        user = 'user'
-        password = 'password'
-        team_id = 'team_id'
-        team_name = 'team_name'
+      context '#login' do
+        it 'with portal_team_id' do
+          user = 'user'
+          password = 'password'
+          team_id = 'team_id'
+          team_name = 'team_name'
 
-        expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, team_id: team_id, team_name: team_name).and_return(mock_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, use_portal: true, use_tunes: false, portal_team_id: team_id, tunes_team_id: nil, team_name: team_name).and_return(mock_client)
 
-        client = Spaceship::ConnectAPI.login(user, password, team_id: team_id, team_name: team_name)
-        expect(client).to eq(Spaceship::ConnectAPI.client)
+          client = Spaceship::ConnectAPI.login(user, password, use_portal: true, use_tunes: false, portal_team_id: team_id, team_name: team_name)
+          expect(client).to eq(Spaceship::ConnectAPI.client)
+        end
+
+        it 'with tunes_team_id' do
+          user = 'user'
+          password = 'password'
+          team_id = 'team_id'
+          team_name = 'team_name'
+
+          expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, use_portal: false, use_tunes: true, portal_team_id: nil, tunes_team_id: team_id, team_name: team_name).and_return(mock_client)
+
+          client = Spaceship::ConnectAPI.login(user, password, use_portal: false, use_tunes: true, tunes_team_id: team_id, team_name: team_name)
+          expect(client).to eq(Spaceship::ConnectAPI.client)
+        end
+
+        it 'with both portal_team_id and tunes_team_id' do
+          user = 'user'
+          password = 'password'
+          team_id = 'team_id'
+          team_name = 'team_name'
+
+          expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, use_portal: true, use_tunes: true, portal_team_id: team_id, tunes_team_id: team_id, team_name: team_name).and_return(mock_client)
+
+          client = Spaceship::ConnectAPI.login(user, password, use_portal: true, use_tunes: true, portal_team_id: team_id, tunes_team_id: team_id, team_name: team_name)
+          expect(client).to eq(Spaceship::ConnectAPI.client)
+        end
       end
     end
   end
@@ -86,18 +112,34 @@ describe Spaceship::ConnectAPI do
     let(:team_id) { "team_id" }
     let(:team_name) { "team name" }
 
-    it 'with client' do
-      allow(Spaceship::ConnectAPI).to receive(:client).and_return(mock_client)
-      expect(mock_client).to receive(:select_team).with(team_id: team_id, team_name: team_name)
+    context 'with client' do
+      it 'with portal_team_id' do
+        allow(Spaceship::ConnectAPI).to receive(:client).and_return(mock_client)
+        expect(mock_client).to receive(:select_team).with(portal_team_id: team_id, tunes_team_id: nil, team_name: team_name)
 
-      Spaceship::ConnectAPI.select_team(team_id: team_id, team_name: team_name)
+        Spaceship::ConnectAPI.select_team(portal_team_id: team_id, team_name: team_name)
+      end
+
+      it 'with tunes_team_id' do
+        allow(Spaceship::ConnectAPI).to receive(:client).and_return(mock_client)
+        expect(mock_client).to receive(:select_team).with(portal_team_id: nil, tunes_team_id: team_id, team_name: team_name)
+
+        Spaceship::ConnectAPI.select_team(tunes_team_id: team_id, team_name: team_name)
+      end
+
+      it 'with both portal_team_id and tunes_team_id' do
+        allow(Spaceship::ConnectAPI).to receive(:client).and_return(mock_client)
+        expect(mock_client).to receive(:select_team).with(portal_team_id: team_id, tunes_team_id: team_id, team_name: team_name)
+
+        Spaceship::ConnectAPI.select_team(portal_team_id: team_id, tunes_team_id: team_id, team_name: team_name)
+      end
     end
 
     it 'without client' do
       allow(Spaceship::ConnectAPI).to receive(:client).and_return(nil)
-      expect(mock_client).not_to(receive(:select_team).with(team_id: team_id, team_name: team_name))
+      expect(mock_client).not_to(receive(:select_team).with(portal_team_id: team_id, tunes_team_id: team_id, team_name: team_name))
 
-      Spaceship::ConnectAPI.select_team(team_id: team_id, team_name: team_name)
+      Spaceship::ConnectAPI.select_team(portal_team_id: team_id, tunes_team_id: team_id, team_name: team_name)
     end
   end
 end


### PR DESCRIPTION
### Motivation and Context
Fixes #17103

### Description
- Separated out portal and tunes team id and can toggle off portal or tunes on `Spaceship::ConnectAPI::Client`
  - `Spaceship::ConnectAPI::Client.login(username, password, use_portal: true, use_tunes: false, portal_team_id: id)`
  - `Spaceship::ConnectAPI::Client.login(username, password, use_portal: false, use_tunes: true, tunes_team_id: id)`
  - `Spaceship::ConnectAPI::Client.login(username, password, portal_team_id: id, tunes_team_id: id)`
  - `Spaceship::ConnectAPI::Client.login(username, password, team_name: team_name)`
  - `Spaceship::ConnectAPI::Client.login(username, password, use_portal: false, team_name: team_name)`
  - `Spaceship::ConnectAPI::Client.login(username, password, use_tunes: false, team_name: team_name)`

### Testing Steps
Update `Gemfile` to 👇 and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-spaceship-connect-api-separate-portal-tunes-team-id"
```
