### PR TITLE
Support new App Store API for getting price tiers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
 
   "Validate Documentation":
     docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.5
     steps:
       - *cache_restore_git
       - checkout

--- a/spaceship/lib/spaceship/tunes/iap_detail.rb
+++ b/spaceship/lib/spaceship/tunes/iap_detail.rb
@@ -242,7 +242,7 @@ module Spaceship
       # @return ([Spaceship::Tunes::PricingInfo]) An array of pricing infos from the same tier
       def world_wide_pricing_info
         client
-          .pricing_tiers
+          .pricing_tiers(application.apple_id)
           .find { |p| p.tier_stem == pricing_intervals.first[:tier].to_s }
           .pricing_info
       end

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -704,9 +704,9 @@ module Spaceship
     #     ...
     # }, {
     # ...
-    def pricing_tiers
+    def pricing_tiers(app_id)
       @pricing_tiers ||= begin
-        r = request(:get, 'ra/apps/pricing/matrix')
+        r = request(:get, "ra/apps/#{app_id}/iaps/pricing/matrix")
         data = parse_response(r, 'data')['pricingTiers']
         data.map { |tier| Spaceship::Tunes::PricingTier.factory(tier) }
       end

--- a/spaceship/spec/tunes/iap_detail_spec.rb
+++ b/spaceship/spec/tunes/iap_detail_spec.rb
@@ -40,7 +40,7 @@ describe Spaceship::Tunes::IAPDetail do
       end
 
       context "when iap is a non-subscription product" do
-        let(:pricing_tiers) { client.pricing_tiers }
+        let(:pricing_tiers) { client.pricing_tiers(app.apple_id) }
         let(:interval) do
           { tier: 1, begin_date: nil, end_date: nil, grandfathered: nil, country: "WW" }
         end

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -313,7 +313,7 @@ class TunesStubbing
     end
 
     def itc_stub_pricing_tiers
-      stub_request(:get, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/pricing/matrix").
+      stub_request(:get, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/iaps/pricing/matrix").
         to_return(status: 200, body: itc_read_fixture_file("pricing_tiers.json"),
                   headers: { "Content-Type" => "application/json" })
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Now the old URL path doesn't work. We have no ability to get the prices for the In-App purchases.

### Description
I suggest changing the old URL in order to support the new API call.
