### PR TITLE
[sigh] fixed "\x82" from ASCII-8BIT to UTF-8

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -139,7 +139,7 @@ module Sigh
           # Skip certificates that failed to download
           next unless current_cert[:downloaded]
           file = Tempfile.new('cert')
-          file.write(current_cert[:downloaded])
+          file.write(current_cert[:downloaded].force_encoding('UTF-8'))
           file.close
           if FastlaneCore::CertChecker.installed?(file.path)
             installed = true
@@ -315,7 +315,7 @@ module Sigh
           certificates = certificates.find_all do |c|
             file = Tempfile.new('cert')
             raw_data = Base64.decode64(c.certificate_content)
-            file.write(raw_data)
+            file.write(raw_data.force_encoding("UTF-8"))
             file.close
 
             FastlaneCore::CertChecker.installed?(file.path)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->
fixed ["\x82" from ASCII-8BIT to UTF-8](https://github.com/fastlane/fastlane/issues/17400)

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
No matter what the encoding of your operating environment is, I will convert the content to utf-8 encoding

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
1. add `gem "fastlane", git:"https://github.com/philCc/fastlane.git"` in your Gemfile
2. run `bundle update fastlane`
3. run your fastlane task