### PR TITLE
[cert] fix issues where to_pem wasn't always getting called when creating a cert

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -190,7 +190,7 @@ module Cert
       begin
         certificate = Spaceship::ConnectAPI::Certificate.create(
           certificate_type: certificate_type,
-          csr_content: csr
+          csr_content: csr.to_pem
         )
       rescue => ex
         type_name = (Cert.config[:development] ? "Development" : "Distribution")


### PR DESCRIPTION
### Motivation and Context
Fixes #17384

### Description
Looks like `to_pem` was getting called implicitly for most users but not all 🤔 So this should totally do it now
