### PR TITLE
[actions] fix an issue where last_git_tag command sometimes didn't return the correct tag

### DIFF
--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -45,6 +45,8 @@ module Fastlane
       command = %w(git describe)
       command << '--tags' if match_lightweight
       command << hash
+      command << '--match' if tag_match_pattern
+      command << tag_match_pattern if tag_match_pattern
       Actions.sh(*command.compact, log: false).chomp
     rescue
       nil

--- a/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -174,7 +174,7 @@ describe Fastlane do
         end").runner.execute(:test)
 
         tag_name = %W(git rev-list --tags=#{tag_match_pattern} --max-count=1).shelljoin
-        describe = %W(git describe --tags #{tag_name}).shelljoin
+        describe = %W(git describe --tags #{tag_name} --match #{tag_match_pattern}).shelljoin
         changelog = %W(git log --pretty=%B #{describe}...HEAD).shelljoin
         expect(result).to eq(changelog)
       end

--- a/fastlane/spec/actions_specs/last_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/last_git_tag_spec.rb
@@ -18,7 +18,7 @@ describe Fastlane do
         end").runner.execute(:test)
 
         tag_name = %W(git rev-list --tags=#{tag_pattern} --max-count=1).shelljoin
-        describe = %W(git describe --tags #{tag_name}).shelljoin
+        describe = %W(git describe --tags #{tag_name} --match #{tag_pattern}).shelljoin
         expect(result).to eq(describe)
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #17203 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Added `--match "<pattern>"` to the `git describe` command

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
- apply multiple tags to a commit in a git repo
- use `last_git_tag` command with a pattern to return a specific tag
- the command should return the correct tag based on the pattern provided
