### PR TITLE
ci: add xcode 12.3 ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,18 +95,24 @@ jobs:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
           when: always  # Run this even when tests fail
-  'Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)':
+  'Execute tests on macOS (Xcode 11.0, Ruby 2.5)':
     <<: *tests_macos
     macos:
-      xcode: '11.0.0'
+      xcode: '11.0'
     environment:
       _RUBY_VERSION: '2.5'
-  'Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)':
+  'Execute tests on macOS (Xcode 11.7, Ruby 2.6)':
     <<: *tests_macos
     macos:
-      xcode: '11.4.0'
+      xcode: '11.7'
     environment:
       _RUBY_VERSION: '2.6'
+  'Execute tests on macOS (Xcode 12.3, Ruby 2.7)':
+    <<: *tests_macos
+    macos:
+      xcode: '12.3'
+    environment:
+      _RUBY_VERSION: '2.7'
 
   'Execute tests on Ubuntu':
     environment:
@@ -227,8 +233,9 @@ workflows:
   build:
     jobs:
       - 'Execute tests on macOS (Xcode 10.2.1, Ruby 2.4)'
-      - 'Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)'
-      - 'Execute tests on macOS (Xcode 11.4.0, Ruby 2.6)'
+      - 'Execute tests on macOS (Xcode 11.0, Ruby 2.5)'
+      - 'Execute tests on macOS (Xcode 11.7, Ruby 2.6)'
+      - 'Execute tests on macOS (Xcode 12.3, Ruby 2.7)'
       - 'Execute tests on Ubuntu'
 
       - "Validate Fastlane.swift Generation"


### PR DESCRIPTION
Since now it is [buildable with ruby 2.7](https://github.com/Homebrew/homebrew-core/pull/68104), adding ruby 2.7 into CI.

Also update some other xcode versions as well.

cc @joshdholtz