### PR TITLE
[frameit] allow setting font_weight for keyword/title

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -164,6 +164,7 @@ The `keyword` and `title` parameters are both used in `default` and `data`. They
 | `color` | The font color for the text. Specify a hex/html color code. | `#000000` (black) |
 | `font` | The font family for the text. Specify the (relative) path to the font file (e.g. an OpenType Font). | The default `imagemagick` font, which is system dependent. |
 | `font_size` | The font size for the text specified in points. If not specified or `0`, font will be scaled automatically to fit the available space. _frameit_ still shrinks the text, if it would not fit. | NA |
+| `font_weight` | The [font weight for the text](https://imagemagick.org/script/command-line-options.php#weight). Specify an integer value (e.g. 900). | NA |
 | `text` | The text that should be used for the `keyword` or `title`. <p> Note: If you want to use localised text, use [`.strings` files](#strings-files). | NA |
 
 ### Example

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -429,6 +429,7 @@ module Frameit
         # Add the actual title
         text_image.combine_options do |i|
           i.font(current_font) if current_font
+          i.weight(@config[key.to_s]['font_weight']) if @config[key.to_s]['font_weight']
           i.gravity("Center")
           i.pointsize(actual_font_size(key))
           i.draw("text 0,0 '#{text}'")


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
    * Just got a couple of exceptions when running `bundle exec fastlane testbacon`: `Failure/Error: require 'bacon'` any ideas?
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Allows defining a font_weight for title and keyword which will be used for rendering the text into the image.

### Testing Steps

add a `"font_weight": "900"` in addition to the "font" setting, will change the `-font` parameter to image magick.
