### PR TITLE
[deliver] fix upload screenshot when display type not yet created

### DIFF
--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -81,7 +81,7 @@ module Deliver
 
         screenshots_per_display_type.each do |display_type, screenshots|
           # create AppScreenshotSet for given display_type if it doesn't exsit
-          app_screenshot_set = app_screenshot_set_per_locale_and_display_type[language][display_type]
+          app_screenshot_set = (app_screenshot_set_per_locale_and_display_type[language] || {})[display_type]
           app_screenshot_set ||= localization.create_app_screenshot_set(attributes: { screenshotDisplayType: display_type })
 
           # iterate over screenshots per display size with index

--- a/deliver/spec/app_screenshot_iterator_spec.rb
+++ b/deliver/spec/app_screenshot_iterator_spec.rb
@@ -102,6 +102,27 @@ describe Deliver::AppScreenshotIterator do
       end
     end
 
+    context 'when a localization does not have app_screenshot_set yet (happens with new apps)' do
+      it 'should iterates app_screenshot_set with corresponding localization' do
+        app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
+                                    app_screenshots: [],
+                                    screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization',
+                              get_app_screenshot_sets: [],
+                              locale: 'en-US')
+
+        screenshot = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+
+        screenshots_per_language = { 'en-US' => [screenshot] }
+
+        expect(localization).to receive(:create_app_screenshot_set)
+          .with(attributes: { screenshotDisplayType: screenshot.device_type })
+          .and_return(app_screenshot_set)
+        actual = described_class.new([localization]).each_local_screenshot(screenshots_per_language).to_a
+        expect(actual).to eq([[localization, app_screenshot_set, screenshot, 0]])
+      end
+    end
+
     context 'when local screenshots are multiple within an app_screenshot_set' do
       it 'should give index incremented on each' do
         app_screenshot_set1 = double('Spaceship::ConnectAPI::AppScreenshotSet',


### PR DESCRIPTION
### Motivation and Context
Upload screenshot broken when screenshot set for display type has not yet been created

### Description
Use `|| {}` if no value is found before looking in hash
