### PR TITLE
[Fastlane.swift] fix: swiftformat issues

### DIFF
--- a/fastlane/swift/Fastfile.swift
+++ b/fastlane/swift/Fastfile.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-open class Fastfile: LaneFile { 
+open class Fastfile: LaneFile {
     override public init() {
         super.init()
     }

--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -22,8 +22,8 @@ public protocol LaneFileProtocol: class {
 
 public extension LaneFileProtocol {
     var fastlaneVersion: String { return "" } // Defaults to "" because that means any is fine
-    func beforeAll(with lane: String) {} // No-op by default
-    func afterAll(with lane: String) {} // No-op by default
+    func beforeAll(with _: String) {} // No-op by default
+    func afterAll(with _: String) {} // No-op by default
     func onError(currentLane _: String, errorInfo _: String) {} // No-op by default
     func recordLaneDescriptions() {} // No-op by default
 }

--- a/fastlane/swift/MainProcess.swift
+++ b/fastlane/swift/MainProcess.swift
@@ -56,6 +56,8 @@ class MainProcess {
                 print(stdout)
                 self.timeBetweenPrints = Int(self.lastPrintDate.timeIntervalSinceNow)
             }
+
+            // swiftformat:disable:next redundantSelf
             _ = Runner.waitWithPolling(self.timeBetweenPrints, toEventually: { $0 > 5 }, timeout: 10)
             thread.start()
         #endif

--- a/fastlane/swift/Runner.swift
+++ b/fastlane/swift/Runner.swift
@@ -37,7 +37,7 @@ class Runner {
         socketClient.send(rubyCommand: command)
 
         let secondsToWait = DispatchTimeInterval.seconds(SocketClient.defaultCommandTimeoutSeconds)
-        // swiftlint:disable next
+        // swiftformat:disable:next redundantSelf
         let timeoutResult = Self.waitWithPolling(self.executeNext[command.id], toEventually: { $0 == true }, timeout: SocketClient.defaultCommandTimeoutSeconds)
         executeNext.removeValue(forKey: command.id)
         let failureMessage = "command didn't execute in: \(SocketClient.defaultCommandTimeoutSeconds) seconds"

--- a/fastlane/swift/SocketClient.swift
+++ b/fastlane/swift/SocketClient.swift
@@ -29,7 +29,7 @@ class SocketClient: NSObject {
     }
 
     static let connectTimeoutSeconds = 2
-    static let defaultCommandTimeoutSeconds = 10_800 // 3 hours
+    static let defaultCommandTimeoutSeconds = 10800 // 3 hours
     static let doneToken = "done" // TODO: remove these
     static let cancelToken = "cancelFastlaneRun"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`Fastlane.swift` is failing with a compilation error related to an explicit `self` missing in a closure, after upgrading.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This explicit `self` was removed by `swiftformat` and can be prevented from happening by disabling the corresponding rule at the corresponding line.