### PR TITLE
[xcode-install] add option to customize number of download retry attempts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source("https://rubygems.org")
 
-gem "xcode-install", ">= 2.2.1" # needed for running xcode-install related tests
+gem "xcode-install", ">= 2.6.7" # needed for running xcode-install related tests
 
 gem "danger", "~> 8.0"
 gem "danger-junit", "~> 1.0"

--- a/fastlane/lib/fastlane/actions/xcode_install.rb
+++ b/fastlane/lib/fastlane/actions/xcode_install.rb
@@ -17,7 +17,7 @@ module Fastlane
         if installer.installed?(params[:version])
           UI.success("Xcode #{params[:version]} is already installed ✨")
         else
-          installer.install_version(params[:version], switch: true, clean: true, install: true, progress: true, url: nil, show_release_notes: true, progress_block: nil, retry_download_count: params[:download_retry_attempts])
+          installer.install_version(params[:version], true, true, true, true, nil, true, nil, params[:download_retry_attempts])
         end
 
         xcode = installer.installed_versions.find { |x| x.version == params[:version] }

--- a/fastlane/lib/fastlane/actions/xcode_install.rb
+++ b/fastlane/lib/fastlane/actions/xcode_install.rb
@@ -17,7 +17,7 @@ module Fastlane
         if installer.installed?(params[:version])
           UI.success("Xcode #{params[:version]} is already installed ✨")
         else
-          installer.install_version(params[:version], true, true, true, true)
+          installer.install_version(params[:version], switch: true, clean: true, install: true, progress: true, url: nil, show_release_notes: true, progress_block: nil, retry_download_count: params[:download_retry_attempts])
         end
 
         xcode = installer.installed_versions.find { |x| x.version == params[:version] }
@@ -49,9 +49,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_XCODE_VERSION",
-                                       description: "The version number of the version of Xcode to install",
-                                       verify_block: proc do |value|
-                                       end),
+                                       description: "The version number of the version of Xcode to install"),
           FastlaneCore::ConfigItem.new(key: :username,
                                        short_option: "-u",
                                        env_name: "XCODE_INSTALL_USER",
@@ -65,7 +63,12 @@ module Fastlane
                                        optional: true,
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:team_id),
-                                       default_value_dynamic: true)
+                                       default_value_dynamic: true),
+          FastlaneCore::ConfigItem.new(key: :download_retry_attempts,
+                                       env_name: "XCODE_INSTALL_DOWNLOAD_RETRY_ATTEMPTS",
+                                       description: "Number of times the download will be retried in case of failure",
+                                       type: Integer,
+                                       default_value: 3)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves https://github.com/fastlane/fastlane/discussions/17608

### Description
Now that xcode-install supports customizing the number of download attempts (https://github.com/xcpretty/xcode-install/pull/400) in v2.6.7, this option can be received by fastlane and forwarded to xcode-install as well 😊 

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-xcode-install-download-retry-attempts"
```

Run this command such as: `xcode_install(version: "12.1", username: "example@email.com, download_retry_attempts: 6)`