### PR TITLE
[spaceship] Handle 429 error response

### DIFF
--- a/spaceship/lib/spaceship/errors.rb
+++ b/spaceship/lib/spaceship/errors.rb
@@ -49,7 +49,7 @@ module Spaceship
     attr_reader :rate_limit_user
 
     def initialize(resp_hash)
-      headers = resp_hash[:response_headers]
+      headers = resp_hash[:response_headers] || {}
       @retry_after = (headers['retry-after'] || 60).to_i
       @rate_limit_user = headers['x-daiquiri-rate-limit-user']
       message = 'Apple 429 detected'

--- a/spaceship/lib/spaceship/errors.rb
+++ b/spaceship/lib/spaceship/errors.rb
@@ -43,6 +43,25 @@ module Spaceship
     end
   end
 
+  # Raised when 429 is received from App Store Connect
+  class TooManyRequestsError < BasicPreferredInfoError
+    attr_reader :retry_after
+    attr_reader :rate_limit_user
+
+    def initialize(resp_hash)
+      headers = resp_hash[:response_headers]
+      @retry_after = (headers['retry-after'] || 60).to_i
+      @rate_limit_user = headers['x-daiquiri-rate-limit-user']
+      message = 'Apple 429 detected'
+      message += " - #{rate_limit_user}" if rate_limit_user
+      super(message)
+    end
+
+    def show_github_issues
+      false
+    end
+  end
+
   class UnexpectedResponse < StandardError
     attr_reader :error_info
 

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -109,6 +109,14 @@ describe Spaceship::Client do
         subject.req_home
       end.to raise_error(Spaceship::ProgramLicenseAgreementUpdated)
     end
+
+    it "raises Spaceship::TooManyRequestsError" do
+      stub_client_request(Spaceship::TooManyRequestsError.new({}), 6, 429, "Program License Agreement")
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::Client::TooManyRequestsError)
+    end
   end
 
   describe 'retry' do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I was working on automating creation of IAP's on Appstore Connect with spaceship, and I kept running into rate limiting errors. I searched issues for the 429 error and there were a few threads on it, but they're all closed and it doesn't look like it was ever solved for in the general case:
Relates to https://github.com/fastlane/fastlane/pull/14084
Resolves https://github.com/fastlane/fastlane/issues/14070
Resolves https://github.com/fastlane/fastlane/issues/13841
Resolves https://github.com/fastlane/fastlane/issues/12845#issuecomment-445042964

### Description
I found a workaround on my side, but got curious and debugged fastlane with Charles. I figured out that the 429 responses contain a `retry-after` header with the timeout. Here's a screenshot of Charles:

<img width="1680" alt="fastlane 429 error charles scrubbed" src="https://user-images.githubusercontent.com/679017/100524085-ab9e9500-317a-11eb-8f29-3545dae65dff.png">

I added a new error type `TooManyRequestsError` that reads the `retry-after` and `x-daiquiri-rate-limit-user` headers for timeout and display, respectively. If the `retry-after` header is missing for some reason, I have it default to 60 seconds (the range I've observed seems to be somewhere between 15-45s). I tried to follow the existing conventions, but I'm new to Ruby so welcome any feedback. I'm also open to feedback about formatting the display output. Here are screenshots of what the fastlane output looks like when it encounters a 429 error (the lines above and below the timeout message are from my script, not fastlane):

With information from headers:
<img width="1316" alt="fastlane 429 error message with headers" src="https://user-images.githubusercontent.com/679017/100524089-c40eaf80-317a-11eb-9acc-3ba97cad5eb7.png">

If the headers are missing:
<img width="1327" alt="fastlane 429 error message without headers" src="https://user-images.githubusercontent.com/679017/100524091-c709a000-317a-11eb-810f-a7843645b810.png">

### Testing Steps
If you'd like me to add a test, I'd be happy to try, but could use some guidance. I can still reproduce the issue with my scripts locally, but don't have a minimal repro that I can share. I could try to create one if that would be helpful.