### PR TITLE
[spaceship] ConnectAPI::App - actually limit get_app_store_versions

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -282,8 +282,13 @@ module Spaceship
 
       def get_app_store_versions(client: nil, filter: {}, includes: Spaceship::ConnectAPI::AppStoreVersion::ESSENTIAL_INCLUDES, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
-        resps = client.get_app_store_versions(app_id: id, filter: filter, includes: includes, limit: limit, sort: sort).all_pages
-        return resps.flat_map(&:to_models)
+        if limit.nil?
+          resps = client.get_app_store_versions(app_id: id, filter: filter, includes: includes, limit: limit, sort: sort).all_pages
+          return resps.flat_map(&:to_models)
+        else
+          resp = client.get_app_store_versions(app_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
+          return resp.to_models
+        end
       end
 
       #


### PR DESCRIPTION
### Motivation and Context
Fix issues where passing a limit would still fetch all pages

### Description
Previously, using `limit` would fetch all pages but with the limited page size. This fix doesn't call `all_pages` if a limit is passed.

