### PR TITLE
[ci] fix CI setup crashes by unshallowing homebrew repositories only if needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,14 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
+            if $(git rev-parse --is-shallow-repository); then
+              # If it's still a shallow repository, unshallow it. It won't be a shallow repository anymore after caching the unshallowed repo.
+              git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
+            fi
+            if $(git rev-parse --is-shallow-repository); then
+              # If it's still a shallow repository, unshallow it. It won't be a shallow repository anymore after caching the unshallowed repo.
+              git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
+            fi
             brew update
             brew untap caskroom/versions || true
             brew install shellcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,14 +87,19 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            if $(git rev-parse --is-shallow-repository); then
-              # If it's still a shallow repository, unshallow it. It won't be a shallow repository anymore after caching the unshallowed repo.
-              git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
-            fi
-            if $(git rev-parse --is-shallow-repository); then
-              # If it's still a shallow repository, unshallow it. It won't be a shallow repository anymore after caching the unshallowed repo.
-              git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
-            fi
+            HOMEBREW_REPOS_TO_UNSHALLOW_IF_NEEDED=(
+              "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core"
+              "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask"
+            )
+            for REPO in "${HOMEBREW_REPOS_TO_UNSHALLOW_IF_NEEDED[@]}"; do
+               if $(git -C "$REPO" rev-parse --is-shallow-repository); then
+                 echo "The repository '$REPO' is shallow and needs to be unshallowed."
+                 echo "This is likely gonna take several minutes, and it's only needed to be done once, until we cache the unshallowed repo."
+                 git -C "$REPO" fetch --unshallow
+               else
+                 echo "The repository '$REPO' is a complete repository (not shallow), so we don't need to unshallow it anymore. :)"
+               fi
+            done
             brew update
             brew untap caskroom/versions || true
             brew install shellcheck


### PR DESCRIPTION
# Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

# Motivation and Context

This PR attempts to solve the CI issues caused by homebrew when they recently changed their policy to avoid unshallowing their huge repo, upon github's ask, to prevent systems' performance degradation.

# Description

## The Problem

The problem here is `brew update` now requires both homebrew repos (`homebrew/homebrew-core` and `homebrew/homebrew-cask`) to not be shallow.
Homebrew used to unshallow them under the hood for us. However, this doesn't happen automatically anymore:
>This restriction has been made on GitHub’s request because updating shallow
clones is an extremely expensive operation due to the tree layout and traffic of
Homebrew/homebrew-core and Homebrew/homebrew-cask. We don’t do this for you
automatically to avoid repeatedly performing an expensive unshallow operation in
CI systems (which should instead be fixed to not use shallow clones). Sorry for
the inconvenience!”

For this reason, we need to unshallow the repos on our own.
However, we can't call the `unshallow` command on a unshallow repo (aka a complete repo). So we must check if the repo is shallow before invoking the `unshallow` command.

_But why would the repo already be complete/unshallow?_
Because we're caching them in its unshallow form :) to avoid causing the same problems to GitHub as brew was causing.
So basically, if it's a cached build, homebrew repos are unshallow, so no need to unshallow them anymore. Otherwise, brew repos will be shallow so we need to unshallow them.

## Alternate Solution (that was discarded)

Although this would technically have the same result: 
https://github.com/fastlane/fastlane/blob/bc686608791d9c717ae994b0885902835d820915/.circleci/config.yml#L90-L91

It's a bit of an obscure code. It's not clear why we're silently ignoring the shallow, and it's swallowing the exception thrown by git. So this PR proposes a simple check: "is shallow? then unshallow." - plus it adds a bit more verbose logging so readers know what's happening, and mainly why (i.e. in which scenarios each flow is valid).

I tested that `git rev-parse --is-shallow-repository` works as expected inside the shell condition I put it in:

<img width="676" alt="image" src="https://user-images.githubusercontent.com/8419048/103179713-68b10980-486d-11eb-8028-8321dba66e3c.png">

```sh
# test.sh

if $(git rev-parse --is-shallow-repository); then
  echo "Yes it is"
else
  echo "No, it's not"
fi
```

## Pros

- This solution seems to solve the problem in CI.
- It's (arguably needlessly) more verbose than the simple solution presented above ☝️ 
- It seems to be the documented way to solve this problem, see [this discussion started in Homebrew forums on Dec 17th 2020](https://discourse.brew.sh/t/brew-update-homebrew-core-is-a-shallow-clone/9300).

## Cons

There's one down side in this story, though. We currently are (and will continue to) cache both of homebrew's repos, and they're quite large:

```sh
No cache is found for key: v3-homebrew-1609163557
Found a cache at v3-homebrew
Size: 7.2 GiB
Cached paths:
  * /usr/local/Homebrew

Downloading cache archive...
Unarchiving cache...
```

And CircleCI [recommends that we don't cache artifacts larger than 500MB](https://circleci.com/docs/2.0/caching/#cache-size). However, to the date there's no enforcement of such guideline, and I'm unsure what are the drawbacks of this strategy. Since this homebrew change is fairly recent, we should probably expect other players (such as CI providers, like Circle) to provide better solutions to this problem, like a distributed caching mechanism, to benefit everyone.

# Testing Steps

Simply pass CI.

## Case 1: Unshallowing is needed

<img width="1628" alt="image" src="https://user-images.githubusercontent.com/8419048/103179906-47511d00-486f-11eb-8dd0-c7d6e4afdc0d.png">

<img width="1631" alt="image" src="https://user-images.githubusercontent.com/8419048/103218741-ae67e380-48fa-11eb-9589-be34f929143d.png">

Total time to unshallow from github, setup, and store cache: 13m44s

## Case 2: Unshallowing is not needed, thus it's skipped.

<img width="1630" alt="image" src="https://user-images.githubusercontent.com/8419048/103219207-d0ae3100-48fb-11eb-9ae9-53c788210087.png">

<img width="1625" alt="image" src="https://user-images.githubusercontent.com/8419048/103219128-a197bf80-48fb-11eb-8e5a-7b49cc32afec.png">
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/8419048/103219135-a8becd80-48fb-11eb-8295-50fa67ca8748.png">
<img width="1625" alt="image" src="https://user-images.githubusercontent.com/8419048/103219497-a6a93e80-48fc-11eb-8f01-6a35828c15c1.png">


Total time to restore from cache, setup, and store cache: 10m34s
I was able to calculate that it downloaded cache at 40MBps - 7.2GB in 180 seconds.


That's a 3m10s gain from cache-less states, considering that we actually need to call `brew update`. This will be re-evaluated as soon as I have some time.