### PR TITLE
[match] Support mac_installer_distribution certificate type

### DIFF
--- a/match/lib/match/module.rb
+++ b/match/lib/match/module.rb
@@ -9,7 +9,7 @@ module Match
   DESCRIPTION = "Easily sync your certificates and profiles across your team"
 
   def self.environments
-    return %w(appstore adhoc development enterprise developer_id)
+    return %w(appstore adhoc development enterprise developer_id mac_installer_distribution)
   end
 
   def self.storage_modes


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently `match` doesn't allow to import `mac_installer_distribution`
This PR allows importing this type of certificate

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Let's say we want to have Mac Installer Distribution Certificate Type for MacOS. 
From the documentation, we could see, that in order to perform this, we need to have `match` cal that will look like this
```ruby
match(
	keychain_name: ENV['KEYCHAIN_NAME'], 
	keychain_password: keychain_password,
	additional_cert_types: ['mac_installer_distribution'], 
	readonly: true,
	generate_apple_certs: false,
	type: 'appstore',
	git_url: "https://rep.ur",
	git_branch: 'branch',
	app_identifier: ["identifier1", "identifier2"]
)
```

The issue is that there's no way to import `mac_installer_distribution` cert type, since it is not supported by `match import`

```shell
bundle exec fastlane match import \
  --platform 'macos' \
  --type "mac_installer_distribution" \
  --team_id 'XXXX' \
  --team_name 'My Team' \
  --app_identifier 'My app id \
  --git_branch 'branch' \
  --verbose
```

![image](https://user-images.githubusercontent.com/119268/98285751-af8c2c80-1fab-11eb-85b9-a6f2a65f37c2.png)


### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

- Create a Mac AppStore Installer Distribution Certificate
- Prepare `.cer` and `.p12` files
- Import profile using the command above
- try to run match with `mac_installer_distribution` type certificate
- Certificate should be successfully imported to the specified keychain