### PR TITLE
[match] fix occasional auth issues with App Store Connect

### DIFF
--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -19,17 +19,17 @@ module Match
       end
 
       UI.message("Verifying that the certificate and profile are still valid on the Dev Portal...")
-      Spaceship.login(user)
-      Spaceship.select_team(team_id: team_id, team_name: team_name)
+      Spaceship::ConnectAPI.login(use_portal: true, use_tunes: false)
+      Spaceship::ConnectAPI.select_team
     end
 
     # The team ID of the currently logged in team
     def team_id
-      return Spaceship.client.team_id
+      return Spaceship::ConnectAPI.client.team_id
     end
 
     def bundle_identifier_exists(username: nil, app_identifier: nil, platform: nil)
-      found = Spaceship.app.find(app_identifier, mac: platform == "macos")
+      found = Spaceship::ConnectAPI::BundleId.find(app_identifier)
       return if found
 
       require 'sigh/runner'
@@ -39,7 +39,7 @@ module Match
       })
       UI.error("An app with that bundle ID needs to exist in order to create a provisioning profile for it")
       UI.error("================================================================")
-      available_apps = Spaceship.app.all.collect { |a| "#{a.bundle_id} (#{a.name})" }
+      available_apps = Spaceship::ConnectAPI::BundleId.all.collect { |a| "#{a.identifier} (#{a.name})" }
       UI.message("Available apps:\n- #{available_apps.join("\n- ")}")
       UI.error("Make sure to run `fastlane match` with the same user and team every time.")
       UI.user_error!("Couldn't find bundle identifier '#{app_identifier}' for the user '#{username}'")

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -10,7 +10,7 @@ module Produce
       @full_bundle_identifier.gsub!('*', Produce.config[:bundle_identifier_suffix].to_s) if wildcard_bundle?
 
       Spaceship::ConnectAPI.login(Produce.config[:username], nil, use_portal: false, use_tunes: true)
-      Spaceship::ConnectAPI.client.select_team
+      Spaceship::ConnectAPI.select_team
 
       create_new_app
     end

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -18,13 +18,13 @@ module Spaceship
         #
 
         def get_apps(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("apps", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("apps", params)
         end
 
         def get_app(app_id: nil, includes: nil)
-          params = @test_flight_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil)
-          @test_flight_request_client.get("apps/#{app_id}", params)
+          params = test_flight_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil)
+          test_flight_request_client.get("apps/#{app_id}", params)
         end
 
         #
@@ -32,8 +32,8 @@ module Spaceship
         #
 
         def get_beta_app_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("betaAppLocalizations", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("betaAppLocalizations", params)
         end
 
         def post_beta_app_localizations(app_id: nil, attributes: {})
@@ -52,7 +52,7 @@ module Spaceship
             }
           }
 
-          @test_flight_request_client.post("betaAppLocalizations", body)
+          test_flight_request_client.post("betaAppLocalizations", body)
         end
 
         def patch_beta_app_localizations(localization_id: nil, attributes: {})
@@ -64,7 +64,7 @@ module Spaceship
             }
           }
 
-          @test_flight_request_client.patch("betaAppLocalizations/#{localization_id}", body)
+          test_flight_request_client.patch("betaAppLocalizations/#{localization_id}", body)
         end
 
         #
@@ -72,8 +72,8 @@ module Spaceship
         #
 
         def get_beta_app_review_detail(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("betaAppReviewDetails", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("betaAppReviewDetails", params)
         end
 
         def patch_beta_app_review_detail(app_id: nil, attributes: {})
@@ -85,7 +85,7 @@ module Spaceship
             }
           }
 
-          @test_flight_request_client.patch("betaAppReviewDetails/#{app_id}", body)
+          test_flight_request_client.patch("betaAppReviewDetails/#{app_id}", body)
         end
 
         #
@@ -93,8 +93,8 @@ module Spaceship
         #
 
         def get_beta_app_review_submissions(filter: {}, includes: nil, limit: nil, sort: nil, cursor: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort, cursor: cursor)
-          @test_flight_request_client.get("betaAppReviewSubmissions", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort, cursor: cursor)
+          test_flight_request_client.get("betaAppReviewSubmissions", params)
         end
 
         def post_beta_app_review_submissions(build_id: nil)
@@ -112,12 +112,12 @@ module Spaceship
             }
           }
 
-          @test_flight_request_client.post("betaAppReviewSubmissions", body)
+          test_flight_request_client.post("betaAppReviewSubmissions", body)
         end
 
         def delete_beta_app_review_submission(beta_app_review_submission_id: nil)
-          params = @test_flight_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil, cursor: nil)
-          @test_flight_request_client.delete("betaAppReviewSubmissions/#{beta_app_review_submission_id}", params)
+          params = test_flight_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil, cursor: nil)
+          test_flight_request_client.delete("betaAppReviewSubmissions/#{beta_app_review_submission_id}", params)
         end
 
         #
@@ -125,8 +125,8 @@ module Spaceship
         #
 
         def get_beta_build_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("betaBuildLocalizations", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("betaBuildLocalizations", params)
         end
 
         def post_beta_build_localizations(build_id: nil, attributes: {})
@@ -145,7 +145,7 @@ module Spaceship
             }
           }
 
-          @test_flight_request_client.post("betaBuildLocalizations", body)
+          test_flight_request_client.post("betaBuildLocalizations", body)
         end
 
         def patch_beta_build_localizations(localization_id: nil, feedbackEmail: nil, attributes: {})
@@ -157,7 +157,7 @@ module Spaceship
             }
           }
 
-          @test_flight_request_client.patch("betaBuildLocalizations/#{localization_id}", body)
+          test_flight_request_client.patch("betaBuildLocalizations/#{localization_id}", body)
         end
 
         #
@@ -165,8 +165,8 @@ module Spaceship
         #
 
         def get_beta_build_metrics(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("betaBuildMetrics", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("betaBuildMetrics", params)
         end
 
         #
@@ -174,8 +174,8 @@ module Spaceship
         #
 
         def get_beta_groups(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("betaGroups", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("betaGroups", params)
         end
 
         def add_beta_groups_to_build(build_id: nil, beta_group_ids: [])
@@ -188,7 +188,7 @@ module Spaceship
             end
           }
 
-          @test_flight_request_client.post("builds/#{build_id}/relationships/betaGroups", body)
+          test_flight_request_client.post("builds/#{build_id}/relationships/betaGroups", body)
         end
 
         def create_beta_group(app_id: nil, group_name: nil, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
@@ -211,7 +211,7 @@ module Spaceship
               type: "betaGroups"
             }
           }
-          @test_flight_request_client.post("betaGroups", body)
+          test_flight_request_client.post("betaGroups", body)
         end
 
         #
@@ -219,8 +219,8 @@ module Spaceship
         #
 
         def get_beta_testers(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("betaTesters", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("betaTesters", params)
         end
 
         # beta_testers - [{email: "", firstName: "", lastName: ""}]
@@ -248,7 +248,7 @@ module Spaceship
             }
           }
 
-          @test_flight_request_client.post("bulkBetaTesterAssignments", body)
+          test_flight_request_client.post("bulkBetaTesterAssignments", body)
         end
 
         def delete_beta_tester_from_apps(beta_tester_id: nil, app_ids: [])
@@ -261,7 +261,7 @@ module Spaceship
             end
           }
 
-          @test_flight_request_client.delete("betaTesters/#{beta_tester_id}/relationships/apps", nil, body)
+          test_flight_request_client.delete("betaTesters/#{beta_tester_id}/relationships/apps", nil, body)
         end
 
         def delete_beta_tester_from_beta_groups(beta_tester_id: nil, beta_group_ids: [])
@@ -274,7 +274,7 @@ module Spaceship
             end
           }
 
-          @test_flight_request_client.delete("betaTesters/#{beta_tester_id}/relationships/betaGroups", nil, body)
+          test_flight_request_client.delete("betaTesters/#{beta_tester_id}/relationships/betaGroups", nil, body)
         end
 
         #
@@ -282,8 +282,8 @@ module Spaceship
         #
 
         def get_beta_tester_metrics(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("betaTesterMetrics", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("betaTesterMetrics", params)
         end
 
         #
@@ -291,17 +291,17 @@ module Spaceship
         #
 
         def get_builds(filter: {}, includes: "buildBetaDetail,betaBuildMetrics", limit: 10, sort: "uploadedDate", cursor: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort, cursor: cursor)
-          @test_flight_request_client.get("builds", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort, cursor: cursor)
+          test_flight_request_client.get("builds", params)
         end
 
         def get_build(build_id: nil, app_store_version_id: nil, includes: nil)
           if build_id
-            params = @test_flight_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil, cursor: nil)
-            return @test_flight_request_client.get("builds/#{build_id}", params)
+            params = test_flight_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil, cursor: nil)
+            return test_flight_request_client.get("builds/#{build_id}", params)
           elsif app_store_version_id
-            params = @test_flight_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil, cursor: nil)
-            return @test_flight_request_client.get("appStoreVersions/#{app_store_version_id}/build", params)
+            params = test_flight_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil, cursor: nil)
+            return test_flight_request_client.get("appStoreVersions/#{app_store_version_id}/build", params)
           else
             return nil
           end
@@ -316,7 +316,7 @@ module Spaceship
             }
           }
 
-          @test_flight_request_client.patch("builds/#{build_id}", body)
+          test_flight_request_client.patch("builds/#{build_id}", body)
         end
 
         #
@@ -324,8 +324,8 @@ module Spaceship
         #
 
         def get_build_beta_details(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("buildBetaDetails", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("buildBetaDetails", params)
         end
 
         def patch_build_beta_details(build_beta_details_id: nil, attributes: {})
@@ -337,7 +337,7 @@ module Spaceship
             }
           }
 
-          @test_flight_request_client.patch("buildBetaDetails/#{build_beta_details_id}", body)
+          test_flight_request_client.patch("buildBetaDetails/#{build_beta_details_id}", body)
         end
 
         #
@@ -345,8 +345,8 @@ module Spaceship
         #
 
         def get_build_deliveries(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("buildDeliveries", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("buildDeliveries", params)
         end
 
         #
@@ -354,8 +354,8 @@ module Spaceship
         #
 
         def get_pre_release_versions(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("preReleaseVersions", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("preReleaseVersions", params)
         end
 
         #
@@ -363,14 +363,14 @@ module Spaceship
         #
 
         def get_beta_feedback(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = @test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          @test_flight_request_client.get("betaFeedbacks", params)
+          params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          test_flight_request_client.get("betaFeedbacks", params)
         end
 
         def delete_beta_feedback(feedback_id: nil)
           raise "Feedback id is nil" if feedback_id.nil?
 
-          @test_flight_request_client.delete("betaFeedbacks/#{feedback_id}")
+          test_flight_request_client.delete("betaFeedbacks/#{feedback_id}")
         end
       end
     end


### PR DESCRIPTION
### Motivation and Context
Fixes #17122
Fixes #17116

### Description
- Needed to log in to `Spaceship::ConnectAPI` in `Match::Spaceship::Ensure`
  - Worked fine if `match` was first thing called
  - Didn’t work if `produce` was called first because `Spaceship::ConnectAPI.client` was still only authed for tunes (not portal)
