### PR TITLE
[action] spm - add `--enable-code-coverage` option to `spm` action `test` command

### DIFF
--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -11,7 +11,7 @@ module Fastlane
         cmd << "--disable-sandbox" if params[:disable_sandbox]
         cmd << "--verbose" if params[:verbose]
         cmd << params[:command] if package_commands.include?(params[:command])
-        cmd << "--enable-code-coverage" if params[:enable_code_coverage] && params[:command] == 'generate-xcodeproj'
+        cmd << "--enable-code-coverage" if params[:enable_code_coverage] && (params[:command] == 'generate-xcodeproj' || params[:command] == 'test')
         if params[:xcconfig]
           cmd << "--xcconfig-overrides #{params[:xcconfig]}"
         end
@@ -47,7 +47,7 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :enable_code_coverage,
                                        env_name: "FL_SPM_ENABLE_CODE_COVERAGE",
-                                       description: "Enables code coverage for the generated Xcode project when using the generate-xcodeproj command",
+                                       description: "Enables code coverage for the test command and the generated Xcode project when using the generate-xcodeproj command",
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :build_path,

--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -47,7 +47,7 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :enable_code_coverage,
                                        env_name: "FL_SPM_ENABLE_CODE_COVERAGE",
-                                       description: "Enables code coverage for the test command and the generated Xcode project when using the generate-xcodeproj command",
+                                       description: "Enables code coverage for the generated Xcode project when using the 'generate-xcodeproj' and the 'test' command",
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :build_path,

--- a/fastlane/spec/actions_specs/spm_spec.rb
+++ b/fastlane/spec/actions_specs/spm_spec.rb
@@ -74,7 +74,7 @@ describe Fastlane do
         expect(result).to eq("swift package generate-xcodeproj")
       end
 
-      it "skips --enable-code-coverage if command is not generate-xcode-proj" do
+      it "skips --enable-code-coverage if command is not generate-xcode-proj or test" do
         result = Fastlane::FastFile.new.parse("lane :test do
           spm(command: 'build', enable_code_coverage: true)
         end").runner.execute(:test)
@@ -163,6 +163,28 @@ describe Fastlane do
               spm
             end").runner.execute(:test)
           end.not_to(raise_error)
+        end
+
+        it "sets --enable-code-coverage to true for test" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            spm(
+              command: 'test',
+              enable_code_coverage: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swift test --enable-code-coverage")
+        end
+
+        it "sets --enable-code-coverage to false for test" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            spm(
+              command: 'test',
+              enable_code_coverage: false
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swift test")
         end
       end
 
@@ -282,7 +304,7 @@ describe Fastlane do
           expect(result).to eq("swift package generate-xcodeproj --xcconfig-overrides Package.xcconfig")
         end
 
-        it "sets --enable-code-coverage to true" do
+        it "sets --enable-code-coverage to true for generate-xcodeproj" do
           result = Fastlane::FastFile.new.parse("lane :test do
             spm(
               command: 'generate-xcodeproj',

--- a/fastlane/spec/actions_specs/spm_spec.rb
+++ b/fastlane/spec/actions_specs/spm_spec.rb
@@ -315,7 +315,7 @@ describe Fastlane do
           expect(result).to eq("swift package generate-xcodeproj --enable-code-coverage")
         end
 
-        it "sets --enable-code-coverage to false" do
+        it "sets --enable-code-coverage to false for generate-xcodeproj" do
           result = Fastlane::FastFile.new.parse("lane :test do
             spm(
               command: 'generate-xcodeproj',


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->
Previously, the --enable-code-coverage option was only available for the generate-xcodeproj command.

Allowing its use for the test command would enable code coverage reports for the test command as well.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
The --enable-code-coverage option is now also usable when using the test command.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Use the spm action with the test command and set the enable_code_coverage option to true: the command should now gather coverage reports.