### PR TITLE
[actions] fix typo in `download_dsyms` action

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -159,7 +159,7 @@ module Fastlane
         latest_build = Spaceship::ConnectAPI.get_builds(filter: filter, sort: "-uploadedDate", includes: "preReleaseVersion").first
 
         if latest_build.nil?
-          UI.user_error!("Could not find latest bulid for version #{version}")
+          UI.user_error!("Could not find latest build for version #{version}")
         end
 
         return latest_build


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes typo in log when an error has occurred:
```
[!] Could not find latest bulid for version 1.0
```
Where `bulid` should be `build`

### Description
Fixed spelling of the word `build`
