### PR TITLE
[precheck] migrate to App Store Connect API (except for IAPs)

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -68,7 +68,8 @@ module Deliver
         default_rule_level: options[:precheck_default_rule_level],
         include_in_app_purchases: options[:precheck_include_in_app_purchases],
         app_identifier: options[:app_identifier],
-        username: options[:username]
+        username: options[:username],
+        platform: options[:platform]
       }
 
       precheck_config = FastlaneCore::Configuration.create(Precheck::Options.available_options, precheck_options)

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -60,6 +60,15 @@ module Precheck
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_ITC_TEAM_NAME"] = value.to_s
                                      end),
+        FastlaneCore::ConfigItem.new(key: :platform,
+                                     short_option: "-j",
+                                     env_name: "PRECHECK_PLATFORM",
+                                     description: "The platform to use (optional)",
+                                     optional: true,
+                                     default_value: "ios",
+                                     verify_block: proc do |value|
+                                       UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)
+                                     end),
         FastlaneCore::ConfigItem.new(key: :default_rule_level,
                                      short_option: "-r",
                                      env_name: "PRECHECK_DEFAULT_RULE_LEVEL",

--- a/precheck/lib/precheck/rule_processor.rb
+++ b/precheck/lib/precheck/rule_processor.rb
@@ -1,4 +1,5 @@
 require 'spaceship/tunes/language_item'
+require 'spaceship/tunes/iap_list'
 require 'fastlane/markdown_table_formatter'
 
 require_relative 'module'

--- a/precheck/lib/precheck/rule_processor.rb
+++ b/precheck/lib/precheck/rule_processor.rb
@@ -43,8 +43,8 @@ module Precheck
   class RuleProcessor
     def self.process_app_and_version(app: nil, app_version: nil, rules: nil)
       items_to_check = []
-      items_to_check += generate_text_items_to_check(app: app, app_version: app_version)
-      items_to_check += generate_url_items_to_check(app: app, app_version: app_version)
+      items_to_check += generate_app_items_to_check(app: app)
+      items_to_check += generate_version_items_to_check(app_version: app_version)
 
       return process_rules(items_to_check: items_to_check, rules: rules)
     end
@@ -125,70 +125,83 @@ module Precheck
       return rule_hash
     end
 
-    def self.generate_url_items_to_check(app: nil, app_version: nil)
+    def self.generate_app_items_to_check(app: nil)
       items = []
-      items += collect_urls_from_hash(hash: app_version.support_url,
-                                 item_name: :support_url,
-                     friendly_name_postfix: "support URL")
-      items += collect_urls_from_hash(hash: app_version.marketing_url,
-                                 item_name: :marketing_url,
-                     friendly_name_postfix: "marketing URL",
-                               is_optional: true)
 
-      items += collect_urls_from_hash(hash: app.details.privacy_url,
-                                 item_name: :privacy_url,
-                     friendly_name_postfix: "privacy URL",
-                               is_optional: true)
-      return items
-    end
+      # App info localizations
+      app_info = app.fetch_edit_app_info
+      app_info_localizations = app_info.get_app_info_localizations
+      app_info_localizations.each do |localization|
+        items << collect_text_items_from_language_item(locale: localization.locale,
+                                                        value: localization.name,
+                                                    item_name: :app_name,
+                                        friendly_name_postfix: "app name")
 
-    def self.collect_urls_from_hash(hash: nil, item_name: nil, friendly_name_postfix: nil, is_optional: false)
-      items = []
-      hash.each do |key, value|
-        items << URLItemToCheck.new(value, item_name, "#{friendly_name_postfix}: (#{key})", is_optional)
+        items << collect_text_items_from_language_item(locale: localization.locale,
+                                                        value: localization.subtitle,
+                                                    item_name: :app_subtitle,
+                                        friendly_name_postfix: "app name subtitle",
+                                                  is_optional: true)
+
+        items << collect_text_items_from_language_item(locale: localization.locale,
+                                                        value: localization.privacy_policy_text,
+                                                    item_name: :privacy_policy_text,
+                                        friendly_name_postfix: " tv privacy policy")
+
+        items << collect_urls_from_language_item(locale: localization.locale,
+                                                        value: localization.privacy_policy_url,
+                                                    item_name: :privacy_policy_url,
+                                        friendly_name_postfix: "privacy URL",
+                                                  is_optional: true)
       end
+
       return items
     end
 
-    def self.generate_text_items_to_check(app: nil, app_version: nil)
+    def self.generate_version_items_to_check(app_version: nil)
       items = []
 
       items << TextItemToCheck.new(app_version.copyright, :copyright, "copyright")
 
-      items += collect_text_items_from_language_item(hash: app_version.keywords,
-                                                item_name: :keywords,
-                                    friendly_name_postfix: "keywords")
+      # Version localizations
+      version_localizations = app_version.get_app_store_version_localizations
+      version_localizations.each do |localization|
+        items << collect_text_items_from_language_item(locale: localization.locale,
+                                                        value: localization.keywords,
+                                                    item_name: :keywords,
+                                        friendly_name_postfix: "keywords")
 
-      items += collect_text_items_from_language_item(hash: app_version.description,
-                                                item_name: :description,
-                                    friendly_name_postfix: "description")
+        items << collect_text_items_from_language_item(locale: localization.locale,
+                                                        value: localization.description,
+                                                    item_name: :description,
+                                        friendly_name_postfix: "description")
 
-      items += collect_text_items_from_language_item(hash: app_version.release_notes,
-                                                item_name: :release_notes,
-                                    friendly_name_postfix: "release notes")
+        items << collect_text_items_from_language_item(locale: localization.locale,
+                                                        value: localization.whats_new,
+                                                    item_name: :release_notes,
+                                        friendly_name_postfix: "what's new")
 
-      items += collect_text_items_from_language_item(hash: app.details.name,
-                                                item_name: :app_name,
-                                    friendly_name_postfix: "app name")
+        items << collect_urls_from_language_item(locale: localization.locale,
+                                                        value: localization.support_url,
+                                                    item_name: :support_url,
+                                        friendly_name_postfix: "support URL")
 
-      items += collect_text_items_from_language_item(hash: app.details.apple_tv_privacy_policy,
-                                                item_name: :app_subtitle,
-                                    friendly_name_postfix: " tv privacy policy")
-
-      items += collect_text_items_from_language_item(hash: app.details.subtitle,
-                                                item_name: :app_subtitle,
-                                    friendly_name_postfix: "app name subtitle",
-                                              is_optional: true)
+        items << collect_urls_from_language_item(locale: localization.locale,
+                                                        value: localization.marketing_url,
+                                                    item_name: :marketing_url,
+                                        friendly_name_postfix: "marketing URL",
+                                                 is_optional: true)
+      end
 
       should_include_iap = Precheck.config[:include_in_app_purchases]
       if should_include_iap
         UI.message("Reading in-app purchases. If you have a lot, this might take a while")
         UI.message("You can disable IAP checking by setting the `include_in_app_purchases` flag to `false`")
-        in_app_purchases = app.in_app_purchases.all
-        in_app_purchases ||= []
-        in_app_purchases.each do |purchase|
-          items += collect_iap_language_items(purchase_edit_versions: purchase.edit.versions)
-        end
+        # in_app_purchases = app.in_app_purchases.all
+        # in_app_purchases ||= []
+        # in_app_purchases.each do |purchase|
+        #   items += collect_iap_language_items(purchase_edit_versions: purchase.edit.versions)
+        # end
         UI.message("Done reading in-app purchases")
       end
 
@@ -207,12 +220,12 @@ module Precheck
     end
 
     # a few attributes are LanguageItem this method creates a TextItemToCheck for each pair
-    def self.collect_text_items_from_language_item(hash: nil, item_name: nil, friendly_name_postfix: nil, is_optional: false)
-      items = []
-      hash.each do |key, value|
-        items << TextItemToCheck.new(value, item_name, "#{friendly_name_postfix}: (#{key})", is_optional)
-      end
-      return items
+    def self.collect_text_items_from_language_item(locale: nil, value: nil, item_name: nil, friendly_name_postfix: nil, is_optional: false)
+      return TextItemToCheck.new(value, item_name, "#{friendly_name_postfix}: (#{locale})", is_optional)
+    end
+
+    def self.collect_urls_from_language_item(locale: nil, value: nil, item_name: nil, friendly_name_postfix: nil, is_optional: false)
+      return URLItemToCheck.new(value, item_name, "#{friendly_name_postfix}: (#{locale})", is_optional)
     end
   end
 end

--- a/precheck/lib/precheck/runner.rb
+++ b/precheck/lib/precheck/runner.rb
@@ -19,9 +19,10 @@ module Precheck
                                              title: "Summary for precheck #{Fastlane::VERSION}")
 
       unless Spaceship::Tunes.client
+        # Team selection passed though FASTLANE_ITC_TEAM_ID and FASTLANE_ITC_TEAM_NAME environment variables
+        # Prompts select team if multiple teams and none specified
         UI.message("Starting login with user '#{Precheck.config[:username]}'")
-        Spaceship::Tunes.login(Precheck.config[:username])
-        Spaceship::Tunes.select_team
+        Spaceship::ConnectAPI.login(Precheck.config[:username], use_portal: false, use_tunes: true)
 
         UI.message("Successfully logged in")
       end
@@ -160,11 +161,12 @@ module Precheck
     end
 
     def app
-      Spaceship::Tunes::Application.find(Precheck.config[:app_identifier])
+      Spaceship::ConnectAPI::App.find(Precheck.config[:app_identifier])
     end
 
     def latest_app_version
-      @latest_version ||= app.latest_version
+      platform = Spaceship::ConnectAPI::Platform.map(Precheck.config[:platform])
+      @latest_version ||= app.get_edit_app_store_version(platform: platform)
     end
 
     # Makes sure the current App ID exists. If not, it will show an appropriate error message

--- a/precheck/spec/rule_processor_spec.rb
+++ b/precheck/spec/rule_processor_spec.rb
@@ -5,8 +5,8 @@ require 'webmock'
 describe Precheck do
   describe Precheck::RuleProcessor do
     let(:fake_happy_app) { "fake_app_object" }
-    let(:fake_happy_app_details) { "fake_app_details" }
     let(:fake_happy_app_version) { "fake_app_version_object" }
+    let(:fake_happy_app_info) { "fake_app_info_object" }
     let(:fake_in_app_purchase) { "fake_in_app_purchase" }
     let(:fake_in_app_purchase_edit) { "fake_in_app_purchase_edit" }
     let(:fake_in_app_purchase_edit_version) { { :"de-DE" => { name: "iap name", description: "iap desc" } } }
@@ -19,24 +19,17 @@ describe Precheck do
     end
 
     def setup_happy_app
-      allow(fake_happy_app).to receive(:apple_id).and_return("com.whatever")
+      allow(fake_happy_app).to receive(:id).and_return("3838204")
       allow(fake_happy_app).to receive(:name).and_return("My Fake App")
       allow(fake_happy_app).to receive(:in_app_purchases).and_return(fake_in_app_purchases)
-      allow(fake_happy_app).to receive(:details).and_return(fake_happy_app_details)
 
-      allow(fake_happy_app_details).to receive(:name).and_return(fake_language_item_for_text_item(fieldname: "name"))
-      allow(fake_happy_app_details).to receive(:apple_tv_privacy_policy).and_return(fake_language_item_for_text_item(fieldname: "apple_tv_privacy_policy"))
-      allow(fake_happy_app_details).to receive(:subtitle).and_return(fake_language_item_for_text_item(fieldname: "subtitle"))
-      allow(fake_happy_app_details).to receive(:privacy_url).and_return(fake_language_item_for_url_item(fieldname: "privacy_url"))
+      allow(fake_happy_app).to receive(:fetch_edit_app_info).and_return(fake_happy_app_info)
+      allow(fake_happy_app_info).to receive(:get_app_info_localizations).and_return([fake_info_localization])
 
       allow(fake_happy_app_version).to receive(:copyright).and_return("Copyright taquitos, #{DateTime.now.year}")
-      allow(fake_happy_app_version).to receive(:keywords).and_return(fake_language_item_for_text_item(fieldname: "keywords"))
-      allow(fake_happy_app_version).to receive(:description).and_return(fake_language_item_for_text_item(fieldname: "description"))
-      allow(fake_happy_app_version).to receive(:release_notes).and_return(fake_language_item_for_text_item(fieldname: "release_notes"))
-      allow(fake_happy_app_version).to receive(:support_url).and_return(fake_language_item_for_url_item(fieldname: "support_url"))
-      allow(fake_happy_app_version).to receive(:marketing_url).and_return(fake_language_item_for_url_item(fieldname: "marketing_url"))
+      allow(fake_happy_app_version).to receive(:get_app_store_version_localizations).and_return([fake_version_localization])
 
-      allow(fake_in_app_purchases).to receive(:all).and_return(fake_in_app_purchases)
+      allow(Precheck::RuleProcessor).to receive(:get_iaps).and_return(fake_in_app_purchases)
       allow(fake_in_app_purchase).to receive(:edit).and_return(fake_in_app_purchase_edit)
       allow(fake_in_app_purchase_edit).to receive(:versions).and_return(fake_in_app_purchase_edit_version)
 
@@ -54,6 +47,28 @@ describe Precheck do
       allow(request).to receive(:head).and_return(head_object)
 
       allow(Faraday).to receive(:new).and_return(request)
+    end
+
+    def fake_version_localization
+      Spaceship::ConnectAPI::AppStoreVersionLocalization.new("id", {
+        "description" =>  "hi! this is fake data",
+        "locale" =>  "locale",
+        "keywords" =>  "hi! this is fake data",
+        "marketingUrl" =>  "http://fastlane.tools",
+        "promotionalText" =>  "hi! this is fake data",
+        "supportUrl" =>  "http://fastlane.tools",
+        "whatsNew" =>  "hi! this is fake data"
+      })
+    end
+
+    def fake_info_localization
+      Spaceship::ConnectAPI::AppInfoLocalization.new("id", {
+        "locale" => "locale",
+        "name" => "hi! this is fake data",
+        "subtitle" => "hi! this is fake data",
+        "privacyPolicyUrl" => "http://fastlane.tools",
+        "privacyPolicyText" => "hi! this is fake data"
+      })
     end
 
     def fake_language_item_for_text_item(fieldname: nil)


### PR DESCRIPTION
### Motivation and Context
Fixes #17150
Fixes #17158

### Description
- Replaced most `Spaceship::Tunes` calls with `Spaceship::ConnectAPI` calls
  - Except for IAPs
- Added in new optional `platform` option
- Updated tests
