### PR TITLE
[deliver] add retry when fetching edit app version and edit app info

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -14,7 +14,7 @@ module Deliver
       [
         FastlaneCore::ConfigItem.new(key: :api_key_path,
                                      env_name: "DELIVER_API_KEY_PATH",
-                                     description: "Path to your App Store Connect API key JSON file",
+                                     description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:username],
                                      verify_block: proc do |value|
@@ -22,7 +22,7 @@ module Deliver
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
                                      env_name: "DELIVER_API_KEY",
-                                     description: "Path to your App Store Connect API key JSON file",
+                                     description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,
                                      sensitive: true,

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -12,6 +12,22 @@ module Deliver
       user ||= ENV["DELIVER_USER"]
 
       [
+        FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                     env_name: "DELIVER_API_KEY_PATH",
+                                     description: "Path to your App Store Connect API key JSON file",
+                                     optional: true,
+                                     conflicting_options: [:username],
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :api_key,
+                                     env_name: "DELIVER_API_KEY",
+                                     description: "Path to your App Store Connect API key JSON file",
+                                     type: Hash,
+                                     optional: true,
+                                     sensitive: true,
+                                     conflicting_options: [:api_key_path, :username]),
+
         FastlaneCore::ConfigItem.new(key: :username,
                                      short_option: "-u",
                                      env_name: "DELIVER_USERNAME",
@@ -129,7 +145,7 @@ module Deliver
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_app_version_update,
                                      env_name: "DELIVER_SKIP_APP_VERSION_UPDATE",
-                                     description: "Don't update app version for submission",
+                                     description: "Don’t create or update the app version that is being prepared for submission",
                                      is_string: false,
                                      default_value: false),
 

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -26,11 +26,22 @@ module Deliver
     end
 
     def login
-      # Team selection passed though FASTLANE_TEAM_ID and FASTLANE_TEAM_NAME environment variables
-      # Prompts select team if multiple teams and none specified
-      UI.message("Login to App Store Connect (#{options[:username]})")
-      Spaceship::ConnectAPI.login(options[:username], nil, use_portal: false, use_tunes: true)
-      UI.message("Login successful")
+      if api_token
+        UI.message("Creating authorization token for App Store Connect API")
+        Spaceship::ConnectAPI.token = api_token
+      else
+        # Team selection passed though FASTLANE_TEAM_ID and FASTLANE_TEAM_NAME environment variables
+        # Prompts select team if multiple teams and none specified
+        UI.message("Login to App Store Connect (#{options[:username]})")
+        Spaceship::ConnectAPI.login(options[:username], nil, use_portal: false, use_tunes: true)
+        UI.message("Login successful")
+      end
+    end
+
+    def api_token
+      @api_token ||= Spaceship::ConnectAPI::Token.create(options[:api_key]) if options[:api_key]
+      @api_token ||= Spaceship::ConnectAPI::Token.from_json_file(options[:api_key_path]) if options[:api_key_path]
+      return @api_token
     end
 
     def run
@@ -67,10 +78,20 @@ module Deliver
       precheck_options = {
         default_rule_level: options[:precheck_default_rule_level],
         include_in_app_purchases: options[:precheck_include_in_app_purchases],
-        app_identifier: options[:app_identifier],
-        username: options[:username],
-        platform: options[:platform]
+        app_identifier: options[:app_identifier]
       }
+
+      if options[:api_key] || options[:api_key_path]
+        if options[:precheck_include_in_app_purchases]
+          UI.user_error!("Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck or use Apple ID login")
+        end
+
+        precheck_options[:api_key] = options[:api_key]
+        precheck_options[:api_key_path] = options[:api_key_path]
+      else
+        precheck_options[:username] = options[:username]
+        precheck_options[:platform] = options[:platform]
+      end
 
       precheck_config = FastlaneCore::Configuration.create(Precheck::Options.available_options, precheck_options)
       Precheck.config = precheck_config
@@ -175,10 +196,17 @@ module Deliver
 
     private
 
+    # If App Store Connect API token, use token.
     # If itc_provider was explicitly specified, use it.
     # If there are multiple teams, infer the provider from the selected team name.
     # If there are fewer than two teams, don't infer the provider.
     def transporter_for_selected_team
+      # Use JWT auth
+      unless api_token.nil?
+        api_token.refresh! if api_token.expired?
+        return FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, api_token.text)
+      end
+
       tunes_client = Spaceship::ConnectAPI.client.tunes_client
 
       generic_transporter = FastlaneCore::ItunesTransporter.new(options[:username], nil, false, options[:itc_provider])

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -414,6 +414,32 @@ module Deliver
         .uniq
     end
 
+    def fetch_edit_app_store_version(app, platform, wait_time: 10)
+      retry_if_nil("Cannot find edit app store version", wait_time: wait_time) do
+        app.get_edit_app_store_version(platform: platform)
+      end
+    end
+
+    def fetch_edit_app_info(app, wait_time: 10)
+      retry_if_nil("Cannot find edit app info", wait_time: wait_time) do
+        app.fetch_edit_app_info
+      end
+    end
+
+    def retry_if_nil(message, tries: 5, wait_time: 10)
+      loop do
+        tries -= 1
+
+        value = yield
+        return value if value
+
+        UI.message("#{message}... Retrying after #{wait_time} seconds (remaining: #{tries})")
+        sleep(wait_time)
+
+        return nil if tries.zero?
+      end
+    end
+
     # Finding languages to enable
     def verify_available_info_languages!(options, app, languages)
       app_info = fetch_edit_app_info(app)
@@ -446,32 +472,6 @@ module Deliver
       end
 
       return localizations
-    end
-
-    def fetch_edit_app_store_version(app, platform, wait_time: 10)
-      retry_if_nil("Cannot find edit app store version", wait_time: wait_time) do
-        app.get_edit_app_store_version(platform: platform)
-      end
-    end
-
-    def fetch_edit_app_info(app, wait_time: 10)
-      retry_if_nil("Cannot find edit app info", wait_time: wait_time) do
-        app.fetch_edit_app_info
-      end
-    end
-
-    def retry_if_nil(message, tries: 5, wait_time: 10)
-      loop do
-        tries -= 1
-
-        value = yield
-        return value if value
-
-        UI.message("#{message}... Retrying after #{wait_time} seconds (remaining: #{tries})")
-        sleep(wait_time)
-
-        return nil if tries.zero?
-      end
     end
 
     # Finding languages to enable

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -96,7 +96,7 @@ module Deliver
 
         if v.nil?
           UI.message("Couldn't find live version, editing the current version on App Store Connect instead")
-          version = app.get_edit_app_store_version(platform: platform)
+          version = fetch_edit_app_store_version(app, platform) 
           # we don't want to update the localised_options and non_localised_options
           # as we also check for `options[:edit_live]` at other areas in the code
           # by not touching those 2 variables, deliver is more consistent with what the option says
@@ -105,7 +105,7 @@ module Deliver
           UI.message("Found live version")
         end
       else
-        version = app.get_edit_app_store_version(platform: platform)
+        version = fetch_edit_app_store_version(app, platform) 
         localised_options = (LOCALISED_VERSION_VALUES.keys + LOCALISED_APP_VALUES.keys)
         non_localised_options = NON_LOCALISED_VERSION_VALUES.keys
       end
@@ -206,7 +206,7 @@ module Deliver
       end
 
       # Update categories
-      app_info = app.fetch_edit_app_info
+      app_info = fetch_edit_app_info(app)
       if app_info
         category_id_map = {}
 
@@ -416,7 +416,7 @@ module Deliver
 
     # Finding languages to enable
     def verify_available_info_languages!(options, app, languages)
-      app_info = app.fetch_edit_app_info
+      app_info = fetch_edit_app_info(app)
 
       unless app_info
         UI.user_error!("Cannot update languages - could not find an editable info")
@@ -448,10 +448,37 @@ module Deliver
       return localizations
     end
 
+    def fetch_edit_app_store_version(app, platform)
+      version = retry_if_nil("Cannot find edit app store version") do
+        app.get_edit_app_store_version(platform: platform)
+      end
+    end
+
+    def fetch_edit_app_info(app)
+      version = retry_if_nil("Cannot find edit app info") do
+        app.fetch_edit_app_info
+      end
+    end
+
+    def retry_if_nil(message, tries: 5)
+      loop do
+        tries -= 1
+
+        value = yield
+        return value if value
+
+        sleep_time = 10
+        UI.message("#{message}... Retrying after #{sleep_time} seconds (remaining: #{tries})")
+        sleep(sleep_time)
+
+        return nil if tries.zero?
+      end
+    end
+
     # Finding languages to enable
     def verify_available_version_languages!(options, app, languages)
       platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
-      version = app.get_edit_app_store_version(platform: platform)
+      version = fetch_edit_app_store_version(app, platform)
 
       unless version
         UI.user_error!("Cannot update languages - could not find an editable version for '#{platform}'")

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -96,7 +96,7 @@ module Deliver
 
         if v.nil?
           UI.message("Couldn't find live version, editing the current version on App Store Connect instead")
-          version = fetch_edit_app_store_version(app, platform) 
+          version = fetch_edit_app_store_version(app, platform)
           # we don't want to update the localised_options and non_localised_options
           # as we also check for `options[:edit_live]` at other areas in the code
           # by not touching those 2 variables, deliver is more consistent with what the option says
@@ -105,7 +105,7 @@ module Deliver
           UI.message("Found live version")
         end
       else
-        version = fetch_edit_app_store_version(app, platform) 
+        version = fetch_edit_app_store_version(app, platform)
         localised_options = (LOCALISED_VERSION_VALUES.keys + LOCALISED_APP_VALUES.keys)
         non_localised_options = NON_LOCALISED_VERSION_VALUES.keys
       end
@@ -449,13 +449,13 @@ module Deliver
     end
 
     def fetch_edit_app_store_version(app, platform)
-      version = retry_if_nil("Cannot find edit app store version") do
+      retry_if_nil("Cannot find edit app store version") do
         app.get_edit_app_store_version(platform: platform)
       end
     end
 
     def fetch_edit_app_info(app)
-      version = retry_if_nil("Cannot find edit app info") do
+      retry_if_nil("Cannot find edit app info") do
         app.fetch_edit_app_info
       end
     end

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -448,28 +448,27 @@ module Deliver
       return localizations
     end
 
-    def fetch_edit_app_store_version(app, platform)
-      retry_if_nil("Cannot find edit app store version") do
+    def fetch_edit_app_store_version(app, platform, wait_time: 10)
+      retry_if_nil("Cannot find edit app store version", wait_time: wait_time) do
         app.get_edit_app_store_version(platform: platform)
       end
     end
 
-    def fetch_edit_app_info(app)
-      retry_if_nil("Cannot find edit app info") do
+    def fetch_edit_app_info(app, wait_time: 10)
+      retry_if_nil("Cannot find edit app info", wait_time: wait_time) do
         app.fetch_edit_app_info
       end
     end
 
-    def retry_if_nil(message, tries: 5)
+    def retry_if_nil(message, tries: 5, wait_time: 10)
       loop do
         tries -= 1
 
         value = yield
         return value if value
 
-        sleep_time = 10
-        UI.message("#{message}... Retrying after #{sleep_time} seconds (remaining: #{tries})")
-        sleep(sleep_time)
+        UI.message("#{message}... Retrying after #{wait_time} seconds (remaining: #{tries})")
+        sleep(wait_time)
 
         return nil if tries.zero?
       end

--- a/deliver/lib/deliver/upload_price_tier.rb
+++ b/deliver/lib/deliver/upload_price_tier.rb
@@ -14,9 +14,14 @@ module Deliver
       attributes = {}
       territory_ids = []
 
-      app_prices = app.fetch_app_prices
+      # As of 2020-09-14:
+      # Official App Store Connect does not have an endpoint to get app prices for an app
+      # Need to get prices from the app's relationships
+      # Prices from app's relationship doess not have price tier so need to fetch app price with price tier relationship
+      app_prices = app.prices
       if app_prices.first
-        old_price = app_prices.first.price_tier.id
+        app_price = Spaceship::ConnectAPI.get_app_price(app_price_id: app_prices.first.id, includes: "priceTier").first
+        old_price = app_price.price_tier.id
       else
         UI.message("App has no prices yet... Enabling all countries in App Store Connect")
         territory_ids = Spaceship::ConnectAPI::Territory.all.map(&:id)

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -169,200 +169,252 @@ describe Deliver::UploadMetadata do
 
     let(:metadata_path) { Dir.mktmpdir }
 
-    before do
-      allow(uploader).to receive(:set_review_information)
-      allow(uploader).to receive(:set_review_attachment_file)
-      allow(uploader).to receive(:set_app_rating)
+    context "fetch app edit" do
+      context "#fetch_edit_app_store_version" do
+        it "no retry" do
+          expect(app).to receive(:get_edit_app_store_version).and_return(version)
 
-      # Verify available languages
-      expect(app).to receive(:id).and_return(id)
-      expect(app).to receive(:get_edit_app_store_version).and_return(version)
-      expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
+          edit_version = uploader.fetch_edit_app_store_version(app, 'IOS', wait_time: 0.1)
+          expect(edit_version).to eq(version)
+        end
 
-      # Get versions
-      expect(app).to receive(:get_edit_app_store_version).and_return(version)
-      expect(version).to receive(:get_app_store_version_localizations).and_return([version_localization_en])
+        it "1 retry" do
+          expect(app).to receive(:get_edit_app_store_version).and_return(nil)
+          expect(app).to receive(:get_edit_app_store_version).and_return(version)
 
-      # Get app infos
-      expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
-      expect(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
-    end
+          edit_version = uploader.fetch_edit_app_store_version(app, 'IOS', wait_time: 0.1)
+          expect(edit_version).to eq(version)
+        end
 
-    context "normal metadata" do
-      it "saves metadata" do
-        options = {
-            app: app,
-            platform: "ios",
-            metadata_path: metadata_path,
-            name: { "en-US" => "App name" },
-            description: { "en-US" => "App description" }
-        }
+        it "5 retry" do
+          expect(app).to receive(:get_edit_app_store_version).and_return(nil).exactly(5).times
 
-        # Get number of verions (used for if whats_new should be sent)
-        expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+          edit_version = uploader.fetch_edit_app_store_version(app, 'IOS', wait_time: 0.1)
+          expect(edit_version).to eq(nil)
+        end
+      end
 
-        expect(version).to receive(:update).with(attributes: {
-          "releaseType" => "MANUAL"
-        })
+      context "#fetch_edit_app_info" do
+        it "no retry" do
+          expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
 
-        # Update version localization
-        expect(version_localization_en).to receive(:update).with(attributes: {
-          "description" => options[:description]["en-US"]
-        })
+          edit_app_info = uploader.fetch_edit_app_info(app, wait_time: 0.1)
+          expect(edit_app_info).to eq(app_info)
+        end
 
-        # Update app info localization
-        expect(app_info_localization_en).to receive(:update).with(attributes: {
-          "name" => options[:name]["en-US"]
-        })
+        it "1 retry" do
+          expect(app).to receive(:fetch_edit_app_info).and_return(nil)
+          expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
 
-        # Update app info
-        expect(app_info).to receive(:update_categories).with(category_id_map: {})
+          edit_app_info = uploader.fetch_edit_app_info(app, wait_time: 0.1)
+          expect(edit_app_info).to eq(app_info)
+        end
 
-        uploader.upload(options)
+        it "5 retry" do
+          expect(app).to receive(:fetch_edit_app_info).and_return(nil).exactly(5).times
+
+          edit_app_info = uploader.fetch_edit_app_info(app, wait_time: 0.1)
+          expect(edit_app_info).to eq(nil)
+        end
       end
     end
 
-    context "with auto_release_date" do
-      it 'with date' do
-        options = {
-            app: app,
-            platform: "ios",
-            metadata_path: metadata_path,
-            auto_release_date: 1_595_395_800_000
-        }
+    context "#upload" do
+      before do
+        allow(uploader).to receive(:set_review_information)
+        allow(uploader).to receive(:set_review_attachment_file)
+        allow(uploader).to receive(:set_app_rating)
 
-        # Get number of verions (used for if whats_new should be sent)
-        expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+        # Verify available languages
+        expect(app).to receive(:id).and_return(id)
+        expect(app).to receive(:get_edit_app_store_version).and_return(version)
+        expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
 
-        expect(version).to receive(:update).with(attributes: {
-          "releaseType" => "SCHEDULED",
-          "earliestReleaseDate" => "2020-07-22T05:00:00+00:00"
-        })
+        # Get versions
+        expect(app).to receive(:get_edit_app_store_version).and_return(version)
+        expect(version).to receive(:get_app_store_version_localizations).and_return([version_localization_en])
 
-        # Update app info
-        expect(app_info).to receive(:update_categories).with(category_id_map: {})
-
-        uploader.upload(options)
-      end
-    end
-
-    context "with phased_release" do
-      it 'with true' do
-        options = {
-            app: app,
-            platform: "ios",
-            metadata_path: metadata_path,
-            phased_release: true
-        }
-
-        # Get number of verions (used for if whats_new should be sent)
-        expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
-
-        # Defaults to release type manual
-        expect(version).to receive(:update).with(attributes: {
-          "releaseType" => "MANUAL"
-        })
-
-        # Get phased release
-        expect(version).to receive(:fetch_app_store_version_phased_release).and_return(nil)
-
-        # Create a phased release
-        expect(version).to receive(:create_app_store_version_phased_release).with(attributes: {
-          phasedReleaseState: Spaceship::ConnectAPI::AppStoreVersionPhasedRelease::PhasedReleaseState::INACTIVE
-        })
-
-        # Update app info
-        expect(app_info).to receive(:update_categories).with(category_id_map: {})
-
-        uploader.upload(options)
+        # Get app infos
+        expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
+        expect(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
       end
 
-      it 'with false' do
-        options = {
-            app: app,
-            platform: "ios",
-            metadata_path: metadata_path,
-            phased_release: false
-        }
+      context "normal metadata" do
+        it "saves metadata" do
+          options = {
+              app: app,
+              platform: "ios",
+              metadata_path: metadata_path,
+              name: { "en-US" => "App name" },
+              description: { "en-US" => "App description" }
+          }
 
-        # Get number of verions (used for if whats_new should be sent)
-        expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+          # Get number of verions (used for if whats_new should be sent)
+          expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
 
-        # Defaults to release type manual
-        expect(version).to receive(:update).with(attributes: {
-          "releaseType" => "MANUAL"
-        })
+          expect(version).to receive(:update).with(attributes: {
+            "releaseType" => "MANUAL"
+          })
 
-        # Get phased release
-        phased_release = double('phased_release')
-        expect(version).to receive(:fetch_app_store_version_phased_release).and_return(phased_release)
+          # Update version localization
+          expect(version_localization_en).to receive(:update).with(attributes: {
+            "description" => options[:description]["en-US"]
+          })
 
-        # Delete phased release
-        expect(phased_release).to receive(:delete!)
+          # Update app info localization
+          expect(app_info_localization_en).to receive(:update).with(attributes: {
+            "name" => options[:name]["en-US"]
+          })
 
-        # Update app info
-        expect(app_info).to receive(:update_categories).with(category_id_map: {})
+          # Update app info
+          expect(app_info).to receive(:update_categories).with(category_id_map: {})
 
-        uploader.upload(options)
-      end
-    end
-
-    context "with reset_ratings" do
-      it 'with true' do
-        options = {
-            app: app,
-            platform: "ios",
-            metadata_path: metadata_path,
-            reset_ratings: true
-        }
-
-        # Get number of verions (used for if whats_new should be sent)
-        expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
-
-        # Defaults to release type manual
-        expect(version).to receive(:update).with(attributes: {
-          "releaseType" => "MANUAL"
-        })
-
-        # Get reset ratings request
-        expect(version).to receive(:fetch_reset_ratings_request).and_return(nil)
-
-        # Create a reset ratings request
-        expect(version).to receive(:create_reset_ratings_request)
-
-        # Update app info
-        expect(app_info).to receive(:update_categories).with(category_id_map: {})
-
-        uploader.upload(options)
+          uploader.upload(options)
+        end
       end
 
-      it 'with false' do
-        options = {
-            app: app,
-            platform: "ios",
-            metadata_path: metadata_path,
-            reset_ratings: false
-        }
+      context "with auto_release_date" do
+        it 'with date' do
+          options = {
+              app: app,
+              platform: "ios",
+              metadata_path: metadata_path,
+              auto_release_date: 1_595_395_800_000
+          }
 
-        # Get number of verions (used for if whats_new should be sent)
-        expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+          # Get number of verions (used for if whats_new should be sent)
+          expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
 
-        # Defaults to release type manual
-        expect(version).to receive(:update).with(attributes: {
-          "releaseType" => "MANUAL"
-        })
+          expect(version).to receive(:update).with(attributes: {
+            "releaseType" => "SCHEDULED",
+            "earliestReleaseDate" => "2020-07-22T05:00:00+00:00"
+          })
 
-        # Get reset ratings request
-        reset_ratings_request = double('reset_ratings_request')
-        expect(version).to receive(:fetch_reset_ratings_request).and_return(reset_ratings_request)
+          # Update app info
+          expect(app_info).to receive(:update_categories).with(category_id_map: {})
 
-        # Delete reset ratings request
-        expect(reset_ratings_request).to receive(:delete!)
+          uploader.upload(options)
+        end
+      end
 
-        # Update app info
-        expect(app_info).to receive(:update_categories).with(category_id_map: {})
+      context "with phased_release" do
+        it 'with true' do
+          options = {
+              app: app,
+              platform: "ios",
+              metadata_path: metadata_path,
+              phased_release: true
+          }
 
-        uploader.upload(options)
+          # Get number of verions (used for if whats_new should be sent)
+          expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+
+          # Defaults to release type manual
+          expect(version).to receive(:update).with(attributes: {
+            "releaseType" => "MANUAL"
+          })
+
+          # Get phased release
+          expect(version).to receive(:fetch_app_store_version_phased_release).and_return(nil)
+
+          # Create a phased release
+          expect(version).to receive(:create_app_store_version_phased_release).with(attributes: {
+            phasedReleaseState: Spaceship::ConnectAPI::AppStoreVersionPhasedRelease::PhasedReleaseState::INACTIVE
+          })
+
+          # Update app info
+          expect(app_info).to receive(:update_categories).with(category_id_map: {})
+
+          uploader.upload(options)
+        end
+
+        it 'with false' do
+          options = {
+              app: app,
+              platform: "ios",
+              metadata_path: metadata_path,
+              phased_release: false
+          }
+
+          # Get number of verions (used for if whats_new should be sent)
+          expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+
+          # Defaults to release type manual
+          expect(version).to receive(:update).with(attributes: {
+            "releaseType" => "MANUAL"
+          })
+
+          # Get phased release
+          phased_release = double('phased_release')
+          expect(version).to receive(:fetch_app_store_version_phased_release).and_return(phased_release)
+
+          # Delete phased release
+          expect(phased_release).to receive(:delete!)
+
+          # Update app info
+          expect(app_info).to receive(:update_categories).with(category_id_map: {})
+
+          uploader.upload(options)
+        end
+      end
+
+      context "with reset_ratings" do
+        it 'with true' do
+          options = {
+              app: app,
+              platform: "ios",
+              metadata_path: metadata_path,
+              reset_ratings: true
+          }
+
+          # Get number of verions (used for if whats_new should be sent)
+          expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+
+          # Defaults to release type manual
+          expect(version).to receive(:update).with(attributes: {
+            "releaseType" => "MANUAL"
+          })
+
+          # Get reset ratings request
+          expect(version).to receive(:fetch_reset_ratings_request).and_return(nil)
+
+          # Create a reset ratings request
+          expect(version).to receive(:create_reset_ratings_request)
+
+          # Update app info
+          expect(app_info).to receive(:update_categories).with(category_id_map: {})
+
+          uploader.upload(options)
+        end
+
+        it 'with false' do
+          options = {
+              app: app,
+              platform: "ios",
+              metadata_path: metadata_path,
+              reset_ratings: false
+          }
+
+          # Get number of verions (used for if whats_new should be sent)
+          expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+
+          # Defaults to release type manual
+          expect(version).to receive(:update).with(attributes: {
+            "releaseType" => "MANUAL"
+          })
+
+          # Get reset ratings request
+          reset_ratings_request = double('reset_ratings_request')
+          expect(version).to receive(:fetch_reset_ratings_request).and_return(reset_ratings_request)
+
+          # Delete reset ratings request
+          expect(reset_ratings_request).to receive(:delete!)
+
+          # Update app info
+          expect(app_info).to receive(:update_categories).with(category_id_map: {})
+
+          uploader.upload(options)
+        end
       end
     end
   end

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -12,7 +12,7 @@ module Pilot
       [
         FastlaneCore::ConfigItem.new(key: :api_key_path,
                                      env_name: "PILOT_API_KEY_PATH",
-                                     description: "Path to your App Store Connect API key JSON file",
+                                     description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:username],
                                      verify_block: proc do |value|
@@ -20,7 +20,7 @@ module Pilot
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
                                      env_name: "PILOT_API_KEY",
-                                     description: "Path to your App Store Connect API key JSON file",
+                                     description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,
                                      sensitive: true,

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -25,6 +25,22 @@ module Precheck
       user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
       [
+        FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                     env_name: "PRECHECK_API_KEY_PATH",
+                                     description: "Path to your App Store Connect API key JSON file",
+                                     optional: true,
+                                     conflicting_options: [:username],
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :api_key,
+                                     env_name: "PRECHECK_API_KEY",
+                                     description: "Path to your App Store Connect API key JSON file",
+                                     type: Hash,
+                                     optional: true,
+                                     sensitive: true,
+                                     conflicting_options: [:api_key_path, :username]),
+
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      short_option: "-a",
                                      env_name: "PRECHECK_APP_IDENTIFIER",

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -27,7 +27,7 @@ module Precheck
       [
         FastlaneCore::ConfigItem.new(key: :api_key_path,
                                      env_name: "PRECHECK_API_KEY_PATH",
-                                     description: "Path to your App Store Connect API key JSON file",
+                                     description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:username],
                                      verify_block: proc do |value|
@@ -35,7 +35,7 @@ module Precheck
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
                                      env_name: "PRECHECK_API_KEY",
-                                     description: "Path to your App Store Connect API key JSON file",
+                                     description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,
                                      sensitive: true,

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
@@ -112,8 +112,8 @@ module Spaceship
       # API
       #
 
-      def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
-        resp = Spaceship::ConnectAPI.get_app_screenshot_sets(filter: filter, includes: includes, limit: limit, sort: sort)
+      def self.all(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+        resp = Spaceship::ConnectAPI.get_app_screenshot_sets(app_store_version_localization_id: app_store_version_localization_id, filter: filter, includes: includes, limit: limit, sort: sort)
         return resp.to_models
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -114,11 +114,8 @@ module Spaceship
         return resp.to_models.first
       end
 
-      # appScreenshotSets,appPreviewSets
-      def get_app_store_version_localizations(filter: {}, includes: "appScreenshotSets", limit: nil, sort: nil)
-        filter ||= {}
-        filter["appStoreVersion"] = id
-        return Spaceship::ConnectAPI::AppStoreVersionLocalization.all(filter: filter, includes: includes, limit: limit, sort: sort)
+      def get_app_store_version_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
+        return Spaceship::ConnectAPI::AppStoreVersionLocalization.all(app_store_version_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
       end
 
       #

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
@@ -39,8 +39,8 @@ module Spaceship
       # API
       #
 
-      def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
-        resp = Spaceship::ConnectAPI.get_app_store_version_localizations(filter: filter, includes: includes, limit: limit, sort: sort)
+      def self.all(app_store_version_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+        resp = Spaceship::ConnectAPI.get_app_store_version_localizations(app_store_version_id: app_store_version_id, filter: filter, includes: includes, limit: limit, sort: sort)
         return resp.to_models
       end
 
@@ -73,9 +73,7 @@ module Spaceship
       #
 
       def get_app_screenshot_sets(filter: {}, includes: "appScreenshots", limit: nil, sort: nil)
-        filter ||= {}
-        filter["appStoreVersionLocalization"] = id
-        return Spaceship::ConnectAPI::AppScreenshotSet.all(filter: filter, includes: includes, limit: limit, sort: sort)
+        return Spaceship::ConnectAPI::AppScreenshotSet.all(app_store_version_localization_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
       end
 
       def create_app_screenshot_set(attributes: nil)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -308,6 +308,11 @@ module Spaceship
           tunes_request_client.get("appPrices", params)
         end
 
+        def get_app_price(app_price_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+          params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          tunes_request_client.get("appPrices/#{app_price_id}", params)
+        end
+
         #
         # appPricePoints
         #
@@ -360,9 +365,9 @@ module Spaceship
         # appScreenshotSets
         #
 
-        def get_app_screenshot_sets(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_app_screenshot_sets(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appScreenshotSets", params)
+          tunes_request_client.get("appStoreVersionLocalizations/#{app_store_version_localization_id}/appScreenshotSets", params)
         end
 
         def get_app_screenshot_set(app_screenshot_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
@@ -453,9 +458,9 @@ module Spaceship
         # appInfos
         #
 
-        def get_app_infos(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_app_infos(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appInfos", params)
+          tunes_request_client.get("apps/#{app_id}/appInfos", params)
         end
 
         def patch_app_info(app_info_id: nil, attributes: {})
@@ -641,9 +646,9 @@ module Spaceship
         # appStoreVersionLocalizations
         #
 
-        def get_app_store_version_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_app_store_version_localizations(app_store_version_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appStoreVersionLocalizations", params)
+          tunes_request_client.get("appStoreVersions/#{app_store_version_id}/appStoreVersionLocalizations", params)
         end
 
         def post_app_store_version_localization(app_store_version_id: nil, attributes: {})

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -18,7 +18,7 @@ class ConnectAPIStubbing
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps").
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 
-        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?filter%5BbundleId%5D=com.joshholtz.FastlaneTest&include=appStoreVersions").
+        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?filter%5BbundleId%5D=com.joshholtz.FastlaneTest&include=appStoreVersions,prices").
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps/123456789").


### PR DESCRIPTION
### Motivation and Context
Fixes #16991

### Description
- Add 5 retries (with 10 second sleep) to fetching edit app version and edit app info
- Big diff in tests is because of indenting a whole section 🤷‍♂️ 

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-deliver-add-retry-fetching-edit-versions"
```
