### PR TITLE
[spaceship] connect api - update functionality for beta test groups

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/beta_group.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_group.rb
@@ -38,6 +38,15 @@ module Spaceship
         return client.post_bulk_beta_tester_assignments(beta_group_id: id, beta_testers: beta_testers)
       end
 
+      def update(client: nil, attributes: nil)
+        return if attributes.empty?
+
+        client ||= Spaceship::ConnectAPI
+
+        attributes = reverse_attr_mapping(attributes)
+        return client.patch_group(group_id: id, attributes: attributes).first
+      end
+
       def delete!
         return Spaceship::ConnectAPI.delete_beta_group(group_id: id)
       end

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -214,6 +214,18 @@ module Spaceship
           test_flight_request_client.post("betaGroups", body)
         end
 
+        def patch_group(group_id: nil, attributes: {})
+          body = {
+            data: {
+              attributes: attributes,
+              id: group_id,
+              type: "betaGroups"
+            }
+          }
+
+          test_flight_request_client.patch("betaGroups/#{group_id}", body)
+        end
+
         def delete_beta_group(group_id: nil)
           raise "group_id is nil" if group_id.nil?
 

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -394,6 +394,29 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           client.add_beta_groups_to_build(build_id: build_id, beta_group_ids: beta_group_ids)
         end
       end
+
+      context 'patch_beta_groups' do
+        let(:path) { "betaGroups" }
+        let(:beta_group_id) { "123" }
+        let(:attributes) { { public_link_enabled: false } }
+        let(:body) do
+          {
+            data: {
+                attributes: attributes,
+                id: beta_group_id,
+                type: "betaGroups"
+              }
+          }
+        end
+
+        it 'succeeds' do
+          url = "#{path}/#{beta_group_id}"
+          req_mock = test_request_body(url, body)
+
+          expect(client).to receive(:request).with(:patch).and_yield(req_mock)
+          client.patch_group(group_id: beta_group_id, attributes: attributes)
+        end
+      end
     end
 
     describe "betaTesters" do


### PR DESCRIPTION
When we create beta test groups we can't have public link. This is due to apple will not allow public link when there is no build. After adding a build to the group, we need a way to update group for public link or any other functionality.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->

### Description
Added patch function on CoonectAPI main file which is spaceship/lib/spaceship/connect_api/testflight/testflight.rb
Then call that function from spaceship/lib/spaceship/connect_api/models/beta_group.rb
Then have a test case to test this function - spaceship/spec/connect_api/testflight/testflight_client_spec.rb

### Testing Steps

-  before the test keep public link as false and also keep at least one build in the group.
Spaceship::ConnectAPI.login
platform = Spaceship::ConnectAPI::Platform.map('ios')
app = Spaceship::ConnectAPI::App.find('anyid')
group = app.get_beta_groups(filter: {name: "Gp1"}).first
puts groups[0].name
puts groups[0].public_link_enabled
group = groups[0].update(attributes: {
        :public_link_enabled => true
 })
  puts groups[0].name
  puts groups[0].public_link_enabled
