### PR TITLE
[fastlane_core][Fastlane.swift][sigh][pem][upload_app_privacy_details_to_app_store] consider only truthy values when evaluating conflicting options

### DIFF
--- a/fastlane/spec/fixtures/plist/Info.plist
+++ b/fastlane/spec/fixtures/plist/Info.plist
@@ -40,7 +40,7 @@
 	<key>CFBundleVersion</key>
 	<string>0.9.14</string>
 	<key>LSApplicationCategoryType</key>
-	<string></string>
+	<string/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -120,8 +120,8 @@ module FastlaneCore
           index = @available_options.find_index { |item| item.key == conflicting_option_key }
           conflicting_option = @available_options[index]
 
-          # ignore conflicts because value of conflict option is nil
-          next if @values[conflicting_option.key].nil?
+          # ignore conflicts because value of conflict option is falsey (nil, false, etc)
+          next unless @values[conflicting_option.key]
 
           if current.conflict_block
             begin

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -29,8 +29,8 @@ describe FastlaneCore do
         expect do
           FastlaneCore::Configuration.create([FastlaneCore::ConfigItem.new(
             key: :cert_name,
-       env_name: "asdf",
-    description: "Set the profile name."
+            env_name: "asdf",
+            description: "Set the profile name."
           )], {})
         end.to raise_error("Do not let descriptions end with a '.', since it's used for user inputs as well for key :cert_name")
       end
@@ -40,12 +40,12 @@ describe FastlaneCore do
           expect do
             FastlaneCore::Configuration.create([FastlaneCore::ConfigItem.new(
               key: :cert_name,
-         env_name: "asdf"
+              env_name: "asdf"
             ),
-                                                FastlaneCore::ConfigItem.new(
-                                                  key: :cert_name,
-                                             env_name: "asdf"
-                                                )], {})
+            FastlaneCore::ConfigItem.new(
+              key: :cert_name,
+              env_name: "asdf"
+            )], {})
           end.to raise_error("Multiple entries for configuration key 'cert_name' found!")
         end
 

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -64,7 +64,7 @@ describe FastlaneCore do
           end.to raise_error("Multiple entries for short_option '-f' found!")
         end
 
-        it "raises an error for unresolved conflict between options" do
+        it "raises an error for unresolved conflict between options with truthy values" do
           conflicting_options = [
             FastlaneCore::ConfigItem.new(key: :foo,
                                          conflicting_options: [:bar, :oof]),
@@ -80,6 +80,29 @@ describe FastlaneCore do
           expect do
             FastlaneCore::Configuration.create(conflicting_options, values)
           end.to raise_error("Unresolved conflict between options: 'foo' and 'bar'")
+        end
+
+        it "doesn't raise for conflicting options that have falsey values" do
+          conflicting_options = [
+            FastlaneCore::ConfigItem.new(key: :foo,
+                                         conflicting_options: [:bar, :oof, :meh]),
+            FastlaneCore::ConfigItem.new(key: :bar,
+                                         optional: true),
+            FastlaneCore::ConfigItem.new(key: :oof,
+                                         is_string: false),
+            FastlaneCore::ConfigItem.new(key: :meh,
+                                         optional: true)
+          ]
+
+          values = {
+              foo: "",
+              bar: nil,
+              oof: false
+          }
+
+          expect do
+            FastlaneCore::Configuration.create(conflicting_options, values)
+          end.not_to raise_error
         end
 
         it "calls custom conflict handler when conflict happens between two options" do

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -38,14 +38,16 @@ describe FastlaneCore do
       describe "config conflicts" do
         it "raises an error if a key was used twice" do
           expect do
-            FastlaneCore::Configuration.create([FastlaneCore::ConfigItem.new(
-              key: :cert_name,
-              env_name: "asdf"
-            ),
-            FastlaneCore::ConfigItem.new(
-              key: :cert_name,
-              env_name: "asdf"
-            )], {})
+            FastlaneCore::Configuration.create([
+                                                 FastlaneCore::ConfigItem.new(
+                                                   key: :cert_name,
+                                                   env_name: "asdf"
+                                                 ),
+                                                 FastlaneCore::ConfigItem.new(
+                                                   key: :cert_name,
+                                                   env_name: "asdf"
+                                                 )
+                                               ], {})
           end.to raise_error("Multiple entries for configuration key 'cert_name' found!")
         end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17343

### Description

A comment of mine, copied from the issue itself:

After analyzing this:

https://github.com/fastlane/fastlane/blob/4753b8dea25c9f9d9b7fc49101b4ee1e4590cb80/sigh/lib/sigh/options.rb#L12-L38

Turns out that in Swift, by omitting the arguments, since they're nonnull Bools, it forwards to ruby as non-optional `false`, so ruby detects as if the user was providing all the options.

### Possible Solutions

1. IMO a reasonable solution would be to add `next if option.value == false` all those `conflict_block`s. However, `option` doesn't seem to have the runtime "value" of the option - does it? 🤔

2. Another solution would be to make those 3 booleans optional. I'm not a fan of optional booleans 🙃 but we use them in other places where reasonable, not sure if there's a strong consensus about good practices around this topic.

3. Simply remove the validation if we agree it's nonsense and is just hurting us 🙈 

#### ❗ [New]❗

4. Similar to `1.`, but this solution is more generic. Instead of consider that condition only for this action/lane, we'd consider that all falsey values would be treated the same as if they were nil, passing the conflicting options validation.

This PR implements solution number `4`, although [it was discussed we could go forward with solution `2`](https://github.com/fastlane/fastlane/issues/17343#issuecomment-757188443).

----

This PR is a fix proposal. If we decide that this global/generic solution would hurt us more than help, I can revert this and apply solution number 2, assuming we only want to fix this issue here. 
However, after using a regex to search for similar issues in the codebase, I found out that there're actually 2 other actions where this issue can be reproduced:

1. `pem` (test by running `pem(appIdentifier: "a", username: "a", p12Password: "a")` in a Swift project)

<img width="666" alt="image" src="https://user-images.githubusercontent.com/8419048/104824409-235e7700-5830-11eb-9b62-b0d1033e5a34.png">

2. `uploadAppPrivacyDetailsToAppStore` (test by running `uploadAppPrivacyDetailsToAppStore(username: "a", appIdentifier: "a")` in a Swift project)

<img width="913" alt="image" src="https://user-images.githubusercontent.com/8419048/104824422-530d7f00-5830-11eb-8ee9-500c3588e4d4.png">

So if we decide to move forward with solution `2`, keep in mind the fix will have to be individually applied in all those 3 actions ☝️ 

#### Solution Safety

Due to its nature, this solution affects all fastlane users. However, its behavior makes lanes/actions more permissive than they used to, instead of more restricting, hence why I believe it's safe. As a plus, I believe it could 

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-fix-conflicting-options-swift"
```

And run `bundle install` to apply the changes.

To test and see the error (in master), you could run either of these lanes:

```swift
func crashScenario1Lane() {
    getProvisioningProfile(appIdentifier: "a", username: "a")
}

func crashScenario2Lane() {
    pem(appIdentifier: "a", username: "a", p12Password: "a")
}

func crashScenario3Lane() {
    uploadAppPrivacyDetailsToAppStore(username: "a", appIdentifier: "a")
}
```

(yeah you can leave in the fake values, it doesn't matter).

If you run the same swift lane in this branch, it will continue without that error, as expected (it will ask for "password for account 'a'" 😄 )