### PR TITLE
[spaceship] automatically select Spaceship::Portal or Spaceship::Tunes team if env is set when logging into Spaceship:: ConnectAPI

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -28,7 +28,6 @@ module Deliver
     def login
       UI.message("Login to App Store Connect (#{options[:username]})")
       Spaceship::ConnectAPI.login(options[:username], nil, use_portal: false, use_tunes: true)
-      Spaceship::ConnectAPI.select_team
       UI.message("Login successful")
     end
 

--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -6,7 +6,6 @@ module Fastlane
 
         UI.message("Login to App Store Connect (#{params[:username]})")
         Spaceship::ConnectAPI.login(params[:username], use_portal: false, use_tunes: true)
-        Spaceship::ConnectAPI.select_team
         UI.message("Login successful")
 
         app = Spaceship::ConnectAPI::App.find(params[:app_identifier])

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -364,10 +364,7 @@ module Pilot
       begin
         team = tunes_client.teams.find { |t| t['contentProvider']['contentProviderId'].to_s == tunes_client.team_id }
         name = team['contentProvider']['name']
-        STDERR.puts("name: #{name}")
-        STDERR.puts("id: #{generic_transporter.provider_ids}")
         provider_id = generic_transporter.provider_ids[name]
-        STDERR.puts("provider_id: #{provider_id}")
         UI.verbose("Inferred provider id #{provider_id} for team #{name}.")
         return FastlaneCore::ItunesTransporter.new(options[:username], nil, false, provider_id)
       rescue => ex

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -24,8 +24,7 @@ module Pilot
         config[:username] ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
         UI.message("Login to App Store Connect (#{config[:username]})")
-        Spaceship::ConnectAPI.login(config[:username], use_portal: false, use_tunes: true)
-        Spaceship::ConnectAPI.select_team(tunes_team_id: config[:team_id], team_name: config[:team_name])
+        Spaceship::ConnectAPI.login(config[:username], use_portal: false, use_tunes: true, tunes_team_id: config[:team_id], team_name: config[:team_name])
         UI.message("Login successful")
       end
     end

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -10,7 +10,6 @@ module Produce
       @full_bundle_identifier.gsub!('*', Produce.config[:bundle_identifier_suffix].to_s) if wildcard_bundle?
 
       Spaceship::ConnectAPI.login(Produce.config[:username], nil, use_portal: false, use_tunes: true)
-      Spaceship::ConnectAPI.select_team
 
       create_new_app
     end

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -19,7 +19,6 @@ module Sigh
 
       UI.message("Starting login with user '#{Sigh.config[:username]}'")
       Spaceship::ConnectAPI.login(Sigh.config[:username], nil, use_portal: true, use_tunes: false)
-      Spaceship::ConnectAPI.select_team
       UI.message("Successfully logged in")
 
       profiles = [] if Sigh.config[:skip_fetch_profiles]

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -51,7 +51,7 @@ module Spaceship
         portal_client = Spaceship::Portal.login(user, password) if use_portal
         tunes_client = Spaceship::Tunes.login(user, password) if use_tunes
 
-        # Check is environment variables are set for Spaceship::Portal or Spaceship::Tunes to select team
+        # Check if environment variables are set for Spaceship::Portal or Spaceship::Tunes to select team
         portal_team_id ||= ENV['FASTLANE_TEAM_ID']
         portal_team_name = team_name || ENV['FASTLANE_TEAM_NAME']
         tunes_team_id ||= ENV['FASTLANE_ITC_TEAM_ID']

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -51,11 +51,15 @@ module Spaceship
         portal_client = Spaceship::Portal.login(user, password) if use_portal
         tunes_client = Spaceship::Tunes.login(user, password) if use_tunes
 
+        # Check is environment variables are set for Spaceship::Portal or Spaceship::Tunes to select team
+        has_portal_team_env = !(ENV['FASTLANE_TEAM_ID'] || ENV['FASTLANE_TEAM_NAME']).to_s.strip.empty?
+        has_tunes_team_env = !(ENV['FASTLANE_ITC_TEAM_ID'] || ENV['FASTLANE_ITC_TEAM_NAME']).to_s.strip.empty?
+
         # The clients will automatically select the first team if none is given
-        if portal_client && (!portal_team_id.nil? || !team_name.nil?)
+        if portal_client && (!portal_team_id.nil? || !team_name.nil? || has_portal_team_env)
           portal_client.select_team(team_id: portal_team_id, team_name: team_name)
         end
-        if tunes_client && (!tunes_team_id.nil? || !team_name.nil?)
+        if tunes_client && (!tunes_team_id.nil? || !team_name.nil? || has_tunes_team_env)
           tunes_client.select_team(team_id: tunes_team_id, team_name: team_name)
         end
 

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -52,14 +52,15 @@ module Spaceship
         tunes_client = Spaceship::Tunes.login(user, password) if use_tunes
 
         # Check is environment variables are set for Spaceship::Portal or Spaceship::Tunes to select team
-        has_portal_team_env = !(ENV['FASTLANE_TEAM_ID'] || ENV['FASTLANE_TEAM_NAME']).to_s.strip.empty?
-        has_tunes_team_env = !(ENV['FASTLANE_ITC_TEAM_ID'] || ENV['FASTLANE_ITC_TEAM_NAME']).to_s.strip.empty?
+        portal_team_id ||= ENV['FASTLANE_TEAM_ID']
+        tunes_team_id ||= ENV['FASTLANE_ITC_TEAM_ID']
+        team_name ||= ENV['FASTLANE_TEAM_NAME'] || ENV['FASTLANE_ITC_TEAM_NAME']
 
         # The clients will automatically select the first team if none is given
-        if portal_client && (!portal_team_id.nil? || !team_name.nil? || has_portal_team_env)
+        if portal_client && (!portal_team_id.to_s.strip.empty? || !team_name.to_s.strip.empty?)
           portal_client.select_team(team_id: portal_team_id, team_name: team_name)
         end
-        if tunes_client && (!tunes_team_id.nil? || !team_name.nil? || has_tunes_team_env)
+        if tunes_client && (!tunes_team_id.to_s.strip.empty? || !team_name.to_s.strip.empty?)
           tunes_client.select_team(team_id: tunes_team_id, team_name: team_name)
         end
 

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -53,15 +53,16 @@ module Spaceship
 
         # Check is environment variables are set for Spaceship::Portal or Spaceship::Tunes to select team
         portal_team_id ||= ENV['FASTLANE_TEAM_ID']
+        portal_team_name = team_name || ENV['FASTLANE_TEAM_NAME']
         tunes_team_id ||= ENV['FASTLANE_ITC_TEAM_ID']
-        team_name ||= ENV['FASTLANE_TEAM_NAME'] || ENV['FASTLANE_ITC_TEAM_NAME']
+        tunes_team_name = team_name || ENV['FASTLANE_ITC_TEAM_NAME']
 
         # The clients will automatically select the first team if none is given
-        if portal_client && (!portal_team_id.to_s.strip.empty? || !team_name.to_s.strip.empty?)
-          portal_client.select_team(team_id: portal_team_id, team_name: team_name)
+        if portal_client && (!portal_team_id.to_s.strip.empty? || !portal_team_name.to_s.strip.empty?)
+          portal_client.select_team(team_id: portal_team_id, team_name: portal_team_name)
         end
-        if tunes_client && (!tunes_team_id.to_s.strip.empty? || !team_name.to_s.strip.empty?)
-          tunes_client.select_team(team_id: tunes_team_id, team_name: team_name)
+        if tunes_client && (!tunes_team_id.to_s.strip.empty? || !tunes_team_name.to_s.strip.empty?)
+          tunes_client.select_team(team_id: tunes_team_id, team_name: tunes_team_name)
         end
 
         return ConnectAPI::Client.new(tunes_client: tunes_client, portal_client: portal_client)

--- a/spaceship/spec/connect_api/client_spec.rb
+++ b/spaceship/spec/connect_api/client_spec.rb
@@ -66,6 +66,8 @@ describe Spaceship::ConnectAPI::Client do
       let(:portal_client) { double('portal_client') }
 
       it 'no team_id or team_name' do
+        stub_const('ENV', {})
+
         expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
         expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
         expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
@@ -74,6 +76,8 @@ describe Spaceship::ConnectAPI::Client do
       end
 
       it 'with portal_team_id' do
+        stub_const('ENV', {})
+
         expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
         expect(Spaceship::TunesClient).not_to(receive(:login).with(username, password))
         expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: nil, portal_client: portal_client)
@@ -84,6 +88,8 @@ describe Spaceship::ConnectAPI::Client do
       end
 
       it 'with tunes_team_id' do
+        stub_const('ENV', {})
+
         expect(Spaceship::PortalClient).not_to(receive(:login).with(username, password))
         expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
         expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: nil)
@@ -94,6 +100,8 @@ describe Spaceship::ConnectAPI::Client do
       end
 
       it 'with team_name' do
+        stub_const('ENV', {})
+
         expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
         expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
         expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)

--- a/spaceship/spec/connect_api/client_spec.rb
+++ b/spaceship/spec/connect_api/client_spec.rb
@@ -102,6 +102,56 @@ describe Spaceship::ConnectAPI::Client do
         expect(portal_client).to receive(:select_team).with(team_id: nil, team_name: team_name)
         Spaceship::ConnectAPI::Client.login(username, password, team_name: team_name)
       end
+
+      context 'with environment variables' do
+        it 'with FASTLANE_TEAM_ID' do
+          stub_const('ENV', { 'FASTLANE_TEAM_ID' => team_id })
+
+          expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
+          expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
+
+          expect(portal_client).to receive(:select_team)
+          expect(tunes_client).not_to(receive(:select_team))
+          Spaceship::ConnectAPI::Client.login(username, password)
+        end
+
+        it 'with FASTLANE_ITC_TEAM_ID' do
+          stub_const('ENV', { 'FASTLANE_ITC_TEAM_ID' => team_id })
+
+          expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
+          expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
+
+          expect(portal_client).not_to(receive(:select_team))
+          expect(tunes_client).to receive(:select_team)
+          Spaceship::ConnectAPI::Client.login(username, password)
+        end
+
+        it 'with FASTLANE_TEAM_NAME' do
+          stub_const('ENV', { 'FASTLANE_TEAM_NAME' => team_name })
+
+          expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
+          expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
+
+          expect(portal_client).to receive(:select_team)
+          expect(tunes_client).not_to(receive(:select_team))
+          Spaceship::ConnectAPI::Client.login(username, password)
+        end
+
+        it 'with FASTLANE_ITC_TEAM_NAME' do
+          stub_const('ENV', { 'FASTLANE_ITC_TEAM_NAME' => team_name })
+
+          expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
+          expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
+
+          expect(portal_client).not_to(receive(:select_team))
+          expect(tunes_client).to receive(:select_team)
+          Spaceship::ConnectAPI::Client.login(username, password)
+        end
+      end
     end
 
     context "#in_house?" do


### PR DESCRIPTION
### Motivation and Context
Fixes #17125

### Description
- Console output was happening because `client.team_id` was being called when being set into the `Spaceship::ConnectAPI::Client`
  - The `select_team` calls were happening right away but this still shouldn’t get printed out to users
- Allow `select_team` to happen in `login` by looking for ENVs
- Remove unneeded `select_team`