### PR TITLE
[spaceship][match] fix and improve team selection flow with Spaceship::ConnectAPI client

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -26,6 +26,8 @@ module Deliver
     end
 
     def login
+      # Team selection passed though FASTLANE_TEAM_ID and FASTLANE_TEAM_NAME environment variables
+      # Prompts select team if multiple teams and none specified
       UI.message("Login to App Store Connect (#{options[:username]})")
       Spaceship::ConnectAPI.login(options[:username], nil, use_portal: false, use_tunes: true)
       UI.message("Login successful")

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -26,6 +26,7 @@ module Fastlane
       end
 
       def self.get_build_number(params)
+        # Prompts select team if multiple teams and none specified
         UI.message("Login to App Store Connect (#{params[:username]})")
         Spaceship::ConnectAPI.login(params[:username], use_portal: false, use_tunes: true, tunes_team_id: params[:team_id], team_name: params[:team_name])
         UI.message("Login successful")

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -10,6 +10,8 @@ module Fastlane
         require 'spaceship'
         require 'net/http'
 
+        # Team selection passed though FASTLANE_ITC_TEAM_ID and FASTLANE_ITC_TEAM_NAME environment variables
+        # Prompts select team if multiple teams and none specified
         UI.message("Login to App Store Connect (#{params[:username]})")
         Spaceship::ConnectAPI.login(params[:username], use_portal: false, use_tunes: true)
         UI.message("Login successful")

--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -4,6 +4,8 @@ module Fastlane
       def self.run(params)
         require 'spaceship'
 
+        # Team selection passed though FASTLANE_ITC_TEAM_ID and FASTLANE_ITC_TEAM_NAME environment variables
+        # Prompts select team if multiple teams and none specified
         UI.message("Login to App Store Connect (#{params[:username]})")
         Spaceship::ConnectAPI.login(params[:username], use_portal: false, use_tunes: true)
         UI.message("Login successful")

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -18,9 +18,9 @@ module Match
         UI.important("More information https://docs.fastlane.tools/actions/match/#access-control")
       end
 
+      # Prompts select team if multiple teams and none specified
       UI.message("Verifying that the certificate and profile are still valid on the Dev Portal...")
-      Spaceship::ConnectAPI.login(use_portal: true, use_tunes: false)
-      Spaceship::ConnectAPI.select_team
+      Spaceship::ConnectAPI.login(user, use_portal: true, use_tunes: false, portal_team_id: team_id, team_name: team_name)
     end
 
     # The team ID of the currently logged in team

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -25,7 +25,7 @@ module Match
 
     # The team ID of the currently logged in team
     def team_id
-      return Spaceship::ConnectAPI.client.team_id
+      return Spaceship::ConnectAPI.client.portal_team_id
     end
 
     def bundle_identifier_exists(username: nil, app_identifier: nil, platform: nil)

--- a/produce/lib/produce/itunes_connect.rb
+++ b/produce/lib/produce/itunes_connect.rb
@@ -9,6 +9,8 @@ module Produce
       @full_bundle_identifier = app_identifier
       @full_bundle_identifier.gsub!('*', Produce.config[:bundle_identifier_suffix].to_s) if wildcard_bundle?
 
+      # Team selection passed though FASTLANE_ITC_TEAM_ID and FASTLANE_ITC_TEAM_NAME environment variables
+      # Prompts select team if multiple teams and none specified
       Spaceship::ConnectAPI.login(Produce.config[:username], nil, use_portal: false, use_tunes: true)
 
       create_new_app

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -17,6 +17,8 @@ module Sigh
                                          hide_keys: [:output_path],
                                              title: "Summary for sigh #{Fastlane::VERSION}")
 
+      # Team selection passed though FASTLANE_ITC_TEAM_ID and FASTLANE_ITC_TEAM_NAME environment variables
+      # Prompts select team if multiple teams and none specified
       UI.message("Starting login with user '#{Sigh.config[:username]}'")
       Spaceship::ConnectAPI.login(Sigh.config[:username], nil, use_portal: true, use_tunes: false)
       UI.message("Successfully logged in")

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -93,6 +93,16 @@ module Spaceship
         )
       end
 
+      def portal_team_id
+        return nil if @portal_client.nil?
+        return @portal_client.team_id
+      end
+
+      def tunes_team_id
+        return nil if @tunes_client.nil?
+        return @tunes_client.team_id
+      end
+
       def in_house?
         if token
           if token.in_house.nil?

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -57,13 +57,11 @@ module Spaceship
         tunes_team_id ||= ENV['FASTLANE_ITC_TEAM_ID']
         tunes_team_name = team_name || ENV['FASTLANE_ITC_TEAM_NAME']
 
-        # The clients will automatically select the first team if none is given
-        if portal_client && (!portal_team_id.to_s.strip.empty? || !portal_team_name.to_s.strip.empty?)
-          portal_client.select_team(team_id: portal_team_id, team_name: portal_team_name)
-        end
-        if tunes_client && (!tunes_team_id.to_s.strip.empty? || !tunes_team_name.to_s.strip.empty?)
-          tunes_client.select_team(team_id: tunes_team_id, team_name: tunes_team_name)
-        end
+        # The clients will prompt for a team selection if:
+        # 1. client exists
+        # 2. team_id and team_name are nil and user belongs to multiple teams
+        portal_client.select_team(team_id: portal_team_id, team_name: portal_team_name) if portal_client
+        tunes_client.select_team(team_id: tunes_team_id, team_name: tunes_team_name) if tunes_client
 
         return ConnectAPI::Client.new(tunes_client: tunes_client, portal_client: portal_client)
       end

--- a/spaceship/spec/connect_api/client_spec.rb
+++ b/spaceship/spec/connect_api/client_spec.rb
@@ -72,6 +72,9 @@ describe Spaceship::ConnectAPI::Client do
         expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
         expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
 
+        expect(portal_client).to receive(:select_team).with(team_id: nil, team_name: nil)
+        expect(tunes_client).to receive(:select_team).with(team_id: nil, team_name: nil)
+
         Spaceship::ConnectAPI::Client.login(username, password)
       end
 
@@ -116,48 +119,48 @@ describe Spaceship::ConnectAPI::Client do
           stub_const('ENV', { 'FASTLANE_TEAM_ID' => team_id })
 
           expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
-          expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
-          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
+          expect(Spaceship::TunesClient).not_to(receive(:login).with(username, password))
+          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: nil, portal_client: portal_client)
 
           expect(portal_client).to receive(:select_team)
           expect(tunes_client).not_to(receive(:select_team))
-          Spaceship::ConnectAPI::Client.login(username, password)
+          Spaceship::ConnectAPI::Client.login(username, password, use_portal: true, use_tunes: false)
         end
 
         it 'with FASTLANE_ITC_TEAM_ID' do
           stub_const('ENV', { 'FASTLANE_ITC_TEAM_ID' => team_id })
 
-          expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
+          expect(Spaceship::PortalClient).not_to(receive(:login).with(username, password))
           expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
-          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: nil)
 
           expect(portal_client).not_to(receive(:select_team))
           expect(tunes_client).to receive(:select_team)
-          Spaceship::ConnectAPI::Client.login(username, password)
+          Spaceship::ConnectAPI::Client.login(username, password, use_portal: false, use_tunes: true)
         end
 
         it 'with FASTLANE_TEAM_NAME' do
           stub_const('ENV', { 'FASTLANE_TEAM_NAME' => team_name })
 
           expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
-          expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
-          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
+          expect(Spaceship::TunesClient).not_to(receive(:login).with(username, password))
+          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: nil, portal_client: portal_client)
 
           expect(portal_client).to receive(:select_team)
           expect(tunes_client).not_to(receive(:select_team))
-          Spaceship::ConnectAPI::Client.login(username, password)
+          Spaceship::ConnectAPI::Client.login(username, password, use_portal: true, use_tunes: false)
         end
 
         it 'with FASTLANE_ITC_TEAM_NAME' do
           stub_const('ENV', { 'FASTLANE_ITC_TEAM_NAME' => team_name })
 
-          expect(Spaceship::PortalClient).to receive(:login).with(username, password).and_return(portal_client)
+          expect(Spaceship::PortalClient).not_to(receive(:login).with(username, password))
           expect(Spaceship::TunesClient).to receive(:login).with(username, password).and_return(tunes_client)
-          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: portal_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:new).with(tunes_client: tunes_client, portal_client: nil)
 
           expect(portal_client).not_to(receive(:select_team))
           expect(tunes_client).to receive(:select_team)
-          Spaceship::ConnectAPI::Client.login(username, password)
+          Spaceship::ConnectAPI::Client.login(username, password, use_portal: false, use_tunes: true)
         end
       end
     end

--- a/spaceship/spec/connect_api/models/app_spec.rb
+++ b/spaceship/spec/connect_api/models/app_spec.rb
@@ -1,5 +1,14 @@
 describe Spaceship::ConnectAPI::App do
-  before { Spaceship::ConnectAPI.login }
+  let(:mock_tunes_client) { double('tunes_client') }
+  let(:username) { 'spaceship@krausefx.com' }
+  let(:password) { 'so_secret' }
+
+  before do
+    allow(mock_tunes_client).to receive(:team_id).and_return("123")
+    allow(mock_tunes_client).to receive(:select_team)
+    allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
+    Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
+  end
 
   describe '#Spaceship::ConnectAPI' do
     it '#get_apps' do

--- a/spaceship/spec/connect_api/models/bundle_id_capability_spec.rb
+++ b/spaceship/spec/connect_api/models/bundle_id_capability_spec.rb
@@ -1,5 +1,14 @@
 describe Spaceship::ConnectAPI::BundleIdCapability do
-  before { Spaceship::Portal.login }
+  let(:mock_portal_client) { double('portal_client') }
+  let(:username) { 'spaceship@krausefx.com' }
+  let(:password) { 'so_secret' }
+
+  before do
+    allow(mock_portal_client).to receive(:team_id).and_return("123")
+    allow(mock_portal_client).to receive(:select_team)
+    allow(Spaceship::PortalClient).to receive(:login).and_return(mock_portal_client)
+    Spaceship::ConnectAPI.login(username, password, use_portal: true, use_tunes: false)
+  end
 
   describe '#client' do
     it 'through #get_bundle_id' do

--- a/spaceship/spec/connect_api/models/bundle_id_spec.rb
+++ b/spaceship/spec/connect_api/models/bundle_id_spec.rb
@@ -1,5 +1,14 @@
 describe Spaceship::ConnectAPI::BundleId do
-  before { Spaceship::Portal.login }
+  let(:mock_portal_client) { double('portal_client') }
+  let(:username) { 'spaceship@krausefx.com' }
+  let(:password) { 'so_secret' }
+
+  before do
+    allow(mock_portal_client).to receive(:team_id).and_return("123")
+    allow(mock_portal_client).to receive(:select_team)
+    allow(Spaceship::PortalClient).to receive(:login).and_return(mock_portal_client)
+    Spaceship::ConnectAPI.login(username, password, use_portal: true, use_tunes: false)
+  end
 
   describe '#client' do
     it '#get_bundle_ids' do

--- a/spaceship/spec/connect_api/models/pre_release_version_spec.rb
+++ b/spaceship/spec/connect_api/models/pre_release_version_spec.rb
@@ -1,5 +1,14 @@
 describe Spaceship::ConnectAPI::PreReleaseVersion do
-  before { Spaceship::Tunes.login }
+  let(:mock_tunes_client) { double('tunes_client') }
+  let(:username) { 'spaceship@krausefx.com' }
+  let(:password) { 'so_secret' }
+
+  before do
+    allow(mock_tunes_client).to receive(:team_id).and_return("123")
+    allow(mock_tunes_client).to receive(:select_team)
+    allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
+    Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
+  end
 
   describe '#Spaceship::ConnectAPI' do
     it '#get_pre_release_versions' do

--- a/spaceship/spec/connect_api/models/profile_spec.rb
+++ b/spaceship/spec/connect_api/models/profile_spec.rb
@@ -1,5 +1,14 @@
 describe Spaceship::ConnectAPI::Profile do
-  before { Spaceship::Portal.login }
+  let(:mock_portal_client) { double('portal_client') }
+  let(:username) { 'spaceship@krausefx.com' }
+  let(:password) { 'so_secret' }
+
+  before do
+    allow(mock_portal_client).to receive(:team_id).and_return("123")
+    allow(mock_portal_client).to receive(:select_team)
+    allow(Spaceship::PortalClient).to receive(:login).and_return(mock_portal_client)
+    Spaceship::ConnectAPI.login(username, password, use_portal: true, use_tunes: false)
+  end
 
   describe '#client' do
     it '#get_profiles' do

--- a/spaceship/spec/connect_api/models/user_spec.rb
+++ b/spaceship/spec/connect_api/models/user_spec.rb
@@ -1,5 +1,14 @@
 describe Spaceship::ConnectAPI::User do
-  before { Spaceship::Tunes.login }
+  let(:mock_tunes_client) { double('tunes_client') }
+  let(:username) { 'spaceship@krausefx.com' }
+  let(:password) { 'so_secret' }
+
+  before do
+    allow(mock_tunes_client).to receive(:team_id).and_return("123")
+    allow(mock_tunes_client).to receive(:select_team)
+    allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
+    Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
+  end
 
   describe '#Spaceship::ConnectAPI' do
     it '#get_users' do

--- a/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
@@ -5,7 +5,7 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
   let(:password) { 'so_secret' }
 
   before do
-    Spaceship::ConnectAPI.login(username, password)
+    Spaceship::ConnectAPI.login(username, password, use_portal: true, use_tunes: false)
   end
 
   context 'sends api request' do

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -7,8 +7,9 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
   before do
     allow(mock_tunes_client).to receive(:team_id).and_return("123")
+    allow(mock_tunes_client).to receive(:select_team)
     allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
-    Spaceship::ConnectAPI.login(username, password)
+    Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
   end
 
   context 'sends api request' do

--- a/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
@@ -7,8 +7,9 @@ describe Spaceship::ConnectAPI::Tunes::Client do
 
   before do
     allow(mock_tunes_client).to receive(:team_id).and_return("123")
+    allow(mock_tunes_client).to receive(:select_team)
     allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
-    Spaceship::ConnectAPI.login(username, password)
+    Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
   end
 
   context 'sends api request' do

--- a/spaceship/spec/connect_api/users/user_client_spec.rb
+++ b/spaceship/spec/connect_api/users/user_client_spec.rb
@@ -7,8 +7,9 @@ describe Spaceship::ConnectAPI::Users::Client do
 
   before do
     allow(mock_tunes_client).to receive(:team_id).and_return("123")
+    allow(mock_tunes_client).to receive(:select_team)
     allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
-    Spaceship::ConnectAPI.login(username, password)
+    Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
   end
 
   context 'sends api request' do


### PR DESCRIPTION
### Motivation and Context
Fixes #17153
Fixes #17157
Fixes #17155

### Description
- `match` was not passing in team id and team name through environment variables to select team so need to manually pass
- Improve `Spaceship::ConnectAPI.login` so always call `select_team` (even if no team id or team name passed in)
  - This is needed to allow manual selecting of team through the UI if nothing passed in
  - `login` still takes parameters for team id and team name or environment variables to prevent UI login
- `Spaceship::ConnectAPI.select_team` is called specifically in actions/tools because `login` handles it

### Testing Steps

Update `Gemfile` and run `bundle update fastlane`, `bundle update`, or `bundle install`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-match-fix-team-select-and-improve-spaceship-connect-team-select"
```
