### PR TITLE
[download_dsyms][docs] change `platform` option optionality (to nonnull) since passing nil would already crash

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -285,7 +285,6 @@ module Fastlane
                                        short_option: "-p",
                                        env_name: "DOWNLOAD_DSYMS_PLATFORM",
                                        description: "The app platform for dSYMs you wish to download (ios, appletvos)",
-                                       optional: true,
                                        default_value: :ios),
           FastlaneCore::ConfigItem.new(key: :version,
                                        short_option: "-v",


### PR DESCRIPTION
### Motivation and Context

This PR https://github.com/fastlane/fastlane/pull/17148 made `download_dsyms` 'platform' parameter required, but the option was still marked as optional.

Discussion: https://github.com/fastlane/fastlane/issues/17677#issuecomment-757344123

### Description
With the changes introduced in #17148, if platform is passed as `nil`, it will actually crash here:

https://github.com/fastlane/fastlane/blob/e2ff4990a44f28fa7b25d745666007dc8e315577/fastlane/lib/fastlane/actions/download_dsyms.rb#L37

Because `Spaceship::ConnectAPI::Platform.map` doesn't actually accept a `nil` value.

If users omit the platform, the default value should be picked up. For this reason, this is a rare corner case since people would rarely **actively** pass a "nil" value, but if anyone did, they'd get a cryptic crash log instead of a nicer one 😊 

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-update-download-dsyms-platform-optionality"
```

And run `bundle install` to apply the changes. 