### PR TITLE
[gym] Handle situations where the `EXECUTABLE_NAME` is not accurate

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -274,11 +274,11 @@ module Gym
       exe_name = Gym.project.build_settings(key: "EXECUTABLE_NAME")
       app_path = File.join(BuildCommandGenerator.archive_path, "Products/Applications/#{exe_name}.app")
 
-      if File.exist?(app_path) == false
+      unless File.exist?(app_path)
         # Apparently the `EXECUTABLE_NAME` is not correct. This can happen when building a workspace which has a project
         # earlier in the build order that has a different `EXECUTABLE_NAME` than the app. Try to find the last `.app` as
         # a fallback for this situation.
-        app_path = Dir[File.join(BuildCommandGenerator.archive_path, "Products/Applications/*.app")].last
+        app_path = Dir[File.join(BuildCommandGenerator.archive_path, "Products", "Applications", "*.app")].last
       end
 
       UI.crash!("Couldn't find application in '#{BuildCommandGenerator.archive_path}'") unless File.exist?(app_path)

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -271,8 +271,7 @@ module Gym
 
     # Copies the .app from the archive into the output directory
     def copy_mac_app
-      exe_name = Gym.project.build_settings(key: "EXECUTABLE_NAME")
-      app_path = File.join(BuildCommandGenerator.archive_path, "Products/Applications/#{exe_name}.app")
+      app_path = Dir[File.join(BuildCommandGenerator.archive_path, "Products/Applications/*.app")].last
 
       UI.crash!("Couldn't find application in '#{BuildCommandGenerator.archive_path}'") unless File.exist?(app_path)
 

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -271,7 +271,12 @@ module Gym
 
     # Copies the .app from the archive into the output directory
     def copy_mac_app
-      app_path = Dir[File.join(BuildCommandGenerator.archive_path, "Products/Applications/*.app")].last
+      exe_name = Gym.project.build_settings(key: "EXECUTABLE_NAME")
+      app_path = File.join(BuildCommandGenerator.archive_path, "Products/Applications/#{exe_name}.app")
+
+      if false == File.exist?(app_path)
+        app_path = Dir[File.join(BuildCommandGenerator.archive_path, "Products/Applications/*.app")].last
+      end
 
       UI.crash!("Couldn't find application in '#{BuildCommandGenerator.archive_path}'") unless File.exist?(app_path)
 

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -275,6 +275,9 @@ module Gym
       app_path = File.join(BuildCommandGenerator.archive_path, "Products/Applications/#{exe_name}.app")
 
       if false == File.exist?(app_path)
+        # Apparently the `EXECUTABLE_NAME` is not correct. This can happen when building a workspace which has a project
+        # earlier in the build order that has a different `EXECUTABLE_NAME` than the app. Try to find the last `.app` as
+        # a fallback for this situation.
         app_path = Dir[File.join(BuildCommandGenerator.archive_path, "Products/Applications/*.app")].last
       end
 

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -274,7 +274,7 @@ module Gym
       exe_name = Gym.project.build_settings(key: "EXECUTABLE_NAME")
       app_path = File.join(BuildCommandGenerator.archive_path, "Products/Applications/#{exe_name}.app")
 
-      if false == File.exist?(app_path)
+      if File.exist?(app_path) == false
         # Apparently the `EXECUTABLE_NAME` is not correct. This can happen when building a workspace which has a project
         # earlier in the build order that has a different `EXECUTABLE_NAME` than the app. Try to find the last `.app` as
         # a fallback for this situation.


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #1337
-->
When copying the Mac app the `EXECUTABLE_NAME` variable does not always match the `EXECUTABLE_NAME` that will be created. For example, when building an app in a workspace the first project's `EXECUTABLE_NAME` is used instead of the app project's `EXECUTABLE_NAME`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This change simply looks for any files with the `.app` file extension and chooses the last one found if there are no files found when looking for the specific executable by name.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Tested manually with our code base.