### PR TITLE
[spaceship] Adding headers attribute to ConnectAPI Response object

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -196,7 +196,7 @@ module Spaceship
 
         store_csrf_tokens(response)
 
-        return Spaceship::ConnectAPI::Response.new(body: response.body, status: response.status, client: self)
+        return Spaceship::ConnectAPI::Response.new(body: response.body, status: response.status, headers: response.headers, client: self)
       end
 
       def handle_401(response)

--- a/spaceship/lib/spaceship/connect_api/response.rb
+++ b/spaceship/lib/spaceship/connect_api/response.rb
@@ -6,11 +6,13 @@ module Spaceship
       include Enumerable
       attr_reader :body
       attr_reader :status
+      attr_reader :headers
       attr_reader :client
 
-      def initialize(body: nil, status: nil, client: nil)
+      def initialize(body: nil, status: nil, headers: nil, client: nil)
         @body = body
         @status = status
+        @headers = headers
         @client = client
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->
Response headers from the Connect API contain rate limit info, which callers might be interested in accessing. This PR adds a `headers` attribute to the `Response` object on the Spaceship side.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Adds a `headers` attribute to `ConnectAPI::Response`, and populates it from http response headers in the `Spaceship::ConnectAPI::APIClient` `handle_response` method.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
