### PR TITLE
[itunes-transporter] fix transporter `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` env var validation

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
@@ -218,7 +218,7 @@ fastlane pilot upload --verbose
 
 ## Firewall Issues
 
-_pilot_ uses the iTunes Transporter to upload metadata and binaries. In case you are behind a firewall, you can specify a different transporter protocol from the command line using
+_pilot_ uses the iTunes [Transporter](https://help.apple.com/itc/transporteruserguide/#/apdATD1E1288-D1E1A1303-D1E1288A1126) to upload metadata and binaries. In case you are behind a firewall, you can specify a different transporter protocol from the command line using
 
 ```no-highlight
 DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS="-t DAV" pilot ...
@@ -230,6 +230,10 @@ If you are using _pilot_ via the [fastlane action](https://docs.fastlane.tools/a
 ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-t DAV"
 pilot...
 ```
+
+Note, however, that Apple recommends you don’t specify the `-t transport` and instead allow Transporter to use automatic transport discovery to determine the best transport mode for your packages. For this reason, if the `t` option is passed, we will raise a warning.
+
+Also note that `-t` is not the only additional parameter that can be used. The string specified in the `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` environment variable will be forwarded to Transporter. For all the available options, check [Apple's Transporter User Guide](https://help.apple.com/itc/transporteruserguide/#/apdATD1E1288-D1E1A1303-D1E1288A1126).
 
 ## Credentials Issues
 

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -160,11 +160,10 @@ module FastlaneCore
       end
 
       deliver_additional_params = env_deliver_additional_params.to_s.strip
-      if !deliver_additional_params.include?("-t ")
-        UI.user_error!("Invalid transport parameter")
-      else
-        return deliver_additional_params
+      if deliver_additional_params.include?("-t ")
+        UI.important("Apple recommends you don’t specify the -t transport and instead allow Transporter to use automatic transport discovery to determine the best transport mode for your packages. For more information, please read Apple's Transporter User Guide 2.1: https://help.apple.com/itc/transporteruserguide/#/apdATD1E1288-D1E1A1303-D1E1288A1126")
       end
+      return deliver_additional_params
     end
   end
 

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -785,26 +785,6 @@ describe FastlaneCore do
       after(:each) { ENV.delete("FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT") }
     end
 
-    describe "with `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` set to wrong value" do
-      it 'failed to generate command for upload with lack of space' do
-        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-tDAV,Signiant"
-        transporter = FastlaneCore::ItunesTransporter.new(email, password)
-        expect do
-          transporter.upload('my.app.id', '/tmp')
-        end.to raise_error(FastlaneCore::Interface::FastlaneError)
-      end
-
-      it 'failed to generate command for upload with incorrect value' do
-        ENV["DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS"] = "-x DAV,Signiant"
-        transporter = FastlaneCore::ItunesTransporter.new(email, password)
-        expect do
-          transporter.upload('my.app.id', '/tmp')
-        end.to raise_error(FastlaneCore::Interface::FastlaneError)
-      end
-
-      after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
-    end
-
     describe "with no special configuration" do
       before(:each) do
         allow(File).to receive(:exist?).and_return(true) unless FastlaneCore::Helper.mac?


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17453

Resources & Related Tickets:

This issue seems to have originated in this PR: https://github.com/fastlane/fastlane/pull/16774
The error described in #17453 was introduced here, more specifically: https://github.com/fastlane/fastlane/pull/16774/commits/977f8721910a512bafba9be3285016744f22d144#diff-e4392686971e0801abe75321cc8a4c90eb2f2c971734d8cc88b0ac5fef5ee12dR163 which goes against [Apple's Transporter User Guide 2.1](https://help.apple.com/itc/transporteruserguide/#/apdATD1E1288-D1E1A1303-D1E1288A1126).

### Description
Looks like the PR aforementioned added a validation to the `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` env var that would throw everytime that var didn't include `-t ` in its contents. However, looks like this option can be used to send other kinds of parameters other than `-t`, and at the same time, Apple suggests that users don't specify `-t` explicitly, but instead allow Transporter to automatically detect the best transport method (which at the moment defaults to `http`).

So removing the forced crash made sense to me, as discussed in #17453. 
Furthermore, I believe that adding a harmless warning/informative logs to the user can never hurt too much, so I added a `UI.important` message when that env var contains a `-t` option.
Lastly, by making those changes, 2 specs started failing. However, I think those specs wrong fundamentally wrong, as they expect that that env var should only be used to inform `-t` additional option, and that doesn't seem to be the case. For this reason, I deleted both of those specs.

### Testing Steps
To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-transporter-t-option"
```

Prior to this PR, passing `-t` option in a `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS ` env var would succeed. If you passed a non-empty value in that same env var, without including `-t`, it would throw an error.
In this PR, if you pass `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` defining `-t`, it will throw a warning only.