### PR TITLE
[deliver] fix a regression in language detection in Deliver::UploadMetadata

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -375,7 +375,7 @@ module Deliver
       # Check folder list (an empty folder signifies a language is required)
       ignore_validation = options[:ignore_language_directory_validation]
       Loader.language_folders(options[:metadata_path], ignore_validation).each do |lang_folder|
-        enabled_languages << lang_folder.language unless enabled_languages.include?(lang_folder.language)
+        enabled_languages << lang_folder.basename unless enabled_languages.include?(lang_folder.basename)
       end
 
       return unless enabled_languages.include?("default")
@@ -414,7 +414,7 @@ module Deliver
       # Check folder list (an empty folder signifies a language is required)
       ignore_validation = options[:ignore_language_directory_validation]
       Loader.language_folders(options[:metadata_path], ignore_validation).each do |lang_folder|
-        enabled_languages << lang_folder.language unless enabled_languages.include?(lang_folder.language)
+        enabled_languages << lang_folder.basename unless enabled_languages.include?(lang_folder.basename)
       end
 
       # Mapping to strings because :default symbol can be passed in
@@ -531,7 +531,7 @@ module Deliver
 
           UI.message("Loading '#{path}'...")
           options[key] ||= {}
-          options[key][lang_folder.language] ||= File.read(path)
+          options[key][lang_folder.basename] ||= File.read(path)
         end
       end
 

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -439,6 +439,18 @@ describe Deliver::UploadMetadata do
 
         expect(languages.sort).to eql(['de-DE', 'el', 'en-US'])
       end
+
+      it "languages are 'en-US', 'default'" do
+        options[:languages] = []
+
+        create_filesystem_language('default')
+        create_filesystem_language('en-US')
+
+        uploader.load_from_filesystem(options)
+        languages = uploader.detect_languages(options)
+
+        expect(languages.sort).to eql(['default', 'en-US'])
+      end
     end
 
     context "detected languages with only config options" do
@@ -465,6 +477,24 @@ describe Deliver::UploadMetadata do
         languages = uploader.detect_languages(options)
 
         expect(languages.sort).to eql(['default', 'es-MX'])
+      end
+    end
+
+    context 'detect languages with file system with default folder' do
+      it "languages are 'en-US', 'default'" do
+        options[:languages] = []
+
+        create_filesystem_language('default')
+        create_filesystem_language('en-US')
+        create_metadata(
+          File.join(tmpdir, 'default', "#{Deliver::UploadMetadata::LOCALISED_VERSION_VALUES[:description]}.txt"),
+          'something'
+        )
+
+        uploader.load_from_filesystem(options)
+        languages = uploader.detect_languages(options)
+
+        expect(languages.sort).to eql(['default', 'en-US'])
       end
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->

Resolves https://github.com/fastlane/fastlane/issues/17713

Prior to this PR, I've applied a refactoring to `deliver` in #17661. This caused a regression reported at #17713.

The root cause was my mistake that I used `Deliver::Loader::LanguageFolder.language` to collect `enabled_languages`, which can be `nil` when a language folder is a special folder; such as "default". As a result, `nil` value was treated as *a  language* and then API request used that `nil` for `locale` parameter. 

This PR fixes the issue described above.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I added test cases that covers regression case alongside fixing the bug.

This fix simply restores what used to be.
https://github.com/fastlane/fastlane/blob/39158d460347f740f548d6a3fab183824592bb22/deliver/lib/deliver/upload_metadata.rb#L414-L418

It was like this when v2.168.0.
https://github.com/fastlane/fastlane/blob/2624a24407dee94f67d7e39b5651f9fdc41dcb00/deliver/lib/deliver/upload_metadata.rb#L416-L423

Since it is guaranteed that an instance of `Deliver::Loader::LanguageFolder` represents a folder/directory (see below), I don't have to check `File.directory?` in `each` block.  

https://github.com/fastlane/fastlane/blob/97b32959acee268d225ad68d4af10b90dc09dabf/deliver/lib/deliver/loader.rb#L47-L48

----

I feel like I can improve coherency in `Deliver::UploadMedata` with leveraging what `Deliver::Loader` is capable of now. I will submit another refactoring (as well as adding more coverage unit test cases, for sure😂).

For example, `Deliver::Loader::LanguageFolder` can denote that which is special folders or language folders so this kind of ad-hoc code can be removed.

https://github.com/fastlane/fastlane/blob/97b32959acee268d225ad68d4af10b90dc09dabf/deliver/lib/deliver/upload_metadata.rb#L463

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

With this in Gemfile 

```ruby
gem 'fastlane', git: 'https://github.com/ainame/fastlane.git', branch: 'fix-enabled-languages-collection'
```

Prepare `default` and `en-US` (or primary language) folders with metadata files simply.

```
% mkdir -p fastlane/metadata/default
% mkdir -p fastlane/metadata/en-US
# and prepare metadata txt files
```

Deactivate all the app store version localizations except primary language and then call `deliver` like below.

```ruby
upload_to_app_store(
  skip_binary_upload: true,
  skip_screenshots: true,
)
```