### PR TITLE
[sigh] fix undefined method `expires` with `expiration_date` in Sigh::Runner

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -327,7 +327,7 @@ module Sigh
         UI.important("Found more than one code signing identity. Choosing the first one. Check out `fastlane sigh --help` to see all available options.")
         UI.important("Available Code Signing Identities for current filters:")
         certificates.each do |c|
-          str = ["\t- Name:", c.display_name, "- ID:", c.id + " - Expires", c.expires.strftime("%d/%m/%Y")].join(" ")
+          str = ["\t- Name:", c.display_name, "- ID:", c.id + " - Expires", c.expiration_date.strftime("%d/%m/%Y")].join(" ")
           UI.message(str.green)
         end
       end

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -327,7 +327,7 @@ module Sigh
         UI.important("Found more than one code signing identity. Choosing the first one. Check out `fastlane sigh --help` to see all available options.")
         UI.important("Available Code Signing Identities for current filters:")
         certificates.each do |c|
-          str = ["\t- Name:", c.display_name, "- ID:", c.id + " - Expires", DateTime.iso8601(c.expiration_date).strftime("%d/%m/%Y")].join(" ")
+          str = ["\t- Name:", c.display_name, "- ID:", c.id + " - Expires", Time.parse(c.expiration_date).strftime("%Y-%m-%d")].join(" ")
           UI.message(str.green)
         end
       end

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -327,7 +327,7 @@ module Sigh
         UI.important("Found more than one code signing identity. Choosing the first one. Check out `fastlane sigh --help` to see all available options.")
         UI.important("Available Code Signing Identities for current filters:")
         certificates.each do |c|
-          str = ["\t- Name:", c.display_name, "- ID:", c.id + " - Expires", c.expiration_date.strftime("%d/%m/%Y")].join(" ")
+          str = ["\t- Name:", c.display_name, "- ID:", c.id + " - Expires", DateTime.iso8601(c.expiration_date).strftime("%d/%m/%Y")].join(" ")
           UI.message(str.green)
         end
       end

--- a/sigh/spec/runner_spec.rb
+++ b/sigh/spec/runner_spec.rb
@@ -146,7 +146,7 @@ describe Sigh do
       it "list certificates found when there're multiple certificates and not in development" do
         options = { skip_certificate_verification: true }
         Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
-        sigh_stub_spaceship_connect()
+        sigh_stub_spaceship_connect
 
         certificates_to_use = fake_runner.certificates_to_use
         expect(certificates_to_use.size).to eq(1)

--- a/sigh/spec/runner_spec.rb
+++ b/sigh/spec/runner_spec.rb
@@ -142,6 +142,17 @@ describe Sigh do
       end
     end
 
+    describe "#certificates_to_use" do
+      it "list certificates found when there're multiple certificates and not in development" do
+        options = { skip_certificate_verification: true }
+        Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+        sigh_stub_spaceship_connect()
+
+        certificates_to_use = fake_runner.certificates_to_use
+        expect(certificates_to_use.size).to eq(1)
+      end
+    end
+
     describe "#profile_type_pretty_type" do
       profile_types = {
         Spaceship::ConnectAPI::Profile::ProfileType::IOS_APP_STORE => "AppStore",

--- a/sigh/spec/runner_spec.rb
+++ b/sigh/spec/runner_spec.rb
@@ -209,14 +209,14 @@ describe Sigh do
         it "fetches profiles with duplicate name and appends timestamp" do
           sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: "com.krausefx.app", all_app_identifiers: ["com.krausefx.app"], app_identifier_and_profile_names: { "com.krausefx.app" => ["com.krausefx.app AppStore"] })
 
-          expect(Time).to receive(:now).and_return("1234")
+          allow(Time).to receive(:now).and_return(Time.at(1_608_653_743))
 
           options = { app_identifier: "com.krausefx.app", skip_install: true, skip_certificate_verification: true, skip_fetch_profiles: false }
           Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
 
           profile = fake_runner.create_profile!
 
-          expect(profile.name).to eq("com.krausefx.app AppStore 1234")
+          expect(profile.name).to eq("com.krausefx.app AppStore 1608653743")
           expect(profile.bundle_id.identifier).to eq("com.krausefx.app")
         end
       end

--- a/sigh/spec/spec_helper.rb
+++ b/sigh/spec/spec_helper.rb
@@ -7,9 +7,11 @@ def sigh_stub_spaceship_connect(inhouse: false, create_profile_app_identifier: n
 
   # Mock cert
   certificate = "certificate"
-  allow(certificate).to receive(:id).and_return("id")
+  allow(certificate).to receive(:id).and_return("123456789")
+  allow(certificate).to receive(:display_name).and_return("Roger Oba")
+  allow(certificate).to receive(:expiration_date).and_return("2021-07-22T00:27:42.000+0000")
   allow(certificate).to receive(:certificate_content).and_return(Base64.encode64("cert content"))
-  allow(Spaceship::ConnectAPI::Certificate).to receive(:all).and_return([certificate])
+  allow(Spaceship::ConnectAPI::Certificate).to receive(:all).and_return([certificate, certificate])
 
   device = "device"
   allow(device).to receive(:id).and_return(1)

--- a/spaceship/spec/connect_api/models/certificate_spec.rb
+++ b/spaceship/spec/connect_api/models/certificate_spec.rb
@@ -31,7 +31,7 @@ describe Spaceship::ConnectAPI::Certificate do
       model = Spaceship::ConnectAPI::Models.parse(certificates_response).first
     end
 
-    context 'with past exiration_date' do
+    context 'with past expiration_date' do
       before { certificate.expiration_date = "1999-02-01T20:50:34.000+0000" }
 
       it 'should be invalid' do
@@ -39,7 +39,7 @@ describe Spaceship::ConnectAPI::Certificate do
       end
     end
 
-    context 'with a future exiration_date' do
+    context 'with a future expiration_date' do
       before { certificate.expiration_date = "9999-02-01T20:50:34.000+0000" }
 
       it 'should be valid' do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves #17549

### Description

After some investigation, looks like we were trying to access a property named `expires` that is only accessible in `Portal`'s Certificate, instead of accessing the same property named `expiration_date`, available via `ConnectAPI`'s `Certificate`.

This issue solution is similar to this one: https://github.com/fastlane/fastlane/pull/17432
However, this time I reviewed the entire affected file to see if more occurrences of the same bug was happening (i.e. accessing properties only present in `Portal`'s `Certificate` instead of `ConnectAPI`'s), and this was the only offending use case left in this file.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-sigh-wrong-certificate-model"
```