### PR TITLE
[match] add `codesign:` to partition IDs in match's `keychain_importer`

### DIFF
--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -39,7 +39,7 @@ module FastlaneCore
       # See https://openradar.appspot.com/28524119
       if Helper.backticks('security -h | grep set-key-partition-list', print: false).length > 0
         command = "security set-key-partition-list"
-        command << " -S apple-tool:,apple:"
+        command << " -S apple-tool:,apple:,codesign:"
         command << " -s" # This is a needed in Catalina to prevent "security: SecKeychainItemCopyAccess: A missing value was detected."
         command << " -k #{keychain_password.to_s.shellescape}"
         command << " #{keychain_path.shellescape}"

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -17,7 +17,7 @@ describe Match do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
+        expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
@@ -36,7 +36,7 @@ describe Match do
         expected_command = "security import item.path -k '#{keychain}' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{keychain} 1> /dev/null"
+        expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{''.shellescape} #{keychain} 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with(keychain).and_return(true)
@@ -61,7 +61,7 @@ describe Match do
         expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-        expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db 1> /dev/null"
+        expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db 1> /dev/null"
 
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)
@@ -79,7 +79,7 @@ describe Match do
           expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
 
           # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-          expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{'user_entered'.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
+          expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{'user_entered'.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
 
           allow(Security::InternetPassword).to receive(:find).and_return(nil)
           allow(FastlaneCore::UI).to receive(:interactive?).and_return(true)
@@ -102,7 +102,7 @@ describe Match do
           expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild 1> /dev/null"
 
           # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
-          expected_partition_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{'from_keychain'.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
+          expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{'from_keychain'.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
 
           item = double
           allow(item).to receive(:password).and_return('from_keychain')


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves #16989 

### Description

This should fix the `errSecInternalComponent` errors as well as the `error: The specified item could not be found in the keychain`. More details can be found in #16989 

This PR simply commits the change proposed by @jakubgs 😇 

### Testing Steps

To test, update your `Gemfile` with the following content:

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-codesign-partition-id"
```

Then run `bundle install`, `bundle update fastlane`, or `bundle update`.