### PR TITLE
[action] App Store Connect API Key for register_device and register_devices

### DIFF
--- a/fastlane/lib/fastlane/actions/register_device.rb
+++ b/fastlane/lib/fastlane/actions/register_device.rb
@@ -11,21 +11,37 @@ module Fastlane
         require 'spaceship'
 
         name = params[:name]
+        platform = params[:platform]
         udid = params[:udid]
 
-        credentials = CredentialsManager::AccountManager.new(user: params[:username])
-        Spaceship.login(credentials.user, credentials.password)
-        Spaceship.select_team
+        platform = Spaceship::ConnectAPI::BundleIdPlatform.map(platform)
+
+        if (token = api_token(params))
+          UI.message("Using App Store Connect API token...")
+          Spaceship::ConnectAPI.token = token
+        else
+          UI.message("Login to App Store Connect (#{params[:username]})")
+          credentials = CredentialsManager::AccountManager.new(user: params[:username])
+          Spaceship::ConnectAPI.login(credentials.user, credentials.password, use_portal: true, use_tunes: false)
+          UI.message("Login successful")
+        end
 
         begin
-          Spaceship::Device.create!(name: name, udid: udid)
+          Spaceship::ConnectAPI::Device.create(name: name, platform: platform, udid: udid)
         rescue => ex
           UI.error(ex.to_s)
-          UI.crash!("Failed to register new device (name: #{name}, UDID: #{udid})")
+          UI.crash!("Failed to register new device (name: #{name}, platform: #{platform}, UDID: #{udid})")
         end
 
         UI.success("Successfully registered new device")
         return udid
+      end
+
+      def self.api_token(params)
+        params[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
+        api_token ||= Spaceship::ConnectAPI::Token.create(params[:api_key]) if params[:api_key]
+        api_token ||= Spaceship::ConnectAPI::Token.from_json_file(params[:api_key_path]) if params[:api_key_path]
+        return api_token
       end
 
       def self.description
@@ -35,14 +51,38 @@ module Fastlane
       def self.available_options
         user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)
         user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
+        platform = Actions.lane_context[Actions::SharedValues::PLATFORM_NAME].to_s
 
         [
           FastlaneCore::ConfigItem.new(key: :name,
                                        env_name: "FL_REGISTER_DEVICE_NAME",
                                        description: "Provide the name of the device to register as"),
+          FastlaneCore::ConfigItem.new(key: :platform,
+                                       env_name: "FL_REGISTER_DEVICE_PLATFORM",
+                                       description: "Provide the platform of the device to register as (ios, mac)",
+                                       optional: true,
+                                       default_value: platform.empty? ? "ios" : platform,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The platform can only be ios or mac") unless %('ios', 'mac').include?(value)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :udid,
                                        env_name: "FL_REGISTER_DEVICE_UDID",
                                        description: "Provide the UDID of the device to register as"),
+          FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                       env_name: "FL_REGISTER_DEVICE_API_KEY_PATH",
+                                       description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
+                                       optional: true,
+                                       conflicting_options: [:api_key],
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :api_key,
+                                       env_name: "FL_REGISTER_DEVICE_API_KEY",
+                                       description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
+                                       type: Hash,
+                                       optional: true,
+                                       sensitive: true,
+                                       conflicting_options: [:api_key_path]),
           FastlaneCore::ConfigItem.new(key: :team_id,
                                      env_name: "REGISTER_DEVICE_TEAM_ID",
                                      code_gen_sensitive: true,
@@ -66,6 +106,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: "DELIVER_USER",
                                        description: "Optional: Your Apple ID",
+                                       optional: true,
                                        default_value: user,
                                        default_value_dynamic: true)
         ]

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -12,6 +12,8 @@ module Fastlane
       end
 
       def self.run(params)
+        platform = Spaceship::ConnectAPI::BundleIdPlatform.map(params[:platform])
+
         if params[:devices]
           new_devices = params[:devices].map do |name, udid|
             [udid, name]
@@ -37,38 +39,52 @@ module Fastlane
         end
 
         require 'spaceship'
-        credentials = CredentialsManager::AccountManager.new(user: params[:username])
-        Spaceship.login(credentials.user, credentials.password)
-        Spaceship.select_team
+        if (token = api_token(params))
+          UI.message("Using App Store Connect API token...")
+          Spaceship::ConnectAPI.token = token
+        else
+          UI.message("Login to App Store Connect (#{params[:username]})")
+          credentials = CredentialsManager::AccountManager.new(user: params[:username])
+          Spaceship::ConnectAPI.login(credentials.user, credentials.password, use_portal: true, use_tunes: false)
+          UI.message("Login successful")
+        end
 
         UI.message("Fetching list of currently registered devices...")
-        all_platforms = Set[params[:platform]]
-        new_devices.each do |device|
-          next if device[2].nil?
-          all_platforms.add(device[2])
-        end
-        supported_platforms = all_platforms.select { |platform| self.is_supported?(platform.to_sym) }
-
-        existing_devices = supported_platforms.flat_map { |platform| Spaceship::Device.all(mac: platform == "mac") }
+        existing_devices = Spaceship::ConnectAPI::Device.all
 
         device_objs = new_devices.map do |device|
           next if existing_devices.map(&:udid).include?(device[0])
 
-          device_platform_supported = !device[2].nil? && self.is_supported?(device[2].to_sym)
-          mac = (device_platform_supported ? device[2] : params[:platform]) == "mac"
+          device_platform = platform
 
-          try_create_device(name: device[1], udid: device[0], mac: mac)
+          device_platform_supported = !device[2].nil? && self.is_supported?(device[2].to_sym)
+          if device_platform_supported
+            if device[2] == "mac"
+              device_platform = Spaceship::ConnectAPI::BundleIdPlatform::MAC_OS
+            else
+              device_platform = Spaceship::ConnectAPI::BundleIdPlatform::IOS
+            end
+          end
+
+          try_create_device(name: device[1], platform: device_platform, udid: device[0])
         end
 
         UI.success("Successfully registered new devices.")
         return device_objs
       end
 
-      def self.try_create_device(name: nil, udid: nil, mac: false)
-        Spaceship::Device.create!(name: name, udid: udid, mac: mac)
+      def self.try_create_device(name: nil, platform: nil, udid: nil)
+        Spaceship::ConnectAPI::Device.create(name: name, platform: platform, udid: udid)
       rescue => ex
         UI.error(ex.to_s)
         UI.crash!("Failed to register new device (name: #{name}, UDID: #{udid})")
+      end
+
+      def self.api_token(params)
+        params[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
+        api_token ||= Spaceship::ConnectAPI::Token.create(params[:api_key]) if params[:api_key]
+        api_token ||= Spaceship::ConnectAPI::Token.from_json_file(params[:api_key_path]) if params[:api_key_path]
+        return api_token
       end
 
       #####################################################
@@ -98,6 +114,21 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Could not find file '#{value}'") unless File.exist?(value)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                       env_name: "FL_REGISTER_DEVICES_API_KEY_PATH",
+                                       description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
+                                       optional: true,
+                                       conflicting_options: [:api_key],
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :api_key,
+                                       env_name: "FL_REGISTER_DEVICES_API_KEY",
+                                       description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
+                                       type: Hash,
+                                       optional: true,
+                                       sensitive: true,
+                                       conflicting_options: [:api_key_path]),
           FastlaneCore::ConfigItem.new(key: :team_id,
                                      env_name: "REGISTER_DEVICES_TEAM_ID",
                                      code_gen_sensitive: true,

--- a/fastlane/spec/actions_specs/register_devices_spec.rb
+++ b/fastlane/spec/actions_specs/register_devices_spec.rb
@@ -31,23 +31,22 @@ describe Fastlane do
       end
 
       it "registers devices with file with platform" do
-        expect(Spaceship::Device).to receive(:all).and_return(fake_devices).with(mac: false)
-        expect(Spaceship::Device).to receive(:all).and_return(fake_devices).with(mac: true)
+        expect(Spaceship::ConnectAPI::Device).to receive(:all).and_return(fake_devices)
 
         expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
           name: 'NAME2',
           udid: 'B123456789012345678901234567890123456789',
-          mac: false
+          platform: "IOS"
         )
         expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
           name: 'NAME3',
           udid: 'A5B5CD50-14AB-5AF7-8B78-AB4751AB10A8',
-          mac: true
+          platform: "MAC_OS"
         )
         expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
           name: 'NAME4',
           udid: 'A5B5CD50-14AB-5AF7-8B78-AB4751AB10A7',
-          mac: true
+          platform: "MAC_OS"
         )
 
         result = Fastlane::FastFile.new.parse("lane :test do
@@ -59,12 +58,12 @@ describe Fastlane do
       end
 
       it "registers devices for ios with file without platform" do
-        expect(Spaceship::Device).to receive(:all).and_return(fake_devices).with(mac: false)
+        expect(Spaceship::ConnectAPI::Device).to receive(:all).and_return(fake_devices)
 
         expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
           name: 'NAME2',
           udid: 'B123456789012345678901234567890123456789',
-          mac: false
+          platform: "IOS"
         )
 
         result = Fastlane::FastFile.new.parse("lane :test do
@@ -77,12 +76,12 @@ describe Fastlane do
       end
 
       it "registers devices for mac with file without platform" do
-        expect(Spaceship::Device).to receive(:all).and_return(fake_devices).with(mac: true)
+        expect(Spaceship::ConnectAPI::Device).to receive(:all).and_return(fake_devices)
 
         expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
           name: 'NAME2',
           udid: 'B123456789012345678901234567890123456789',
-          mac: true
+          platform: "MAC_OS"
         )
 
         result = Fastlane::FastFile.new.parse("lane :test do

--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -86,5 +86,29 @@ module Spaceship
         end
       end
     end
+
+    # Defined in the App Store Connect API docs:
+    #
+    # Used for creating BundleId and Device
+    module BundleIdPlatform
+      IOS = "IOS"
+      MAC_OS = "MAC_OS"
+
+      ALL = [IOS, MAC_OS]
+
+      def self.map(platform)
+        return platform if ALL.include?(platform)
+
+        # Map from fastlane input and Spaceship::TestFlight platform values
+        case platform.to_sym
+        when :osx, :macos, :mac
+          return Spaceship::ConnectAPI::Platform::MAC_OS
+        when :ios
+          return Spaceship::ConnectAPI::Platform::IOS
+        else
+          raise "Cannot find a matching platform for '#{platform}' - valid values are #{ALL.join(', ')}"
+        end
+      end
+    end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -48,6 +48,11 @@ module Spaceship
         resps = Spaceship::ConnectAPI.get_devices(filter: filter, includes: includes).all_pages
         return resps.flat_map(&:to_models)
       end
+
+      def self.create(name: nil, platform: nil, udid: nil)
+        resp = Spaceship::ConnectAPI.post_device(name: name, platform: platform, udid: udid)
+        return resp.to_models.first
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -71,6 +71,23 @@ module Spaceship
           end
         end
 
+        def post_device(name: nil, platform: nil, udid: nil)
+          attributes = {
+            name: name,
+            platform: platform,
+            udid: udid
+          }
+
+          body = {
+            data: {
+              attributes: attributes,
+              type: "devices"
+            }
+          }
+
+          provisioning_request_client.post("devices", body)
+        end
+
         #
         # profiles
         #


### PR DESCRIPTION
### Motivation and Context
Fixes https://github.com/fastlane/fastlane/discussions/17407
Fixes https://github.com/fastlane/fastlane/discussions/17395


### Description
- Adds `api_key` and `api_key_path` for `register_device` and `register_devices`
