### PR TITLE
[deliver] optimize metadata uploading speed

### DIFF
--- a/deliver/lib/deliver/queue_worker.rb
+++ b/deliver/lib/deliver/queue_worker.rb
@@ -19,6 +19,12 @@ module Deliver
       @queue.push(job)
     end
 
+    # @param jobs (Array<Object>) - An array of arbitary object that keeps parameters
+    def batch_enqueue(jobs)
+      raise(ArgumentError, "Enqueue Array instead of #{jobs.class}") unless jobs.kind_of?(Array)
+      jobs.each { |job| enqueue(job) }
+    end
+
     # Call this after you enqueuned all the jobs you want to process
     # This method blocks current thread until all the enqueued jobs are processed
     def start

--- a/deliver/lib/deliver/queue_worker.rb
+++ b/deliver/lib/deliver/queue_worker.rb
@@ -6,9 +6,11 @@ module Deliver
   # Use this when you have all the items that you'll process in advance.
   # Simply enqueue them to this and call `QueueWorker#start`.
   class QueueWorker
+    NUMBER_OF_THREADS = Helper.test? ? 1 : [ENV.fetch("DELIVER_NUMBER_OF_THREADS", 10).to_i, 10].min
+
     # @param concurrency (Numeric) - A number of threads to be created
     # @param block (Proc) - A task you want to execute with enqueued items
-    def initialize(concurrency, &block)
+    def initialize(concurrency = NUMBER_OF_THREADS, &block)
       @concurrency = concurrency
       @block = block
       @queue = Queue.new

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -198,7 +198,7 @@ module Deliver
       sleep(1)
 
       # Update app store version localizations
-      store_version_worker = Deliver::QueueWorker.new(Helper.test? ? 1 : 10) do |app_store_version_localization|
+      store_version_worker = Deliver::QueueWorker.new do |app_store_version_localization|
         attributes = localized_version_attributes_by_locale[app_store_version_localization.locale]
         if attributes
           UI.message("Uploading metadata to App Store Connect for localized version '#{app_store_version_localization.locale}'")
@@ -209,7 +209,7 @@ module Deliver
       store_version_worker.start
 
       # Update app info localizations
-      app_info_worker = Deliver::QueueWorker.new(Helper.test? ? 1 : 10) do |app_info_localization|
+      app_info_worker = Deliver::QueueWorker.new do |app_info_localization|
         attributes = localized_info_attributes_by_locale[app_info_localization.locale]
         if attributes
           UI.message("Uploading metadata to App Store Connect for localized info '#{app_info_localization.locale}'")

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -13,8 +13,6 @@ module Deliver
     DeleteScreenshotJob = Struct.new(:app_screenshot, :localization, :app_screenshot_set)
     UploadScreenshotJob = Struct.new(:app_screenshot_set, :path)
 
-    NUMBER_OF_THREADS = Helper.test? ? 1 : [ENV.fetch("DELIVER_NUMBER_OF_THREADS", 10).to_i, 10].min
-
     def upload(options, screenshots)
       return if options[:skip_screenshots]
       return if options[:edit_live]
@@ -69,7 +67,7 @@ module Deliver
     def delete_screenshots(localizations, screenshots_per_language, tries: 5)
       tries -= 1
 
-      worker = QueueWorker.new(NUMBER_OF_THREADS) do |job|
+      worker = QueueWorker.new do |job|
         start_time = Time.now
         target = "#{job.localization.locale} #{job.app_screenshot_set.screenshot_display_type} #{job.app_screenshot.id}"
         begin
@@ -115,7 +113,7 @@ module Deliver
       tries -= 1
 
       # Upload screenshots
-      worker = QueueWorker.new(NUMBER_OF_THREADS) do |job|
+      worker = QueueWorker.new do |job|
         begin
           UI.verbose("Uploading '#{job.path}'...")
           start_time = Time.now
@@ -236,7 +234,7 @@ module Deliver
       iterator = AppScreenshotIterator.new(localizations)
 
       # Re-order screenshots within app_screenshot_set
-      worker = QueueWorker.new(NUMBER_OF_THREADS) do |app_screenshot_set|
+      worker = QueueWorker.new do |app_screenshot_set|
         original_ids = app_screenshot_set.app_screenshots.map(&:id)
         sorted_ids = app_screenshot_set.app_screenshots.sort_by(&:file_name).map(&:id)
         if original_ids != sorted_ids

--- a/deliver/spec/queue_worker_spec.rb
+++ b/deliver/spec/queue_worker_spec.rb
@@ -1,6 +1,13 @@
 require 'deliver/queue_worker'
 
 describe Deliver::QueueWorker do
+  describe '#new' do
+    it 'should initialize an instance' do
+      expect(described_class.new { |_| }).to be_kind_of(described_class)
+      expect(described_class.new(1) { |_| }).to be_kind_of(described_class)
+    end
+  end
+
   describe '#enqueue' do
     subject { described_class.new(1) { |_| } }
 

--- a/deliver/spec/queue_worker_spec.rb
+++ b/deliver/spec/queue_worker_spec.rb
@@ -12,6 +12,15 @@ describe Deliver::QueueWorker do
     end
   end
 
+  describe '#batch_enqueue' do
+    subject { described_class.new(1) { |_| } }
+
+    it 'should take an array as multiple jobs' do
+      expect { subject.batch_enqueue([1, 2, 3]) }.not_to(raise_error)
+      expect { subject.batch_enqueue(1) }.to(raise_error(ArgumentError))
+    end
+  end
+
   describe '#start' do
     it 'should dispatch enqueued items to given block in FIFO order' do
       dispatched_jobs = []


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Since #16972, `deliver` has `Deliver::QueueWorker` to make network requests work in parallel. I found it easy to apply that to `Deliver::UploadMetadata` to make the flow slightly faster. This also helps a bit for fastlane contributor having to run `deliver` locally a lot🙂 

### Description

Just did it😄 I wrapped code where updates store version localisation and app info localisation with `QueueWorker` to let them run in parallel. Like this. (I added `Deliver::QueueWorker.batch_enqueue` to help it to enqueue an array of objects in one go easily.)

```diff
       # Update app store version localizations
       # Update app store version localizations
-      app_store_version_localizations.each do |app_store_version_localization|
+      store_version_worker = Deliver::QueueWorker.new(Helper.test? ? 1 : 10) do |app_store_version_localization|
         attributes = localized_version_attributes_by_locale[app_store_version_localization.locale]
         if attributes
           UI.message("Uploading metadata to App Store Connect for localized version '#{app_store_version_localization.locale}'")
           app_store_version_localization.update(attributes: attributes)
         end
       end
+      store_version_worker.batch_enqueue(app_store_version_localizations)
+      store_version_worker.start
```

-----------

By the way, additionally, I simplified `Deliver::QueueWorker` a lot as I just realised it can be very simple in the expected use cases lately. There's no need to have `wait_thread` to observe if the queue becomes empty, after all🙈

### Testing Steps

```ruby
   upload_to_app_store(
     skip_metadata: false,
     skip_screenshots: true,
     skip_binary_upload: true,
     run_precheck_before_submit: false,
   )
```

With these options, I measured the time between followings logs.

```
WARN [2020-10-09 23:54:55.30]: Will begin uploading metadata for '10.10.0' on App Store Connect # <= begin to measure
...
INFO [2020-10-09 23:55:17.44]: Uploading app review information to App Store Connect  # <= end to measure
```

Before: It took 22 secs for 20 localisations. (v2.162.0)

```
WARN [2020-10-09 23:54:55.30]: Will begin uploading metadata for '10.10.0' on App Store Connect
ERROR [2020-10-09 23:54:55.30]: Skipping 'release_notes'... this is the first version of the app
INFO [2020-10-09 23:54:55.31]: Uploading metadata to App Store Connect for version
INFO [2020-10-09 23:54:55.70]: Uploading metadata to App Store Connect for localized version 'en-US'
INFO [2020-10-09 23:54:56.17]: Uploading metadata to App Store Connect for localized version 'es-MX'
...
INFO [2020-10-09 23:55:13.54]: Uploading metadata to App Store Connect for localized info 'zh-Hans'
INFO [2020-10-09 23:55:14.08]: Uploading metadata to App Store Connect for localized info 'zh-Hant'
INFO [2020-10-09 23:55:17.44]: Uploading app review information to App Store Connect
```

After: It took 5 secs for 20 localisations.
```
WARN [2020-10-09 23:56:37.04]: Will begin uploading metadata for '10.10.0' on App Store Connect
ERROR [2020-10-09 23:56:37.04]: Skipping 'release_notes'... this is the first version of the app
WARN [2020-10-09 23:56:37.04]: Release type will not be set because neither `automatic_release` nor `auto_release_date` were provided. Please explicitly set one of these options if you need a release type set
INFO [2020-10-09 23:56:37.04]: Uploading metadata to App Store Connect for version
INFO [2020-10-09 23:56:40.45]: Uploading metadata to App Store Connect for localized version 'es-MX'
INFO [2020-10-09 23:56:40.46]: Uploading metadata to App Store Connect for localized version 'fr-FR'
...
INFO [2020-10-09 23:56:42.37]: Uploading metadata to App Store Connect for localized info 'zh-Hans'
INFO [2020-10-09 23:56:42.38]: Uploading metadata to App Store Connect for localized info 'zh-Hant'
INFO [2020-10-09 23:56:45.75]: Uploading app review information to App Store Connect
```