### PR TITLE
[action] update_fastlane fixed for rubygems >= 3.1.0 and added homebrew support

### DIFF
--- a/fastlane/lib/fastlane/actions/update_fastlane.rb
+++ b/fastlane/lib/fastlane/actions/update_fastlane.rb
@@ -45,30 +45,46 @@ module Fastlane
         end
 
         # suppress updater output - very noisy
-        Gem::DefaultUserInteraction.ui = Gem::SilentUI.new
+        Gem::DefaultUserInteraction.ui = Gem::SilentUI.new unless FastlaneCore::Globals.verbose?
 
         update_needed.each do |tool_info|
-          tool = tool_info[0]
+          tool = self.get_gem_name(tool_info)
           local_version = Gem::Version.new(highest_versions[tool].version)
           latest_official_version = FastlaneCore::UpdateChecker.fetch_latest(tool)
 
           UI.message("Updating #{tool} from #{local_version.to_s.yellow} to #{latest_official_version.to_s.yellow}... 🚀")
 
-          # Approximate_recommendation will create a string like "~> 0.10" from a version 0.10.0, e.g. one that is valid for versions >= 0.10 and <1.0
-          requirement_version = local_version.approximate_recommendation
-          updater.update_gem(tool, Gem::Requirement.new(requirement_version))
+          if Helper.homebrew?
+            Helper.backticks('brew upgrade fastlane')
+          else
+            # Approximate_recommendation will create a string like "~> 0.10" from a version 0.10.0, e.g. one that is valid for versions >= 0.10 and <1.0
+            requirement_version = local_version.approximate_recommendation
+            updater.update_gem(tool, Gem::Requirement.new(requirement_version))
+          end
 
           UI.success("Finished updating #{tool}")
         end
 
-        UI.message("Cleaning up old versions...")
-        cleaner.options[:args] = tools_to_update
-        cleaner.execute
+        unless Helper.homebrew?
+          UI.message("Cleaning up old versions...")
+          cleaner.options[:args] = tools_to_update
+          cleaner.execute
+        end
 
         UI.message("fastlane.tools successfully updated! I will now restart myself... 😴")
 
         # Set no_update to true so we don't try to update again
         exec("FL_NO_UPDATE=true #{$PROGRAM_NAME} #{ARGV.join(' ')}")
+      end
+
+      def self.get_gem_name(tool_info)
+        if tool_info.kind_of?(Array)
+          return tool_info[0]
+        elsif tool_info.respond_to?(:name) # Gem::NameTuple in RubyGems >= 3.1.0
+          return tool_info.name
+        else
+          UI.crash!("Unknown gem update information returned from RubyGems. Please file a new issue for this... 🤷")
+        end
       end
 
       def self.description

--- a/fastlane/spec/actions_specs/update_fastlane_spec.rb
+++ b/fastlane/spec/actions_specs/update_fastlane_spec.rb
@@ -1,0 +1,122 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "update_fastlane" do
+      let(:mock_updater) { double("mock_updater") }
+      let(:mock_cleanup) { double("mock_cleanup") }
+      let(:mock_instance) do
+        {
+          update: mock_updater,
+          cleanup: mock_cleanup
+        }
+      end
+
+      it "when no update needed" do
+        expect(Gem::CommandManager).to receive(:instance).and_return(mock_instance).twice
+
+        expect(UI).to receive(:success).with("Driving the lane 'test' 🚀")
+        expect(UI).to receive(:message).with("Looking for updates for fastlane...")
+        expect(UI).to receive(:success).with("Nothing to update ✅")
+
+        expect(mock_updater).to receive(:highest_installed_gems).and_return({})
+        expect(mock_updater).to receive(:which_to_update).and_return({})
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          update_fastlane
+        end").runner.execute(:test)
+      end
+
+      it "when update with RubyGems" do
+        expect(Gem::CommandManager).to receive(:instance).and_return(mock_instance).twice
+
+        # Start
+        expect(UI).to receive(:success).with("Driving the lane 'test' 🚀")
+        expect(UI).to receive(:message).with("Looking for updates for fastlane...")
+
+        # Find outdated version
+        expect(mock_updater).to receive(:highest_installed_gems).and_return({
+          "fastlane" => Gem::Specification.new do |s|
+            s.name        = 'fastlane'
+            s.version     = '2.143.0'
+          end
+        })
+        expect(mock_updater).to receive(:which_to_update).and_return([["fastlane", "2.143.0"]])
+
+        # Fetch latest version and update
+        expect(FastlaneCore::UpdateChecker).to receive(:fetch_latest).and_return("2.165.0")
+        expect(UI).to receive(:message).with(/Updating fastlane from/)
+        expect(mock_updater).to receive(:update_gem)
+        expect(UI).to receive(:success).with("Finished updating fastlane")
+
+        # Clean
+        expect(UI).to receive(:message).with("Cleaning up old versions...")
+        expect(mock_cleanup).to receive(:options).and_return({})
+        expect(mock_cleanup).to receive(:execute)
+
+        # Restart process
+        expect(UI).to receive(:message).with("fastlane.tools successfully updated! I will now restart myself... 😴")
+        expect(Fastlane::Actions::UpdateFastlaneAction).to receive(:exec)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          update_fastlane
+        end").runner.execute(:test)
+      end
+
+      it "when update with Homebrew" do
+        expect(Fastlane::Helper).to receive(:homebrew?).and_return(true).twice
+        expect(Gem::CommandManager).to receive(:instance).and_return(mock_instance).twice
+
+        # Start
+        expect(UI).to receive(:success).with("Driving the lane 'test' 🚀")
+        expect(UI).to receive(:message).with("Looking for updates for fastlane...")
+
+        # Find outdated version
+        expect(mock_updater).to receive(:highest_installed_gems).and_return({
+          "fastlane" => Gem::Specification.new do |s|
+            s.name        = 'fastlane'
+            s.version     = '2.143.0'
+          end
+        })
+        expect(mock_updater).to receive(:which_to_update).and_return([["fastlane", "2.143.0"]])
+
+        # Fetch latest version and update
+        expect(FastlaneCore::UpdateChecker).to receive(:fetch_latest).and_return("2.165.0")
+        expect(UI).to receive(:message).with(/Updating fastlane from/)
+        expect(Fastlane::Helper).to receive(:backticks).with("brew upgrade fastlane")
+        expect(UI).to receive(:success).with("Finished updating fastlane")
+
+        # Restart process
+        expect(UI).to receive(:message).with("fastlane.tools successfully updated! I will now restart myself... 😴")
+        expect(Fastlane::Actions::UpdateFastlaneAction).to receive(:exec)
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          update_fastlane
+        end").runner.execute(:test)
+      end
+
+      describe "#get_gem_name" do
+        it "with RubyGems < 3.1" do
+          require 'rubygems'
+          tool_info = ["fastlane", Gem::Version.new("1.2.3")]
+          name = Fastlane::Actions::UpdateFastlaneAction.get_gem_name(tool_info)
+          expect(name).to eq("fastlane")
+        end
+
+        it "with RubyGems >= 3.1" do
+          tool_info = OpenStruct.new
+          tool_info.name = "fastlane"
+          tool_info.version = "1.2.3"
+
+          name = Fastlane::Actions::UpdateFastlaneAction.get_gem_name(tool_info)
+          expect(name).to eq("fastlane")
+        end
+
+        it "with unsupported RubyGems" do
+          expect do
+            tool_info = OpenStruct.new
+            Fastlane::Actions::UpdateFastlaneAction.get_gem_name(tool_info)
+          end.to raise_error(FastlaneCore::Interface::FastlaneCrash, /Unknown gem update information returned from RubyGems. Please file a new issue for this/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation and Context
Fixes #16127

### Description
- RubyGems >= 3.1.0 returns an array of `Gem::NameTuple` instead of an array of arrays and `update_fastlane` now handles both
  - Looks for first element in array if array
  - Gets `name` attribute from tuple 
  - Otherwise errors
- Also calls `brew upgrade fastlane` if homebrew install 
