### PR TITLE
[scan] fix crash on TestResultParser when disable_xcpretty=true

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -83,6 +83,8 @@ module Scan
     end
 
     def handle_results(tests_exit_status)
+      return if Scan.config[:disable_xcpretty]
+
       result = TestResultParser.new.parse_result(test_results)
       SlackPoster.new.run(result)
 
@@ -144,8 +146,6 @@ module Scan
     end
 
     def test_results
-      return if Scan.config[:disable_xcpretty]
-
       temp_junit_report = Scan.cache[:temp_junit_report]
       return File.read(temp_junit_report) if temp_junit_report && File.file?(temp_junit_report)
 

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -64,6 +64,20 @@ describe Scan do
           end.to raise_error(FastlaneCore::Interface::FastlaneTestFailure, "Tests have failed")
         end
       end
+
+      describe "with scan option :disable_xcpretty set to true" do
+        it "does not generate a temp junit report", requires_xcodebuild: true do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            output_directory: '/tmp/scan_results',
+            project: './scan/examples/standard/app.xcodeproj',
+            disable_xcpretty: true
+          })
+
+          Scan.cache[:temp_junit_report] = '/var/folders/non_existent_file.junit'
+          @scan.handle_results(0)
+          expect(Scan.cache[:temp_junit_report]).to(eq('/var/folders/non_existent_file.junit'))
+        end
+      end
     end
 
     describe "test_results" do
@@ -103,21 +117,6 @@ describe Scan do
           Scan.cache[:temp_junit_report] = '/var/folders/non_existent_file.junit'
           expect(@scan.test_results).to_not(be_nil)
           expect(Scan.cache[:temp_junit_report]).to_not(eq('/var/folders/non_existent_file.junit'))
-        end
-      end
-
-      describe "with scan option :disable_xcpretty set to true" do
-        it "does not generate a temp junit report", requires_xcodebuild: true do
-          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
-            output_directory: '/tmp/scan_results',
-            project: './scan/examples/standard/app.xcodeproj',
-            include_simulator_logs: false,
-            disable_xcpretty: true
-          })
-
-          Scan.cache[:temp_junit_report] = '/var/folders/non_existent_file.junit'
-          expect(@scan.test_results).to(be_nil)
-          expect(Scan.cache[:temp_junit_report]).to(eq('/var/folders/non_existent_file.junit'))
         end
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #16480

### Description
`test_results` used to early return when `disable_xcpretty` is true, but that would lead into a crash inside `handle_test_results` (the only method that calls `test_results`) because it doesn't check for nil. I'm changing the early return to be in `handle_test_results` instead so the whole thing is skipped.

### Testing Steps
I believe any combination of `disable_xcpretty: true` without `fail_build: false` would lead into the crash before this fix. I used to have `fail_build: true` so I had never detected it myself.
