### PR TITLE
[fastlane_core] recognize "Buddy" CI service as a CI environment

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -74,7 +74,7 @@ module FastlaneCore
       return true if self.is_circle_ci?
 
       # Check for Jenkins, Travis CI, ... environment variables
-      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CI', 'APPCENTER_BUILD_ID', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS', 'TF_BUILD', 'GITHUB_ACTION', 'GITHUB_ACTIONS', 'BITRISE_IO'].each do |current|
+      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CI', 'APPCENTER_BUILD_ID', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS', 'TF_BUILD', 'GITHUB_ACTION', 'GITHUB_ACTIONS', 'BITRISE_IO', 'BUDDY'].each do |current|
         return true if ENV.key?(current)
       end
       return false


### PR DESCRIPTION
Buddy is a CI/CD service. 
Please add this VAR to automatically setup the keychain and match to work with CI.

Here is a list of defaults ENV VARs in Buddy:
https://buddy.works/docs/pipelines/environment-variables#default-environment-variables