### PR TITLE
[spaceship] prevent error on update app territory_ids

### DIFF
--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -185,8 +185,11 @@ module Spaceship
             type: "apps",
             id: app_id
           }
-          data[:attributes] = attributes unless attributes.empty?
           data[:relationships] = relationships unless relationships.empty?
+
+          if !attributes.nil? && !attributes.empty?
+            data[:attributes] = attributes
+          end
 
           # Body
           body = {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When I try to update territories using the `update` method on the `Spaceship::ConnectAPI::App` model I got ``` NoMethodError: undefined method `empty?' for nil:NilClass ``` error.

```ruby
app = Spaceship::ConnectAPI::App.find(ENV['bundle_id'])
app.update(territory_ids: ['BRA'])
```

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

It occurs because the `Spaceship::ConnectAPI.patch_app` method waits for an empty object, but `app.update` method passes a `nil` value by default to it.

```ruby
# app.update
def update(attributes: nil, app_price_tier_id: nil, territory_ids: nil)
  attributes = reverse_attr_mapping(attributes)
  return Spaceship::ConnectAPI.patch_app(app_id: id, attributes: attributes, app_price_tier_id: app_price_tier_id, territory_ids: territory_ids)
end
```

I just check if `attributes` is `nil` as well.

