### PR TITLE
[fastlane_core] skip analytics message on first run if opted out

### DIFF
--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -19,7 +19,7 @@ module FastlaneCore
     end
 
     def action_launched(launch_context: nil)
-      unless did_show_message?
+      if should_show_message?
         show_message
       end
 
@@ -52,16 +52,15 @@ module FastlaneCore
       UI.message("You can disable this by adding `opt_out_usage` at the top of your Fastfile")
     end
 
-    def did_show_message?
+    def should_show_message?
+      return false if FastlaneCore::Env.truthy?("FASTLANE_OPT_OUT_USAGE")
+
       file_name = ".did_show_opt_info"
-
       new_path = File.join(FastlaneCore.fastlane_user_dir, file_name)
-      did_show = File.exist?(new_path)
-
-      return did_show if did_show
+      return false if File.exist?(new_path)
 
       File.write(new_path, '1')
-      false
+      true
     end
 
     def finalize_session


### PR DESCRIPTION
Don't show analytics opt-out message on first run if the user has already opted out, regardless of whether the `.did_show_opt_info` file has been created on disk.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes: #16874

### Description
When deciding whether to show the analytics message, previously the only thing that was considered was whether the file `.did_show_opt_info` exists, meaning the message had been shown before. This changes the logic to also consider whether the user has opted out (either via ENV variable or fastfile), and skips showing the message if they have, even if the file `.did_show_opt_info` has not been created yet.

### Testing Steps
```bash
rm ~/.fastlane/.did_show_opt_info
FASTLANE_OPT_OUT_USAGE=YES fastlane
```

Before this patch: analytics message is displayed
After this patch: analytics message is not displayed
