### PR TITLE
[sigh] add support for App Store Connect API Key

### DIFF
--- a/cert/lib/cert/options.rb
+++ b/cert/lib/cert/options.rb
@@ -41,7 +41,7 @@ module Cert
                                      env_name: "DELIVER_API_KEY_PATH",
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
-                                     conflicting_options: [:username],
+                                     conflicting_options: [:api_key],
                                      verify_block: proc do |value|
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
@@ -51,7 +51,7 @@ module Cert
                                      type: Hash,
                                      optional: true,
                                      sensitive: true,
-                                     conflicting_options: [:api_key_path, :username]),
+                                     conflicting_options: [:api_key_path]),
 
         # Apple ID
         FastlaneCore::ConfigItem.new(key: :username,

--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -171,7 +171,7 @@ module Cert
         when 'ios', 'tvos'
           cert_type = Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION
           cert_type = Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION if Spaceship::ConnectAPI.client.in_house?
-          cert_type = Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPMENT if Cert.config[:development]
+          cert_type = Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DEVELOPMENT if Cert.config[:development]
 
         when 'macos'
           cert_type = Spaceship::ConnectAPI::Certificate::CertificateType::MAC_APP_DISTRIBUTION

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -16,7 +16,7 @@ module Deliver
                                      env_name: "DELIVER_API_KEY_PATH",
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
-                                     conflicting_options: [:username],
+                                     conflicting_options: [:api_key],
                                      verify_block: proc do |value|
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
@@ -26,7 +26,7 @@ module Deliver
                                      type: Hash,
                                      optional: true,
                                      sensitive: true,
-                                     conflicting_options: [:api_key_path, :username]),
+                                     conflicting_options: [:api_key_path]),
 
         FastlaneCore::ConfigItem.new(key: :username,
                                      short_option: "-u",

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -11,6 +11,10 @@ class MockSession
   def team_id
     'abc'
   end
+
+  def csrf_tokens
+    nil
+  end
 end
 
 class MockTransporter

--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -26,11 +26,14 @@ module Match
         generate_apple_certs: params[:generate_apple_certs],
         output_path: output_path,
         force: true, # we don't need a certificate without its private key, we only care about a new certificate
+        api_key_path: params[:api_key_path],
+        api_key: params[:api_key],
         username: params[:username],
         team_id: params[:team_id],
         team_name: params[:team_name],
         keychain_path: FastlaneCore::Helper.keychain_path(params[:keychain_name]),
-        keychain_password: params[:keychain_password]
+        keychain_password: params[:keychain_password],
+        skip_set_partition_list: params[:skip_set_partition_list]
       })
 
       Cert.config = arguments
@@ -80,6 +83,8 @@ module Match
         cert_id: certificate_id,
         provisioning_name: profile_name,
         ignore_profiles_with_different_name: true,
+        api_key_path: params[:api_key_path],
+        api_key: params[:api_key],
         team_id: params[:team_id],
         team_name: params[:team_name],
         template_name: params[:template_name],

--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -28,10 +28,17 @@ module Match
         google_cloud_bucket_name: params[:google_cloud_bucket_name].to_s,
         google_cloud_keys_file: params[:google_cloud_keys_file].to_s,
         google_cloud_project_id: params[:google_cloud_project_id].to_s,
+        s3_bucket: params[:s3_bucket],
+        s3_region: params[:s3_region],
+        s3_access_key: params[:s3_access_key],
+        s3_secret_access_key: params[:s3_secret_access_key],
+        s3_object_prefix: params[:s3_object_prefix],
         readonly: params[:readonly],
         username: params[:username],
         team_id: params[:team_id],
-        team_name: params[:team_name]
+        team_name: params[:team_name],
+        api_key_path: params[:api_key_path],
+        api_key: params[:api_key]
       })
       storage.download
 
@@ -48,11 +55,25 @@ module Match
 
       case cert_type
       when :development
-        certificate_type = Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DEVELOPMENT + "," + Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPMENT
+        certificate_type = [
+          Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DEVELOPMENT,
+          Spaceship::ConnectAPI::Certificate::CertificateType::MAC_APP_DEVELOPMENT,
+          Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPMENT
+        ].join(',')
       when :distribution, :enterprise
-        certificate_type = Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION + "," + Spaceship::ConnectAPI::Certificate::CertificateType::DISTRIBUTION
+        certificate_type = [
+          Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION,
+          Spaceship::ConnectAPI::Certificate::CertificateType::MAC_APP_DISTRIBUTION,
+          Spaceship::ConnectAPI::Certificate::CertificateType::DISTRIBUTION
+        ].join(',')
       when :developer_id_application
-        certificate_type = Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION
+        certificate_type = [
+          Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION
+        ].join(',')
+      when :mac_installer_distribution
+        certificate_type = [
+          Spaceship::ConnectAPI::Certificate::CertificateType::MAC_INSTALLER_DISTRIBUTION
+        ].join(',')
       else
         UI.user_error!("Cert type '#{cert_type}' is not supported")
       end
@@ -62,8 +83,14 @@ module Match
       output_dir_profiles = File.join(storage.prefixed_working_directory, "profiles", prov_type.to_s)
 
       # Need to get the cert id by comparing base64 encoded cert content with certificate content from the API responses
-      Spaceship::Portal.login(params[:username])
-      Spaceship::Portal.select_team(team_id: params[:team_id], team_name: params[:team_name])
+      token = api_token(params)
+      if token
+        UI.message("Creating authorization token for App Store Connect API")
+        Spaceship::ConnectAPI.token = token
+      else
+        UI.message("Login to App Store Connect (#{params[:username]})")
+        Spaceship::ConnectAPI.login(params[:username], use_portal: true, use_tunes: false, portal_team_id: params[:team_id], team_name: params[:team_name])
+      end
       certs = Spaceship::ConnectAPI::Certificate.all(filter: { certificateType: certificate_type })
 
       # Base64 encode contents to find match from API to find a cert ID
@@ -107,6 +134,12 @@ module Match
       file_path = File.exist?(file_path) ? file_path : nil
       UI.user_error!("#{file_description} does not exist at path: #{file_path}") unless !file_path.nil? || optional
       file_path
+    end
+
+    def api_token(params)
+      @api_token ||= Spaceship::ConnectAPI::Token.create(params[:api_key]) if params[:api_key]
+      @api_token ||= Spaceship::ConnectAPI::Token.from_json_file(params[:api_key_path]) if params[:api_key_path]
+      return @api_token
     end
   end
 end

--- a/match/lib/match/migrate.rb
+++ b/match/lib/match/migrate.rb
@@ -42,9 +42,14 @@ module Match
       # while on Git we recommend using the git branch instead. As there is
       # no concept of branches in Google Cloud Storage (omg thanks), we use
       # the team id properly
-      spaceship = SpaceshipEnsure.new(params[:username], params[:team_id], params[:team_name])
+      spaceship = SpaceshipEnsure.new(params[:username], params[:team_id], params[:team_name], api_token(params))
       team_id = spaceship.team_id
-      UI.message("Detected team ID '#{team_id}' to use for Google Cloud Storage...")
+
+      if team_id.to_s.empty?
+        UI.user_error!("The `team_id` option is required. fastlane cannot automatically determine portal team id via the App Store Connect API (yet)")
+      else
+        UI.message("Detected team ID '#{team_id}' to use for Google Cloud Storage...")
+      end
 
       files_to_commit = []
       Dir.chdir(git_storage.working_directory) do
@@ -83,6 +88,12 @@ module Match
       UI.success("You can also remove the `git_url`, as well as any other git related configurations from your Fastfile and Matchfile")
       UI.message("")
       UI.input("Please make sure to read the above and confirm with enter")
+    end
+
+    def api_token(params)
+      @api_token ||= Spaceship::ConnectAPI::Token.create(params[:api_key]) if params[:api_key]
+      @api_token ||= Spaceship::ConnectAPI::Token.from_json_file(params[:api_key_path]) if params[:api_key_path]
+      return @api_token
     end
 
     def ensure_parameters_are_valid(params)

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -44,7 +44,7 @@ module Match
         s3_access_key: params[:s3_access_key].to_s,
         s3_secret_access_key: params[:s3_secret_access_key].to_s,
         s3_bucket: params[:s3_bucket].to_s,
-        team_id: params[:team_id] || Spaceship.client.team_id
+        team_id: params[:team_id] || Spaceship::ConnectAPI.client.portal_team_id
       })
       self.storage.download
 
@@ -97,10 +97,14 @@ module Match
     end
 
     def spaceship_login
-      Spaceship.login(params[:username])
-      Spaceship.select_team(team_id: params[:team_id], team_name: params[:team_name])
+      if api_token
+        UI.message("Creating authorization token for App Store Connect API")
+        Spaceship::ConnectAPI.token = api_token
+      else
+        Spaceship::ConnectAPI.login(params[:username], use_portal: true, use_tunes: false, portal_team_id: params[:team_id], team_name: params[:team_name])
+      end
 
-      if Spaceship.client.in_house? && (type == "distribution" || type == "enterprise")
+      if Spaceship::ConnectAPI.client.in_house? && (type == "distribution" || type == "enterprise")
         UI.error("---")
         UI.error("⚠️ Warning: This seems to be an Enterprise account!")
         UI.error("By nuking your account's distribution, all your apps deployed via ad-hoc will stop working!") if type == "distribution"
@@ -109,6 +113,12 @@ module Match
 
         UI.user_error!("Enterprise account nuke cancelled") unless UI.confirm("Do you really want to nuke your Enterprise account?")
       end
+    end
+
+    def api_token
+      @api_token ||= Spaceship::ConnectAPI::Token.create(params[:api_key]) if params[:api_key]
+      @api_token ||= Spaceship::ConnectAPI::Token.from_json_file(params[:api_key_path]) if params[:api_key_path]
+      return @api_token
     end
 
     # Collect all the certs/profiles
@@ -125,8 +135,10 @@ module Match
       # Get all iOS and macOS profile
       self.profiles = []
       prov_types.each do |prov_type|
-        self.profiles += profile_type(prov_type).all(mac: false)
-        self.profiles += profile_type(prov_type).all(mac: true)
+        types = profile_types(prov_type)
+        # Filtering on 'profileType' seems to be undocumented as of 2020-07-30
+        # but works on both web session and official API
+        self.profiles += Spaceship::ConnectAPI::Profile.all(filter: { profileType: types.join(",") })
       end
 
       # Gets the main and additional cert types
@@ -138,7 +150,7 @@ module Match
       self.certs = []
       self.certs += cert_types.map do |ct|
         certificate_type(ct).flat_map do |cert|
-          cert.all(mac: false) + cert.all(mac: true)
+          Spaceship::ConnectAPI::Certificate.all(filter: { certificateType: cert })
         end
       end.flatten
 
@@ -165,7 +177,7 @@ module Match
       puts("")
       if self.certs.count > 0
         rows = self.certs.collect do |cert|
-          cert_expiration = cert.expires.nil? ? "Unknown" : cert.expires.strftime("%Y-%m-%d")
+          cert_expiration = cert.expiration_date.nil? ? "Unknown" : Time.parse(cert.expiration_date).strftime("%Y-%m-%d")
           [cert.name, cert.id, cert.class.to_s.split("::").last, cert_expiration]
         end
         puts(Terminal::Table.new({
@@ -178,11 +190,11 @@ module Match
 
       if self.profiles.count > 0
         rows = self.profiles.collect do |p|
-          status = p.status == 'Active' ? p.status.green : p.status.red
+          status = p.valid? ? p.profile_state.green : p.profile_state.red
 
           # Expires is sometimes nil
-          expires = p.expires ? p.expires.strftime("%Y-%m-%d") : nil
-          [p.name, p.id, status, p.type, expires]
+          expires = p.expiration_date ? Time.parse(p.expiration_date).strftime("%Y-%m-%d") : nil
+          [p.name, p.id, status, p.profile_type, expires]
         end
         puts(Terminal::Table.new({
           title: "Provisioning Profiles that are going to be revoked".green,
@@ -227,7 +239,7 @@ module Match
       self.certs.each do |cert|
         UI.message("Revoking certificate '#{cert.name}' (#{cert.id})...")
         begin
-          cert.revoke!
+          cert.delete!
         rescue => ex
           UI.message(ex.to_s)
         end
@@ -274,31 +286,62 @@ module Match
     def certificate_type(type)
       case type.to_sym
       when :mac_installer_distribution
-        return [Spaceship.certificate.mac_installer_distribution]
+        return [
+          Spaceship::ConnectAPI::Certificate::CertificateType::MAC_INSTALLER_DISTRIBUTION
+        ]
       when :distribution
-        return [Spaceship.certificate.production, Spaceship.certificate.apple_distribution]
+        return [
+          Spaceship::ConnectAPI::Certificate::CertificateType::MAC_APP_DISTRIBUTION,
+          Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION,
+          Spaceship::ConnectAPI::Certificate::CertificateType::DISTRIBUTION
+        ]
       when :development
-        return [Spaceship.certificate.development, Spaceship.certificate.apple_development]
+        return [
+          Spaceship::ConnectAPI::Certificate::CertificateType::MAC_APP_DEVELOPMENT,
+          Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DEVELOPMENT,
+          Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPMENT
+        ]
       when :enterprise
-        return [Spaceship.certificate.in_house]
+        return [
+          Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION
+        ]
       else
         raise "Unknown type '#{type}'"
       end
     end
 
     # The kind of provisioning profile we're interested in
-    def profile_type(prov_type)
+    def profile_types(prov_type)
       case prov_type.to_sym
       when :appstore
-        return Spaceship.provisioning_profile.app_store
+        return [
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE,
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_STORE,
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_STORE,
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_STORE
+        ]
       when :development
-        return Spaceship.provisioning_profile.development
+        return [
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_DEVELOPMENT,
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DEVELOPMENT,
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_DEVELOPMENT,
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DEVELOPMENT
+        ]
       when :enterprise
-        return Spaceship.provisioning_profile.in_house
+        return [
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_INHOUSE,
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_INHOUSE
+        ]
       when :adhoc
-        return Spaceship.provisioning_profile.ad_hoc
+        return [
+          Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_ADHOC,
+          Spaceship::ConnectAPI::Profile::ProfileType::TVOS_APP_ADHOC
+        ]
       when :developer_id
-        return Spaceship.provisioning_profile.direct
+        return [
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT,
+          Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
+        ]
       else
         raise "Unknown provisioning type '#{prov_type}'"
       end

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -62,7 +62,6 @@ module Match
                                      type: Boolean,
                                      default_value: false),
 
-        # app
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      short_option: "-a",
                                      env_name: "MATCH_APP_IDENTIFIER",
@@ -72,10 +71,30 @@ module Match
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
                                      default_value_dynamic: true),
+
+        # App Store Connect API
+        FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                     env_name: "SIGH_API_KEY_PATH",
+                                     description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
+                                     optional: true,
+                                     conflicting_options: [:api_key],
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :api_key,
+                                     env_name: "SIGH_API_KEY",
+                                     description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
+                                     type: Hash,
+                                     optional: true,
+                                     sensitive: true,
+                                     conflicting_options: [:api_key_path]),
+
+        # Apple ID
         FastlaneCore::ConfigItem.new(key: :username,
                                      short_option: "-u",
                                      env_name: "MATCH_USERNAME",
                                      description: "Your Apple ID Username",
+                                     optional: true,
                                      default_value: user,
                                      default_value_dynamic: true),
         FastlaneCore::ConfigItem.new(key: :team_id,
@@ -268,6 +287,12 @@ module Match
                                      env_name: "MATCH_OUTPUT_PATH",
                                      description: "Path in which to export certificates, key and profile",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :skip_set_partition_list,
+                                     short_option: "-P",
+                                     env_name: "MATCH_SKIP_SET_PARTITION_LIST",
+                                     description: "Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing",
+                                     type: Boolean,
+                                     default_value: false),
 
         # other
         FastlaneCore::ConfigItem.new(key: :verbose,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -55,7 +55,9 @@ module Match
         readonly: params[:readonly],
         username: params[:readonly] ? nil : params[:username], # only pass username if not readonly
         team_id: params[:team_id],
-        team_name: params[:team_name]
+        team_name: params[:team_name],
+        api_key_path: params[:api_key_path],
+        api_key: params[:api_key]
       })
       storage.download
 
@@ -67,7 +69,7 @@ module Match
       encryption.decrypt_files if encryption
 
       unless params[:readonly]
-        self.spaceship = SpaceshipEnsure.new(params[:username], params[:team_id], params[:team_name])
+        self.spaceship = SpaceshipEnsure.new(params[:username], params[:team_id], params[:team_name], api_token(params))
         if params[:type] == "enterprise" && !Spaceship.client.in_house?
           UI.user_error!("You defined the profile type 'enterprise', but your Apple account doesn't support In-House profiles")
         end
@@ -100,7 +102,7 @@ module Match
       end
 
       cert_ids << cert_id
-      spaceship.certificates_exists(username: params[:username], certificate_ids: cert_ids, platform: params[:platform]) if spaceship
+      spaceship.certificates_exists(username: params[:username], certificate_ids: cert_ids) if spaceship
 
       # Provisioning Profiles
       unless params[:skip_provisioning_profiles]
@@ -135,6 +137,12 @@ module Match
       storage.clear_changes if storage
     end
     # rubocop:enable Metrics/PerceivedComplexity
+
+    def api_token(params)
+      @api_token ||= Spaceship::ConnectAPI::Token.create(params[:api_key]) if params[:api_key]
+      @api_token ||= Spaceship::ConnectAPI::Token.from_json_file(params[:api_key_path]) if params[:api_key_path]
+      return @api_token
+    end
 
     # Used when creating a new certificate or profile
     def prefixed_working_directory
@@ -316,22 +324,42 @@ module Match
 
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]
-      portal_profile = Spaceship.provisioning_profile.all.detect { |i| i.uuid == uuid }
+
+      all_profiles = Spaceship::ConnectAPI::Profile.all(includes: "devices")
+      portal_profile = all_profiles.detect { |i| i.uuid == uuid }
 
       if portal_profile
-        profile_device_count = portal_profile.devices.count
+        profile_device_count = portal_profile.fetch_all_devices.count
 
-        portal_device_count =
+        device_classes =
           case platform
           when :ios
-            Spaceship.device.all_ios_profile_devices.count
+            [
+              Spaceship::ConnectAPI::Device::DeviceClass::IPAD,
+              Spaceship::ConnectAPI::Device::DeviceClass::IPHONE,
+              Spaceship::ConnectAPI::Device::DeviceClass::IPOD,
+              Spaceship::ConnectAPI::Device::DeviceClass::APPLE_WATCH
+            ]
           when :tvos
-            Spaceship.device.all_apple_tvs.count
+            [
+              Spaceship::ConnectAPI::Device::DeviceClass::APPLE_TV
+            ]
           when :mac, :catalyst
-            Spaceship.device.all_macs.count
+            [
+              Spaceship::ConnectAPI::Device::DeviceClass::MAC
+            ]
           else
-            Spaceship.device.all.count
+            []
           end
+
+        devices = Spaceship::ConnectAPI::Device.all
+        unless device_classes.empty?
+          devices = devices.select do |device|
+            device_classes.include?(device.device_class)
+          end
+        end
+
+        portal_device_count = devices.size
 
         return portal_device_count != profile_device_count
       end

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -4,28 +4,38 @@ require_relative 'module'
 module Match
   # Ensures the certificate and profiles are also available on App Store Connect
   class SpaceshipEnsure
-    def initialize(user, team_id, team_name)
-      # We'll try to manually fetch the password
-      # to tell the user that a password is optional
-      require 'credentials_manager/account_manager'
+    attr_accessor :team_id
 
-      keychain_entry = CredentialsManager::AccountManager.new(user: user)
-
-      if keychain_entry.password(ask_if_missing: false).to_s.length == 0
-        UI.important("You can also run `fastlane match` in readonly mode to not require any access to the")
-        UI.important("Developer Portal. This way you only share the keys and credentials")
-        UI.command("fastlane match --readonly")
-        UI.important("More information https://docs.fastlane.tools/actions/match/#access-control")
-      end
-
-      # Prompts select team if multiple teams and none specified
+    def initialize(user, team_id, team_name, api_token)
       UI.message("Verifying that the certificate and profile are still valid on the Dev Portal...")
-      Spaceship::ConnectAPI.login(user, use_portal: true, use_tunes: false, portal_team_id: team_id, team_name: team_name)
+
+      if api_token
+        UI.message("Creating authorization token for App Store Connect API")
+        Spaceship::ConnectAPI.token = api_token
+        self.team_id = team_id
+      else
+        # We'll try to manually fetch the password
+        # to tell the user that a password is optional
+        require 'credentials_manager/account_manager'
+
+        keychain_entry = CredentialsManager::AccountManager.new(user: user)
+
+        if keychain_entry.password(ask_if_missing: false).to_s.length == 0
+          UI.important("You can also run `fastlane match` in readonly mode to not require any access to the")
+          UI.important("Developer Portal. This way you only share the keys and credentials")
+          UI.command("fastlane match --readonly")
+          UI.important("More information https://docs.fastlane.tools/actions/match/#access-control")
+        end
+
+        # Prompts select team if multiple teams and none specified
+        Spaceship::ConnectAPI.login(user, use_portal: true, use_tunes: false, portal_team_id: team_id, team_name: team_name)
+        self.team_id = Spaceship::ConnectAPI.client.portal_team_id
+      end
     end
 
     # The team ID of the currently logged in team
     def team_id
-      return Spaceship::ConnectAPI.client.portal_team_id
+      return @team_id
     end
 
     def bundle_identifier_exists(username: nil, app_identifier: nil, platform: nil)
@@ -45,12 +55,8 @@ module Match
       UI.user_error!("Couldn't find bundle identifier '#{app_identifier}' for the user '#{username}'")
     end
 
-    def certificates_exists(username: nil, certificate_ids: [], platform: nil)
-      if platform == :catalyst.to_s
-        platform = :macos.to_s
-      end
-
-      Spaceship.certificate.all(mac: platform == "macos").each do |cert|
+    def certificates_exists(username: nil, certificate_ids: [])
+      Spaceship::ConnectAPI::Certificate.all.each do |cert|
         certificate_ids.delete(cert.id)
       end
       return if certificate_ids.empty?

--- a/match/lib/match/storage/google_cloud_storage.rb
+++ b/match/lib/match/storage/google_cloud_storage.rb
@@ -23,6 +23,8 @@ module Match
       attr_reader :username
       attr_reader :team_id
       attr_reader :team_name
+      attr_reader :api_key_path
+      attr_reader :api_key
 
       # Managed values
       attr_accessor :gc_storage
@@ -44,7 +46,9 @@ module Match
           readonly: params[:readonly],
           username: params[:username],
           team_id: params[:team_id],
-          team_name: params[:team_name]
+          team_name: params[:team_name],
+          api_key_path: params[:api_key_path],
+          api_key: params[:api_key]
         )
       end
 
@@ -56,7 +60,9 @@ module Match
                      readonly: nil,
                      username: nil,
                      team_id: nil,
-                     team_name: nil)
+                     team_name: nil,
+                     api_key_path: nil,
+                     api_key: nil)
         @type = type if type
         @platform = platform if platform
         @google_cloud_project_id = google_cloud_project_id if google_cloud_project_id
@@ -66,6 +72,9 @@ module Match
         @username = username
         @team_id = team_id
         @team_name = team_name
+
+        @api_key_path = api_key_path
+        @api_key = api_key
 
         @google_cloud_keys_file = ensure_keys_file_exists(google_cloud_keys_file, google_cloud_project_id)
 
@@ -106,9 +115,17 @@ module Match
           # see `prefixed_working_directory` comments for more details
           return self.team_id
         else
-          spaceship = SpaceshipEnsure.new(self.username, self.team_id, self.team_name)
+          UI.user_error!("The `team_id` option is required. fastlane cannot automatically determine portal team id via the App Store Connect API (yet)") if self.team_id.to_s.empty?
+
+          spaceship = SpaceshipEnsure.new(self.username, self.team_id, self.team_name, self.api_token)
           return spaceship.team_id
         end
+      end
+
+      def api_token
+        api_token ||= Spaceship::ConnectAPI::Token.create(self.api_key) if self.api_key
+        api_token ||= Spaceship::ConnectAPI::Token.from_json_file(self.api_key_path) if self.api_key_path
+        return api_token
       end
 
       def prefixed_working_directory

--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -19,6 +19,8 @@ module Match
       attr_reader :username
       attr_reader :team_id
       attr_reader :team_name
+      attr_reader :api_key_path
+      attr_reader :api_key
 
       def self.configure(params)
         s3_region = params[:s3_region]
@@ -43,7 +45,9 @@ module Match
           readonly: params[:readonly],
           username: params[:username],
           team_id: params[:team_id],
-          team_name: params[:team_name]
+          team_name: params[:team_name],
+          api_key_path: params[:api_key_path],
+          api_key: params[:api_key]
         )
       end
 
@@ -55,7 +59,9 @@ module Match
                      readonly: nil,
                      username: nil,
                      team_id: nil,
-                     team_name: nil)
+                     team_name: nil,
+                     api_key_path: nil,
+                     api_key: nil)
         @s3_bucket = s3_bucket
         @s3_region = s3_region
         @s3_client = Fastlane::Helper::S3ClientHelper.new(access_key: s3_access_key, secret_access_key: s3_secret_access_key, region: s3_region)
@@ -64,6 +70,8 @@ module Match
         @username = username
         @team_id = team_id
         @team_name = team_name
+        @api_key_path = api_key_path
+        @api_key = api_key
       end
 
       # To make debugging easier, we have a custom exception here
@@ -180,9 +188,17 @@ module Match
           # see `prefixed_working_directory` comments for more details
           return self.team_id
         else
-          spaceship = SpaceshipEnsure.new(self.username, self.team_id, self.team_name)
+          UI.user_error!("The `team_id` option is required. fastlane cannot automatically determine portal team id via the App Store Connect API (yet)") if self.team_id.to_s.empty?
+
+          spaceship = SpaceshipEnsure.new(self.username, self.team_id, self.team_name, api_token)
           return spaceship.team_id
         end
+      end
+
+      def api_token
+        api_token ||= Spaceship::ConnectAPI::Token.create(self.api_key) if self.api_key
+        api_token ||= Spaceship::ConnectAPI::Token.from_json_file(self.api_key_path) if self.api_key_path
+        return api_token
       end
     end
   end

--- a/match/spec/importer_spec.rb
+++ b/match/spec/importer_spec.rb
@@ -48,8 +48,7 @@ describe Match do
       repo_dir = Dir.mktmpdir
       setup_fake_storage(repo_dir, config)
 
-      expect(Spaceship::Portal).to receive(:login)
-      expect(Spaceship::Portal).to receive(:select_team)
+      expect(Spaceship::ConnectAPI).to receive(:login)
       expect(Spaceship::ConnectAPI::Certificate).to receive(:all).and_return([mock_cert])
       expect(fake_storage).to receive(:save_changes!).with(
         files_to_commit: [
@@ -66,8 +65,7 @@ describe Match do
       repo_dir = Dir.mktmpdir
       setup_fake_storage(repo_dir, config)
 
-      expect(Spaceship::Portal).to receive(:login)
-      expect(Spaceship::Portal).to receive(:select_team)
+      expect(Spaceship::ConnectAPI).to receive(:login)
       expect(Spaceship::ConnectAPI::Certificate).to receive(:all).and_return([mock_cert])
       expect(fake_storage).to receive(:save_changes!).with(
         files_to_commit: [
@@ -85,8 +83,7 @@ describe Match do
       setup_fake_storage(repo_dir, config)
 
       expect(UI).to receive(:input).and_return("")
-      expect(Spaceship::Portal).to receive(:login)
-      expect(Spaceship::Portal).to receive(:select_team)
+      expect(Spaceship::ConnectAPI).to receive(:login)
       expect(Spaceship::ConnectAPI::Certificate).to receive(:all).and_return([mock_cert])
       expect(fake_storage).to receive(:save_changes!).with(
         files_to_commit: [
@@ -105,8 +102,7 @@ describe Match do
       setup_fake_storage(repo_dir, developer_id_config)
 
       expect(UI).to receive(:input).and_return("")
-      expect(Spaceship::Portal).to receive(:login)
-      expect(Spaceship::Portal).to receive(:select_team)
+      expect(Spaceship::ConnectAPI).to receive(:login)
       expect(Spaceship::ConnectAPI::Certificate).to receive(:all).and_return([mock_cert])
       expect(fake_storage).to receive(:save_changes!).with(
         files_to_commit: [
@@ -132,10 +128,17 @@ describe Match do
         google_cloud_bucket_name: "",
         google_cloud_keys_file: "",
         google_cloud_project_id: "",
+        s3_bucket: nil,
+        s3_region: nil,
+        s3_access_key: nil,
+        s3_secret_access_key: nil,
+        s3_object_prefix: nil,
         readonly: false,
         username: config[:username],
         team_id: nil,
-        team_name: nil
+        team_name: nil,
+        api_key_path: nil,
+        api_key: nil
       ).and_return(fake_storage)
 
       expect(fake_storage).to receive(:download).and_return(nil)

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -63,7 +63,9 @@ describe Match do
             readonly: false,
             username: values[:username],
             team_id: nil,
-            team_name: nil
+            team_name: nil,
+            api_key_path: nil,
+            api_key: nil
           ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
@@ -146,7 +148,9 @@ describe Match do
             readonly: false,
             username: values[:username],
             team_id: nil,
-            team_name: nil
+            team_name: nil,
+            api_key_path: nil,
+            api_key: nil
           ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
@@ -228,7 +232,9 @@ describe Match do
             readonly: false,
             username: values[:username],
             team_id: nil,
-            team_name: nil
+            team_name: nil,
+            api_key_path: nil,
+            api_key: nil
           ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
@@ -296,7 +302,9 @@ describe Match do
             readonly: false,
             username: values[:username],
             team_id: nil,
-            team_name: nil
+            team_name: nil,
+            api_key_path: nil,
+            api_key: nil
           ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -54,6 +54,25 @@ module Sigh
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
                                      default_value_dynamic: true),
+
+        # App Store Connect API
+        FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                     env_name: "DELIVER_API_KEY_PATH",
+                                     description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
+                                     optional: true,
+                                     conflicting_options: [:username],
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :api_key,
+                                     env_name: "DELIVER_API_KEY",
+                                     description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
+                                     type: Hash,
+                                     optional: true,
+                                     sensitive: true,
+                                     conflicting_options: [:api_key_path, :username]),
+
+        # Apple ID
         FastlaneCore::ConfigItem.new(key: :username,
                                      short_option: "-u",
                                      env_name: "SIGH_USERNAME",
@@ -82,6 +101,8 @@ module Sigh
                                      verify_block: proc do |value|
                                        ENV["FASTLANE_TEAM_NAME"] = value.to_s
                                      end),
+
+        # Other options
         FastlaneCore::ConfigItem.new(key: :provisioning_name,
                                      short_option: "-n",
                                      env_name: "SIGH_PROVISIONING_PROFILE_NAME",

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -57,7 +57,7 @@ module Sigh
 
         # App Store Connect API
         FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                     env_name: "DELIVER_API_KEY_PATH",
+                                     env_name: "SIGH_API_KEY_PATH",
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:username],
@@ -65,7 +65,7 @@ module Sigh
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "DELIVER_API_KEY",
+                                     env_name: "SIGH_API_KEY",
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -60,7 +60,7 @@ module Sigh
                                      env_name: "SIGH_API_KEY_PATH",
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
-                                     conflicting_options: [:username],
+                                     conflicting_options: [:api_key],
                                      verify_block: proc do |value|
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
@@ -70,7 +70,7 @@ module Sigh
                                      type: Hash,
                                      optional: true,
                                      sensitive: true,
-                                     conflicting_options: [:api_key_path, :username]),
+                                     conflicting_options: [:api_key_path]),
 
         # Apple ID
         FastlaneCore::ConfigItem.new(key: :username,

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -269,21 +269,21 @@ module Sigh
       return [] if !Sigh.config[:development] && !Sigh.config[:adhoc]
 
       device_classes = case Sigh.config[:platform].to_s
-                     when 'ios'
-                       [
-                         Spaceship::ConnectAPI::Device::DeviceClass::APPLE_WATCH,
-                         Spaceship::ConnectAPI::Device::DeviceClass::IPAD,
-                         Spaceship::ConnectAPI::Device::DeviceClass::IPHONE,
-                         Spaceship::ConnectAPI::Device::DeviceClass::IPOD
-                       ]
-                     when 'tvos'
-                       [Spaceship::ConnectAPI::Device::DeviceClass::APPLE_TV]
-                     when 'macos', 'catalyst'
-                       [Spaceship::ConnectAPI::Device::DeviceClass::MAC]
-                     end
+                       when 'ios'
+                         [
+                           Spaceship::ConnectAPI::Device::DeviceClass::APPLE_WATCH,
+                           Spaceship::ConnectAPI::Device::DeviceClass::IPAD,
+                           Spaceship::ConnectAPI::Device::DeviceClass::IPHONE,
+                           Spaceship::ConnectAPI::Device::DeviceClass::IPOD
+                         ]
+                       when 'tvos'
+                         [Spaceship::ConnectAPI::Device::DeviceClass::APPLE_TV]
+                       when 'macos', 'catalyst'
+                         [Spaceship::ConnectAPI::Device::DeviceClass::MAC]
+                       end
 
       if api_token
-        return Spaceship::ConnectAPI::Device.all().select do |device|
+        return Spaceship::ConnectAPI::Device.all.select do |device|
           device_classes.include?(device.device_class)
         end
       else

--- a/sigh/spec/spec_helper.rb
+++ b/sigh/spec/spec_helper.rb
@@ -9,6 +9,7 @@ def sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: n
   certificate = "certificate"
   allow(certificate).to receive(:id).and_return("id")
   allow(certificate).to receive(:certificate_content).and_return(Base64.encode64("cert content"))
+  allow(Spaceship::ConnectAPI::Certificate).to receive(:all).and_return([certificate])
 
   device = "device"
   allow(device).to receive(:id).and_return(1)

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -196,7 +196,7 @@ module Spaceship
       self.new(cookie: another_client.instance_variable_get(:@cookie), current_team_id: another_client.team_id)
     end
 
-    def initialize(cookie: nil, current_team_id: nil, timeout: nil)
+    def initialize(cookie: nil, current_team_id: nil, csrf_tokens: nil, timeout: nil)
       options = {
        request: {
           timeout:       (ENV["SPACESHIP_TIMEOUT"] || timeout || 300).to_i,
@@ -204,6 +204,7 @@ module Spaceship
         }
       }
       @current_team_id = current_team_id
+      @csrf_tokens = csrf_tokens
       @cookie = cookie || HTTP::CookieJar.new
 
       @client = Faraday.new(self.class.hostname, options) do |c|

--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -17,7 +17,7 @@ module Spaceship
       #####################################################
 
       # Instantiates a client with cookie session or a JWT token.
-      def initialize(cookie: nil, current_team_id: nil, token: nil, another_client: nil)
+      def initialize(cookie: nil, current_team_id: nil, token: nil, csrf_tokens: nil, another_client: nil)
         params_count = [cookie, token, another_client].compact.size
         if params_count != 1
           raise "Must initialize with one of :cookie, :token, or :another_client"
@@ -25,10 +25,10 @@ module Spaceship
 
         if token.nil?
           if another_client.nil?
-            super(cookie: cookie, current_team_id: current_team_id, timeout: 1200)
+            super(cookie: cookie, current_team_id: current_team_id, csrf_tokens: csrf_tokens, timeout: 1200)
             return
           end
-          super(cookie: another_client.instance_variable_get(:@cookie), current_team_id: another_client.team_id)
+          super(cookie: another_client.instance_variable_get(:@cookie), current_team_id: another_client.team_id, csrf_tokens: another_client.csrf_tokens)
         else
           options = {
             request: {

--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -97,8 +97,18 @@ module Spaceship
       end
 
       def portal_team_id
-        return nil if @portal_client.nil?
-        return @portal_client.team_id
+        if token
+          message = [
+            "Cannot determine portal team id via the App Store Connect API (yet)",
+            "Look to see if you can get the portal team id from somewhere else",
+            "View more info in the docs at https://docs.fastlane.tools/app-store-connect-api/"
+          ]
+          raise message.join('. ')
+        elsif @portal_client
+          return @portal_client.team_id
+        else
+          raise "No App Store Connect API token or Portal Client set"
+        end
       end
 
       def tunes_team_id
@@ -126,7 +136,7 @@ module Spaceship
               "Or set the 'SPACESHIP_CONNECT_API_IN_HOUSE' environment variable to 'true'",
               "View more info in the docs at https://docs.fastlane.tools/app-store-connect-api/"
             ]
-            raise message.join('\n')
+            raise message.join('. ')
           end
           return !!token.in_house
         elsif @portal_client

--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -9,6 +9,7 @@ module Spaceship
 
       attr_accessor :certificate_content
       attr_accessor :display_name
+      attr_accessor :expiration_date
       attr_accessor :name
       attr_accessor :platform
       attr_accessor :serial_number

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -27,7 +27,8 @@ module Spaceship
         "expirationDate" => "expiration_date",
 
         "bundleId" => "bundle_id",
-        "certificates" => "certificates"
+        "certificates" => "certificates",
+        "devices" => "devices"
       })
 
       module ProfileState
@@ -81,6 +82,11 @@ module Spaceship
           }
         )
         return resp.to_models.first
+      end
+
+      def fetch_all_devices(filter: {}, includes: nil, sort: nil)
+        resps = Spaceship::ConnectAPI.get_devices(profile_id: id, filter: filter, includes: includes).all_pages
+        return resps.flat_map(&:to_models)
       end
 
       def delete!

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -62,9 +62,13 @@ module Spaceship
         # devices
         #
 
-        def get_devices(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_devices(profile_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = provisioning_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          provisioning_request_client.get("devices", params)
+          if profile_id.nil?
+            provisioning_request_client.get("devices", params)
+          else
+            provisioning_request_client.get("profiles/#{profile_id}/devices", params)
+          end
         end
 
         #

--- a/spaceship/spec/connect_api/client_spec.rb
+++ b/spaceship/spec/connect_api/client_spec.rb
@@ -191,6 +191,7 @@ describe Spaceship::ConnectAPI::Client do
       it "with portal client" do
         mock_portal_client =  double('portal client')
         allow(mock_portal_client).to receive(:team_id)
+        allow(mock_portal_client).to receive(:csrf_tokens)
 
         client = Spaceship::ConnectAPI::Client.new(portal_client: mock_portal_client)
 

--- a/spaceship/spec/connect_api/models/app_spec.rb
+++ b/spaceship/spec/connect_api/models/app_spec.rb
@@ -6,6 +6,7 @@ describe Spaceship::ConnectAPI::App do
   before do
     allow(mock_tunes_client).to receive(:team_id).and_return("123")
     allow(mock_tunes_client).to receive(:select_team)
+    allow(mock_tunes_client).to receive(:csrf_tokens)
     allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
     Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
   end

--- a/spaceship/spec/connect_api/models/bundle_id_capability_spec.rb
+++ b/spaceship/spec/connect_api/models/bundle_id_capability_spec.rb
@@ -6,6 +6,7 @@ describe Spaceship::ConnectAPI::BundleIdCapability do
   before do
     allow(mock_portal_client).to receive(:team_id).and_return("123")
     allow(mock_portal_client).to receive(:select_team)
+    allow(mock_portal_client).to receive(:csrf_tokens)
     allow(Spaceship::PortalClient).to receive(:login).and_return(mock_portal_client)
     Spaceship::ConnectAPI.login(username, password, use_portal: true, use_tunes: false)
   end

--- a/spaceship/spec/connect_api/models/bundle_id_spec.rb
+++ b/spaceship/spec/connect_api/models/bundle_id_spec.rb
@@ -6,6 +6,7 @@ describe Spaceship::ConnectAPI::BundleId do
   before do
     allow(mock_portal_client).to receive(:team_id).and_return("123")
     allow(mock_portal_client).to receive(:select_team)
+    allow(mock_portal_client).to receive(:csrf_tokens)
     allow(Spaceship::PortalClient).to receive(:login).and_return(mock_portal_client)
     Spaceship::ConnectAPI.login(username, password, use_portal: true, use_tunes: false)
   end

--- a/spaceship/spec/connect_api/models/pre_release_version_spec.rb
+++ b/spaceship/spec/connect_api/models/pre_release_version_spec.rb
@@ -6,6 +6,7 @@ describe Spaceship::ConnectAPI::PreReleaseVersion do
   before do
     allow(mock_tunes_client).to receive(:team_id).and_return("123")
     allow(mock_tunes_client).to receive(:select_team)
+    allow(mock_tunes_client).to receive(:csrf_tokens)
     allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
     Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
   end

--- a/spaceship/spec/connect_api/models/profile_spec.rb
+++ b/spaceship/spec/connect_api/models/profile_spec.rb
@@ -6,6 +6,7 @@ describe Spaceship::ConnectAPI::Profile do
   before do
     allow(mock_portal_client).to receive(:team_id).and_return("123")
     allow(mock_portal_client).to receive(:select_team)
+    allow(mock_portal_client).to receive(:csrf_tokens)
     allow(Spaceship::PortalClient).to receive(:login).and_return(mock_portal_client)
     Spaceship::ConnectAPI.login(username, password, use_portal: true, use_tunes: false)
   end

--- a/spaceship/spec/connect_api/models/user_spec.rb
+++ b/spaceship/spec/connect_api/models/user_spec.rb
@@ -6,6 +6,7 @@ describe Spaceship::ConnectAPI::User do
   before do
     allow(mock_tunes_client).to receive(:team_id).and_return("123")
     allow(mock_tunes_client).to receive(:select_team)
+    allow(mock_tunes_client).to receive(:csrf_tokens)
     allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
     Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
   end

--- a/spaceship/spec/connect_api/spaceship_spec.rb
+++ b/spaceship/spec/connect_api/spaceship_spec.rb
@@ -14,6 +14,8 @@ describe Spaceship::ConnectAPI do
     before(:each) do
       allow(mock_tunes_client).to receive(:team_id).and_return("team_id")
       allow(mock_portal_client).to receive(:team_id).and_return("team_id")
+      allow(mock_tunes_client).to receive(:csrf_tokens)
+      allow(mock_portal_client).to receive(:csrf_tokens)
     end
 
     context 'with implicit client' do

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -8,6 +8,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
   before do
     allow(mock_tunes_client).to receive(:team_id).and_return("123")
     allow(mock_tunes_client).to receive(:select_team)
+    allow(mock_tunes_client).to receive(:csrf_tokens)
     allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
     Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
   end

--- a/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
@@ -8,6 +8,7 @@ describe Spaceship::ConnectAPI::Tunes::Client do
   before do
     allow(mock_tunes_client).to receive(:team_id).and_return("123")
     allow(mock_tunes_client).to receive(:select_team)
+    allow(mock_tunes_client).to receive(:csrf_tokens)
     allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
     Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
   end

--- a/spaceship/spec/connect_api/users/user_client_spec.rb
+++ b/spaceship/spec/connect_api/users/user_client_spec.rb
@@ -8,6 +8,7 @@ describe Spaceship::ConnectAPI::Users::Client do
   before do
     allow(mock_tunes_client).to receive(:team_id).and_return("123")
     allow(mock_tunes_client).to receive(:select_team)
+    allow(mock_tunes_client).to receive(:csrf_tokens)
     allow(Spaceship::TunesClient).to receive(:login).and_return(mock_tunes_client)
     Spaceship::ConnectAPI.login(username, password, use_portal: false, use_tunes: true)
   end


### PR DESCRIPTION
### Motivation and Context
App Store Connect API is the best API ❤️ And last big step to get `match` fully working with App Store Connect API

### Description
- Added `api_key` and `api_key_path` options to `sigh`
- Used different versions of endpoints that are compatible with both the Apple ID and Token session
- Using updated `Spaceship::ConnectAPI::Certificate`
- Official ASC API does not support filtering by `deviceClass` so need to do it in code 🤷‍♂️  (filing radar for this)

#### Examples

##### 1. New action
```rb
lane :release do
  api_key = app_store_connect_api_key(
    key_id: "D383SF739",
    issuer_id: "6053b7fe-68a8-4acb-89be-165aa6465141",
    key_filepath: "./D383SF739.p8",
    duration: 1200, # optional
    in_house: false, # optional but may be required if using match/sigh
  )

  sigh( api_key: api_key )
end
```

##### 2. New file format

```js
{
  "key_id": "D383SF739",
  "issuer_id": "6053b7fe-68a8-4acb-89be-165aa6465141",
  "key": "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHknlhdlYdLu\n-----END PRIVATE KEY-----",
  “duration”: 1200, # optional
  “in_house”: false, # optional but may be required if using match/sigh
}

```

```rb
lane :release do
  sigh( api_key_path: "fastlane/me.json" )
end

```

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-sigh-app-store-connect-api-key"
```
