### PR TITLE
[spaceship] share tunes and portal session when logging in with apple id from connect api

### DIFF
--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -48,8 +48,8 @@ module Spaceship
       #
       # @return (Spaceship::ConnectAPI::Client) The client the login method was called for
       def self.login(user = nil, password = nil, use_portal: true, use_tunes: true, portal_team_id: nil, tunes_team_id: nil, team_name: nil)
-        portal_client = PortalClient.login(user, password) if use_portal
-        tunes_client = TunesClient.login(user, password) if use_tunes
+        portal_client = Spaceship::Portal.login(user, password) if use_portal
+        tunes_client = Spaceship::Tunes.login(user, password) if use_tunes
 
         # The clients will automatically select the first team if none is given
         if portal_client && (!portal_team_id.nil? || !team_name.nil?)


### PR DESCRIPTION
### Motivation and Context
Fixes #17108

### Description
Log in to global `Spaceship::Portal` and `Spaceship::Tunes` from a client for backwards compatibility with tools like `Sigh`
