### PR TITLE
[xcodebuild] add (partial) support for xcframework generation

### DIFF
--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -670,7 +670,7 @@ module Fastlane
       end
 
       def self.description
-        "Packages multiple build configurations of a given library or framework into a single xcframework"
+        "Packages multiple frameworks into a single xcframework"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -659,7 +659,7 @@ module Fastlane
       def self.example_code
         [
           'xccreatexcframework(
-            framework: ["FrameworkA.framework", "FrameworkB.framework"],
+            frameworks: ["FrameworkA.framework", "FrameworkB.framework"],
             output: "UniversalFramework.xcframework"
           )'
         ]

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -41,7 +41,6 @@ module Fastlane
         export_profile: "-exportProvisioningProfile",
         export_signing_identity: "-exportSigningIdentity",
         export_with_original_signing_identity: "-exportWithOriginalSigningIdentity",
-        frameworks: "-framework",
         hide_shell_script_environment: "-hideShellScriptEnvironment",
         jobs: "-jobs",
         output: "-output",
@@ -108,10 +107,11 @@ module Fastlane
 
         if params
           # Operation bools
-          archiving    = params.key? :archive
-          exporting    = params.key? :export_archive
-          testing      = params.key? :test
-          xcpretty_utf = params[:xcpretty_utf]
+          archiving            = params.key? :archive
+          creating_xcframework = params.key? :create_xcframework
+          exporting            = params.key? :export_archive
+          testing              = params.key? :test
+          xcpretty_utf         = params[:xcpretty_utf]
 
           if params.key? :raw_buildlog
             raw_buildlog = params[:raw_buildlog]
@@ -342,6 +342,8 @@ module Fastlane
             end.join(' ')
           elsif k == :destination
             [*v].collect { |dst| "-destination \"#{dst}\"" }.join(' ')
+          elsif k == :frameworks
+            [*v].map { |framework| "-framework \"#{framework}\"" }.join(' ')
           elsif k == :keychain && v.to_s.length > 0
             # If keychain is specified, append as OTHER_CODE_SIGN_FLAGS
             "OTHER_CODE_SIGN_FLAGS=\"--keychain #{v}\""
@@ -643,8 +645,7 @@ module Fastlane
 
     class XccreatexcframeworkAction < Action
       def self.run(params)
-        params_hash = params || {}
-        params_hash[:create_xcframework] = true
+        params_hash = { create_xcframework: true }.merge(params)
 
         XcodebuildAction.run(params_hash)
       end

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -21,9 +21,11 @@ module Fastlane
         test: "test",
 
         # parameters
+        allow_internal_distribution: "-allow-internal-distribution",
         alltargets: "-alltargets",
         arch: "-arch",
         archive_path: "-archivePath",
+        create_xcframework: "-create-xcframework",
         configuration: "-configuration",
         derivedDataPath: "-derivedDataPath",
         destination_timeout: "-destination-timeout",
@@ -39,8 +41,10 @@ module Fastlane
         export_profile: "-exportProvisioningProfile",
         export_signing_identity: "-exportSigningIdentity",
         export_with_original_signing_identity: "-exportWithOriginalSigningIdentity",
+        framework: "-framework",
         hide_shell_script_environment: "-hideShellScriptEnvironment",
         jobs: "-jobs",
+        output: "-output",
         parallelize_targets: "-parallelizeTargets",
         project: "-project",
         result_bundle_path: "-resultBundlePath",
@@ -634,6 +638,48 @@ module Fastlane
 
       def self.author
         "dtrenz"
+      end
+    end
+
+    class XccreatexcframeworkAction < Action
+      def self.run(params)
+        params_hash = params || {}
+        params_hash[:create_xcframework] = true
+
+        XcodebuildAction.run(params_hash)
+      end
+
+      def self.example_code
+        [
+          'xccreatexcframework(
+            framework: ["FrameworkA.framework", "FrameworkB.framework"],
+            output: "UniversalFramework.xcframework"
+          )'
+        ]
+      end
+
+      def self.category
+        :building
+      end
+
+      def self.description
+        "Packages multiple build configurations of a given library or framework into a single xcframework"
+      end
+
+      def self.available_options
+        [
+          ['framework', 'List of frameworks to add to resulting xcframework'],
+          ['output', 'The path to write the xcframework to'],
+          ['allow_internal_distribution', 'Specifies that the created xcframework contains information not suitable for public distribution']
+        ]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include? platform
+      end
+
+      def self.author
+        "jgongo"
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -343,7 +343,8 @@ module Fastlane
           elsif k == :destination
             [*v].collect { |dst| "-destination \"#{dst}\"" }.join(' ')
           elsif k == :frameworks
-            [*v].map { |framework| "-framework \"#{framework}\"" }.join(' ')
+            frameworks = v.kind_of?(Array)? v : v.to_s.split(',')
+            frameworks.map { |framework| "-framework \"#{framework}\"" }.join(' ')
           elsif k == :keychain && v.to_s.length > 0
             # If keychain is specified, append as OTHER_CODE_SIGN_FLAGS
             "OTHER_CODE_SIGN_FLAGS=\"--keychain #{v}\""

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -41,7 +41,7 @@ module Fastlane
         export_profile: "-exportProvisioningProfile",
         export_signing_identity: "-exportSigningIdentity",
         export_with_original_signing_identity: "-exportWithOriginalSigningIdentity",
-        framework: "-framework",
+        frameworks: "-framework",
         hide_shell_script_environment: "-hideShellScriptEnvironment",
         jobs: "-jobs",
         output: "-output",
@@ -668,7 +668,7 @@ module Fastlane
 
       def self.available_options
         [
-          ['framework', 'List of frameworks to add to resulting xcframework'],
+          ['frameworks', 'List of frameworks to add to resulting xcframework'],
           ['output', 'The path to write the xcframework to'],
           ['allow_internal_distribution', 'Specifies that the created xcframework contains information not suitable for public distribution']
         ]

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -163,6 +163,11 @@ module Fastlane
             params[:enableCodeCoverage] = params[:enable_code_coverage] ? 'YES' : 'NO'
           end
 
+          if creating_xcframework
+            allowed_params = %i(create_xcframework frameworks output allow_internal_distribution)
+            params.select! { |k, _| allowed_params.include?(k) }
+          end
+
           # Maps parameter hash to CLI args
           params = export_options_to_plist(params)
           if hash_args = hash_to_args(params)

--- a/fastlane/spec/action_metadata_spec.rb
+++ b/fastlane/spec/action_metadata_spec.rb
@@ -13,7 +13,7 @@ describe Fastlane::Action do
       end
 
       it "file name follows our convention and matches the class name" do
-        exceptions = %w(plugin_scores xcarchive xcbuild xcclean xcexport xctest)
+        exceptions = %w(plugin_scores xcarchive xcbuild xcclean xcexport xctest xccreatexcframework)
 
         action_path = File.join(Dir.pwd, "fastlane/lib/fastlane/actions/#{name}.rb")
         unless exceptions.include?(name)

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -19,9 +19,11 @@ describe Fastlane do
             installsrc: true,
             test: true,
             arch: 'architecture',
+            allow_internal_distribution: true,
             alltargets: true,
             archive_path: './build/MyApp.xcarchive',
             configuration: 'Debug',
+            create_xcframework: true,
             derivedDataPath: '/derived/data/path',
             destination: 'name=iPhone 5s,OS=8.1',
             destination_timeout: 240,
@@ -37,10 +39,12 @@ describe Fastlane do
             export_profile: 'MyApp Distribution',
             export_signing_identity: 'Distribution: MyCompany, LLC',
             export_with_original_signing_identity: true,
+            framework: ['FrameworkA.framework', 'FrameworkB.framework'],
             hide_shell_script_environment: true,
             jobs: 5,
             parallelize_targets: true,
             keychain: '/path/to/My.keychain',
+            output: 'UniversalFramework.xcframework',
             project: 'MyApp.xcodeproj',
             result_bundle_path: '/result/bundle/path',
             scheme: 'MyApp',
@@ -59,11 +63,15 @@ describe Fastlane do
 
         expect(result).to eq(
           "set -o pipefail && xcodebuild analyze archive build clean install installsrc test -arch \"architecture\" " \
-          "-alltargets -archivePath \"./build/MyApp.xcarchive\" -configuration \"Debug\" -derivedDataPath \"/derived/data/path\" " \
+          "-allow-internal-distribution " \
+          "-alltargets -archivePath \"./build/MyApp.xcarchive\" -configuration \"Debug\" " \
+          "-create-xcframework -derivedDataPath \"/derived/data/path\" " \
           "-destination \"name=iPhone 5s,OS=8.1\" -destination-timeout \"240\" -dry-run -exportArchive -exportFormat \"ipa\" " \
           "-exportInstallerIdentity -exportOptionsPlist \"/path/to/plist\" -exportPath \"./build/MyApp\" -exportProvisioningProfile " \
           "\"MyApp Distribution\" -exportSigningIdentity \"Distribution: MyCompany, LLC\" -exportWithOriginalSigningIdentity " \
-          "-hideShellScriptEnvironment -jobs \"5\" -parallelizeTargets OTHER_CODE_SIGN_FLAGS=\"--keychain /path/to/My.keychain\" -project " \
+          "-framework \"FrameworkA.framework\" -framework \"FrameworkB.framework\" " \
+          "-hideShellScriptEnvironment -jobs \"5\" -output \"UniversalFramework.xcframework\" " \
+          "-parallelizeTargets OTHER_CODE_SIGN_FLAGS=\"--keychain /path/to/My.keychain\" -project " \
           "\"MyApp.xcodeproj\" -resultBundlePath \"/result/bundle/path\" -scheme \"MyApp\" -sdk \"iphonesimulator\" -skipUnavailableActions -target " \
           "\"MyAppTarget\" -toolchain \"toolchain name\" -workspace \"MyApp.xcworkspace\" -xcconfig \"my.xcconfig\" -newArgument YES -enableAddressSanitizer " \
           "\"YES\" -enableThreadSanitizer \"NO\" -enableCodeCoverage \"YES\" | tee 'mypath/xcodebuild.log' | xcpretty --color --test"
@@ -407,6 +415,18 @@ describe Fastlane do
 
         expect(result).to eq(
           "set -o pipefail && xcodebuild clean | tee '#{build_log_path}' | xcpretty --color --simple"
+        )
+      end
+    end
+
+    describe "xccreatexcframework" do
+      it "is equivalent to 'xcodebuild -create-xcframework'" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xccreatexcframework
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "set -o pipefail && xcodebuild -create-xcframework | tee '#{build_log_path}' | xcpretty --color --simple"
         )
       end
     end

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -285,7 +285,7 @@ describe Fastlane do
           xcodebuild(
             create_xcframework: true,
             frameworks: ['FrameworkA.framework', 'FrameworkB.framework'],
-            otuput: './build-dir/UniversalFramework.xcframework',
+            output: './build-dir/UniversalFramework.xcframework',
             allow_internal_distribution: true
           )
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -39,7 +39,7 @@ describe Fastlane do
             export_profile: 'MyApp Distribution',
             export_signing_identity: 'Distribution: MyCompany, LLC',
             export_with_original_signing_identity: true,
-            framework: ['FrameworkA.framework', 'FrameworkB.framework'],
+            frameworks: ['FrameworkA.framework', 'FrameworkB.framework'],
             hide_shell_script_environment: true,
             jobs: 5,
             parallelize_targets: true,

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -281,6 +281,28 @@ describe Fastlane do
         )
       end
 
+      it "can create xcframework" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xcodebuild(
+            create_xcframework: true,
+            frameworks: ['FrameworkA.framework', 'FrameworkB.framework'],
+            otuput: './build-dir/UniversalFramework.xcframework',
+            allow_internal_distribution: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "-create-xcframework " \
+          + "-framework \"FrameworkA.framework\" " \
+          + "-framework \"FrameworkB.framework\" " \
+          + "-output \"./build-dir/UniversalFramework.xcframework\" " \
+          + "-allow-internal-distribution " \
+          + "| tee '#{build_log_path}' | xcpretty --color --simple"
+        )
+      end
+
       it "can export" do
         ENV.delete("XCODE_SCHEME")
         ENV.delete("XCODE_WORKSPACE")
@@ -427,6 +449,56 @@ describe Fastlane do
 
         expect(result).to eq(
           "set -o pipefail && xcodebuild -create-xcframework | tee '#{build_log_path}' | xcpretty --color --simple"
+        )
+      end
+
+      it "can create an xcframework with a single framework" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xccreatexcframework(
+            frameworks: 'FrameworkA.framework',
+            output: 'UniversalFramework.xcframework'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          "xcodebuild -create-xcframework -framework \"FrameworkA.framework\" " \
+          "-output \"UniversalFramework.xcframework\" " \
+          "| tee '#{build_log_path}' | xcpretty --color --simple"
+        )
+      end
+
+      it "can create an xcframework with an array of frameworks" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xccreatexcframework(
+            frameworks: ['FrameworkA.framework', 'FrameworkB.framework'],
+            output: 'UniversalFramework.xcframework'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          "xcodebuild -create-xcframework -framework \"FrameworkA.framework\" " \
+          "-framework \"FrameworkB.framework\" " \
+          "-output \"UniversalFramework.xcframework\" " \
+          "| tee '#{build_log_path}' | xcpretty --color --simple"
+        )
+      end
+
+      it "can create an xcframework with a comma separated list of frameworks" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          xccreatexcframework(
+            frameworks: 'FrameworkA.framework,FrameworkB.framework',
+            output: 'UniversalFramework.xcframework'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          "xcodebuild -create-xcframework -framework \"FrameworkA.framework\" " \
+          "-framework \"FrameworkB.framework\" " \
+          "-output \"UniversalFramework.xcframework\" " \
+          "| tee '#{build_log_path}' | xcpretty --color --simple"
         )
       end
     end

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -23,7 +23,6 @@ describe Fastlane do
             alltargets: true,
             archive_path: './build/MyApp.xcarchive',
             configuration: 'Debug',
-            create_xcframework: true,
             derivedDataPath: '/derived/data/path',
             destination: 'name=iPhone 5s,OS=8.1',
             destination_timeout: 240,
@@ -65,13 +64,13 @@ describe Fastlane do
           "set -o pipefail && xcodebuild analyze archive build clean install installsrc test -arch \"architecture\" " \
           "-allow-internal-distribution " \
           "-alltargets -archivePath \"./build/MyApp.xcarchive\" -configuration \"Debug\" " \
-          "-create-xcframework -derivedDataPath \"/derived/data/path\" " \
+          "-derivedDataPath \"/derived/data/path\" " \
           "-destination \"name=iPhone 5s,OS=8.1\" -destination-timeout \"240\" -dry-run -exportArchive -exportFormat \"ipa\" " \
           "-exportInstallerIdentity -exportOptionsPlist \"/path/to/plist\" -exportPath \"./build/MyApp\" -exportProvisioningProfile " \
           "\"MyApp Distribution\" -exportSigningIdentity \"Distribution: MyCompany, LLC\" -exportWithOriginalSigningIdentity " \
           "-framework \"FrameworkA.framework\" -framework \"FrameworkB.framework\" " \
-          "-hideShellScriptEnvironment -jobs \"5\" -output \"UniversalFramework.xcframework\" " \
-          "-parallelizeTargets OTHER_CODE_SIGN_FLAGS=\"--keychain /path/to/My.keychain\" -project " \
+          "-hideShellScriptEnvironment -jobs \"5\" -parallelizeTargets OTHER_CODE_SIGN_FLAGS=\"--keychain /path/to/My.keychain\" " \
+          "-output \"UniversalFramework.xcframework\" -project " \
           "\"MyApp.xcodeproj\" -resultBundlePath \"/result/bundle/path\" -scheme \"MyApp\" -sdk \"iphonesimulator\" -skipUnavailableActions -target " \
           "\"MyAppTarget\" -toolchain \"toolchain name\" -workspace \"MyApp.xcworkspace\" -xcconfig \"my.xcconfig\" -newArgument YES -enableAddressSanitizer " \
           "\"YES\" -enableThreadSanitizer \"NO\" -enableCodeCoverage \"YES\" | tee 'mypath/xcodebuild.log' | xcpretty --color --test"


### PR DESCRIPTION
## Note ❗ This PR is mutually exclusive with https://github.com/fastlane/fastlane/pull/17844

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
-->

Resolves #17836 

### Description
<!-- Describe your changes in detail. -->
I have added a new action mimicking the already existing actions related with `xcodebuild`. I don't know if this is the proper approach for this, as the `xcodebuild` action has a lot of parameters that doesn't make sense when building xcframeworks. This also made a bit complex to add the `-library` and `-headers` parameters, as these parameters have to be coupled and the header option is optional for each library. Due to this I only provide support for the `-framework` parameter.

<!-- Please describe in detail how you tested your changes. -->
I have added tests to check that the command is properly built for the allowed parameters.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
```
bundle exec fastlane test
```