### PR TITLE
[fastlane_core] install both old and new WWDR certificates

### DIFF
--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -2,7 +2,7 @@ describe FastlaneCore do
   describe FastlaneCore::CertChecker do
     describe '#installed_identies' do
       it 'should print an error when no local code signing identities are found' do
-        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
+        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificates_installed?).and_return(true)
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
         expect(FastlaneCore::UI).to receive(:error).with(/There are no local code signing identities found/)
 
@@ -10,11 +10,19 @@ describe FastlaneCore do
       end
 
       it 'should not be fooled by 10 local code signing identities available' do
-        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
+        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificates_installed?).and_return(true)
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
         expect(FastlaneCore::UI).not_to(receive(:error))
 
         FastlaneCore::CertChecker.installed_identies
+      end
+    end
+
+    describe '#install_wwdr_certificates' do
+      it 'should install all the official WWDR certificates' do
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with(/AppleWWDRCA/)
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with(/AppleWWDRCAG3/)
+        FastlaneCore::CertChecker.install_wwdr_certificates
       end
     end
 
@@ -27,7 +35,7 @@ describe FastlaneCore do
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
         expect(FastlaneCore::Helper).to receive(:backticks).with(name_regex, anything).and_return("")
 
-        FastlaneCore::CertChecker.wwdr_certificate_installed?
+        FastlaneCore::CertChecker.wwdr_certificates_installed?
       end
 
       it 'uses the correct command to import it' do
@@ -41,7 +49,7 @@ describe FastlaneCore do
         expect(Open3).to receive(:capture3).with(cmd).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-        expect(FastlaneCore::CertChecker.install_wwdr_certificate).to be(true)
+        expect(FastlaneCore::CertChecker.install_wwdr_certificate('https://developer.apple.com/certificationauthority/AppleWWDRCA.cer')).to be(true)
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Closes #17328

### Description
Modified `CertChecker` to install both the older WWDR certificate and the new one.

### Testing Steps
* updated unit tests
* tested the patch against my private project, which has recently had a new enterprise certificate generated, causing build failures in CI due to the missing WWDR certificate.