### PR TITLE
[match] skip committing changes when nuking if the repo is already empty

### DIFF
--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -253,11 +253,13 @@ module Match
       self.encryption.encrypt_files if self.encryption
 
       if files_to_delete.count > 0
-        # Now we need to commit and push all this too, if needed
+        # Now we need to save all this to the storage too, if needed
         message = ["[fastlane]", "Nuked", "files", "for", type.to_s].join(" ")
         self.storage.save_changes!(files_to_commit: [],
                                    files_to_delete: files_to_delete,
                                    custom_message: message)
+      else
+        UI.message("Your storage had no files to be deleted. This happens when you run `nuke` with an empty storage. Nothing to be worried about!")
       end
     end
 

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -252,11 +252,13 @@ module Match
 
       self.encryption.encrypt_files if self.encryption
 
-      # Now we need to commit and push all this too
-      message = ["[fastlane]", "Nuked", "files", "for", type.to_s].join(" ")
-      self.storage.save_changes!(files_to_commit: [],
-                                 files_to_delete: files_to_delete,
-                                 custom_message: message)
+      if files_to_delete.count > 0
+        # Now we need to commit and push all this too, if needed
+        message = ["[fastlane]", "Nuked", "files", "for", type.to_s].join(" ")
+        self.storage.save_changes!(files_to_commit: [],
+                                   files_to_delete: files_to_delete,
+                                   custom_message: message)
+      end
     end
 
     private


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17451

### Description
Seems like when the repository is already empty, performing `match nuke` would throw an undesired error because there were not files to delete. This PR fixes that by skipping the "save_changes" when there's nothing to be saved.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-match-nuke-commit-changes-if-needed"
```

And run `fastlane match nuke development` for instance.