### PR TITLE
[actions] add App Store Connect API key to app_store_build_number action

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -118,20 +118,20 @@ module Fastlane
         user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
         [
           FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                       env_name: "PILOT_API_KEY_PATH",
+                                       env_name: "APPSTORE_BUILD_NUMBER_API_KEY_PATH",
                                        description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                        optional: true,
-                                       conflicting_options: [:username],
+                                       conflicting_options: [:api_key],
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_key,
-                                       env_name: "PILOT_API_KEY",
+                                       env_name: "APPSTORE_BUILD_NUMBER_API_KEY",
                                        description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                        type: Hash,
                                        optional: true,
                                        sensitive: true,
-                                       conflicting_options: [:api_key_path, :username]),
+                                       conflicting_options: [:api_key_path]),
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",
                                        description: "sets the build number to given value if no build is in current train",

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -220,6 +220,14 @@ module Fastlane
             live: false,
             app_identifier: "app.identifier",
             version: "1.2.9"
+          )',
+          'api_key = app_store_connect_api_key(
+            key_id: "MyKeyID12345",
+            issuer_id: "00000000-0000-0000-0000-000000000000",
+            key_filepath: "./AuthKey.p8"
+          )
+          build_num = app_store_build_number(
+            api_key: api_key
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -27,7 +27,8 @@ module Fastlane
 
       def self.get_build_number(params)
         # Prompts select team if multiple teams and none specified
-        if (token = self.api_token)
+        token = self.api_token(params)
+        if token
           UI.message("Using App Store Connect API token...")
           Spaceship::ConnectAPI.token = token
         else
@@ -97,10 +98,10 @@ module Fastlane
         versions.map(&:to_s).sort_by { |v| Gem::Version.new(v) }
       end
 
-      def self.api_token
-        api_token ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
-        api_token ||= Spaceship::ConnectAPI::Token.create(@config[:api_key]) if @config[:api_key]
-        api_token ||= Spaceship::ConnectAPI::Token.from_json_file(@config[:api_key_path]) if @config[:api_key_path]
+      def self.api_token(params)
+        params[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
+        api_token ||= Spaceship::ConnectAPI::Token.create(params[:api_key]) if params[:api_key]
+        api_token ||= Spaceship::ConnectAPI::Token.from_json_file(params[:api_key_path]) if params[:api_key_path]
         return api_token
       end
 

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -37,6 +37,21 @@ module Fastlane
         user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
         [
+          FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                       env_name: "PILOT_API_KEY_PATH",
+                                       description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
+                                       optional: true,
+                                       conflicting_options: [:username],
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :api_key,
+                                       env_name: "PILOT_API_KEY",
+                                       description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
+                                       type: Hash,
+                                       optional: true,
+                                       sensitive: true,
+                                       conflicting_options: [:api_key_path, :username]),
           FastlaneCore::ConfigItem.new(key: :live,
                                        short_option: "-l",
                                        env_name: "CURRENT_BUILD_NUMBER_LIVE",

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -38,20 +38,20 @@ module Fastlane
 
         [
           FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                       env_name: "PILOT_API_KEY_PATH",
+                                       env_name: "APPSTORE_BUILD_NUMBER_API_KEY_PATH",
                                        description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                        optional: true,
-                                       conflicting_options: [:username],
+                                       conflicting_options: [:api_key],
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_key,
-                                       env_name: "PILOT_API_KEY",
+                                       env_name: "APPSTORE_BUILD_NUMBER_API_KEY",
                                        description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                        type: Hash,
                                        optional: true,
                                        sensitive: true,
-                                       conflicting_options: [:api_key_path, :username]),
+                                       conflicting_options: [:api_key_path]),
           FastlaneCore::ConfigItem.new(key: :live,
                                        short_option: "-l",
                                        env_name: "CURRENT_BUILD_NUMBER_LIVE",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves #16620

We automate our version numbers using the app_store_build_action (via latest_testflight_build_number) in our CI workflow. This change allows us to use our Connect API key instead of relying on `FASTLANE_SESSION`.

<!-- If it fixes an open issue, please link to the issue here. -->
I searched for an issue, but couldn't find one.

### Description
<!-- Describe your changes in detail. -->
Following the example of other actions, this allows the `app_store_build_number` action to use App Store Connect API keys, instead of requiring a login using two-factor auth.

<!-- Please describe in detail how you tested your changes. -->
I tested this change primarily in my own repository by doing the following:

* Changing my `Gemfile` to point to my specific repo/branch containing these changes
* Running Fastlane in my CI environment (Github Actions)
* Confirmed that the action runs correctly and returns the expected results

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->

Create a Fastfile which uses `app_store_connect_api_key`, and then passes the API key to `latest_testflight_build_number`, using the same options as other actions:

```
api_key = app_store_connect_api_key(
  key_id: "0000",
  issuer_id: "000,
  key_filepath: "./AuthKey.p8"
)
build_num = latest_testflight_build_number(
  api_key: api_key
)
```

You should expect this to work without needing to pass a `FASTLANE_SESSION` variable in a CI environment.

<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
