### PR TITLE
[add_git_tag] add option to omit the current lane from tag and message

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -10,7 +10,7 @@ module Fastlane
           tag = options[:tag]
         elsif options[:build_number]
           tag_components = [options[:grouping]]
-          tag_components << lane_name if options[:includes_lane_in_tag]
+          tag_components << lane_name if options[:includes_lane]
           tag_components << "#{options[:prefix]}#{options[:build_number]}#{options[:postfix]}"
           tag = tag_components.join('/')
         else
@@ -37,7 +37,7 @@ module Fastlane
       def self.details
         list = <<-LIST.markdown_list
           `grouping` is just to keep your tags organised under one 'folder', defaults to 'builds'
-          `lane` is the name of the current fastlane lane, if chosen to be included via 'includes_lane_in_tag' option, which defaults to 'true'
+          `lane` is the name of the current fastlane lane, if chosen to be included via 'includes_lane' option, which defaults to 'true'
           `prefix` is anything you want to stick in front of the version number, e.g. 'v'
           `postfix` is anything you want to stick at the end of the version number, e.g. '-RC1'
           `build_number` is the build number, which defaults to the value emitted by the `increment_build_number` action
@@ -60,9 +60,9 @@ module Fastlane
                                        env_name: "FL_GIT_TAG_GROUPING",
                                        description: "Is used to keep your tags organised under one 'folder'",
                                        default_value: 'builds'),
-          FastlaneCore::ConfigItem.new(key: :includes_lane_in_tag,
-                                       env_name: "FL_GIT_TAG_INCLUDES_LANE_IN_TAG",
-                                       description: "Whether the current lane should be included in the tag composition, e.g. '<grouping>/<lane>/<prefix><build_number><postfix>'",
+          FastlaneCore::ConfigItem.new(key: :includes_lane,
+                                       env_name: "FL_GIT_TAG_INCLUDES_LANE",
+                                       description: "Whether the current lane should be included in the tag and message composition, e.g. '<grouping>/<lane>/<prefix><build_number><postfix>'",
                                        is_string: false,
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :prefix,
@@ -110,7 +110,7 @@ module Fastlane
           'add_git_tag # simple tag with default values',
           'add_git_tag(
             grouping: "fastlane-builds",
-            includes_lane_in_tag: true,
+            includes_lane: true,
             prefix: "v",
             postfix: "-RC1",
             build_number: 123

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -35,6 +35,18 @@ describe Fastlane do
         expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
       end
 
+      it "allows you to not include the current lane in the tag and message" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          add_git_tag ({
+            includes_lane_in_tag: false,
+          })
+        end").runner.execute(:test)
+
+        message = "builds/#{build_number} (fastlane)"
+        tag = "builds/#{build_number}"
+        expect(result).to eq("git tag -am #{message.shellescape} #{tag.shellescape}")
+      end
+
       it "allows you to specify a prefix" do
         prefix = '16309-'
 

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -38,7 +38,7 @@ describe Fastlane do
       it "allows you to not include the current lane in the tag and message" do
         result = Fastlane::FastFile.new.parse("lane :test do
           add_git_tag ({
-            includes_lane_in_tag: false,
+            includes_lane: false,
           })
         end").runner.execute(:test)
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17637
This was a feature requested by a couple users, so I decided to implement it, as I see no harm 😊 

### Description
This simple new option should enable users to not include the current lane in the tag/message composition. 
I considered creating a "lane" option instead of "includes lane", but this option didn't sound nice, semantically speaking. Like why would one pass a "lane" value other than the current lane (i.e. different than the default value) 🤔 I also refrained from generalizing the solution to a new option called "subgroup" (and defaulting that one to the current lane), although it was my second favorite solution. I'm open to discuss this :) 

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-add-git-tag-includes-lane-in-tag"
```

And then run `add_git_tag` action using the new `includes_lane` option, which receives a boolean.