### PR TITLE
[nexus_upload] fail action when the underlying nexus upload command line fails

### DIFF
--- a/fastlane/lib/fastlane/actions/nexus_upload.rb
+++ b/fastlane/lib/fastlane/actions/nexus_upload.rb
@@ -5,6 +5,7 @@ module Fastlane
         command = []
         command << "curl"
         command << verbose(params)
+        command << "--fail"
         command += ssl_options(params)
         command += proxy_options(params)
         command += upload_options(params)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17444

### Description
After reviewing #17444 I noticed that the OP suggested a fix that would resolve the issue for them, but they couldn't sign Google's CLA to open a PR to _fastlane_. This PR simply applies the suggested fix :) 

OP @firecodeing suggested that this option could be optional and default to the current implementation to avoid possible regressions, but both him and I agree that the current behavior should be considered a bug, since it's error prone, and should be fixed instead. So I decided to unconditionally add the `--fail` option to the command.

The `--fail` option is provided by is `curl` option: https://curl.se/docs/manpage.html

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-fail-nexus-upload-on-error"
```

Then run [nexus_upload](https://docs.fastlane.tools/actions/nexus_upload/) in a way that it could fail, to witness the `--fail` option doing its magic and failing the lane 😊 

### Credits

Credits to this solution goes 100% to @firecodeing for doing the research and providing the solution 🙏 