### PR TITLE
[docs] improve GitHub Pull Request template by guiding users to properly link PRs to Issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,9 @@
 
 ### Motivation and Context
 <!-- Why is this change required? What problem does it solve? -->
-<!-- If it fixes an open issue, please link to the issue here. -->
+<!-- If it fixes an open issue, please link to the issue following this format:
+Resolves #1337
+-->
 
 ### Description
 <!-- Describe your changes in detail. -->


### PR DESCRIPTION
### Motivation and Context

1️⃣ PRs are closed and their respective issues are not, because the two weren't properly linked.
2️⃣ Fastlane maintainers sometimes edit people's PR descriptions to properly link them to issues, to avoid 1️⃣ 

### Description

Hopefully by making this small modification to the template, users will link the issues together correctly so we'll have to worry less about this 😊 

Not sure if any documentation needs to be updated, probably not. Hopefully this change is enough 🙏 

### Testing Steps

There's no way to test this before merging it to master :P After it gets merged, attempt to open a new PR to see the changes in the template.