### PR TITLE
[spaceship] allow authentication to take key content instead of just its file path

### DIFF
--- a/spaceship/lib/spaceship/connect_api/client.rb
+++ b/spaceship/lib/spaceship/connect_api/client.rb
@@ -13,20 +13,23 @@ module Spaceship
 
       # Initializes client with Apple's App Store Connect JWT auth key.
       #
-      # This method will automatically use the key id, issuer id, and filepath from environment
+      # This method will automatically use the arguments from environment
       # variables if not given.
       #
-      # All three parameters are needed to authenticate.
+      # The key_id, issuer_id and either filepath or key are needed to authenticate.
       #
       # @param key_id (String) (optional): The key id
       # @param issuer_id (String) (optional): The issuer id
       # @param filepath (String) (optional): The filepath
+      # @param key (String) (optional): The key
+      # @param duration (Integer) (optional): How long this session should last
+      # @param in_house (Boolean) (optional): Whether this session is an Enterprise one
       #
       # @raise InvalidUserCredentialsError: raised if authentication failed
       #
       # @return (Spaceship::ConnectAPI::Client) The client the login method was called for
-      def self.auth(key_id: nil, issuer_id: nil, filepath: nil)
-        token = Spaceship::ConnectAPI::Token.create(key_id: key_id, issuer_id: issuer_id, filepath: filepath)
+      def self.auth(key_id: nil, issuer_id: nil, filepath: nil, key: nil, duration: nil, in_house: nil)
+        token = Spaceship::ConnectAPI::Token.create(key_id: key_id, issuer_id: issuer_id, filepath: filepath, key: key, duration: duration, in_house: in_house)
         return ConnectAPI::Client.new(token: token)
       end
 

--- a/spaceship/lib/spaceship/connect_api/spaceship.rb
+++ b/spaceship/lib/spaceship/connect_api/spaceship.rb
@@ -44,20 +44,23 @@ module Spaceship
 
       # Initializes client with Apple's App Store Connect JWT auth key.
       #
-      # This method will automatically use the key id, issuer id, and filepath from environment
+      # This method will automatically use the arguments from environment
       # variables if not given.
       #
-      # All three parameters are needed to authenticate.
+      # The key_id, issuer_id and either filepath or key are needed to authenticate.
       #
       # @param key_id (String) (optional): The key id
       # @param issuer_id (String) (optional): The issuer id
       # @param filepath (String) (optional): The filepath
+      # @param key (String) (optional): The key
+      # @param duration (Integer) (optional): How long this session should last
+      # @param in_house (Boolean) (optional): Whether this session is an Enterprise one
       #
       # @raise InvalidUserCredentialsError: raised if authentication failed
       #
       # @return (Spaceship::ConnectAPI::Client) The client the login method was called for
-      def auth(key_id: nil, issuer_id: nil, filepath: nil)
-        @client = ConnectAPI::Client.auth(key_id: key_id, issuer_id: issuer_id, filepath: filepath)
+      def auth(key_id: nil, issuer_id: nil, filepath: nil, key: nil, duration: nil, in_house: nil)
+        @client = ConnectAPI::Client.auth(key_id: key_id, issuer_id: issuer_id, filepath: filepath, key: key, duration: duration, in_house: in_house)
       end
 
       # Authenticates with Apple's web services. This method has to be called once

--- a/spaceship/spec/connect_api/client_spec.rb
+++ b/spaceship/spec/connect_api/client_spec.rb
@@ -43,17 +43,32 @@ describe Spaceship::ConnectAPI::Client do
       expect(client.users_request_client).to eq(users_client)
     end
 
-    it '#auth' do
-      key_id = "key_id"
-      issuer_id = "issuer_id"
-      filepath = "filepath"
+    context '#auth' do
+      it 'with filepath' do
+        key_id = "key_id"
+        issuer_id = "issuer_id"
+        filepath = "filepath"
 
-      token = double('token')
+        token = double('token')
 
-      expect(Spaceship::ConnectAPI::Token).to receive(:create).with(key_id: key_id, issuer_id: issuer_id, filepath: filepath).and_return(token)
-      expect(Spaceship::ConnectAPI::Client).to receive(:new).with(token: token)
+        expect(Spaceship::ConnectAPI::Token).to receive(:create).with(key_id: key_id, issuer_id: issuer_id, filepath: filepath, key: nil, duration: nil, in_house: nil).and_return(token)
+        expect(Spaceship::ConnectAPI::Client).to receive(:new).with(token: token)
 
-      Spaceship::ConnectAPI::Client.auth(key_id: key_id, issuer_id: issuer_id, filepath: filepath)
+        Spaceship::ConnectAPI::Client.auth(key_id: key_id, issuer_id: issuer_id, filepath: filepath)
+      end
+
+      it 'with key' do
+        key_id = "key_id"
+        issuer_id = "issuer_id"
+        key = "key"
+
+        token = double('token')
+
+        expect(Spaceship::ConnectAPI::Token).to receive(:create).with(key_id: key_id, issuer_id: issuer_id, filepath: nil, key: key, duration: 100, in_house: true).and_return(token)
+        expect(Spaceship::ConnectAPI::Client).to receive(:new).with(token: token)
+
+        Spaceship::ConnectAPI::Client.auth(key_id: key_id, issuer_id: issuer_id, key: key, duration: 100, in_house: true)
+      end
     end
 
     context '#login' do

--- a/spaceship/spec/connect_api/spaceship_spec.rb
+++ b/spaceship/spec/connect_api/spaceship_spec.rb
@@ -62,7 +62,7 @@ describe Spaceship::ConnectAPI do
         issuer_id = 'issuer_id'
         filepath = 'filepath'
 
-        expect(Spaceship::ConnectAPI::Client).to receive(:auth).with(key_id: key_id, issuer_id: issuer_id, filepath: filepath).and_return(mock_client)
+        expect(Spaceship::ConnectAPI::Client).to receive(:auth).with(key_id: key_id, issuer_id: issuer_id, filepath: filepath, key: nil, duration: nil, in_house: nil).and_return(mock_client)
 
         client = Spaceship::ConnectAPI.auth(key_id: key_id, issuer_id: issuer_id, filepath: filepath)
         expect(client).to eq(Spaceship::ConnectAPI.client)


### PR DESCRIPTION
🔑 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

When using spaceship in a standalone ruby script, I noticed the lack of these arguments. I had to work around this using uglier code 😅 such as:

```ruby
Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(key_id: "my key id", issuer_id: "my issuer id", key: "-----BEGIN PRIVATE KEY-----\n- the actual valid key contents was here -\n-----END PRIVATE KEY-----")
```

Instead of

```ruby
Spaceship::ConnectAPI.auth(key_id: "my key id", issuer_id: "my issuer id", key: "-----BEGIN PRIVATE KEY-----\n- the actual valid key contents was here -\n-----END PRIVATE KEY-----")
```

### Description

While working on [this](https://github.com/rogerluan/app-store-connect-notifier/issues/9) (which uses a standalone ruby script), I wanted to authenticate on _spaceship_ using key contents instead of key file path. I tested creating it with a file path first to verify that everything was working fine using `Spaceship::ConnectAPI.auth(key_id: "my key id", issuer_id: "my issuer id", filepath: File.absolute_path("api-key.p8"))` and it worked fine. So this PR adds those extra arguments to allow authentication via key contents.

### Testing Steps

I actually couldn't test this 😭 please see [this discussion](https://github.com/fastlane/fastlane/discussions/17368) for more info on my difficulties - any help will be highly appreciated! 🙏🙏🙏