### PR TITLE
[snapshot] move fake artifacts to temp directory in tests

### DIFF
--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 describe Snapshot do
   describe Snapshot::TestCommandGenerator do
     let(:os_version) { "9.3" }
@@ -248,20 +250,24 @@ describe Snapshot do
       end
 
       context 'fixed derivedDataPath' do
+        let(:temp) { Dir.mktmpdir }
+
         before do
-          configure(options.merge(derived_data_path: 'fake/derived/path'))
+          configure(options.merge(derived_data_path: temp))
         end
 
         it 'uses the fixed derivedDataPath if given', requires_xcode: true do
           expect(Dir).not_to(receive(:mktmpdir))
           command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("-derivedDataPath fake/derived/path")
+          expect(command.join('')).to include("-derivedDataPath #{temp}")
         end
       end
 
       context 'test-without-building' do
+        let(:temp) { Dir.mktmpdir }
+
         before do
-          configure(options.merge(derived_data_path: 'fake/derived/path', test_without_building: true))
+          configure(options.merge(derived_data_path: temp, test_without_building: true))
         end
 
         it 'uses the "test-without-building" command and not the default "build test"', requires_xcode: true do

--- a/snapshot/spec/test_command_generator_xcode_8_spec.rb
+++ b/snapshot/spec/test_command_generator_xcode_8_spec.rb
@@ -194,14 +194,16 @@ describe Snapshot do
       end
 
       context 'fixed derivedDataPath' do
+        let(:temp) { Dir.mktmpdir }
+
         before do
-          configure(options.merge(derived_data_path: 'fake/derived/path'))
+          configure(options.merge(derived_data_path: temp))
         end
 
         it 'uses the fixed derivedDataPath if given', requires_xcode: true do
           expect(Dir).not_to(receive(:mktmpdir))
           command = Snapshot::TestCommandGeneratorXcode8.generate(device_type: "iPhone 6", language: "en", locale: nil)
-          expect(command.join('')).to include("-derivedDataPath fake/derived/path")
+          expect(command.join('')).to include("-derivedDataPath #{temp}")
         end
       end
 


### PR DESCRIPTION
### Motivation and Context
Prevent test artifacts from appearing in root project directory

### Description
- Move `fake` artifacts to `Dir.mktmpdir`
