### PR TITLE
[Fastlane.swift] fix crash in `LaneFileProtocol.swift` when executing fastlane Swift without using SPM

### DIFF
--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -102,9 +102,6 @@ open class LaneFile: NSObject, LaneFileProtocol {
             // in the executable's scope that loads the library, so in that case `className()` won't be the
             // expected Fastfile and so, we do not dynamically load it as we do without SPM.
             loadFastfile()
-        #endif
-
-        #if !SWIFT_PACKAGE
             guard let fastfileInstance: LaneFile = self.fastfileInstance else {
                 let message = "Unable to instantiate class named: \(className())"
                 log(message: message)

--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -33,7 +33,7 @@ open class LaneFile: NSObject, LaneFileProtocol {
     private(set) static var fastfileInstance: LaneFile?
 
     // Called before any lane is executed.
-    private func setupAllTheThings() {
+    private func setUpAllTheThings() {
         LaneFile.fastfileInstance!.beforeAll()
     }
 
@@ -135,8 +135,8 @@ open class LaneFile: NSObject, LaneFileProtocol {
             return false
         }
 
-        fastfileInstance.setupAllTheThings()
         // Call all methods that need to be called before we start calling lanes.
+        fastfileInstance.setUpAllTheThings()
 
         // We need to catch all possible errors here and display a nice message.
         _ = fastfileInstance.perform(NSSelectorFromString(laneMethod), with: parameters)

--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -21,11 +21,11 @@ public protocol LaneFileProtocol: class {
 }
 
 public extension LaneFileProtocol {
-    var fastlaneVersion: String { return "" } // default "" because that means any is fine
-    func beforeAll() {} // no op by default
-    func afterAll(currentLane _: String) {} // no op by default
-    func onError(currentLane _: String, errorInfo _: String) {} // no op by default
-    func recordLaneDescriptions() {} // no op by default
+    var fastlaneVersion: String { return "" } // Defaults to "" because that means any is fine
+    func beforeAll() {} // No-op by default
+    func afterAll(currentLane _: String) {} // No-op by default
+    func onError(currentLane _: String, errorInfo _: String) {} // No-op by default
+    func recordLaneDescriptions() {} // No-op by default
 }
 
 @objcMembers
@@ -51,8 +51,8 @@ open class LaneFile: NSObject, LaneFileProtocol {
         #if !SWIFT_PACKAGE
             let methodList = class_copyMethodList(self, &methodCount)
         #else
-            // In SPM we're calling this functions out of the scope of the normal binary that it
-            // is being built, so self in this scope would be the SPM executable instead of the Fastfile
+            // In SPM we're calling this functions out of the scope of the normal binary that it's
+            // being built, so *self* in this scope would be the SPM executable instead of the Fastfile
             // that we'd normally expect.
             let methodList = class_copyMethodList(type(of: fastfileInstance!), &methodCount)
         #endif
@@ -98,9 +98,7 @@ open class LaneFile: NSObject, LaneFileProtocol {
     public static func runLane(from fastfile: LaneFile?, named: String, parameters: [String: String]) -> Bool {
         log(message: "Running lane: \(named)")
         #if !SWIFT_PACKAGE
-            // In SPM we do not load the Fastfile class from its `className()`, because we're in another
-            // in the executable's scope that loads the library, so in that case `className()` won't be the
-            // expected Fastfile and so, we do not dynamically load it as we do without SPM.
+            // When not in SPM environment, we load the Fastfile from its `className()`.
             loadFastfile()
             guard let fastfileInstance: LaneFile = self.fastfileInstance else {
                 let message = "Unable to instantiate class named: \(className())"
@@ -108,8 +106,9 @@ open class LaneFile: NSObject, LaneFileProtocol {
                 fatalError(message)
             }
         #else
-            // We load the fastfile as a Lanefile in a static way, by parameter, because the Fastlane library
-            // cannot know nothing about the caller (in this case, the executable).
+            // When in SPM environment, we can't load the Fastfile from its `className()` because the executable is in
+            // another scope, so `className()` won't be the expected Fastfile. Instead, we load the Fastfile as a Lanefile
+            // in a static way, by parameter.
             guard let fastfileInstance: LaneFile = fastfile else {
                 log(message: "Found nil instance of fastfile")
                 preconditionFailure()
@@ -136,13 +135,13 @@ open class LaneFile: NSObject, LaneFileProtocol {
             return false
         }
 
-        // call all methods that need to be called before we start calling lanes
         fastfileInstance.setupAllTheThings()
+        // Call all methods that need to be called before we start calling lanes.
 
-        // We need to catch all possible errors here and display a nice message
+        // We need to catch all possible errors here and display a nice message.
         _ = fastfileInstance.perform(NSSelectorFromString(laneMethod), with: parameters)
 
-        // only call on success
+        // Call only on success.
         fastfileInstance.afterAll(currentLane: named)
         log(message: "Done running lane: \(named) 🚀")
         return true

--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -117,8 +117,8 @@ open class LaneFile: NSObject, LaneFileProtocol {
                 log(message: "Found nil instance of fastfile")
                 preconditionFailure()
             }
+            self.fastfileInstance = fastfileInstance
         #endif
-        self.fastfileInstance = fastfile!
         let currentLanes = lanes
         let lowerCasedLaneRequested = named.lowercased()
 


### PR DESCRIPTION
🔑 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves #17275
Resolves #17222

### Description

The main change that fixes this issue is just changing `fastfile!` to `fastfileInstance`. All the other changes were mere style and misc improvements: 
- Moved the `self.fastfileInstance` assignment to be within the SPM directive conditional because it's redundant in the non-SPM scenario.
- Removed redundant !SPM directive conditional, to reduce complexity and improve readability.
- Improved docs (wording, style, typos, capitalization, etc)
- Renamed function that was starting with a noun (setup) instead of a verb (set up) - or phrasal verb, for the matter 🤓 

### Testing Steps

With these changes, when using fastlane Swift without using SPM, it will work again.

If you want to test this branch, edit your `Gemfile`:

```ruby
gem "fastlane", :git => "https://github.com/rogerluan/fastlane.git", :branch => "fix-force-unwrap-crash"
```