### PR TITLE
[Fastlane.Swift] fix: beforeAll method not called

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/kareman/SwiftShell",
         "state": {
           "branch": null,
-          "revision": "fb7fc2c9ad8811caf324431a508fb79e3fb74f99",
-          "version": "5.0.1"
+          "revision": "99680b2efc7c7dbcace1da0b3979d266f02e213c",
+          "version": "5.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "Fastlane", targets: ["Fastlane"])
     ],
     dependencies: [
-        .package(url: "https://github.com/kareman/SwiftShell", .upToNextMajor(from: "5.0.1"))
+        .package(url: "https://github.com/kareman/SwiftShell", .upToNextMajor(from: "5.1.0"))
     ],
     targets: [
         .target(

--- a/fastlane/swift/MainProcess.swift
+++ b/fastlane/swift/MainProcess.swift
@@ -28,7 +28,7 @@ class MainProcess {
     @objc func connectToFastlaneAndRunLane(_ fastfile: LaneFile?) {
         runner.startSocketThread(port: argumentProcessor.port)
 
-        let completedRun = Fastfile.runLane(from: fastfile, named: argumentProcessor.currentLane, parameters: argumentProcessor.laneParameters())
+        let completedRun = Fastfile.runLane(from: fastfile, named: argumentProcessor.currentLane, with: argumentProcessor.laneParameters())
         if completedRun {
             runner.disconnectFromFastlaneProcess()
         }

--- a/fastlane/swift/main.swift
+++ b/fastlane/swift/main.swift
@@ -20,7 +20,7 @@ class MainProcess {
     @objc func connectToFastlaneAndRunLane() {
         runner.startSocketThread(port: argumentProcessor.port)
 
-        let completedRun = Fastfile.runLane(from: nil, named: argumentProcessor.currentLane, parameters: argumentProcessor.laneParameters())
+        let completedRun = Fastfile.runLane(from: nil, named: argumentProcessor.currentLane, with: argumentProcessor.laneParameters())
         if completedRun {
             runner.disconnectFromFastlaneProcess()
         }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The method `beforeAll` is not called since the last update (`2.161.0`).

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Calling both `beforeAll` and `afterAll` methods via selector solved the issue.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Tested via Xcode Project, all works as expected now.