### PR TITLE
[match] Only include enabled devices for force_for_new_devices

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -390,7 +390,7 @@ lane :beta do
 end
 ```
 
-By using the `force_for_new_devices` parameter, _match_ will check if the device count has changed since the last time you ran _match_, and automatically re-generate the provisioning profile if necessary. You can also use `force: true` to re-generate the provisioning profile on each run.
+By using the `force_for_new_devices` parameter, _match_ will check if the (enabled) device count has changed since the last time you ran _match_, and automatically re-generate the provisioning profile if necessary. You can also use `force: true` to re-generate the provisioning profile on each run.
 
 _**Important:** The `force_for_new_devices` parameter is ignored for App Store provisioning profiles since they don't contain any device information._
 

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -355,7 +355,7 @@ module Match
         devices = Spaceship::ConnectAPI::Device.all
         unless device_classes.empty?
           devices = devices.select do |device|
-            device_classes.include?(device.device_class)
+            device_classes.include?(device.device_class) && device.enabled?
           end
         end
 

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -333,5 +333,42 @@ describe Match do
         end
       end
     end
+
+    describe "#device_count_different?" do
+      let(:profile_file) { double("profile file") }
+      let(:uuid) { "1234-1234-1234-1234" }
+      let(:parsed_profile) { { "UUID" => uuid } }
+      let(:profile) { double("profile") }
+      let(:profile_device) { double("profile_device") }
+
+      before do
+        allow(profile).to receive(:uuid).and_return(uuid)
+        allow(profile).to receive(:fetch_all_devices).and_return([profile_device])
+      end
+
+      it "device is enabled" do
+        expect(FastlaneCore::ProvisioningProfile).to receive(:parse).and_return(parsed_profile)
+        expect(Spaceship::ConnectAPI::Profile).to receive(:all).and_return([profile])
+        expect(Spaceship::ConnectAPI::Device).to receive(:all).and_return([profile_device])
+
+        expect(profile_device).to receive(:device_class).and_return(Spaceship::ConnectAPI::Device::DeviceClass::IPOD)
+        expect(profile_device).to receive(:enabled?).and_return(true)
+
+        runner = Match::Runner.new
+        expect(runner.device_count_different?(profile: profile_file, platform: :ios)).to be(false)
+      end
+
+      it "device is disabled" do
+        expect(FastlaneCore::ProvisioningProfile).to receive(:parse).and_return(parsed_profile)
+        expect(Spaceship::ConnectAPI::Profile).to receive(:all).and_return([profile])
+        expect(Spaceship::ConnectAPI::Device).to receive(:all).and_return([profile_device])
+
+        expect(profile_device).to receive(:device_class).and_return(Spaceship::ConnectAPI::Device::DeviceClass::IPOD)
+        expect(profile_device).to receive(:enabled?).and_return(false)
+
+        runner = Match::Runner.new
+        expect(runner.device_count_different?(profile: profile_file, platform: :ios)).to be(true)
+      end
+    end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -40,6 +40,10 @@ module Spaceship
         return "devices"
       end
 
+      def enabled?
+        return status == Status::ENABLED
+      end
+
       #
       # API
       #

--- a/spaceship/spec/connect_api/models/device_spec.rb
+++ b/spaceship/spec/connect_api/models/device_spec.rb
@@ -20,6 +20,11 @@ describe Spaceship::ConnectAPI::Device do
       expect(model.status).to eq("ENABLED")
       expect(model.udid).to eq("184098239048390489012849018")
       expect(model.added_date).to eq("2018-10-10T01:43:27.000+0000")
+
+      expect(model.enabled?).to eq(true)
+
+      model.status = "DISABLED"
+      expect(model.enabled?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This pull request resolves #17694. This is an issue where disabled devices are included when determining whether to create a new provisioning profile in case the `force_for_new_devices` option is set to `true`. As disabled devices cannot be added to a provisioning profile, this results in a new provisioning profile being created when it should not be.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:

-->

### Description
This changes the `device_count_different` function to not only check the device type to count, but also whether the device is actually enabled.

### Testing Steps
`match` should be run (for either `development` or `adhoc` profiles), with `force_for_new_devices` set to `true`, using an Apple account that contains disabled devices. Before the fix a new provisioning profile is created every time. After the fix the provisioning profile should only be created at most once.
