### PR TITLE
Dysm download date filter

### DIFF
--- a/fastlane/lib/fastlane/actions/clean_build_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/clean_build_artifacts.rb
@@ -23,6 +23,7 @@ module Fastlane
 
         Actions.lane_context[Actions::SharedValues::SIGH_PROFILE_PATHS] = nil
         Actions.lane_context[Actions::SharedValues::DSYM_PATHS] = nil
+        Actions.lane_context[Actions::SharedValues::DSYM_LATEST_UPLOADED_DATE] = nil
 
         UI.success('Cleaned up build artifacts 🐙')
       end

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -2,13 +2,14 @@ module Fastlane
   module Actions
     module SharedValues
       DSYM_PATHS = :DSYM_PATHS
+      DSYM_LATEST_UPLOADED_DATE = :DSYM_LATEST_UPLOADED_DATE
     end
     class DownloadDsymsAction < Action
-      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         require 'openssl'
         require 'spaceship'
         require 'net/http'
+        require 'date'
 
         # Team selection passed though FASTLANE_ITC_TEAM_ID and FASTLANE_ITC_TEAM_NAME environment variables
         # Prompts select team if multiple teams and none specified
@@ -30,6 +31,7 @@ module Fastlane
         wait_for_dsym_processing = params[:wait_for_dsym_processing]
         wait_timeout = params[:wait_timeout]
         min_version = Gem::Version.new(params[:min_version]) if params[:min_version]
+        after_uploaded_date = DateTime.parse(params[:after_uploaded_date]) unless params[:after_uploaded_date].nil?
 
         platform = Spaceship::ConnectAPI::Platform.map(itc_platform)
 
@@ -81,6 +83,7 @@ module Fastlane
         builds.each do |build|
           asc_app_version = build.app_version
           asc_build_number = build.version
+          uploaded_date = DateTime.parse(build.uploaded_date)
 
           message = []
           message << "Found train (version): #{asc_app_version}"
@@ -97,6 +100,11 @@ module Fastlane
             next
           end
 
+          if after_uploaded_date && after_uploaded_date >= uploaded_date
+            UI.verbose("Upload date #{after_uploaded_date} not reached: #{uploaded_date}")
+            next
+          end
+
           message = []
           message << "Found build version: #{asc_build_number}"
           message << ", comparing to supplied build_number: #{build_number}" if build_number
@@ -108,11 +116,11 @@ module Fastlane
           end
 
           UI.verbose("Build_version: #{asc_build_number} matches #{build_number}, grabbing dsym_url") if build_number
-          get_details_and_download_dsym(app: app, train: asc_app_version, build_number: asc_build_number, platform: itc_platform, wait_for_dsym_processing: wait_for_dsym_processing, wait_timeout: wait_timeout, output_directory: output_directory)
+          get_details_and_download_dsym(app: app, train: asc_app_version, build_number: asc_build_number, uploaded_date: uploaded_date, platform: itc_platform, wait_for_dsym_processing: wait_for_dsym_processing, wait_timeout: wait_timeout, output_directory: output_directory)
         end
       end
 
-      def self.get_details_and_download_dsym(app: nil, train: nil, build_number: nil, platform: nil, wait_for_dsym_processing: nil, wait_timeout: nil, output_directory: nil)
+      def self.get_details_and_download_dsym(app: nil, train: nil, build_number: nil, uploaded_date: nil, platform: nil, wait_for_dsym_processing: nil, wait_timeout: nil, output_directory: nil)
         start = Time.now
         download_url = nil
 
@@ -144,7 +152,7 @@ module Fastlane
         end
 
         if download_url
-          self.download(download_url, app.bundle_id, train, build_number, output_directory)
+          self.download(download_url, app.bundle_id, train, build_number, uploaded_date, output_directory)
           return if build_number
         else
           UI.message("No dSYM URL for #{build_number} (#{train})")
@@ -165,13 +173,21 @@ module Fastlane
         return latest_build
       end
 
-      def self.download(download_url, bundle_id, train_number, build_version, output_directory)
+      def self.download(download_url, bundle_id, train_number, build_version, uploaded_date, output_directory)
         result = self.download_file(download_url)
         path   = write_dsym(result, bundle_id, train_number, build_version, output_directory)
         UI.success("🔑  Successfully downloaded dSYM file for #{train_number} - #{build_version} to '#{path}'")
 
         Actions.lane_context[SharedValues::DSYM_PATHS] ||= []
         Actions.lane_context[SharedValues::DSYM_PATHS] << File.expand_path(path)
+
+        unless uploaded_date.nil?
+          Actions.lane_context[SharedValues::DSYM_LATEST_UPLOADED_DATE] ||= uploaded_date
+          current_latest = Actions.lane_context[SharedValues::DSYM_LATEST_UPLOADED_DATE]
+          Actions.lane_context[SharedValues::DSYM_LATEST_UPLOADED_DATE] = [current_latest, uploaded_date].max
+          UI.message("Build upload date #{uploaded_date}")
+          UI.message("Latest uploaded date #{Actions.lane_context[SharedValues::DSYM_LATEST_UPLOADED_DATE]}")
+        end
       end
 
       def self.write_dsym(data, bundle_id, train_number, build_number, output_directory)
@@ -286,6 +302,12 @@ module Fastlane
                                        env_name: "DOWNLOAD_DSYMS_MIN_VERSION",
                                        description: "The minimum app version for dSYMs you wish to download",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :after_uploaded_date,
+                                       short_option: "-d",
+                                       env_name: "DOWNLOAD_DSYMS_AFTER_UPLOADED_DATE",
+                                       description: "The uploaded date after which you wish to download dSYMs",
+                                       optional: true,
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :output_directory,
                                        short_option: "-s",
                                        env_name: "DOWNLOAD_DSYMS_OUTPUT_DIRECTORY",
@@ -310,7 +332,8 @@ module Fastlane
 
       def self.output
         [
-          ['DSYM_PATHS', 'An array to all the zipped dSYM files']
+          ['DSYM_PATHS', 'An array to all the zipped dSYM files'],
+          ['DSYM_LATEST_UPLOADED_DATE', 'Date of the most recent uploaded time of successfully downloaded dSYM files']
         ]
       end
 
@@ -332,7 +355,8 @@ module Fastlane
           'download_dsyms(version: "1.0.0", build_number: "345")',
           'download_dsyms(version: "1.0.1", build_number: 42)',
           'download_dsyms(version: "live")',
-          'download_dsyms(min_version: "1.2.3")'
+          'download_dsyms(min_version: "1.2.3")',
+          'download_dsyms(after_uploaded_date: "2020-09-11T19:00:00+01:00")'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -185,8 +185,7 @@ module Fastlane
           Actions.lane_context[SharedValues::DSYM_LATEST_UPLOADED_DATE] ||= uploaded_date
           current_latest = Actions.lane_context[SharedValues::DSYM_LATEST_UPLOADED_DATE]
           Actions.lane_context[SharedValues::DSYM_LATEST_UPLOADED_DATE] = [current_latest, uploaded_date].max
-          UI.message("Build upload date #{uploaded_date}")
-          UI.message("Latest uploaded date #{Actions.lane_context[SharedValues::DSYM_LATEST_UPLOADED_DATE]}")
+          UI.verbose("Latest uploaded date #{Actions.lane_context[SharedValues::DSYM_LATEST_UPLOADED_DATE]}")
         end
       end
 

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -73,12 +73,18 @@ describe Fastlane do
         it 'downloads all dsyms of all builds in all trains' do
           expect(build_resp).to receive(:to_models).and_return([build1, build2, build3, build4, build5, build6])
 
-          [[build1, '1.0.0', '1'], [build2, '1.0.0', '2'], [build3, '1.7.0', '4'], [build4, '2.0.0', '1'], [build5, '2.0.0', '2'], [build6, '2.0.0', '5']].each do |build, version, build_number|
+          [[build1, '1.0.0', '1', '2020-09-12T10:00:00+01:00'],
+           [build2, '1.0.0', '2', '2020-09-12T11:00:00+01:00'],
+           [build3, '1.7.0', '4', '2020-09-12T12:00:00+01:00'],
+           [build4, '2.0.0', '1', '2020-09-12T13:00:00+01:00'],
+           [build5, '2.0.0', '2', '2020-09-12T14:00:00+01:00'],
+           [build6, '2.0.0', '5', '2020-09-12T15:00:00+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
             expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
             expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
-            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, DateTime.parse(uploaded_date), nil)
           end
 
           expect(Fastlane::Actions::DownloadDsymsAction).not_to(receive(:download))
@@ -93,12 +99,13 @@ describe Fastlane do
         it 'downloads all dsyms of all builds in train 1.07.0' do
           expect(build_resp).to receive(:to_models).and_return([build1])
 
-          [[build1, '1.7.0', '3']].each do |build, version, build_number|
+          [[build1, '1.7.0', '3', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
             expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
             expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
-            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, DateTime.parse(uploaded_date), nil)
           end
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -111,12 +118,13 @@ describe Fastlane do
         it 'downloads the correct dsyms' do
           expect(build_resp).to receive(:to_models).and_return([build1])
 
-          [[build1, '2.0.0', '2']].each do |build, version, build_number|
+          [[build1, '2.0.0', '2', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
             expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
             expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
-            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, DateTime.parse(uploaded_date), nil)
           end
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -134,18 +142,20 @@ describe Fastlane do
 
           expect(build_resp).to receive(:to_models).and_return([build1, build2])
 
-          [[build1, '2.0.0', '2']].each do |build, version, build_number|
+          [[build1, '2.0.0', '2', '2020-09-12T10:00:00+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
           end
 
-          [[build2, '2.0.0', '3']].each do |build, version, build_number|
+          [[build2, '2.0.0', '3', '2020-09-12T11:00:00+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version).twice
             expect(build).to receive(:version).and_return(build_number).twice
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
 
             expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
             expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
-            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, DateTime.parse(uploaded_date), nil)
           end
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -164,18 +174,20 @@ describe Fastlane do
 
           expect(build_resp).to receive(:to_models).and_return([build1, build2])
 
-          [[build1, '1.0.0', '33']].each do |build, version, build_number|
+          [[build1, '1.0.0', '33', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
           end
 
-          [[build2, '1.0.0', '42']].each do |build, version, build_number|
+          [[build2, '1.0.0', '42', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
 
             expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
             expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
-            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, DateTime.parse(uploaded_date), nil)
           end
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -188,22 +200,55 @@ describe Fastlane do
         it 'downloads only dsyms of trains newer than or equal min_version' do
           expect(build_resp).to receive(:to_models).and_return([build1, build2])
 
-          [[build1, '1.0.0', '33']].each do |build, version, build_number|
+          [[build1, '1.0.0', '33', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
           end
 
-          [[build2, '2.0.0', '42']].each do |build, version, build_number|
+          [[build2, '2.0.0', '42', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
 
             expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
             expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
-            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, nil)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, DateTime.parse(uploaded_date), nil)
           end
 
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', min_version: '2.0.0')
+          end").runner.execute(:test)
+        end
+      end
+
+      context 'with after_uploaded_date' do
+        it 'downloads dsyms with more recent uploaded_date' do
+          expect(build_resp).to receive(:to_models).and_return([build1, build2, build3, build4, build5, build6])
+
+          [[build1, '1.0.0', '1', '2020-09-12T10:00:00+01:00'],
+           [build2, '1.0.0', '2', '2020-09-12T11:00:00+01:00'],
+           [build3, '1.7.0', '4', '2020-09-12T12:00:00+01:00'],
+           [build4, '2.0.0', '1', '2020-09-12T13:00:00+01:00']].each do |build, verison, build_number, uploaded_date|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
+          end
+
+          [[build5, '2.0.0', '2', '2020-09-12T14:00:00+01:00'],
+           [build6, '2.0.0', '5', '2020-09-12T15:00:00+01:00']].each do |build, version, build_number, uploaded_date|
+            expect(build).to receive(:app_version).and_return(version)
+            expect(build).to receive(:version).and_return(build_number)
+            expect(build).to receive(:uploaded_date).and_return(uploaded_date)
+            expect(tunes_client).to receive(:build_details).with(app_id: app.id, train: version, build_number: build_number, platform: :ios).and_return(build_detail_resp)
+            expect(Spaceship::Tunes::BuildDetails).to receive(:factory).with(build_detail_resp).and_return(build_detail)
+            expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, app.bundle_id, version, build_number, DateTime.parse(uploaded_date), nil)
+          end
+
+          expect(Fastlane::Actions::DownloadDsymsAction).not_to(receive(:download))
+
+          Fastlane::FastFile.new.parse("lane :test do
+            download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', after_uploaded_date: '2020-09-12T13:00:00+01:00')
           end").runner.execute(:test)
         end
       end

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -24,6 +24,13 @@ describe Fastlane do
       let(:empty_build_detail) { double('empty_build_detail') }
 
       let(:download_url) { 'https://example.com/myapp-dsym' }
+      
+      date1 = '2020-09-12T10:00:00+01:00'
+      date2 = '2020-09-12T11:00:00+01:00'
+      date3 = '2020-09-12T12:00:00+01:00'
+      date4 = '2020-09-12T13:00:00+01:00'
+      date5 = '2020-09-12T14:00:00+01:00'
+      date6 = '2020-09-12T15:00:00+01:00'
 
       before do
         allow(Spaceship::Tunes).to receive(:client).and_return(tunes_client)
@@ -73,12 +80,12 @@ describe Fastlane do
         it 'downloads all dsyms of all builds in all trains' do
           expect(build_resp).to receive(:to_models).and_return([build1, build2, build3, build4, build5, build6])
 
-          [[build1, '1.0.0', '1', '2020-09-12T10:00:00+01:00'],
-           [build2, '1.0.0', '2', '2020-09-12T11:00:00+01:00'],
-           [build3, '1.7.0', '4', '2020-09-12T12:00:00+01:00'],
-           [build4, '2.0.0', '1', '2020-09-12T13:00:00+01:00'],
-           [build5, '2.0.0', '2', '2020-09-12T14:00:00+01:00'],
-           [build6, '2.0.0', '5', '2020-09-12T15:00:00+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build1, '1.0.0', '1', date1],
+           [build2, '1.0.0', '2', date2],
+           [build3, '1.7.0', '4', date3],
+           [build4, '2.0.0', '1', date4],
+           [build5, '2.0.0', '2', date5],
+           [build6, '2.0.0', '5', date6]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
@@ -99,7 +106,7 @@ describe Fastlane do
         it 'downloads all dsyms of all builds in train 1.07.0' do
           expect(build_resp).to receive(:to_models).and_return([build1])
 
-          [[build1, '1.7.0', '3', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build1, '1.7.0', '3', date1]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
@@ -118,7 +125,7 @@ describe Fastlane do
         it 'downloads the correct dsyms' do
           expect(build_resp).to receive(:to_models).and_return([build1])
 
-          [[build1, '2.0.0', '2', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build1, '2.0.0', '2', date1]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
@@ -142,13 +149,13 @@ describe Fastlane do
 
           expect(build_resp).to receive(:to_models).and_return([build1, build2])
 
-          [[build1, '2.0.0', '2', '2020-09-12T10:00:00+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build1, '2.0.0', '2', date1]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
           end
 
-          [[build2, '2.0.0', '3', '2020-09-12T11:00:00+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build2, '2.0.0', '3', date2]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version).twice
             expect(build).to receive(:version).and_return(build_number).twice
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
@@ -174,13 +181,13 @@ describe Fastlane do
 
           expect(build_resp).to receive(:to_models).and_return([build1, build2])
 
-          [[build1, '1.0.0', '33', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build1, '1.0.0', '33', date1]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
           end
 
-          [[build2, '1.0.0', '42', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build2, '1.0.0', '42', date2]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
@@ -200,13 +207,13 @@ describe Fastlane do
         it 'downloads only dsyms of trains newer than or equal min_version' do
           expect(build_resp).to receive(:to_models).and_return([build1, build2])
 
-          [[build1, '1.0.0', '33', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build1, '1.0.0', '33', date1]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
           end
 
-          [[build2, '2.0.0', '42', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build2, '2.0.0', '42', date2]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
@@ -226,17 +233,17 @@ describe Fastlane do
         it 'downloads dsyms with more recent uploaded_date' do
           expect(build_resp).to receive(:to_models).and_return([build1, build2, build3, build4, build5, build6])
 
-          [[build1, '1.0.0', '1', '2020-09-12T10:00:00+01:00'],
-           [build2, '1.0.0', '2', '2020-09-12T11:00:00+01:00'],
-           [build3, '1.7.0', '4', '2020-09-12T12:00:00+01:00'],
-           [build4, '2.0.0', '1', '2020-09-12T13:00:00+01:00']].each do |build, verison, build_number, uploaded_date|
+          [[build1, '1.0.0', '1', date1],
+           [build2, '1.0.0', '2', date2],
+           [build3, '1.7.0', '4', date3],
+           [build4, '2.0.0', '1', date4]].each do |build, verison, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
           end
 
-          [[build5, '2.0.0', '2', '2020-09-12T14:00:00+01:00'],
-           [build6, '2.0.0', '5', '2020-09-12T15:00:00+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build5, '2.0.0', '2', date5],
+           [build6, '2.0.0', '5', date6]].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
@@ -248,7 +255,7 @@ describe Fastlane do
           expect(Fastlane::Actions::DownloadDsymsAction).not_to(receive(:download))
 
           Fastlane::FastFile.new.parse("lane :test do
-            download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', after_uploaded_date: '2020-09-12T13:00:00+01:00')
+                                       download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', after_uploaded_date: '#{date4}')
           end").runner.execute(:test)
         end
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
Note that on my system the keychain tests fail, but this occurs before PR:
```
Fastlane
  Fastlane::FastFile
    Create keychain Integration
      with name and password options
        works when keychain doesn't exist
        work when keychain already exist
        works with a password that contain spaces or `"` (FAILED - 1)
        works with keychain-settings (FAILED - 2)
        works with default_keychain (FAILED - 3)
        works with unlock (FAILED - 4)
        works with all params (FAILED - 5)
        sets the correct keychain path
      with path and password options
        successfully creates the keychain
        sets the correct keychain path
```

- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
Note that there is one warning:

```
fastlane/lib/fastlane/actions/download_dsyms.rb:8:7: C: Perceived complexity for run is too high. [27/18]
      def self.run(params)
      ^^^
```
This was present prior to this PR

- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently download_dsyms can fetch all dsym files, or specific files based on app version, build, live or latest. For some situations when an app may have live version, and multiple versions in development / TestFlight, these options don't provide a means to ensure all dsyms are downloaded without requesting all files every time the command is run.

By adding an option to download files newer than a given uploaded_date, and providing the most recent date of files downloaded during a pass, a controlling script can track the date and request only newer files each time.

### Description
The PR adds a new command option `after_uploaded_date` which takes a date / time string in any format supported by the ruby date parser. When provided only downloads dsym files for builds with an uploaded date more recent than the option.

The most recent uploaded date of the builds that symbols were downloaded for is added to the SharedValues hash as `DSYM_LATEST_UPLOADED_DATE`. 

Additionally the `DSYM_LATEST_UPLOADED_DATE` `SharedValue` is cleared by `clean_build_artifacts`. Although this is not a build artifact it is logical that it would be reset along with `DSYM_FILES`.

<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
Have added additional unit test to download_dsyms_specs to validate the correct download calls are made:

```
$ bundle exec rspec --pattern "**{,/*/**}/download_dsyms_spec.rb"
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /Users/markw/.gem/specifications/open4-1.3.4.gemspec:16.
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Changing stdout to /var/folders/6w/4yzk82317zbc8jwwdr9cn2xw0000gp/T/fastlane_tests, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)

Fastlane
  Fastlane::FastFile
    download_dsyms
      with no special options
        downloads all dsyms of all builds in all trains
      with version with leading zero
        downloads all dsyms of all builds in train 1.07.0
      when build_number is an integer
        downloads the correct dsyms
      when version is latest
        downloads only dsyms of latest build in latest train
      when version is live
        downloads only dsyms of live build
      when min_version is set
        downloads only dsyms of trains newer than or equal min_version
      with after_uploaded_date
        downloads dsyms with more recent uploaded_date

Finished in 0.12012 seconds (files took 3.53 seconds to load)
7 examples, 0 failures
```

Have run on our developer accounts and applications to check it correctly selects the expected dsyms when the new option is provided, and that the `DSYM_LATEST_UPLOADED_DATE` is correct.

Finally, this is my first dive into ruby + fastlane codebase so all feedback appreciated !
