### PR TITLE
[actions] fix download_dsyms, app_store_build_number, and test_flight_build_number

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -37,7 +37,7 @@ module Fastlane
         if params[:live]
           UI.message("Fetching the latest build number for live-version")
           live_version = app.get_live_app_store_version(platform: platform)
-          
+
           UI.user_error!("Could not find a live-version of #{params[:app_identifier]} on App Store Connect") unless live_version
           build_nr = live_version.build.version
 

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -27,26 +27,29 @@ module Fastlane
 
       def self.get_build_number(params)
         UI.message("Login to App Store Connect (#{params[:username]})")
-        Spaceship::Tunes.login(params[:username])
-        Spaceship::Tunes.select_team(team_id: params[:team_id], team_name: params[:team_name])
+        Spaceship::ConnectAPI.login(params[:username], use_portal: false, use_tunes: true, tunes_team_id: params[:team_id], team_name: params[:team_name])
         UI.message("Login successful")
 
-        app = Spaceship::Tunes::Application.find(params[:app_identifier], mac: params[:platform] == "osx")
+        platform = Spaceship::ConnectAPI::Platform.map(params[:platform])
+
+        app = Spaceship::ConnectAPI::App.find(params[:app_identifier])
         UI.user_error!("Could not find an app on App Store Connect with app_identifier: #{params[:app_identifier]}") unless app
         if params[:live]
           UI.message("Fetching the latest build number for live-version")
-          UI.user_error!("Could not find a live-version of #{params[:app_identifier]} on iTC") unless app.live_version
-          build_nr = app.live_version.current_build_number
+          live_version = app.get_live_app_store_version(platform: platform)
+          
+          UI.user_error!("Could not find a live-version of #{params[:app_identifier]} on App Store Connect") unless live_version
+          build_nr = live_version.build.version
 
-          UI.message("Latest upload for live-version #{app.live_version.version} is build: #{build_nr}")
+          UI.message("Latest upload for live-version #{live_version.version_string} is build: #{build_nr}")
 
-          return OpenStruct.new({ build_nr: build_nr, build_v: app.live_version.version })
+          return OpenStruct.new({ build_nr: build_nr, build_v: live_version.version_string })
         else
           version_number = params[:version]
           platform = params[:platform]
 
           # Create filter for get_builds with optional version number
-          filter = { app: app.apple_id }
+          filter = { app: app.id }
           if version_number
             filter["preReleaseVersion.version"] = version_number
             version_number_message = "version #{version_number}"

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -6,16 +6,16 @@ module Fastlane
     class DownloadDsymsAction < Action
       # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
+        require 'openssl'
         require 'spaceship'
         require 'net/http'
 
         UI.message("Login to App Store Connect (#{params[:username]})")
-        Spaceship::Tunes.login(params[:username])
-        Spaceship::Tunes.select_team
+        Spaceship::ConnectAPI.login(params[:username], use_portal: false, use_tunes: true)
         UI.message("Login successful")
 
         # Get App
-        app = Spaceship::Application.find(params[:app_identifier])
+        app = Spaceship::ConnectAPI::App.find(params[:app_identifier])
         unless app
           UI.user_error!("Could not find app with bundle identifier '#{params[:app_identifier]}' on account #{params[:username]}")
         end
@@ -23,38 +23,35 @@ module Fastlane
         # Process options
         version = params[:version]
         build_number = params[:build_number].to_s unless params[:build_number].nil?
-        platform = params[:platform]
+        itc_platform = params[:platform]
         output_directory = params[:output_directory]
         wait_for_dsym_processing = params[:wait_for_dsym_processing]
         wait_timeout = params[:wait_timeout]
         min_version = Gem::Version.new(params[:min_version]) if params[:min_version]
 
+        platform = Spaceship::ConnectAPI::Platform.map(itc_platform)
+
         # Set version if it is latest
         if version == 'latest'
           # Try to grab the edit version first, else fallback to live version
           UI.message("Looking for latest version...")
-          latest_version = app.edit_version(platform: platform) || app.live_version(platform: platform)
+          latest_version = app.get_edit_app_store_version(platform: platform) || app.get_live_app_store_version(platform: platform)
 
-          UI.user_error!("Could not find latest version for your app, please try setting a specific version") if latest_version.version.nil?
+          UI.user_error!("Could not find latest version for your app, please try setting a specific version") if latest_version.nil?
 
-          latest_candidate_build = latest_version.candidate_builds.max_by(&:upload_date)
-          if latest_candidate_build.nil?
-            version = latest_version.version
-            build_number = latest_version.build_version
-          else
-            # The build_version of a candidate build does not always match the one in latest_version so get the version and build number from the same place.
-            version = latest_candidate_build.train_version
-            build_number = latest_candidate_build.build_version
-          end
+          latest_build = get_latest_build!(app_id: app.id, version: latest_version.version_string, platform: platform)
+
+          version = latest_build.app_version
+          build_number = latest_build.version
         elsif version == 'live'
           UI.message("Looking for live version...")
-          live_version = app.live_version(platform: platform)
+          live_version = app.get_live_app_store_version(platform: platform)
 
           UI.user_error!("Could not find live version for your app, please try setting 'latest' or a specific version") if live_version.nil?
 
           # No need to search for candidates, because released App Store version should only have one build
-          version = live_version.version
-          build_number = live_version.build_version
+          version = live_version.version_string
+          build_number = live_version.build.version
         end
 
         # Remove leading zeros from version string (eg. 1.02 -> 1.2)
@@ -74,75 +71,97 @@ module Fastlane
         message << "(#{build_number})" if build_number
         UI.message(message.join(" "))
 
-        app.tunes_all_build_trains(platform: platform).each do |train|
+        filter = { app: app.id }
+        filter["preReleaseVersion.platform"] = platform
+        build_resps = Spaceship::ConnectAPI.get_builds(filter: filter, sort: "-uploadedDate", includes: "preReleaseVersion").all_pages
+        builds = build_resps.flat_map(&:to_models)
+
+        builds.each do |build|
+          asc_app_version = build.app_version
+          asc_build_number = build.version
+
           message = []
-          message << "Found train (version): #{train.version_string}"
+          message << "Found train (version): #{asc_app_version}"
           message << ", comparing to supplied version: #{version}" if version
           UI.verbose(message.join(" "))
 
-          if version && version != train.version_string
-            UI.verbose("Version #{version} doesn't match: #{train.version_string}")
+          if version && version != asc_app_version
+            UI.verbose("Version #{version} doesn't match: #{asc_app_version}")
             next
           end
 
-          if min_version && min_version > Gem::Version.new(train.version_string)
-            UI.verbose("Min version #{min_version} not reached: #{train.version_string}")
+          if min_version && min_version > Gem::Version.new(asc_app_version)
+            UI.verbose("Min version #{min_version} not reached: #{asc_app_version}")
             next
           end
 
-          app.tunes_all_builds_for_train(train: train.version_string, platform: platform).each do |build|
-            message = []
-            message << "Found build version: #{build.build_version}"
-            message << ", comparing to supplied build_number: #{build_number}" if build_number
-            UI.verbose(message.join(" "))
+          message = []
+          message << "Found build version: #{asc_build_number}"
+          message << ", comparing to supplied build_number: #{build_number}" if build_number
+          UI.verbose(message.join(" "))
 
-            if build_number && build.build_version != build_number
-              UI.verbose("build_version: #{build.build_version} doesn't match: #{build_number}")
+          if build_number && asc_build_number != build_number
+            UI.verbose("build_version: #{asc_build_number} doesn't match: #{build_number}")
+            next
+          end
+
+          UI.verbose("Build_version: #{asc_build_number} matches #{build_number}, grabbing dsym_url") if build_number
+          get_details_and_download_dsym(app_id: app.id, train: asc_app_version, build_number: asc_build_number, platform: itc_platform, wait_for_dsym_processing: wait_for_dsym_processing, wait_timeout: wait_timeout, output_directory: output_directory)
+        end
+      end
+
+      def self.get_details_and_download_dsym(app_id: nil, train: nil, build_number: nil, platform: nil, wait_for_dsym_processing: nil, wait_timeout: nil, output_directory: nil)
+        start = Time.now
+        download_url = nil
+
+        loop do
+          begin
+            resp = Spaceship::Tunes.client.build_details(app_id: app_id, train: train, build_number: build_number, platform: platform)
+
+            resp['apple_id'] = app_id
+            build_details = Spaceship::Tunes::BuildDetails.factory(resp)
+
+            download_url = build_details.dsym_url
+            UI.verbose("dsym_url: #{download_url}")
+          rescue Spaceship::TunesClient::ITunesConnectError => ex
+            UI.error("Error accessing dSYM file for build\n\n#{build}\n\nException: #{ex}")
+          end
+
+          unless download_url
+            if !wait_for_dsym_processing || (Time.now - start) > wait_timeout
+              # In some cases, AppStoreConnect does not process the dSYMs, thus no error should be thrown.
+              UI.message("Could not find any dSYM for #{build_number} (#{train})")
+            else
+              UI.message("Waiting for dSYM file to appear...")
+              sleep(30)
               next
             end
-
-            UI.verbose("Build_version: #{build.build_version} matches #{build_number}, grabbing dsym_url") if build_number
-
-            start = Time.now
-            download_url = nil
-
-            loop do
-              begin
-                build_details = app.tunes_build_details(train: train.version_string, build_number: build.build_version, platform: platform)
-                download_url = build_details.dsym_url
-                UI.verbose("dsym_url: #{download_url}")
-              rescue Spaceship::TunesClient::ITunesConnectError => ex
-                UI.error("Error accessing dSYM file for build\n\n#{build}\n\nException: #{ex}")
-              end
-
-              unless download_url
-                if !wait_for_dsym_processing || (Time.now - start) > wait_timeout
-                  # In some cases, AppStoreConnect does not process the dSYMs, thus no error should be thrown.
-                  UI.message("Could not find any dSYM for #{build.build_version} (#{train.version_string})")
-                else
-                  UI.message("Waiting for dSYM file to appear...")
-                  sleep(30)
-                  next
-                end
-              end
-
-              break
-            end
-
-            if download_url
-              self.download(download_url, app.bundle_id, train.version_string, build.build_version, output_directory)
-              break if build_number
-            else
-              UI.message("No dSYM URL for #{build.build_version} (#{train.version_string})")
-            end
           end
+
+          return
         end
 
-        if (Actions.lane_context[SharedValues::DSYM_PATHS] || []).count == 0
-          UI.error("No dSYM files found on App Store Connect - this usually happens when no recompiling has happened yet")
+        if download_url
+          self.download(download_url, app.bundle_id, train.version_string, build.build_version, output_directory)
+          return if build_number
+        else
+          UI.message("No dSYM URL for #{build.build_version} (#{train.version_string})")
         end
       end
       # rubocop:enable Metrics/PerceivedComplexity
+
+      def self.get_latest_build!(app_id: nil, version: nil, platform: nil)
+        filter = { app: app_id }
+        filter["preReleaseVersion.version"] = version
+        filter["preReleaseVersion.platform"] = platform
+        latest_build = Spaceship::ConnectAPI.get_builds(filter: filter, sort: "-uploadedDate", includes: "preReleaseVersion").first
+
+        if latest_build.nil?
+          UI.user_error!("Could not find latest bulid for version #{version}")
+        end
+
+        return latest_build
+      end
 
       def self.download(download_url, bundle_id, train_number, build_version, output_directory)
         result = self.download_file(download_url)

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -106,19 +106,19 @@ module Fastlane
           end
 
           UI.verbose("Build_version: #{asc_build_number} matches #{build_number}, grabbing dsym_url") if build_number
-          get_details_and_download_dsym(app_id: app.id, train: asc_app_version, build_number: asc_build_number, platform: itc_platform, wait_for_dsym_processing: wait_for_dsym_processing, wait_timeout: wait_timeout, output_directory: output_directory)
+          get_details_and_download_dsym(app: app, train: asc_app_version, build_number: asc_build_number, platform: itc_platform, wait_for_dsym_processing: wait_for_dsym_processing, wait_timeout: wait_timeout, output_directory: output_directory)
         end
       end
 
-      def self.get_details_and_download_dsym(app_id: nil, train: nil, build_number: nil, platform: nil, wait_for_dsym_processing: nil, wait_timeout: nil, output_directory: nil)
+      def self.get_details_and_download_dsym(app: nil, train: nil, build_number: nil, platform: nil, wait_for_dsym_processing: nil, wait_timeout: nil, output_directory: nil)
         start = Time.now
         download_url = nil
 
         loop do
           begin
-            resp = Spaceship::Tunes.client.build_details(app_id: app_id, train: train, build_number: build_number, platform: platform)
+            resp = Spaceship::Tunes.client.build_details(app_id: app.id, train: train, build_number: build_number, platform: platform)
 
-            resp['apple_id'] = app_id
+            resp['apple_id'] = app.id
             build_details = Spaceship::Tunes::BuildDetails.factory(resp)
 
             download_url = build_details.dsym_url
@@ -138,14 +138,14 @@ module Fastlane
             end
           end
 
-          return
+          break
         end
 
         if download_url
-          self.download(download_url, app.bundle_id, train.version_string, build.build_version, output_directory)
+          self.download(download_url, app.bundle_id, train, build_number, output_directory)
           return if build_number
         else
-          UI.message("No dSYM URL for #{build.build_version} (#{train.version_string})")
+          UI.message("No dSYM URL for #{build_number} (#{train})")
         end
       end
       # rubocop:enable Metrics/PerceivedComplexity

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -3,58 +3,86 @@ describe Fastlane do
     describe "download_dsyms" do
       # 1 app, 2 trains/versions, 2 builds each
       let(:app) { double('app') }
+      let(:build_resp) { double('build_resp') }
+      let(:tunes_client) { double('tunes_client') }
+
       let(:version) { double('version') }
       let(:live_version) { double('live_version') }
-      let(:train) { double('train') }
-      let(:train2) { double('train2') }
-      let(:train3) { double('train3') }
-      let(:build) { double('build') }
+
+      let(:build1) { double('build1') }
       let(:build2) { double('build2') }
       let(:build3) { double('build3') }
       let(:build4) { double('build4') }
+      let(:build5) { double('build5') }
+      let(:build6) { double('build6') }
+
       let(:empty_build) { double('empty_build') }
+
+      let(:build_detail_resp) { double('build_detail_resp') }
       let(:build_detail) { double('build_detail') }
+      let(:empty_build_detail_resp) { double('empty_build_detail_resp') }
       let(:empty_build_detail) { double('empty_build_detail') }
+
       let(:download_url) { 'https://example.com/myapp-dsym' }
+
       before do
+        allow(Spaceship::Tunes).to receive(:client).and_return(tunes_client)
+
         # login
-        allow(Spaceship::Tunes).to receive(:login)
-        allow(Spaceship::Tunes).to receive(:select_team)
-        allow(Spaceship::Application).to receive(:find).and_return(app)
-        # trains
-        allow(app).to receive(:tunes_all_build_trains).and_return([train, train2, train3])
-        # build_detail + download
+        allow(Spaceship::ConnectAPI).to receive(:login)
+        allow(Spaceship::ConnectAPI::App). to receive(:find).and_return(app)
+        allow(app).to receive(:id).and_return("id")
+        allow(app).to receive(:bundle_id).and_return('tools.fastlane.myapp')
+
+        # builds
+        allow(Spaceship::ConnectAPI).to receive(:get_builds).and_return(build_resp)
+        allow(build_resp).to receive(:all_pages).and_return([build_resp])
+
+        allow(build_detail_resp).to receive(:[]=).with("apple_id", app.id)
+        allow(empty_build_detail).to receive(:[]=).with("apple_id", app.id)
+
         allow(build_detail).to receive(:dsym_url).and_return(download_url)
         allow(empty_build_detail).to receive(:dsym_url).and_return(nil)
-        allow(app).to receive(:bundle_id).and_return('tools.fastlane.myapp')
-        allow(train).to receive(:version_string).and_return('1.0.0')
-        allow(train2).to receive(:version_string).and_return('1.7.0')
-        allow(train3).to receive(:version_string).and_return('2.0.0')
-        allow(build).to receive(:build_version).and_return('1')
-        allow(build2).to receive(:build_version).and_return('2')
-        allow(build3).to receive(:build_version).and_return('3')
-        allow(build4).to receive(:build_version).and_return('4')
-        allow(empty_build).to receive(:build_version).and_return('5')
+
         allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)
       end
 
+      # before do
+      #   # login
+      #   allow(Spaceship::Tunes).to receive(:login)
+      #   allow(Spaceship::Tunes).to receive(:select_team)
+      #   allow(Spaceship::Application).to receive(:find).and_return(app)
+      #   # trains
+      #   allow(app).to receive(:tunes_all_build_trains).and_return([train, train2, train3])
+      #   # build_detail + download
+      #   allow(build_detail).to receive(:dsym_url).and_return(download_url)
+      #   allow(empty_build_detail).to receive(:dsym_url).and_return(nil)
+      #   allow(app).to receive(:bundle_id).and_return('tools.fastlane.myapp')
+      #   allow(train).to receive(:version_string).and_return('1.0.0')
+      #   allow(train2).to receive(:version_string).and_return('1.7.0')
+      #   allow(train3).to receive(:version_string).and_return('2.0.0')
+      #   allow(build).to receive(:build_version).and_return('1')
+      #   allow(build2).to receive(:build_version).and_return('2')
+      #   allow(build3).to receive(:build_version).and_return('3')
+      #   allow(build4).to receive(:build_version).and_return('4')
+      #   allow(empty_build).to receive(:build_version).and_return('5')
+      #   allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)
+      # end
+
       context 'with no special options' do
         it 'downloads all dsyms of all builds in all trains' do
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build3])
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, empty_build])
-          expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '1', platform: :ios).and_return(build_detail)
-          expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '2', platform: :ios).and_return(build_detail)
-          expect(app).to receive(:tunes_build_details).with(train: '1.7.0', build_number: '3', platform: :ios).and_return(build_detail)
-          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '1', platform: :ios).and_return(build_detail)
-          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
-          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '5', platform: :ios).and_return(empty_build_detail)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build.build_version, nil)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build2.build_version, nil)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build3.build_version, nil)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build.build_version, nil)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build2.build_version, nil)
+          expect(build_resp).to receive(:to_models).and_return([build1, build2, build3, build4, build5, build6])
+
+          [[build1, '1.0.0', '1'], [build2, '1.0.0', '2'], [build3, '1.7.0', '4'], [build4, '2.0.0', '1'], [build5, '2.0.0', '2'], [build6, '2.0.0', '5']].each do |build, version, build_number|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+            expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
+            expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+          end
+
           expect(Fastlane::Actions::DownloadDsymsAction).not_to(receive(:download))
+
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp')
           end").runner.execute(:test)
@@ -63,9 +91,16 @@ describe Fastlane do
 
       context 'with version with leading zero' do
         it 'downloads all dsyms of all builds in train 1.07.0' do
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build3])
-          expect(app).to receive(:tunes_build_details).with(train: '1.7.0', build_number: '3', platform: :ios).and_return(build_detail)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train2.version_string, build3.build_version, nil)
+          expect(build_resp).to receive(:to_models).and_return([build1])
+
+          [[build1, '1.7.0', '3']].each do |build, version, build_number|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+            expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
+            expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+          end
+
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: '1.07.0')
           end").runner.execute(:test)
@@ -74,9 +109,16 @@ describe Fastlane do
 
       context 'when build_number is an integer' do
         it 'downloads the correct dsyms' do
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build2])
-          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build2.build_version, nil)
+          expect(build_resp).to receive(:to_models).and_return([build1])
+
+          [[build1, '2.0.0', '2']].each do |build, version, build_number|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+            expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
+            expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+          end
+
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: '2.0.0', build_number: 2)
           end").runner.execute(:test)
@@ -84,21 +126,28 @@ describe Fastlane do
       end
 
       context 'when version is latest' do
-        before do
-          # latest
-          allow(app).to receive(:edit_version).and_return(version)
-          allow(version).to receive(:version).and_return('2.0.0')
-          allow(version).to receive(:candidate_builds).and_return([build2, build3])
-          allow(build2).to receive(:train_version).and_return('2.0.0')
-          allow(build2).to receive(:upload_date).and_return(1_547_145_145_000)
-          allow(build3).to receive(:train_version).and_return('2.0.0')
-          allow(build3).to receive(:build_version).and_return('2')
-          allow(build3).to receive(:upload_date).and_return(1_547_196_482_000)
-        end
         it 'downloads only dsyms of latest build in latest train' do
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, build3])
-          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build2.build_version, nil)
+          expect(app).to receive(:get_edit_app_store_version).and_return(version)
+          expect(version).to receive(:version_string).and_return('2.0.0')
+
+          expect(Spaceship::ConnectAPI).to receive(:get_builds).and_return([build2, build1])
+
+          expect(build_resp).to receive(:to_models).and_return([build1, build2])
+
+          [[build1, '2.0.0', '2']].each do |build, version, build_number|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+          end
+
+          [[build2, '2.0.0', '3']].each do |build, version, build_number|
+            expect(build).to receive(:app_version).and_return(version).twice
+            expect(build).to receive(:version).and_return(build_number).twice
+
+            expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
+            expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+          end
+
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: 'latest')
           end").runner.execute(:test)
@@ -106,19 +155,28 @@ describe Fastlane do
       end
 
       context 'when version is live' do
-        before do
-          # live
-          allow(app).to receive(:live_version).and_return(live_version)
-          allow(live_version).to receive(:version).and_return('1.0.0')
-          allow(live_version).to receive(:build_version).and_return('42')
-          allow(live_version).to receive(:candidate_builds).and_return([build])
-          allow(build).to receive(:build_version).and_return('42')
-          allow(build).to receive(:upload_date).and_return(1_547_196_482_000)
-        end
         it 'downloads only dsyms of live build' do
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2, build3])
-          expect(app).to receive(:tunes_build_details).with(train: '1.0.0', build_number: '42', platform: :ios).and_return(build_detail)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train.version_string, build.build_version, nil)
+          expect(app).to receive(:get_live_app_store_version).and_return(version)
+          expect(version).to receive(:version_string).and_return('1.0.0')
+          version_build = double('version_build')
+          expect(version_build).to receive(:version).and_return('42')
+          expect(version).to receive(:build).and_return(version_build)
+
+          expect(build_resp).to receive(:to_models).and_return([build1, build2])
+
+          [[build1, '1.0.0', '33']].each do |build, version, build_number|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+          end
+
+          [[build2, '1.0.0', '42']].each do |build, version, build_number|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+
+            expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
+            expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+          end
 
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', version: 'live')
@@ -128,11 +186,21 @@ describe Fastlane do
 
       context 'when min_version is set' do
         it 'downloads only dsyms of trains newer than or equal min_version' do
-          expect(app).to receive(:tunes_all_builds_for_train).and_return([build, build2])
-          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '1', platform: :ios).and_return(build_detail)
-          expect(app).to receive(:tunes_build_details).with(train: '2.0.0', build_number: '2', platform: :ios).and_return(build_detail)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build.build_version, nil)
-          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, train3.version_string, build2.build_version, nil)
+          expect(build_resp).to receive(:to_models).and_return([build1, build2])
+
+          [[build1, '1.0.0', '33']].each do |build, version, build_number|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+          end
+
+          [[build2, '2.0.0', '42']].each do |build, version, build_number|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+
+            expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
+            expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+          end
 
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', min_version: '2.0.0')

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -6,6 +6,7 @@ require 'logger'
 require 'tmpdir'
 require 'cgi'
 require 'tempfile'
+require 'openssl'
 
 require 'fastlane/version'
 require_relative 'helper/net_http_generic_request'

--- a/spaceship/lib/spaceship/connect_api/file_uploader.rb
+++ b/spaceship/lib/spaceship/connect_api/file_uploader.rb
@@ -4,6 +4,8 @@ require 'faraday_middleware'
 
 require 'spaceship/globals'
 
+require 'openssl'
+
 module Spaceship
   class ConnectAPI
     module FileUploader


### PR DESCRIPTION
### Motivation and Context
Fixes #17140
Fixes #17132

### Description
- Replace deprecated `Spaceship::Tunes` calls with `Spaceship::ConnectAPI`
  - `app.live_version` to `app.get_live_app_store_version`
  - `app.edit_version` to `get_edit_app_store_version`

### Testing Steps

Update `Gemfile` and run `bundle update fastlane`, `bundle update`, or `bundle install`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-fix-broken-live-version-edit-version-actions"
```
