### PR TITLE
[cert][deliver][match][precheck][sigh] use `api_key` config from `app_store_connect_api_key`

### DIFF
--- a/fastlane/lib/fastlane/actions/check_app_store_metadata.rb
+++ b/fastlane/lib/fastlane/actions/check_app_store_metadata.rb
@@ -7,6 +7,7 @@ module Fastlane
       def self.run(config)
         require 'precheck'
         Precheck.config = config
+        Precheck.config[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
         return Precheck::Runner.new.run
       end
 

--- a/fastlane/lib/fastlane/actions/get_certificates.rb
+++ b/fastlane/lib/fastlane/actions/get_certificates.rb
@@ -13,6 +13,7 @@ module Fastlane
 
         begin
           Cert.config = params # we alread have the finished config
+          Cert.config[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
 
           Cert::Runner.new.launch
           cert_file_path = ENV["CER_FILE_PATH"]

--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -15,6 +15,7 @@ module Fastlane
         require 'credentials_manager/appfile_config'
 
         Sigh.config = values # we already have the finished config
+        Sigh.config[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
 
         path = Sigh::Manager.start
 

--- a/fastlane/lib/fastlane/actions/sync_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/sync_code_signing.rb
@@ -10,6 +10,7 @@ module Fastlane
         require 'match'
 
         params.load_configuration_file("Matchfile")
+        params[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
         Match::Runner.new.run(params)
 
         define_profile_type(params)

--- a/fastlane/lib/fastlane/actions/upload_to_app_store.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_app_store.rb
@@ -12,6 +12,7 @@ module Fastlane
           config[:screenshots_path] = Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH] if Actions.lane_context[SharedValues::SNAPSHOT_SCREENSHOTS_PATH]
           config[:ipa] = Actions.lane_context[SharedValues::IPA_OUTPUT_PATH] if Actions.lane_context[SharedValues::IPA_OUTPUT_PATH]
           config[:pkg] = Actions.lane_context[SharedValues::PKG_OUTPUT_PATH] if Actions.lane_context[SharedValues::PKG_OUTPUT_PATH]
+          config[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
 
           return config if Helper.test?
           Deliver::Runner.new(config).run


### PR DESCRIPTION
🔑 

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves #17385 
Resolves #17177

### Description

I searched for documentation to update and didn't find any. The existing documentation [here](https://docs.fastlane.tools/app-store-connect-api/#use-the-shared-value-in-lane-context) is vague enough that it only mentions pilot as an example, but it suggests that other actions are supported (and now they are 😄 ).

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```ruby
gem "fastlane", :git => "https://github.com/rogerluan/fastlane.git", :branch => "pull-api-key-from-shared-lane-context"
```
