### PR TITLE
[CI] support Ruby 2.7 on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,12 @@ jobs:
       xcode: '11.4.0'
     environment:
       _RUBY_VERSION: '2.6'
+  'Execute tests on macOS (Xcode 12.3.0, Ruby 2.7)':
+    <<: *tests_macos
+    macos:
+      xcode: '12.3.0'
+    environment:
+      _RUBY_VERSION: '2.7'
 
   'Execute tests on Ubuntu':
     environment:
@@ -229,6 +235,7 @@ workflows:
       - 'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)'
       - 'Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)'
       - 'Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)'
+      - 'Execute tests on macOS (Xcode 12.3.0, Ruby 2.7)'
       - 'Execute tests on Ubuntu'
 
       - "Validate Fastlane.swift Generation"

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -471,7 +471,7 @@ lane :beta do
   sigh(app_identifier: "hi"
 end
 RUBY
-        expect(UI).to receive(:user_error!).with(%r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSytnaxError:17: syntax error, unexpected (keyword_end|end), expecting '\)'})
+        expect(UI).to receive(:user_error!).with(%r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSytnaxError:17: syntax error, unexpected (keyword_end|end|`end'), expecting '\)'})
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileSytnaxError')
       end
 
@@ -482,7 +482,7 @@ RUBY
           cases = [:abc,
         end
         RUBY
-        expect(UI).to receive(:user_error!).with(/Syntax error in your Fastfile on line 3: \(eval\):3: syntax error, unexpected (keyword_end|end), expecting '\]'\n        end\n.*/)
+        expect(UI).to receive(:user_error!).with(/Syntax error in your Fastfile on line 3: \(eval\):3: syntax error, unexpected (keyword_end|end|`end'), expecting '\]'\n        end\n.*/)
 
         ff = Fastlane::FastFile.new.parse(<<-RUBY.chomp)
         lane :test do
@@ -513,7 +513,7 @@ lane :beta do
   sigh(app_identifier: "hi"
 end
 RUBY
-        expect(UI).to receive(:user_error!).with(%r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSytnaxError:17: syntax error, unexpected (keyword_end|end), expecting '\)'})
+        expect(UI).to receive(:user_error!).with(%r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSytnaxError:17: syntax error, unexpected (keyword_end|end|`end'), expecting '\)'})
         ff.import('./FastfileSytnaxError')
       end
 

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -51,7 +51,7 @@ describe FastlaneCore do
 
     def shell_provider_id_command(jwt: nil)
       # Ruby doesn't escape "+" with Shellwords.escape from 2.7 https://bugs.ruby-lang.org/issues/14429
-      escaped_password = if RUBY_VERSION > "2.7.0"
+      escaped_password = if RUBY_VERSION >= "2.7.0"
                            "'\\!\\>\\ p@\\$s_-+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'"
                          else
                            "'\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'"

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -50,11 +50,17 @@ describe FastlaneCore do
     end
 
     def shell_provider_id_command(jwt: nil)
+      # Ruby doesn't escape "+" with Shellwords.escape from 2.7 https://bugs.ruby-lang.org/issues/14429
+      escaped_password = if RUBY_VERSION > "2.7.0"
+                           "'\\!\\>\\ p@\\$s_-+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'"
+                         else
+                           "'\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'"
+                         end
       [
         '"' + FastlaneCore::Helper.transporter_path + '"',
         "-m provider",
         ('-u "fabric.devtools@gmail.com"' if jwt.nil?),
-        ("-p '\\!\\>\\ p@\\$s_-\\+\\=w'\"\\'\"'o\\%rd\\\"\\&\\#\\*\\<'" if jwt.nil?),
+        ("-p #{escaped_password}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?)
       ].compact.join(' ')
     end
@@ -122,8 +128,8 @@ describe FastlaneCore do
         'com.apple.transporter.Application',
         '-m provider',
         ('-u fabric.devtools@gmail.com' if jwt.nil?),
-        ("-p \\!\\>\\ p@\\$s_-\\+\\=w\\'o\\%rd\\\"\\&\\#\\*\\<" if jwt.nil?),
-        ("-jwt #{jwt}" unless jwt.nil?),
+        ("-p #{password.shellescape}" if jwt.nil?),
+        ("-jwt #{jwt}" if jwt),
         '2>&1'
       ].compact.join(' ')
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->

It's been a year since Ruby 2.7 was released and then "3.0" was just released on the last Christmas day. As fastlane is a large size Ruby project, it's inevitable to continue following the latest version of Ruby. However, whilst fastlane does seem to be running with Ruby 2.7, it hasn't officially supported a bunch of unit tests running on Circle CI yet, which makes us feel less confident to develop fastlane for new Ruby versions. There is an attempt to make CI work with Ruby 2.7 https://github.com/fastlane/fastlane/pull/16407 but It has never had testing working all successfully yet. 

This PR fixes all the failures in unit testing with Ruby 2.7 and enables CI settings to run tests with it. This PR hasn't addressed warnings or deprecation messages appearing when running fastlane command yet. (See details here https://github.com/fastlane/fastlane/issues/16342)

### Description

You can see what exactly failing with Ruby 2.7 here https://gist.github.com/ainame/4d412e39fc69eb1f8aec153d3cd206c7

There are two kinds of failures due to version bumps of Ruby -

1. Syntax error message change https://github.com/fastlane/fastlane/commit/85f95f8cfcae51c5dd9d11467642fb76a505d0f5
2. Behaviour change in `Shellwords.escape` https://github.com/fastlane/fastlane/commit/c1c2804143b98e40745c29fdfaa5a465617da4b8

**1. Syntax error message change**

There was very minor change in error message that cause failures in unit testing. For example, this broken ruby code can show differences. 
 
```ruby
lane :beta do
  sigh(app_identifier: "hi"
end
```

```
% rbenv local 2.6.6
% ruby -c a.rb
a.rb:3: syntax error, unexpected end, expecting ')'
% rbenv local 2.7.2
% ruby -c a.rb
a.rb:3: syntax error, unexpected `end', expecting ')'
```

"end" in the message is now just quated! 😄 I added this to the regex pattern in testing.

**2. Behaviour change in `Shellwords.escape`**

There seemed to be a bug report to Ruby that causes very very minor behaviour change in `shellwords` module in the past and then it got fixed in Ruby 2.7 finally.
https://bugs.ruby-lang.org/issues/14429

This changes made `Shellwords.escape` not escape "+"

```
% rbenv local 2.6.6
% ruby -rshellwords -e 'puts Shellwords.escape("a+b")'
a\+b
% rbenv local 2.7.2
% ruby -rshellwords -e 'puts Shellwords.escape("a+b")'
a+b
```

So I fixed unit test cases accordingly....

### Testing Steps

See if tests all completes successfully on Circle CI or you can trigger tests locally.

```
% rbenv local 2.7.2
% bundle install
% bundle exec fastlane execute_tests
```
