### PR TITLE
Fix comment about using `force` option

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -153,7 +153,7 @@ module Deliver
         FastlaneCore::ConfigItem.new(key: :force,
                                      short_option: "-f",
                                      env_name: "DELIVER_FORCE",
-                                     description: "Skip the HTML report file verification",
+                                     description: "Skip verification of HTML preview file",
                                      is_string: false,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :overwrite_screenshots,

--- a/fastlane/lib/fastlane/actions/upload_to_app_store.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_app_store.rb
@@ -50,7 +50,7 @@ module Fastlane
       def self.example_code
         [
           'upload_to_app_store(
-            force: true, # Set to true to skip PDF verification
+            force: true, # Set to true to skip HTML verification
             itc_provider: "abcde12345" # pass a specific value to the iTMSTransporter -itc_provider option
           )',
           'deliver   # alias for "upload_to_app_store"',

--- a/fastlane/lib/fastlane/actions/upload_to_app_store.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_app_store.rb
@@ -26,7 +26,7 @@ module Fastlane
         [
           "Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.",
           "",
-          "If you don't want a PDF report for App Store builds, use the `:force` option.",
+          "If you don't want to verify an HTML preview for App Store builds, use the `:force` option.",
           "This is useful when running _fastlane_ on your Continuous Integration server:",
           "`_upload_to_app_store_(force: true)`",
           "If your account is on multiple teams and you need to tell the `iTMSTransporter` which 'provider' to use, you can set the `:itc_provider` option to pass this info."
@@ -50,7 +50,7 @@ module Fastlane
       def self.example_code
         [
           'upload_to_app_store(
-            force: true, # Set to true to skip HTML verification
+            force: true, # Set to true to skip verification of HTML preview
             itc_provider: "abcde12345" # pass a specific value to the iTMSTransporter -itc_provider option
           )',
           'deliver   # alias for "upload_to_app_store"',


### PR DESCRIPTION
Using `force` option in `upload_to_app_store` is designed to skip the HTML verification step.

Not 100% sure if there is or is NOT some sort of PDF report which is being referenced in line 29:
"If you don't want a PDF report for App Store builds, use the `:force` option." So I am not including any sort of change regarding that.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Just a simple documentation fix. Helps reduce confusion.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
Changed single reference to "PDF" to "HTML"
<!-- Please describe in detail how you tested your changes. -->
Documentation change, no testing needed.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
