### PR TITLE
[deliver] support the latest 6.5 inch screenshot size

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -187,7 +187,9 @@ module Deliver
       return {
         ScreenSize::IOS_65_MESSAGES => [
           [1242, 2688],
-          [2688, 1242]
+          [2688, 1242],
+          [1284, 2778],
+          [2778, 1284]
         ],
         ScreenSize::IOS_61_MESSAGES => [
           [828, 1792],
@@ -243,7 +245,9 @@ module Deliver
       return {
         ScreenSize::IOS_65 => [
           [1242, 2688],
-          [2688, 1242]
+          [2688, 1242],
+          [1284, 2778],
+          [2778, 1284]
         ],
         ScreenSize::IOS_61 => [
           [828, 1792],

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -55,6 +55,8 @@ describe Deliver::AppScreenshot do
       it "should calculate all 6.5 inch iPhone resolutions" do
         expect_screen_size_from_file("iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(ScreenSize::IOS_65)
         expect_screen_size_from_file("iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(ScreenSize::IOS_65)
+        expect_screen_size_from_file("iPhone12ProMax-Portrait{1284x2778}.jpg").to eq(ScreenSize::IOS_65)
+        expect_screen_size_from_file("iPhone12ProMax-Landscape{2778x1284}.jpg").to eq(ScreenSize::IOS_65)
       end
 
       it "should calculate all 5.8 inch iPhone resolutions" do
@@ -134,6 +136,8 @@ describe Deliver::AppScreenshot do
       it "should calculate all 6.5 inch iPhone resolutions" do
         expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(ScreenSize::IOS_65_MESSAGES)
         expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(ScreenSize::IOS_65_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhone12ProMax-Portrait{1284x2778}.jpg").to eq(ScreenSize::IOS_65_MESSAGES)
+        expect_screen_size_from_file("iMessage/en-GB/iPhone12ProMax-Landscape{2778x1284}.jpg").to eq(ScreenSize::IOS_65_MESSAGES)
       end
 
       it "should calculate all 5.8 inch iPhone resolutions" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves https://github.com/fastlane/fastlane/issues/17583

Lately, Apple silently updated its App Store screenshots specifications for the 6.5-inch screen category. It used to be 1242x2688 or 2688x 1242 but now it's 1284x2778 or 2778x1284, which matches iPhone 12 Pro Max's screen resolution. (See https://help.apple.com/app-store-connect/#/devd274dd925)

This PR introduces the latest size to `Deliver::AppScreenshot` to be able to upload screenshots in the new size.

### Description

I simply added and tested it. It worked on my end for both app's screenshots and iMessage screenshots. As far as I tested, (at least with web session) App Store Connect still accepts existing old size ones. So I left them, too.

### Testing Steps

1. Prepare screenshots in the size 1284x2778

e.g. 

```
$ cd fastlane/screenshots/en-US
$ mogrify -resize 1284x2778! 6.5_1.jpg 6.5_2.jpg 6.5_3.jpg
```

2. Upload them with deliver

e.g.

```ruby
upload_to_app_store(
  overwrite_screenshots: true,
  skip_binary_upload: true,
  skip_metadata: true,
)
```

3. See if it's uploaded without getting errors on App Store Connect