### PR TITLE
[pilot] Fix TypeError in `list` by ignoring nil counts

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -192,7 +192,7 @@ module Pilot
         [
           build.app_version,
           build.version,
-          (build.beta_build_metrics || []).map(&:install_count).reduce(:+)
+          (build.beta_build_metrics || []).map(&:install_count).compact.reduce(:+)
         ]
       end
 


### PR DESCRIPTION

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
TestFlight build metrics appear to have started sending `null` when an install count is `0`. Here's an excerpt from ASC's `/builds` endpoint:

```json
{
    "type" : "betaBuildMetrics",
    "id" : "<redacted>",
    "attributes" : {
      "installCount" : null,
      "crashCount" : null,
      "inviteCount" : null,
      "sevenDayTesterCount" : null,
      "sevenDaySessionCount" : null,
      "feedbackCount" : null,
      "bundleId" : "<redacted>"
    },
    "links" : {
      "self" : "https://appstoreconnect.apple.com/iris/v1/betaBuildMetrics/<redacted>"
    }
  }
```

Pilot handles when _all_ the build metrics are missing (#14858), but not when the metrics are present but installCount is null.

### Testing Steps

`bundle exec fastlane pilot list -a <app identifier>` previously was failing with 
```
TypeError: [!] nil can't be coerced into Integer
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/pilot/lib/pilot/build_manager.rb:195:in `+'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/pilot/lib/pilot/build_manager.rb:195:in `reduce'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/pilot/lib/pilot/build_manager.rb:195:in `block in list'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/pilot/lib/pilot/build_manager.rb:191:in `map'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/pilot/lib/pilot/build_manager.rb:191:in `list'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/pilot/lib/pilot/commands_generator.rb:90:in `block (2 levels) in run'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:178:in `call'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/commander-fastlane-4.4.6/lib/commander/command.rb:153:in `run'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/commander-fastlane-4.4.6/lib/commander/runner.rb:476:in `run_active_command'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:76:in `run!'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/commander-fastlane-4.4.6/lib/commander/delegates.rb:15:in `run!'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/pilot/lib/pilot/commands_generator.rb:166:in `run'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/pilot/lib/pilot/commands_generator.rb:18:in `start'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/fastlane/lib/fastlane/cli_tools_distributor.rb:111:in `take_off'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/gems/fastlane-2.162.0/bin/fastlane:23:in `<top (required)>'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/bin/fastlane:23:in `load'
  /Users/emw/iphone/vendor/bundle/ruby/2.6.0/bin/fastlane:23:in `<top (required)>'
```

now it's working successfully!

AFAICT, there are no unit tests for `pilot list` and nothing I can update to test this case.
