### PR TITLE
[action] git_commit - skip commit if git status is clean for paths

### DIFF
--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -11,9 +11,9 @@ module Fastlane
         skip_git_hooks = params[:skip_git_hooks] ? '--no-verify' : ''
 
         if params[:allow_nothing_to_commit]
-          nothing_staged = Actions.sh("git --no-pager diff --name-only --staged").empty?
-          UI.success("Nothing staged to commit ✅.") if nothing_staged
-          return if nothing_staged
+          repo_clean = Actions.sh("git status #{paths} --porcelain").empty?
+          UI.success("Nothing to commit, working tree clean ✅.") if repo_clean
+          return if repo_clean
         end
 
         command = "git commit -m #{params[:message].shellescape} #{paths} #{skip_git_hooks}".strip

--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -11,6 +11,10 @@ module Fastlane
         skip_git_hooks = params[:skip_git_hooks] ? '--no-verify' : ''
 
         if params[:allow_nothing_to_commit]
+          # Here we check if the path passed in parameter contains any modification
+          # and we skip the `git commit` command if there is none.
+          # That means you can have other files modified that are not in the path parameter
+          # and still make use of allow_nothing_to_commit.
           repo_clean = Actions.sh("git status #{paths} --porcelain").empty?
           UI.success("Nothing to commit, working tree clean ✅.") if repo_clean
           return if repo_clean
@@ -42,7 +46,7 @@ module Fastlane
                                        type: Boolean,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :allow_nothing_to_commit,
-                                       description: "Set to true to allow commit without any git changes",
+                                       description: "Set to true to allow commit without any git changes in the files you want to commit",
                                        type: Boolean,
                                        optional: true)
         ]

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -54,10 +54,10 @@ describe Fastlane do
       end
 
       it "generates the correct git command when configured to allow nothing to commit and there are changes to commit" do
-        allow(Fastlane::Actions).to receive(:sh)
+        expect(Fastlane::Actions).to receive(:sh)
           .with("git status ./fastlane/README.md --porcelain")
           .and_return("M  ./fastlane/README.md")
-        allow(Fastlane::Actions).to receive(:sh)
+        expect(Fastlane::Actions).to receive(:sh)
           .with("git commit -m message ./fastlane/README.md")
           .and_call_original
 
@@ -69,7 +69,7 @@ describe Fastlane do
       end
 
       it "does not generate the git command when configured to allow nothing to commit and there are no changes to commit" do
-        allow(Fastlane::Actions).to receive(:sh)
+        expect(Fastlane::Actions).to receive(:sh)
           .with("git status ./fastlane/README.md --porcelain")
           .and_return("")
         result = Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -54,6 +54,13 @@ describe Fastlane do
       end
 
       it "generates the correct git command when configured to allow nothing to commit and there are changes to commit" do
+        allow(Fastlane::Actions).to receive(:sh)
+          .with("git status ./fastlane/README.md --porcelain")
+          .and_return("M  ./fastlane/README.md")
+        allow(Fastlane::Actions).to receive(:sh)
+          .with("git commit -m message ./fastlane/README.md")
+          .and_call_original
+
         result = Fastlane::FastFile.new.parse("lane :test do
           git_commit(path: './fastlane/README.md', message: 'message', allow_nothing_to_commit: true)
         end").runner.execute(:test)
@@ -63,7 +70,7 @@ describe Fastlane do
 
       it "does not generate the git command when configured to allow nothing to commit and there are no changes to commit" do
         allow(Fastlane::Actions).to receive(:sh)
-          .with("git --no-pager diff --name-only --staged")
+          .with("git status ./fastlane/README.md --porcelain")
           .and_return("")
         result = Fastlane::FastFile.new.parse("lane :test do
           git_commit(path: './fastlane/README.md', message: 'message', allow_nothing_to_commit: true)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->

Reverts the commit ef1ccf17 and fix a regression introduced in #17804.

There is an issue when the `git_commit` lane is executed alone (meaning without `git_add` before).
In this case, it is not possible to run the sh command `git commit` because there is no staged files and `git --no-pager diff --name-only --staged` always returns an empty string.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

The proposed solution is to run `git status #{paths} --porcelain` to check if the git status is clean, **only** for the paths we want to commit. This way, even if there are other files modified, the `git commit` can be skipped.

In practice, there are two cases:

1. *fileA* is modified (meaning `git status fileA --porcelain` will return a non empty string)
1.1 if we call `git_commit(path: "fileA", allow_nothing_to_commit: true)` -> the commit is created
1.2 if we call `git_commit(path: "fileA", allow_nothing_to_commit: false)` -> the commit is created

2. *fileA* is not modified (meaning `git status fileA --porcelain` will return an empty string)
2.1 we call `git_commit(path: "fileA", allow_nothing_to_commit: true)` -> the commit is skipped (even if there are other files modified, i.e. `git status --porcelain` does not return an empty string)
2.2 we call `git_commit(path: "fileA", allow_nothing_to_commit: false)` -> an error occurs because *fileA* can't be staged

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
