### PR TITLE
[push_to_git_remote] add `--push-options` option to `push_to_git_remote` action

### DIFF
--- a/fastlane/lib/fastlane/actions/push_to_git_remote.rb
+++ b/fastlane/lib/fastlane/actions/push_to_git_remote.rb
@@ -32,6 +32,9 @@ module Fastlane
         # optionally add the set-upstream component
         command << '--set-upstream' if params[:set_upstream]
 
+        # optionally add the --push_options components
+        params[:push_options].each { |push_option| command << "--push-option=#{push_option}" }
+
         # execute our command
         Actions.sh('pwd')
         return command.join(' ') if Helper.test?
@@ -84,7 +87,12 @@ module Fastlane
                                        env_name: "FL_GIT_PUSH_USE_SET_UPSTREAM",
                                        description: "Whether or not to use --set-upstream",
                                        type: Boolean,
-                                       default_value: false)
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :push_options,
+                                       env_name: "FL_GIT_PUSH_PUSH_OPTION",
+                                       description: "Array of strings to be passed using the '--push-option' option",
+                                       type: Array,
+                                       default_value: [])
         ]
       end
 

--- a/fastlane/spec/actions_specs/push_to_git_remote_spec.rb
+++ b/fastlane/spec/actions_specs/push_to_git_remote_spec.rb
@@ -94,6 +94,26 @@ describe Fastlane do
         expect(result).to eq("git push origin master:master --tags --set-upstream")
       end
 
+      it "runs git push with 1 element in push-options" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            push_to_git_remote(
+              push_options: ['something-to-tell-remote-git-server']
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("git push origin master:master --tags --push-option=something-to-tell-remote-git-server")
+      end
+
+      it "runs git push with 2 elements in push-options" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            push_to_git_remote(
+              push_options: ['something-to-tell-remote-git-server', 'something-else']
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("git push origin master:master --tags --push-option=something-to-tell-remote-git-server --push-option=something-else")
+      end
+
       context "runs git push without local_branch" do
         it "should raise an error if get current branch failed" do
           allow(Fastlane::Actions).to receive(:git_branch).and_return(nil)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17719

### Description
Small addition to `push_to_git_remote`, to add the `push_option` option to `git push`: https://git-scm.com/docs/git-push#Documentation/git-push.txt---push-optionltoptiongt

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-push-options"
```

And then run `push_to_git_remote` action using the new `push_options` option, which receives an array of strings.