### PR TITLE
update PULL_REQUEST_TEMPLATE's sample issue to a fake issue number

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 ### Motivation and Context
 <!-- Why is this change required? What problem does it solve? -->
 <!-- If it fixes an open issue, please link to the issue following this format:
-Resolves #1337
+Resolves #999999
 -->
 
 ### Description


### PR DESCRIPTION
### Motivation and Context

Check out what happened here 😅  https://github.com/fastlane/fastlane/issues/1337 


<img width="935" alt="image" src="https://user-images.githubusercontent.com/8419048/104093318-9718e680-5268-11eb-98d2-f655f3f1e829.png">


### Description

This is because, even when `#1337` is commented out in the PR's descriptions (from the template), fastlane bot still picks it up 😅 I figured that simply changing the template was a lot easier than updating the bot's behavior to take markdown comments into consideration 🙇 

### Testing Steps
N/A