### PR TITLE
Version bump to 2.160.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,43 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-</tr>
-<tr>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
@@ -78,31 +46,63 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
 </td>
 </tr>
 <tr>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
 <td id='max-ott'>
 <a href='https://github.com/max-ott'>
 <img src='https://github.com/max-ott.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+</tr>
+<tr>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
@@ -110,11 +110,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+</tr>
+<tr>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
@@ -128,51 +148,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-</tr>
-<tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/endocrimes'>
 <img src='https://github.com/endocrimes.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
 </tr>
 <tr>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
 </a>
-<h4 align='center'>Jimmy Dee</h4>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Jimmy Dee",
-                        "Iulian Onofrei",
+  spec.authors       = ["Jorge Revuelta H",
+                        "Helmut Januschka",
+                        "Felix Krause",
                         "Kohki Miki",
-                        "Daniel Jankowski",
-                        "Olivier Halligon",
-                        "Matthew Ellis",
-                        "Danielle Tomlinson",
+                        "Joshua Liebowitz",
+                        "Manu Wallner",
                         "Max Ott",
+                        "Jérôme Lacoste",
+                        "Jimmy Dee",
                         "Luka Mirosevic",
+                        "Matthew Ellis",
                         "Maksym Grebenets",
                         "Josh Holtz",
-                        "Joshua Liebowitz",
-                        "Stefan Natchev",
-                        "Aaron Brager",
-                        "Jorge Revuelta H",
                         "Jan Piotrowski",
-                        "Jérôme Lacoste",
-                        "Andrew McBurney",
+                        "Stefan Natchev",
+                        "Daniel Jankowski",
+                        "Olivier Halligon",
+                        "Danielle Tomlinson",
                         "Fumiya Nakamura",
-                        "Helmut Januschka",
-                        "Manu Wallner",
-                        "Felix Krause"]
+                        "Aaron Brager",
+                        "Andrew McBurney",
+                        "Iulian Onofrei"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.159.0'.freeze
+  VERSION = '2.160.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -17,4 +17,4 @@ public class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.159.0
+// Generated with fastlane 2.160.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -2,6 +2,12 @@
 // Copyright (c) 2020 FastlaneTools
 
 public protocol DeliverfileProtocol: class {
+    /// Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+    var apiKeyPath: String? { get }
+
+    /// Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
+    var apiKey: [String: Any]? { get }
+
     /// Your Apple ID Username
     var username: String { get }
 
@@ -44,7 +50,7 @@ public protocol DeliverfileProtocol: class {
     /// Don't upload the metadata (e.g. title, description). This will still upload screenshots
     var skipMetadata: Bool { get }
 
-    /// Don't update app version for submission
+    /// Don’t create or update the app version that is being prepared for submission
     var skipAppVersionUpdate: Bool { get }
 
     /// Skip the HTML report file verification
@@ -184,6 +190,8 @@ public protocol DeliverfileProtocol: class {
 }
 
 public extension DeliverfileProtocol {
+    var apiKeyPath: String? { return nil }
+    var apiKey: [String: Any]? { return nil }
     var username: String { return "" }
     var appIdentifier: String? { return nil }
     var appVersion: String? { return nil }
@@ -248,4 +256,4 @@ public extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.42]
+// FastlaneRunnerAPIVersion [0.9.43]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -462,6 +462,8 @@ public func appledoc(input: Any,
  Alias for the `upload_to_app_store` action
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - appIdentifier: The bundle identifier of your app
    - appVersion: The version that should be edited or created
@@ -476,7 +478,7 @@ public func appledoc(input: Any,
    - skipBinaryUpload: Skip uploading an ipa or pkg to App Store Connect
    - skipScreenshots: Don't upload the screenshots
    - skipMetadata: Don't upload the metadata (e.g. title, description). This will still upload screenshots
-   - skipAppVersionUpdate: Don't update app version for submission
+   - skipAppVersionUpdate: Don’t create or update the app version that is being prepared for submission
    - force: Skip the HTML report file verification
    - overwriteScreenshots: Clear all previously uploaded screenshots before uploading the new ones
    - submitForReview: Submit the new version for Review after uploading everything
@@ -530,7 +532,9 @@ public func appledoc(input: Any,
  `_upload_to_app_store_(force: true)`
  If your account is on multiple teams and you need to tell the `iTMSTransporter` which 'provider' to use, you can set the `:itc_provider` option to pass this info.
  */
-public func appstore(username: String,
+public func appstore(apiKeyPath: String? = nil,
+                     apiKey: [String: Any]? = nil,
+                     username: String,
                      appIdentifier: String? = nil,
                      appVersion: String? = nil,
                      ipa: String? = nil,
@@ -591,7 +595,9 @@ public func appstore(username: String,
                      precheckIncludeInAppPurchases: Bool = true,
                      app: Any)
 {
-    let command = RubyCommand(commandID: "", methodName: "appstore", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
+    let command = RubyCommand(commandID: "", methodName: "appstore", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                            RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                            RubyCommand.Argument(name: "username", value: username),
                                                                                             RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                             RubyCommand.Argument(name: "app_version", value: appVersion),
                                                                                             RubyCommand.Argument(name: "ipa", value: ipa),
@@ -1951,6 +1957,8 @@ public func chatwork(apiToken: String,
  Check your app's metadata before you submit your app to review (via _precheck_)
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - appIdentifier: The bundle identifier of your app
    - username: Your Apple ID Username
    - teamId: The ID of your App Store Connect team if you're in multiple teams
@@ -1973,7 +1981,9 @@ public func chatwork(apiToken: String,
 
  More information: https://fastlane.tools/precheck
  */
-public func checkAppStoreMetadata(appIdentifier: String,
+public func checkAppStoreMetadata(apiKeyPath: String? = nil,
+                                  apiKey: [String: Any]? = nil,
+                                  appIdentifier: String,
                                   username: String,
                                   teamId: String? = nil,
                                   teamName: String? = nil,
@@ -1991,7 +2001,9 @@ public func checkAppStoreMetadata(appIdentifier: String,
                                   copyrightDate: Any? = nil,
                                   unreachableUrls: Any? = nil)
 {
-    let command = RubyCommand(commandID: "", methodName: "check_app_store_metadata", className: nil, args: [RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
+    let command = RubyCommand(commandID: "", methodName: "check_app_store_metadata", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                            RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                                            RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                                             RubyCommand.Argument(name: "username", value: username),
                                                                                                             RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                                             RubyCommand.Argument(name: "team_name", value: teamName),
@@ -2562,6 +2574,8 @@ public func deleteKeychain(name: String? = nil,
  Alias for the `upload_to_app_store` action
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - appIdentifier: The bundle identifier of your app
    - appVersion: The version that should be edited or created
@@ -2576,7 +2590,7 @@ public func deleteKeychain(name: String? = nil,
    - skipBinaryUpload: Skip uploading an ipa or pkg to App Store Connect
    - skipScreenshots: Don't upload the screenshots
    - skipMetadata: Don't upload the metadata (e.g. title, description). This will still upload screenshots
-   - skipAppVersionUpdate: Don't update app version for submission
+   - skipAppVersionUpdate: Don’t create or update the app version that is being prepared for submission
    - force: Skip the HTML report file verification
    - overwriteScreenshots: Clear all previously uploaded screenshots before uploading the new ones
    - submitForReview: Submit the new version for Review after uploading everything
@@ -2630,7 +2644,9 @@ public func deleteKeychain(name: String? = nil,
  `_upload_to_app_store_(force: true)`
  If your account is on multiple teams and you need to tell the `iTMSTransporter` which 'provider' to use, you can set the `:itc_provider` option to pass this info.
  */
-public func deliver(username: Any = deliverfile.username,
+public func deliver(apiKeyPath: Any? = deliverfile.apiKeyPath,
+                    apiKey: [String: Any]? = deliverfile.apiKey,
+                    username: Any = deliverfile.username,
                     appIdentifier: Any? = deliverfile.appIdentifier,
                     appVersion: Any? = deliverfile.appVersion,
                     ipa: Any? = deliverfile.ipa,
@@ -2691,7 +2707,9 @@ public func deliver(username: Any = deliverfile.username,
                     precheckIncludeInAppPurchases: Bool = deliverfile.precheckIncludeInAppPurchases,
                     app: Any = deliverfile.app)
 {
-    let command = RubyCommand(commandID: "", methodName: "deliver", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
+    let command = RubyCommand(commandID: "", methodName: "deliver", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                           RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                           RubyCommand.Argument(name: "username", value: username),
                                                                                            RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                            RubyCommand.Argument(name: "app_version", value: appVersion),
                                                                                            RubyCommand.Argument(name: "ipa", value: ipa),
@@ -2831,6 +2849,7 @@ public func download(url: String) {
    - version: The app version for dSYMs you wish to download, pass in 'latest' to download only the latest build's dSYMs or 'live' to download only the live version dSYMs
    - buildNumber: The app build_number for dSYMs you wish to download
    - minVersion: The minimum app version for dSYMs you wish to download
+   - afterUploadedDate: The uploaded date after which you wish to download dSYMs
    - outputDirectory: Where to save the download dSYMs, defaults to the current path
    - waitForDsymProcessing: Wait for dSYMs to process
    - waitTimeout: Number of seconds to wait for dSYMs to process
@@ -2854,6 +2873,7 @@ public func downloadDsyms(username: String,
                           version: String? = nil,
                           buildNumber: Any? = nil,
                           minVersion: String? = nil,
+                          afterUploadedDate: String? = nil,
                           outputDirectory: String? = nil,
                           waitForDsymProcessing: Bool = false,
                           waitTimeout: Int = 300)
@@ -2866,6 +2886,7 @@ public func downloadDsyms(username: String,
                                                                                                   RubyCommand.Argument(name: "version", value: version),
                                                                                                   RubyCommand.Argument(name: "build_number", value: buildNumber),
                                                                                                   RubyCommand.Argument(name: "min_version", value: minVersion),
+                                                                                                  RubyCommand.Argument(name: "after_uploaded_date", value: afterUploadedDate),
                                                                                                   RubyCommand.Argument(name: "output_directory", value: outputDirectory),
                                                                                                   RubyCommand.Argument(name: "wait_for_dsym_processing", value: waitForDsymProcessing),
                                                                                                   RubyCommand.Argument(name: "wait_timeout", value: waitTimeout)])
@@ -5184,8 +5205,8 @@ public func pem(development: Bool = false,
  Alias for the `upload_to_testflight` action
 
  - parameters:
-   - apiKeyPath: Path to your App Store Connect API key JSON file
-   - apiKey: Path to your App Store Connect API key JSON file
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - appIdentifier: The bundle identifier of the app to upload or manage testers (optional)
    - appPlatform: The platform to use (optional)
@@ -5472,6 +5493,8 @@ public func podioItem(clientId: String,
  Alias for the `check_app_store_metadata` action
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - appIdentifier: The bundle identifier of your app
    - username: Your Apple ID Username
    - teamId: The ID of your App Store Connect team if you're in multiple teams
@@ -5485,7 +5508,9 @@ public func podioItem(clientId: String,
 
  More information: https://fastlane.tools/precheck
  */
-public func precheck(appIdentifier: Any = precheckfile.appIdentifier,
+public func precheck(apiKeyPath: Any? = precheckfile.apiKeyPath,
+                     apiKey: [String: Any]? = precheckfile.apiKey,
+                     appIdentifier: Any = precheckfile.appIdentifier,
                      username: Any = precheckfile.username,
                      teamId: Any? = precheckfile.teamId,
                      teamName: Any? = precheckfile.teamName,
@@ -5494,7 +5519,9 @@ public func precheck(appIdentifier: Any = precheckfile.appIdentifier,
                      includeInAppPurchases: Bool = precheckfile.includeInAppPurchases,
                      freeStuffInIap: Any? = precheckfile.freeStuffInIap)
 {
-    let command = RubyCommand(commandID: "", methodName: "precheck", className: nil, args: [RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
+    let command = RubyCommand(commandID: "", methodName: "precheck", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                            RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                            RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                             RubyCommand.Argument(name: "username", value: username),
                                                                                             RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                             RubyCommand.Argument(name: "team_name", value: teamName),
@@ -7762,8 +7789,8 @@ public func testfairy(apiKey: String,
  Alias for the `upload_to_testflight` action
 
  - parameters:
-   - apiKeyPath: Path to your App Store Connect API key JSON file
-   - apiKey: Path to your App Store Connect API key JSON file
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - appIdentifier: The bundle identifier of the app to upload or manage testers (optional)
    - appPlatform: The platform to use (optional)
@@ -8356,6 +8383,8 @@ public func uploadSymbolsToSentry(apiHost: String = "https://app.getsentry.com/a
  Upload metadata and binary to App Store Connect (via _deliver_)
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - appIdentifier: The bundle identifier of your app
    - appVersion: The version that should be edited or created
@@ -8370,7 +8399,7 @@ public func uploadSymbolsToSentry(apiHost: String = "https://app.getsentry.com/a
    - skipBinaryUpload: Skip uploading an ipa or pkg to App Store Connect
    - skipScreenshots: Don't upload the screenshots
    - skipMetadata: Don't upload the metadata (e.g. title, description). This will still upload screenshots
-   - skipAppVersionUpdate: Don't update app version for submission
+   - skipAppVersionUpdate: Don’t create or update the app version that is being prepared for submission
    - force: Skip the HTML report file verification
    - overwriteScreenshots: Clear all previously uploaded screenshots before uploading the new ones
    - submitForReview: Submit the new version for Review after uploading everything
@@ -8424,7 +8453,9 @@ public func uploadSymbolsToSentry(apiHost: String = "https://app.getsentry.com/a
  `_upload_to_app_store_(force: true)`
  If your account is on multiple teams and you need to tell the `iTMSTransporter` which 'provider' to use, you can set the `:itc_provider` option to pass this info.
  */
-public func uploadToAppStore(username: String,
+public func uploadToAppStore(apiKeyPath: String? = nil,
+                             apiKey: [String: Any]? = nil,
+                             username: String,
                              appIdentifier: String? = nil,
                              appVersion: String? = nil,
                              ipa: String? = nil,
@@ -8485,7 +8516,9 @@ public func uploadToAppStore(username: String,
                              precheckIncludeInAppPurchases: Bool = true,
                              app: Any)
 {
-    let command = RubyCommand(commandID: "", methodName: "upload_to_app_store", className: nil, args: [RubyCommand.Argument(name: "username", value: username),
+    let command = RubyCommand(commandID: "", methodName: "upload_to_app_store", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                       RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                                       RubyCommand.Argument(name: "username", value: username),
                                                                                                        RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                                        RubyCommand.Argument(name: "app_version", value: appVersion),
                                                                                                        RubyCommand.Argument(name: "ipa", value: ipa),
@@ -8711,8 +8744,8 @@ public func uploadToPlayStoreInternalAppSharing(packageName: String,
  Upload new binary to App Store Connect for TestFlight beta testing (via _pilot_)
 
  - parameters:
-   - apiKeyPath: Path to your App Store Connect API key JSON file
-   - apiKey: Path to your App Store Connect API key JSON file
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - appIdentifier: The bundle identifier of the app to upload or manage testers (optional)
    - appPlatform: The platform to use (optional)
@@ -9273,4 +9306,4 @@ public let snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.95]
+// FastlaneRunnerAPIVersion [0.9.96]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -17,4 +17,4 @@ public class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.159.0
+// Generated with fastlane 2.160.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -184,4 +184,4 @@ public extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.45]
+// FastlaneRunnerAPIVersion [0.9.46]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -17,4 +17,4 @@ public class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.159.0
+// Generated with fastlane 2.160.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -168,4 +168,4 @@ public extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.39]
+// FastlaneRunnerAPIVersion [0.9.40]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -17,4 +17,4 @@ public class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.159.0
+// Generated with fastlane 2.160.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -2,6 +2,12 @@
 // Copyright (c) 2020 FastlaneTools
 
 public protocol PrecheckfileProtocol: class {
+    /// Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+    var apiKeyPath: String? { get }
+
+    /// Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
+    var apiKey: [String: Any]? { get }
+
     /// The bundle identifier of your app
     var appIdentifier: String { get }
 
@@ -28,6 +34,8 @@ public protocol PrecheckfileProtocol: class {
 }
 
 public extension PrecheckfileProtocol {
+    var apiKeyPath: String? { return nil }
+    var apiKey: [String: Any]? { return nil }
     var appIdentifier: String { return "" }
     var username: String { return "" }
     var teamId: String? { return nil }
@@ -40,4 +48,4 @@ public extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.38]
+// FastlaneRunnerAPIVersion [0.9.39]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -17,4 +17,4 @@ public class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.159.0
+// Generated with fastlane 2.160.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -260,4 +260,4 @@ public extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.50]
+// FastlaneRunnerAPIVersion [0.9.51]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -17,4 +17,4 @@ public class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.159.0
+// Generated with fastlane 2.160.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -96,4 +96,4 @@ public extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.40]
+// FastlaneRunnerAPIVersion [0.9.41]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -17,4 +17,4 @@ public class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.159.0
+// Generated with fastlane 2.160.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -184,4 +184,4 @@ public extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.34]
+// FastlaneRunnerAPIVersion [0.9.35]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.159.0':**

* [spaceship] support PENDING_APPLE_RELEASE (#17254) via Josh Holtz
* [deliver] add support for App Store Connect API Key (#17238) via Josh Holtz
* [deliver] add retry when fetching edit app version and edit app info (#17235) via Josh Holtz
* [frameit] allow setting font_weight for keyword/title (#17159) via Herbert Poul
* [actions] add filter date to download_dsyms (#17228) via Mark Woollard
