### PR TITLE
[action] artifactory - add option to authenticate using an API key

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -71,6 +71,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('tty-screen', '>= 0.6.3', '< 1.0.0') # detect the terminal width
   spec.add_dependency('tty-spinner', '>= 0.8.0', '< 1.0.0') # loading indicators
 
+  spec.add_dependency('artifactory', '~> 3.0') # Used to export to an artifactory server
   spec.add_dependency('babosa', '>= 1.0.3', "< 2.0.0") # library for creating human-friendly identifiers, aka "slugs"
   spec.add_dependency('colored') # colored terminal output
   spec.add_dependency('commander-fastlane', '>= 4.4.6', '< 5.0.0') # CLI parser

--- a/fastlane/lib/fastlane/actions/artifactory.rb
+++ b/fastlane/lib/fastlane/actions/artifactory.rb
@@ -15,7 +15,7 @@ module Fastlane
         UI.user_error!("Cannot connect to Artifactory - 'password' was provided but it's missing 'username'") if !params[:username] && params[:password]
         UI.user_error!("Cannot connect to Artifactory - either 'api_key', or 'username' and 'password' must be provided") if !params[:api_key] && !params[:username]
         file_path = File.absolute_path(params[:file])
-        
+
         if File.exist?(file_path)
           client = connect_to_artifactory(params)
           artifact = Artifactory::Resource::Artifact.new

--- a/fastlane/spec/actions_specs/artifactory_spec.rb
+++ b/fastlane/spec/actions_specs/artifactory_spec.rb
@@ -1,0 +1,45 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "artifactory" do
+      it "Call the artifactory plugin with 'username' and 'password' " do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            artifactory(username:'username', password: 'password', endpoint: 'artifactory.example.com', file: 'file.txt', repo: '/file.txt')
+          end").runner.execute(:test)
+
+        expect(result).to be true
+      end
+
+      it "Call the artifactory plugin with 'api_key' " do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            artifactory(api_key:'MY_API_KEY', endpoint: 'artifactory.example.com', file: 'file.txt', repo: '/file.txt')
+          end").runner.execute(:test)
+
+        expect(result).to be true
+      end
+
+      it "Require 'username' or 'api_key' parameter" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+              artifactory(endpoint: 'artifactory.example.com', file: 'file.txt', repo: '/file.txt')
+          end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+
+      it "Require 'password' if 'username' is provided" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+              artifactory(username:'username', endpoint: 'artifactory.example.com', file: 'file.txt', repo: '/file.txt')
+            end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+
+      it "Require 'username' if 'password' is provided" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+              artifactory(username:'username', endpoint: 'artifactory.example.com', file: 'file.txt', repo: '/file.txt')
+          end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+    end
+  end
+end

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -700,7 +700,6 @@ public func apteligent(dsym: String? = nil,
    - endpoint: Artifactory endpoint
    - username: Artifactory username
    - password: Artifactory password
-   - apiKey: Artifactory API key
    - properties: Artifact properties hash
    - sslPemFile: Location of pem file to use for ssl verification
    - sslVerify: Verify SSL
@@ -709,15 +708,14 @@ public func apteligent(dsym: String? = nil,
    - proxyAddress: Proxy address
    - proxyPort: Proxy port
    - readTimeout: Read timeout
-*/
+ */
 public func artifactory(file: String,
                         repo: String,
                         repoPath: String,
                         endpoint: String,
-                        username: String? = nil,
-                        password: String? = nil,
-                        apiKey: String? = nil,
-                        properties: [String : Any] = [:],
+                        username: String,
+                        password: String,
+                        properties: [String: Any] = [:],
                         sslPemFile: String? = nil,
                         sslVerify: Bool = true,
                         proxyUsername: String? = nil,
@@ -732,7 +730,6 @@ public func artifactory(file: String,
                                                                                                RubyCommand.Argument(name: "endpoint", value: endpoint),
                                                                                                RubyCommand.Argument(name: "username", value: username),
                                                                                                RubyCommand.Argument(name: "password", value: password),
-                                                                                               RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                                RubyCommand.Argument(name: "properties", value: properties),
                                                                                                RubyCommand.Argument(name: "ssl_pem_file", value: sslPemFile),
                                                                                                RubyCommand.Argument(name: "ssl_verify", value: sslVerify),

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -700,6 +700,7 @@ public func apteligent(dsym: String? = nil,
    - endpoint: Artifactory endpoint
    - username: Artifactory username
    - password: Artifactory password
+   - apiKey: Artifactory API key
    - properties: Artifact properties hash
    - sslPemFile: Location of pem file to use for ssl verification
    - sslVerify: Verify SSL
@@ -708,14 +709,15 @@ public func apteligent(dsym: String? = nil,
    - proxyAddress: Proxy address
    - proxyPort: Proxy port
    - readTimeout: Read timeout
- */
+*/
 public func artifactory(file: String,
                         repo: String,
                         repoPath: String,
                         endpoint: String,
-                        username: String,
-                        password: String,
-                        properties: [String: Any] = [:],
+                        username: String? = nil,
+                        password: String? = nil,
+                        apiKey: String? = nil,
+                        properties: [String : Any] = [:],
                         sslPemFile: String? = nil,
                         sslVerify: Bool = true,
                         proxyUsername: String? = nil,
@@ -730,6 +732,7 @@ public func artifactory(file: String,
                                                                                                RubyCommand.Argument(name: "endpoint", value: endpoint),
                                                                                                RubyCommand.Argument(name: "username", value: username),
                                                                                                RubyCommand.Argument(name: "password", value: password),
+                                                                                               RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                                RubyCommand.Argument(name: "properties", value: properties),
                                                                                                RubyCommand.Argument(name: "ssl_pem_file", value: sslPemFile),
                                                                                                RubyCommand.Argument(name: "ssl_verify", value: sslVerify),


### PR DESCRIPTION
Signed-off-by: STAINE Florian <florian.staine@orange.com>

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass (except the ones that where already not passing on master, not related to the Artifactory action)
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->
The _Artifactory_ plugin allows to upload artifacts to a given Artifactory repository.
The lib used to send the artifacts allow to use a username/password or tu use an API key (prefered), but the lane was only accepting the username/password parameters. 

The objective of this PR to to enable logging in with an API key.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This changes allow to pass an 'api_key' parameter to the _artifactory_ lane action.
Verifications are made so that only api_key or username & password parameters are used, providing a clear message to the user if any other combination of crendentials is used.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
To test this new feature, an Artifactory server is required.

To send an artifact using the API key:
`artifactory(api_key: <MY_API_KEY>, endpoint: <ENDPOINT>, file: <FILE.EXT>, repo: <REPO>, repo_path: <REPO_PATH>`