### PR TITLE
[fastlane_core][deliver] allow FASTLANE_ITUNES_TRANSPORTER_PATH to work again

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -203,9 +203,17 @@ module FastlaneCore
       return File.join(self.itms_path, 'iTMSTransporter')
     end
 
+    def self.user_defined_itms_path?
+      return FastlaneCore::Env.truthy?("FASTLANE_ITUNES_TRANSPORTER_PATH")
+    end
+
+    def self.user_defined_itms_path
+      return ENV["FASTLANE_ITUNES_TRANSPORTER_PATH"] if self.user_defined_itms_path?
+    end
+
     # @return the full path to the iTMSTransporter executable
     def self.itms_path
-      return ENV["FASTLANE_ITUNES_TRANSPORTER_PATH"] if FastlaneCore::Env.truthy?("FASTLANE_ITUNES_TRANSPORTER_PATH")
+      return self.user_defined_itms_path if FastlaneCore::Env.truthy?("FASTLANE_ITUNES_TRANSPORTER_PATH")
 
       if self.mac?
         # First check for manually install iTMSTransporter

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -254,7 +254,7 @@ module FastlaneCore
   class JavaTransporterExecutor < TransporterExecutor
     def build_upload_command(username, password, source = "/tmp", provider_short_name = "", jwt = nil)
       use_jwt = !jwt.to_s.empty?
-      if Helper.mac? && Helper.xcode_at_least?(11)
+      if !Helper.user_defined_itms_path? && Helper.mac? && Helper.xcode_at_least?(11)
         [
           ("ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}" unless use_jwt),
           'xcrun iTMSTransporter',
@@ -294,7 +294,7 @@ module FastlaneCore
 
     def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "", jwt = nil)
       use_jwt = !jwt.to_s.empty?
-      if Helper.mac? && Helper.xcode_at_least?(11)
+      if !Helper.user_defined_itms_path? && Helper.mac? && Helper.xcode_at_least?(11)
         [
           ("ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}" unless use_jwt),
           'xcrun iTMSTransporter',
@@ -332,7 +332,7 @@ module FastlaneCore
 
     def build_provider_ids_command(username, password, jwt = nil)
       use_jwt = !jwt.to_s.empty?
-      if Helper.mac? && Helper.xcode_at_least?(11)
+      if !Helper.user_defined_itms_path? && Helper.mac? && Helper.xcode_at_least?(11)
         [
           ("ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}" unless use_jwt),
           'xcrun iTMSTransporter',

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -135,6 +135,42 @@ describe FastlaneCore do
       it "#xcode_version", requires_xcode: true do
         expect(FastlaneCore::Helper.xcode_version).to match(/^\d[\.\d]+$/)
       end
+
+      context "#user_defined_itms_path?" do
+        it "not defined", requires_xcode: true do
+          stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
+          expect(FastlaneCore::Helper.user_defined_itms_path?).to be(false)
+        end
+
+        it "is defined", requires_xcode: true do
+          stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/some/path/to/something' })
+          expect(FastlaneCore::Helper.user_defined_itms_path?).to be(true)
+        end
+      end
+
+      context "#user_defined_itms_path" do
+        it "not defined", requires_xcode: true do
+          stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
+          expect(FastlaneCore::Helper.user_defined_itms_path).to be(nil)
+        end
+
+        it "is defined", requires_xcode: true do
+          stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/some/path/to/something' })
+          expect(FastlaneCore::Helper.user_defined_itms_path).to eq('/some/path/to/something')
+        end
+      end
+
+      context "#itms_path" do
+        it "default", requires_xcode: true do
+          stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
+          expect(FastlaneCore::Helper.itms_path).to match(/itms/)
+        end
+
+        it "uses FASTLANE_ITUNES_TRANSPORTER_PATH", requires_xcode: true do
+          stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/some/path/to/something' })
+          expect(FastlaneCore::Helper.itms_path).to eq('/some/path/to/something')
+        end
+      end
     end
 
     describe "#zip_directory" do

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -647,13 +647,17 @@ describe FastlaneCore do
     end
 
     describe "with Xcode 11.x installed" do
+      before(:each) do
+        allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('11.1')
+        allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+        allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
+      end
+
       describe "with username and password" do
         describe "with default itms_path" do
           before(:each) do
-            allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('11.1')
-            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
-            allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
             allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
           end
 
           describe "upload command generation" do
@@ -695,9 +699,6 @@ describe FastlaneCore do
 
         describe "with user defined itms_path" do
           before(:each) do
-            allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('11.1')
-            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
-            allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
             stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/tmp' })
           end
 
@@ -718,6 +719,11 @@ describe FastlaneCore do
       end
 
       describe "with JWT" do
+        before(:each) do
+          allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+          stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
+        end
+
         describe "upload command generation" do
           it 'generates a call to xcrun iTMSTransporter' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -59,7 +59,7 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def java_upload_command(provider_short_name: nil, transporter: nil, jwt: nil)
+    def java_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, classpath: true)
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
@@ -69,8 +69,9 @@ describe FastlaneCore do
         '-Xms1024m',
         '-Djava.awt.headless=true',
         '-Dsun.net.http.retryPost=false',
-        "-classpath #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}",
-        'com.apple.transporter.Application',
+        ("-classpath #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}" if classpath),
+        ('com.apple.transporter.Application' if classpath),
+        ("-jar #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}" unless classpath),
         "-m upload",
         ("-u #{email.shellescape}" if jwt.nil?),
         ("-p #{password.shellescape}" if jwt.nil?),
@@ -83,7 +84,7 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def java_download_command(provider_short_name = nil, jwt: nil)
+    def java_download_command(provider_short_name = nil, jwt: nil, classpath: true)
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
         "-Djava.ext.dirs=#{FastlaneCore::Helper.transporter_java_ext_dir.shellescape}",
@@ -93,8 +94,9 @@ describe FastlaneCore do
         '-Xms1024m',
         '-Djava.awt.headless=true',
         '-Dsun.net.http.retryPost=false',
-        "-classpath #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}",
-        'com.apple.transporter.Application',
+        ("-classpath #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}" if classpath),
+        ('com.apple.transporter.Application' if classpath),
+        ("-jar #{FastlaneCore::Helper.transporter_java_jar_path.shellescape}" unless classpath),
         '-m lookupMetadata',
         ("-u #{email.shellescape}" if jwt.nil?),
         ("-p #{password.shellescape}" if jwt.nil?),
@@ -649,43 +651,68 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('11.1')
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
       end
 
       describe "with username and password" do
-        describe "upload command generation" do
-          it 'generates a call to xcrun iTMSTransporter' do
-            transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+        describe "with default itms_path" do
+          before(:each) do
+            allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+          end
+
+          describe "upload command generation" do
+            it 'generates a call to xcrun iTMSTransporter' do
+              transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
+              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+            end
+          end
+
+          describe "upload command generation with DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS set" do
+            before(:each) { ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV,Signiant" }
+
+            it 'generates a call to java directly' do
+              transporter = FastlaneCore::ItunesTransporter.new(email, password)
+              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant"))
+            end
+
+            after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
+          end
+
+          describe "upload command generation with DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS set with empty string" do
+            before(:each) { ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = " " }
+
+            it 'generates a call to java directly' do
+              transporter = FastlaneCore::ItunesTransporter.new(email, password)
+              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+            end
+
+            after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
+          end
+
+          describe "download command generation" do
+            it 'generates a call to xcrun iTMSTransporter' do
+              transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
+              expect(transporter.download('my.app.id', '/tmp')).to eq(xcrun_download_command)
+            end
           end
         end
 
-        describe "upload command generation with DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS set" do
-          before(:each) { ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV,Signiant" }
-
-          it 'generates a call to java directly' do
-            transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant"))
+        describe "with user defined itms_path" do
+          before(:each) do
+            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/tmp' })
           end
 
-          after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
-        end
-
-        describe "upload command generation with DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS set with empty string" do
-          before(:each) { ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = " " }
-
-          it 'generates a call to java directly' do
-            transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+          describe "upload command generation" do
+            it 'generates a call to xcrun iTMSTransporter' do
+              transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
+              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(classpath: false))
+            end
           end
 
-          after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
-        end
-
-        describe "download command generation" do
-          it 'generates a call to xcrun iTMSTransporter' do
-            transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(xcrun_download_command)
+          describe "download command generation" do
+            it 'generates a call to xcrun iTMSTransporter' do
+              transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
+              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command(classpath: false))
+            end
           end
         end
       end

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -647,15 +647,12 @@ describe FastlaneCore do
     end
 
     describe "with Xcode 11.x installed" do
-      before(:each) do
-        allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('11.1')
-        allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
-        allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
-      end
-
       describe "with username and password" do
         describe "with default itms_path" do
           before(:each) do
+            allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('11.1')
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+            allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
             allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
           end
 
@@ -698,6 +695,9 @@ describe FastlaneCore do
 
         describe "with user defined itms_path" do
           before(:each) do
+            allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('11.1')
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+            allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
             stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/tmp' })
           end
 


### PR DESCRIPTION
### Motivation and Context
Fixes #17448

### Description
- Fallback to using java upload command (not xcrun) when `FASTLANE_ITUNES_TRANSPORTER_PATH` is given
- Added tests in both `FastlaneCore::Helper` and `FastlaneCore::ItmsTransporter` that would have caught this 🤷‍♂️ 

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-allow-FASTLANE_ITUNES_TRANSPORTER_PATH-again"
```
