### PR TITLE
[gym] Fix building project with unicode characters in a name

### DIFF
--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -66,14 +66,14 @@ module Gym
         if path
           # Try to find IPA file in the output directory, used when app thinning was not set
           Gym.cache[:ipa_path] = File.join(temporary_output_path, "#{Gym.config[:output_name]}.ipa")
-          FileUtils.mv(path, Gym.cache[:ipa_path]) unless File.expand_path(path).casecmp(File.expand_path(Gym.cache[:ipa_path]).downcase).zero?
+          FileUtils.mv(path, Gym.cache[:ipa_path]) unless File.expand_path(path).casecmp?(File.expand_path(Gym.cache[:ipa_path]).downcase)
         elsif Dir.exist?(apps_path)
           # Try to find "generic" IPA file inside "Apps" folder, used when app thinning was set
           files = Dir[File.join(apps_path, "*.ipa")]
           # Generic IPA file doesn't have suffix so its name is the shortest
           path = files.min_by(&:length)
           Gym.cache[:ipa_path] = File.join(temporary_output_path, "#{Gym.config[:output_name]}.ipa")
-          FileUtils.cp(path, Gym.cache[:ipa_path]) unless File.expand_path(path).casecmp(File.expand_path(Gym.cache[:ipa_path]).downcase).zero?
+          FileUtils.cp(path, Gym.cache[:ipa_path]) unless File.expand_path(path).casecmp?(File.expand_path(Gym.cache[:ipa_path]).downcase)
         else
           ErrorHandler.handle_empty_archive unless path
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #17365 
Fixes #17398 
Fixes #17296 

> Projects with Bundle name in Russian fails, but projects with English bundle names are ok. Seems to be the main reason of the issue.

```ruby
build_app(scheme: "myscheme")
```

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

According to the error logs, the issue is related to comparing the paths with the project name that contains unicode characters:

```bash
bundler: failed to load command: fastlane (/usr/local/bin/fastlane)
ArgumentError: [!] same file: /var/folders/rl/tll64rc12j78qr60h_mm6mp00000gn/T/gym_output20201002-29737-y9jgjr/Транспондеры.ipa and /var/folders/rl/tll64rc12j78qr60h_mm6mp00000gn/T/gym_output20201002-29737-y9jgjr/Транспондеры.ipa
  /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/fileutils.rb:1556:in `block in fu_each_src_dest'
  /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/fileutils.rb:1573:in `fu_each_src_dest0'
  /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/fileutils.rb:1555:in `fu_each_src_dest'
  /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/fileutils.rb:520:in `mv'
  /Library/Ruby/Gems/2.6.0/gems/fastlane-2.162.0/gym/lib/gym/generators/package_command_generator_xcode7.rb:69:in `ipa_path'
```

The source code:

https://github.com/fastlane/fastlane/blob/48151291f2c4949c3b1b9919ba2cc81a7cc33293/gym/lib/gym/generators/package_command_generator_xcode7.rb#L60-L79

The root cause is [`casecmp`](https://ruby-doc.org/core-2.4.0/String.html#method-i-casecmp) method that **does not support** unicode characters comparison. 

[`casecmp?`](https://ruby-doc.org/core-2.4.0/String.html#method-i-casecmp-3F) method (available since Ruby 2.4) supports unicode characters. [`fastlane` supports minimum Ruby 2.4](https://github.com/fastlane/fastlane/pull/16408) version, so we can use it.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

**Manual Testing**

I created a project with a unicode characters in the name: `ProjectΔ`.

Before the fix:

```bash
[09:09:59]: same file: /var/folders/n0/8g1hyb49749b08r3c1yf45pw0000gq/T/gym_output20201007-38126-gdqsbu/ProjectΔ.ipa and /var/folders/n0/8g1hyb49749b08r3c1yf45pw0000gq/T/gym_output20201007-38126-gdqsbu/ProjectΔ.ipa

+------+------------------+-------------+
|           fastlane summary            |
+------+------------------+-------------+
| Step | Action           | Time (in s) |
+------+------------------+-------------+
| 1    | default_platform | 0           |
| 💥   | build_app        | 20          |
+------+------------------+-------------+

[09:09:59]: fastlane finished with errors
```

After the fix:

```bash
[09:12:22]: Successfully exported and signed the ipa file:
[09:12:22]: /Users/mollyiv/Desktop/ProjectΔ/ProjectΔ.ipa

+------+------------------+-------------+
|           fastlane summary            |
+------+------------------+-------------+
| Step | Action           | Time (in s) |
+------+------------------+-------------+
| 1    | default_platform | 0           |
| 2    | build_app        | 13          |
+------+------------------+-------------+

[09:12:22]: fastlane.tools finished successfully 🎉
```

If you'd like to test the changes from this pull request yourself, set the following `fastlane` source in a Gemfile:

```
# gem 'fastlane', :git => 'https://github.com/mollyIV/fastlane.git', :branch => 'gym-fix-building-projects-with-unicode-characters-in-name'
```

🎊 🎊 

Unfortunately, I couldn't add unit tests easily due to `FileUtils` being used in a `PackageCommandGeneratorXcode7`. If you have suggestion how we could unit test the changes, feel free to suggest it 😊 