### PR TITLE
[frameit] add support for new iPhone 12-family devices and their new colors

### DIFF
--- a/frameit/lib/frameit/device_types.rb
+++ b/frameit/lib/frameit/device_types.rb
@@ -45,6 +45,8 @@ module Frameit
     GREEN ||= "Green"
     PINK ||= "Pink"
     PURPLE ||= "Purple"
+    GRAPHITE ||= "Graphite"
+    PACIFIC_BLUE ||= "Pacific Blue"
 
     def self.all_colors
       Color.constants.map { |c| Color.const_get(c).upcase.gsub(' ', '_') }
@@ -118,6 +120,10 @@ module Frameit
     IPHONE_11 ||= Frameit::Device.new("iphone-11", "Apple iPhone 11", 9, [[828, 1792], [1792, 828]], 326, Color::BLACK, Platform::IOS)
     IPHONE_11_PRO ||= Frameit::Device.new("iphone-11-pro", "Apple iPhone 11 Pro", 9, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS)
     IPHONE_11_PRO_MAX ||= Frameit::Device.new("iphone11-pro-max", "Apple iPhone 11 Pro Max", 9, [[1242, 2688], [2688, 1242]], 458, Color::SPACE_GRAY, Platform::IOS)
+    IPHONE_12 ||= Frameit::Device.new("iphone-12", "Apple iPhone 12", 10, [[1170, 2532], [2532, 1170]], 460, Color::BLACK, Platform::IOS)
+    IPHONE_12_PRO ||= Frameit::Device.new("iphone-12-pro", "Apple iPhone 12 Pro", 10, [[1170, 2532], [2532, 1170]], 460, Color::SPACE_GRAY, Platform::IOS)
+    IPHONE_12_PRO_MAX ||= Frameit::Device.new("iphone12-pro-max", "Apple iPhone 12 Pro Max", 10, [[1284, 2778], [2778, 1284]], 458, Color::GRAPHITE, Platform::IOS)
+    IPHONE_12_MINI ||= Frameit::Device.new("iphone-12-mini", "Apple iPhone 12 Mini", 10, [[1125, 2436], [2436, 1125]], 476, Color::BLACK, Platform::IOS)
     IPAD_10_2 ||= Frameit::Device.new("ipad-10-2", "Apple iPad 10.2", 1, [[1620, 2160], [2160, 1620]], 264, Color::SPACE_GRAY, Platform::IOS)
     IPAD_AIR_2 ||= Frameit::Device.new("ipad-air-2", "Apple iPad Air 2", 1, [[1536, 2048], [2048, 1536]], 264, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
     IPAD_AIR_2019 ||= Frameit::Device.new("ipad-air-2019", "Apple iPad Air (2019)", 2, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS)

--- a/frameit/spec/device_spec.rb
+++ b/frameit/spec/device_spec.rb
@@ -33,7 +33,7 @@ describe Frameit::Device do
         expect_screen_size_from_file("Apple iPhone XS-Landscape{2436x1125}.jpg", Platform::IOS).to eq(Devices::IPHONE_XS)
       end
 
-      it "should detect iPhone 11 Pro in portrait and landscape based on priority" do
+      it "should detect iPhone 12 Mini in portrait and landscape based on priority" do
         expect_screen_size_from_file("screenshot-Portrait{1125x2436}.jpg", Platform::IOS).to eq(Devices::IPHONE_12_MINI)
         expect_screen_size_from_file("screenshot-Landscape{2436x1125}.jpg", Platform::IOS).to eq(Devices::IPHONE_12_MINI)
       end

--- a/frameit/spec/device_spec.rb
+++ b/frameit/spec/device_spec.rb
@@ -34,8 +34,8 @@ describe Frameit::Device do
       end
 
       it "should detect iPhone 11 Pro in portrait and landscape based on priority" do
-        expect_screen_size_from_file("screenshot-Portrait{1125x2436}.jpg", Platform::IOS).to eq(Devices::IPHONE_11_PRO)
-        expect_screen_size_from_file("screenshot-Landscape{2436x1125}.jpg", Platform::IOS).to eq(Devices::IPHONE_11_PRO)
+        expect_screen_size_from_file("screenshot-Portrait{1125x2436}.jpg", Platform::IOS).to eq(Devices::IPHONE_12_MINI)
+        expect_screen_size_from_file("screenshot-Landscape{2436x1125}.jpg", Platform::IOS).to eq(Devices::IPHONE_12_MINI)
       end
 
       it "should detect iPhone X instead of iPhone XS because of the file name containing device name" do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Add support for new iPhone 12 devices (12, 12 Pro, 12 Pro Max, 12 Mini) to frameit
This PR replaces https://github.com/fastlane/fastlane/pull/17732 because that one had CLA issues.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Add support for new iPhone 12 devices (12, 12 Pro, 12 Pro Max, 12 Mini) to frameit
- added 2 new colors in frameit/devices_type.rb (Graphite & Pacific Blue)
- added 4 new devices in frameit/devices_type.rb (iPhone 12, iPhone 12 Pro, iPhone 12 Pro Max, iPhone 12 Mini)

Note: iPhone 12 Mini device screen size doesn't match the official Apple screen specification but the size of the screenshot generated with a iPhone 12 Mini simulator (1125x2436 instead of 1080x2340). When using official size, frameit doesn't match the screenshot with iPhone 12 Mini frame.

Related: https://github.com/fastlane/frameit-frames/pull/15

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/nimau/fastlane.git", :branch => "nimau-frameit-iphone12-devices"
```

And run `bundle install` to apply the changes.