### PR TITLE
[match] fix MATCH_GIT_PRIVATE_KEY ignored on repo push

### DIFF
--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -89,15 +89,7 @@ module Match
           command += " -b #{self.branch.shellescape} --single-branch"
         end
 
-        unless self.git_private_key.nil?
-          if File.file?(self.git_private_key)
-            ssh_add = File.expand_path(self.git_private_key).shellescape.to_s
-          else
-            UI.message("Private key file does not exist, will continue by using it as a raw key.")
-            ssh_add = "- <<< \"#{self.git_private_key}\""
-          end
-          command = "ssh-agent bash -c 'ssh-add #{ssh_add}; #{command}'"
-        end
+        command = command_from_private_key(command) unless self.git_private_key.nil?
 
         UI.message("Cloning remote git repo...")
         if self.branch && !self.clone_branch_directly
@@ -170,6 +162,16 @@ module Match
         Dir[File.join(working_directory, "**", file_name, "*.#{file_ext}")]
       end
 
+      def command_from_private_key(command)
+        if File.file?(self.git_private_key)
+          ssh_add = File.expand_path(self.git_private_key).shellescape.to_s
+        else
+          UI.message("Private key file does not exist, will continue by using it as a raw key.")
+          ssh_add = "- <<< \"#{self.git_private_key}\""
+        end
+        return "ssh-agent bash -c 'ssh-add #{ssh_add}; #{command}'"
+      end
+
       private
 
       # Create and checkout an specific branch in the git repo
@@ -231,17 +233,9 @@ module Match
       def git_push(commands: [], commit_message: nil)
         commit_message ||= generate_commit_message
         commands << "git commit -m #{commit_message.shellescape}"
-        command = "git push origin #{self.branch.shellescape}"
-        unless self.git_private_key.nil?
-          if File.file?(self.git_private_key)
-            ssh_add = File.expand_path(self.git_private_key).shellescape.to_s
-          else
-            UI.message("Private key file does not exist, will continue by using it as a raw key.")
-            ssh_add = "- <<< \"#{self.git_private_key}\""
-          end
-          command = "ssh-agent bash -c 'ssh-add #{ssh_add}; #{command}'"
-        end
-        commands << command
+        git_push_command = "git push origin #{self.branch.shellescape}"
+        git_push_command = command_from_private_key(git_push_command) unless self.git_private_key.nil?
+        commands << git_push_command
 
         UI.message("Pushing changes to remote git repo...")
         Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17827

### Description
I added the same wrapper as the pull before so the key is also loaded in this push command.

EDIT by @rogerluan : since the solution caused code duplication, I factored out the duplicated logic into a utility function and added 2 simple tests for it.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/chickahoona/fastlane.git", :branch => "17827-fix-match-git-private-key-ignored"
```

And run `bundle install` to apply the changes. 
Then you can run match using `MATCH_GIT_PRIVATE_KEY` env var and it should be able to push changes to remote without facing auth issues.