### PR TITLE
[deliver] add support for App Store Connect API Key

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -145,7 +145,7 @@ module Deliver
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_app_version_update,
                                      env_name: "DELIVER_SKIP_APP_VERSION_UPDATE",
-                                     description: "Don’t created or update the app version that is being prepared for submission",
+                                     description: "Don’t create or update the app version that is being prepared for submission",
                                      is_string: false,
                                      default_value: false),
 

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -145,7 +145,7 @@ module Deliver
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_app_version_update,
                                      env_name: "DELIVER_SKIP_APP_VERSION_UPDATE",
-                                     description: "Don't update app version for submission",
+                                     description: "Don’t created or update the app version that is being prepared for submission",
                                      is_string: false,
                                      default_value: false),
 

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -12,6 +12,22 @@ module Deliver
       user ||= ENV["DELIVER_USER"]
 
       [
+        FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                     env_name: "DELIVER_API_KEY_PATH",
+                                     description: "Path to your App Store Connect API key JSON file",
+                                     optional: true,
+                                     conflicting_options: [:username],
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :api_key,
+                                     env_name: "DELIVER_API_KEY",
+                                     description: "Path to your App Store Connect API key JSON file",
+                                     type: Hash,
+                                     optional: true,
+                                     sensitive: true,
+                                     conflicting_options: [:api_key_path, :username]),
+
         FastlaneCore::ConfigItem.new(key: :username,
                                      short_option: "-u",
                                      env_name: "DELIVER_USERNAME",

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -78,10 +78,20 @@ module Deliver
       precheck_options = {
         default_rule_level: options[:precheck_default_rule_level],
         include_in_app_purchases: options[:precheck_include_in_app_purchases],
-        app_identifier: options[:app_identifier],
-        username: options[:username],
-        platform: options[:platform]
+        app_identifier: options[:app_identifier]
       }
+
+      if options[:api_key] || options[:api_key_path]
+        if options[:precheck_include_in_app_purchases]
+          UI.user_error!("Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck or use Apple ID login")
+        end
+
+        precheck_options[:api_key] = options[:api_key]
+        precheck_options[:api_key_path] = options[:api_key_path]
+      else
+        precheck_options[:username] = options[:username]
+        precheck_options[:platform] = options[:platform]
+      end
 
       precheck_config = FastlaneCore::Configuration.create(Precheck::Options.available_options, precheck_options)
       Precheck.config = precheck_config

--- a/deliver/lib/deliver/upload_price_tier.rb
+++ b/deliver/lib/deliver/upload_price_tier.rb
@@ -14,9 +14,11 @@ module Deliver
       attributes = {}
       territory_ids = []
 
-      app_prices = app.fetch_app_prices
+      app_prices = app.prices
       if app_prices.first
-        old_price = app_prices.first.price_tier.id
+        app_price = Spaceship::ConnectAPI.get_app_price(app_price_id: app_prices.first.id, includes: "priceTier").first
+
+        old_price = app_price.price_tier.id
       else
         UI.message("App has no prices yet... Enabling all countries in App Store Connect")
         territory_ids = Spaceship::ConnectAPI::Territory.all.map(&:id)

--- a/deliver/lib/deliver/upload_price_tier.rb
+++ b/deliver/lib/deliver/upload_price_tier.rb
@@ -14,10 +14,13 @@ module Deliver
       attributes = {}
       territory_ids = []
 
+      # As of 2020-09-14:
+      # Official App Store Connect does not have an endpoint to get app prices for an app
+      # Need to get prices from the app's relationships
+      # Prices from app's relationship doess not have price tier so need to fetch app price with price tier relationship
       app_prices = app.prices
       if app_prices.first
         app_price = Spaceship::ConnectAPI.get_app_price(app_price_id: app_prices.first.id, includes: "priceTier").first
-
         old_price = app_price.price_tier.id
       else
         UI.message("App has no prices yet... Enabling all countries in App Store Connect")

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -25,6 +25,22 @@ module Precheck
       user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
       [
+        FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                     env_name: "PRECHECK_API_KEY_PATH",
+                                     description: "Path to your App Store Connect API key JSON file",
+                                     optional: true,
+                                     conflicting_options: [:username],
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :api_key,
+                                     env_name: "PRECHECK_API_KEY",
+                                     description: "Path to your App Store Connect API key JSON file",
+                                     type: Hash,
+                                     optional: true,
+                                     sensitive: true,
+                                     conflicting_options: [:api_key_path, :username]),
+
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      short_option: "-a",
                                      env_name: "PRECHECK_APP_IDENTIFIER",

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -16,6 +16,7 @@ module Spaceship
       attr_accessor :available_in_new_territories
       attr_accessor :content_rights_declaration
       attr_accessor :app_store_versions
+      attr_accessor :prices
 
       module ContentRightsDeclaration
         USES_THIRD_PARTY_CONTENT = "USES_THIRD_PARTY_CONTENT"
@@ -34,7 +35,8 @@ module Spaceship
 
         "contentRightsDeclaration" => "content_rights_declaration",
 
-        "appStoreVersions" => "app_store_versions"
+        "appStoreVersions" => "app_store_versions",
+        "prices" => "prices"
       })
 
       def self.type
@@ -45,7 +47,7 @@ module Spaceship
       # Apps
       #
 
-      def self.all(filter: {}, includes: "appStoreVersions", limit: nil, sort: nil)
+      def self.all(filter: {}, includes: "appStoreVersions,prices", limit: nil, sort: nil)
         resps = Spaceship::ConnectAPI.get_apps(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
         return resps.flat_map(&:to_models)
       end
@@ -106,8 +108,7 @@ module Spaceship
           Spaceship::ConnectAPI::AppInfo::AppStoreState::INVALID_BINARY
         ]
 
-        filter = { app: id }
-        resp = Spaceship::ConnectAPI.get_app_infos(filter: filter, includes: includes)
+        resp = Spaceship::ConnectAPI.get_app_infos(app_id: id, includes: includes)
         return resp.to_models.select do |model|
           states.include?(model.app_store_state)
         end.first
@@ -128,8 +129,6 @@ module Spaceship
       #
 
       def fetch_app_prices(filter: {}, includes: "priceTier", limit: nil, sort: nil)
-        filter ||= {}
-        filter[:app] = id
         resp = Spaceship::ConnectAPI.get_app_prices(app_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
         return resp.to_models
       end

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -91,8 +91,7 @@ module Spaceship
           Spaceship::ConnectAPI::AppInfo::AppStoreState::IN_REVIEW
         ]
 
-        filter = { app: id }
-        resp = Spaceship::ConnectAPI.get_app_infos(filter: filter, includes: includes)
+        resp = Spaceship::ConnectAPI.get_app_infos(app_id: id, includes: includes)
         return resp.to_models.select do |model|
           states.include?(model.app_store_state)
         end.first

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -39,6 +39,11 @@ module Spaceship
         "prices" => "prices"
       })
 
+      ESSENTIAL_INCLUDES = [
+        "appStoreVersions",
+        "prices"
+      ].join(",")
+
       def self.type
         return "apps"
       end
@@ -47,7 +52,7 @@ module Spaceship
       # Apps
       #
 
-      def self.all(filter: {}, includes: "appStoreVersions,prices", limit: nil, sort: nil)
+      def self.all(filter: {}, includes: ESSENTIAL_INCLUDES, limit: nil, sort: nil)
         resps = Spaceship::ConnectAPI.get_apps(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
         return resps.flat_map(&:to_models)
       end

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
@@ -112,8 +112,8 @@ module Spaceship
       # API
       #
 
-      def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
-        resp = Spaceship::ConnectAPI.get_app_screenshot_sets(filter: filter, includes: includes, limit: limit, sort: sort)
+      def self.all(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+        resp = Spaceship::ConnectAPI.get_app_screenshot_sets(app_store_version_localization_id: app_store_version_localization_id, filter: filter, includes: includes, limit: limit, sort: sort)
         return resp.to_models
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -114,8 +114,6 @@ module Spaceship
         return resp.to_models.first
       end
 
-      # appScreenshotSets,appPreviewSets
-      # def get_app_store_version_localizations(filter: {}, includes: "appScreenshotSets", limit: nil, sort: nil)
       def get_app_store_version_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
         return Spaceship::ConnectAPI::AppStoreVersionLocalization.all(app_store_version_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
       end

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -115,10 +115,9 @@ module Spaceship
       end
 
       # appScreenshotSets,appPreviewSets
-      def get_app_store_version_localizations(filter: {}, includes: "appScreenshotSets", limit: nil, sort: nil)
-        filter ||= {}
-        filter["appStoreVersion"] = id
-        return Spaceship::ConnectAPI::AppStoreVersionLocalization.all(filter: filter, includes: includes, limit: limit, sort: sort)
+      #def get_app_store_version_localizations(filter: {}, includes: "appScreenshotSets", limit: nil, sort: nil)
+      def get_app_store_version_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
+        return Spaceship::ConnectAPI::AppStoreVersionLocalization.all(app_store_version_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
       end
 
       #

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -115,7 +115,7 @@ module Spaceship
       end
 
       # appScreenshotSets,appPreviewSets
-      #def get_app_store_version_localizations(filter: {}, includes: "appScreenshotSets", limit: nil, sort: nil)
+      # def get_app_store_version_localizations(filter: {}, includes: "appScreenshotSets", limit: nil, sort: nil)
       def get_app_store_version_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
         return Spaceship::ConnectAPI::AppStoreVersionLocalization.all(app_store_version_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
       end

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
@@ -39,8 +39,8 @@ module Spaceship
       # API
       #
 
-      def self.all(filter: {}, includes: nil, limit: nil, sort: nil)
-        resp = Spaceship::ConnectAPI.get_app_store_version_localizations(filter: filter, includes: includes, limit: limit, sort: sort)
+      def self.all(app_store_version_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+        resp = Spaceship::ConnectAPI.get_app_store_version_localizations(app_store_version_id: app_store_version_id, filter: filter, includes: includes, limit: limit, sort: sort)
         return resp.to_models
       end
 
@@ -73,9 +73,7 @@ module Spaceship
       #
 
       def get_app_screenshot_sets(filter: {}, includes: "appScreenshots", limit: nil, sort: nil)
-        filter ||= {}
-        filter["appStoreVersionLocalization"] = id
-        return Spaceship::ConnectAPI::AppScreenshotSet.all(filter: filter, includes: includes, limit: limit, sort: sort)
+        return Spaceship::ConnectAPI::AppScreenshotSet.all(app_store_version_localization_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
       end
 
       def create_app_screenshot_set(attributes: nil)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -308,6 +308,11 @@ module Spaceship
           tunes_request_client.get("appPrices", params)
         end
 
+        def get_app_price(app_price_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+          params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          tunes_request_client.get("appPrices/#{app_price_id}", params)
+        end
+
         #
         # appPricePoints
         #
@@ -360,9 +365,9 @@ module Spaceship
         # appScreenshotSets
         #
 
-        def get_app_screenshot_sets(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_app_screenshot_sets(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appScreenshotSets", params)
+          tunes_request_client.get("appStoreVersionLocalizations/#{app_store_version_localization_id}/appScreenshotSets", params)
         end
 
         def get_app_screenshot_set(app_screenshot_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
@@ -453,9 +458,9 @@ module Spaceship
         # appInfos
         #
 
-        def get_app_infos(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_app_infos(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appInfos", params)
+          tunes_request_client.get("apps/#{app_id}/appInfos", params)
         end
 
         def patch_app_info(app_info_id: nil, attributes: {})
@@ -641,9 +646,9 @@ module Spaceship
         # appStoreVersionLocalizations
         #
 
-        def get_app_store_version_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_app_store_version_localizations(app_store_version_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appStoreVersionLocalizations", params)
+          tunes_request_client.get("appStoreVersions/#{app_store_version_id}/appStoreVersionLocalizations", params)
         end
 
         def post_app_store_version_localization(app_store_version_id: nil, attributes: {})

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -18,7 +18,7 @@ class ConnectAPIStubbing
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps").
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 
-        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?filter%5BbundleId%5D=com.joshholtz.FastlaneTest&include=appStoreVersions").
+        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?filter%5BbundleId%5D=com.joshholtz.FastlaneTest&include=appStoreVersions,prices").
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps/123456789").


### PR DESCRIPTION
### Motivation and Context
Enable App Store Connect API Key auth with `deliver` (no Apple ID)

### Description
- Added `api_key` and `api_key_path` options to `deliver`
- Used different versions of endpoints that are compatible with both the Apple ID and Token session

#### Examples

##### 1. New action
```rb
lane :release do
  api_key = app_store_connect_api_key(
    key_id: "D383SF739",
    issuer_id: "6053b7fe-68a8-4acb-89be-165aa6465141",
    key_filepath: "./D383SF739.p8",
    duration: 1200, # optional
    in_house: false, # optional but may be required if using match/sigh
  )

  deliver( api_key: api_key )
end
```

##### 2. New file format

```js
{
  "key_id": "D383SF739",
  "issuer_id": "6053b7fe-68a8-4acb-89be-165aa6465141",
  "key": "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHknlhdlYdLu\n-----END PRIVATE KEY-----",
  “duration”: 1200, # optional
  “in_house”: false, # optional but may be required if using match/sigh
}

```

```rb
lane :release do
  deliver( api_key_path: "fastlane/me.json" )
end

```

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-deliver-app-store-connect-api-key"
```
