### PR TITLE
[scan] retry after failure

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -472,11 +472,16 @@ module Scan
                                      type: Boolean,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :use_system_scm,
-                                     env_name: "SCAN_USE_SYSTEM_SCM",
-                                     description: "Lets xcodebuild use system's scm configuration",
-                                     optional: true,
-                                     type: Boolean,
-                                     default_value: false)
+                                    env_name: "SCAN_USE_SYSTEM_SCM",
+                                    description: "Lets xcodebuild use system's scm configuration",
+                                    optional: true,
+                                    type: Boolean,
+                                    default_value: false),
+        FastlaneCore::ConfigItem.new(key: :number_of_retries,
+                                    env_name: 'SCAN_NUMBER_OF_RETRIES',
+                                    description: "The number of times a test can fail before scan should stop retrying",
+                                    type: Integer,
+                                    default_value: 1),
 
       ]
     end

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -481,7 +481,7 @@ module Scan
                                     env_name: 'SCAN_NUMBER_OF_RETRIES',
                                     description: "The number of times a test can fail before scan should stop retrying",
                                     type: Integer,
-                                    default_value: 1),
+                                    default_value: 0),
 
       ]
     end

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -481,7 +481,7 @@ module Scan
                                     env_name: 'SCAN_NUMBER_OF_RETRIES',
                                     description: "The number of times a test can fail before scan should stop retrying",
                                     type: Integer,
-                                    default_value: 0),
+                                    default_value: 0)
 
       ]
     end

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -52,6 +52,11 @@ module Scan
       end
 
       command = @test_command_generator.generate
+
+      execute(command: command, devices: Scan.devices)
+    end
+
+    def execute(retries = 0, command: nil, devices: nil)
       prefix_hash = [
         {
           prefix: "Running Tests: ",
@@ -79,7 +84,18 @@ module Scan
                                                   raise ex
                                                 end
                                               end)
+
       exit_status
+    end
+
+    def retry_tests(retries, command, language, locale, launch_args, devices)
+      UI.important("Retrying on devices: #{devices.join(', ')}")
+      UI.important("Number of retries remaining: #{launcher_config.number_of_retries - retries - 1}")
+
+      # Clear errors so a successful retry isn't reported as an over failure
+      self.collected_errors = []
+
+      execute(retries + 1, command: command, devices: devices)
     end
 
     def handle_results(tests_exit_status)

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -78,7 +78,7 @@ module Scan
                                                   exit_status = $?.exitstatus
                                                   if retries < Scan.config[:number_of_retries]
                                                     # If there are retries remaining, run the tests again
-                                                    retry_tests(retries, command)
+                                                    return retry_tests(retries, command)
                                                   else
                                                     ErrorHandler.handle_build_error(error_output, @test_command_generator.xcodebuild_log_path)
                                                   end

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -97,23 +97,23 @@ module Scan
 
     def retryable_tests(input)
       input = Helper.strip_ansi_colors(input)
-      
+
       retryable_tests = []
-  
+
       suites = input.match(/Test Suite ([\w\s]+)\.xctest started/).captures
-      for suite in suites
+      suites.each do |suite|
         executed_tests = input.split("Test Suite #{suite}\.xctest started\n")[1]
         test_class = executed_tests.split("\n")[0]
 
         prefix = "#{suite}/#{test_class}/"
         failing_tests = executed_tests.split("\n\n")[0].split("\n")
-          .select { |line| line.start_with? /\s*✗/ }
-          .map { |line| line.match(/\s*✗\s*(\w+)/).captures[0]  }
-          .map { |test_case| prefix + test_case }
+                                      .select { |line| line.start_with?(/\s*✗/) }
+                                      .map { |line| line.match(/\s*✗\s*(\w+)/).captures[0] }
+                                      .map { |test_case| prefix + test_case }
 
         retryable_tests += failing_tests
       end
-  
+
       retryable_tests
     end
 

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -101,8 +101,9 @@ module Scan
       retryable_tests = []
 
       failing_tests = input.split("Failing tests:\n")[1]
-      suites = failing_tests.split(/\n {8}(?=\w)/)
-                            .map { |string| string.split("\n\n")[0] }
+                           .split("\n\n")[0]
+
+      suites = failing_tests.split(/(?=\n\s+[\w\s]+:\n)/)
 
       suites.each do |suite|
         suite_name = suite.match(/\s*([\w\s]+):/).captures[0]

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -102,16 +102,16 @@ module Scan
 
       failing_tests = input.split("Failing tests:\n")[1]
       suites = failing_tests.split(/\n {8}(?=\w)/)
-        .map { |string| string.split("\n\n")[0] }
+                            .map { |string| string.split("\n\n")[0] }
 
       suites.each do |suite|
         suite_name = suite.match(/\s*([\w\s]+):/).captures[0]
-    
+
         test_cases = suite.split(":\n")[1].split("\n").each
-            .select { |line| line.start_with?(/\s+/) }
-            .map { |line| line.strip.gsub(".", "/").gsub("()", "") }
-            .map { |line| suite_name + "/" + line }
-    
+                          .select { |line| line.start_with?(/\s+/) }
+                          .map { |line| line.strip.gsub(".", "/").gsub("()", "") }
+                          .map { |line| suite_name + "/" + line }
+
         retryable_tests += test_cases
       end
 

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -162,16 +162,16 @@ module Scan
       Scan.cache[:build_path]
     end
 
+    # The path to the result bundle
     def result_bundle_path
-      unless Scan.cache[:result_bundle_path]
-        ext = FastlaneCore::Helper.xcode_version.to_i >= 11 ? '.xcresult' : '.test_result'
-        path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ext
-        if File.directory?(path)
-          FileUtils.remove_dir(path)
-        end
-        Scan.cache[:result_bundle_path] = path
+      ext = FastlaneCore::Helper.xcode_version.to_i >= 11 ? '.xcresult' : '.test_result'
+      path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ext
+      if File.directory?(path)
+        FileUtils.remove_dir(path)
       end
-      return Scan.cache[:result_bundle_path]
+      Scan.cache[:result_bundle_path] = path
+
+      return path
     end
   end
 end

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -92,6 +92,38 @@ describe Scan do
       end
     end
 
+    describe "retry_execute" do
+      before(:each) do
+        @scan = Scan::Runner.new
+      end
+
+      it "retry a failed test" do
+        error_output = <<-ERROR_OUTPUT
+Failing tests:
+  FastlaneAppTests:
+          FastlaneAppTests.testCoinToss()
+          ERROR_OUTPUT
+
+        expect(Fastlane::UI).to receive(:important).with("Retrying tests: FastlaneAppTests/FastlaneAppTests/testCoinToss").once
+        expect(Fastlane::UI).to receive(:important).with("Number of retries remaining: 4").once
+        expect(@scan).to receive(:execute)
+
+        @scan.retry_execute(retries: 5, error_output: error_output)
+      end
+
+      it "fail to parse error output" do
+        error_output = <<-ERROR_OUTPUT
+Failing tests:
+FastlaneAppTests:
+FastlaneAppTests.testCoinToss()
+          ERROR_OUTPUT
+
+        expect do
+          @scan.retry_execute(retries: 5, error_output: error_output)
+        end.to raise_error(FastlaneCore::Interface::FastlaneCrash, "Failed to find failed tests to retry (could not parse error output)")
+      end
+    end
+
     describe "test_results" do
       before(:each) do
         Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -97,7 +97,7 @@ describe Scan do
         @scan = Scan::Runner.new
       end
 
-      it "retry a failed test" do
+      it "retry a failed test", requires_xcodebuild: true do
         error_output = <<-ERROR_OUTPUT
 Failing tests:
   FastlaneAppTests:
@@ -111,7 +111,7 @@ Failing tests:
         @scan.retry_execute(retries: 5, error_output: error_output)
       end
 
-      it "fail to parse error output" do
+      it "fail to parse error output", requires_xcodebuild: true do
         error_output = <<-ERROR_OUTPUT
 Failing tests:
 FastlaneAppTests:


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
(Solves https://github.com/fastlane/fastlane/issues/8648)

UI tests are still a bit too unpredictable to entirely trust them. Many developers use UI testing as E2E tests, which opens them up to more intermittent errors like network failures.
Making UI tests more resilient against any kind of failure is cumbersome to impossible. Mostly, testers want to just retry tests (as a human would in many situations), and this PR enables this for fastlane's `scan`.

There are some plugins that add the possibility to retry tests to fastlane (perhaps most notably [test-center](https://github.com/lyndsey-ferguson/fastlane-plugin-test_center). I have tried many, but found that most of them have tradeoffs or just don't work.

### Description

Adds a new parameter to `scan`: `number_of_retries`, (which is zero by default, keeping current behavior.)
This will retry any failing tests (and only the failing tests) after a test run.

This works by extracting the failed tests from `error_output` and re-running them using `Scan.config[:only_testing]`.

(Please excuse my ruby. I rarely write it these days, and I'm happy for any kind of feedback 👍)

### Testing Steps
1. Create a new app for testing and run `fastlane init`
2. Create a test that fails randomly
```swift
func testCoinToss() {
    XCTAssert(Bool.random())
}
```
3. Run scan with the `number-of-retries` flag
```
bundle exec fastlane scan --number-of-retries 3
```

The tests should pass, even if `testCoinToss` initially fails. All passing tests should only run once, while `testCoinToss` should be run multiple times until it succeeds (at most 3 times).