### PR TITLE
[match] Fix match import adhoc profile name

### DIFF
--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -56,8 +56,9 @@ module Match
         UI.user_error!("Cert type '#{cert_type}' is not supported")
       end
 
+      prov_type = Match.profile_type_sym(params[:type])
       output_dir_certs = File.join(storage.prefixed_working_directory, "certs", cert_type.to_s)
-      output_dir_profiles = File.join(storage.prefixed_working_directory, "profiles", cert_type.to_s)
+      output_dir_profiles = File.join(storage.prefixed_working_directory, "profiles", prov_type.to_s)
 
       # Need to get the cert id by comparing base64 encoded cert content with certificate content from the API responses
       Spaceship::Portal.login(params[:username])
@@ -86,7 +87,8 @@ module Match
         FileUtils.mkdir_p(output_dir_profiles)
         bundle_id = FastlaneCore::ProvisioningProfile.bundle_id(profile_path)
         profile_extension = FastlaneCore::ProvisioningProfile.profile_extension(profile_path)
-        dest_profile_path = File.join(output_dir_profiles, "#{cert_type.to_s.capitalize}_#{bundle_id}#{profile_extension}")
+        profile_type_name = Match::Generator.profile_type_name(prov_type)
+        dest_profile_path = File.join(output_dir_profiles, "#{profile_type_name}_#{bundle_id}#{profile_extension}")
         files_to_commit.push(dest_profile_path)
         IO.copy_stream(profile_path, dest_profile_path)
       end

--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -2,6 +2,7 @@ require_relative 'spaceship_ensure'
 require_relative 'encryption'
 require_relative 'storage'
 require_relative 'module'
+require_relative 'generator'
 require 'fastlane_core/provisioning_profile'
 require 'fileutils'
 

--- a/match/spec/importer_spec.rb
+++ b/match/spec/importer_spec.rb
@@ -55,7 +55,7 @@ describe Match do
         files_to_commit: [
           File.join(repo_dir, "certs", "distribution", "#{mock_cert.id}.cer"),
           File.join(repo_dir, "certs", "distribution", "#{mock_cert.id}.p12"),
-          File.join(repo_dir, "profiles", "distribution", "Distribution_tools.fastlane.app.mobileprovision")
+          File.join(repo_dir, "profiles", "appstore", "AppStore_tools.fastlane.app.mobileprovision")
         ]
       )
 
@@ -73,7 +73,7 @@ describe Match do
         files_to_commit: [
           File.join(repo_dir, "certs", "distribution", "#{mock_cert.id}.cer"),
           File.join(repo_dir, "certs", "distribution", "#{mock_cert.id}.p12"),
-          File.join(repo_dir, "profiles", "distribution", "Distribution_tools.fastlane.app.provisionprofile")
+          File.join(repo_dir, "profiles", "appstore", "AppStore_tools.fastlane.app.provisionprofile")
         ]
       )
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We were trying to import our existing adhoc and development profiles using **match import** command and I noticed that the file and folder formats were different in some cases.

There is a bug ticket here: https://github.com/fastlane/fastlane/issues/17003

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I changed the **importer.rb** file to use the correct method for retrieving the provisioning profile prefix.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Tested with **development, appstore, adhoc and inhouse** profiles for **iOS**. We do not have **developer_id** profiles and we couldn't test that.

As noted above in the checklist I ran all the tests and rubocop. Tests failed for the importing appstore provisioning profiles and I saw that they were wrong and corrected the tests.

Please note that I'm not a ruby programmer and I don't know if the changes that I made are OK.
