### PR TITLE
[scan] fix scan regression caused by not setting `slack_default_payloads` option

### DIFF
--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -18,7 +18,7 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
 
         require 'fastlane/actions/slack'
-        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+        options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
           slack_url: 'https://127.0.0.1',
           message: message,
           success: false,
@@ -30,7 +30,7 @@ describe Fastlane do
           default_payloads: [:lane, :test_result, :git_branch, :git_author, :last_git_commit_hash]
         })
 
-        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+        notifier, attachments = Fastlane::Actions::SlackAction.run(options)
 
         expect(notifier.config.defaults[:username]).to eq('fastlane')
         expect(notifier.config.defaults[:channel]).to eq(channel)
@@ -59,7 +59,7 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
 
         require 'fastlane/actions/slack'
-        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+        options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
           slack_url: 'https://127.0.0.1',
           message: message,
           pretext: pretext,
@@ -67,7 +67,7 @@ describe Fastlane do
           channel: channel
         })
 
-        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+        notifier, attachments = Fastlane::Actions::SlackAction.run(options)
 
         expect(notifier.config.defaults[:username]).to eq('fastlane')
         expect(notifier.config.defaults[:channel]).to eq(channel)
@@ -85,7 +85,7 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
 
         require 'fastlane/actions/slack'
-        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+        options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
           slack_url: 'https://127.0.0.1',
           message: message,
           success: false,
@@ -101,7 +101,7 @@ describe Fastlane do
           }
         })
 
-        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+        notifier, attachments = Fastlane::Actions::SlackAction.run(options)
 
         fields = attachments[:fields]
 
@@ -123,7 +123,7 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
 
         require 'fastlane/actions/slack'
-        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+        options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
           slack_url: 'https://127.0.0.1',
           message: message,
           success: false,
@@ -131,7 +131,7 @@ describe Fastlane do
           default_payloads: "lane,test_result"
         })
 
-        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+        notifier, attachments = Fastlane::Actions::SlackAction.run(options)
 
         fields = attachments[:fields]
 
@@ -148,7 +148,7 @@ describe Fastlane do
         message = "Custom Message"
 
         require 'fastlane/actions/slack'
-        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+        options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
           slack_url: 'https://127.0.0.1',
           message: message,
           success: false,
@@ -156,7 +156,7 @@ describe Fastlane do
           default_payloads: [:git_branch, :last_git_commit_hash]
         })
 
-        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+        notifier, attachments = Fastlane::Actions::SlackAction.run(options)
 
         fields = attachments[:fields]
 
@@ -174,7 +174,8 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
 
         require 'fastlane/actions/slack'
-        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+
+        options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
           slack_url: 'https://127.0.0.1',
           message: message,
           success: false,
@@ -190,6 +191,7 @@ describe Fastlane do
         expect(attachments[:color]).to eq('danger')
         expect(attachments[:text]).to eq(message)
         expect(attachments[:pretext]).to eq(nil)
+        notifier, attachments = Fastlane::Actions::SlackAction.run(options)
 
         fields = attachments[:fields]
         expect(fields[0][:title]).to eq('Lane')
@@ -215,14 +217,14 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
 
         require 'fastlane/actions/slack'
-        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+        options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
           slack_url: 'https://127.0.0.1',
           message: input_message,
           success: false,
           channel: channel
         })
 
-        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+        notifier, attachments = Fastlane::Actions::SlackAction.run(options)
 
         expect(notifier.config.defaults[:username]).to eq('fastlane')
         expect(notifier.config.defaults[:channel]).to eq(channel)
@@ -243,14 +245,14 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
 
         require 'fastlane/actions/slack'
-        arguments = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::SlackAction, {
+        options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
           slack_url: 'https://127.0.0.1',
           pretext: input_pretext,
           success: false,
           channel: channel
         })
 
-        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
+        notifier, attachments = Fastlane::Actions::SlackAction.run(options)
 
         expect(notifier.config.defaults[:username]).to eq('fastlane')
         expect(notifier.config.defaults[:channel]).to eq(channel)

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -182,15 +182,6 @@ describe Fastlane do
           channel: channel,
           default_payloads: nil
         })
-
-        notifier, attachments = Fastlane::Actions::SlackAction.run(arguments)
-
-        expect(notifier.config.defaults[:username]).to eq('fastlane')
-        expect(notifier.config.defaults[:channel]).to eq(channel)
-
-        expect(attachments[:color]).to eq('danger')
-        expect(attachments[:text]).to eq(message)
-        expect(attachments[:pretext]).to eq(nil)
         notifier, attachments = Fastlane::Actions::SlackAction.run(options)
 
         fields = attachments[:fields]

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -44,7 +44,7 @@ module Scan
         }
       end
 
-      options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
+      arguments = {
         message: "#{Scan.config[:app_name] || Scan.project.app_name} Tests:\n#{Scan.config[:slack_message]}",
         channel: channel,
         slack_url: Scan.config[:slack_url].to_s,
@@ -56,8 +56,11 @@ module Scan
         attachment_properties: {
           fields: fields
         }
-      })
-      Fastlane::Actions::SlackAction.run(options)
+      }
+      options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, arguments)
+      result = Fastlane::Actions::SlackAction.run(options)
+      return arguments if Helper.test? # Used to help validate the arguments passed to SlackAction
+      return result
     end
   end
 end

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -44,7 +44,7 @@ module Scan
         }
       end
 
-      arguments = {
+      options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
         message: "#{Scan.config[:app_name] || Scan.project.app_name} Tests:\n#{Scan.config[:slack_message]}",
         channel: channel,
         slack_url: Scan.config[:slack_url].to_s,
@@ -56,11 +56,8 @@ module Scan
         attachment_properties: {
           fields: fields
         }
-      }
-      options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, arguments)
-      result = Fastlane::Actions::SlackAction.run(options)
-      return arguments if Helper.test? # Used to help validate the arguments passed to SlackAction
-      return result
+      })
+      Fastlane::Actions::SlackAction.run(options)
     end
   end
 end

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -1,5 +1,6 @@
 require 'fastlane/action'
 require 'fastlane/actions/slack'
+require 'fastlane_core/configuration/configuration'
 
 require_relative 'module'
 
@@ -43,7 +44,7 @@ module Scan
         }
       end
 
-      Fastlane::Actions::SlackAction.run({
+      options = FastlaneCore::Configuration.create(Fastlane::Actions::SlackAction.available_options, {
         message: "#{Scan.config[:app_name] || Scan.project.app_name} Tests:\n#{Scan.config[:slack_message]}",
         channel: channel,
         slack_url: Scan.config[:slack_url].to_s,
@@ -56,6 +57,7 @@ module Scan
           fields: fields
         }
       })
+      Fastlane::Actions::SlackAction.run(options)
     end
   end
 end

--- a/scan/spec/slack_poster_spec.rb
+++ b/scan/spec/slack_poster_spec.rb
@@ -80,8 +80,8 @@ describe Scan::SlackPoster do
       end
     end
 
-    def expect_slack_poster_arguments_match
-      expect(Scan::SlackPoster.new.run({ tests: 0, failures: 0 })).to match(hash_including({
+    def expected_slack_poster_arguments
+      hash = {
         message: a_string_matching(' Tests:'),
         channel: nil,
         slack_url: 'https://slack/hook/url',
@@ -102,7 +102,7 @@ describe Scan::SlackPoster do
             }
           ]
         }
-      }))
+      }
     end
 
     describe "with slack_url option set to a URL value" do
@@ -116,7 +116,12 @@ describe Scan::SlackPoster do
             slack_url: 'https://slack/hook/url'
           })
 
-          expect_slack_poster_arguments_match
+          expect(FastlaneCore::Configuration).to(
+            receive(:create)
+            .with(any_args, hash_including(expected_slack_poster_arguments))
+            .and_call_original
+          )
+          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
         end
       end
     end
@@ -130,7 +135,12 @@ describe Scan::SlackPoster do
             project: './scan/examples/standard/app.xcodeproj'
           })
 
-          expect_slack_poster_arguments_match
+          expect(FastlaneCore::Configuration).to(
+            receive(:create)
+            .with(any_args, hash_including(expected_slack_poster_arguments))
+            .and_call_original
+          )
+          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
         end
       end
     end

--- a/scan/spec/slack_poster_spec.rb
+++ b/scan/spec/slack_poster_spec.rb
@@ -80,31 +80,29 @@ describe Scan::SlackPoster do
       end
     end
 
-    def expect_slack_posting
-      expect(Fastlane::Actions::SlackAction).to receive(:run).with(
-        hash_including({
-          message: a_string_matching(' Tests:'),
-          channel: nil,
-          slack_url: 'https://slack/hook/url',
-          username: 'fastlane',
-          icon_url: 'https://fastlane.tools/assets/img/fastlane_icon.png',
-          default_payloads: nil,
-          attachment_properties: {
-            fields: [
-              {
-                title: 'Test Failures',
-                value: '0',
-                short: true
-              },
-              {
-                title: 'Successful Tests',
-                value: '0',
-                short: true
-              }
-            ]
-          }
-        })
-      )
+    def expect_slack_poster_arguments_match
+      expect(Scan::SlackPoster.new.run({ tests: 0, failures: 0 })).to match(hash_including({
+        message: a_string_matching(' Tests:'),
+        channel: nil,
+        slack_url: 'https://slack/hook/url',
+        username: 'fastlane',
+        icon_url: 'https://fastlane.tools/assets/img/fastlane_icon.png',
+        default_payloads: nil,
+        attachment_properties: {
+          fields: [
+            {
+              title: 'Test Failures',
+              value: '0',
+              short: true
+            },
+            {
+              title: 'Successful Tests',
+              value: '0',
+              short: true
+            }
+          ]
+        }
+      }))
     end
 
     describe "with slack_url option set to a URL value" do
@@ -112,14 +110,13 @@ describe Scan::SlackPoster do
         # ensures that people's local environment variable doesn't interfere with this test
         FastlaneSpec::Env.with_env_values('SLACK_URL' => nil) do
           expect(ENV['SLACK_URL']).to eq(nil)
-          expect_slack_posting
 
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
             project: './scan/examples/standard/app.xcodeproj',
             slack_url: 'https://slack/hook/url'
           })
 
-          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
+          expect_slack_poster_arguments_match
         end
       end
     end
@@ -128,13 +125,12 @@ describe Scan::SlackPoster do
       it "does Slack posting", requires_xcodebuild: true do
         FastlaneSpec::Env.with_env_values('SLACK_URL' => 'https://slack/hook/url') do
           expect(ENV['SLACK_URL']).to eq('https://slack/hook/url')
-          expect_slack_posting
 
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
             project: './scan/examples/standard/app.xcodeproj'
           })
 
-          Scan::SlackPoster.new.run({ tests: 0, failures: 0 })
+          expect_slack_poster_arguments_match
         end
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17915
Resolves #17898
This PR fixes a regression introduced in https://github.com/fastlane/fastlane/pull/17866

This PR supersedes https://github.com/fastlane/fastlane/pull/17919 (also please do read the comments there, for extra context!)

### Description

By passing `nil` in scan's `slack_default_payloads` option (or omitting), then slack action (called down the road within scan) would crashes.
Slack action's `default_payloads` option is non-null and has a default value. Theoretically, if you pass nil to it, it should pick up the default value and just work.
However, in this very specific scenario, scan was calling the Slack action without invoking the options initializer - it was just passing a raw hash to Slack's runner. Naturally, by not invoking the options initializer, the default values wouldn't be loaded into Slack's options.

So the fix for this issue is just the first commit, where I modify how scan invokes Slack action.

The subsequent commits are meant to improve code by making it more consistent, by swapping `Fastlane::ConfigurationHelper.parse` with `FastlaneCore::Configuration.create`. The former was pretty much only used in this file, while the latter is being used in over 300+ occurrences - seems just like the right way to do it 😊

I also cleaned up the test I had written earlier.

NOTE: I'm not too happy with the changes I had to made here https://github.com/fastlane/fastlane/commit/3e801137e96767ec7c85fe3fa02498e4f20d3ef3 - not sure if what we had before is an anti-pattern, or if what **I** did is an anti-pattern, but neither looks/feels great 😬 I appreciate any and every feedback wrt these specs 🙏 

### Testing Steps

Demo project, kindly provided by @crazymanish: [Demo.zip](https://github.com/fastlane/fastlane/files/5785134/Demo.zip)

#### Before (as of master):

cd into the demo project, run `bundle install`, then `bundle exec fastlane test`. It will crash with `undefined method `map' for nil:NilClass` error.

#### Now (in this branch):

To test this branch, modify your demo project's Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-fix-scan-slack-integration"
```

And run `bundle install` to apply the changes. 

Now if you run `bundle exec fastlane test`, it will still fail, but it's because we're providing a fake slack_url 😇
If you test this branch in your own project, it should succeed 👍

cc @crazymanish 🤗 