### PR TITLE
[fastlane_core] disable colors for colorize gem too

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,6 +95,7 @@ Require/MissingRequireStatement:
     - '**/spec/**/*.rb'
     - '**/spec_helper.rb'
     - 'spaceship/lib/spaceship/babosa_fix.rb'
+    - 'fastlane_core/lib/fastlane_core/ui/disable_colors.rb'
     - '**/Fastfile'
     - '**/*.gemspec'
     - 'rakelib/**/*'

--- a/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
+++ b/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
@@ -19,7 +19,7 @@ end
 # If a plugin uses the colorize gem, we also want to disable that
 begin
   require 'colorize'
-  String.disable_colorization = true 
+  String.disable_colorization = true
 rescue
   # Colorize gem is not used by any plugin
 end

--- a/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
+++ b/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
@@ -20,6 +20,6 @@ end
 begin
   require 'colorize'
   String.disable_colorization = true
-rescue
+rescue LoadError
   # Colorize gem is not used by any plugin
 end

--- a/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
+++ b/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
@@ -15,3 +15,11 @@ class String
     end
   end
 end
+
+# If a plugin uses the colorize gem, we also want to disable that
+begin
+  require 'colorize'
+  String.disable_colorization = true 
+rescue
+  # Colorize gem is not used by any plugin
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some plugins might use the colorize gem for coloring the texts. If we can import that, we should also disable the colors for that too. It would also override the String coloring methods that we disabled, making some of the output colored again.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Only fastlane in gem/pluginfile initially
```
export FASTLANE_DISABLE_COLORS=1
bundle install
bundle exec fastlane not_existing_lane
bundle exec fastlane add_plugin test_center
bundle install
bundle exec fastlane not_existing_lane
```
