### PR TITLE
[fastlane_core] use unzip for IPA files that are too big (usually larger than 4GB)

### DIFF
--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -1,3 +1,4 @@
+require 'open3'
 require 'zip'
 
 require_relative 'core_ext/cfpropertylist'
@@ -37,27 +38,51 @@ module FastlaneCore
 
     def self.fetch_info_plist_file(path)
       UI.user_error!("Could not find file at path '#{path}'") unless File.exist?(path)
-      Zip::File.open(path, "rb") do |zipfile|
-        file = zipfile.glob('**/Payload/*.app/Info.plist').first
-        return nil unless file
+      plist_data = self.fetch_info_plist_with_rubyzip(path)
+      if plist_data.nil?
+        # Xcode produces invalid zip files for IPAs larger than 4GB. RubyZip
+        # can't read them, but the unzip command is able to work around this.
+        plist_data = self.fetch_info_plist_with_unzip(path)
+      end
+      return nil if plist_data.nil?
 
-        # Creates a temporary directory with a unique name tagged with 'fastlane'
-        # The directory is deleted automatically at the end of the block
-        Dir.mktmpdir("fastlane") do |tmp|
-          # The XML file has to be properly unpacked first
-          tmp_path = File.join(tmp, "Info.plist")
-          File.open(tmp_path, 'wb') do |output|
-            output.write(zipfile.read(file))
-          end
-          result = CFPropertyList.native_types(CFPropertyList::List.new(file: tmp_path).value)
+      # Creates a temporary directory with a unique name tagged with 'fastlane'
+      # The directory is deleted automatically at the end of the block
+      Dir.mktmpdir("fastlane") do |tmp|
+        # The XML file has to be properly unpacked first
+        tmp_path = File.join(tmp, "Info.plist")
+        File.open(tmp_path, 'wb') do |output|
+          output.write(plist_data)
+        end
+        result = CFPropertyList.native_types(CFPropertyList::List.new(file: tmp_path).value)
 
-          if result['CFBundleIdentifier'] || result['CFBundleVersion']
-            return result
-          end
+        if result['CFBundleIdentifier'] || result['CFBundleVersion']
+          return result
         end
       end
 
       return nil
+    end
+
+    def self.fetch_info_plist_with_rubyzip(path)
+      Zip::File.open(path, "rb") do |zipfile|
+        file = zipfile.glob('**/Payload/*.app/Info.plist').first
+        return nil unless file
+        zipfile.read(file)
+      end
+    end
+
+    def self.fetch_info_plist_with_unzip(path)
+      list, error, = Open3.capture3("unzip", "-Z", "-1", path)
+      UI.command_output(error) unless error.empty?
+      return nil if list.empty?
+      entry = list.chomp.split("\n").find do |e|
+        File.fnmatch("**/Payload/*.app/Info.plist", e, File::FNM_PATHNAME)
+      end
+      data, error, = Open3.capture3("unzip", "-p", path, entry)
+      UI.command_output(error) unless error.empty?
+      return nil if data.empty?
+      data
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Xcode produces invalid zip files for apps larger than 4GB. Resolves #17806.

### Description
If rubyzip can't find the Info.plist, try shelling out to unzip. This works on my 13gb app.

### Testing Steps
Create an app with a 10GB on-demand resource, export it, and try to use IpaFileAnalyser on it.
