### PR TITLE
[scan] fix scan regression caused by not setting `slack_default_payloads` option

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -187,7 +187,9 @@ module Fastlane
 
       def self.generate_slack_attachments(options)
         color = (options[:success] ? 'good' : 'danger')
-        should_add_payload = ->(payload_name) { options[:default_payloads].map(&:to_sym).include?(payload_name.to_sym) }
+        default_payloads = self.available_options.find { |a| a.key == :default_payloads }
+        default_payloads_value = options[:default_payloads] || default_payloads.default_value
+        should_add_payload = ->(payload_name) { default_payloads_value.map(&:to_sym).include?(payload_name.to_sym) }
 
         slack_attachment = {
           fallback: options[:message],


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves https://github.com/fastlane/fastlane/issues/17915
Resolves https://github.com/fastlane/fastlane/issues/17898

### Description
- If we are passing `nil` from the scan's slack_default_payloads to slack action, then slack action is crashing.
- Now using the default value inside slack action in case scan will pass the nil value

### Testing Steps
- Update Gemfile: gem 'fastlane', :git => "git://github.com/crazymanish/fastlane.git", :branch => "slack-issue-fix"
- Run scan without passing `slack_default_payloads ` option.
- Slack action should not raise exception and will send the slack notification successfully

cc: @rogerluan for code-review 😊
