### PR TITLE
[screengrab] allow locales with underscores and map to dash (ex: en_US to en-US)

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -24,6 +24,8 @@ module Screengrab
     end
 
     def run
+      # Standardize the locales
+      @config[:locales].map! { |locale| locale.gsub("_", "-") }
       FastlaneCore::PrintTable.print_values(config: @config, hide_keys: [], title: "Summary for screengrab #{Fastlane::VERSION}")
 
       app_apk_path = @config.fetch(:app_apk_path, ask: false)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I ran into a problem today, I used capture_android_screenshots with "en_US" as a locale, and it failed to pull the screenshots.

Locales with underscores are valid for Android, so capture_android_screenshots runs fine until it's time to pull the screenshots.
The screenshot pulling breaks because the valid path is with a dash '-', like /data/data/com.myapp.prod/files/com.myapp.prod/screengrab/__de-DE__/images/screenshots for example

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Converts the @config[:locales] parameter from "__en_US__" to "__en-US__".
It permits the execution of:
```ruby
capture_android_screenshots(
  locales: ["en_US", "fr_FR", "ja_JP"],
  clear_previous_screenshots: true,
  app_apk_path: "build/outputs/apk/example-debug.apk",
  tests_apk_path: "build/outputs/apk/example-debug-androidTest-unaligned.apk"
)
```
### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
run
```ruby
capture_android_screenshots(
  locales: ["en_US", "fr_FR", "ja_JP"],
  clear_previous_screenshots: true,
  app_apk_path: "build/outputs/apk/example-debug.apk",
  tests_apk_path: "build/outputs/apk/example-debug-androidTest-unaligned.apk"
)
```