### PR TITLE
Tiny wording change to improve clarity in the description of an option

### DIFF
--- a/cert/lib/cert/options.rb
+++ b/cert/lib/cert/options.rb
@@ -109,7 +109,7 @@ module Cert
                                      short_option: "-p",
                                      env_name: "CERT_KEYCHAIN_PASSWORD",
                                      sensitive: true,
-                                     description: "This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password",
+                                     description: "This might be required the first time you access certificates on a new mac. For the login/default keychain this is your macOS account password",
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :skip_set_partition_list,
                                      short_option: "-P",

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -227,7 +227,7 @@ module Match
                                      short_option: "-p",
                                      env_name: "MATCH_KEYCHAIN_PASSWORD",
                                      sensitive: true,
-                                     description: "This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password",
+                                     description: "This might be required the first time you access certificates on a new mac. For the login/default keychain this is your macOS account password",
                                      optional: true),
 
         # settings


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The wording is ambiguous and it isn't 100% clear which account is meant. Someone can mistakenly assume that App Store Connect or git service provider account or some such is meant by the word "account".

### Description
Make it more clear which account is meant in two similar options.
I couldn't run `bundle exec rspec` nor  `bundle exec rubocop -a` since `bundle install` failed for me with:
```
Gem::RuntimeRequirementNotMetError: pry-stack_explorer requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
An error occurred while installing pry-stack_explorer (0.5.1), and Bundler cannot continue.
Make sure that `gem install pry-stack_explorer -v '0.5.1'` succeeds before bundling
```
I assume 2.5.0 to be the newest package on Ubuntu 18.04 LTS. I am aware I could spend my time setting up some ruby version management system instead of updating my whole OS. But I wanted to spend way less time on this driveby documentation commit than I already have. I'm sorry. I respect your procedure enough to have tried to run them and to fill in this form though.

### Testing Steps
Documentation changes. Not much to test Observe if the following sites have the new wording after changes:
https://docs.fastlane.tools/actions/sync_code_signing/
https://docs.fastlane.tools/actions/cert/
