### PR TITLE
[supply] skip sending user fraction if it's 1.0 when promoting track

### DIFF
--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -49,7 +49,7 @@ module Supply
                                      end),
         FastlaneCore::ConfigItem.new(key: :rollout,
                                      short_option: "-r",
-                                     description: "The percentage of the user fraction when uploading to the rollout track",
+                                     description: "The percentage of the user fraction when uploading to the rollout track (setting to 1 will complete the rollout)",
                                      optional: true,
                                      verify_block: proc do |value|
                                        min = 0.0

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -192,9 +192,10 @@ module Supply
       release = releases.first
       track_to = client.tracks(Supply.config[:track_promote_to]).first
 
-      if Supply.config[:rollout]
+      rollout = (Supply.config[:rollout] || 0).to_f
+      if rollout > 0 && rollout < 1
         release.status = Supply::ReleaseStatus::IN_PROGRESS
-        release.user_fraction = Supply.config[:rollout]
+        release.user_fraction = rollout
       else
         release.status = Supply::ReleaseStatus::COMPLETED
         release.user_fraction = nil


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17605

### Description

Looks like after this PR https://github.com/fastlane/fastlane/pull/15668, we missed 1 instance where the `rollout` had to be checked. This PR adds the check for the last occurrence of `rollout` (to see if it's 1.0 and, if so, skip setting it).

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-supply-skip-user-fraction-if-one"
```