### PR TITLE
[precheck] allow precheck to be run on live app versions as well as edit ones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,8 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
+            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow || true
+            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow || true
             brew update
             brew untap caskroom/versions || true
             brew install shellcheck

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -97,7 +97,12 @@ module Precheck
                                      description: "Should check in-app purchases?",
                                      is_string: false,
                                      optional: true,
-                                     default_value: true)
+                                     default_value: true),
+        FastlaneCore::ConfigItem.new(key: :use_live,
+                                     env_name: "PRECHECK_USE_LIVE",
+                                     description: "Should force check live app?",
+                                     is_string: false,
+                                     default_value: false)
       ] + rules
     end
   end

--- a/precheck/lib/precheck/rule_processor.rb
+++ b/precheck/lib/precheck/rule_processor.rb
@@ -130,7 +130,7 @@ module Precheck
       items = []
 
       # App info localizations
-      app_info = app.fetch_latest_app_info
+      app_info = Precheck.config[:use_live] ? app.fetch_live_app_info : app.fetch_latest_app_info
       app_info_localizations = app_info.get_app_info_localizations
       app_info_localizations.each do |localization|
         items << collect_text_items_from_language_item(locale: localization.locale,

--- a/precheck/lib/precheck/rule_processor.rb
+++ b/precheck/lib/precheck/rule_processor.rb
@@ -130,7 +130,7 @@ module Precheck
       items = []
 
       # App info localizations
-      app_info = app.fetch_edit_app_info
+      app_info = app.fetch_latest_app_info
       app_info_localizations = app_info.get_app_info_localizations
       app_info_localizations.each do |localization|
         items << collect_text_items_from_language_item(locale: localization.locale,

--- a/precheck/lib/precheck/runner.rb
+++ b/precheck/lib/precheck/runner.rb
@@ -185,7 +185,7 @@ module Precheck
 
     def latest_app_version
       platform = Spaceship::ConnectAPI::Platform.map(Precheck.config[:platform])
-      @latest_version ||= app.get_latest_app_store_version(platform: platform)
+      @latest_version ||= Precheck.config[:use_live] ? app.get_live_app_store_version(platform: platform) : app.get_latest_app_store_version(platform: platform)
     end
 
     # Makes sure the current App ID exists. If not, it will show an appropriate error message

--- a/precheck/lib/precheck/runner.rb
+++ b/precheck/lib/precheck/runner.rb
@@ -185,7 +185,7 @@ module Precheck
 
     def latest_app_version
       platform = Spaceship::ConnectAPI::Platform.map(Precheck.config[:platform])
-      @latest_version ||= app.get_edit_app_store_version(platform: platform)
+      @latest_version ||= app.get_latest_app_store_version(platform: platform)
     end
 
     # Makes sure the current App ID exists. If not, it will show an appropriate error message

--- a/precheck/spec/rule_processor_spec.rb
+++ b/precheck/spec/rule_processor_spec.rb
@@ -23,7 +23,7 @@ describe Precheck do
       allow(fake_happy_app).to receive(:name).and_return("My Fake App")
       allow(fake_happy_app).to receive(:in_app_purchases).and_return(fake_in_app_purchases)
 
-      allow(fake_happy_app).to receive(:fetch_edit_app_info).and_return(fake_happy_app_info)
+      allow(fake_happy_app).to receive(:fetch_latest_app_info).and_return(fake_happy_app_info)
       allow(fake_happy_app_info).to receive(:get_app_info_localizations).and_return([fake_info_localization])
 
       allow(fake_happy_app_version).to receive(:copyright).and_return("Copyright taquitos, #{DateTime.now.year}")

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -144,6 +144,12 @@ module Spaceship
         end.first
       end
 
+      def fetch_latest_app_info(client: nil, includes: Spaceship::ConnectAPI::AppInfo::ESSENTIAL_INCLUDES)
+        client ||= Spaceship::ConnectAPI
+        resp = client.get_app_infos(app_id: id, includes: includes)
+        return resp.to_models.first
+      end
+
       #
       # Available Territories
       #


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17208
Resolves #17176
Resolves #17434

### Description
As of master, only "editable" app versions are able to be prechecked. However, based on the testimonials [here](https://github.com/fastlane/fastlane/issues/17208#issuecomment-734002754), this sounded like a regression. So I investigated further [in _precheck_ history](https://github.com/fastlane/fastlane/commits/master/precheck/lib/precheck/rule_processor.rb), and looks like prior to Sep 4th 2020 _precheck_ could be used to check metadata of both edit **and** live app versions, thus introducing these regressions via https://github.com/fastlane/fastlane/pull/17167 

As I don't see any reason to limit it to only editable versions, I modified the code to allow live versions to be prechecked as well.

While testing, I also realized that this PR fixed another issue 🎉 which's #17176 :) 

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-allow-precheck-live-apps"
```

Then you should be able to run `fastlane precheck` regardless of what state your app is (live or edit). Such as:

```sh
bundle exec fastlane precheck -u email@example.com -a com.apple.example
```