### PR TITLE
[supply] Upload Rejects releases with empty version_codes

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -110,6 +110,7 @@ module Supply
       track = tracks.first
       releases = track.releases
 
+      releases = releases.reject { |r| r.version_codes.nil? || r.version_codes.empty? } if version_code
       releases = releases.select { |r| r.status == status } if status
       releases = releases.select { |r| r.version_codes.map(&:to_s).include?(version_code.to_s) } if version_code
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -110,9 +110,8 @@ module Supply
       track = tracks.first
       releases = track.releases
 
-      releases = releases.reject { |r| r.version_codes.nil? || r.version_codes.empty? } if version_code
       releases = releases.select { |r| r.status == status } if status
-      releases = releases.select { |r| r.version_codes.map(&:to_s).include?(version_code.to_s) } if version_code
+      releases = releases.select { |r| (r.version_codes || []).map(&:to_s).include?(version_code.to_s) } if version_code
 
       if releases.size > 1
         UI.user_error!("More than one release found in this track. Please specify with the :version_code option to select a release.")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I was getting an error of undefined method `map` for nil on the method `fetch_track_and_release` on the uploader. There was [This issue](https://github.com/fastlane/fastlane/issues/17086) with the same problem but it was closed. 

Resolves #17086 

### Description

Adds a small defensive programming, filtering out releases with nil or empty version_codes
