### PR TITLE
[swiftlint] avoid throwing error for new types of reporters

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -139,13 +139,13 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :reporter,
                                        env_name: "FL_SWIFTLINT_REPORTER",
-                                       description: "Choose output reporter. Available: xcode, json, csv, checkstyle, junit, html, \
-                                                     emoji, sonarqube, markdown, github-actions-logging",
+                                       description: "Choose output reporter. Available: xcode, json, csv, checkstyle, codeclimate, \
+                                                     junit, html, emoji, sonarqube, markdown, github-actions-logging",
                                        is_string: true,
                                        optional: true,
                                        verify_block: proc do |value|
-                                         available = ['xcode', 'json', 'csv', 'checkstyle', 'junit', 'html', 'emoji', 'sonarqube', 'markdown', 'github-actions-logging']
-                                         UI.user_error!("Available values are '#{available.join("', '")}'") unless available.include?(value)
+                                         available = ['xcode', 'json', 'csv', 'checkstyle', 'codeclimate', 'junit', 'html', 'emoji', 'sonarqube', 'markdown', 'github-actions-logging']
+                                         UI.warning("Known 'reporter' values are '#{available.join("', '")}'. If you're receiving errors from swiftlint related to the reporter, make sure the reporter identifier you're using is correct and it's supported by your version of swiftlint.") unless available.include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :quiet,
                                        env_name: "FL_SWIFTLINT_QUIET",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17855

### Description

Whenever new reporters are introduced, fastlane would validate the new ones out and prevent users from using them. This behavior has changed from throwing an error to throwing just a friendlier warning, so it's future-ready for new reporters.

### Testing Steps
To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-swiftlint-new-reporters"
```

And run `bundle install` to apply the changes. 