### PR TITLE
[spaceship] Spaceship::ConnectAPI - added betaGroup delete and get builds for the group functions

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/beta_group.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_group.rb
@@ -36,6 +36,15 @@ module Spaceship
       def post_bulk_beta_tester_assignments(beta_testers: nil)
         return Spaceship::ConnectAPI.post_bulk_beta_tester_assignments(beta_group_id: id, beta_testers: beta_testers)
       end
+
+      def delete!
+        return Spaceship::ConnectAPI.delete_beta_group(group_id: id)
+      end
+
+      def builds
+        resps = Spaceship::ConnectAPI.get_builds_for_beta_group(group_id: id).all_pages
+        return resps.flat_map(&:to_models)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/beta_group.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_group.rb
@@ -41,7 +41,7 @@ module Spaceship
         return Spaceship::ConnectAPI.delete_beta_group(group_id: id)
       end
 
-      def builds
+      def fetch_builds
         resps = Spaceship::ConnectAPI.get_builds_for_beta_group(group_id: id).all_pages
         return resps.flat_map(&:to_models)
       end

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -214,6 +214,18 @@ module Spaceship
           test_flight_request_client.post("betaGroups", body)
         end
 
+        def delete_beta_group(group_id: nil)
+          raise "group_id is nil" if group_id.nil?
+
+          test_flight_request_client.delete("betaGroups/#{group_id}")
+        end
+
+        def get_builds_for_beta_group(group_id: nil)
+          raise "group_id is nil" if group_id.nil?
+
+          test_flight_request_client.get("betaGroups/#{group_id}/builds")
+        end
+
         #
         # betaTesters
         #

--- a/spaceship/spec/connect_api/models/beta_group_spec.rb
+++ b/spaceship/spec/connect_api/models/beta_group_spec.rb
@@ -22,5 +22,19 @@ describe Spaceship::ConnectAPI::BetaGroup do
       expect(model.public_link_limit).to eq(10)
       expect(model.public_link).to eq("https://testflight.apple.com/join/abcd1234")
     end
+
+    it '#delete!' do
+      response = Spaceship::ConnectAPI.get_beta_groups
+      expect(response).to be_an_instance_of(Spaceship::ConnectAPI::Response)
+
+      expect(response.count).to eq(3)
+      response.each do |model|
+        expect(model).to be_an_instance_of(Spaceship::ConnectAPI::BetaGroup)
+      end
+
+      model = response.first
+      expect(model.id).to eq("123456789")
+      model.delete!
+    end
   end
 end

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -66,6 +66,9 @@ class ConnectAPIStubbing
 
         stub_request(:post, "https://appstoreconnect.apple.com/iris/v1/betaGroups").
           to_return(status: 200, body: read_fixture_file('beta_create_group.json'), headers: { 'Content-Type' => 'application/json' })
+
+        stub_request(:delete, "https://appstoreconnect.apple.com/iris/v1/betaGroups/123456789").
+          to_return(status: 200, body: "", headers: {})
       end
 
       def stub_beta_testers


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adding new features.

1. Delete TestFlight beta group.
2. Get builds for a TestFlight beta group.

### Description
1. Added a function delete! in BetaGroup class. We can call delete! will delete the group. It leaves the build as it is.
2. Added a function builds in BetaGroup class. We can call builds to get builds which are associated to the group.

### Testing Steps
```
Spaceship::ConnectAPI.login
platform = Spaceship::ConnectAPI::Platform.map('ios')
app = Spaceship::ConnectAPI::App.find('anyid')
group = app.get_beta_groups(filter: {name: "Gp1"}).first
group.fetch_builds.each do | build |
      puts  build.version
end
group.delete!
```