### PR TITLE
[docs] update AppStoreConnect.md - replace deprecated Spaceship::Tunes calls 

### DIFF
--- a/spaceship/docs/AppStoreConnect.md
+++ b/spaceship/docs/AppStoreConnect.md
@@ -88,21 +88,21 @@ app.update_price_tier!("3")
 
 <img src="/spaceship/assets/docs/AppVersions.png" width="500">
 
-You can have up to 2 app versions at the same time. One is usually the version already available in the App Store (`live_version`) and one being the one you can edit (`edit_version`).
+You can have up to 2 app versions at the same time. One is usually the version already available in the App Store (`get_live_app_store_version`) and one being the one you can edit (`get_edit_app_store_version`).
 
 While you usually can modify some values in the production version (e.g. app description), most options are already locked.
 
 With _spaceship_ you can access the versions like this
 
 ```ruby
-app.live_version # the version that's currently available in the App Store
-app.edit_version # the version that's in `Prepare for Submission` mode
+app.get_live_app_store_version # the version that's currently available in the App Store
+app.get_edit_app_store_version # the version that's in `Prepare for Submission` mode
 ```
 
 You can then go ahead and modify app metadata on the version objects:
 
 ```ruby
-v = app.edit_version
+v = app.get_edit_app_store_version
 
 # Access information
 v.app_status        # => "Waiting for Review"
@@ -211,7 +211,7 @@ attr_reader :screenshots
 ### Select a build for review
 
 ```ruby
-version = app.edit_version
+version = app.get_edit_app_store_version
 
 builds = version.candidate_builds
 version.select_build(builds.first)


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Replace deprecated `Spaceship::Tunes` calls with `Spaceship::ConnectAPI`
- `app.live_version` to `app.get_live_app_store_version` 
- `app.edit_version` to `app.get_edit_app_store_version` 


### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Simple documentation corrected it by (#17148) 
