### PR TITLE
[action] new create_xcframework action

### DIFF
--- a/fastlane/lib/fastlane/actions/create_xcframework.rb
+++ b/fastlane/lib/fastlane/actions/create_xcframework.rb
@@ -6,13 +6,11 @@ module Fastlane
 
     class CreateXcframeworkAction < Action
       def self.run(params)
-        UI.user_error!("Please provide either :frameworks or :libraries to be packaged into the xcframework") unless params[:frameworks] or params[:libraries]
+        UI.user_error!("Please provide either :frameworks or :libraries to be packaged into the xcframework") unless params[:frameworks] || params[:libraries]
 
         create_command = ['xcodebuild', '-create-xcframework']
-        create_command << params[:frameworks].map { |framework| ['-framework', "\"#{framework}\""]  }.flatten if params[:frameworks]
-        create_command << params[:libraries].map { |library, headers|
-          ['-library', "\"#{library}\""] + (headers.empty? ? [] : ['-headers', "\"#{headers}\""])
-        } if params[:libraries]
+        create_command << params[:frameworks].map { |framework| ['-framework', "\"#{framework}\""] }.flatten if params[:frameworks]
+        create_command << params[:libraries].map { |library, headers| ['-library', "\"#{library}\""] + (headers.empty? ? [] : ['-headers', "\"#{headers}\""]) } if params[:libraries]
         create_command << ['-output', "\"#{params[:output]}\""]
         create_command << ['-allow-internal-distribution'] if params[:allow_internal_distribution]
 
@@ -56,11 +54,11 @@ module Fastlane
                                        optional: true,
                                        conflicting_options: [:libraries],
                                        verify_block: proc do |value|
-                                         value.each { |framework|
+                                         value.each do |framework|
                                            UI.user_error!("#{framework} doesn't end with '.framework'. Is this really a framework?") unless framework.end_with?('.framework')
                                            UI.user_error!("Couldn't find framework at #{framework}") unless File.exist?(framework)
                                            UI.user_error!("#{framework} doesn't seem to be a framework") unless File.directory?(framework)
-                                         }
+                                         end
                                        end),
           FastlaneCore::ConfigItem.new(key: :libraries,
                                        env_name: "FL_CREATE_XCFRAMEWORK_LIBRARIES",
@@ -69,10 +67,10 @@ module Fastlane
                                        optional: true,
                                        conflicting_options: [:frameworks],
                                        verify_block: proc do |value|
-                                         value.each { |library, headers|
+                                         value.each do |library, headers|
                                            UI.user_error!("Couldn't find library at #{library}") unless File.exist?(library)
-                                           UI.user_error!("#{headers} doesn't exist or is not a directory") unless headers.empty? or File.directory?(headers)
-                                         }
+                                           UI.user_error!("#{headers} doesn't exist or is not a directory") unless headers.empty? || File.directory?(headers)
+                                         end
                                        end),
           FastlaneCore::ConfigItem.new(key: :output,
                                        env_name: "FL_CREATE_XCFRAMEWORK_OUTPUT",

--- a/fastlane/lib/fastlane/actions/create_xcframework.rb
+++ b/fastlane/lib/fastlane/actions/create_xcframework.rb
@@ -1,0 +1,109 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      XCFRAMEWORK_PATH ||= :XCFRAMEWORK_PATH
+    end
+
+    class CreateXcframeworkAction < Action
+      def self.run(params)
+        UI.user_error!("Please provide either :frameworks or :libraries to be packaged into the xcframework") unless params[:frameworks] or params[:libraries]
+
+        create_command = ['xcodebuild', '-create-xcframework']
+        create_command << params[:frameworks].map { |framework| ['-framework', "\"#{framework}\""]  }.flatten if params[:frameworks]
+        create_command << params[:libraries].map { |library, headers|
+          ['-library', "\"#{library}\""] + (headers.empty? ? [] : ['-headers', "\"#{headers}\""])
+        } if params[:libraries]
+        create_command << ['-output', "\"#{params[:output]}\""]
+        create_command << ['-allow-internal-distribution'] if params[:allow_internal_distribution]
+
+        Actions.lane_context[SharedValues::XCFRAMEWORK_PATH] = params[:output]
+
+        sh(create_command)
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Package multiple build configs of a library/framework into a single xcframework"
+      end
+
+      def self.details
+        <<~DETAILS
+          Utility for packaging multiple build configurations of a given library
+          or framework into a single xcframework.
+
+          If you want to package several frameworks just provide an array containing
+          the list of frameworks to be packaged using the :frameworks parameter.
+
+          If you want to package several libraries with their corresponding headers
+          provide a hash containing the library as the key and the directory containing
+          its headers as the value (or an empty string if there are no headers associated
+          with the provided library).
+
+          Finally specify the location of the xcframework to be generated using the :output
+          parameter.
+        DETAILS
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :frameworks,
+                                       env_name: "FL_CREATE_XCFRAMEWORK_FRAMEWORKS",
+                                       description: "Frameworks to add to the target xcframework",
+                                       type: Array,
+                                       optional: true,
+                                       conflicting_options: [:libraries],
+                                       verify_block: proc do |value|
+                                         value.each { |framework|
+                                           UI.user_error!("#{framework} doesn't end with '.framework'. Is this really a framework?") unless framework.end_with?('.framework')
+                                           UI.user_error!("Couldn't find framework at #{framework}") unless File.exist?(framework)
+                                           UI.user_error!("#{framework} doesn't seem to be a framework") unless File.directory?(framework)
+                                         }
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :libraries,
+                                       env_name: "FL_CREATE_XCFRAMEWORK_LIBRARIES",
+                                       description: "Libraries to add to the target xcframework, with their corresponding headers",
+                                       type: Hash,
+                                       optional: true,
+                                       conflicting_options: [:frameworks],
+                                       verify_block: proc do |value|
+                                         value.each { |library, headers|
+                                           UI.user_error!("Couldn't find library at #{library}") unless File.exist?(library)
+                                           UI.user_error!("#{headers} doesn't exist or is not a directory") unless headers.empty? or File.directory?(headers)
+                                         }
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :output,
+                                       env_name: "FL_CREATE_XCFRAMEWORK_OUTPUT",
+                                       description: "The path to write the xcframework to",
+                                       type: String,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :allow_internal_distribution,
+                                       env_name: "FL_CREATE_XCFRAMEWORK_ALLOW_INTERNAL_DISTRIBUTION",
+                                       description: "Specifies that the created xcframework contains information not suitable for public distribution",
+                                       type: Boolean,
+                                       optional: true,
+                                       default_value: false)
+        ]
+      end
+
+      def self.output
+        [
+          ['XCFRAMEWORK_PATH', 'Location of the generated xcframework']
+        ]
+      end
+
+      def self.return_value
+      end
+
+      def self.authors
+        ["jgongo"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/create_xcframework.rb
+++ b/fastlane/lib/fastlane/actions/create_xcframework.rb
@@ -95,6 +95,17 @@ module Fastlane
       def self.return_value
       end
 
+      def self.example_code
+        [
+          "create_xcframework(frameworks: ['FrameworkA.framework', 'FrameworkB.framework'], output: 'UniversalFramework.xcframework')",
+          "create_xcframework(libraries: { 'LibraryA.so' => '', 'LibraryB.so' => 'LibraryBHeaders'}, output: 'UniversalFramework.xcframework')"
+        ]
+      end
+
+      def self.category
+        :building
+      end
+
       def self.authors
         ["jgongo"]
       end

--- a/fastlane/spec/actions_specs/create_xcframework_spec.rb
+++ b/fastlane/spec/actions_specs/create_xcframework_spec.rb
@@ -1,0 +1,200 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Create XCFramework Action" do
+      before(:each) do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:directory?).and_call_original
+      end
+
+      it "requires to either provide :frameworks or :libraries" do
+        begin
+          Fastlane::FastFile.new.parse("lane :test do
+            create_xcframework(
+              output: 'UniversalFramework.xcframework'
+            )
+          end").runner.execute(:test)
+        rescue => e
+          expect(e.to_s).to eq("Please provide either :frameworks or :libraries to be packaged into the xcframework")
+        else
+          fail("Error should have been raised")
+        end
+      end
+
+      it "forbids to provide both :frameworks and :libraries" do
+        allow(File).to receive(:exist?).with('FrameworkA.framework').and_return(true)
+        allow(File).to receive(:directory?).with('FrameworkA.framework').and_return(true)
+        allow(File).to receive(:exist?).with('LibraryA.so').and_return(true)
+
+        begin
+          Fastlane::FastFile.new.parse("lane :test do
+            create_xcframework(
+              frameworks: ['FrameworkA.framework'],
+              libraries: { 'LibraryA.so' => '' },
+              output: 'UniversalFramework.xcframework'
+            )
+          end").runner.execute(:test)
+        rescue => e
+          expect(e.to_s).to eq("Unresolved conflict between options: 'frameworks' and 'libraries'")
+        else
+          fail("Error should have been raised")
+        end
+      end
+
+      context "when packaging frameworks" do
+        context "which exist" do
+          before(:each) do
+            allow(File).to receive(:exist?).with('FrameworkA.framework').and_return(true)
+            allow(File).to receive(:exist?).with('FrameworkB.framework').and_return(true)
+          end
+
+          context "and are directories" do
+            before(:each) do
+              allow(File).to receive(:directory?).with('FrameworkA.framework').and_return(true)
+              allow(File).to receive(:directory?).with('FrameworkB.framework').and_return(true)
+            end
+
+            it "should work properly for public frameworks" do
+              result = Fastlane::FastFile.new.parse("lane :test do
+                create_xcframework(
+                  frameworks: ['FrameworkA.framework', 'FrameworkB.framework'],
+                  output: 'UniversalFramework.xcframework'
+                )
+              end").runner.execute(:test)
+
+              expect(result).to eq('xcodebuild -create-xcframework ' \
+                + '-framework "FrameworkA.framework" -framework "FrameworkB.framework" ' \
+                + '-output "UniversalFramework.xcframework"')
+            end
+
+            it "should work properly for internal frameworks" do
+              result = Fastlane::FastFile.new.parse("lane :test do
+                create_xcframework(
+                  frameworks: ['FrameworkA.framework', 'FrameworkB.framework'],
+                  output: 'UniversalFramework.xcframework',
+                  allow_internal_distribution: true
+                )
+              end").runner.execute(:test)
+
+              expect(result).to eq('xcodebuild -create-xcframework ' \
+                + '-framework "FrameworkA.framework" -framework "FrameworkB.framework" ' \
+                + '-output "UniversalFramework.xcframework" ' \
+                + '-allow-internal-distribution')
+            end
+          end
+
+          context "and are not directories" do
+            it "should fail due to wrong framework" do
+              begin
+                Fastlane::FastFile.new.parse("lane :test do
+                  create_xcframework(
+                    frameworks: ['FrameworkA.framework', 'FrameworkB.framework'],
+                    output: 'UniversalFramework.xcframework'
+                  )
+                end").runner.execute(:test)
+              rescue => e
+                expect(e.to_s).to eq("FrameworkA.framework doesn't seem to be a framework")
+              else
+                fail("Error should have been raised")
+              end
+            end
+          end
+        end
+
+        context "which don't exist" do
+          it "should fail due to missing framework" do
+            begin
+              Fastlane::FastFile.new.parse("lane :test do
+                create_xcframework(
+                  frameworks: ['FrameworkA.framework', 'FrameworkB.framework'],
+                  output: 'UniversalFramework.xcframework'
+                )
+              end").runner.execute(:test)
+            rescue => e
+              expect(e.to_s).to eq("Couldn't find framework at FrameworkA.framework")
+            else
+              fail("Error should have been raised")
+            end
+          end
+        end
+      end
+
+
+      context "when packaging libraries" do
+        context "which exist" do
+          before(:each) do
+            allow(File).to receive(:exist?).with('LibraryA.so').and_return(true)
+            allow(File).to receive(:exist?).with('LibraryB.so').and_return(true)
+          end
+
+          context "which headers is a directory" do
+            before(:each) do
+              allow(File).to receive(:directory?).with('headers').and_return(true)
+            end
+
+            it "should work properly for public frameworks" do
+              result = Fastlane::FastFile.new.parse("lane :test do
+                create_xcframework(
+                  libraries: { 'LibraryA.so' => '', 'LibraryB.so' => 'headers' },
+                  output: 'UniversalFramework.xcframework'
+                )
+              end").runner.execute(:test)
+
+              expect(result).to eq('xcodebuild -create-xcframework ' \
+                + '-library "LibraryA.so" -library "LibraryB.so" -headers "headers" ' \
+                + '-output "UniversalFramework.xcframework"')
+            end
+
+            it "should work properly for internal frameworks" do
+              result = Fastlane::FastFile.new.parse("lane :test do
+                create_xcframework(
+                  libraries: { 'LibraryA.so' => '', 'LibraryB.so' => 'headers' },
+                  output: 'UniversalFramework.xcframework',
+                  allow_internal_distribution: true
+                )
+              end").runner.execute(:test)
+
+              expect(result).to eq('xcodebuild -create-xcframework ' \
+                + '-library "LibraryA.so" -library "LibraryB.so" -headers "headers" ' \
+                + '-output "UniversalFramework.xcframework" ' \
+                + '-allow-internal-distribution')
+            end
+          end
+
+          context "which headers is not a directory" do
+            it "should fail due to wrong headers directory" do
+              begin
+                Fastlane::FastFile.new.parse("lane :test do
+                  create_xcframework(
+                    libraries: { 'LibraryA.so' => '', 'LibraryB.so' => 'headers' },
+                    output: 'UniversalFramework.xcframework'
+                  )
+                end").runner.execute(:test)
+              rescue => e
+                expect(e.to_s).to eq("headers doesn't exist or is not a directory")
+              else
+                fail("Error should have been raised")
+              end
+            end
+          end
+        end
+
+        context "which don't exist" do
+          it "should fail due to missing library" do
+            begin
+              Fastlane::FastFile.new.parse("lane :test do
+                create_xcframework(
+                  libraries: { 'LibraryA.so' => '' },
+                  output: 'UniversalFramework.xcframework'
+                )
+              end").runner.execute(:test)
+            rescue => e
+              expect(e.to_s).to eq("Couldn't find library at LibraryA.so")
+            else
+              fail("Error should have been raised")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/create_xcframework_spec.rb
+++ b/fastlane/spec/actions_specs/create_xcframework_spec.rb
@@ -118,7 +118,6 @@ describe Fastlane do
         end
       end
 
-
       context "when packaging libraries" do
         context "which exist" do
           before(:each) do


### PR DESCRIPTION
## Note ❗ This PR is mutually exclusive with https://github.com/fastlane/fastlane/pull/17837

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->
Resolves #17836 
Conflict with #17837: only one should be merged into master

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I have created a new `create_xcframework` action, separated from the `xcodebuild` action, although this action also generates a `xcodebuild` command. I think it made more sense to do it this way as the set of parameters of `-create-xcframework` is quite small and completely independent from the rest of parameters of `xcodebuild` (I think only `-output` it's used in other commands)

I'm rather new to Ruby, so please feel free to comment anything about the code (without hurting my delicate developer heart ❤️😝 ). Specifically, the `-create-xcframework` action supports a list of libraries which may have an associated headers directory. I have modeled this input parameter as a hash with library paths as keys and headers directory paths as values, using an empty string in the case that a library doesn't have associated headers. If you can think of a better way of expressing this in Ruby just tell me!

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
I have added a test suite providing tests for the most common scenarios.
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
```
bundle exec fastlane test
```