### PR TITLE
Clarify Sigh Arg Conflicts Error Messages

### DIFF
--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -16,7 +16,7 @@ module Sigh
                                      default_value: false,
                                      conflicting_options: [:developer_id, :development],
                                      conflict_block: proc do |option|
-                                       UI.user_error!("You can't enable both :#{option.key} and :adhoc")
+                                       UI.user_error!("You can't pass arguments for both :#{option.key} and :adhoc")
                                      end),
         FastlaneCore::ConfigItem.new(key: :developer_id,
                                      env_name: "SIGH_DEVELOPER_ID",
@@ -25,7 +25,7 @@ module Sigh
                                      default_value: false,
                                      conflicting_options: [:adhoc, :development],
                                      conflict_block: proc do |option|
-                                       UI.user_error!("You can't enable both :#{option.key} and :developer_id")
+                                       UI.user_error!("You can't pass arguments for both :#{option.key} and :developer_id")
                                      end),
         FastlaneCore::ConfigItem.new(key: :development,
                                      env_name: "SIGH_DEVELOPMENT",
@@ -34,7 +34,7 @@ module Sigh
                                      default_value: false,
                                      conflicting_options: [:adhoc, :developer_id],
                                      conflict_block: proc do |option|
-                                       UI.user_error!("You can't enable both :#{option.key} and :development")
+                                       UI.user_error!("You can't pass arguments for both :#{option.key} and :development")
                                      end),
         FastlaneCore::ConfigItem.new(key: :skip_install,
                                      env_name: "SIGH_SKIP_INSTALL",
@@ -147,7 +147,7 @@ module Sigh
                                      default_value: false,
                                      conflicting_options: [:force],
                                      conflict_block: proc do |value|
-                                       UI.user_error!("You can't enable both :force and :readonly")
+                                       UI.user_error!("You can't pass arguments for both :force and :readonly")
                                      end),
         FastlaneCore::ConfigItem.new(key: :template_name,
                                      env_name: "SIGH_PROVISIONING_PROFILE_TEMPLATE_NAME",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Sigh propagates an error if the user passes in two arguments that sigh
perceives as being mutually exclusive. For example, if the user passes
both an `:adhoc` and a `:development` arg, it will fail.

The error message that it currently propagates however states that "You can't enable both
:development and :adhoc".

This is problematic because the word "enable" suggests that the two
boolean arguments can't both be `true` when in reality sigh will still
error if given values of `false` and `false` or `false` and `true`.

This commit thus removes the word "enable" and clarifies that the problem is
caused by mutually exclusive arguments.

### Testing Steps
`bundle exec fastlane run sigh adhoc:true development:false`
