### PR TITLE
[CI]  Fix homebrew issue on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,6 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            brew untap caskroom/versions || true
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
       - *cache_save_homebrew
@@ -172,7 +171,6 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            brew untap caskroom/versions
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
       - *cache_save_homebrew

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,12 @@ aliases:
     restore_cache:
       name: cache | restore homebrew
       keys:
-        - v3-homebrew-{{ epoch }}
-        - v3-homebrew
+        - v4-homebrew-{{ epoch }}
+        - v4-homebrew
   - &cache_save_homebrew
     save_cache:
       name: cache | store homebrew
-      key: v3-homebrew-{{ epoch }}
+      key: v4-homebrew-{{ epoch }}
       paths:
         - "/usr/local/Homebrew"
 
@@ -87,9 +87,6 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
-            brew update
             brew untap caskroom/versions || true
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,19 +27,6 @@ aliases:
       paths:
         - ".bundle"
 
-  - &cache_restore_homebrew
-    restore_cache:
-      name: cache | restore homebrew
-      keys:
-        - v4-homebrew-{{ epoch }}
-        - v4-homebrew
-  - &cache_save_homebrew
-    save_cache:
-      name: cache | store homebrew
-      key: v4-homebrew-{{ epoch }}
-      paths:
-        - "/usr/local/Homebrew"
-
   - &cache_restore_rubocop
     restore_cache:
       name: cache | restore rubocop
@@ -77,7 +64,6 @@ jobs:
       - checkout
       - *cache_save_git
       - *cache_restore_bundler
-      - *cache_restore_homebrew
       - *set_ruby
       - run:
           name: debug | ruby version
@@ -93,7 +79,6 @@ jobs:
             mkdir -p ~/test-reports
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
-      - *cache_save_homebrew
       - *cache_save_bundler
       - run:
           name: Check PR Metadata
@@ -169,7 +154,6 @@ jobs:
       - checkout
       - *cache_save_git
       - *cache_restore_bundler
-      - *cache_restore_homebrew
       - *set_ruby
       - run:
           name: Setup Build
@@ -177,7 +161,6 @@ jobs:
             mkdir -p ~/test-reports
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
-      - *cache_save_homebrew
       - *cache_save_bundler
       - run: bundle exec fastlane generate_swift_api
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,10 @@ jobs:
           command: |
             ruby -v
       - run:
+          name: debug | brew version
+          command: |
+            brew -v
+      - run:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->

While working on #17861, I realised that a bug was introduced in `.circleci/config.yml` in #17708 (see below).  The behaviour of homebrew seemed to be changed in Homebrew/brew#8883 so I suppose something was changed in cache compatibility around that as well🤔  The temporary solution made at https://github.com/fastlane/fastlane/pull/17708/commits/287b4f607c26df957a2b0b1470609d8c41b49fdd doesn't work for subsequent builds after all.

This is the error I mentioned.

```
#!/bin/bash --login -eo pipefail
mkdir -p ~/test-reports
git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
brew update
brew untap caskroom/versions || true
brew install shellcheck
bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
fatal: --unshallow on a complete repository does not make sense

Exited with code exit status 128
CircleCI received exit code 128
```

https://app.circleci.com/pipelines/github/fastlane/fastlane/1796/workflows/e077559c-1757-447c-a66f-0fc24413fb80/jobs/58879

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

There are 3 changes in my PR. The main change is 1. to fix the error but the other two are good to do together since I investigated all the related issue around that.

1. Remove `brew update` called unnecessarily
2. Stop caching homebrew updates
3. Remove `brew untap caskroom/versions` workaround 

I will explain the details one by one.

**1. Remove `brew update` called unnecessarily**

`brew update` was actually what caused the error. It was added in https://github.com/fastlane/fastlane/pull/16537 but the original issue https://github.com/fastlane/fastlane/issues/16536 seemed to be resolved by dropping "Xcode 9.4.1, Ruby 2.4" test condition.  Since Homebrew normally tries to update itself before running "install" subcommand, there is no reason to do it. Importantly "brew install"  without `brew update` don't get the error previously we got.

(I couldn't find any bug reports related to the issue within homebrew's project, but hope this change is just okay🙏 )

**2. Stop caching homebrew updates** 

The cache for homebrew was introduced here https://github.com/fastlane/fastlane/pull/11489. I suppose it was okay and did speed up builds at that moment but nowadays saving/restoring homebrew repo's cache is not that cheap as the formula repo grew (just like CocoaPods/Specs). It comes with gigabytes of data, which takes time anyway. (See also @rogerluan's attempt in https://github.com/fastlane/fastlane/pull/17870) 

In fact, in the official document, caching homebrew is not mentioned at all. (And instead, they suggest `HOMEBREW_NO_AUTO_UPDATE` when the install versions don't matter) https://circleci.com/docs/2.0/testing-ios/#optimizing-homebrew

So I think removing cache for homebrew is the simplest and pragmatic way to keep sane at this moment. Possibly we can use `HOMEBREW_NO_AUTO_UPDATE` if needed in future. 

----

Caching/Restoring cache takes time for "shallow" clone. Without them, "Setup Build" will just take 2-3 mins.

<img width="300" alt="Screenshot 2020-12-30 at 04 48 51" src="https://user-images.githubusercontent.com/748949/103330661-6bbd1d00-4a5a-11eb-9624-b36fbf171411.png">

https://app.circleci.com/pipelines/github/fastlane/fastlane/1816/workflows/4f02d12a-4a32-4b31-850d-db9aaf9e6a40/jobs/59037

This can be even worse with "unshallowed" clone.
https://github.com/fastlane/fastlane/pull/17870

----

**3. Remove `brew untap caskroom/versions` workaround**

`brew untap` is an also workaround added here https://github.com/fastlane/fastlane/pull/15532 but the original issue in homebrew itself was resolved later https://github.com/Homebrew/brew/pull/6703 so there is not really a reason to keep it. 

#### Build time

As a result, the build time is much faster than "unshallow" one without any issue. 

before|after
--|--
<img width="1340" alt="Screenshot 2020-12-30 at 04 41 48" src="https://user-images.githubusercontent.com/748949/103330432-60b5bd00-4a59-11eb-9ebf-38f3762890ed.png">|<img width="1352" alt="Screenshot 2020-12-30 at 04 40 56" src="https://user-images.githubusercontent.com/748949/103330431-5f849000-4a59-11eb-9fcc-5961b3865177.png">

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

See if CI passes in all conditions. And see the last empty commit if the other cache is working fine and build time is not terrible.

### Notes

While working on CI stuff, I noticed a few issues existing. I will work on fixing them in another PR.

* Danger stopped working at some point (Already asked Josh)
* Bundler's cache doesn't effectively work since it's cached by CPU arch and not Ruby version...
