### PR TITLE
[action] fix register_devices to compare udids without case

### DIFF
--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -53,7 +53,10 @@ module Fastlane
         existing_devices = Spaceship::ConnectAPI::Device.all
 
         device_objs = new_devices.map do |device|
-          next if existing_devices.map(&:udid).include?(device[0])
+          if existing_devices.map(&:udid).map(&:downcase).include?(device[0].downcase)
+            UI.verbose("UDID #{device[0]} already exists - Skipping...")
+            next
+          end
 
           device_platform = platform
 


### PR DESCRIPTION
### Motivation and Context
Fixes #17429

### Description
- It seems like the App Store Connect API might sometimes return UDIDs with a different case for devices. We are now going to do a case insensitive compare to be safe 😇 

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-register_devices-downcase-udid"
```
