### PR TITLE
[supply] fix user local env interfering with supply specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,8 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
+            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow || true
+            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow || true
             brew update
             brew untap caskroom/versions || true
             brew install shellcheck

--- a/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
+++ b/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
@@ -7,23 +7,29 @@ describe Fastlane do
 
       describe "without :json_key or :json_key_data" do
         it "without :json_key or :json_key_data - could not find file" do
-          expect(UI).to receive(:interactive?).and_return(true)
-          expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'")
-          expect(UI).to receive(:input).with(anything).and_return("not_a_file")
-          expect do
-            Fastlane::FastFile.new.parse("lane :test do
-              create_app_on_managed_play_store()
-            end").runner.execute(:test)
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not find service account json file at path/)
+          # Ensures that people's local environment variable doesn't interfere with this test
+          FastlaneSpec::Env.with_env_values('SUPPLY_JSON_KEY' => nil, 'SUPPLY_JSON_KEY_DATA' => nil) do
+            expect(UI).to receive(:interactive?).and_return(true)
+            expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'")
+            expect(UI).to receive(:input).with(anything).and_return("not_a_file")
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                create_app_on_managed_play_store()
+              end").runner.execute(:test)
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not find service account json file at path/)
+          end
         end
 
         it "without :json_key or :json_key_data - crashes in a not an interactive place" do
-          expect(UI).to receive(:interactive?).and_return(false)
-          expect do
-            Fastlane::FastFile.new.parse("lane :test do
-              create_app_on_managed_play_store()
-            end").runner.execute(:test)
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not load Google authentication. Make sure it has been added as an environment variable in 'json_key' or 'json_key_data'")
+          # Ensures that people's local environment variable doesn't interfere with this test
+          FastlaneSpec::Env.with_env_values('SUPPLY_JSON_KEY' => nil, 'SUPPLY_JSON_KEY_DATA' => nil) do
+            expect(UI).to receive(:interactive?).and_return(false)
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                create_app_on_managed_play_store()
+              end").runner.execute(:test)
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not load Google authentication. Make sure it has been added as an environment variable in 'json_key' or 'json_key_data'")
+          end
         end
       end
 

--- a/fastlane/spec/actions_specs/get_managed_play_store_publishing_rights_spec.rb
+++ b/fastlane/spec/actions_specs/get_managed_play_store_publishing_rights_spec.rb
@@ -7,25 +7,31 @@ describe Fastlane do
 
       describe "without options" do
         it "could not find file" do
-          expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'")
-          expect(UI).to receive(:input).with(anything).and_return("not_a_file")
-          expect(UI).to receive(:user_error!).with(/Could not find service account json file at path*/).and_raise("boom")
+          # Ensures that people's local environment variable doesn't interfere with this test
+          FastlaneSpec::Env.with_env_values('SUPPLY_JSON_KEY' => nil) do
+            expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'")
+            expect(UI).to receive(:input).with(anything).and_return("not_a_file")
+            expect(UI).to receive(:user_error!).with(/Could not find service account json file at path*/).and_raise("boom")
 
-          expect do
-            Fastlane::FastFile.new.parse("lane :test do
-              get_managed_play_store_publishing_rights()
-            end").runner.execute(:test)
-          end.to raise_error("boom")
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                get_managed_play_store_publishing_rights()
+              end").runner.execute(:test)
+            end.to raise_error("boom")
+          end
         end
 
         it "found file" do
-          expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'").once
-          expect(UI).to receive(:input).with(anything).and_return(json_key_path)
-          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
+          # Ensures that people's local environment variable doesn't interfere with this test
+          FastlaneSpec::Env.with_env_values('SUPPLY_JSON_KEY' => nil) do
+            expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'").once
+            expect(UI).to receive(:input).with(anything).and_return(json_key_path)
+            expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
 
-          Fastlane::FastFile.new.parse("lane :test do
-            get_managed_play_store_publishing_rights()
-          end").runner.execute(:test)
+            Fastlane::FastFile.new.parse("lane :test do
+              get_managed_play_store_publishing_rights()
+            end").runner.execute(:test)
+          end
         end
       end
 
@@ -41,13 +47,16 @@ describe Fastlane do
         end
 
         it "with :json_key_data" do
-          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
+          # Ensures that people's local environment variable doesn't interfere with this test
+          FastlaneSpec::Env.with_env_values('SUPPLY_JSON_KEY' => nil) do
+            expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
 
-          Fastlane::FastFile.new.parse("lane :test do
-            get_managed_play_store_publishing_rights(
-              json_key_data: '#{json_key_data}'
-            )
-          end").runner.execute(:test)
+            Fastlane::FastFile.new.parse("lane :test do
+              get_managed_play_store_publishing_rights(
+                json_key_data: '#{json_key_data}'
+              )
+            end").runner.execute(:test)
+          end
         end
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17391

### Description
Turns out that my env vars were the problem 😇 I applied the same fix as seen in many other places throughout the test suite.

### Testing Steps
Simply run `bundle exec rspec` or `bundle exec fastlane test` - CI gotta pass all tests.