### PR TITLE
Version bump to 2.162.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
 <td id='fumiya-nakamura'>
 <a href='https://github.com/nafu'>
@@ -58,43 +52,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-</tr>
-<tr>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
 <img src='https://github.com/KrauseFx.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 </tr>
 <tr>
@@ -110,49 +78,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'>Jimmy Dee</h4>
 </td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-</tr>
-<tr>
 <td id='jan-piotrowski'>
 <a href='https://github.com/janpio'>
 <img src='https://github.com/janpio.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
@@ -173,6 +109,70 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <img src='https://github.com/taquitos.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+</tr>
+<tr>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+</tr>
+<tr>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Jan Piotrowski",
-                        "Kohki Miki",
-                        "Manu Wallner",
-                        "Josh Holtz",
-                        "Jérôme Lacoste",
-                        "Jimmy Dee",
-                        "Maksym Grebenets",
-                        "Iulian Onofrei",
-                        "Helmut Januschka",
-                        "Luka Mirosevic",
-                        "Olivier Halligon",
-                        "Jorge Revuelta H",
-                        "Max Ott",
-                        "Felix Krause",
+  spec.authors       = ["Kohki Miki",
                         "Danielle Tomlinson",
-                        "Daniel Jankowski",
-                        "Fumiya Nakamura",
-                        "Joshua Liebowitz",
                         "Aaron Brager",
-                        "Matthew Ellis",
+                        "Fumiya Nakamura",
+                        "Maksym Grebenets",
+                        "Felix Krause",
+                        "Joshua Liebowitz",
+                        "Jérôme Lacoste",
+                        "Iulian Onofrei",
+                        "Max Ott",
+                        "Daniel Jankowski",
+                        "Josh Holtz",
+                        "Olivier Halligon",
+                        "Stefan Natchev",
                         "Andrew McBurney",
-                        "Stefan Natchev"]
+                        "Luka Mirosevic",
+                        "Jimmy Dee",
+                        "Matthew Ellis",
+                        "Manu Wallner",
+                        "Helmut Januschka",
+                        "Jorge Revuelta H",
+                        "Jan Piotrowski"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.161.0'.freeze
+  VERSION = '2.162.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -17,4 +17,4 @@ public class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.161.0
+// Generated with fastlane 2.162.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -256,4 +256,4 @@ public extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.44]
+// FastlaneRunnerAPIVersion [0.9.45]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1844,6 +1844,8 @@ public func carthage(command: String = "bootstrap",
    - type: Create specific certificate type (takes precedence over :development)
    - force: Create a certificate even if an existing certificate exists
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - teamId: The ID of your Developer Portal team if you're in multiple teams
    - teamName: The name of your Developer Portal team if you're in multiple teams
@@ -1851,6 +1853,7 @@ public func carthage(command: String = "bootstrap",
    - outputPath: The path to a directory in which all certificates and private keys should be stored
    - keychainPath: Path to a custom keychain
    - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
+   - skipSetPartitionList: Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing
    - platform: Set the provisioning profile's platform (ios, macos)
 
  **Important**: It is recommended to use [match](https://docs.fastlane.tools/actions/match/) according to the [codesigning.guide](https://codesigning.guide) for generating and maintaining your certificates. Use _cert_ directly only if you want full control over what's going on and know more about codesigning.
@@ -1860,6 +1863,8 @@ public func cert(development: Bool = false,
                  type: String? = nil,
                  force: Bool = false,
                  generateAppleCerts: Bool = true,
+                 apiKeyPath: String? = nil,
+                 apiKey: [String: Any]? = nil,
                  username: String,
                  teamId: String? = nil,
                  teamName: String? = nil,
@@ -1867,12 +1872,15 @@ public func cert(development: Bool = false,
                  outputPath: String = ".",
                  keychainPath: String,
                  keychainPassword: String? = nil,
+                 skipSetPartitionList: Bool = false,
                  platform: String = "ios")
 {
     let command = RubyCommand(commandID: "", methodName: "cert", className: nil, args: [RubyCommand.Argument(name: "development", value: development),
                                                                                         RubyCommand.Argument(name: "type", value: type),
                                                                                         RubyCommand.Argument(name: "force", value: force),
                                                                                         RubyCommand.Argument(name: "generate_apple_certs", value: generateAppleCerts),
+                                                                                        RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                        RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                         RubyCommand.Argument(name: "username", value: username),
                                                                                         RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                         RubyCommand.Argument(name: "team_name", value: teamName),
@@ -1880,6 +1888,7 @@ public func cert(development: Bool = false,
                                                                                         RubyCommand.Argument(name: "output_path", value: outputPath),
                                                                                         RubyCommand.Argument(name: "keychain_path", value: keychainPath),
                                                                                         RubyCommand.Argument(name: "keychain_password", value: keychainPassword),
+                                                                                        RubyCommand.Argument(name: "skip_set_partition_list", value: skipSetPartitionList),
                                                                                         RubyCommand.Argument(name: "platform", value: platform)])
     _ = runner.executeCommand(command)
 }
@@ -3323,6 +3332,8 @@ public func getBuildNumberRepository(useHgRevisionNumber: Bool = false) {
    - type: Create specific certificate type (takes precedence over :development)
    - force: Create a certificate even if an existing certificate exists
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - teamId: The ID of your Developer Portal team if you're in multiple teams
    - teamName: The name of your Developer Portal team if you're in multiple teams
@@ -3330,6 +3341,7 @@ public func getBuildNumberRepository(useHgRevisionNumber: Bool = false) {
    - outputPath: The path to a directory in which all certificates and private keys should be stored
    - keychainPath: Path to a custom keychain
    - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
+   - skipSetPartitionList: Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing
    - platform: Set the provisioning profile's platform (ios, macos)
 
  **Important**: It is recommended to use [match](https://docs.fastlane.tools/actions/match/) according to the [codesigning.guide](https://codesigning.guide) for generating and maintaining your certificates. Use _cert_ directly only if you want full control over what's going on and know more about codesigning.
@@ -3339,6 +3351,8 @@ public func getCertificates(development: Bool = false,
                             type: String? = nil,
                             force: Bool = false,
                             generateAppleCerts: Bool = true,
+                            apiKeyPath: String? = nil,
+                            apiKey: [String: Any]? = nil,
                             username: String,
                             teamId: String? = nil,
                             teamName: String? = nil,
@@ -3346,12 +3360,15 @@ public func getCertificates(development: Bool = false,
                             outputPath: String = ".",
                             keychainPath: String,
                             keychainPassword: String? = nil,
+                            skipSetPartitionList: Bool = false,
                             platform: String = "ios")
 {
     let command = RubyCommand(commandID: "", methodName: "get_certificates", className: nil, args: [RubyCommand.Argument(name: "development", value: development),
                                                                                                     RubyCommand.Argument(name: "type", value: type),
                                                                                                     RubyCommand.Argument(name: "force", value: force),
                                                                                                     RubyCommand.Argument(name: "generate_apple_certs", value: generateAppleCerts),
+                                                                                                    RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                    RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                                     RubyCommand.Argument(name: "username", value: username),
                                                                                                     RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                                     RubyCommand.Argument(name: "team_name", value: teamName),
@@ -3359,6 +3376,7 @@ public func getCertificates(development: Bool = false,
                                                                                                     RubyCommand.Argument(name: "output_path", value: outputPath),
                                                                                                     RubyCommand.Argument(name: "keychain_path", value: keychainPath),
                                                                                                     RubyCommand.Argument(name: "keychain_password", value: keychainPassword),
+                                                                                                    RubyCommand.Argument(name: "skip_set_partition_list", value: skipSetPartitionList),
                                                                                                     RubyCommand.Argument(name: "platform", value: platform)])
     _ = runner.executeCommand(command)
 }
@@ -3495,6 +3513,8 @@ public func getManagedPlayStorePublishingRights(jsonKey: String? = nil,
    - skipInstall: By default, the certificate will be added to your local machine. Setting this flag will skip this action
    - force: Renew provisioning profiles regardless of its state - to automatically add all devices for ad hoc profiles
    - appIdentifier: The bundle identifier of your app
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - teamId: The ID of your Developer Portal team if you're in multiple teams
    - teamName: The name of your Developer Portal team if you're in multiple teams
@@ -3521,6 +3541,8 @@ public func getProvisioningProfile(adhoc: Bool = false,
                                    skipInstall: Bool = false,
                                    force: Bool = false,
                                    appIdentifier: String,
+                                   apiKeyPath: String? = nil,
+                                   apiKey: [String: Any]? = nil,
                                    username: String,
                                    teamId: String? = nil,
                                    teamName: String? = nil,
@@ -3543,6 +3565,8 @@ public func getProvisioningProfile(adhoc: Bool = false,
                                                                                                             RubyCommand.Argument(name: "skip_install", value: skipInstall),
                                                                                                             RubyCommand.Argument(name: "force", value: force),
                                                                                                             RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
+                                                                                                            RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                            RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                                             RubyCommand.Argument(name: "username", value: username),
                                                                                                             RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                                             RubyCommand.Argument(name: "team_name", value: teamName),
@@ -4710,6 +4734,8 @@ public func makeChangelogFromJenkins(fallbackChangelog: String = "",
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
    - skipProvisioningProfiles: Skip syncing provisioning profiles
    - appIdentifier: The bundle identifier(s) of your app (comma-separated)
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - teamId: The ID of your Developer Portal team if you're in multiple teams
    - teamName: The name of your Developer Portal team if you're in multiple teams
@@ -4743,6 +4769,7 @@ public func makeChangelogFromJenkins(fallbackChangelog: String = "",
    - profileName: A custom name for the provisioning profile. This will replace the default provisioning profile name if specified
    - failOnNameTaken: Should the command fail if it was about to create a duplicate of an existing provisioning profile. It can happen due to issues on Apple Developer Portal, when profile to be recreated was not properly deleted first
    - outputPath: Path in which to export certificates, key and profile
+   - skipSetPartitionList: Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing
    - verbose: Print out extra information and all commands
 
  More information: https://docs.fastlane.tools/actions/match/
@@ -4753,7 +4780,9 @@ public func match(type: Any = matchfile.type,
                   generateAppleCerts: Bool = matchfile.generateAppleCerts,
                   skipProvisioningProfiles: Bool = matchfile.skipProvisioningProfiles,
                   appIdentifier: [String] = matchfile.appIdentifier,
-                  username: Any = matchfile.username,
+                  apiKeyPath: Any? = matchfile.apiKeyPath,
+                  apiKey: [String: Any]? = matchfile.apiKey,
+                  username: Any? = matchfile.username,
                   teamId: Any? = matchfile.teamId,
                   teamName: Any? = matchfile.teamName,
                   storageMode: Any = matchfile.storageMode,
@@ -4786,6 +4815,7 @@ public func match(type: Any = matchfile.type,
                   profileName: Any? = matchfile.profileName,
                   failOnNameTaken: Bool = matchfile.failOnNameTaken,
                   outputPath: Any? = matchfile.outputPath,
+                  skipSetPartitionList: Bool = matchfile.skipSetPartitionList,
                   verbose: Bool = matchfile.verbose)
 {
     let command = RubyCommand(commandID: "", methodName: "match", className: nil, args: [RubyCommand.Argument(name: "type", value: type),
@@ -4794,6 +4824,8 @@ public func match(type: Any = matchfile.type,
                                                                                          RubyCommand.Argument(name: "generate_apple_certs", value: generateAppleCerts),
                                                                                          RubyCommand.Argument(name: "skip_provisioning_profiles", value: skipProvisioningProfiles),
                                                                                          RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
+                                                                                         RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                         RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                          RubyCommand.Argument(name: "username", value: username),
                                                                                          RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                          RubyCommand.Argument(name: "team_name", value: teamName),
@@ -4827,6 +4859,7 @@ public func match(type: Any = matchfile.type,
                                                                                          RubyCommand.Argument(name: "profile_name", value: profileName),
                                                                                          RubyCommand.Argument(name: "fail_on_name_taken", value: failOnNameTaken),
                                                                                          RubyCommand.Argument(name: "output_path", value: outputPath),
+                                                                                         RubyCommand.Argument(name: "skip_set_partition_list", value: skipSetPartitionList),
                                                                                          RubyCommand.Argument(name: "verbose", value: verbose)])
     _ = runner.executeCommand(command)
 }
@@ -6811,6 +6844,8 @@ public func setupTravis(force: Bool = false) {
    - skipInstall: By default, the certificate will be added to your local machine. Setting this flag will skip this action
    - force: Renew provisioning profiles regardless of its state - to automatically add all devices for ad hoc profiles
    - appIdentifier: The bundle identifier of your app
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - teamId: The ID of your Developer Portal team if you're in multiple teams
    - teamName: The name of your Developer Portal team if you're in multiple teams
@@ -6837,6 +6872,8 @@ public func sigh(adhoc: Bool = false,
                  skipInstall: Bool = false,
                  force: Bool = false,
                  appIdentifier: String,
+                 apiKeyPath: String? = nil,
+                 apiKey: [String: Any]? = nil,
                  username: String,
                  teamId: String? = nil,
                  teamName: String? = nil,
@@ -6859,6 +6896,8 @@ public func sigh(adhoc: Bool = false,
                                                                                         RubyCommand.Argument(name: "skip_install", value: skipInstall),
                                                                                         RubyCommand.Argument(name: "force", value: force),
                                                                                         RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
+                                                                                        RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                        RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                         RubyCommand.Argument(name: "username", value: username),
                                                                                         RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                         RubyCommand.Argument(name: "team_name", value: teamName),
@@ -7601,6 +7640,8 @@ public func swiftlint(mode: Any = "lint",
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
    - skipProvisioningProfiles: Skip syncing provisioning profiles
    - appIdentifier: The bundle identifier(s) of your app (comma-separated)
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - username: Your Apple ID Username
    - teamId: The ID of your Developer Portal team if you're in multiple teams
    - teamName: The name of your Developer Portal team if you're in multiple teams
@@ -7634,6 +7675,7 @@ public func swiftlint(mode: Any = "lint",
    - profileName: A custom name for the provisioning profile. This will replace the default provisioning profile name if specified
    - failOnNameTaken: Should the command fail if it was about to create a duplicate of an existing provisioning profile. It can happen due to issues on Apple Developer Portal, when profile to be recreated was not properly deleted first
    - outputPath: Path in which to export certificates, key and profile
+   - skipSetPartitionList: Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing
    - verbose: Print out extra information and all commands
 
  More information: https://docs.fastlane.tools/actions/match/
@@ -7644,7 +7686,9 @@ public func syncCodeSigning(type: String = "development",
                             generateAppleCerts: Bool = true,
                             skipProvisioningProfiles: Bool = false,
                             appIdentifier: [String],
-                            username: String,
+                            apiKeyPath: String? = nil,
+                            apiKey: [String: Any]? = nil,
+                            username: String? = nil,
                             teamId: String? = nil,
                             teamName: String? = nil,
                             storageMode: String = "git",
@@ -7677,6 +7721,7 @@ public func syncCodeSigning(type: String = "development",
                             profileName: String? = nil,
                             failOnNameTaken: Bool = false,
                             outputPath: String? = nil,
+                            skipSetPartitionList: Bool = false,
                             verbose: Bool = false)
 {
     let command = RubyCommand(commandID: "", methodName: "sync_code_signing", className: nil, args: [RubyCommand.Argument(name: "type", value: type),
@@ -7685,6 +7730,8 @@ public func syncCodeSigning(type: String = "development",
                                                                                                      RubyCommand.Argument(name: "generate_apple_certs", value: generateAppleCerts),
                                                                                                      RubyCommand.Argument(name: "skip_provisioning_profiles", value: skipProvisioningProfiles),
                                                                                                      RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
+                                                                                                     RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                     RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                                      RubyCommand.Argument(name: "username", value: username),
                                                                                                      RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                                      RubyCommand.Argument(name: "team_name", value: teamName),
@@ -7718,6 +7765,7 @@ public func syncCodeSigning(type: String = "development",
                                                                                                      RubyCommand.Argument(name: "profile_name", value: profileName),
                                                                                                      RubyCommand.Argument(name: "fail_on_name_taken", value: failOnNameTaken),
                                                                                                      RubyCommand.Argument(name: "output_path", value: outputPath),
+                                                                                                     RubyCommand.Argument(name: "skip_set_partition_list", value: skipSetPartitionList),
                                                                                                      RubyCommand.Argument(name: "verbose", value: verbose)])
     _ = runner.executeCommand(command)
 }
@@ -9309,4 +9357,4 @@ public let snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.97]
+// FastlaneRunnerAPIVersion [0.9.98]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -17,4 +17,4 @@ public class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.161.0
+// Generated with fastlane 2.162.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -184,4 +184,4 @@ public extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.47]
+// FastlaneRunnerAPIVersion [0.9.48]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -17,4 +17,4 @@ public class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.161.0
+// Generated with fastlane 2.162.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -20,8 +20,14 @@ public protocol MatchfileProtocol: class {
     /// The bundle identifier(s) of your app (comma-separated)
     var appIdentifier: [String] { get }
 
+    /// Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+    var apiKeyPath: String? { get }
+
+    /// Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
+    var apiKey: [String: Any]? { get }
+
     /// Your Apple ID Username
-    var username: String { get }
+    var username: String? { get }
 
     /// The ID of your Developer Portal team if you're in multiple teams
     var teamId: String? { get }
@@ -119,6 +125,9 @@ public protocol MatchfileProtocol: class {
     /// Path in which to export certificates, key and profile
     var outputPath: String? { get }
 
+    /// Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing
+    var skipSetPartitionList: Bool { get }
+
     /// Print out extra information and all commands
     var verbose: Bool { get }
 }
@@ -130,7 +139,9 @@ public extension MatchfileProtocol {
     var generateAppleCerts: Bool { return true }
     var skipProvisioningProfiles: Bool { return false }
     var appIdentifier: [String] { return [] }
-    var username: String { return "" }
+    var apiKeyPath: String? { return nil }
+    var apiKey: [String: Any]? { return nil }
+    var username: String? { return nil }
     var teamId: String? { return nil }
     var teamName: String? { return nil }
     var storageMode: String { return "git" }
@@ -163,9 +174,10 @@ public extension MatchfileProtocol {
     var profileName: String? { return nil }
     var failOnNameTaken: Bool { return false }
     var outputPath: String? { return nil }
+    var skipSetPartitionList: Bool { return false }
     var verbose: Bool { return false }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.41]
+// FastlaneRunnerAPIVersion [0.9.42]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -17,4 +17,4 @@ public class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.161.0
+// Generated with fastlane 2.162.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -48,4 +48,4 @@ public extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.40]
+// FastlaneRunnerAPIVersion [0.9.41]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -17,4 +17,4 @@ public class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.161.0
+// Generated with fastlane 2.162.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -260,4 +260,4 @@ public extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.52]
+// FastlaneRunnerAPIVersion [0.9.53]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -17,4 +17,4 @@ public class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.161.0
+// Generated with fastlane 2.162.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -96,4 +96,4 @@ public extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.42]
+// FastlaneRunnerAPIVersion [0.9.43]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -17,4 +17,4 @@ public class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.161.0
+// Generated with fastlane 2.162.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -184,4 +184,4 @@ public extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.36]
+// FastlaneRunnerAPIVersion [0.9.37]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.161.0':**

* [match] add support for App Store Connect API Key (#17291) via Josh Holtz
* [sigh] add support for App Store Connect API Key (#17265) via Josh Holtz
* [cert] migrate to App Store Connect API endpoints and can use App Store Connect API Key (#17263) via Josh Holtz
* [deliver] fix screenshot uploads issue when overwrite_screenshot option is set to false (#17346) via Satoshi Namai
* [fastlane_core] skip analytics message on first run if opted out (#17345) via Brandon Siegel
* [deliver] transform string key to symbol, since hash args in options from CLI keyed by string (#17302) via TragedyStar
* [spaceship] add ability to delete multiple beta testers at a time (#17304) via Eric Wu
* [spaceship] support for adding & removing users (#17315) via Max Ott
