### PR TITLE
[sigh] fix resigning of OnDemandResources when app has space in name

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -535,7 +535,7 @@ function resign {
     fi
 
     # Check for and resign OnDemandResource folders
-    ODR_DIR="$(dirname $APP_PATH)/OnDemandResources"
+    ODR_DIR="$(dirname "$APP_PATH")/OnDemandResources"
     if [ -d "$ODR_DIR" ]; then
         for assetpack in "$ODR_DIR"/*
         do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
If the app path has a space in it, the call to dirname here results in the following error, which is silently ignored
```
usage: dirname path
```

The following line of code then checks if `/OnDemandResources` is a directory, which never will be, and this code is never executed.

### Description
Just wrapping the $APP_PATH variable in double quotes to ensure it will work for paths with spaces in them.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
