### PR TITLE
[action] git_commit - skip commit if nothing is staged

### DIFF
--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -11,9 +11,9 @@ module Fastlane
         skip_git_hooks = params[:skip_git_hooks] ? '--no-verify' : ''
 
         if params[:allow_nothing_to_commit]
-          repo_clean = Actions.sh("git status --porcelain").empty?
-          UI.success("Nothing to commit, working tree clean ✅.") if repo_clean
-          return if repo_clean
+          nothing_staged = Actions.sh("git --no-pager diff --name-only --staged").empty?
+          UI.success("Nothing staged to commit ✅.") if nothing_staged
+          return if nothing_staged
         end
 
         command = "git commit -m #{params[:message].shellescape} #{paths} #{skip_git_hooks}".strip

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -63,7 +63,7 @@ describe Fastlane do
 
       it "does not generate the git command when configured to allow nothing to commit and there are no changes to commit" do
         allow(Fastlane::Actions).to receive(:sh)
-          .with("git status --porcelain")
+          .with("git --no-pager diff --name-only --staged")
           .and_return("")
         result = Fastlane::FastFile.new.parse("lane :test do
           git_commit(path: './fastlane/README.md', message: 'message', allow_nothing_to_commit: true)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->

For now, the action `git commit(allow_nothing_to_commit: true)` skips the command `git commit` only if the git status is clean. 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This PR improves the effect of `allow_nothing_to_commit`. The `git commit` command is skipped if nothing is staged. Meaning you can have a dirty repository, and still use `allow_nothing_to_commit`.
