### PR TITLE
[scan] add Catalyst support

### DIFF
--- a/Testing.md
+++ b/Testing.md
@@ -93,7 +93,7 @@ bundle update
 in your project’s root directory. After doing so, you can verify you’re using the local version by running
 
 ```
-bundle show fastlane
+bundle info fastlane
 ```
 
 which should print out the path to your local development environment.

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -209,7 +209,9 @@ module Scan
       end
 
       # building up the destination now
-      if Scan.devices && Scan.devices.count > 0
+      if Scan.building_mac_catalyst_for_mac?
+        Scan.config[:destination] = "platform=macOS,variant=Mac Catalyst"
+      elsif Scan.devices && Scan.devices.count > 0
         Scan.config[:destination] = Scan.devices.map { |d| "platform=#{d.os_type} Simulator,id=#{d.udid}" }
       elsif Scan.project.mac_app?
         Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -210,7 +210,7 @@ module Scan
 
       # building up the destination now
       if Scan.building_mac_catalyst_for_mac?
-        Scan.config[:destination] = "platform=macOS,variant=Mac Catalyst"
+        Scan.config[:destination] = ["platform=macOS,variant=Mac Catalyst"]
       elsif Scan.devices && Scan.devices.count > 0
         Scan.config[:destination] = Scan.devices.map { |d| "platform=#{d.os_type} Simulator,id=#{d.udid}" }
       elsif Scan.project.mac_app?

--- a/scan/lib/scan/module.rb
+++ b/scan/lib/scan/module.rb
@@ -21,6 +21,10 @@ module Scan
     def scanfile_name
       "Scanfile"
     end
+
+    def building_mac_catalyst_for_mac?
+      Scan.project.supports_mac_catalyst? && Scan.config[:catalyst_platform] == "macos"
+    end
   end
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -419,6 +419,15 @@ module Scan
                                      description: "Use only if you're a pro, use the other options instead",
                                      is_string: false,
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :catalyst_platform,
+                                     env_name: "SCAN_CATALYST_PLATFORM",
+                                     description: "Platform to build when using a Catalyst enabled app. Valid values are: ios, macos",
+                                     type: String,
+                                     optional: true,
+                                     verify_block: proc do |value|
+                                       av = %w(ios macos)
+                                       UI.user_error!("Unsupported export_method '#{value}', must be: #{av}") unless av.include?(value)
+                                     end),
         FastlaneCore::ConfigItem.new(key: :custom_report_file_name,
                                      env_name: "SCAN_CUSTOM_REPORT_FILE_NAME",
                                      description: "Sets custom full report file name when generating a single report",

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -16,21 +16,21 @@ describe Scan do
     end
 
     describe "#detect_destination" do
-      it "ios" do
+      it "ios", requires_xcodebuild: true do
         options = { project: "./scan/examples/standard/app.xcodeproj" }
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         expect(Scan.config[:destination].first).to match(/platform=iOS/)
       end
 
       context "catalyst" do
-        it "ios" do
+        it "ios", requires_xcodebuild: true do
           options = { project: "./scan/examples/standard/app.xcodeproj" }
           expect_any_instance_of(FastlaneCore::Project).to receive(:supports_mac_catalyst?).and_return(true)
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
           expect(Scan.config[:destination].first).to match(/platform=iOS/)
         end
 
-        it "mac" do
+        it "mac", requires_xcodebuild: true do
           options = { project: "./scan/examples/standard/app.xcodeproj", catalyst_platform: "macos" }
           expect_any_instance_of(FastlaneCore::Project).to receive(:supports_mac_catalyst?).and_return(true)
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -15,6 +15,30 @@ describe Scan do
       end
     end
 
+    describe "#detect_destination" do
+      it "ios" do
+        options = { project: "./scan/examples/standard/app.xcodeproj" }
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        expect(Scan.config[:destination].first).to match(/platform=iOS/)
+      end
+
+      context "catalyst" do
+        it "ios" do
+          options = { project: "./scan/examples/standard/app.xcodeproj" }
+          expect_any_instance_of(FastlaneCore::Project).to receive(:supports_mac_catalyst?).and_return(true)
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+          expect(Scan.config[:destination].first).to match(/platform=iOS/)
+        end
+
+        it "mac" do
+          options = { project: "./scan/examples/standard/app.xcodeproj", catalyst_platform: "macos" }
+          expect_any_instance_of(FastlaneCore::Project).to receive(:supports_mac_catalyst?).and_return(true)
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+          expect(Scan.config[:destination].first).to match(/platform=macOS,variant=Mac Catalyst/)
+        end
+      end
+    end
+
     describe "validation" do
       it "advises of problems with multiple output_types and a custom_report_file_name", requires_xcodebuild: true do
         options = {


### PR DESCRIPTION
Add a catalyst_platform param to allow running tests of Catalyst-enabled iOS apps on macOS similar to how gym supports building Catalyst apps.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR builds on #12195 and and obviates the need for the workaround to run tests for Catalyst applications described in issue #15719.

### Description

This PR adds a `catalyst_platform` parameter to scan. Allowed values are `ios` and `macos` which allow to run tests on the iOS device (as before) or on the local Mac (new).

### Testing Steps

I've tested the local change with a Swift-based configuration as follows:
```
  func testMacOSLane() {
    desc("Runs all the tests")
    runTests(project: project, scheme: scheme, configuration: "Automation", catalystPlatform: "macos")
  }
```