### PR TITLE
[add_git_tag] make `build_number` parameter optional and validate presence of `tag`

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -6,7 +6,13 @@ module Fastlane
         # lane name in lane_context could be nil because you can just call $fastlane add_git_tag which has no context
         lane_name = Actions.lane_context[Actions::SharedValues::LANE_NAME].to_s.delete(' ') # no spaces allowed
 
-        tag = options[:tag] || "#{options[:grouping]}/#{lane_name}/#{options[:prefix]}#{options[:build_number]}#{options[:postfix]}"
+        if options[:tag]
+          tag = options[:tag]
+        elsif options[:build_number]
+          tag = "#{options[:grouping]}/#{lane_name}/#{options[:prefix]}#{options[:build_number]}#{options[:postfix]}"
+        else
+          UI.user_error!("No value found for 'tag' or 'build_number'. At least one of them must be provided. Note that if you do specify a tag, all other arguments are ignored.")
+        end
         message = options[:message] || "#{tag} (fastlane)"
 
         cmd = ['git tag']
@@ -64,7 +70,8 @@ module Fastlane
                                        description: "The build number. Defaults to the result of increment_build_number if you\'re using it",
                                        default_value: Actions.lane_context[Actions::SharedValues::BUILD_NUMBER],
                                        default_value_dynamic: true,
-                                       is_string: false),
+                                       is_string: false,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "FL_GIT_TAG_MESSAGE",
                                        description: "The tag message. Defaults to the tag's name",

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -76,6 +76,16 @@ describe Fastlane do
         expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
+      it "raises error if no tag or build_number are provided" do
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER] = nil
+
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            add_git_tag ({})
+          end").runner.execute(:test)
+        end.to raise_error(/No value found for 'tag' or 'build_number'. At least one of them must be provided. Note that if you do specify a tag, all other arguments are ignored./)
+      end
+
       it "specified tag overrides generate tag" do
         tag = '2.0.0'
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17492

### Description

According to the [existing documentation](https://docs.fastlane.tools/actions/add_git_tag/#3-examples) if the `tag` is provided, all the other parameters are ignored (including the `build_number`). However, if the `build_number` was then marked as non-optional and its default value could be nil if the user isn't using `increment_build_number` action prior to calling this action.
I believe the solution should be to make `build_number` optional, and then validate the existence of the `tag` or `build_number` during the execution of the action itself.

<sub>(as a side note, I believe `FastlaneCore.ConfigItem` should have a built-in way to validate presence of an dependent items, similar to the "mutually exclusive" option (called `conflicting_options`) 😄 )</sub>

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-fix-add-git-tag-build-number-optionality"
```