### PR TITLE
[spaceship] add skip_select_team to Spaceship::ConnectAPI.login

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - 'Execute tests on macOS (Xcode 9.4.1, Ruby 2.4)'
       - 'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)'
       - 'Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)'
       - 'Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,51 +63,6 @@ aliases:
 version: 2
 
 jobs:
-  'Execute tests on macOS (Xcode 9.4.1, Ruby 2.4)': &tests_macos  # define alias
-    macos:
-      xcode: '9.4.1'
-    environment:
-      CIRCLE_TEST_REPORTS: '~/test-reports'
-      LC_ALL: 'en_US.UTF-8'
-      LANG: 'en_US.UTF-8'
-      _RUBY_VERSION: '2.4'
-    shell: '/bin/bash --login -eo pipefail'
-    steps:
-      - *cache_restore_git
-      - checkout
-      - *cache_save_git
-      - *cache_restore_bundler
-      - *cache_restore_homebrew
-      - *set_ruby
-      - run:
-          name: debug | ruby version
-          command: |
-            ruby -v
-      - run:
-          name: Setup Build
-          command: |
-            mkdir -p ~/test-reports
-            brew update
-            brew untap caskroom/versions || true
-            brew install shellcheck
-            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
-      - *cache_save_homebrew
-      - *cache_save_bundler
-      - run:
-          name: Check PR Metadata
-          command: bundle exec danger || echo "danger failed"
-      - *cache_restore_rubocop
-      - run: bundle exec fastlane execute_tests
-      - *cache_save_rubocop
-      - store_test_results:
-          path: ~/test-reports
-      - store_artifacts:
-          path: ~/test-reports/rspec
-          destination: test-reports
-      - run:
-          name: Post Test Results to GitHub
-          command: bundle exec danger || echo "danger failed"
-          when: always  # Run this even when tests fail
   'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)':
     <<: *tests_macos
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,51 @@ aliases:
 version: 2
 
 jobs:
-  'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)':
-    <<: *tests_macos
+  'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)': &tests_macos  # define alias
     macos:
       xcode: '10.2.1'
     environment:
+      CIRCLE_TEST_REPORTS: '~/test-reports'
+      LC_ALL: 'en_US.UTF-8'
+      LANG: 'en_US.UTF-8'
       _RUBY_VERSION: '2.4'
+    shell: '/bin/bash --login -eo pipefail'
+    steps:
+      - *cache_restore_git
+      - checkout
+      - *cache_save_git
+      - *cache_restore_bundler
+      - *cache_restore_homebrew
+      - *set_ruby
+      - run:
+          name: debug | ruby version
+          command: |
+            ruby -v
+      - run:
+          name: Setup Build
+          command: |
+            mkdir -p ~/test-reports
+            brew update
+            brew untap caskroom/versions || true
+            brew install shellcheck
+            bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
+      - *cache_save_homebrew
+      - *cache_save_bundler
+      - run:
+          name: Check PR Metadata
+          command: bundle exec danger || echo "danger failed"
+      - *cache_restore_rubocop
+      - run: bundle exec fastlane execute_tests
+      - *cache_save_rubocop
+      - store_test_results:
+          path: ~/test-reports
+      - store_artifacts:
+          path: ~/test-reports/rspec
+          destination: test-reports
+      - run:
+          name: Post Test Results to GitHub
+          command: bundle exec danger || echo "danger failed"
+          when: always  # Run this even when tests fail
   'Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)':
     <<: *tests_macos
     macos:

--- a/spaceship/lib/spaceship/connect_api/spaceship.rb
+++ b/spaceship/lib/spaceship/connect_api/spaceship.rb
@@ -73,12 +73,13 @@ module Spaceship
       # @param portal_team_id (String) (optional): The Spaceship::Portal team id
       # @param tunes_team_id (String) (optional): The Spaceship::Tunes team id
       # @param team_name (String) (optional): The team name
+      # @param skip_select_team (Boolean) (optional): Whether to skip automatic selection or prompt for team
       #
       # @raise InvalidUserCredentialsError: raised if authentication failed
       #
       # @return (Spaceship::ConnectAPI::Client) The client the login method was called for
-      def login(user = nil, password = nil, use_portal: true, use_tunes: true, portal_team_id: nil, tunes_team_id: nil, team_name: nil)
-        @client = ConnectAPI::Client.login(user, password, use_portal: use_portal, use_tunes: use_tunes, portal_team_id: portal_team_id, tunes_team_id: tunes_team_id, team_name: team_name)
+      def login(user = nil, password = nil, use_portal: true, use_tunes: true, portal_team_id: nil, tunes_team_id: nil, team_name: nil, skip_select_team: false)
+        @client = ConnectAPI::Client.login(user, password, use_portal: use_portal, use_tunes: use_tunes, portal_team_id: portal_team_id, tunes_team_id: tunes_team_id, team_name: team_name, skip_select_team: skip_select_team)
       end
 
       # Open up the team selection for the user (if necessary).

--- a/spaceship/spec/connect_api/spaceship_spec.rb
+++ b/spaceship/spec/connect_api/spaceship_spec.rb
@@ -73,7 +73,7 @@ describe Spaceship::ConnectAPI do
           team_id = 'team_id'
           team_name = 'team_name'
 
-          expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, use_portal: true, use_tunes: false, portal_team_id: team_id, tunes_team_id: nil, team_name: team_name).and_return(mock_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, use_portal: true, use_tunes: false, portal_team_id: team_id, tunes_team_id: nil, team_name: team_name, skip_select_team: false).and_return(mock_client)
 
           client = Spaceship::ConnectAPI.login(user, password, use_portal: true, use_tunes: false, portal_team_id: team_id, team_name: team_name)
           expect(client).to eq(Spaceship::ConnectAPI.client)
@@ -85,7 +85,7 @@ describe Spaceship::ConnectAPI do
           team_id = 'team_id'
           team_name = 'team_name'
 
-          expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, use_portal: false, use_tunes: true, portal_team_id: nil, tunes_team_id: team_id, team_name: team_name).and_return(mock_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, use_portal: false, use_tunes: true, portal_team_id: nil, tunes_team_id: team_id, team_name: team_name, skip_select_team: false).and_return(mock_client)
 
           client = Spaceship::ConnectAPI.login(user, password, use_portal: false, use_tunes: true, tunes_team_id: team_id, team_name: team_name)
           expect(client).to eq(Spaceship::ConnectAPI.client)
@@ -97,7 +97,7 @@ describe Spaceship::ConnectAPI do
           team_id = 'team_id'
           team_name = 'team_name'
 
-          expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, use_portal: true, use_tunes: true, portal_team_id: team_id, tunes_team_id: team_id, team_name: team_name).and_return(mock_client)
+          expect(Spaceship::ConnectAPI::Client).to receive(:login).with(user, password, use_portal: true, use_tunes: true, portal_team_id: team_id, tunes_team_id: team_id, team_name: team_name, skip_select_team: false).and_return(mock_client)
 
           client = Spaceship::ConnectAPI.login(user, password, use_portal: true, use_tunes: true, portal_team_id: team_id, tunes_team_id: team_id, team_name: team_name)
           expect(client).to eq(Spaceship::ConnectAPI.client)


### PR DESCRIPTION
### Motivation and Context
Sometimes we don't want to select team and query teams

### Description
- Added optional `skip_select_team` onto `login`
- Added `portal_teams` and `tunes_teams` onto client

### Testing Steps

```rb
Spaceship::ConnectAPI.login('your@email.com', skip_select_team: true)
puts "portal teams: #{Spaceship::ConnectAPI.client.portal_teams.map { |t| [t['teamId'], t['name']].join(' - ') }.join(',')}"
puts "tunes teams: #{Spaceship::ConnectAPI.client.tunes_teams.map { |t| [t['contentProvider']['contentProviderId'], t['contentProvider']['name']].join(' - ') }.join(',')}"
```
