### PR TITLE
Version bump to 2.168.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,49 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
@@ -84,43 +46,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
 </tr>
 <tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
 <td id='daniel-jankowski'>
 <a href='https://github.com/mollyIV'>
@@ -128,8 +78,70 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
 </tr>
 <tr>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+</tr>
+<tr>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
 <img src='https://github.com/hjanuschka.png?size=140'>
@@ -142,18 +154,6 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
 <img src='https://github.com/joshdholtz.png?size=140'>
@@ -162,17 +162,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
 <td id='fumiya-nakamura'>
 <a href='https://github.com/nafu'>
 <img src='https://github.com/nafu.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Matthew Ellis",
-                        "Jorge Revuelta H",
-                        "Jérôme Lacoste",
-                        "Max Ott",
-                        "Josh Holtz",
-                        "Aaron Brager",
-                        "Andrew McBurney",
-                        "Daniel Jankowski",
-                        "Fumiya Nakamura",
-                        "Jimmy Dee",
-                        "Kohki Miki",
-                        "Iulian Onofrei",
-                        "Manu Wallner",
-                        "Stefan Natchev",
-                        "Felix Krause",
-                        "Joshua Liebowitz",
-                        "Jan Piotrowski",
-                        "Olivier Halligon",
-                        "Luka Mirosevic",
+  spec.authors       = ["Aaron Brager",
                         "Danielle Tomlinson",
+                        "Matthew Ellis",
+                        "Joshua Liebowitz",
+                        "Felix Krause",
+                        "Manu Wallner",
+                        "Daniel Jankowski",
+                        "Iulian Onofrei",
+                        "Josh Holtz",
+                        "Jérôme Lacoste",
+                        "Fumiya Nakamura",
+                        "Andrew McBurney",
+                        "Max Ott",
+                        "Jan Piotrowski",
+                        "Jorge Revuelta H",
+                        "Stefan Natchev",
+                        "Luka Mirosevic",
+                        "Jimmy Dee",
+                        "Maksym Grebenets",
+                        "Kohki Miki",
                         "Helmut Januschka",
-                        "Maksym Grebenets"]
+                        "Olivier Halligon"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.167.0'.freeze
+  VERSION = '2.168.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -17,4 +17,4 @@ public class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.167.0
+// Generated with fastlane 2.168.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -256,4 +256,4 @@ public extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.50]
+// FastlaneRunnerAPIVersion [0.9.51]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1861,7 +1861,7 @@ public func carthage(command: String = "bootstrap",
    - filename: The filename of certificate to store
    - outputPath: The path to a directory in which all certificates and private keys should be stored
    - keychainPath: Path to a custom keychain
-   - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
+   - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your macOS account password
    - skipSetPartitionList: Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing
    - platform: Set the provisioning profile's platform (ios, macos)
 
@@ -3349,7 +3349,7 @@ public func getBuildNumberRepository(useHgRevisionNumber: Bool = false) {
    - filename: The filename of certificate to store
    - outputPath: The path to a directory in which all certificates and private keys should be stored
    - keychainPath: Path to a custom keychain
-   - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
+   - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your macOS account password
    - skipSetPartitionList: Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing
    - platform: Set the provisioning profile's platform (ios, macos)
 
@@ -4743,7 +4743,7 @@ public func makeChangelogFromJenkins(fallbackChangelog: String = "",
  Alias for the `sync_code_signing` action
 
  - parameters:
-   - type: Define the profile type, can be appstore, adhoc, development, enterprise, developer_id
+   - type: Define the profile type, can be appstore, adhoc, development, enterprise, developer_id, mac_installer_distribution
    - additionalCertTypes: Create additional cert types needed for macOS installers (valid values: mac_installer_distribution, developer_id_installer)
    - readonly: Only fetch existing certificates and profiles, don't generate new ones
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
@@ -4773,7 +4773,7 @@ public func makeChangelogFromJenkins(fallbackChangelog: String = "",
    - s3Bucket: Name of the S3 bucket
    - s3ObjectPrefix: Prefix to be used on all objects uploaded to S3
    - keychainName: Keychain the items should be imported to
-   - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
+   - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your macOS account password
    - force: Renew the provisioning profiles every time you run match
    - forceForNewDevices: Renew the provisioning profiles if the device count on the developer portal has changed. Ignored for profile type 'appstore'
    - skipConfirmation: Disables confirmation prompts during nuke, answering them with yes
@@ -7125,7 +7125,7 @@ public func slather(buildDirectory: String? = nil,
                     ignore: [String]? = nil,
                     verbose: Bool? = nil,
                     useBundleExec: Bool = false,
-                    binaryBasename: Bool = false,
+                    binaryBasename: [String]? = nil,
                     binaryFile: [String]? = nil,
                     arch: String? = nil,
                     sourceFiles: Bool = false,
@@ -7517,7 +7517,7 @@ public func ssh(username: String,
    - versionCode: Version code (used when updating rollout or promoting specific versions)
    - releaseStatus: Release status (used when uploading new apks/aabs) - valid values are completed, draft, halted, inProgress
    - track: The track of the application to use. The default available tracks are: production, beta, alpha, internal
-   - rollout: The percentage of the user fraction when uploading to the rollout track
+   - rollout: The percentage of the user fraction when uploading to the rollout track (setting to 1 will complete the rollout)
    - metadataPath: Path to the directory containing the metadata files
    - key: **DEPRECATED!** Use `--json_key` instead - The p12 File used to authenticate with Google
    - issuer: **DEPRECATED!** Use `--json_key` instead - The issuer of the p12 file (email address of the service account)
@@ -7682,7 +7682,7 @@ public func swiftlint(mode: Any = "lint",
  Easily sync your certificates and profiles across your team (via _match_)
 
  - parameters:
-   - type: Define the profile type, can be appstore, adhoc, development, enterprise, developer_id
+   - type: Define the profile type, can be appstore, adhoc, development, enterprise, developer_id, mac_installer_distribution
    - additionalCertTypes: Create additional cert types needed for macOS installers (valid values: mac_installer_distribution, developer_id_installer)
    - readonly: Only fetch existing certificates and profiles, don't generate new ones
    - generateAppleCerts: Create a certificate type for Xcode 11 and later (Apple Development or Apple Distribution)
@@ -7712,7 +7712,7 @@ public func swiftlint(mode: Any = "lint",
    - s3Bucket: Name of the S3 bucket
    - s3ObjectPrefix: Prefix to be used on all objects uploaded to S3
    - keychainName: Keychain the items should be imported to
-   - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
+   - keychainPassword: This might be required the first time you access certificates on a new mac. For the login/default keychain this is your macOS account password
    - force: Renew the provisioning profiles every time you run match
    - forceForNewDevices: Renew the provisioning profiles if the device count on the developer portal has changed. Ignored for profile type 'appstore'
    - skipConfirmation: Disables confirmation prompts during nuke, answering them with yes
@@ -8692,7 +8692,7 @@ public func uploadToAppStore(apiKeyPath: String? = nil,
    - versionCode: Version code (used when updating rollout or promoting specific versions)
    - releaseStatus: Release status (used when uploading new apks/aabs) - valid values are completed, draft, halted, inProgress
    - track: The track of the application to use. The default available tracks are: production, beta, alpha, internal
-   - rollout: The percentage of the user fraction when uploading to the rollout track
+   - rollout: The percentage of the user fraction when uploading to the rollout track (setting to 1 will complete the rollout)
    - metadataPath: Path to the directory containing the metadata files
    - key: **DEPRECATED!** Use `--json_key` instead - The p12 File used to authenticate with Google
    - issuer: **DEPRECATED!** Use `--json_key` instead - The issuer of the p12 file (email address of the service account)
@@ -9408,4 +9408,4 @@ public let snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.103]
+// FastlaneRunnerAPIVersion [0.9.104]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -17,4 +17,4 @@ public class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.167.0
+// Generated with fastlane 2.168.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -184,4 +184,4 @@ public extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.53]
+// FastlaneRunnerAPIVersion [0.9.54]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -17,4 +17,4 @@ public class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.167.0
+// Generated with fastlane 2.168.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 FastlaneTools
 
 public protocol MatchfileProtocol: class {
-    /// Define the profile type, can be appstore, adhoc, development, enterprise, developer_id
+    /// Define the profile type, can be appstore, adhoc, development, enterprise, developer_id, mac_installer_distribution
     var type: String { get }
 
     /// Create additional cert types needed for macOS installers (valid values: mac_installer_distribution, developer_id_installer)
@@ -92,7 +92,7 @@ public protocol MatchfileProtocol: class {
     /// Keychain the items should be imported to
     var keychainName: String { get }
 
-    /// This might be required the first time you access certificates on a new mac. For the login/default keychain this is your account password
+    /// This might be required the first time you access certificates on a new mac. For the login/default keychain this is your macOS account password
     var keychainPassword: String? { get }
 
     /// Renew the provisioning profiles every time you run match
@@ -184,4 +184,4 @@ public extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.47]
+// FastlaneRunnerAPIVersion [0.9.48]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -17,4 +17,4 @@ public class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.167.0
+// Generated with fastlane 2.168.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -48,4 +48,4 @@ public extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.46]
+// FastlaneRunnerAPIVersion [0.9.47]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -17,4 +17,4 @@ public class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.167.0
+// Generated with fastlane 2.168.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -264,4 +264,4 @@ public extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.58]
+// FastlaneRunnerAPIVersion [0.9.59]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -17,4 +17,4 @@ public class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.167.0
+// Generated with fastlane 2.168.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -96,4 +96,4 @@ public extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.48]
+// FastlaneRunnerAPIVersion [0.9.49]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -17,4 +17,4 @@ public class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.167.0
+// Generated with fastlane 2.168.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -184,4 +184,4 @@ public extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.42]
+// FastlaneRunnerAPIVersion [0.9.43]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.167.0':**

* [spaceship] add client optional parameter in model helpers (#17475) via Bolo Michelin
* [match] support mac_installer_distribution certificate type (#17561) via Paul Taykalo
* [docs] improve docs by specific which account we refer to. (#17604) via Roger Oba
* [action] add support for arrays in in slather action for binary_basename and FL_SLATHER_BINARY_BASENAME environment variable (#17606) via José González
* [fastlane] also support NO_COLOR for disabling colors (#17611) via Benedek Kozma
* [deliver] read values from SharedValues context only if needed. (#17616) via Roger Oba
* [scan] fix crash on TestResultParser when disable_xcpretty=true (#17623) via Marcelo Gobetti
* [supply] skip sending user fraction if it's 1.0 when promoting track (#17617) via Roger Oba
* [docs] improve template by guiding users to actually link PRs to Issues. (#17618) via Roger Oba
