### PR TITLE
[pilot] update to new emoji regex

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -281,7 +281,7 @@ module Pilot
 
     def self.strip_emoji(changelog)
       if changelog && changelog =~ emoji_regex
-        changelog.gsub!(EmojiRegex::Regex, "")
+        changelog.gsub!(emoji_regex, "")
         UI.important("Emoji symbols have been removed from the changelog, since they're not allowed by Apple.")
       end
       changelog

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -273,8 +273,14 @@ module Pilot
       changelog
     end
 
+    def self.emoji_regex
+      # EmojiRegex::RGIEmoji is now preferred over EmojiRegex::Regex which is deprecated as of 3.2.0
+      # https://github.com/ticky/ruby-emoji-regex/releases/tag/v3.2.0
+      return defined?(EmojiRegex::RGIEmoji) ? EmojiRegex::RGIEmoji : EmojiRegex::Regex
+    end
+
     def self.strip_emoji(changelog)
-      if changelog && changelog =~ EmojiRegex::Regex
+      if changelog && changelog =~ emoji_regex
         changelog.gsub!(EmojiRegex::Regex, "")
         UI.important("Emoji symbols have been removed from the changelog, since they're not allowed by Apple.")
       end


### PR DESCRIPTION
### Motivation and Context
The `emoji_regex` gem that is used in `pilot` has a new regex that is preferred and the other is deprecated - https://github.com/ticky/ruby-emoji-regex/releases/tag/v3.2.0

### Description
- Check if new regex constant exists and use it otherwise use the other