### PR TITLE
[supply] remove promoGraphic since no longer supported

### DIFF
--- a/supply/lib/supply.rb
+++ b/supply/lib/supply.rb
@@ -16,7 +16,7 @@ module Supply
   end
 
   AVAILABLE_METADATA_FIELDS = %w(title short_description full_description video)
-  IMAGES_TYPES = %w(featureGraphic icon promoGraphic tvBanner)
+  IMAGES_TYPES = %w(featureGraphic icon tvBanner)
   SCREENSHOT_TYPES = %w(phoneScreenshots sevenInchScreenshots tenInchScreenshots tvScreenshots wearScreenshots)
 
   IMAGES_FOLDER_NAME = "images"

--- a/supply/lib/supply.rb
+++ b/supply/lib/supply.rb
@@ -16,7 +16,7 @@ module Supply
   end
 
   AVAILABLE_METADATA_FIELDS = %w(title short_description full_description video)
-  IMAGES_TYPES = %w(featureGraphic icon tvBanner)
+  IMAGES_TYPES = %w(featureGraphic icon tvBanner) # https://developers.google.com/android-publisher/api-ref/rest/v3/AppImageType
   SCREENSHOT_TYPES = %w(phoneScreenshots sevenInchScreenshots tenInchScreenshots tvScreenshots wearScreenshots)
 
   IMAGES_FOLDER_NAME = "images"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fix issue with promoGraphic/image

No longer listed in https://developers.google.com/android-publisher/api-ref/rest/v3/AppImageType