### PR TITLE
[gym][snapshot] fix gym `use_system_scm` option and add `use_system_scm` option to snapshot

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -102,7 +102,7 @@ Gem::Specification.new do |spec|
 
   # Development only
   spec.add_development_dependency('rake')
-  spec.add_development_dependency('rspec', '~> 3.9.0')
+  spec.add_development_dependency('rspec', '~> 3.10.0')
   spec.add_development_dependency('rspec_junit_formatter', '~> 0.4.1')
   spec.add_development_dependency('pry')
   spec.add_development_dependency('pry-byebug')

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -322,6 +322,7 @@ module FastlaneCore
       proj << "-configuration #{options[:configuration].shellescape}" if options[:configuration]
       proj << "-derivedDataPath #{options[:derived_data_path].shellescape}" if options[:derived_data_path]
       proj << "-xcconfig #{options[:xcconfig].shellescape}" if options[:xcconfig]
+      proj << "-scmProvider system" if options[:use_system_scm]
 
       if FastlaneCore::Helper.xcode_at_least?('11.0') && options[:cloned_source_packages_path]
         proj << "-clonedSourcePackagesDirPath #{options[:cloned_source_packages_path].shellescape}"

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -510,6 +510,34 @@ describe FastlaneCore do
       end
     end
 
+    describe "xcodebuild use_system_scm" do
+      it 'generates an xcodebuild -showBuildSettings command that includes scmProvider if provided in options', requires_xcode: true do
+        project = FastlaneCore::Project.new({
+          project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+          use_system_scm: true
+        })
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -scmProvider system"
+        expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+      end
+
+      it 'generates an xcodebuild -showBuildSettings command that does not include scmProvider when not provided in options', requires_xcode: true do
+        project = FastlaneCore::Project.new({
+          project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+        })
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+        expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+      end
+
+      it 'generates an xcodebuild -showBuildSettings command that does not include scmProvider when the option provided is false', requires_xcode: true do
+        project = FastlaneCore::Project.new({
+          project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+          use_system_scm: false
+        })
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+        expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+      end
+    end
+
     describe 'xcodebuild command for SwiftPM', requires_xcode: true do
       it 'generates an xcodebuild -resolvePackageDependencies command with Xcode >= 11' do
         allow(FastlaneCore::Helper).to receive(:xcode_at_least?).and_return(true)

--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -39,7 +39,9 @@ module Gym
         options << "-destination '#{config[:destination]}'" if config[:destination]
         options << "-archivePath #{archive_path.shellescape}" unless config[:skip_archive]
         options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
-        options << "-scmProvider system" if config[:use_system_scm]
+        if config[:use_system_scm] && !options.include?("-scmProvider system")
+          options << "-scmProvider system"
+        end
         options << config[:xcargs] if config[:xcargs]
         options << "OTHER_SWIFT_FLAGS=\"-Xfrontend -debug-time-function-bodies\"" if config[:analyze_build_time]
 

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -6,6 +6,7 @@ describe Gym do
   end
 
   before(:each) do
+    @project.options.values.delete(:use_system_scm)
     allow(Gym).to receive(:project).and_return(@project)
   end
 
@@ -92,7 +93,23 @@ describe Gym do
       options = { project: "./gym/examples/standard/Example.xcodeproj", use_system_scm: true }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
       result = Gym::BuildCommandGenerator.generate
-      expect(result).to include("-scmProvider system")
+      expect(result).to include("-scmProvider system").once
+    end
+
+    it "uses system scm via project options", requires_xcodebuild: true do
+      options = { project: "./gym/examples/standard/Example.xcodeproj" }
+      @project.options[:use_system_scm] = true
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+      result = Gym::BuildCommandGenerator.generate
+      expect(result).to include("-scmProvider system").once
+    end
+
+    it "uses system scm options exactly once", requires_xcodebuild: true do
+      options = { project: "./gym/examples/standard/Example.xcodeproj", use_system_scm: true }
+      @project.options[:use_system_scm] = true
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+      result = Gym::BuildCommandGenerator.generate
+      expect(result).to include("-scmProvider system").once
     end
 
     it "defaults to Xcode scm when option is not provided", requires_xcodebuild: true do

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -32,12 +32,14 @@ module Scan
 
       options = []
       options += project_path_array unless config[:xctestrun]
-      options << "-scmProvider system" if config[:use_system_scm]
       options << "-sdk '#{config[:sdk]}'" if config[:sdk]
       options << destination # generated in `detect_values`
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
       if config[:derived_data_path] && !options.include?("-derivedDataPath #{config[:derived_data_path].shellescape}")
         options << "-derivedDataPath #{config[:derived_data_path].shellescape}"
+      end
+      if config[:use_system_scm] && !options.include?("-scmProvider system")
+        options << "-scmProvider system"
       end
       options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
       if FastlaneCore::Helper.xcode_at_least?(10)

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -76,6 +76,7 @@ describe Scan do
   describe Scan::TestCommandGenerator do
     before(:each) do
       @test_command_generator = Scan::TestCommandGenerator.new
+      @project.options.values.delete(:use_system_scm)
     end
 
     it "raises an exception when project path wasn't found" do
@@ -163,7 +164,23 @@ describe Scan do
       options = { project: "./scan/examples/standard/app.xcodeproj", use_system_scm: true }
       Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
       result = @test_command_generator.generate
-      expect(result).to include("-scmProvider system")
+      expect(result).to include("-scmProvider system").once
+    end
+
+    it "uses system scm via project options", requires_xcodebuild: true do
+      options = { project: "./scan/examples/standard/app.xcodeproj" }
+      @project.options[:use_system_scm] = true
+      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+      result = @test_command_generator.generate
+      expect(result).to include("-scmProvider system").once
+    end
+
+    it "uses system scm options exactly once", requires_xcodebuild: true do
+      options = { project: "./scan/examples/standard/app.xcodeproj", use_system_scm: true }
+      @project.options[:use_system_scm] = true
+      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+      result = @test_command_generator.generate
+      expect(result).to include("-scmProvider system").once
     end
 
     it "defaults to Xcode scm when option is not provided", requires_xcodebuild: true do

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -283,7 +283,12 @@ module Snapshot
                                      env_name: "SNAPSHOT_SUPPRESS_XCODE_OUTPUT",
                                      description: "Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path",
                                      type: Boolean,
-                                     optional: true)
+                                     optional: true),
+        FastlaneCore::ConfigItem.new(key: :use_system_scm,
+                                     env_name: "SNAPSHOT_USE_SYSTEM_SCM",
+                                     description: "Lets xcodebuild use system's scm configuration",
+                                     type: Boolean,
+                                     default_value: false)
       ]
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17767

### Description
This PR is a follow up of #17644, that introduced the use_system_scm parameter to `gym` and `scan`.
The issue was that that option was not being forwarded to (or read by, actually) `xcodebuild`'s ``-showBuildSettings` command.

Prior to this PR:

```
$ be fastlane run gym use_system_scm:true 
[✔] 🚀 
[18:13:37]: -----------------
[18:13:37]: --- Step: gym ---
[18:13:37]: -----------------
Select Scheme: 
1. redacted1
2. redacted2
3. redacted3
4. redacted4
5. redacted5
6. redacted6
7. redacted7
8. redacted8
9. redacted9
?  6
[18:13:39]: Resolving Swift Package Manager dependencies...
[18:13:39]: $ xcodebuild -resolvePackageDependencies -workspace ./redacted.xcworkspace -scheme redacted6
```

After this PR:

```
$ be fastlane run gym use_system_scm:true
[✔] 🚀 
[18:14:52]: -----------------
[18:14:52]: --- Step: gym ---
[18:14:52]: -----------------
Select Scheme: 
1. redacted1
2. redacted2
3. redacted3
4. redacted4
5. redacted5
6. redacted6
7. redacted7
8. redacted8
9. redacted9
?  6
[18:14:54]: Resolving Swift Package Manager dependencies...
[18:14:54]: $ xcodebuild -resolvePackageDependencies -workspace ./redacted.xcworkspace -scheme redacted6 -scmProvider system
```

This PR also adds `use_system_scm` option to snapshot, to fix specs.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-fix-gym-use-system-scm"
```

Then you can test it by running gym/build_app command using the `use_system_scm` option, such as:

`bundle exec fastlane run gym use_system_scm:true`

And verifying that it appends `-scmProvider system` to the end of the xcodebuild command.