### PR TITLE
[scan][slack] add `slack_default_payloads` option to scan and improve slack action's `default_payloads` docs

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -115,8 +115,8 @@ module Fastlane
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :default_payloads,
                                        env_name: "FL_SLACK_DEFAULT_PAYLOADS",
-                                       description: "Remove some of the default payloads. More information about the available payloads on GitHub",
-                                       optional: true,
+                                       description: "Specifies default payloads to include. Pass an empty array to suppress all the default payloads",
+                                       default_value: ['lane', 'test_result', 'git_branch', 'git_author', 'last_git_commit', 'last_git_commit_hash'],
                                        type: Array),
           FastlaneCore::ConfigItem.new(key: :attachment_properties,
                                        env_name: "FL_SLACK_ATTACHMENT_PROPERTIES",
@@ -159,8 +159,7 @@ module Fastlane
               "Build Date" => Time.new.to_s,
               "Built by" => "Jenkins",
             },
-            default_payloads: [:git_branch, :git_author], # Optional, lets you specify an allowlist of default payloads to include. Pass an empty array to suppress all the default payloads.
-                                                          # Don\'t add this key, or pass nil, if you want all the default payloads. The available default payloads are: `lane`, `test_result`, `git_branch`, `git_author`, `last_git_commit`, `last_git_commit_hash`.
+            default_payloads: [:git_branch, :git_author], # Optional, lets you specify default payloads to include. Pass an empty array to suppress all the default payloads.
             attachment_properties: { # Optional, lets you specify any other properties available for attachments in the slack API (see https://api.slack.com/docs/attachments).
                                      # This hash is deep merged with the existing properties set using the other properties above. This allows your own fields properties to be appended to the existing fields that were created using the `payload` property for instance.
               thumb_url: "http://example.com/path/to/thumb.png",
@@ -188,7 +187,7 @@ module Fastlane
 
       def self.generate_slack_attachments(options)
         color = (options[:success] ? 'good' : 'danger')
-        should_add_payload = ->(payload_name) { options[:default_payloads].nil? || options[:default_payloads].map(&:to_sym).include?(payload_name.to_sym) }
+        should_add_payload = ->(payload_name) { options[:default_payloads].map(&:to_sym).include?(payload_name.to_sym) }
 
         slack_attachment = {
           fallback: options[:message],

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -166,6 +166,43 @@ describe Fastlane do
         expect(fields[1][:title]).to eq('Git Commit Hash')
       end
 
+      it "receives default_payloads as nil and falls back to its default value" do
+        channel = "#myChannel"
+        message = "Custom Message"
+        lane_name = "lane_name"
+
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+
+        require 'fastlane/actions/slack'
+        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+          slack_url: 'https://127.0.0.1',
+          message: message,
+          success: false,
+          channel: channel,
+          default_payloads: nil
+        })
+
+        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+
+        expect(notifier.config.defaults[:username]).to eq('fastlane')
+        expect(notifier.config.defaults[:channel]).to eq(channel)
+
+        expect(attachments[:color]).to eq('danger')
+        expect(attachments[:text]).to eq(message)
+        expect(attachments[:pretext]).to eq(nil)
+
+        fields = attachments[:fields]
+        expect(fields[0][:title]).to eq('Lane')
+        expect(fields[0][:value]).to eq(lane_name)
+        expect(fields[1][:title]).to eq('Result')
+        expect(fields[2][:title]).to eq('Git Branch')
+        expect(fields[3][:title]).to eq('Git Author')
+        expect(fields[4][:title]).to eq('Git Commit')
+        expect(fields[5][:title]).to eq('Git Commit Hash')
+
+        expect(fields.count).to eq(6)
+      end
+
       # https://github.com/fastlane/fastlane/issues/14141
       it "prints line breaks on message parameter to slack" do
         channel = "#myChannel"

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -411,6 +411,11 @@ module Scan
                                      description: "Only post on Slack if the tests fail",
                                      is_string: false,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :slack_default_payloads,
+                                     env_name: "SCAN_SLACK_DEFAULT_PAYLOADS",
+                                     description: "Specifies default payloads to include in Slack messages. For more info visit https://docs.fastlane.tools/actions/slack",
+                                     optional: true,
+                                     type: Array),
 
         # misc
         FastlaneCore::ConfigItem.new(key: :destination,

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -51,6 +51,7 @@ module Scan
         username: username,
         icon_url: icon_url,
         payload: {},
+        default_payloads: Scan.config[:slack_default_payloads],
         attachment_properties: {
           fields: fields
         }

--- a/scan/spec/slack_poster_spec.rb
+++ b/scan/spec/slack_poster_spec.rb
@@ -88,6 +88,7 @@ describe Scan::SlackPoster do
           slack_url: 'https://slack/hook/url',
           username: 'fastlane',
           icon_url: 'https://fastlane.tools/assets/img/fastlane_icon.png',
+          default_payloads: nil,
           attachment_properties: {
             fields: [
               {


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17853

### Description

tl;dr 😇 Scan uses Slack action. Slack action features a config that Scan doesn't (`default_payloads`) so this PR exposes that config to Scan.

While I was on this, I decided to refactor Slack action a little bit to be a bit more consistent with how it should consume "available options", more specifically the how it handle default values.

I tested the scenario where Scan receives a `nil` `slack_default_payloads` and forwards that to Slack's non-optional `default_payloads`, and that works as expected: it falls back to Slack's `default_payloads` predefined default value.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-improve-scan-slack"
```

And run `bundle install` to apply the changes. Then you can run scan using the new `slack_default_payloads` option.

I also checked that Fastlane.swift is generated correctly:

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/8419048/103165239-ec2e1480-47f3-11eb-957e-b5dc78630ff2.png">
