### PR TITLE
[match] fix recursion when MATCH_PASSWORD is not set

### DIFF
--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -30,6 +30,7 @@ module Match
 
       def encrypt_files
         files = []
+        password = fetch_password!
         iterate(self.working_directory) do |current|
           files << current
           encrypt_specific_file(path: current, password: password)
@@ -41,6 +42,7 @@ module Match
 
       def decrypt_files
         files = []
+        password = fetch_password!
         iterate(self.working_directory) do |current|
           files << current
           begin
@@ -50,8 +52,7 @@ module Match
             UI.error("Couldn't decrypt the repo, please make sure you enter the right password!")
             UI.user_error!("Invalid password passed via 'MATCH_PASSWORD'") if ENV["MATCH_PASSWORD"]
             clear_password
-            # After clearing the password from Keychain, retry if MATCH_PASSWORD is set
-            self.decrypt_files if ENV["MATCH_PASSWORD"]
+            self.decrypt_files
             return
           end
           UI.success("🔓  Decrypted '#{File.basename(current)}'") if FastlaneCore::Globals.verbose?
@@ -84,7 +85,7 @@ module Match
       end
 
       # Access the MATCH_PASSWORD, either from ENV variable, Keychain or user input
-      def password
+      def fetch_password!
         password = ENV["MATCH_PASSWORD"]
         unless password
           item = Security::InternetPassword.find(server: server_name(self.keychain_name))

--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -50,7 +50,8 @@ module Match
             UI.error("Couldn't decrypt the repo, please make sure you enter the right password!")
             UI.user_error!("Invalid password passed via 'MATCH_PASSWORD'") if ENV["MATCH_PASSWORD"]
             clear_password
-            self.decrypt_files # call itself
+            # After clearing the password from Keychain, retry if MATCH_PASSWORD is set
+            self.decrypt_files if ENV["MATCH_PASSWORD"]
             return
           end
           UI.success("🔓  Decrypted '#{File.basename(current)}'") if FastlaneCore::Globals.verbose?

--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -52,7 +52,7 @@ module Match
             UI.error("Couldn't decrypt the repo, please make sure you enter the right password!")
             UI.user_error!("Invalid password passed via 'MATCH_PASSWORD'") if ENV["MATCH_PASSWORD"]
             clear_password
-            self.decrypt_files
+            self.decrypt_files # Call itself
             return
           end
           UI.success("🔓  Decrypted '#{File.basename(current)}'") if FastlaneCore::Globals.verbose?

--- a/match/spec/commands_generator_spec.rb
+++ b/match/spec/commands_generator_spec.rb
@@ -89,7 +89,7 @@ describe Match::CommandsGenerator do
     end
 
     it "can use the git_url short flag from tool options" do
-      stub_const('ENV', {'MATCH_PASSWORD' => ''})
+      stub_const('ENV', { 'MATCH_PASSWORD' => '' })
       stub_commander_runner_args(['decrypt', '-r', 'git@github.com:you/your_repo.git'])
 
       expect_githelper_clone_with('git@github.com:you/your_repo.git', false, { branch: 'master', clone_branch_directly: false })
@@ -98,7 +98,7 @@ describe Match::CommandsGenerator do
     end
 
     it "can use the shallow_clone flag from tool options" do
-      stub_const('ENV', {'MATCH_PASSWORD' => ''})
+      stub_const('ENV', { 'MATCH_PASSWORD' => '' })
       stub_commander_runner_args(['decrypt', '-r', 'git@github.com:you/your_repo.git', '--shallow_clone', 'true'])
 
       expect_githelper_clone_with('git@github.com:you/your_repo.git', true, { branch: 'master', clone_branch_directly: false })

--- a/match/spec/commands_generator_spec.rb
+++ b/match/spec/commands_generator_spec.rb
@@ -89,6 +89,7 @@ describe Match::CommandsGenerator do
     end
 
     it "can use the git_url short flag from tool options" do
+      stub_const('ENV', {'MATCH_PASSWORD' => ''})
       stub_commander_runner_args(['decrypt', '-r', 'git@github.com:you/your_repo.git'])
 
       expect_githelper_clone_with('git@github.com:you/your_repo.git', false, { branch: 'master', clone_branch_directly: false })
@@ -97,6 +98,7 @@ describe Match::CommandsGenerator do
     end
 
     it "can use the shallow_clone flag from tool options" do
+      stub_const('ENV', {'MATCH_PASSWORD' => ''})
       stub_commander_runner_args(['decrypt', '-r', 'git@github.com:you/your_repo.git', '--shallow_clone', 'true'])
 
       expect_githelper_clone_with('git@github.com:you/your_repo.git', true, { branch: 'master', clone_branch_directly: false })

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -123,7 +123,7 @@ module Snapshot
                                      type: Boolean),
         FastlaneCore::ConfigItem.new(key: :override_status_bar,
                                      env_name: 'SNAPSHOT_OVERRIDE_STATUS_BAR',
-                                     description: "Enabling this option wil automatically override the status bar to show 9:41 AM, full battery, and full reception",
+                                     description: "Enabling this option will automatically override the status bar to show 9:41 AM, full battery, and full reception",
                                      default_value: false,
                                      is_string: false),
         FastlaneCore::ConfigItem.new(key: :localize_simulator,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves #17524

### Description

From my understanding, looks like the recursive call is there to retry in case the password was present in Keychain, but outdated/wrong. However, it should only retry if there's a password to be retried 🤓 in this case, in the `MATCH_PASSWORD` env var.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-fix-match-recursion"
```