### PR TITLE
Version bump to 2.163.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
 <td id='andrew-mcburney'>
 <a href='https://github.com/armcburney'>
 <img src='https://github.com/armcburney.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
@@ -64,8 +46,12 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
-</tr>
-<tr>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
 <td id='iulian-onofrei'>
 <a href='https://github.com/revolter'>
 <img src='https://github.com/revolter.png?size=140'>
@@ -78,17 +64,63 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'>Jimmy Dee</h4>
 </td>
+</tr>
+<tr>
 <td id='jan-piotrowski'>
 <a href='https://github.com/janpio'>
 <img src='https://github.com/janpio.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+</tr>
+<tr>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
 <img src='https://github.com/minuscorp.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
@@ -98,61 +130,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-</tr>
-<tr>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
 <img src='https://github.com/hjanuschka.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
@@ -160,19 +148,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
 </tr>
 <tr>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Kohki Miki",
+  spec.authors       = ["Daniel Jankowski",
+                        "Kohki Miki",
+                        "Helmut Januschka",
                         "Danielle Tomlinson",
-                        "Aaron Brager",
                         "Fumiya Nakamura",
-                        "Maksym Grebenets",
-                        "Felix Krause",
                         "Joshua Liebowitz",
                         "Jérôme Lacoste",
-                        "Iulian Onofrei",
-                        "Max Ott",
-                        "Daniel Jankowski",
-                        "Josh Holtz",
-                        "Olivier Halligon",
-                        "Stefan Natchev",
-                        "Andrew McBurney",
-                        "Luka Mirosevic",
-                        "Jimmy Dee",
-                        "Matthew Ellis",
-                        "Manu Wallner",
-                        "Helmut Januschka",
+                        "Aaron Brager",
                         "Jorge Revuelta H",
-                        "Jan Piotrowski"]
+                        "Iulian Onofrei",
+                        "Jimmy Dee",
+                        "Jan Piotrowski",
+                        "Luka Mirosevic",
+                        "Felix Krause",
+                        "Max Ott",
+                        "Stefan Natchev",
+                        "Manu Wallner",
+                        "Matthew Ellis",
+                        "Josh Holtz",
+                        "Maksym Grebenets",
+                        "Andrew McBurney",
+                        "Olivier Halligon"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.162.0'.freeze
+  VERSION = '2.163.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -17,4 +17,4 @@ public class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.162.0
+// Generated with fastlane 2.163.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -53,7 +53,7 @@ public protocol DeliverfileProtocol: class {
     /// Don’t create or update the app version that is being prepared for submission
     var skipAppVersionUpdate: Bool { get }
 
-    /// Skip the HTML report file verification
+    /// Skip verification of HTML preview file
     var force: Bool { get }
 
     /// Clear all previously uploaded screenshots before uploading the new ones
@@ -66,7 +66,7 @@ public protocol DeliverfileProtocol: class {
     var rejectIfPossible: Bool { get }
 
     /// Should the app be automatically released once it's approved? (Can not be used together with `auto_release_date`)
-    var automaticRelease: Bool { get }
+    var automaticRelease: Bool? { get }
 
     /// Date in milliseconds for automatically releasing on pending approval (Can not be used together with `automatic_release`)
     var autoReleaseDate: Int? { get }
@@ -211,7 +211,7 @@ public extension DeliverfileProtocol {
     var overwriteScreenshots: Bool { return false }
     var submitForReview: Bool { return false }
     var rejectIfPossible: Bool { return false }
-    var automaticRelease: Bool { return false }
+    var automaticRelease: Bool? { return nil }
     var autoReleaseDate: Int? { return nil }
     var phasedRelease: Bool { return false }
     var resetRatings: Bool { return false }
@@ -256,4 +256,4 @@ public extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.45]
+// FastlaneRunnerAPIVersion [0.9.46]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -98,6 +98,8 @@ public func addGitTag(tag: String? = nil,
  Returns the current build_number of either live or edit version
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - initialBuildNumber: sets the build number to given value if no build is in current train
    - appIdentifier: The bundle identifier of your app
    - username: Your Apple ID Username
@@ -110,7 +112,9 @@ public func addGitTag(tag: String? = nil,
  Returns the current build number of either the live or testflight version - it is useful for getting the build_number of the current or ready-for-sale app version, and it also works on non-live testflight version.
  If you need to handle more build-trains please see `latest_testflight_build_number`.
  */
-public func appStoreBuildNumber(initialBuildNumber: Any,
+public func appStoreBuildNumber(apiKeyPath: String? = nil,
+                                apiKey: [String: Any]? = nil,
+                                initialBuildNumber: Any,
                                 appIdentifier: String,
                                 username: String,
                                 teamId: Any? = nil,
@@ -119,7 +123,9 @@ public func appStoreBuildNumber(initialBuildNumber: Any,
                                 platform: String = "ios",
                                 teamName: String? = nil)
 {
-    let command = RubyCommand(commandID: "", methodName: "app_store_build_number", className: nil, args: [RubyCommand.Argument(name: "initial_build_number", value: initialBuildNumber),
+    let command = RubyCommand(commandID: "", methodName: "app_store_build_number", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                          RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                                          RubyCommand.Argument(name: "initial_build_number", value: initialBuildNumber),
                                                                                                           RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                                           RubyCommand.Argument(name: "username", value: username),
                                                                                                           RubyCommand.Argument(name: "team_id", value: teamId),
@@ -138,6 +144,7 @@ public func appStoreBuildNumber(initialBuildNumber: Any,
    - issuerId: The issuer ID
    - keyFilepath: The path to the key p8 file
    - keyContent: The content of the key p8 file
+   - isKeyContentBase64: Whether :key_content is Base64 encoded or not
    - duration: The token session duration
    - inHouse: Is App Store or Enterprise (in house) team? App Store Connect API cannot not determine this on its own (yet)
 
@@ -147,6 +154,7 @@ public func appStoreConnectApiKey(keyId: String,
                                   issuerId: String,
                                   keyFilepath: String? = nil,
                                   keyContent: String? = nil,
+                                  isKeyContentBase64: Bool = false,
                                   duration: Int? = nil,
                                   inHouse: Bool? = nil)
 {
@@ -154,6 +162,7 @@ public func appStoreConnectApiKey(keyId: String,
                                                                                                              RubyCommand.Argument(name: "issuer_id", value: issuerId),
                                                                                                              RubyCommand.Argument(name: "key_filepath", value: keyFilepath),
                                                                                                              RubyCommand.Argument(name: "key_content", value: keyContent),
+                                                                                                             RubyCommand.Argument(name: "is_key_content_base64", value: isKeyContentBase64),
                                                                                                              RubyCommand.Argument(name: "duration", value: duration),
                                                                                                              RubyCommand.Argument(name: "in_house", value: inHouse)])
     _ = runner.executeCommand(command)
@@ -479,7 +488,7 @@ public func appledoc(input: Any,
    - skipScreenshots: Don't upload the screenshots
    - skipMetadata: Don't upload the metadata (e.g. title, description). This will still upload screenshots
    - skipAppVersionUpdate: Don’t create or update the app version that is being prepared for submission
-   - force: Skip the HTML report file verification
+   - force: Skip verification of HTML preview file
    - overwriteScreenshots: Clear all previously uploaded screenshots before uploading the new ones
    - submitForReview: Submit the new version for Review after uploading everything
    - rejectIfPossible: Rejects the previously submitted build if it's in a state where it's possible
@@ -527,7 +536,7 @@ public func appledoc(input: Any,
 
  Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.
 
- If you don't want a PDF report for App Store builds, use the `:force` option.
+ If you don't want to verify an HTML preview for App Store builds, use the `:force` option.
  This is useful when running _fastlane_ on your Continuous Integration server:
  `_upload_to_app_store_(force: true)`
  If your account is on multiple teams and you need to tell the `iTMSTransporter` which 'provider' to use, you can set the `:itc_provider` option to pass this info.
@@ -553,7 +562,7 @@ public func appstore(apiKeyPath: String? = nil,
                      overwriteScreenshots: Bool = false,
                      submitForReview: Bool = false,
                      rejectIfPossible: Bool = false,
-                     automaticRelease: Bool = false,
+                     automaticRelease: Bool? = nil,
                      autoReleaseDate: Int? = nil,
                      phasedRelease: Bool = false,
                      resetRatings: Bool = false,
@@ -2600,7 +2609,7 @@ public func deleteKeychain(name: String? = nil,
    - skipScreenshots: Don't upload the screenshots
    - skipMetadata: Don't upload the metadata (e.g. title, description). This will still upload screenshots
    - skipAppVersionUpdate: Don’t create or update the app version that is being prepared for submission
-   - force: Skip the HTML report file verification
+   - force: Skip verification of HTML preview file
    - overwriteScreenshots: Clear all previously uploaded screenshots before uploading the new ones
    - submitForReview: Submit the new version for Review after uploading everything
    - rejectIfPossible: Rejects the previously submitted build if it's in a state where it's possible
@@ -2648,7 +2657,7 @@ public func deleteKeychain(name: String? = nil,
 
  Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.
 
- If you don't want a PDF report for App Store builds, use the `:force` option.
+ If you don't want to verify an HTML preview for App Store builds, use the `:force` option.
  This is useful when running _fastlane_ on your Continuous Integration server:
  `_upload_to_app_store_(force: true)`
  If your account is on multiple teams and you need to tell the `iTMSTransporter` which 'provider' to use, you can set the `:itc_provider` option to pass this info.
@@ -2674,7 +2683,7 @@ public func deliver(apiKeyPath: Any? = deliverfile.apiKeyPath,
                     overwriteScreenshots: Bool = deliverfile.overwriteScreenshots,
                     submitForReview: Bool = deliverfile.submitForReview,
                     rejectIfPossible: Bool = deliverfile.rejectIfPossible,
-                    automaticRelease: Bool = deliverfile.automaticRelease,
+                    automaticRelease: Bool? = deliverfile.automaticRelease,
                     autoReleaseDate: Int? = deliverfile.autoReleaseDate,
                     phasedRelease: Bool = deliverfile.phasedRelease,
                     resetRatings: Bool = deliverfile.resetRatings,
@@ -4595,6 +4604,8 @@ public func jira(url: String,
  Fetches most recent build number from TestFlight
 
  - parameters:
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - live: Query the live version (ready-for-sale)
    - appIdentifier: The bundle identifier of your app
    - username: Your Apple ID Username
@@ -4609,7 +4620,9 @@ public func jira(url: String,
  Provides a way to have `increment_build_number` be based on the latest build you uploaded to iTC.
  Fetches the most recent build number from TestFlight based on the version number. Provides a way to have `increment_build_number` be based on the latest build you uploaded to iTC.
  */
-@discardableResult public func latestTestflightBuildNumber(live: Bool = false,
+@discardableResult public func latestTestflightBuildNumber(apiKeyPath: String? = nil,
+                                                           apiKey: [String: Any]? = nil,
+                                                           live: Bool = false,
                                                            appIdentifier: String,
                                                            username: String,
                                                            version: String? = nil,
@@ -4618,7 +4631,9 @@ public func jira(url: String,
                                                            teamId: Any? = nil,
                                                            teamName: String? = nil) -> Int
 {
-    let command = RubyCommand(commandID: "", methodName: "latest_testflight_build_number", className: nil, args: [RubyCommand.Argument(name: "live", value: live),
+    let command = RubyCommand(commandID: "", methodName: "latest_testflight_build_number", className: nil, args: [RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                                  RubyCommand.Argument(name: "api_key", value: apiKey),
+                                                                                                                  RubyCommand.Argument(name: "live", value: live),
                                                                                                                   RubyCommand.Argument(name: "app_identifier", value: appIdentifier),
                                                                                                                   RubyCommand.Argument(name: "username", value: username),
                                                                                                                   RubyCommand.Argument(name: "version", value: version),
@@ -5772,7 +5787,10 @@ public func recreateSchemes(project: String) {
 
  - parameters:
    - name: Provide the name of the device to register as
+   - platform: Provide the platform of the device to register as (ios, mac)
    - udid: Provide the UDID of the device to register as
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - teamId: The ID of your Developer Portal team if you're in multiple teams
    - teamName: The name of your Developer Portal team if you're in multiple teams
    - username: Optional: Your Apple ID
@@ -5782,13 +5800,19 @@ public func recreateSchemes(project: String) {
  The action will connect to the Apple Developer Portal using the username you specified in your `Appfile` with `apple_id`, but you can override it using the `:username` option.
  */
 @discardableResult public func registerDevice(name: String,
+                                              platform: String = "ios",
                                               udid: String,
+                                              apiKeyPath: String? = nil,
+                                              apiKey: [String: Any]? = nil,
                                               teamId: String? = nil,
                                               teamName: String? = nil,
-                                              username: String) -> String
+                                              username: String? = nil) -> String
 {
     let command = RubyCommand(commandID: "", methodName: "register_device", className: nil, args: [RubyCommand.Argument(name: "name", value: name),
+                                                                                                   RubyCommand.Argument(name: "platform", value: platform),
                                                                                                    RubyCommand.Argument(name: "udid", value: udid),
+                                                                                                   RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                   RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                                    RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                                    RubyCommand.Argument(name: "team_name", value: teamName),
                                                                                                    RubyCommand.Argument(name: "username", value: username)])
@@ -5801,6 +5825,8 @@ public func recreateSchemes(project: String) {
  - parameters:
    - devices: A hash of devices, with the name as key and the UDID as value
    - devicesFile: Provide a path to a file with the devices to register. For the format of the file see the examples
+   - apiKeyPath: Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
+   - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)
    - teamId: The ID of your Developer Portal team if you're in multiple teams
    - teamName: The name of your Developer Portal team if you're in multiple teams
    - username: Optional: Your Apple ID
@@ -5812,6 +5838,8 @@ public func recreateSchemes(project: String) {
  */
 public func registerDevices(devices: [String: Any]? = nil,
                             devicesFile: String? = nil,
+                            apiKeyPath: String? = nil,
+                            apiKey: [String: Any]? = nil,
                             teamId: String? = nil,
                             teamName: String? = nil,
                             username: String,
@@ -5819,6 +5847,8 @@ public func registerDevices(devices: [String: Any]? = nil,
 {
     let command = RubyCommand(commandID: "", methodName: "register_devices", className: nil, args: [RubyCommand.Argument(name: "devices", value: devices),
                                                                                                     RubyCommand.Argument(name: "devices_file", value: devicesFile),
+                                                                                                    RubyCommand.Argument(name: "api_key_path", value: apiKeyPath),
+                                                                                                    RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                                     RubyCommand.Argument(name: "team_id", value: teamId),
                                                                                                     RubyCommand.Argument(name: "team_name", value: teamName),
                                                                                                     RubyCommand.Argument(name: "username", value: username),
@@ -8451,7 +8481,7 @@ public func uploadSymbolsToSentry(apiHost: String = "https://app.getsentry.com/a
    - skipScreenshots: Don't upload the screenshots
    - skipMetadata: Don't upload the metadata (e.g. title, description). This will still upload screenshots
    - skipAppVersionUpdate: Don’t create or update the app version that is being prepared for submission
-   - force: Skip the HTML report file verification
+   - force: Skip verification of HTML preview file
    - overwriteScreenshots: Clear all previously uploaded screenshots before uploading the new ones
    - submitForReview: Submit the new version for Review after uploading everything
    - rejectIfPossible: Rejects the previously submitted build if it's in a state where it's possible
@@ -8499,7 +8529,7 @@ public func uploadSymbolsToSentry(apiHost: String = "https://app.getsentry.com/a
 
  Using _upload_to_app_store_ after _build_app_ and _capture_screenshots_ will automatically upload the latest ipa and screenshots with no other configuration.
 
- If you don't want a PDF report for App Store builds, use the `:force` option.
+ If you don't want to verify an HTML preview for App Store builds, use the `:force` option.
  This is useful when running _fastlane_ on your Continuous Integration server:
  `_upload_to_app_store_(force: true)`
  If your account is on multiple teams and you need to tell the `iTMSTransporter` which 'provider' to use, you can set the `:itc_provider` option to pass this info.
@@ -8525,7 +8555,7 @@ public func uploadToAppStore(apiKeyPath: String? = nil,
                              overwriteScreenshots: Bool = false,
                              submitForReview: Bool = false,
                              rejectIfPossible: Bool = false,
-                             automaticRelease: Bool = false,
+                             automaticRelease: Bool? = nil,
                              autoReleaseDate: Int? = nil,
                              phasedRelease: Bool = false,
                              resetRatings: Bool = false,
@@ -9211,7 +9241,7 @@ public func xcov(workspace: String? = nil,
                  coverallsServiceJobId: String? = nil,
                  coverallsRepoToken: String? = nil,
                  xcconfig: String? = nil,
-                 ideFoundationPath: String = "/Applications/Xcode-11.5.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
+                 ideFoundationPath: String = "/Applications/Xcode-11.7.app/Contents/Developer/../Frameworks/IDEFoundation.framework/Versions/A/IDEFoundation",
                  legacySupport: Bool = false)
 {
     let command = RubyCommand(commandID: "", methodName: "xcov", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
@@ -9357,4 +9387,4 @@ public let snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.98]
+// FastlaneRunnerAPIVersion [0.9.99]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -17,4 +17,4 @@ public class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.162.0
+// Generated with fastlane 2.163.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -184,4 +184,4 @@ public extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.48]
+// FastlaneRunnerAPIVersion [0.9.49]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -17,4 +17,4 @@ public class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.162.0
+// Generated with fastlane 2.163.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -180,4 +180,4 @@ public extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.42]
+// FastlaneRunnerAPIVersion [0.9.43]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -17,4 +17,4 @@ public class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.162.0
+// Generated with fastlane 2.163.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -48,4 +48,4 @@ public extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.41]
+// FastlaneRunnerAPIVersion [0.9.42]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -17,4 +17,4 @@ public class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.162.0
+// Generated with fastlane 2.163.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -260,4 +260,4 @@ public extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.53]
+// FastlaneRunnerAPIVersion [0.9.54]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -17,4 +17,4 @@ public class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.162.0
+// Generated with fastlane 2.163.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -96,4 +96,4 @@ public extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.43]
+// FastlaneRunnerAPIVersion [0.9.44]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -17,4 +17,4 @@ public class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.162.0
+// Generated with fastlane 2.163.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -184,4 +184,4 @@ public extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.37]
+// FastlaneRunnerAPIVersion [0.9.38]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.162.0':**

* [action] App Store Connect API Key for register_device and register_devices (#17426) via Josh Holtz
* [snapshot] update SnapshotHelper.swift to work with tvOS (#17360) via Pierre Felgines
* [deliver] fix comment about using `force` option (#17387) via Paul BROWN
* [cert][deliver][match][precheck][sigh]  pull "api_key" config from shared lane context. (#17390) via Roger Oba
* [gym] fix building project with unicode characters in a name (#17397) via Daniel Jankowski
* [action] add is_key_content_base64 to app_store_connect_api_key to make easier for env and CI (#17401) via Josh Holtz
* [actions] add App Store Connect API key to app_store_build_number action (#17413) via Jake Wood
* [spaceship] show proper 401 error message for Spaceship::ConnectAPI (#17393) via Josh Holtz
* [deliver] make automatic_release optional for app types that aren't a ble to set it (like Apple Arcade and Pre Release) (#17383) via Josh Holtz
* [sigh] fix download_all to also use App Store Connect API Key (#17382) via Josh Holtz
* [Fastlane.Swift] fix: beforeAll method not called (#17336) via Jean Mainguy
