### PR TITLE
[action] add -scmProvider option to xcodebuild command for the gym and scan actions

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -39,6 +39,7 @@ module Gym
         options << "-destination '#{config[:destination]}'" if config[:destination]
         options << "-archivePath #{archive_path.shellescape}" unless config[:skip_archive]
         options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
+        options << "-scmProvider system" if config[:use_system_scm]
         options << config[:xcargs] if config[:xcargs]
         options << "OTHER_SWIFT_FLAGS=\"-Xfrontend -debug-time-function-bodies\"" if config[:analyze_build_time]
 

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -284,7 +284,7 @@ module Gym
                                      env_name: "GYM_USE_SYSTEM_SCM",
                                      description: "Lets xcodebuild use system's scm configuration",
                                      optional: true,
-                                     is_string: false,
+                                     type: Boolean,
                                      default_value: false)
       ]
     end

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -279,7 +279,13 @@ module Gym
                                      env_name: "GYM_CLONED_SOURCE_PACKAGES_PATH",
                                      description: "Sets a custom path for Swift Package Manager dependencies",
                                      type: String,
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :use_system_scm,
+                                     env_name: "GYM_USE_SYSTEM_SCM",
+                                     description: "Lets xcodebuild use system's scm configuration",
+                                     optional: true,
+                                     is_string: false,
+                                     default_value: false)
       ]
     end
   end

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -87,7 +87,7 @@ describe Gym do
                              "--utf"
                            ])
     end
-    
+
     it "uses system scm", requires_xcodebuild: true do
       options = { project: "./gym/examples/standard/Example.xcodeproj", use_system_scm: true }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
@@ -99,7 +99,7 @@ describe Gym do
       options = { project: "./gym/examples/standard/Example.xcodeproj" }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
       result = Gym::BuildCommandGenerator.generate
-      expect(result).to_not include("-scmProvider system")
+      expect(result).to_not(include("-scmProvider system"))
     end
 
     it "uses the correct build command when `skip_archive` is used", requires_xcodebuild: true do

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -87,6 +87,20 @@ describe Gym do
                              "--utf"
                            ])
     end
+    
+    it "uses system scm", requires_xcodebuild: true do
+      options = { project: "./gym/examples/standard/Example.xcodeproj", use_system_scm: true }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+      result = Gym::BuildCommandGenerator.generate
+      expect(result).to include("-scmProvider system")
+    end
+
+    it "defaults to Xcode scm when option is not provided", requires_xcodebuild: true do
+      options = { project: "./gym/examples/standard/Example.xcodeproj" }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+      result = Gym::BuildCommandGenerator.generate
+      expect(result).to_not include("-scmProvider system")
+    end
 
     it "uses the correct build command when `skip_archive` is used", requires_xcodebuild: true do
       log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -445,7 +445,13 @@ module Scan
                                     env_name: "SCAN_CLONED_SOURCE_PACKAGES_PATH",
                                     description: "Sets a custom path for Swift Package Manager dependencies",
                                     type: String,
-                                    optional: true)
+                                    optional: true),
+        FastlaneCore::ConfigItem.new(key: :use_system_scm,
+                                     env_name: "SCAN_USE_SYSTEM_SCM",
+                                     description: "Lets xcodebuild use system's scm configuration",
+                                     optional: true,
+                                     is_string: false,
+                                     default_value: false)
 
       ]
     end

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -450,7 +450,7 @@ module Scan
                                      env_name: "SCAN_USE_SYSTEM_SCM",
                                      description: "Lets xcodebuild use system's scm configuration",
                                      optional: true,
-                                     is_string: false,
+                                     type: Boolean,
                                      default_value: false)
 
       ]

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -32,6 +32,7 @@ module Scan
 
       options = []
       options += project_path_array unless config[:xctestrun]
+      options << "-scmProvider system" if config[:use_system_scm]
       options << "-sdk '#{config[:sdk]}'" if config[:sdk]
       options << destination # generated in `detect_values`
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -170,7 +170,7 @@ describe Scan do
       options = { project: "./scan/examples/standard/app.xcodeproj" }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       result = @test_command_generator.generate
-      expect(result).to_not include("-scmProvider system")
+      expect(result).to_not(include("-scmProvider system"))
     end
 
     describe "Standard Example" do

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -159,6 +159,20 @@ describe Scan do
       expect(result.last).to include("| xcpretty -f 'custom-formatter.rb'")
     end
 
+    it "uses system scm", requires_xcodebuild: true do
+      options = { project: "./scan/examples/standard/app.xcodeproj", use_system_scm: true }
+      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+      result = @test_command_generator.generate
+      expect(result).to include("-scmProvider system")
+    end
+
+    it "defaults to Xcode scm when option is not provided", requires_xcodebuild: true do
+      options = { project: "./scan/examples/standard/app.xcodeproj" }
+      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+      result = @test_command_generator.generate
+      expect(result).to_not include("-scmProvider system")
+    end
+
     describe "Standard Example" do
       before do
         options = { project: "./scan/examples/standard/app.xcodeproj" }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->
The gym and scan actions do not currently include the option to force xcodebuild to use the system's SCM configuration.

This option would be useful for projects using privately hosted Swift Packages, as xcodebuild could simply use the system's configuration without requiring an additional script to use as a workaround for the bug (50686014) described in the [Xcode 11 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-11-release-notes) related to SSH fingerprinting, which is currently unsolved in Xcode 12.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Added the use_system_scm option to the scan and gym actions.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Use the scan and/or gym actions with the option provided and ensure the xcodebuild command includes the `-scmProvider system` argument.
For a more thorough test, use the scan and/or gym actions with the option provided to build a project using privately hosted Swift Packages and ensure the packages are fetched correctly.
