### PR TITLE
[fastlane_core] Support `SUPPORTS_UIKITFORMAC` build setting

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -275,7 +275,7 @@ module FastlaneCore
     end
 
     def supports_mac_catalyst?
-      build_settings(key: "SUPPORTS_MACCATALYST") == "YES"
+      build_settings(key: "SUPPORTS_MACCATALYST") == "YES" || build_settings(key: "SUPPORTS_UIKITFORMAC") == "YES"
     end
 
     def command_line_tool?


### PR DESCRIPTION
This build setting was originally used to determine whether an app supports Mac Catalyst and is still a valid flag.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->
While trying to automate the builds of our Mac Catalyst app I ran into an issue where Fastlane failed to determine that our app supported Mac Catalyst. After some troubleshooting I figured out that it was due to the fact that we were using the original flag to indicate Mac Catalyst support (`SUPPORTS_UIKITFORMAC`) instead of the current flag that is used for that purpose (`SUPPORTS_MACCATALYST`). I think it would be helpful to support the legacy flag since it is still supported by Xcode.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
The change is very simple -- instead of looking at only the `SUPPORTS_MACCATALYST` flag to determine whether an app supports Mac Catalyst the new code now looks at that flag and the `SUPPORTS_UIKITFORMAC` flag and if either are true then it treats the app as supporting Mac Catalyst.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Tested manually with our codebase.