### PR TITLE
[action] fixed issue in app_store_connect_api_key with loading key content from env variable

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -17,6 +17,10 @@ module Fastlane
           UI.user_error!(":key_content or :key_filepath is required")
         end
 
+        # New lines don't get read properly when coming from an ENV
+        # Replacing them literal version with a new line
+        key_content = key_content.gsub('\n', "\n") if key_content
+
         # This hash matches the named arguments on
         # the Spaceship::ConnectAPI::Token.create method
         key = {


### PR DESCRIPTION
### Motivation and Context
Fixes issue in described in https://github.com/fastlane/fastlane/pull/17061#issuecomment-699061061

### Description
Private key content didn't load correctly from an ENV because of new lines being seen as literal "\n". Replaces the "\n" with actually carriage returns.

cc: @xanderbuck
