### PR TITLE
[deliver] improve screenshot validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,8 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
+            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
+            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
             brew update
             brew untap caskroom/versions || true
             brew install shellcheck

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -84,7 +84,7 @@ module Deliver
     # @param screen_size (Deliver::AppScreenshot::ScreenSize) the screen size, which
     #  will automatically be calculated when you don't set it. (Deprecated)
     def initialize(path, language, screen_size = nil)
-      UI.deprecated('`screen_size` for Deliver::AppScreenshot.new is deperecated in favor of the default behavior to calculate size automatically. Passed value is no longer validated.') if screen_size
+      UI.deprecated('`screen_size` for Deliver::AppScreenshot.new is deprecated in favor of the default behavior to calculate size automatically. Passed value is no longer validated.') if screen_size
       self.path = path
       self.language = language
       self.screen_size = screen_size || self.class.calculate_screen_size(path)

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -82,15 +82,12 @@ module Deliver
     # @param path (String) path to the screenshot file
     # @param language (String) Language of this screenshot (e.g. English)
     # @param screen_size (Deliver::AppScreenshot::ScreenSize) the screen size, which
-    #  will automatically be calculated when you don't set it.
+    #  will automatically be calculated when you don't set it. (Deperecated)
     def initialize(path, language, screen_size = nil)
+      UI.deprecated('screen_size param for Deliver::AppScreenshot.new is deperecated.') if screen_size
       self.path = path
       self.language = language
-      screen_size ||= self.class.calculate_screen_size(path)
-
-      self.screen_size = screen_size
-
-      UI.error("Looks like the screenshot given (#{path}) does not match the requirements of #{screen_size}") unless self.is_valid?
+      self.screen_size = screen_size || self.class.calculate_screen_size(path)
     end
 
     # The iTC API requires a different notation for the device
@@ -161,6 +158,7 @@ module Deliver
 
     # Validates the given screenshots (size and format)
     def is_valid?
+      UI.deprecated('Deliver::AppScreenshot#is_valid? is depereated in favor of Deliver::AppScreenshotValidator')
       return false unless ["png", "PNG", "jpg", "JPG", "jpeg", "JPEG"].include?(self.path.split(".").last)
 
       return self.screen_size == self.class.calculate_screen_size(self.path)
@@ -350,7 +348,7 @@ module Deliver
         end
       end
 
-      UI.user_error!("Unsupported screen size #{size} for path '#{path}'")
+      nil
     end
   end
 

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -84,7 +84,7 @@ module Deliver
     # @param screen_size (Deliver::AppScreenshot::ScreenSize) the screen size, which
     #  will automatically be calculated when you don't set it. (Deprecated)
     def initialize(path, language, screen_size = nil)
-      UI.deprecated('`screen_size` for Deliver::AppScreenshot.new is deperecated in favor of the default behavior to calculate size automatically.') if screen_size
+      UI.deprecated('`screen_size` for Deliver::AppScreenshot.new is deperecated in favor of the default behavior to calculate size automatically. Passed value is no longer validated.') if screen_size
       self.path = path
       self.language = language
       self.screen_size = screen_size || self.class.calculate_screen_size(path)

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -84,7 +84,7 @@ module Deliver
     # @param screen_size (Deliver::AppScreenshot::ScreenSize) the screen size, which
     #  will automatically be calculated when you don't set it. (Deprecated)
     def initialize(path, language, screen_size = nil)
-      UI.deprecated('screen_size param for Deliver::AppScreenshot.new is deperecated.') if screen_size
+      UI.deprecated('`screen_size` for Deliver::AppScreenshot.new is deperecated in favor of the default behavior to calculate size automatically.') if screen_size
       self.path = path
       self.language = language
       self.screen_size = screen_size || self.class.calculate_screen_size(path)

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -82,7 +82,7 @@ module Deliver
     # @param path (String) path to the screenshot file
     # @param language (String) Language of this screenshot (e.g. English)
     # @param screen_size (Deliver::AppScreenshot::ScreenSize) the screen size, which
-    #  will automatically be calculated when you don't set it. (Deperecated)
+    #  will automatically be calculated when you don't set it. (Deprecated)
     def initialize(path, language, screen_size = nil)
       UI.deprecated('screen_size param for Deliver::AppScreenshot.new is deperecated.') if screen_size
       self.path = path
@@ -158,7 +158,7 @@ module Deliver
 
     # Validates the given screenshots (size and format)
     def is_valid?
-      UI.deprecated('Deliver::AppScreenshot#is_valid? is depereated in favor of Deliver::AppScreenshotValidator')
+      UI.deprecated('Deliver::AppScreenshot#is_valid? is deprecated in favor of Deliver::AppScreenshotValidator')
       return false unless ["png", "PNG", "jpg", "JPG", "jpeg", "JPEG"].include?(self.path.split(".").last)
 
       return self.screen_size == self.class.calculate_screen_size(self.path)

--- a/deliver/lib/deliver/app_screenshot_validator.rb
+++ b/deliver/lib/deliver/app_screenshot_validator.rb
@@ -2,14 +2,14 @@ require 'fastimage'
 
 module Deliver
   class AppScreenshotValidator
-    # A simple structure that holds error information as well as format error message consistently
-    # Set `true` to `to_skip` when just needing to skip uploading rather than causing a crash.
+    # A simple structure that holds error information as well as formatted error messages consistently
+    # Set `to_skip` to `true` when just needing to skip uploading rather than causing a crash.
     class ValidationError
       # Constants that can be given to `type` param
       INVALID_SCREEN_SIZE = 'Invalid screen size'.freeze
       UNACCEPTABLE_DEVICE = 'Not an accepted App Store Connect device'.freeze
       INVALID_FILE_EXTENSION = 'Invalid file extension'.freeze
-      FILE_EXTENSION_MISMATCH = 'File extension mistmaches its image format'.freeze
+      FILE_EXTENSION_MISMATCH = 'File extension mismatches its image format'.freeze
 
       attr_reader :type, :path, :debug_info, :to_skip
 
@@ -32,8 +32,8 @@ module Deliver
     # Access each array by symbol returned from FastImage.type
     ALLOWED_SCREENSHOT_FILE_EXTENSION = { png: ['png', 'PNG'], jpeg: ['jpg', 'JPG', 'jpeg', 'JPEG'] }.freeze
 
-    # Validate a screenshot and inform an error message via `errors` parameters. `errors` is mutated
-    # to append the messages and each message should contain the corresponding path to let users know which file gets the error.
+    # Validate a screenshot and inform an error message via `errors` parameter. `errors` is mutated
+    # to append the messages and each message should contain the corresponding path to let users know which file is throwing the error.
     #
     # @param screenshot [AppScreenshot]
     # @param errors [Array<Deliver::AppScreenshotValidator::ValidationError>] Pass an array object to add validation errors when detecting errors
@@ -83,11 +83,11 @@ module Deliver
       end
 
       format = FastImage.type(screenshot.path)
-      is_extension_macthed = ALLOWED_SCREENSHOT_FILE_EXTENSION[format] &&
+      is_extension_matched = ALLOWED_SCREENSHOT_FILE_EXTENSION[format] &&
                              ALLOWED_SCREENSHOT_FILE_EXTENSION[format].include?(extension)
 
       # This error only appears when file extension is valid
-      if is_valid_extension && !is_extension_macthed
+      if is_valid_extension && !is_extension_matched
         errors_found << ValidationError.new(type: ValidationError::FILE_EXTENSION_MISMATCH,
                                             path: screenshot.path,
                                             debug_info: "Actual format is #{format}")

--- a/deliver/lib/deliver/app_screenshot_validator.rb
+++ b/deliver/lib/deliver/app_screenshot_validator.rb
@@ -1,0 +1,103 @@
+require 'fastimage'
+
+module Deliver
+  class AppScreenshotValidator
+    # A simple structure that holds error information as well as format error message consistently
+    # Set `true` to `to_skip` when just needing to skip uploading rather than causing a crash.
+    class ValidationError
+      # Constants that can be given to `type` param
+      INVALID_SCREEN_SIZE = 'Invalid screen size'.freeze
+      UNACCEPTABLE_DEVICE = 'Not an accepted App Store Connect device'.freeze
+      INVALID_FILE_EXTENSION = 'Invalid file extension'.freeze
+      FILE_EXTENSION_MISMATCH = 'File extension mistmaches its image format'.freeze
+
+      attr_reader :type, :path, :debug_info, :to_skip
+
+      def initialize(type: nil, path: nil, debug_info: nil, to_skip: false)
+        @type = type
+        @path = path
+        @debug_info = debug_info
+        @to_skip = to_skip
+      end
+
+      def to_s
+        "#{to_skip ? '🏃 Skipping' : '🚫 Error'}: #{path} - #{type} (#{debug_info})"
+      end
+
+      def inspect
+        "\"#{type}\""
+      end
+    end
+
+    # Access each array by symbol returned from FastImage.type
+    ALLOWED_SCREENSHOT_FILE_EXTENSION = { png: ['png', 'PNG'], jpeg: ['jpg', 'JPG', 'jpeg', 'JPEG'] }.freeze
+
+    # Validate a screenshot and inform an error message via `errors` parameters. `errors` is mutated
+    # to append the messages and each message should contain the corresponding path to let users know which file gets the error.
+    #
+    # @param screenshot [AppScreenshot]
+    # @param errors [Array<Deliver::AppScreenshotValidator::ValidationError>] Pass an array object to add validation errors when detecting errors
+    # @return [Boolean] true if given screenshot is valid
+    def self.validate(screenshot, errors)
+      # Given screenshot will be diagnosed and errors found are accumulated
+      errors_found = []
+
+      validate_screen_size(screenshot, errors_found)
+      validate_device_type(screenshot, errors_found)
+      validate_file_extension_and_format(screenshot, errors_found)
+
+      # Merge errors found into given errors array
+      errors_found.each { |error| errors.push(error) }
+      errors_found.empty?
+    end
+
+    def self.validate_screen_size(screenshot, errors_found)
+      if screenshot.screen_size.nil?
+        errors_found << ValidationError.new(type: ValidationError::INVALID_SCREEN_SIZE,
+                                            path: screenshot.path,
+                                            debug_info: "Actual size is #{get_formatted_size(screenshot)}")
+      end
+    end
+
+    # Checking if the device type exists in spaceship
+    # Ex: iPhone 6.1 inch isn't supported in App Store Connect but need
+    # to have it in there for frameit support
+    def self.validate_device_type(screenshot, errors_found)
+      if !screenshot.screen_size.nil? && screenshot.device_type.nil?
+        errors_found << ValidationError.new(type: ValidationError::UNACCEPTABLE_DEVICE,
+                                            path: screenshot.path,
+                                            debug_info: "Screen size #{screenshot.screen_size} is not accepted",
+                                            to_skip: true)
+      end
+    end
+
+    def self.validate_file_extension_and_format(screenshot, errors_found)
+      extension = File.extname(screenshot.path).delete('.')
+      valid_file_extensions = ALLOWED_SCREENSHOT_FILE_EXTENSION.values.flatten
+      is_valid_extension = valid_file_extensions.include?(extension)
+
+      unless is_valid_extension
+        errors_found << ValidationError.new(type: ValidationError::INVALID_FILE_EXTENSION,
+                                            path: screenshot.path,
+                                            debug_info: "Only #{valid_file_extensions.join(', ')} are allowed")
+      end
+
+      format = FastImage.type(screenshot.path)
+      is_extension_macthed = ALLOWED_SCREENSHOT_FILE_EXTENSION[format] &&
+                             ALLOWED_SCREENSHOT_FILE_EXTENSION[format].include?(extension)
+
+      # This error only appears when file extension is valid
+      if is_valid_extension && !is_extension_macthed
+        errors_found << ValidationError.new(type: ValidationError::FILE_EXTENSION_MISMATCH,
+                                            path: screenshot.path,
+                                            debug_info: "Actual format is #{format}")
+      end
+    end
+
+    def self.get_formatted_size(screenshot)
+      size = FastImage.size(screenshot.path)
+      return size.join('x') if size
+      nil
+    end
+  end
+end

--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -3,6 +3,7 @@ require 'spaceship/tunes/tunes'
 
 require_relative 'module'
 require_relative 'app_screenshot'
+require_relative 'app_screenshot_validator'
 require_relative 'upload_metadata'
 require_relative 'languages'
 
@@ -100,36 +101,22 @@ module Deliver
       end
 
       errors = []
-      valid_screenshots = screenshots.select { |screenshot| validate_screenshot(screenshot, errors) }
+      valid_screenshots = screenshots.select { |screenshot| Deliver::AppScreenshotValidator.validate(screenshot, errors) }
 
-      unless errors.empty?
-        UI.important("Unaccepted device screenshots are detected! 🚫 Screenshot file will be skipped. 🏃")
-        errors.each { |error| UI.important(error) }
+      errors_to_skip, errors_to_crash = errors.partition(&:to_skip)
+
+      unless errors_to_skip.empty?
+        UI.important("🏃 Screenshots to be skipped are detected!")
+        errors_to_skip.each { |error| UI.message(error) }
+      end
+
+      unless errors_to_crash.empty?
+        UI.important("🚫 Invalid screenshots are detected! Here's the reasons.")
+        errors_to_crash.each { |error| UI.error(error) }
+        UI.user_error!("Canceled uploading screenshot. Please check above error messages and correct screenshots.")
       end
 
       valid_screenshots
-    end
-
-    # Validate a screenshot and inform an error message via `errors` parameters. `errors` is mutated
-    # to append the messages and each message should contain the corresponding path to let users know which file gets the error.
-    #
-    # @param screenshot [AppScreenshot]
-    # @param errors [Array<String>] Pass an array object to add error messages when finding an error
-    # @return [Boolean] true if given screenshot is valid
-    def self.validate_screenshot(screenshot, errors)
-      # Given screenshot will be diagnosed and errors found are accumulated
-      errors_found = []
-
-      # Checking if the device type exists in spaceship
-      # Ex: iPhone 6.1 inch isn't supported in App Store Connect but need
-      # to have it in there for frameit support
-      if screenshot.device_type.nil?
-        errors_found << "🏃 Skipping screenshot file: #{screenshot.path} - Not an accepted App Store Connect device..."
-      end
-
-      # Merge errors found into given errors array
-      errors_found.each { |error| errors.push(error) }
-      errors_found.empty?
     end
 
     # Returns the list of language folders

--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -81,7 +81,7 @@ module Deliver
       end
     end
 
-    # Returns the list of valid app screenshot
+    # Returns the list of valid app screenshot. When detecting invalid screenshots, this will cause an error.
     #
     # @param root [String] A directory path
     # @param ignore_validation [String] Set false not to raise the error when finding invalid folder name

--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -111,9 +111,9 @@ module Deliver
       end
 
       unless errors_to_crash.empty?
-        UI.important("🚫 Invalid screenshots are detected! Here's the reasons.")
+        UI.important("🚫 Invalid screenshots were detected! Here are the reasons:")
         errors_to_crash.each { |error| UI.error(error) }
-        UI.user_error!("Canceled uploading screenshot. Please check above error messages and correct screenshots.")
+        UI.user_error!("Canceled uploading screenshots. Please check the error messages above and fix the screenshots.")
       end
 
       valid_screenshots

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -191,9 +191,7 @@ describe Deliver::AppScreenshot do
 
     describe "invalid screen sizes" do
       def expect_invalid_screen_size_from_file(file)
-        expect do
-          Deliver::AppScreenshot.calculate_screen_size(file)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, "Unsupported screen size #{screen_size_from(file)} for path '#{file}'")
+        expect(Deliver::AppScreenshot.calculate_screen_size(file)).to be_nil
       end
 
       it "shouldn't allow native resolution 5.5 inch iPhone screenshots" do
@@ -267,72 +265,73 @@ describe Deliver::AppScreenshot do
   end
 
   describe "#device_type" do
-    before do
-      allow_any_instance_of(Deliver::AppScreenshot).to receive(:is_valid?).and_return(true)
+    def app_screenshot_with(screen_size, path = '', language = 'en-US')
+      allow(Deliver::AppScreenshot).to receive(:calculate_screen_size).and_return(screen_size)
+      Deliver::AppScreenshot.new(path, language)
     end
 
     it "should return iphone35 for 3.5 inch displays" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_35).device_type).to eq("APP_IPHONE_35")
+      expect(app_screenshot_with(ScreenSize::IOS_35).device_type).to eq("APP_IPHONE_35")
     end
 
     it "should return iphone4 for 4 inch displays" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_40).device_type).to eq("APP_IPHONE_40")
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_40_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_40")
+      expect(app_screenshot_with(ScreenSize::IOS_40).device_type).to eq("APP_IPHONE_40")
+      expect(app_screenshot_with(ScreenSize::IOS_40_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_40")
     end
 
     it "should return iphone6 for 4.7 inch displays" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_47).device_type).to eq("APP_IPHONE_47")
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_47_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_47")
+      expect(app_screenshot_with(ScreenSize::IOS_47).device_type).to eq("APP_IPHONE_47")
+      expect(app_screenshot_with(ScreenSize::IOS_47_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_47")
     end
 
     it "should return iphone6Plus for 5.5 inch displays" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_55).device_type).to eq("APP_IPHONE_55")
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_55_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_55")
+      expect(app_screenshot_with(ScreenSize::IOS_55).device_type).to eq("APP_IPHONE_55")
+      expect(app_screenshot_with(ScreenSize::IOS_55_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_55")
     end
 
     it "should return nil for 6.1 inch displays (iPhone XR)" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_61).device_type).to be_nil
+      expect(app_screenshot_with(ScreenSize::IOS_61).device_type).to be_nil
     end
 
     it "should return iphone65 for 6.5 inch displays" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_65).device_type).to eq("APP_IPHONE_65")
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_65_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_65")
+      expect(app_screenshot_with(ScreenSize::IOS_65).device_type).to eq("APP_IPHONE_65")
+      expect(app_screenshot_with(ScreenSize::IOS_65_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_65")
     end
 
     it "should return ipad for 9.7 inch displays" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD).device_type).to eq("APP_IPAD_97")
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_97")
+      expect(app_screenshot_with(ScreenSize::IOS_IPAD).device_type).to eq("APP_IPAD_97")
+      expect(app_screenshot_with(ScreenSize::IOS_IPAD_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_97")
     end
 
     it "should return ipad105 for 10.5 inch displays" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_10_5).device_type).to eq("APP_IPAD_105")
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_10_5_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_105")
+      expect(app_screenshot_with(ScreenSize::IOS_IPAD_10_5).device_type).to eq("APP_IPAD_105")
+      expect(app_screenshot_with(ScreenSize::IOS_IPAD_10_5_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_105")
     end
 
     it "should return ipadPro11 for 11 inch displays" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_11).device_type).to eq("APP_IPAD_PRO_3GEN_11")
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_11_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_PRO_3GEN_11")
+      expect(app_screenshot_with(ScreenSize::IOS_IPAD_11).device_type).to eq("APP_IPAD_PRO_3GEN_11")
+      expect(app_screenshot_with(ScreenSize::IOS_IPAD_11_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_PRO_3GEN_11")
     end
 
     it "should return ipadPro for 12.9 inch displays" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_PRO).device_type).to eq("APP_IPAD_PRO_129")
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_IPAD_PRO_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_PRO_129")
+      expect(app_screenshot_with(ScreenSize::IOS_IPAD_PRO).device_type).to eq("APP_IPAD_PRO_129")
+      expect(app_screenshot_with(ScreenSize::IOS_IPAD_PRO_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_PRO_129")
     end
 
     it "should return watch for original Apple Watch" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_APPLE_WATCH).device_type).to eq("APP_WATCH_SERIES_3")
+      expect(app_screenshot_with(ScreenSize::IOS_APPLE_WATCH).device_type).to eq("APP_WATCH_SERIES_3")
     end
 
     it "should return watchSeries4 for Apple Watch Series 4" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::IOS_APPLE_WATCH_SERIES4).device_type).to eq("APP_WATCH_SERIES_4")
+      expect(app_screenshot_with(ScreenSize::IOS_APPLE_WATCH_SERIES4).device_type).to eq("APP_WATCH_SERIES_4")
     end
 
     it "should return appleTV for Apple TV" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::APPLE_TV).device_type).to eq("APP_APPLE_TV")
+      expect(app_screenshot_with(ScreenSize::APPLE_TV).device_type).to eq("APP_APPLE_TV")
     end
 
     it "should return desktop for Mac" do
-      expect(Deliver::AppScreenshot.new("", "", ScreenSize::MAC).device_type).to eq("APP_DESKTOP")
+      expect(app_screenshot_with(ScreenSize::MAC).device_type).to eq("APP_DESKTOP")
     end
   end
 end

--- a/deliver/spec/app_screenshot_validator_spec.rb
+++ b/deliver/spec/app_screenshot_validator_spec.rb
@@ -60,4 +60,13 @@ describe Deliver::AppScreenshotValidator do
       expect(error.to_skip).to be(true)
     end
   end
+
+  describe '.validate_file_extension_and_format' do
+    it 'should provide ideal filename to match content format' do
+      errors_found = []
+      described_class.validate(app_screenshot_with(ScreenSize::IOS_65, :png, 'image.jpeg'), errors_found)
+      error = errors_found.find { |e| e.type == Error::FILE_EXTENSION_MISMATCH }
+      expect(error.debug_info).to match(/image\.png/)
+    end
+  end
 end

--- a/deliver/spec/app_screenshot_validator_spec.rb
+++ b/deliver/spec/app_screenshot_validator_spec.rb
@@ -1,0 +1,63 @@
+require 'deliver/app_screenshot'
+require 'deliver/setup'
+
+describe Deliver::AppScreenshotValidator do
+  ScreenSize = Deliver::AppScreenshot::ScreenSize
+  Error = Deliver::AppScreenshotValidator::ValidationError
+
+  def app_screenshot_with(screen_size, format = :png, path = 'image.png', language = 'en-US')
+    allow(Deliver::AppScreenshot).to receive(:calculate_screen_size).and_return(screen_size)
+    allow(FastImage).to receive(:type).and_return(format)
+    Deliver::AppScreenshot.new(path, language)
+  end
+
+  describe '.validate' do
+    def expect_errors_to_include(screenshot, *error_types)
+      errors_to_collect = []
+      described_class.validate(screenshot, errors_to_collect)
+
+      expect(errors_to_collect).to satisfy("be the same as \"#{error_types.join(', ')}\"") do |errors|
+        errors.all? { |error| error_types.any? { |error_type| error.type == error_type } }
+      end
+
+      expect(errors_to_collect).not_to be_empty
+    end
+
+    def expect_no_error(screenshot)
+      expect(described_class.validate(screenshot, [])).to be(true)
+    end
+
+    it 'should return true for valid screenshot' do
+      expect_no_error(app_screenshot_with(ScreenSize::IOS_65, :png, 'image.png'))
+      expect_no_error(app_screenshot_with(ScreenSize::IOS_65, :jpeg, 'image.jpeg'))
+    end
+
+    it 'should detect valid size screenshot' do
+      expect_errors_to_include(app_screenshot_with(nil, :png, 'image.png'), Error::INVALID_SCREEN_SIZE)
+    end
+
+    it 'should detect unacceptable screen size' do
+      expect_errors_to_include(app_screenshot_with('Unknown device'), Error::UNACCEPTABLE_DEVICE)
+      expect_errors_to_include(app_screenshot_with(ScreenSize::IOS_61), Error::UNACCEPTABLE_DEVICE)
+    end
+
+    it 'should detect invalid file extension' do
+      expect_errors_to_include(app_screenshot_with(ScreenSize::IOS_65, :gif, 'image.gif'), Error::INVALID_FILE_EXTENSION)
+      expect_errors_to_include(app_screenshot_with(ScreenSize::IOS_65, :png, 'image.gif'), Error::INVALID_FILE_EXTENSION, Error::FILE_EXTENSION_MISMATCH)
+    end
+
+    it 'should detect file extension mismatch' do
+      expect_errors_to_include(app_screenshot_with(ScreenSize::IOS_65, :jpeg, 'image.png'), Error::FILE_EXTENSION_MISMATCH)
+      expect_errors_to_include(app_screenshot_with(ScreenSize::IOS_65, :png, 'image.jpeg'), Error::FILE_EXTENSION_MISMATCH)
+    end
+  end
+
+  describe '.validate_device_type' do
+    it 'should give a validation error to skip uploading screenshot' do
+      errors_found = []
+      described_class.validate(app_screenshot_with(ScreenSize::IOS_61), errors_found)
+      error = errors_found.find { |e| e.type == Error::UNACCEPTABLE_DEVICE }
+      expect(error.to_skip).to be(true)
+    end
+  end
+end

--- a/deliver/spec/loader_spec.rb
+++ b/deliver/spec/loader_spec.rb
@@ -153,6 +153,14 @@ describe Deliver::Loader do
       allow(FastImage).to receive(:size) do |path|
         path.match(/{([0-9]+)x([0-9]+)}/).captures.map(&:to_i)
       end
+
+      allow(FastImage).to receive(:type) do |path|
+        # work out valid format symbol
+        found = Deliver::AppScreenshotValidator::ALLOWED_SCREENSHOT_FILE_EXTENSION.find do |_, extensions|
+          extensions.include?(File.extname(path).delete('.'))
+        end
+        found.first if found
+      end
     end
 
     it "should not find any screenshots when the directory is empty" do
@@ -222,7 +230,7 @@ describe Deliver::Loader do
       add_screenshot("/Screenshots/iMessage/en-GB/AppleTV-01First{3840x2160}.jpg")
       expect do
         collect_screenshots_from_dir("/Screenshots/")
-      end.to raise_error(FastlaneCore::Interface::FastlaneError, "Unsupported screen size [3840, 2160] for path '/Screenshots/iMessage/en-GB/AppleTV-01First{3840x2160}.jpg'")
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /Canceled uploading screenshot/)
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->

Resolves https://github.com/fastlane/fastlane/discussions/17191

Prior to this PR, in https://github.com/fastlane/fastlane/pull/17661, I refactored `Deliver::UploadScreenshots.collect_screenshots` to report better error details for screenshot validation.

There are two issues to improve in `deliver`.

1. `Deliver::AppScreenshot.new` currently crashes (UI.user_error!) when the given screenshot has the wrong size
2. `deliver` doesn't check screenshot's image format before uploading and results in getting errors from App Store Connect API

With this PR, error reports for screenshot validation will become like below.

* Error reports include all the possible error details for each image (as many checks as implemented)
* Error reports include all the wrong screenshots (deliver won't crash before completing all checks)
* Error reports include some debug information for users

As a result, `deliver` users will be able to resolve screenshots issues easily and save time.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I implemented a new validation rule to check if screenshot's file extension matches its file format and ported file extension checks implemented in `Deliver::AppScreenshot.is_valid?`. Then, I extracted the entire validation logic to `Deliver::AppScreenshotValidator`. `Deliver::AppScreenshot.is_valid?` will be deprecated.

And also I changed `DeliverAppScreenshot.new` not to crash when not detecting valid screen size to allow us to report errors for all the images located. I assume that crash behaviour was implemented to make sure that given `screen_size` param at initialiser matches the actual size calculated. However, if we were to not use `screen_size` param, we wouldn't have to worry about it after all. Since nothing in fastlane code uses `screen_size` param apart from tests, I'd like to deprecate it in favour of `Deliver::AppScreenshotValidator`.

Since the unintentional crash will be fixed, `deliver` won't crash with the current `Deliver::Loader.load_app_screenshots` even when detecting invalid screenshots. So I've introduced a new control flow here in `load_app_screenshots` to avoid unwanted uploading. This way `deliver` still offers better error reports but the previous behaviour to prevent uploading screenshots will remain.

https://github.com/fastlane/fastlane/blob/effa740f61bed9b0a634ed0e9fe2f34c7dca6341/deliver/lib/deliver/loader.rb#L103-L117

As a result, you can see the error reports like this. 

<img width="1493" alt="Screenshot 2020-12-03 at 02 19 02" src="https://user-images.githubusercontent.com/748949/100955252-169af380-350e-11eb-9294-9eb4eed47b07.png">

To compare with existing behaviour, this is what you only get with 2.168 with the same screenshot sets.

<img width="986" alt="Screenshot 2020-12-03 at 02 35 58" src="https://user-images.githubusercontent.com/748949/100957064-b8700f80-3511-11eb-8722-da7a7236590c.png">

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

With this in Gemfile 

```ruby
gem 'fastlane', git: 'https://github.com/ainame/fastlane.git', branch: 'fix-app-screenshot-init-crash'
```

you can run deliver like this for checking if both metadata and screenshot upload s work.

```ruby
upload_to_app_store(
  skip_binary_upload: true,
  overwrite_screenshots: true,
)
```

You can also test if existing validation still works by making images wrong size.

```
% cd fastlane/screenshots/en-US
% mogrify -resize 388x392! 5.5_*.jpg # to create invalid screen size screenshots
% mogrify -resize 828x1792! 12.9_*.jpg # to create unaccepted device's screenshots
% mv 6.5_1.jpg 6.5_1.png # to create invalid screenshots that mismatch its content format and file extension
```