### PR TITLE
[sigh] fix undefined method owner_name with display_name in Sigh::Runner

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -303,7 +303,7 @@ module Sigh
         end
 
         if Sigh.config[:cert_owner_name]
-          next unless c.owner_name.strip == Sigh.config[:cert_owner_name].strip
+          next unless c.display_name.strip == Sigh.config[:cert_owner_name].strip
         end
 
         true
@@ -327,7 +327,7 @@ module Sigh
         UI.important("Found more than one code signing identity. Choosing the first one. Check out `fastlane sigh --help` to see all available options.")
         UI.important("Available Code Signing Identities for current filters:")
         certificates.each do |c|
-          str = ["\t- Name:", c.owner_name, "- ID:", c.id + " - Expires", c.expires.strftime("%d/%m/%Y")].join(" ")
+          str = ["\t- Name:", c.display_name, "- ID:", c.id + " - Expires", c.expires.strftime("%d/%m/%Y")].join(" ")
           UI.message(str.green)
         end
       end

--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -51,10 +51,6 @@ module Spaceship
         Time.parse(expiration_date) > Time.now
       end
 
-      def owner_name
-        [requester_first_name, requester_last_name].join ' '
-      end
-
       # Create a new code signing request that can be used to
       # generate a new certificate
       # @example

--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -51,6 +51,10 @@ module Spaceship
         Time.parse(expiration_date) > Time.now
       end
 
+      def owner_name
+        [requester_first_name, requester_last_name].join ' '
+      end
+
       # Create a new code signing request that can be used to
       # generate a new certificate
       # @example


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
`owner_name` was deprecated. `requester_first_name` + `requester_last_name` appears to be the new fields.
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/fastlane/fastlane/issues/17428

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/addbrick.git", :branch => "brick/cert_owner_name_helper"
```
