### PR TITLE
[deliver] correct dependencies

### DIFF
--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -1,6 +1,3 @@
-require 'fastlane_core/languages'
-require 'spaceship/tunes/tunes'
-
 require_relative 'module'
 require_relative 'app_screenshot'
 require_relative 'upload_metadata'

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -1,3 +1,5 @@
+require 'spaceship'
+
 require_relative 'module'
 require_relative 'queue_worker'
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->

While working on #17708, I noticed that there are unnecessary `require` called in `deliver/lib/deliver/loader.rb`. 

https://github.com/fastlane/fastlane/blob/a046b0671127577567d4f26bd94f964ddc0f8566/deliver/lib/deliver/loader.rb#L1-L2

However, if I delete them, Rubocop then points this out.

```
% bundle exec rubocop -a deliver/lib/deliver
Inspecting 18 files
Parser::Source::Rewriter is deprecated.
Please update your code to use Parser::Source::TreeRewriter instead
....C.............

Offenses:

deliver/lib/deliver/upload_metadata.rb:85:18: C: Spaceship::ConnectAPI::Platform not found, you're probably missing a require statement or there is a cycle in your dependencies.
      platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deliver/lib/deliver/upload_metadata.rb:178:24: C: Spaceship::ConnectAPI::AppStoreVersion::ReleaseType::SCHEDULED not found, you're probably missing a require statement or there is a cycle in your dependencies.
                       Spaceship::ConnectAPI::AppStoreVersion::ReleaseType::SCHEDULED
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deliver/lib/deliver/upload_metadata.rb:180:24: C: Spaceship::ConnectAPI::AppStoreVersion::ReleaseType::AFTER_APPROVAL not found, you're probably missing a require statement or there is a cycle in your dependencies.
                       Spaceship::ConnectAPI::AppStoreVersion::ReleaseType::AFTER_APPROVAL
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deliver/lib/deliver/upload_metadata.rb:182:24: C: Spaceship::ConnectAPI::AppStoreVersion::ReleaseType::MANUAL not found, you're probably missing a require statement or there is a cycle in your dependencies.
                       Spaceship::ConnectAPI::AppStoreVersion::ReleaseType::MANUAL
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deliver/lib/deliver/upload_metadata.rb:238:20: C: Spaceship::ConnectAPI::AppCategory not found, you're probably missing a require statement or there is a cycle in your dependencies.
          mapped = Spaceship::ConnectAPI::AppCategory.map_category_from_itc(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deliver/lib/deliver/upload_metadata.rb:314:35: C: Spaceship::ConnectAPI::AppStoreVersionPhasedRelease::PhasedReleaseState::INACTIVE not found, you're probably missing a require statement or there is a cycle in your dependencies.
              phasedReleaseState: Spaceship::ConnectAPI::AppStoreVersionPhasedRelease::PhasedReleaseState::INACTIVE
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
deliver/lib/deliver/upload_metadata.rb:658:19: C: Spaceship::ConnectAPI::AgeRatingDeclaration not found, you're probably missing a require statement or there is a cycle in your dependencies.
        new_key = Spaceship::ConnectAPI::AgeRatingDeclaration.map_key_from_itc(k)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

18 files inspected, 7 offenses detected
```

This PR corrects that issue.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

`deliver/lib/deliver/upload_metadata.rb` depended on `Spaceship` module via `deliver/lib/deliver/loader.rb` loading `spaceship/tunes/tunes/`. Whilst it technically works fine to run, Rubocop evaluates files individually and warns "missing  require statement". So `upload_metadata.rb` should call `require` by itself to declare its dependencies.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

See `bundle exec rubocop -a` has no warning.

And give it run to see if there is a reference error. 

```ruby
gem 'fastlane', git: 'https://github.com/ainame/fastlane.git', branch: 'clean-up-dependencies'
```

Don't forget to upload metadata since this PR affects `Deliver::UploadMetadata`.

```ruby
upload_to_app_store(
  skip_binary_upload: true,
)
```