### PR TITLE
Modify `Net::HTTPGenericRequest` monkeypatch so that only Apple domains are affected

### DIFF
--- a/spaceship/lib/spaceship/helper/net_http_generic_request.rb
+++ b/spaceship/lib/spaceship/helper/net_http_generic_request.rb
@@ -5,10 +5,16 @@ require 'net/http'
 # Certain apple endpoints return 415 responses if a Content-Type is supplied.
 # Net::HTTP will default a content-type if none is provided by faraday
 # This monkey-patch allows us to leave out the content-type if we do not specify one.
-module Net
-  class HTTPGenericRequest
-    def supply_default_content_type
-      return if content_type
-    end
+module NetHTTPGenericRequestMonkeypatch
+  def supply_default_content_type
+    # Return no content type if we communicating with an apple.com domain
+    return if !self['host'].nil? && self['host'].end_with?('.apple.com')
+
+    # Otherwise use the default implementation
+    super
   end
 end
+
+# We prepend the monkeypatch so the patch has access to the original implementation
+# using `super`.
+Net::HTTPGenericRequest.prepend(NetHTTPGenericRequestMonkeypatch)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Commit eb8d59959fe80d237bbe548ae413eb5803b08665 introduced a monkeypatch of `Net::HTTPGenericRequest#supply_default_content_type` in `lib/spaceship/helper/net_http_generic_request.rb` that resolved an issue whereby a Content-Type header was being automatically added to a HTTP request that deliberately lacked one, causing the request to fail. The patch modifies `Net::HTTP`'s behaviour so that this automatic header is not added.

This patch however is very broad, and affects `Net::HTTP`'s behaviour globally. In our case, we added fastlane to an internal project as a gem to utilise it programatically, and noted that unrelated areas of the project began to inexplicably fail as fastlane's monkeypatch changed this behaviour for all HTTP requests in the project.

### Description
Based on the description of what the patch is intending to fix, it seems that its scope can be significantly limited, thus making the patch play nice with other code that relies on the default behaviour.

This modification ensures that the skipping of the Content-Type header only occurs for Apple subdomains, which covers the patch's intended targets, while preventing projects that include fastlane from suffering from strange unrelated failures when they include the gem.

### Testing Steps
Automated testing suite has run. I have also verified that POST requests using the `Spaceship::Client` methods trigger the monkeypatch's conditions. Internal tests in our codebase verify the monkeypatch no longer affects the methods in the project that were broken by it.

Looking at the hostnames the commit affects, it seems to be "developer.apple.com", "idmsa.apple.com" and "developerservices2.apple.com", all of which are covered by the condition.