### PR TITLE
[onesignal]Update onesignal.rb to include optional organization_id

### DIFF
--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -142,7 +142,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :organization_id,
                                        env_name: "ORGANIZATION_ID",
                                        sensitive: true,
-                                       description: "ONESIGNAL ORGANIZATION ID",
+                                       description: "OneSignal Organization ID",
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -17,6 +17,7 @@ module Fastlane
         apns_p12_password = params[:apns_p12_password]
         android_token = params[:android_token]
         android_gcm_sender_id = params[:android_gcm_sender_id]
+        organization_id = params[:organization_id].to_s.strip
 
         has_app_id = !app_id.empty?
         has_app_name = !app_name.empty?
@@ -43,6 +44,7 @@ module Fastlane
 
         payload["gcm_key"] = android_token unless android_token.nil?
         payload["android_gcm_sender_id"] = android_gcm_sender_id unless android_gcm_sender_id.nil?
+        payload["organization_id"] = organization_id unless organization_id.nil?
 
         # here's the actual lifting - POST or PUT to OneSignal
 
@@ -135,7 +137,13 @@ module Fastlane
                                        env_name: "APNS_ENV",
                                        description: "APNS environment",
                                        optional: true,
-                                       default_value: 'production')
+                                       default_value: 'production'),
+
+          FastlaneCore::ConfigItem.new(key: :organization_id,
+                                       env_name: "ORGANIZATION_ID",
+                                       sensitive: true,
+                                       description: "ONESIGNAL ORGANIZATION ID",
+                                       optional: true)
         ]
       end
 
@@ -163,7 +171,8 @@ module Fastlane
             android_gcm_sender_id: "Your Android GCM Sender ID (optional)",
             apns_p12: "Path to Apple .p12 file (optional)",
             apns_p12_password: "Password for .p12 file (optional)",
-            apns_env: "production/sandbox (defaults to production)"
+            apns_env: "production/sandbox (defaults to production)",
+            organization_id: "Onesignal organization id (optional)"
           )',
           'onesignal(
             app_id: "Your OneSignal App ID",
@@ -173,7 +182,8 @@ module Fastlane
             android_gcm_sender_id: "Your Android GCM Sender ID (optional)",
             apns_p12: "Path to Apple .p12 file (optional)",
             apns_p12_password: "Password for .p12 file (optional)",
-            apns_env: "production/sandbox (defaults to production)"
+            apns_env: "production/sandbox (defaults to production)",
+            organization_id: "Onesignal organization id (optional)"
           )'
         ]
       end
@@ -184,3 +194,4 @@ module Fastlane
     end
   end
 end
+

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -17,7 +17,7 @@ module Fastlane
         apns_p12_password = params[:apns_p12_password]
         android_token = params[:android_token]
         android_gcm_sender_id = params[:android_gcm_sender_id]
-        organization_id = params[:organization_id].to_s.strip
+        organization_id = params[:organization_id]
 
         has_app_id = !app_id.empty?
         has_app_name = !app_name.empty?

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -140,7 +140,7 @@ module Fastlane
                                        default_value: 'production'),
 
           FastlaneCore::ConfigItem.new(key: :organization_id,
-                                       env_name: "ORGANIZATION_ID",
+                                       env_name: "ONE_SIGNAL_ORGANIZATION_ID",
                                        sensitive: true,
                                        description: "OneSignal Organization ID",
                                        optional: true)

--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -194,4 +194,3 @@ module Fastlane
     end
   end
 end
-


### PR DESCRIPTION
🔑 adds optional, organization_id, paramater to onesignal.rb

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change adds the [Onesignal](https://documentation.onesignal.com/reference/create-an-app) organization_id as an optional parameter.  Presently, when new Onesignal applications are created, they are created without being assigned to an organization.  This allows end users to specify an organization_id if desired.  Apps created under an organization will delegate the Onesignal org-level-admins to that application.  Org-level-admins are unable to view/modify apps not within the organization.

No issue has been created.  Please let me know if you'd like an issue created for this PR.

### Description
The additional parameter was added inline with the other parameters in onesignal.rb.  Payload has been updated along with self.available_options, and self.example_code.  

Both `bundle exec rubocop -a` and `bundle exec rspec` as referenced [here](https://github.com/fastlane/fastlane/blob/master/Testing.md) were ran following the changes.
  

### Testing Steps
`bundle exec onesignal` was ran with a Fastfile containing the necessary parameters including `organization_id`.   This resulted in a new application being created within Onesignal under the provided organization_id. This allowed org-level-admins to view the newly created onesignal application.  Additionally,  the changes were ran on an app update successfully, and on an app without the organization_id provided.  On the latter, the app was created without being assigned to an organization. The changes will also update an application that was created outside of an organization and will move it under the provided organization.
