### PR TITLE
[spaceship] pause, resume and complete a appstore version in phased release

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_phased_release.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_phased_release.rb
@@ -11,6 +11,9 @@ module Spaceship
 
       module PhasedReleaseState
         INACTIVE = "INACTIVE"
+        ACTIVE = "ACTIVE"
+        PAUSED = "PAUSED"
+        COMPLETE = "COMPLETE"
       end
 
       attr_mapping({
@@ -28,8 +31,26 @@ module Spaceship
       # API
       #
 
+      def pause
+        update(PhasedReleaseState::PAUSED)
+      end
+
+      def resume
+        update(PhasedReleaseState::ACTIVE)
+      end
+
+      def complete
+        update(PhasedReleaseState::COMPLETE)
+      end
+
       def delete!(filter: {}, includes: nil, limit: nil, sort: nil)
         Spaceship::ConnectAPI.delete_app_store_version_phased_release(app_store_version_phased_release_id: id)
+      end
+
+      private def update(state)
+        Spaceship::ConnectAPI.patch_app_store_version_phased_release(app_store_version_phased_release_id: id, attributes: {
+          phasedReleaseState: state
+        }).to_models.first
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -710,6 +710,18 @@ module Spaceship
           tunes_request_client.post("appStoreVersionPhasedReleases", body)
         end
 
+        def patch_app_store_version_phased_release(app_store_version_phased_release_id: nil, attributes: {})
+          body = {
+            data: {
+              type: "appStoreVersionPhasedReleases",
+              attributes: attributes,
+              id: app_store_version_phased_release_id
+            }
+          }
+
+          tunes_request_client.patch("appStoreVersionPhasedReleases/#{app_store_version_phased_release_id}", body)
+        end
+
         def delete_app_store_version_phased_release(app_store_version_phased_release_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
           tunes_request_client.delete("appStoreVersionPhasedReleases/#{app_store_version_phased_release_id}", params)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Previously you were only able to create or delete a phased release when submitting an app for review, but you were not able to update the phased release state.

### Description
I've added `pause`, `resume` and `complete` methods to the `AppStoreVersionPhasedRelease` class to be able to update and complete a phased release.

#### Example

```rb
version = app.get_live_app_store_version(platform: Spaceship::ConnectAPI::Platform::IOS)
version.fetch_app_store_version_phased_release.complete
```

You can also call `pause` and `resume`

### Testing Steps
I had an app which was currently in phased release, and I tried pausing it, resuming it and completing the phased release, all successfully.
