### PR TITLE
[docs] improve GitHub Pull Request template by unifying two similar items of the checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,7 @@
 <!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
 
 ### Checklist
-- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
-- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
+- [ ] I've run `bundle exec fastlane test` from the root directory to see all new and existing tests pass
 - [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
 - [ ] I've updated the documentation if necessary.
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Having those two similar items seemed wrong to me, since we have `bundle exec fastlane test` that performs both actions.

### Description

I think the those two items can be unified since there's an action that would check both items of the checklist at once. This makes opening PRs 1.3 seconds faster, which would have saved us a total of 135 minutes in the lifetime of this repository since it was created 😇 😂 

### Testing Steps

Nothing, really. Just updating the PR template :) 