### PR TITLE
[deliver] fix screenshot uploads issue when overwrite_screenshot option is set to false

### DIFF
--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -52,10 +52,10 @@ module Deliver
       end
     end
 
-    # Iterate given local app_screenshot over localizations and app_screenshot_sets with index within each app_screenshot_set
+    # Iterate given local app_screenshot over localizations and app_screenshot_sets
     #
     # @param screenshots_per_language [Hash<String, Array<Deliver::AppScreenshot>]
-    # @yield [localization, app_screenshot_set, app_screenshot, index]
+    # @yield [localization, app_screenshot_set, app_screenshot]
     # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreVersionLocalization] localization
     # @yieldparam [optional, Spaceship::ConnectAPI::AppStoreScreenshotSet] app_screenshot_set
     # @yieldparam [optional, Deliver::AppScreenshot] screenshot
@@ -85,8 +85,8 @@ module Deliver
           app_screenshot_set ||= localization.create_app_screenshot_set(attributes: { screenshotDisplayType: display_type })
 
           # iterate over screenshots per display size with index
-          screenshots.each.with_index do |screenshot, index|
-            yield(localization, app_screenshot_set, screenshot, index)
+          screenshots.each do |screenshot|
+            yield(localization, app_screenshot_set, screenshot)
           end
         end
       end

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -126,13 +126,14 @@ module Deliver
         end
       end
 
-      number_of_screenshots = 0
+      # Each app_screenshot_set can have only 10 images
+      number_of_screenshots_per_set = {}
+      total_number_of_screenshots = 0
+
       iterator = AppScreenshotIterator.new(localizations)
-      iterator.each_local_screenshot(screenshots_per_language) do |localization, app_screenshot_set, screenshot, index|
-        if index >= 10
-          UI.error("Too many screenshots found for device '#{screenshot.device_type}' in '#{screenshot.language}', skipping this one (#{screenshot.path})")
-          next
-        end
+      iterator.each_local_screenshot(screenshots_per_language) do |localization, app_screenshot_set, screenshot|
+        # Initialize counter on each app screenshot set
+        number_of_screenshots_per_set[app_screenshot_set] ||= (app_screenshot_set.app_screenshots || []).count
 
         checksum = UploadScreenshots.calculate_checksum(screenshot.path)
         duplicate = (app_screenshot_set.app_screenshots || []).any? { |s| s.source_file_checksum == checksum }
@@ -140,11 +141,16 @@ module Deliver
         # Enqueue uploading job if it's not duplicated otherwise screenshot will be skipped
         if duplicate
           UI.message("Previous uploaded. Skipping '#{screenshot.path}'...")
+        elsif number_of_screenshots_per_set[app_screenshot_set] >= 10
+          UI.error("Too many screenshots found for device '#{screenshot.device_type}' in '#{screenshot.language}', skipping this one (#{screenshot.path})")
+          next
         else
+          UI.verbose("Queued uplaod sceeenshot job for #{localization.locale} #{app_screenshot_set.screenshot_display_type} #{screenshot.path}")
           worker.enqueue(UploadScreenshotJob.new(app_screenshot_set, screenshot.path))
+          number_of_screenshots_per_set[app_screenshot_set] += 1
         end
 
-        number_of_screenshots += 1
+        total_number_of_screenshots += 1
       end
 
       worker.start
@@ -154,7 +160,7 @@ module Deliver
       Helper.show_loading_indicator("Waiting for all the screenshots processed...")
       states = wait_for_complete(iterator)
       Helper.hide_loading_indicator
-      retry_upload_screenshots_if_needed(iterator, states, number_of_screenshots, tries, localizations, screenshots_per_language)
+      retry_upload_screenshots_if_needed(iterator, states, total_number_of_screenshots, tries, localizations, screenshots_per_language)
 
       UI.message("Successfully uploaded all screenshots")
     end
@@ -203,12 +209,21 @@ module Deliver
       # Check if local screenshots' checksum exist on App Store Connect
       checksum_to_app_screenshot = iterator.each_app_screenshot.map { |_, _, app_screenshot| [app_screenshot.source_file_checksum, app_screenshot] }.to_h
 
-      missing_local_screenshots = iterator.each_local_screenshot(screenshots_per_language).select do |_, _, local_screenshot, index|
+      number_of_screenshots_per_set = {}
+      missing_local_screenshots = iterator.each_local_screenshot(screenshots_per_language).select do |_, app_screenshot_set, local_screenshot|
+        number_of_screenshots_per_set[app_screenshot_set] ||= (app_screenshot_set.app_screenshots || []).count
         checksum = UploadScreenshots.calculate_checksum(local_screenshot.path)
-        checksum_to_app_screenshot[checksum].nil? && index < 10 # if index is more than 10, it's skipped
+
+        if checksum_to_app_screenshot[checksum]
+          next(false)
+        else
+          is_missing = number_of_screenshots_per_set[app_screenshot_set] < 10 # if it's more than 10, it's skipped
+          number_of_screenshots_per_set[app_screenshot_set] += 1
+          next(is_missing)
+        end
       end
 
-      missing_local_screenshots.each do |_, _, screenshot, _|
+      missing_local_screenshots.each do |_, _, screenshot|
         UI.error("#{screenshot.path} is missing on App Store Connect.")
       end
 

--- a/deliver/spec/app_screenshot_iterator_spec.rb
+++ b/deliver/spec/app_screenshot_iterator_spec.rb
@@ -119,7 +119,7 @@ describe Deliver::AppScreenshotIterator do
           .with(attributes: { screenshotDisplayType: screenshot.device_type })
           .and_return(app_screenshot_set)
         actual = described_class.new([localization]).each_local_screenshot(screenshots_per_language).to_a
-        expect(actual).to eq([[localization, app_screenshot_set, screenshot, 0]])
+        expect(actual).to eq([[localization, app_screenshot_set, screenshot]])
       end
     end
 
@@ -147,8 +147,8 @@ describe Deliver::AppScreenshotIterator do
         screenshots_per_language = { 'en-US' => [screenshot1, screenshot2], 'fr-FR' => [screenshot3, screenshot4] }
 
         actual = described_class.new([localization1, localization2]).each_local_screenshot(screenshots_per_language).to_a
-        expect(actual).to eq([[localization1, app_screenshot_set1, screenshot1, 0], [localization1, app_screenshot_set1, screenshot2, 1],
-                              [localization2, app_screenshot_set2, screenshot3, 0], [localization2, app_screenshot_set2, screenshot4, 1]])
+        expect(actual).to eq([[localization1, app_screenshot_set1, screenshot1], [localization1, app_screenshot_set1, screenshot2],
+                              [localization2, app_screenshot_set2, screenshot3], [localization2, app_screenshot_set2, screenshot4]])
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
@@ -111,7 +111,9 @@ module Spaceship
           timeout_minutes = (ENV["SPACESHIP_SCREENSHOT_UPLOAD_TIMEOUT"] || 20).to_i
 
           loop do
-            puts("Waiting for screenshot to appear before uploading...")
+            # This error handling needs to be resived since any error occured can reach here.
+            # It should handle errors based on what status code is.
+            puts("Waiting for screenshots to appear before uploading. This is unlikely to be recovered unless it's 503 error. error=\"#{error}\"")
             sleep(30)
 
             screenshots = Spaceship::ConnectAPI::AppScreenshotSet

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb
@@ -111,7 +111,7 @@ module Spaceship
           timeout_minutes = (ENV["SPACESHIP_SCREENSHOT_UPLOAD_TIMEOUT"] || 20).to_i
 
           loop do
-            # This error handling needs to be resived since any error occured can reach here.
+            # This error handling needs to be revised since any error occured can reach here.
             # It should handle errors based on what status code is.
             puts("Waiting for screenshots to appear before uploading. This is unlikely to be recovered unless it's 503 error. error=\"#{error}\"")
             sleep(30)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

https://github.com/fastlane/fastlane/issues/17243
In this issue, it's reported that `deliver` got stuck with the message "Waiting for screenshot to appear before uploading..." and didn't recover from it shortly. That message comes from this bit.

https://github.com/fastlane/fastlane/blob/53ce1fab1f616b981fc80d3abd97320f65187ba7/spaceship/lib/spaceship/connect_api/models/app_screenshot.rb#L100-L115

After some investigations, I managed to replicate the similar errors locally and concluded that it was a regression caused in #16972.  

https://github.com/fastlane/fastlane/issues/17243#issuecomment-700347130 

Whilst #16972 gives significant performance improvements, it seemed to have a slight behaviour change when `overiwrite_screenshots` option is set to `false`. 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

(This is just copied from  https://github.com/fastlane/fastlane/issues/17243#issuecomment-700347130 )

https://github.com/fastlane/fastlane/blob/53ce1fab1f616b981fc80d3abd97320f65187ba7/deliver/lib/deliver/upload_screenshots.rb#L131-L148

The above check code "index >= 10" still works without "overwrite_screenshots: true" **if you append images to only the end of the set**. But in the scenario below, "index" will kind of make a contradiction... 

Let's say we have already uploaded 6 screenshots for 6.5-inch screen like this. 

1. "6.5_1.jpg" (uploaded)
1. "6.5_2.jpg" (uploaded)
1. "6.5_3.jpg" (uploaded)
1. "6.5_4.jpg" (uploaded)
1. "6.5_5.jpg" (uploaded)
1. "6.5_6.jpg" (uploaded)

And then you happen to copy another lang's 6.5inch screenshots and paste to the directory ^ those screenshots are stored. It will be like this if sorted. (This would sound weird but was the easiest way to replicate this actually.)

1. "6.5_1 copy.jpg" (local)
1. "6.5_1.jpg" (uploaded)
1. "6.5_2 copy.jpg" (local)
1. "6.5_2.jpg" (uploaded)
1. "6.5_3 copy.jpg" (local)
1. "6.5_3.jpg" (uploaded)
1. "6.5_4 copy.jpg" (local)
1. "6.5_4.jpg" (uploaded)
1. "6.5_5 copy.jpg" (local)
1. "6.5_5.jpg" (uploaded)
1. "6.5_6 copy.jpg" (local)
1. "6.5_6.jpg" (uploaded)

With the current code, it's going to pick up the first 10 images from the above list to decide "skip" or "upload", which means -

* 5 local images; "6.5_1 copy.jpg", "6.5_2 copy.jpg", "6.5_3 copy.jpg", "6.5_4 copy.jpg" and "6.5_5 copy.jpg", are going to be newly uploaded and "6.5_1.jpg", "6.5_2.jpg" , "6.5_3.jpg" , "6.5_4.jpg" , "6.5_5.jpg" are skipped
* "6.5_6 copy.jpg" and "6.5_6.jpg" will be just ignored
* Since 6 images "6.5_[1-6].jpg" have been uploaded already, at least one of those uploads must fail (it's concurrently working so can't tell which one fails)

------------------------

This behaviour was covered by this initialisation of the count of existing uploaded screenshots.

https://github.com/fastlane/fastlane/blob/8c1d2c9cd894d76b29abf1fe40ef3c830e23a166/deliver/lib/deliver/upload_screenshots.rb#L140-L144

But with the refactoring of extractions of iterators, it was changed to rely only on index worked out from local data.
https://github.com/fastlane/fastlane/blob/53ce1fab1f616b981fc80d3abd97320f65187ba7/deliver/lib/deliver/app_screenshot_iterator.rb#L87-L91

This PR obsoleted that `index` params returned from the iterator and then restore counting logic with initialising `app_screenshot_set.app_screenshots.count` like before.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

You can test this with the scenario in the description. I also added a unit test case to cover the scenario.
