### PR TITLE
[get_version_number] update `xcodeproj` option to accept both Xcode project filepath or its containing directory

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -8,7 +8,7 @@ module Fastlane
       require 'shellwords'
 
       def self.run(params)
-        xcodeproj_path_or_dir = params[:xcodeproj] ? "#{params[:xcodeproj]}" : "."
+        xcodeproj_path_or_dir = params[:xcodeproj] || '.'
         xcodeproj_dir = File.extname(xcodeproj_path_or_dir) == ".xcodeproj" ? File.dirname(xcodeproj_path_or_dir) : xcodeproj_path_or_dir
         target_name = params[:target]
         configuration = params[:configuration]
@@ -41,7 +41,6 @@ module Fastlane
       end
 
       def self.get_project!(xcodeproj_path_or_dir)
-        puts "something something"
         require 'xcodeproj'
         if File.extname(xcodeproj_path_or_dir) == ".xcodeproj"
           project_path = xcodeproj_path_or_dir
@@ -158,7 +157,7 @@ module Fastlane
                              optional: true,
                              verify_block: proc do |value|
                                UI.user_error!("Please pass the path to the project or its containing directory, not the workspace path") if value.end_with?(".xcworkspace")
-                               UI.user_error!("Could not find file or directory at path '#{File.expand_path(value)}'") if !(File.exist?(value))
+                               UI.user_error!("Could not find file or directory at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                UI.user_error!("Could not find Xcode project in directory at path '#{File.expand_path(value)}'") if File.extname(value) != ".xcodeproj" && Dir.glob("#{value}/*.xcodeproj").empty?
                              end),
           FastlaneCore::ConfigItem.new(key: :target,

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -48,7 +48,7 @@ module Fastlane
           project_path = Dir.glob("#{xcodeproj_path_or_dir}/*.xcodeproj").first
         end
 
-        if project_path
+        if project_path && File.exist?(project_path)
           return Xcodeproj::Project.open(project_path)
         else
           UI.user_error!("Unable to find Xcode project in folder: #{folder}")

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -202,9 +202,9 @@ module Fastlane
 
       def self.example_code
         [
-          'version = get_version_number(xcodeproj: "Project.xcodeproj")',
+          'version = get_version_number(xcodeproj_filename: "Project.xcodeproj")',
           'version = get_version_number(
-            xcodeproj: "Project.xcodeproj",
+            xcodeproj_filename: "Project.xcodeproj",
             target: "App"
           )'
         ]

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -51,7 +51,7 @@ module Fastlane
         if project_path && File.exist?(project_path)
           return Xcodeproj::Project.open(project_path)
         else
-          UI.user_error!("Unable to find Xcode project in folder: #{folder}")
+          UI.user_error!("Unable to find Xcode project at #{project_path || xcodeproj_path_or_dir}")
         end
       end
 

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -13,13 +13,6 @@ describe Fastlane do
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version number for 'TargetA' using xcodeproj_filename without extension", requires_xcodeproj: true do
-        result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetA')
-        end").runner.execute(:test)
-        expect(result).to eq("4.3.2")
-      end
-
       it "gets the correct version number for 'TargetA' using xcodeproj_filename with extension", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{File.join(xcodeproj_dir, xcodeproj_filename)}', target: 'TargetA')

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -4,10 +4,26 @@ describe Fastlane do
       require 'shellwords'
 
       path = File.absolute_path("./fastlane/spec/fixtures/actions/get_version_number/get_version_number/")
+      xcodeproj_filename_without_extension = "get_version_number"
+      xcodeproj_filename_with_extension = "get_version_number.xcodeproj"
 
       it "gets the correct version number for 'TargetA'", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{path}', target: 'TargetA')
+        end").runner.execute(:test)
+        expect(result).to eq("4.3.2")
+      end
+
+      it "gets the correct version number for 'TargetA' using xcodeproj_filename without extension", requires_xcodeproj: true do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '#{path}', xcodeproj_dir: '#{path}', xcodeproj_filename: '#{xcodeproj_filename_without_extension}', target: 'TargetA')
+        end").runner.execute(:test)
+        expect(result).to eq("4.3.2")
+      end
+
+      it "gets the correct version number for 'TargetA' using xcodeproj_filename with extension", requires_xcodeproj: true do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          get_version_number(xcodeproj: '#{path}', xcodeproj_dir: '#{path}', xcodeproj_filename: '#{xcodeproj_filename_with_extension}', target: 'TargetA')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
@@ -200,12 +216,28 @@ describe Fastlane do
         expect(result).to eq("3.2.1")
       end
 
-      it "raises an exception when use passes workspace" do
+      it "raises an exception when user passes workspace as the xcodeproj" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
             get_version_number(xcodeproj: 'project.xcworkspace')
           end").runner.execute(:test)
         end.to raise_error("Please pass the path to the project, not the workspace")
+      end
+
+      it "raises an exception when user passes workspace as the xcodeproj_dir" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj_dir: 'path/to/project.xcworkspace')
+          end").runner.execute(:test)
+        end.to raise_error("Please pass the path to the directory of the xcodeproj, not the workspace")
+      end
+
+      it "raises an exception when user passes workspace as the xcodeproj_filename" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj_filename: 'project.xcworkspace')
+          end").runner.execute(:test)
+        end.to raise_error("Please pass the filename of the project, not the workspace")
       end
     end
   end

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -3,27 +3,26 @@ describe Fastlane do
     describe "Get Version Number Integration" do
       require 'shellwords'
 
-      path = File.absolute_path("./fastlane/spec/fixtures/actions/get_version_number/get_version_number/")
-      xcodeproj_filename_without_extension = "get_version_number"
-      xcodeproj_filename_with_extension = "get_version_number.xcodeproj"
+      xcodeproj_dir = File.absolute_path("./fastlane/spec/fixtures/actions/get_version_number/")
+      xcodeproj_filename = "get_version_number.xcodeproj"
 
       it "gets the correct version number for 'TargetA'", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetA')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetA')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
 
       it "gets the correct version number for 'TargetA' using xcodeproj_filename without extension", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', xcodeproj_dir: '#{path}', xcodeproj_filename: '#{xcodeproj_filename_without_extension}', target: 'TargetA')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetA')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
 
       it "gets the correct version number for 'TargetA' using xcodeproj_filename with extension", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', xcodeproj_dir: '#{path}', xcodeproj_filename: '#{xcodeproj_filename_with_extension}', target: 'TargetA')
+          get_version_number(xcodeproj: '#{File.join(xcodeproj_dir, xcodeproj_filename)}', target: 'TargetA')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
@@ -31,14 +30,14 @@ describe Fastlane do
       context "Target Settings" do
         it "gets the correct version number for 'TargetVariableParentheses'", requires_xcodeproj: true do
           result = Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj: '#{path}', target: 'TargetVariableParentheses')
+            get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetVariableParentheses')
           end").runner.execute(:test)
           expect(result).to eq("4.3.2")
         end
 
         it "gets the correct version number for 'TargetVariableCurlyBraces'", requires_xcodeproj: true do
           result = Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj: '#{path}', target: 'TargetVariableCurlyBraces')
+            get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetVariableCurlyBraces')
           end").runner.execute(:test)
           expect(result).to eq("4.3.2")
         end
@@ -47,14 +46,14 @@ describe Fastlane do
       context "Project Settings" do
         it "gets the correct version number for 'TargetVariableParenthesesBuildSettings'", requires_xcodeproj: true do
           result = Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj: '#{path}', target: 'TargetVariableParenthesesBuildSettings')
+            get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetVariableParenthesesBuildSettings')
           end").runner.execute(:test)
           expect(result).to eq("7.6.5")
         end
 
         it "gets the correct version number for 'TargetVariableCurlyBracesBuildSettings'", requires_xcodeproj: true do
           result = Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj: '#{path}', target: 'TargetVariableCurlyBracesBuildSettings')
+            get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetVariableCurlyBracesBuildSettings')
           end").runner.execute(:test)
           expect(result).to eq("7.6.5")
         end
@@ -63,7 +62,7 @@ describe Fastlane do
       context "xcconfig defined version" do
         it "gets the correct version numer for 'TargetConfigVersion'", requires_xcodeproj: true do
           result = Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj: '#{path}', target: 'TargetConfigVersion')
+            get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetConfigVersion')
           end").runner.execute(:test)
           expect(result).to eq("4.2.1")
         end
@@ -71,42 +70,42 @@ describe Fastlane do
 
       it "gets the correct version number for 'TargetATests'", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetATests')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetATests')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
 
       it "gets the correct version number for 'TargetB'", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetB')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetB')
         end").runner.execute(:test)
         expect(result).to eq("5.4.3")
       end
 
       it "gets the correct version number for 'TargetBTests'", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetBTests')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetBTests')
         end").runner.execute(:test)
         expect(result).to eq("5.4.3")
       end
 
       it "gets the correct version number for 'TargetC_internal'", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetC_internal')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetC_internal')
         end").runner.execute(:test)
         expect(result).to eq("7.5.2")
       end
 
       it "gets the correct version number for 'TargetC_production'", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetC_production')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetC_production')
         end").runner.execute(:test)
         expect(result).to eq("6.4.9")
       end
 
       it "gets the correct version number for 'SampleProject_tests'", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'SampleProject_tests')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'SampleProject_tests')
         end").runner.execute(:test)
         expect(result).to eq("1.0")
       end
@@ -117,7 +116,7 @@ describe Fastlane do
         end
 
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
@@ -131,21 +130,21 @@ describe Fastlane do
         end
 
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}')
         end").runner.execute(:test)
         expect(result).to eq("4.3.2")
       end
 
       it "gets the correct version with $(SRCROOT)", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetSRC')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetSRC')
         end").runner.execute(:test)
         expect(result).to eq("1.5.9")
       end
 
       it "gets the correct version when info-plist is relative path", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetRelativePath')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetRelativePath')
         end").runner.execute(:test)
         expect(result).to eq("3.37.0")
       end
@@ -163,7 +162,7 @@ describe Fastlane do
 
           # when
           result = Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj: '#{path}', target: 'TargetAbsolutePath')
+            get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetAbsolutePath')
           end").runner.execute(:test)
 
           # then
@@ -183,7 +182,7 @@ describe Fastlane do
 
         expect do
           result = Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj: '#{path}', target: 'ThisIsNotATarget')
+            get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'ThisIsNotATarget')
           end").runner.execute(:test)
         end.to raise_error(FastlaneCore::Interface::FastlaneError, "Cannot find target named 'ThisIsNotATarget'")
       end
@@ -191,7 +190,7 @@ describe Fastlane do
       it "raises if in non-interactive mode with no target", requires_xcodeproj: true do
         expect do
           result = Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj: '#{path}')
+            get_version_number(xcodeproj: '#{xcodeproj_dir}')
           end").runner.execute(:test)
         end.to raise_error(FastlaneCore::Interface::FastlaneCrash, /non-interactive mode/)
       end
@@ -199,19 +198,19 @@ describe Fastlane do
       it "raises if in non-interactive mode if cannot infer configuration", requires_xcodeproj: true do
         expect do
           result = Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj: '#{path}', target: 'TargetDifferentConfigurations')
+            get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetDifferentConfigurations')
           end").runner.execute(:test)
         end.to raise_error(FastlaneCore::Interface::FastlaneCrash, /non-interactive mode/)
       end
 
       it "gets correct version for different configurations", requires_xcodeproj: true do
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetDifferentConfigurations', configuration: 'Debug')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetDifferentConfigurations', configuration: 'Debug')
         end").runner.execute(:test)
         expect(result).to eq("1.2.3")
 
         result = Fastlane::FastFile.new.parse("lane :test do
-          get_version_number(xcodeproj: '#{path}', target: 'TargetDifferentConfigurations', configuration: 'Release')
+          get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetDifferentConfigurations', configuration: 'Release')
         end").runner.execute(:test)
         expect(result).to eq("3.2.1")
       end
@@ -221,23 +220,23 @@ describe Fastlane do
           Fastlane::FastFile.new.parse("lane :test do
             get_version_number(xcodeproj: 'project.xcworkspace')
           end").runner.execute(:test)
-        end.to raise_error("Please pass the path to the project, not the workspace")
+        end.to raise_error("Please pass the path to the project or its containing directory, not the workspace path")
       end
 
-      it "raises an exception when user passes workspace as the xcodeproj_dir" do
+      it "raises an exception when user passes non-existent directory" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj_dir: 'path/to/project.xcworkspace')
+            get_version_number(xcodeproj: '/path/to/random/directory')
           end").runner.execute(:test)
-        end.to raise_error("Please pass the path to the directory of the xcodeproj, not the workspace")
+        end.to raise_error(/Could not find file or directory at path/)
       end
 
-      it "raises an exception when user passes workspace as the xcodeproj_filename" do
+      it "raises an exception when user passes existent directory with no Xcode project inside" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do
-            get_version_number(xcodeproj_filename: 'project.xcworkspace')
+            get_version_number(xcodeproj: '#{File.dirname(xcodeproj_dir)}')
           end").runner.execute(:test)
-        end.to raise_error("Please pass the filename of the project, not the workspace")
+        end.to raise_error(/Could not find Xcode project in directory at path/)
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #16215
Context: https://github.com/fastlane/fastlane/issues/16215#issuecomment-723665844
Relevant docs: https://docs.fastlane.tools/actions/get_version_number/#2-examples

### Description

The conclusion from my analysis was that this was just poor documentation VS misleading behavior. I decided to not introduce breaking changes (i.e. silently modifying the underlying behavior) to avoid breaking compatibility with existing users. Instead, I deprecated the existing parameter and introduced 2 new parameters (dir and filename), making them behave like expected.

Please evaluate whether the docs I wrote are not only correct but also easy to understand and not misleading. 

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-improve-get-version-number-xcodeproj-setting"
```