### PR TITLE
[gym] update identifier used to looked up the bundle ID when parsing provisioning profile

### DIFF
--- a/fastlane/lib/fastlane/actions/build_app.rb
+++ b/fastlane/lib/fastlane/actions/build_app.rb
@@ -50,7 +50,8 @@ module Fastlane
               begin
                 profile = FastlaneCore::ProvisioningProfile.parse(profile_path)
                 app_id_prefix = profile["ApplicationIdentifierPrefix"].first
-                bundle_id = profile["Entitlements"]["application-identifier"].gsub("#{app_id_prefix}.", "")
+                entitlements = profile["Entitlements"]
+                bundle_id = (entitlements["application-identifier"] || entitlements["com.apple.application-identifier"]).gsub("#{app_id_prefix}.", "")
                 values[:export_options][:provisioningProfiles][bundle_id] = profile["Name"]
               rescue => ex
                 UI.error("Couldn't load profile at path: #{profile_path}")

--- a/fastlane/lib/fastlane/actions/build_app.rb
+++ b/fastlane/lib/fastlane/actions/build_app.rb
@@ -8,6 +8,7 @@ module Fastlane
     end
 
     class BuildAppAction < Action
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(values)
         require 'gym'
 


### PR DESCRIPTION

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
  - there are a few test failures currently (expected, due to not supporting the old key name yet)
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
  - none needed

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->
This is just a quick draft of trying to resolve https://github.com/fastlane/fastlane/issues/17864. This is my first time contributing to Fastlane (and also my first time using it) so I just wanted to file the issue and get a draft up to see if I'm going in the right direction.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

When using the `build_mac_app` action, Fastlane parses the provisioning profile, but it errors out (see linked issue for more details) when it tries to read the application identifier from a key `application-identifier`. The profile contains the required info in the `com.apple.application-identifier` key, which I suppose was a change made by Apple, but I'm not entirely sure.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I made this change locally and it resolved my issue with parsing the provisioning profile.