### PR TITLE
[action] import_from_git - Add caching support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -319,6 +319,7 @@ Style/MethodCallWithArgsParentheses:
     - 'platform'
     # rspec tests code below
     - 'to'
+    - 'not_to'
     - 'describe'
     - 'it'
     - 'be'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,4 +46,7 @@ before_test:
 build: off
 
 test_script:
+  # Uncomment the first line and comment the second one to debug failing tests
+  # on Windows (some tests might fail with this).
+  # - cmd /V /C "set DEBUG=1 && bundle exec fastlane execute_tests"
   - bundle exec fastlane execute_tests

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -94,7 +94,6 @@ lane :execute_tests do
     UI.user_error!("fastlane gem is above 1 MB, make sure no additional resources are included by mistake") if size_in_mb > 1
 
     # Run the tests
-    #
     sh("bundle exec rake test_all")
   end
 end

--- a/fastlane/lib/fastlane/actions/import_from_git.rb
+++ b/fastlane/lib/fastlane/actions/import_from_git.rb
@@ -19,6 +19,9 @@ module Fastlane
 
       def self.available_options
         [
+          # Because the `run` method is actually implemented in `fast_file.rb`,
+          # and because magic, some of the parameters on `ConfigItem`s (e.g.
+          # `conflicting_options`, `verify_block`) are completely ignored.
           FastlaneCore::ConfigItem.new(key: :url,
                                        description: "The URL of the repository to import the Fastfile from",
                                        default_value: nil),
@@ -38,6 +41,10 @@ module Fastlane
                                        description: "The version to checkout on the repository. Optimistic match operator or multiple conditions can be used to select the latest version within constraints",
                                        default_value: nil,
                                        is_string: false,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :cache_path,
+                                       description: "The path to a directory where the repository should be cloned into. This is ignored if `version` is not specified. Defaults to `nil`, which causes the repository to be cloned on every call, to a temporary directory",
+                                       default_value: nil,
                                        optional: true)
         ]
       end
@@ -62,7 +69,8 @@ module Fastlane
             url: "git@github.com:fastlane/fastlane.git", # The URL of the repository to import the Fastfile from.
             branch: "HEAD", # The branch to checkout on the repository
             path: "fastlane/Fastfile", # The path of the Fastfile in the repository
-            version: [">= 1.1.0", "< 2.0.0"] # The version to checkout on the repository. Multiple conditions can be used to select the latest version within constraints.
+            version: [">= 1.1.0", "< 2.0.0"], # The version to checkout on the repository. Multiple conditions can be used to select the latest version within constraints.
+            cache_path: "~/.cache/fastlane/imported" # A directory in which the repository will be added, which means that it will not be cloned again on subsequent calls.
           )'
         ]
       end

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -295,6 +295,9 @@ module Fastlane
 
           checkout_dependencies = dependencies.map(&:shellescape).join(" ")
 
+          # If the current call is eligible for caching, we check out all the
+          # files and directories. If not, we only check out the specified
+          # `path` and `dependencies`.
           checkout_path = is_eligible_for_caching ? "" : "#{path.shellescape} #{checkout_dependencies}"
 
           if Dir[clone_folder].empty?
@@ -333,6 +336,9 @@ module Fastlane
 
           Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")
 
+          # Knowing that we check out all the files and directories when the
+          # current call is eligible for caching, we don't need to also
+          # explicitly check out the "actions" directory.
           unless is_eligible_for_caching
             # We also want to check out all the local actions of this fastlane setup
             containing = path.split(File::SEPARATOR)[0..-2]

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -303,7 +303,7 @@ module Fastlane
               # When using cached clones, we need the entire repository history
               # so we can switch between tags or branches instantly, or else,
               # it would defeat the caching's purpose.
-              Actions.sh("git clone #{url.shellescape} #{clone_folder.shellescape} #{is_eligible_for_caching ? '' : '--depth 1'} -n #{branch_option}")
+              Actions.sh("git clone #{url.shellescape} #{clone_folder.shellescape} #{is_eligible_for_caching ? '' : '--depth 1'} --no-checkout #{branch_option}")
             end
           end
 

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -282,7 +282,7 @@ module Fastlane
 
         is_eligible_for_caching = !version.nil? && !cache_path.nil?
 
-        ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"] = "1" if Helper.test? && is_eligible_for_caching
+        UI.message("Eligible for caching") if is_eligible_for_caching
 
         # Checkout the repo
         repo_name = url.split("/").last

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -319,6 +319,8 @@ module Fastlane
                 end
 
                 checkout_param = find_tag(folder: clone_folder, version: version, remote: false)
+              else
+                UI.message("Found tag #{checkout_param}. No git repo update needed.")
               end
             else
               checkout_param = find_tag(folder: clone_folder, version: version, remote: true)

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -320,7 +320,7 @@ module Fastlane
                 # Update the repo and try again before failing
                 UI.message("Updating git repo...")
                 Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
-                  Actions.sh("cd #{clone_folder.shellescape} && git checkout '#{branch}' && git reset --hard && git pull --all")
+                  Actions.sh("cd #{clone_folder.shellescape} && git checkout #{branch} && git reset --hard && git pull --all")
                 end
 
                 checkout_param = find_tag(folder: clone_folder, version: version, remote: false)

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -259,11 +259,20 @@ module Fastlane
       return return_value
     end
 
+    def find_tag(folder: nil, version: nil, remote: false)
+      req = Gem::Requirement.new(version)
+      all_tags = get_tags(folder: folder, remote: remote)
+
+      return all_tags.select { |t| req =~ FastlaneCore::TagVersion.new(t) }.last
+    end
+
     # @param url [String] The git URL to clone the repository from
     # @param branch [String] The branch to checkout in the repository
     # @param path [String] The path to the Fastfile
     # @param version [String, Array] Version requirement for repo tags
-    def import_from_git(url: nil, branch: 'HEAD', path: 'fastlane/Fastfile', version: nil, dependencies: [])
+    # @param dependencies [Array] An optional array of additional Fastfiles in the repository
+    # @param cache_path [String] An optional path to a directory where the repository should be cloned into
+    def import_from_git(url: nil, branch: 'HEAD', path: 'fastlane/Fastfile', version: nil, dependencies: [], cache_path: nil) # rubocop:disable Metrics/PerceivedComplexity
       UI.user_error!("Please pass a path to the `import_from_git` action") if url.to_s.length == 0
 
       Actions.execute_action('import_from_git') do
@@ -271,12 +280,16 @@ module Fastlane
 
         action_launched('import_from_git')
 
+        is_eligible_for_caching = !version.nil? && !cache_path.nil?
+
+        ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"] = "1" if Helper.test? && is_eligible_for_caching
+
         # Checkout the repo
         repo_name = url.split("/").last
         checkout_param = branch
 
-        Dir.mktmpdir("fl_clone") do |tmp_path|
-          clone_folder = File.join(tmp_path, repo_name)
+        import_block = proc do |target_path|
+          clone_folder = File.join(target_path, repo_name)
 
           branch_option = "--branch #{branch}" if branch != 'HEAD'
 
@@ -284,28 +297,48 @@ module Fastlane
 
           checkout_path = "#{path.shellescape} #{checkout_dependencies}"
 
-          UI.message("Cloning remote git repo...")
-          Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
-            Actions.sh("git clone #{url.shellescape} #{clone_folder.shellescape} --depth 1 -n #{branch_option}")
+          if Dir[clone_folder].empty?
+            UI.message("Cloning remote git repo...")
+            Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+              # When using cached clones, we need the entire repository history
+              # so we can switch between tags or branches instantly, or else,
+              # it would defeat the caching's purpose.
+              Actions.sh("git clone #{url.shellescape} #{clone_folder.shellescape} #{is_eligible_for_caching ? '' : '--depth 1'} -n #{branch_option}")
+            end
           end
 
           unless version.nil?
-            req = Gem::Requirement.new(version)
-            all_tags = fetch_remote_tags(folder: clone_folder)
-            checkout_param = all_tags.select { |t| req =~ FastlaneCore::TagVersion.new(t) }.last
+            if is_eligible_for_caching
+              checkout_param = find_tag(folder: clone_folder, version: version, remote: false)
+
+              if checkout_param.nil?
+                # Update the repo and try again before failing
+                UI.message("Updating git repo...")
+                Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+                  Actions.sh("cd #{clone_folder.shellescape} && git checkout '#{branch}' && git reset --hard && git pull --all")
+                end
+
+                checkout_param = find_tag(folder: clone_folder, version: version, remote: false)
+              end
+            else
+              checkout_param = find_tag(folder: clone_folder, version: version, remote: true)
+            end
+
             UI.user_error!("No tag found matching #{version.inspect}") if checkout_param.nil?
           end
 
-          Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")
+          Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{is_eligible_for_caching ? '' : checkout_path}")
 
-          # We also want to check out all the local actions of this fastlane setup
-          containing = path.split(File::SEPARATOR)[0..-2]
-          containing = "." if containing.count == 0
-          actions_folder = File.join(containing, "actions")
-          begin
-            Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{actions_folder.shellescape}")
-          rescue
-            # We don't care about a failure here, as local actions are optional
+          unless is_eligible_for_caching
+            # We also want to check out all the local actions of this fastlane setup
+            containing = path.split(File::SEPARATOR)[0..-2]
+            containing = "." if containing.count == 0
+            actions_folder = File.join(containing, "actions")
+            begin
+              Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{actions_folder.shellescape}")
+            rescue
+              # We don't care about a failure here, as local actions are optional
+            end
           end
 
           return_value = nil
@@ -320,6 +353,12 @@ module Fastlane
 
           return return_value
         end
+
+        if is_eligible_for_caching
+          import_block.call(File.expand_path(cache_path))
+        else
+          Dir.mktmpdir("fl_clone", &import_block)
+        end
       end
     end
 
@@ -327,10 +366,12 @@ module Fastlane
     # @!group Versioning helpers
     #####################################################
 
-    def fetch_remote_tags(folder: nil)
-      UI.message("Fetching remote git tags...")
-      Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
-        Actions.sh("cd #{folder.shellescape} && git fetch --all --tags -q")
+    def get_tags(folder: nil, remote: false)
+      if remote
+        UI.message("Fetching remote git tags...")
+        Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+          Actions.sh("cd #{folder.shellescape} && git fetch --all --tags -q")
+        end
       end
 
       # Fetch all possible tags

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -295,7 +295,7 @@ module Fastlane
 
           checkout_dependencies = dependencies.map(&:shellescape).join(" ")
 
-          checkout_path = "#{path.shellescape} #{checkout_dependencies}"
+          checkout_path = is_eligible_for_caching ? "" : "#{path.shellescape} #{checkout_dependencies}"
 
           if Dir[clone_folder].empty?
             UI.message("Cloning remote git repo...")
@@ -303,7 +303,9 @@ module Fastlane
               # When using cached clones, we need the entire repository history
               # so we can switch between tags or branches instantly, or else,
               # it would defeat the caching's purpose.
-              Actions.sh("git clone #{url.shellescape} #{clone_folder.shellescape} #{is_eligible_for_caching ? '' : '--depth 1'} --no-checkout #{branch_option}")
+              depth = is_eligible_for_caching ? "" : "--depth 1"
+
+              Actions.sh("git clone #{url.shellescape} #{clone_folder.shellescape} #{depth} --no-checkout #{branch_option}")
             end
           end
 
@@ -329,7 +331,7 @@ module Fastlane
             UI.user_error!("No tag found matching #{version.inspect}") if checkout_param.nil?
           end
 
-          Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{is_eligible_for_caching ? '' : checkout_path}")
+          Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")
 
           unless is_eligible_for_caching
             # We also want to check out all the local actions of this fastlane setup

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -10,6 +10,8 @@ describe Fastlane do
       end
 
       describe "with caching" do
+        let(:caching_message) { "Eligible for caching" }
+
         source_directory_path = nil
 
         cache_directory_path = nil
@@ -58,11 +60,9 @@ describe Fastlane do
           FileUtils.remove_dir(missing_cache_directory_path)
         end
 
-        before :each do
-          ENV.delete("IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING")
-        end
-
         it "works with version" do
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works since v1')
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -70,11 +70,11 @@ describe Fastlane do
 
             works
           end").runner.execute(:test)
-
-          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
         end
 
         it "works with dependencies and version" do
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works from extra since v2')
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -82,11 +82,11 @@ describe Fastlane do
 
             works_extra
           end").runner.execute(:test)
-
-          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
         end
 
         it "works with path and version" do
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works from root since v3')
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -94,11 +94,11 @@ describe Fastlane do
 
             works_root
           end").runner.execute(:test)
-
-          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
         end
 
         it "works with actions" do
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works from action since v4')
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -106,8 +106,6 @@ describe Fastlane do
 
             work_action
           end").runner.execute(:test)
-
-          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
         end
 
         # This is based on the fact that rspec runs the tests in the order
@@ -115,6 +113,8 @@ describe Fastlane do
         # works with an older version after a newer one was previously checked
         # out.
         it "works with older version" do
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works since v1')
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -122,8 +122,6 @@ describe Fastlane do
 
             works
           end").runner.execute(:test)
-
-          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
         end
 
         # Meaning, a `git pull` is performed when the specified tag is not found
@@ -137,6 +135,8 @@ describe Fastlane do
             `git tag "5"`
           end
 
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works until v5')
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -144,8 +144,6 @@ describe Fastlane do
 
             works
           end").runner.execute(:test)
-
-          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
         end
 
         # Actually, `git checkout` makes sure of this, but I think it's ok to
@@ -163,6 +161,7 @@ describe Fastlane do
         end
 
         it "ignores it when branch is specified" do
+          expect(UI).not_to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works since v2.1')
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -170,8 +169,6 @@ describe Fastlane do
 
             works
           end").runner.execute(:test)
-
-          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to be_nil
         end
 
         # Because we don't know if the specified value represents a branch or a
@@ -179,6 +176,7 @@ describe Fastlane do
         # points to a different commit when one is added, as opposed to a tag,
         # we decided to enable caching only when used with the `version` param.
         it "ignores it when tag is specified via branch param" do
+          expect(UI).not_to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works since v1')
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -186,16 +184,14 @@ describe Fastlane do
 
             works
           end").runner.execute(:test)
-
-          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to be_nil
         end
 
         it "ignores it when version is not specified" do
+          expect(UI).not_to receive(:message).with(caching_message)
+
           Fastlane::FastFile.new.parse("lane :test do
             import_from_git(url: '#{source_directory_path}', cache_path: '#{cache_directory_path}')
           end").runner.execute(:test)
-
-          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to be_nil
         end
 
         after :all do

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -8,6 +8,204 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Please pass a path to the `import_from_git` action")
       end
+
+      describe "with caching" do
+        source_directory_path = nil
+
+        cache_directory_path = nil
+        missing_cache_directory_path = nil
+
+        before :all do
+          # This is needed for tag searching that `import_from_git` needs.
+          ENV["FORCE_SH_DURING_TESTS"] = "1"
+
+          source_directory_path = Dir.mktmpdir("fl_spec_import_from_git_source")
+
+          Dir.chdir(source_directory_path) do
+            `git init`
+
+            `mkdir fastlane`
+            `echo "lane :works do\n\tUI.important('Works since v1')\nend" > fastlane/Fastfile`
+            `git add .`
+            `git commit --message "Version 1"`
+            `git tag "1"`
+
+            `echo "lane :works_extra do\n\tUI.important('Works from extra since v2')\nend" > fastlane/FastfileExtra`
+            `git add .`
+            `git commit --message "Version 2"`
+            `git tag "2"`
+
+            `echo "lane :works_root do\n\tUI.important('Works from root since v3')\nend" > FastfileRoot`
+            `git add .`
+            `git commit --message "Version 3"`
+            `git tag "3"`
+
+            `mkdir fastlane/actions`
+            `echo "module Fastlane\n\tmodule Actions\n\t\tclass WorkActionAction < Action\n\t\t\tdef self.run(params)\n\t\t\t\tUI.important('Works from action since v4')\n\t\t\tend\n\n\t\t\tdef self.is_supported?(platform)\n\t\t\t\ttrue\n\t\t\tend\n\t\tend\n\tend\nend" > fastlane/actions/work_action.rb`
+            `git add .`
+            `git commit --message "Version 4"`
+            `git tag "4"`
+
+            `git checkout tags/2 -b version-2.1 > /dev/null 2>&1`
+            `echo "lane :works do\n\tUI.important('Works since v2.1')\nend" > fastlane/Fastfile`
+            `git add .`
+            `git commit --message "Version 2.1"`
+          end
+
+          cache_directory_path = Dir.mktmpdir("fl_spec_import_from_git_cache")
+
+          missing_cache_directory_path = Dir.mktmpdir("fl_spec_import_from_git_missing_cache")
+          FileUtils.remove_dir(missing_cache_directory_path)
+        end
+
+        before :each do
+          ENV.delete("IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING")
+        end
+
+        it "works with version" do
+          expect(UI).to receive(:important).with('Works since v1')
+
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', version: '1', cache_path: '#{cache_directory_path}')
+
+            works
+          end").runner.execute(:test)
+
+          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
+        end
+
+        it "works with dependencies and version" do
+          expect(UI).to receive(:important).with('Works from extra since v2')
+
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', dependencies: ['fastlane/FastfileExtra'], version: '2', cache_path: '#{cache_directory_path}')
+
+            works_extra
+          end").runner.execute(:test)
+
+          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
+        end
+
+        it "works with path and version" do
+          expect(UI).to receive(:important).with('Works from root since v3')
+
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', path: 'FastfileRoot', version: '3', cache_path: '#{cache_directory_path}')
+
+            works_root
+          end").runner.execute(:test)
+
+          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
+        end
+
+        it "works with actions" do
+          expect(UI).to receive(:important).with('Works from action since v4')
+
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', version: '4', cache_path: '#{cache_directory_path}')
+
+            work_action
+          end").runner.execute(:test)
+
+          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
+        end
+
+        # This is based on the fact that rspec runs the tests in the order
+        # they're defined in this file, so it tests the fact that importing
+        # works with an older version after a newer one was previously checked
+        # out.
+        it "works with older version" do
+          expect(UI).to receive(:important).with('Works since v1')
+
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', version: '1', cache_path: '#{cache_directory_path}')
+
+            works
+          end").runner.execute(:test)
+
+          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
+        end
+
+        # Meaning, a `git pull` is performed when the specified tag is not found
+        # in the local clone.
+        it "works with new tags" do
+          Dir.chdir(source_directory_path) do
+            `git checkout "master" > /dev/null 2>&1`
+            `echo "lane :works do\n\tUI.important('Works until v5')\nend" > fastlane/Fastfile`
+            `git add .`
+            `git commit --message "Version 5"`
+            `git tag "5"`
+          end
+
+          expect(UI).to receive(:important).with('Works until v5')
+
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', branch: 'master', version: '5', cache_path: '#{cache_directory_path}')
+
+            works
+          end").runner.execute(:test)
+
+          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to eq("1")
+        end
+
+        # Actually, `git checkout` makes sure of this, but I think it's ok to
+        # keep this test, in case we change the implementation.
+        it "works with inexistent paths" do
+          expect(UI).to receive(:important).with('Works since v1')
+
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+              import_from_git(url: '#{source_directory_path}', version: '3', cache_path: '#{missing_cache_directory_path}')
+
+              works
+            end").runner.execute(:test)
+          end.not_to(raise_error)
+        end
+
+        it "ignores it when branch is specified" do
+          expect(UI).to receive(:important).with('Works since v2.1')
+
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', branch: 'version-2.1', cache_path: '#{cache_directory_path}')
+
+            works
+          end").runner.execute(:test)
+
+          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to be_nil
+        end
+
+        # Because we don't know if the specified value represents a branch or a
+        # tag. And knowing that it doesn't make sense to cache a branch, that
+        # points to a different commit when one is added, as opposed to a tag,
+        # we decided to enable caching only when used with the `version` param.
+        it "ignores it when tag is specified via branch param" do
+          expect(UI).to receive(:important).with('Works since v1')
+
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', branch: '3', cache_path: '#{cache_directory_path}')
+
+            works
+          end").runner.execute(:test)
+
+          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to be_nil
+        end
+
+        it "ignores it when version is not specified" do
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', cache_path: '#{cache_directory_path}')
+          end").runner.execute(:test)
+
+          expect(ENV["IMPORT_FROM_GIT_IS_ELIGIBLE_FOR_CACHING"]).to be_nil
+        end
+
+        after :all do
+          ENV.delete("FORCE_SH_DURING_TESTS")
+
+          FileUtils.remove_dir(source_directory_path)
+          FileUtils.remove_dir(missing_cache_directory_path)
+          FileUtils.remove_dir(cache_directory_path)
+        end
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -25,31 +25,64 @@ describe Fastlane do
 
           Dir.chdir(source_directory_path) do
             `git init`
+            `git config user.email "you@example.com"`
+            `git config user.name "Your Name"`
 
             `mkdir fastlane`
-            `echo "lane :works do\n\tUI.important('Works since v1')\nend" > fastlane/Fastfile`
+            File.write('fastlane/Fastfile', <<-FASTFILE)
+              lane :works do
+                UI.important('Works since v1')
+              end
+            FASTFILE
             `git add .`
             `git commit --message "Version 1"`
             `git tag "1"`
 
-            `echo "lane :works_extra do\n\tUI.important('Works from extra since v2')\nend" > fastlane/FastfileExtra`
+            File.write('fastlane/FastfileExtra', <<-FASTFILE)
+              lane :works_extra do
+                UI.important('Works from extra since v2')
+              end
+            FASTFILE
             `git add .`
             `git commit --message "Version 2"`
             `git tag "2"`
 
-            `echo "lane :works_root do\n\tUI.important('Works from root since v3')\nend" > FastfileRoot`
+            File.write('FastfileRoot', <<-FASTFILE)
+              lane :works_root do
+                UI.important('Works from root since v3')
+              end
+            FASTFILE
             `git add .`
             `git commit --message "Version 3"`
             `git tag "3"`
 
             `mkdir fastlane/actions`
-            `echo "module Fastlane\n\tmodule Actions\n\t\tclass WorkActionAction < Action\n\t\t\tdef self.run(params)\n\t\t\t\tUI.important('Works from action since v4')\n\t\t\tend\n\n\t\t\tdef self.is_supported?(platform)\n\t\t\t\ttrue\n\t\t\tend\n\t\tend\n\tend\nend" > fastlane/actions/work_action.rb`
+            FileUtils.mkdir_p('fastlane/actions')
+            File.write('fastlane/actions/work_action.rb', <<-FASTFILE)
+              module Fastlane
+                module Actions
+                  class WorkActionAction < Action
+                    def self.run(params)
+                      UI.important('Works from action since v4')
+                    end
+
+                    def self.is_supported?(platform)
+                      true
+                    end
+                  end
+                end
+              end
+            FASTFILE
             `git add .`
             `git commit --message "Version 4"`
             `git tag "4"`
 
-            `git checkout tags/2 -b version-2.1 > /dev/null 2>&1`
-            `echo "lane :works do\n\tUI.important('Works since v2.1')\nend" > fastlane/Fastfile`
+            `git checkout tags/2 -b version-2.1 2>&1`
+            File.write('fastlane/Fastfile', <<-FASTFILE)
+              lane :works do
+                UI.important('Works since v2.1')
+              end
+            FASTFILE
             `git add .`
             `git commit --message "Version 2.1"`
           end
@@ -128,8 +161,12 @@ describe Fastlane do
         # in the local clone.
         it "works with new tags" do
           Dir.chdir(source_directory_path) do
-            `git checkout "master" > /dev/null 2>&1`
-            `echo "lane :works do\n\tUI.important('Works until v5')\nend" > fastlane/Fastfile`
+            `git checkout "master" 2>&1`
+            File.write('fastlane/Fastfile', <<-FASTFILE)
+              lane :works do
+                UI.important('Works until v5')
+              end
+            FASTFILE
             `git add .`
             `git commit --message "Version 5"`
             `git tag "5"`
@@ -157,7 +194,7 @@ describe Fastlane do
 
               works
             end").runner.execute(:test)
-          end.not_to(raise_error)
+          end.not_to raise_error
         end
 
         it "ignores it when branch is specified" do

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -66,7 +66,7 @@ module FastlaneCore
 
     # @return true if it is enabled to execute external commands
     def self.sh_enabled?
-      !self.test?
+      !self.test? || ENV["FORCE_SH_DURING_TESTS"]
     end
 
     # @return [boolean] true if building in a known CI environment

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -224,9 +224,7 @@ describe Spaceship::Client do
 
           # making sure we use env var for phone number selection
           it 'does not prompt user to choose number' do
-            # rubocop:disable Style/MethodCallWithArgsParentheses
             expect(subject).not_to receive(:choose_phone_number)
-            # rubocop:enable Style/MethodCallWithArgsParentheses
 
             bool = subject.handle_two_factor(response)
             expect(bool).to eq(true)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Even if you use `import_from_git` with a specific branch or tag, the respective repository is cloned every time you run it. This means that a lane that uses this actions is delayed some time, which increases indirectly proportional with the quality of the current Internet connection.

It's even worse when you call it from an Xcode build script! Because it means that every build of your app is delayed.

<!-- If it fixes an open issue, please link to the issue here. -->

### Description

<!-- Describe your changes in detail. -->

If one the `branch` or `version` parameters is specified, along with the newly added `cache_path`, the repository at the specified `url` parameter is cloned into the specified static path, instead of being cloned into a temporary directory that gets deleted after the action finishes running. After this, on subsequent calls, the specified `branch` or `version` is searched in the locally cached repository, and only if it's not found, an update from remote is performed (`git pull`), which it's also faster than a full download (`git clone`).

<!-- Please describe in detail how you tested your changes. -->

I tested using manual repositories and `Fastfile`s, but then I moved them entirely in the spec file.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
