### PR TITLE
Version bump to 2.166.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
 </td>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/endocrimes'>
@@ -46,11 +46,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
@@ -58,37 +64,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
 </tr>
 <tr>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
@@ -98,11 +98,23 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
 <td id='iulian-onofrei'>
 <a href='https://github.com/revolter'>
@@ -110,69 +122,57 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-</tr>
-<tr>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
-</td>
-</tr>
-<tr>
 <td id='maksym-grebenets'>
 <a href='https://github.com/mgrebenets'>
 <img src='https://github.com/mgrebenets.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+</tr>
+<tr>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+</tr>
+<tr>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Jorge Revuelta H",
-                        "Matthew Ellis",
-                        "Felix Krause",
+  spec.authors       = ["Andrew McBurney",
+                        "Joshua Liebowitz",
+                        "Max Ott",
                         "Josh Holtz",
-                        "Danielle Tomlinson",
                         "Jérôme Lacoste",
-                        "Kohki Miki",
-                        "Maksym Grebenets",
+                        "Stefan Natchev",
+                        "Olivier Halligon",
+                        "Jorge Revuelta H",
+                        "Jan Piotrowski",
+                        "Helmut Januschka",
+                        "Matthew Ellis",
+                        "Manu Wallner",
                         "Aaron Brager",
                         "Jimmy Dee",
-                        "Max Ott",
+                        "Maksym Grebenets",
+                        "Daniel Jankowski",
                         "Luka Mirosevic",
-                        "Manu Wallner",
-                        "Jan Piotrowski",
-                        "Stefan Natchev",
-                        "Andrew McBurney",
+                        "Danielle Tomlinson",
                         "Fumiya Nakamura",
                         "Iulian Onofrei",
-                        "Olivier Halligon",
-                        "Joshua Liebowitz",
-                        "Daniel Jankowski",
-                        "Helmut Januschka"]
+                        "Felix Krause",
+                        "Kohki Miki"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.165.0'.freeze
+  VERSION = '2.166.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -17,4 +17,4 @@ public class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.165.0
+// Generated with fastlane 2.166.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -256,4 +256,4 @@ public extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.48]
+// FastlaneRunnerAPIVersion [0.9.49]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -6077,6 +6077,7 @@ public func rubyVersion() {
    - skipSlack: Don't publish to slack, even when an URL is given
    - slackOnlyOnFailure: Only post on Slack if the tests fail
    - destination: Use only if you're a pro, use the other options instead
+   - catalystPlatform: Platform to build when using a Catalyst enabled app. Valid values are: ios, macos
    - customReportFileName: **DEPRECATED!** Use `--output_files` instead - Sets custom full report file name when generating a single report
    - xcodebuildCommand: Allows for override of the default `xcodebuild` command
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
@@ -6143,6 +6144,7 @@ public func runTests(workspace: String? = nil,
                      skipSlack: Bool = false,
                      slackOnlyOnFailure: Bool = false,
                      destination: Any? = nil,
+                     catalystPlatform: String? = nil,
                      customReportFileName: String? = nil,
                      xcodebuildCommand: String = "env NSUnbufferedIO=YES xcodebuild",
                      clonedSourcePackagesPath: String? = nil,
@@ -6207,6 +6209,7 @@ public func runTests(workspace: String? = nil,
                                                                                              RubyCommand.Argument(name: "skip_slack", value: skipSlack),
                                                                                              RubyCommand.Argument(name: "slack_only_on_failure", value: slackOnlyOnFailure),
                                                                                              RubyCommand.Argument(name: "destination", value: destination),
+                                                                                             RubyCommand.Argument(name: "catalyst_platform", value: catalystPlatform),
                                                                                              RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
                                                                                              RubyCommand.Argument(name: "xcodebuild_command", value: xcodebuildCommand),
                                                                                              RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
@@ -6353,6 +6356,7 @@ public func say(text: Any,
    - skipSlack: Don't publish to slack, even when an URL is given
    - slackOnlyOnFailure: Only post on Slack if the tests fail
    - destination: Use only if you're a pro, use the other options instead
+   - catalystPlatform: Platform to build when using a Catalyst enabled app. Valid values are: ios, macos
    - customReportFileName: **DEPRECATED!** Use `--output_files` instead - Sets custom full report file name when generating a single report
    - xcodebuildCommand: Allows for override of the default `xcodebuild` command
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
@@ -6419,6 +6423,7 @@ public func scan(workspace: Any? = scanfile.workspace,
                  skipSlack: Bool = scanfile.skipSlack,
                  slackOnlyOnFailure: Bool = scanfile.slackOnlyOnFailure,
                  destination: Any? = scanfile.destination,
+                 catalystPlatform: Any? = scanfile.catalystPlatform,
                  customReportFileName: Any? = scanfile.customReportFileName,
                  xcodebuildCommand: Any = scanfile.xcodebuildCommand,
                  clonedSourcePackagesPath: Any? = scanfile.clonedSourcePackagesPath,
@@ -6483,6 +6488,7 @@ public func scan(workspace: Any? = scanfile.workspace,
                                                                                         RubyCommand.Argument(name: "skip_slack", value: skipSlack),
                                                                                         RubyCommand.Argument(name: "slack_only_on_failure", value: slackOnlyOnFailure),
                                                                                         RubyCommand.Argument(name: "destination", value: destination),
+                                                                                        RubyCommand.Argument(name: "catalyst_platform", value: catalystPlatform),
                                                                                         RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
                                                                                         RubyCommand.Argument(name: "xcodebuild_command", value: xcodebuildCommand),
                                                                                         RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
@@ -9399,4 +9405,4 @@ public let snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.101]
+// FastlaneRunnerAPIVersion [0.9.102]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -17,4 +17,4 @@ public class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.165.0
+// Generated with fastlane 2.166.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -184,4 +184,4 @@ public extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.51]
+// FastlaneRunnerAPIVersion [0.9.52]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -17,4 +17,4 @@ public class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.165.0
+// Generated with fastlane 2.166.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -184,4 +184,4 @@ public extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.45]
+// FastlaneRunnerAPIVersion [0.9.46]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -17,4 +17,4 @@ public class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.165.0
+// Generated with fastlane 2.166.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -48,4 +48,4 @@ public extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.44]
+// FastlaneRunnerAPIVersion [0.9.45]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -17,4 +17,4 @@ public class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.165.0
+// Generated with fastlane 2.166.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -179,6 +179,9 @@ public protocol ScanfileProtocol: class {
     /// Use only if you're a pro, use the other options instead
     var destination: String? { get }
 
+    /// Platform to build when using a Catalyst enabled app. Valid values are: ios, macos
+    var catalystPlatform: String? { get }
+
     /// **DEPRECATED!** Use `--output_files` instead - Sets custom full report file name when generating a single report
     var customReportFileName: String? { get }
 
@@ -252,6 +255,7 @@ public extension ScanfileProtocol {
     var skipSlack: Bool { return false }
     var slackOnlyOnFailure: Bool { return false }
     var destination: String? { return nil }
+    var catalystPlatform: String? { return nil }
     var customReportFileName: String? { return nil }
     var xcodebuildCommand: String { return "env NSUnbufferedIO=YES xcodebuild" }
     var clonedSourcePackagesPath: String? { return nil }
@@ -260,4 +264,4 @@ public extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.56]
+// FastlaneRunnerAPIVersion [0.9.57]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -17,4 +17,4 @@ public class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.165.0
+// Generated with fastlane 2.166.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -96,4 +96,4 @@ public extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.46]
+// FastlaneRunnerAPIVersion [0.9.47]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -17,4 +17,4 @@ public class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.165.0
+// Generated with fastlane 2.166.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -184,4 +184,4 @@ public extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.40]
+// FastlaneRunnerAPIVersion [0.9.41]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.165.0':**

* [cert] fix issues where to_pem wasn't always getting called when creating a cert (#17540) via Josh Holtz
* [action] update homebrew install for appledoc action (#17513) via seanmcneil
* [fastlane_core][deliver] allow FASTLANE_ITUNES_TRANSPORTER_PATH to work again (#17502) via Josh Holtz
* [action] update_fastlane fixed for rubygems > 3.1.0 and added homebrew support (#17530) via Josh Holtz
* [supply] remove promoGraphic since no longer supported (#17518) via Max Ott
* [snapshot] pass FASTLANE_LANGUAGE env variable to xcode for use in run scripts (#17505) via Josh Holtz
* Fixed typo with misspell (#17499) via Hiroshi SHIBATA
* [scan] add Catalyst support (#17496) via Ingmar Stein
