### PR TITLE
[scan] fix scan not failing when disable_xcpretty and fail_build are true

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -83,7 +83,12 @@ module Scan
     end
 
     def handle_results(tests_exit_status)
-      return if Scan.config[:disable_xcpretty]
+      if Scan.config[:disable_xcpretty]
+        unless tests_exit_status == 0
+          UI.test_failure!("Test execution failed. Exit status: #{tests_exit_status}")
+        end
+        return
+      end
 
       result = TestResultParser.new.parse_result(test_results)
       SlackPoster.new.run(result)

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -77,6 +77,18 @@ describe Scan do
           @scan.handle_results(0)
           expect(Scan.cache[:temp_junit_report]).to(eq('/var/folders/non_existent_file.junit'))
         end
+
+        it "fails if tests_exit_status is not 0", requires_xcodebuild: true do
+          expect do
+            Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+              output_directory: '/tmp/scan_results',
+              project: './scan/examples/standard/app.xcodeproj',
+              disable_xcpretty: true
+            })
+
+            @scan.handle_results(1)
+          end.to raise_error(FastlaneCore::Interface::FastlaneTestFailure, "Test execution failed. Exit status: 1")
+        end
       end
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves https://github.com/fastlane/fastlane/issues/17945.

### Description

In `handle_results`,  if `disable_xcpretty` is true, then throw a `test_failure`.
If `fail_build` is false, the manager will catch the exception and make scan succeed.
If `fail_build` is true, the manager will throw the exception further and make scan fail.

### Testing Steps

Tested locally with a failing test:
- if `disable_xcpretty` and `fail_build` are true, scan fails
- if `disable_xcpretty` is true and `fail_build` is false, scan does not fail