### PR TITLE
[scan] fix default device list when using `skip_detect_devices`

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -187,15 +187,12 @@ module Scan
         end
       end
 
+      # Convert array to lazy enumerable (evaluate map only when needed)
       # grab the first unempty evaluated array
-      if default
-        Scan.devices = [matches, default].lazy.map { |x|
-          arr = x.call
-          arr unless arr.empty?
-        }.reject(&:nil?).first
-      else
-        Scan.devices = []
-      end
+      Scan.devices = [matches, default].lazy.reject(&:nil?).map { |x|
+        arr = x.call
+        arr unless arr.empty?
+      }.reject(&:nil?).first
     end
 
     def self.min_xcode8?


### PR DESCRIPTION
This change fixes a bug where the `devices` list is not used when `skip_detect_devices` is `true`.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

For our UI tests, we want our tests to run on specific simulators (e.g. '["iPhone 6s", "iPad Air"]'). However, if Scan cannot find these simulators because they are not installed on the machine running the tests, we want the tests to fail as opposed to automatically finding another installed simulator. In the Scan docs, there is a configuration value called `skip_detect_devices` which specifically states:

> Should skip auto detecting of devices if none were specified

Therefore, setting this configuration to `true` should remove the ability to automatically detect another simulator and force Scan to use one of the simulators we specified in the `devices` list.

However, as it is currently written, if you set `skip_detect_devices` and also have a list of simulators to test with using the `devices` array, those simulators you specified will not be used and the execution of Scan will error with the following message:

```
xcodebuild: error: Failed to build workspace [Workspace] with scheme [Scheme].
	Reason: A build only device cannot be used to run this target.
	Recovery suggestion: No supported devices are available running a compatible version of iOS. Connect a device with a newer version of iOS in order to run your application (or choose a simulated device as the destination).
```

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This change makes it so that `matches` are not thrown out if the `default` option is `null` by assigning `default` to an empty array when `skip_detect_devices` is `true`. I tested my proposed fix by running `scan` with the following command and successfully ran the tests with the following simulators:

```
  desc "Runs all the tests"
  lane :lane_test do
    scan(
      workspace: ENV["XCWORKSPACE"],
      scheme: ENV["SCHEME"],
      configuration: "Local",
      skip_build: true,
      skip_detect_devices: true,
      devices: ["iPhone 6s", "iPad Air"]
    )
  end
```

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

```
bundle exec fastlane lane_test
```