### PR TITLE
[deliver] transform string key to symbol, since hash args in options from CLI keyed by string

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -583,7 +583,7 @@ module Deliver
 
     def set_review_information(version, options)
       return unless options[:app_review_information]
-      info = options[:app_review_information]
+      info = options[:app_review_information].transform_keys(&:to_sym)
       UI.user_error!("`app_review_information` must be a hash", show_github_issues: true) unless info.kind_of?(Hash)
 
       attributes = {}

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -583,7 +583,8 @@ module Deliver
 
     def set_review_information(version, options)
       return unless options[:app_review_information]
-      info = options[:app_review_information].transform_keys(&:to_sym)
+      info = options[:app_review_information]
+      info = info.collect { |k, v| [k.to_sym, v] }.to_h
       UI.user_error!("`app_review_information` must be a hash", show_github_issues: true) unless info.kind_of?(Hash)
 
       attributes = {}


### PR DESCRIPTION
transform string key to symbol, since hash args in options from CLI keyed by string

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`app_review_information` passed into deliver from CLI is parsed to hash keyed by string but not symbol. This makes `set_review_information` failed.

### Description
I'm not very familiar with Ruby and I haven't much time, so my solution looks a bit ugly.
Better way to fix this problem is to make sure hash args in options keyed by symbol when generate options, hope maintainers can help me.

### Testing Steps
I use command below to test
```
DELIVER_SUBMISSION_INFO='{"add_id_info_limits_tracking":true,"add_id_info_serves_ads":false,"add_id_info_tracks_action":false,"add_id_info_tracks_install":true,"add_id_info_uses_idfa":true}'

DELIVER_APP_REVIEW_INFO='{"demo_user":"xxxxx","demo_password":"xxxxx"}'

fastlane deliver submit_build --username 'email' --team_id 000000 --app_identifier 'com.xxxx.xxxx' --platform 'ios' --app_version $app_version --build_number $build_number --skip_binary_upload true --skip_screenshots true --skip_app_version_update true --automatic_release false --phased_release true --reset_ratings false --submission_information "$DELIVER_SUBMISSION_INFO" --app_review_information "$DELIVER_APP_REVIEW_INFO" --reject_if_possible true --force true
```
