### PR TITLE
[fastlane_core] use additional key for fetching bundle ID from provisioning profile (com.apple.application-identifier)

### DIFF
--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -47,7 +47,9 @@ module FastlaneCore
       def bundle_id(path, keychain_path = nil)
         profile = parse(path, keychain_path)
         app_id_prefix = profile["ApplicationIdentifierPrefix"].first
-        bundle_id = profile["Entitlements"]["application-identifier"].gsub("#{app_id_prefix}.", "")
+        entitlements = profile["Entitlements"]
+        app_identifier = entitlements["application-identifier"] || entitlements["com.apple.application-identifier"]
+        bundle_id = app_identifier.gsub("#{app_id_prefix}.", "")
         bundle_id
       rescue
         UI.error("Unable to extract the Bundle Id from the provided provisioning profile '#{path}'.")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fastlane fails to get bundle id from the provisioning profile
![image](https://user-images.githubusercontent.com/119268/98164405-e2bbb680-1eec-11eb-842e-65b937318f37.png)

After some investigation, we found that decoded provisioning profile will have slightly different key naming
```
<key>Entitlements</key>
<dict>
	...
	// New key
	<key>com.apple.application-identifier</key>   
	<string>TEAMIDXXXXXXX.com.mybundle.Myapp</string>
	...
	// Fastlane expects this key
	<key>application-identifier</key>   
	<string>TEAMIDXXXXXXX.com.mybundle.Myapp</string>	
</dict>
	
```

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This PR adds an additional check for the new key name.


### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
While I cannot post the distribution profile itself here, I suggest creating one for the Mac OS / AppStore Distribution. 
Two of our Mac OS / AppStore distribution profiles have `com.apple.application-identifier` key fro app id.  
iOS / AppStore distribution profile has the `application-identifier` key.   
