### PR TITLE
[pilot] make key contents sensitive

### DIFF
--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -4,22 +4,24 @@ module Fastlane
       LANE_NAME = :LANE_NAME
       PLATFORM_NAME = :PLATFORM_NAME
       ENVIRONMENT = :ENVIRONMENT
-    end
 
-    class LaneContextValues < Hash
-      def initialize
-        @sensitive_context = {}
-      end
-
-      def set_sensitive(key, value)
-        @sensitive_context[key] = value
-      end
-
-      def [](key)
-        if @sensitive_context.key?(key)
-          return @sensitive_context[key]
+      # A slighly decorated hash that will store and fetc sensitive data
+      # but not display it while iterating keys and values
+      class LaneContextValues < Hash
+        def initialize
+          @sensitive_context = {}
         end
-        super
+
+        def set_sensitive(key, value)
+          @sensitive_context[key] = value
+        end
+
+        def [](key)
+          if @sensitive_context.key?(key)
+            return @sensitive_context[key]
+          end
+          super
+        end
       end
     end
 
@@ -44,7 +46,7 @@ module Fastlane
 
     # The shared hash can be accessed by any action and contains information like the screenshots path or beta URL
     def self.lane_context
-      @lane_context ||= LaneContextValues.new
+      @lane_context ||= SharedValues::LaneContextValues.new
     end
 
     # Used in tests to get a clear lane before every test

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -6,20 +6,18 @@ module Fastlane
       ENVIRONMENT = :ENVIRONMENT
     end
 
-    class LaneContext < Hash
-      attr_accessor :sensitive_context
-
+    class LaneContextValues < Hash
       def initialize
         @sensitive_context = {}
       end
 
       def set_sensitive(key, value)
-        sensitive_context[key] = value
+        @sensitive_context[key] = value
       end
 
       def [](key)
-        if sensitive_context.key?(key)
-          return sensitive_context[key]
+        if @sensitive_context.key?(key)
+          return @sensitive_context[key]
         end
         super
       end
@@ -46,7 +44,7 @@ module Fastlane
 
     # The shared hash can be accessed by any action and contains information like the screenshots path or beta URL
     def self.lane_context
-      @lane_context ||= LaneContext.new
+      @lane_context ||= LaneContextValues.new
     end
 
     # Used in tests to get a clear lane before every test

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -6,6 +6,25 @@ module Fastlane
       ENVIRONMENT = :ENVIRONMENT
     end
 
+    class LaneContext < Hash
+      attr_accessor :sensitive_context
+
+      def initialize
+        @sensitive_context = {}
+      end
+
+      def set_sensitive(key, value)
+        sensitive_context[key] = value
+      end
+
+      def [](key)
+        if sensitive_context.key?(key)
+          return sensitive_context[key]
+        end
+        super
+      end
+    end
+
     def self.reset_aliases
       @alias_actions = nil
     end
@@ -27,7 +46,7 @@ module Fastlane
 
     # The shared hash can be accessed by any action and contains information like the screenshots path or beta URL
     def self.lane_context
-      @lane_context ||= {}
+      @lane_context ||= LaneContext.new
     end
 
     # Used in tests to get a clear lane before every test

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -5,7 +5,7 @@ module Fastlane
       PLATFORM_NAME = :PLATFORM_NAME
       ENVIRONMENT = :ENVIRONMENT
 
-      # A slighly decorated hash that will store and fetc sensitive data
+      # A slighly decorated hash that will store and fetch sensitive data
       # but not display it while iterating keys and values
       class LaneContextValues < Hash
         def initialize

--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -55,6 +55,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :key_content,
                                        env_name: "APP_STORE_CONNECT_API_KEY_KEY",
                                        description: "The content of the key p8 file",
+                                       sensitive: true,
                                        optional: true,
                                        conflicting_options: [:filepath]),
           FastlaneCore::ConfigItem.new(key: :duration,

--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -27,7 +27,7 @@ module Fastlane
           in_house: in_house
         }
 
-        Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY] = key
+        Actions.lane_context.set_sensitive(SharedValues::APP_STORE_CONNECT_API_KEY, key)
 
         return key
       end


### PR DESCRIPTION
🔑 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves #17239

### Description

This PR should make the key contents sensitive, which should avoid displaying it.

### Testing Steps

```ruby
gem "fastlane", :git => "https://github.com/rogerluan/fastlane.git", :branch => "roger/make-key-content-sensitive"
```