### PR TITLE
Version bump to 2.172.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,87 +34,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
-</td>
-<td id='olivier-halligon'>
-<a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='daniel-jankowski'>
-<a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='jimmy-dee'>
-<a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
-</a>
-<h4 align='center'>Jimmy Dee</h4>
-</td>
-</tr>
-<tr>
-<td id='danielle-tomlinson'>
-<a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
@@ -122,37 +46,81 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
 <td id='andrew-mcburney'>
 <a href='https://github.com/armcburney'>
 <img src='https://github.com/armcburney.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+</td>
 </tr>
 <tr>
+<td id='olivier-halligon'>
+<a href='https://github.com/AliSoftware'>
+<img src='https://github.com/AliSoftware.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
+</td>
+<td id='kohki-miki'>
+<a href='https://github.com/giginet'>
+<img src='https://github.com/giginet.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+</td>
+<td id='jimmy-dee'>
+<a href='https://github.com/jdee'>
+<img src='https://github.com/jdee.png?size=140'>
+</a>
+<h4 align='center'>Jimmy Dee</h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
+</td>
+</tr>
+<tr>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
 <td id='max-ott'>
 <a href='https://github.com/max-ott'>
 <img src='https://github.com/max-ott.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
@@ -162,17 +130,49 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
-<td id='kohki-miki'>
-<a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
+<td id='danielle-tomlinson'>
+<a href='https://github.com/endocrimes'>
+<img src='https://github.com/endocrimes.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
+<h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
+</tr>
+<tr>
+<td id='daniel-jankowski'>
+<a href='https://github.com/mollyIV'>
+<img src='https://github.com/mollyIV.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+</td>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,28 +15,28 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Maksym Grebenets",
-                        "Kohki Miki",
-                        "Jan Piotrowski",
-                        "Helmut Januschka",
-                        "Joshua Liebowitz",
-                        "Aaron Brager",
-                        "Andrew McBurney",
+  spec.authors       = ["Andrew McBurney",
+                        "Olivier Halligon",
+                        "Felix Krause",
+                        "Daniel Jankowski",
                         "Danielle Tomlinson",
+                        "Jimmy Dee",
+                        "Max Ott",
+                        "Stefan Natchev",
+                        "Maksym Grebenets",
+                        "Jérôme Lacoste",
+                        "Jan Piotrowski",
                         "Jorge Revuelta H",
-                        "Manu Wallner",
+                        "Kohki Miki",
+                        "Aaron Brager",
+                        "Luka Mirosevic",
                         "Josh Holtz",
                         "Iulian Onofrei",
-                        "Stefan Natchev",
-                        "Olivier Halligon",
-                        "Max Ott",
-                        "Daniel Jankowski",
-                        "Luka Mirosevic",
-                        "Jérôme Lacoste",
+                        "Helmut Januschka",
+                        "Joshua Liebowitz",
                         "Fumiya Nakamura",
-                        "Felix Krause",
-                        "Jimmy Dee",
-                        "Matthew Ellis"]
+                        "Matthew Ellis",
+                        "Manu Wallner"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.171.0'.freeze
+  VERSION = '2.172.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -1,5 +1,5 @@
 // Deliverfile.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 // This class is automatically included in FastlaneRunner during build
 
@@ -17,4 +17,4 @@ public class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.171.0
+// Generated with fastlane 2.172.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -1,5 +1,5 @@
 // DeliverfileProtocol.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 public protocol DeliverfileProtocol: class {
     /// Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
@@ -256,4 +256,4 @@ public extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.54]
+// FastlaneRunnerAPIVersion [0.9.55]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -1,5 +1,5 @@
 // Fastlane.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 import Foundation
 /**
@@ -700,6 +700,7 @@ public func apteligent(dsym: String? = nil,
    - endpoint: Artifactory endpoint
    - username: Artifactory username
    - password: Artifactory password
+   - apiKey: Artifactory API key
    - properties: Artifact properties hash
    - sslPemFile: Location of pem file to use for ssl verification
    - sslVerify: Verify SSL
@@ -708,13 +709,16 @@ public func apteligent(dsym: String? = nil,
    - proxyAddress: Proxy address
    - proxyPort: Proxy port
    - readTimeout: Read timeout
+
+ Connect to the artifactory server using either a username/password or an api_key
  */
 public func artifactory(file: String,
                         repo: String,
                         repoPath: String,
                         endpoint: String,
-                        username: String,
-                        password: String,
+                        username: String? = nil,
+                        password: String? = nil,
+                        apiKey: String? = nil,
                         properties: [String: Any] = [:],
                         sslPemFile: String? = nil,
                         sslVerify: Bool = true,
@@ -730,6 +734,7 @@ public func artifactory(file: String,
                                                                                                RubyCommand.Argument(name: "endpoint", value: endpoint),
                                                                                                RubyCommand.Argument(name: "username", value: username),
                                                                                                RubyCommand.Argument(name: "password", value: password),
+                                                                                               RubyCommand.Argument(name: "api_key", value: apiKey),
                                                                                                RubyCommand.Argument(name: "properties", value: properties),
                                                                                                RubyCommand.Argument(name: "ssl_pem_file", value: sslPemFile),
                                                                                                RubyCommand.Argument(name: "ssl_verify", value: sslVerify),
@@ -953,7 +958,7 @@ public func buildAndroidApp(task: String? = nil,
    - skipPackagePkg: Should we skip packaging the pkg?
    - includeSymbols: Should the ipa file include symbols?
    - includeBitcode: Should the ipa file include bitcode?
-   - exportMethod: Method used to export the archive. Valid values are: app-store, ad-hoc, package, enterprise, development, developer-id
+   - exportMethod: Method used to export the archive. Valid values are: app-store, validation, ad-hoc, package, enterprise, development, developer-id and mac-application
    - exportOptions: Path to an export options plist or a hash with export options. Use 'xcodebuild -help' to print the full set of available options
    - exportXcargs: Pass additional arguments to xcodebuild for the package phase. Be sure to quote the setting names and values e.g. OTHER_LDFLAGS="-ObjC -lstdc++"
    - skipBuildArchive: Export ipa from previously built xcarchive. Uses archive_path as source
@@ -984,6 +989,8 @@ public func buildAndroidApp(task: String? = nil,
    - xcprettyUtf: Have xcpretty use unicode encoding when reporting builds
    - skipProfileDetection: Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
+   - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - useSystemScm: Lets xcodebuild use system's scm configuration
 
  - returns: The absolute path to the generated ipa file
@@ -1034,6 +1041,8 @@ public func buildApp(workspace: String? = nil,
                      xcprettyUtf: Bool? = nil,
                      skipProfileDetection: Bool = false,
                      clonedSourcePackagesPath: String? = nil,
+                     skipPackageDependenciesResolution: Bool = false,
+                     disablePackageAutomaticUpdates: Bool = false,
                      useSystemScm: Bool = false)
 {
     let command = RubyCommand(commandID: "", methodName: "build_app", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
@@ -1080,6 +1089,8 @@ public func buildApp(workspace: String? = nil,
                                                                                              RubyCommand.Argument(name: "xcpretty_utf", value: xcprettyUtf),
                                                                                              RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection),
                                                                                              RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                             RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
+                                                                                             RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                              RubyCommand.Argument(name: "use_system_scm", value: useSystemScm)])
     _ = runner.executeCommand(command)
 }
@@ -1100,7 +1111,7 @@ public func buildApp(workspace: String? = nil,
    - skipPackageIpa: Should we skip packaging the ipa?
    - includeSymbols: Should the ipa file include symbols?
    - includeBitcode: Should the ipa file include bitcode?
-   - exportMethod: Method used to export the archive. Valid values are: app-store, ad-hoc, package, enterprise, development, developer-id
+   - exportMethod: Method used to export the archive. Valid values are: app-store, validation, ad-hoc, package, enterprise, development, developer-id and mac-application
    - exportOptions: Path to an export options plist or a hash with export options. Use 'xcodebuild -help' to print the full set of available options
    - exportXcargs: Pass additional arguments to xcodebuild for the package phase. Be sure to quote the setting names and values e.g. OTHER_LDFLAGS="-ObjC -lstdc++"
    - skipBuildArchive: Export ipa from previously built xcarchive. Uses archive_path as source
@@ -1129,6 +1140,8 @@ public func buildApp(workspace: String? = nil,
    - xcprettyUtf: Have xcpretty use unicode encoding when reporting builds
    - skipProfileDetection: Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
+   - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - useSystemScm: Lets xcodebuild use system's scm configuration
 
  - returns: The absolute path to the generated ipa file
@@ -1176,6 +1189,8 @@ public func buildIosApp(workspace: String? = nil,
                         xcprettyUtf: Bool? = nil,
                         skipProfileDetection: Bool = false,
                         clonedSourcePackagesPath: String? = nil,
+                        skipPackageDependenciesResolution: Bool = false,
+                        disablePackageAutomaticUpdates: Bool = false,
                         useSystemScm: Bool = false)
 {
     let command = RubyCommand(commandID: "", methodName: "build_ios_app", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
@@ -1219,6 +1234,8 @@ public func buildIosApp(workspace: String? = nil,
                                                                                                  RubyCommand.Argument(name: "xcpretty_utf", value: xcprettyUtf),
                                                                                                  RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection),
                                                                                                  RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                                 RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
+                                                                                                 RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                                  RubyCommand.Argument(name: "use_system_scm", value: useSystemScm)])
     _ = runner.executeCommand(command)
 }
@@ -1239,7 +1256,7 @@ public func buildIosApp(workspace: String? = nil,
    - skipPackagePkg: Should we skip packaging the pkg?
    - includeSymbols: Should the ipa file include symbols?
    - includeBitcode: Should the ipa file include bitcode?
-   - exportMethod: Method used to export the archive. Valid values are: app-store, ad-hoc, package, enterprise, development, developer-id
+   - exportMethod: Method used to export the archive. Valid values are: app-store, validation, ad-hoc, package, enterprise, development, developer-id and mac-application
    - exportOptions: Path to an export options plist or a hash with export options. Use 'xcodebuild -help' to print the full set of available options
    - exportXcargs: Pass additional arguments to xcodebuild for the package phase. Be sure to quote the setting names and values e.g. OTHER_LDFLAGS="-ObjC -lstdc++"
    - skipBuildArchive: Export ipa from previously built xcarchive. Uses archive_path as source
@@ -1269,6 +1286,8 @@ public func buildIosApp(workspace: String? = nil,
    - xcprettyUtf: Have xcpretty use unicode encoding when reporting builds
    - skipProfileDetection: Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
+   - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - useSystemScm: Lets xcodebuild use system's scm configuration
 
  - returns: The absolute path to the generated ipa file
@@ -1317,6 +1336,8 @@ public func buildMacApp(workspace: String? = nil,
                         xcprettyUtf: Bool? = nil,
                         skipProfileDetection: Bool = false,
                         clonedSourcePackagesPath: String? = nil,
+                        skipPackageDependenciesResolution: Bool = false,
+                        disablePackageAutomaticUpdates: Bool = false,
                         useSystemScm: Bool = false)
 {
     let command = RubyCommand(commandID: "", methodName: "build_mac_app", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
@@ -1361,6 +1382,8 @@ public func buildMacApp(workspace: String? = nil,
                                                                                                  RubyCommand.Argument(name: "xcpretty_utf", value: xcprettyUtf),
                                                                                                  RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection),
                                                                                                  RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                                 RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
+                                                                                                 RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                                  RubyCommand.Argument(name: "use_system_scm", value: useSystemScm)])
     _ = runner.executeCommand(command)
 }
@@ -1546,11 +1569,14 @@ public func captureAndroidScreenshots(androidHome: String? = nil,
    - concurrentSimulators: Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
    - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
+   - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - testplan: The testplan associated with the scheme that should be used for testing
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
    - disableXcpretty: Disable xcpretty formatting of build
    - suppressXcodeOutput: Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path
+   - useSystemScm: Lets xcodebuild use system's scm configuration
  */
 public func captureIosScreenshots(workspace: String? = nil,
                                   project: String? = nil,
@@ -1591,11 +1617,14 @@ public func captureIosScreenshots(workspace: String? = nil,
                                   concurrentSimulators: Bool = true,
                                   disableSlideToType: Bool = false,
                                   clonedSourcePackagesPath: String? = nil,
+                                  skipPackageDependenciesResolution: Bool = false,
+                                  disablePackageAutomaticUpdates: Bool = false,
                                   testplan: String? = nil,
                                   onlyTesting: Any? = nil,
                                   skipTesting: Any? = nil,
                                   disableXcpretty: Bool? = nil,
-                                  suppressXcodeOutput: Bool? = nil)
+                                  suppressXcodeOutput: Bool? = nil,
+                                  useSystemScm: Bool = false)
 {
     let command = RubyCommand(commandID: "", methodName: "capture_ios_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                            RubyCommand.Argument(name: "project", value: project),
@@ -1636,11 +1665,14 @@ public func captureIosScreenshots(workspace: String? = nil,
                                                                                                            RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
                                                                                                            RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
                                                                                                            RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                                           RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
+                                                                                                           RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                                            RubyCommand.Argument(name: "testplan", value: testplan),
                                                                                                            RubyCommand.Argument(name: "only_testing", value: onlyTesting),
                                                                                                            RubyCommand.Argument(name: "skip_testing", value: skipTesting),
                                                                                                            RubyCommand.Argument(name: "disable_xcpretty", value: disableXcpretty),
-                                                                                                           RubyCommand.Argument(name: "suppress_xcode_output", value: suppressXcodeOutput)])
+                                                                                                           RubyCommand.Argument(name: "suppress_xcode_output", value: suppressXcodeOutput),
+                                                                                                           RubyCommand.Argument(name: "use_system_scm", value: useSystemScm)])
     _ = runner.executeCommand(command)
 }
 
@@ -1687,11 +1719,14 @@ public func captureIosScreenshots(workspace: String? = nil,
    - concurrentSimulators: Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
    - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
+   - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - testplan: The testplan associated with the scheme that should be used for testing
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
    - disableXcpretty: Disable xcpretty formatting of build
    - suppressXcodeOutput: Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path
+   - useSystemScm: Lets xcodebuild use system's scm configuration
  */
 public func captureScreenshots(workspace: String? = nil,
                                project: String? = nil,
@@ -1732,11 +1767,14 @@ public func captureScreenshots(workspace: String? = nil,
                                concurrentSimulators: Bool = true,
                                disableSlideToType: Bool = false,
                                clonedSourcePackagesPath: String? = nil,
+                               skipPackageDependenciesResolution: Bool = false,
+                               disablePackageAutomaticUpdates: Bool = false,
                                testplan: String? = nil,
                                onlyTesting: Any? = nil,
                                skipTesting: Any? = nil,
                                disableXcpretty: Bool? = nil,
-                               suppressXcodeOutput: Bool? = nil)
+                               suppressXcodeOutput: Bool? = nil,
+                               useSystemScm: Bool = false)
 {
     let command = RubyCommand(commandID: "", methodName: "capture_screenshots", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                                        RubyCommand.Argument(name: "project", value: project),
@@ -1777,11 +1815,14 @@ public func captureScreenshots(workspace: String? = nil,
                                                                                                        RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
                                                                                                        RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
                                                                                                        RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                                       RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
+                                                                                                       RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                                        RubyCommand.Argument(name: "testplan", value: testplan),
                                                                                                        RubyCommand.Argument(name: "only_testing", value: onlyTesting),
                                                                                                        RubyCommand.Argument(name: "skip_testing", value: skipTesting),
                                                                                                        RubyCommand.Argument(name: "disable_xcpretty", value: disableXcpretty),
-                                                                                                       RubyCommand.Argument(name: "suppress_xcode_output", value: suppressXcodeOutput)])
+                                                                                                       RubyCommand.Argument(name: "suppress_xcode_output", value: suppressXcodeOutput),
+                                                                                                       RubyCommand.Argument(name: "use_system_scm", value: useSystemScm)])
     _ = runner.executeCommand(command)
 }
 
@@ -2480,6 +2521,7 @@ public func createKeychain(name: String? = nil,
 
  - parameters:
    - apiToken: Personal API Token for GitHub - generate one at https://github.com/settings/tokens
+   - apiBearer: Use a Bearer authorization token. Usually generated by Github Apps, e.g. GitHub Actions GITHUB_TOKEN environment variable
    - repo: The name of the repository you want to submit the pull request to
    - title: The title of the pull request
    - body: The contents of the pull request
@@ -2495,7 +2537,8 @@ public func createKeychain(name: String? = nil,
 
  - returns: The pull request URL when successful
  */
-public func createPullRequest(apiToken: String,
+public func createPullRequest(apiToken: String? = nil,
+                              apiBearer: String? = nil,
                               repo: String,
                               title: String,
                               body: String? = nil,
@@ -2510,6 +2553,7 @@ public func createPullRequest(apiToken: String,
                               teamReviewers: [String]? = nil)
 {
     let command = RubyCommand(commandID: "", methodName: "create_pull_request", className: nil, args: [RubyCommand.Argument(name: "api_token", value: apiToken),
+                                                                                                       RubyCommand.Argument(name: "api_bearer", value: apiBearer),
                                                                                                        RubyCommand.Argument(name: "repo", value: repo),
                                                                                                        RubyCommand.Argument(name: "title", value: title),
                                                                                                        RubyCommand.Argument(name: "body", value: body),
@@ -2522,6 +2566,42 @@ public func createPullRequest(apiToken: String,
                                                                                                        RubyCommand.Argument(name: "assignees", value: assignees),
                                                                                                        RubyCommand.Argument(name: "reviewers", value: reviewers),
                                                                                                        RubyCommand.Argument(name: "team_reviewers", value: teamReviewers)])
+    _ = runner.executeCommand(command)
+}
+
+/**
+ Package multiple build configs of a library/framework into a single xcframework
+
+ - parameters:
+   - frameworks: Frameworks to add to the target xcframework
+   - libraries: Libraries to add to the target xcframework, with their corresponding headers
+   - output: The path to write the xcframework to
+   - allowInternalDistribution: Specifies that the created xcframework contains information not suitable for public distribution
+
+ Utility for packaging multiple build configurations of a given library
+ or framework into a single xcframework.
+
+ If you want to package several frameworks just provide an array containing
+ the list of frameworks to be packaged using the :frameworks parameter.
+
+ If you want to package several libraries with their corresponding headers
+ provide a hash containing the library as the key and the directory containing
+ its headers as the value (or an empty string if there are no headers associated
+ with the provided library).
+
+ Finally specify the location of the xcframework to be generated using the :output
+ parameter.
+
+ */
+public func createXcframework(frameworks: [String]? = nil,
+                              libraries: [String: Any]? = nil,
+                              output: String,
+                              allowInternalDistribution: Bool = false)
+{
+    let command = RubyCommand(commandID: "", methodName: "create_xcframework", className: nil, args: [RubyCommand.Argument(name: "frameworks", value: frameworks),
+                                                                                                      RubyCommand.Argument(name: "libraries", value: libraries),
+                                                                                                      RubyCommand.Argument(name: "output", value: output),
+                                                                                                      RubyCommand.Argument(name: "allow_internal_distribution", value: allowInternalDistribution)])
     _ = runner.executeCommand(command)
 }
 
@@ -3753,7 +3833,7 @@ public func gitAdd(path: Any? = nil,
    - path: The file you want to commit
    - message: The commit message that should be used
    - skipGitHooks: Set to true to pass --no-verify to git
-   - allowNothingToCommit: Set to true to allow commit without any git changes
+   - allowNothingToCommit: Set to true to allow commit without any git changes in the files you want to commit
  */
 public func gitCommit(path: Any,
                       message: String,
@@ -4005,7 +4085,7 @@ public func gradle(task: String? = nil,
    - skipPackagePkg: Should we skip packaging the pkg?
    - includeSymbols: Should the ipa file include symbols?
    - includeBitcode: Should the ipa file include bitcode?
-   - exportMethod: Method used to export the archive. Valid values are: app-store, ad-hoc, package, enterprise, development, developer-id
+   - exportMethod: Method used to export the archive. Valid values are: app-store, validation, ad-hoc, package, enterprise, development, developer-id and mac-application
    - exportOptions: Path to an export options plist or a hash with export options. Use 'xcodebuild -help' to print the full set of available options
    - exportXcargs: Pass additional arguments to xcodebuild for the package phase. Be sure to quote the setting names and values e.g. OTHER_LDFLAGS="-ObjC -lstdc++"
    - skipBuildArchive: Export ipa from previously built xcarchive. Uses archive_path as source
@@ -4036,6 +4116,8 @@ public func gradle(task: String? = nil,
    - xcprettyUtf: Have xcpretty use unicode encoding when reporting builds
    - skipProfileDetection: Do not try to build a profile mapping from the xcodeproj. Match or a manually provided mapping should be used
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
+   - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - useSystemScm: Lets xcodebuild use system's scm configuration
 
  - returns: The absolute path to the generated ipa file
@@ -4086,6 +4168,8 @@ public func gym(workspace: Any? = gymfile.workspace,
                 xcprettyUtf: Bool? = gymfile.xcprettyUtf,
                 skipProfileDetection: Bool = gymfile.skipProfileDetection,
                 clonedSourcePackagesPath: Any? = gymfile.clonedSourcePackagesPath,
+                skipPackageDependenciesResolution: Bool = gymfile.skipPackageDependenciesResolution,
+                disablePackageAutomaticUpdates: Bool = gymfile.disablePackageAutomaticUpdates,
                 useSystemScm: Bool = gymfile.useSystemScm)
 {
     let command = RubyCommand(commandID: "", methodName: "gym", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
@@ -4132,6 +4216,8 @@ public func gym(workspace: Any? = gymfile.workspace,
                                                                                        RubyCommand.Argument(name: "xcpretty_utf", value: xcprettyUtf),
                                                                                        RubyCommand.Argument(name: "skip_profile_detection", value: skipProfileDetection),
                                                                                        RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                       RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
+                                                                                       RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                        RubyCommand.Argument(name: "use_system_scm", value: useSystemScm)])
     _ = runner.executeCommand(command)
 }
@@ -5904,7 +5990,7 @@ public func registerDevices(devices: [String: Any]? = nil,
                             apiKey: [String: Any]? = nil,
                             teamId: String? = nil,
                             teamName: String? = nil,
-                            username: String,
+                            username: String? = nil,
                             platform: String = "ios")
 {
     let command = RubyCommand(commandID: "", methodName: "register_devices", className: nil, args: [RubyCommand.Argument(name: "devices", value: devices),
@@ -6141,6 +6227,8 @@ public func rubyVersion() {
    - customReportFileName: **DEPRECATED!** Use `--output_files` instead - Sets custom full report file name when generating a single report
    - xcodebuildCommand: Allows for override of the default `xcodebuild` command
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
+   - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - useSystemScm: Lets xcodebuild use system's scm configuration
    - failBuild: Should this step stop the build if the tests fail? Set this to false if you're using trainer
 
@@ -6210,6 +6298,8 @@ public func runTests(workspace: String? = nil,
                      customReportFileName: String? = nil,
                      xcodebuildCommand: String = "env NSUnbufferedIO=YES xcodebuild",
                      clonedSourcePackagesPath: String? = nil,
+                     skipPackageDependenciesResolution: Bool = false,
+                     disablePackageAutomaticUpdates: Bool = false,
                      useSystemScm: Bool = false,
                      failBuild: Bool = true)
 {
@@ -6277,6 +6367,8 @@ public func runTests(workspace: String? = nil,
                                                                                              RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
                                                                                              RubyCommand.Argument(name: "xcodebuild_command", value: xcodebuildCommand),
                                                                                              RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                             RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
+                                                                                             RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                              RubyCommand.Argument(name: "use_system_scm", value: useSystemScm),
                                                                                              RubyCommand.Argument(name: "fail_build", value: failBuild)])
     _ = runner.executeCommand(command)
@@ -6426,6 +6518,8 @@ public func say(text: Any,
    - customReportFileName: **DEPRECATED!** Use `--output_files` instead - Sets custom full report file name when generating a single report
    - xcodebuildCommand: Allows for override of the default `xcodebuild` command
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
+   - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - useSystemScm: Lets xcodebuild use system's scm configuration
    - failBuild: Should this step stop the build if the tests fail? Set this to false if you're using trainer
 
@@ -6495,6 +6589,8 @@ public func scan(workspace: Any? = scanfile.workspace,
                  customReportFileName: Any? = scanfile.customReportFileName,
                  xcodebuildCommand: Any = scanfile.xcodebuildCommand,
                  clonedSourcePackagesPath: Any? = scanfile.clonedSourcePackagesPath,
+                 skipPackageDependenciesResolution: Bool = scanfile.skipPackageDependenciesResolution,
+                 disablePackageAutomaticUpdates: Bool = scanfile.disablePackageAutomaticUpdates,
                  useSystemScm: Bool = scanfile.useSystemScm,
                  failBuild: Bool = scanfile.failBuild)
 {
@@ -6562,6 +6658,8 @@ public func scan(workspace: Any? = scanfile.workspace,
                                                                                         RubyCommand.Argument(name: "custom_report_file_name", value: customReportFileName),
                                                                                         RubyCommand.Argument(name: "xcodebuild_command", value: xcodebuildCommand),
                                                                                         RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                        RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
+                                                                                        RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                         RubyCommand.Argument(name: "use_system_scm", value: useSystemScm),
                                                                                         RubyCommand.Argument(name: "fail_build", value: failBuild)])
     _ = runner.executeCommand(command)
@@ -7282,11 +7380,14 @@ public func slather(buildDirectory: String? = nil,
    - concurrentSimulators: Take snapshots on multiple simulators concurrently. Note: This option is only applicable when running against Xcode 9
    - disableSlideToType: Disable the simulator from showing the 'Slide to type' prompt
    - clonedSourcePackagesPath: Sets a custom path for Swift Package Manager dependencies
+   - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
+   - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - testplan: The testplan associated with the scheme that should be used for testing
    - onlyTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to run
    - skipTesting: Array of strings matching Test Bundle/Test Suite/Test Cases to skip
    - disableXcpretty: Disable xcpretty formatting of build
    - suppressXcodeOutput: Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path
+   - useSystemScm: Lets xcodebuild use system's scm configuration
  */
 public func snapshot(workspace: Any? = snapshotfile.workspace,
                      project: Any? = snapshotfile.project,
@@ -7327,11 +7428,14 @@ public func snapshot(workspace: Any? = snapshotfile.workspace,
                      concurrentSimulators: Bool = snapshotfile.concurrentSimulators,
                      disableSlideToType: Bool = snapshotfile.disableSlideToType,
                      clonedSourcePackagesPath: Any? = snapshotfile.clonedSourcePackagesPath,
+                     skipPackageDependenciesResolution: Bool = snapshotfile.skipPackageDependenciesResolution,
+                     disablePackageAutomaticUpdates: Bool = snapshotfile.disablePackageAutomaticUpdates,
                      testplan: Any? = snapshotfile.testplan,
                      onlyTesting: Any? = snapshotfile.onlyTesting,
                      skipTesting: Any? = snapshotfile.skipTesting,
                      disableXcpretty: Bool? = snapshotfile.disableXcpretty,
-                     suppressXcodeOutput: Bool? = snapshotfile.suppressXcodeOutput)
+                     suppressXcodeOutput: Bool? = snapshotfile.suppressXcodeOutput,
+                     useSystemScm: Bool = snapshotfile.useSystemScm)
 {
     let command = RubyCommand(commandID: "", methodName: "snapshot", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
                                                                                             RubyCommand.Argument(name: "project", value: project),
@@ -7372,11 +7476,14 @@ public func snapshot(workspace: Any? = snapshotfile.workspace,
                                                                                             RubyCommand.Argument(name: "concurrent_simulators", value: concurrentSimulators),
                                                                                             RubyCommand.Argument(name: "disable_slide_to_type", value: disableSlideToType),
                                                                                             RubyCommand.Argument(name: "cloned_source_packages_path", value: clonedSourcePackagesPath),
+                                                                                            RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
+                                                                                            RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                             RubyCommand.Argument(name: "testplan", value: testplan),
                                                                                             RubyCommand.Argument(name: "only_testing", value: onlyTesting),
                                                                                             RubyCommand.Argument(name: "skip_testing", value: skipTesting),
                                                                                             RubyCommand.Argument(name: "disable_xcpretty", value: disableXcpretty),
-                                                                                            RubyCommand.Argument(name: "suppress_xcode_output", value: suppressXcodeOutput)])
+                                                                                            RubyCommand.Argument(name: "suppress_xcode_output", value: suppressXcodeOutput),
+                                                                                            RubyCommand.Argument(name: "use_system_scm", value: useSystemScm)])
     _ = runner.executeCommand(command)
 }
 
@@ -7713,7 +7820,7 @@ public func supply(packageName: String,
    - files: List of files to process
    - ignoreExitStatus: Ignore the exit status of the SwiftLint command, so that serious violations                                                     don't fail the build (true/false)
    - raiseIfSwiftlintError: Raises an error if swiftlint fails, so you can fail CI/CD jobs if necessary                                                     (true/false)
-   - reporter: Choose output reporter. Available: xcode, json, csv, checkstyle, junit, html,                                                      emoji, sonarqube, markdown, github-actions-logging
+   - reporter: Choose output reporter. Available: xcode, json, csv, checkstyle, codeclimate,                                                      junit, html, emoji, sonarqube, markdown, github-actions-logging
    - quiet: Don't print status logs like 'Linting <file>' & 'Done linting'
    - executable: Path to the `swiftlint` executable on your machine
    - format: Format code when mode is :autocorrect
@@ -9523,4 +9630,4 @@ public let snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.107]
+// FastlaneRunnerAPIVersion [0.9.108]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -1,5 +1,5 @@
 // Gymfile.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 // This class is automatically included in FastlaneRunner during build
 
@@ -17,4 +17,4 @@ public class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.171.0
+// Generated with fastlane 2.172.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -1,5 +1,5 @@
 // GymfileProtocol.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 public protocol GymfileProtocol: class {
     /// Path to the workspace file
@@ -41,7 +41,7 @@ public protocol GymfileProtocol: class {
     /// Should the ipa file include bitcode?
     var includeBitcode: Bool? { get }
 
-    /// Method used to export the archive. Valid values are: app-store, ad-hoc, package, enterprise, development, developer-id
+    /// Method used to export the archive. Valid values are: app-store, validation, ad-hoc, package, enterprise, development, developer-id and mac-application
     var exportMethod: String? { get }
 
     /// Path to an export options plist or a hash with export options. Use 'xcodebuild -help' to print the full set of available options
@@ -134,6 +134,12 @@ public protocol GymfileProtocol: class {
     /// Sets a custom path for Swift Package Manager dependencies
     var clonedSourcePackagesPath: String? { get }
 
+    /// Skips resolution of Swift Package Manager dependencies
+    var skipPackageDependenciesResolution: Bool { get }
+
+    /// Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
+    var disablePackageAutomaticUpdates: Bool { get }
+
     /// Lets xcodebuild use system's scm configuration
     var useSystemScm: Bool { get }
 }
@@ -183,9 +189,11 @@ public extension GymfileProtocol {
     var xcprettyUtf: Bool? { return nil }
     var skipProfileDetection: Bool { return false }
     var clonedSourcePackagesPath: String? { return nil }
+    var skipPackageDependenciesResolution: Bool { return false }
+    var disablePackageAutomaticUpdates: Bool { return false }
     var useSystemScm: Bool { return false }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.57]
+// FastlaneRunnerAPIVersion [0.9.58]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -1,5 +1,5 @@
 // Matchfile.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 // This class is automatically included in FastlaneRunner during build
 
@@ -17,4 +17,4 @@ public class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.171.0
+// Generated with fastlane 2.172.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -1,5 +1,5 @@
 // MatchfileProtocol.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 public protocol MatchfileProtocol: class {
     /// Define the profile type, can be appstore, adhoc, development, enterprise, developer_id, mac_installer_distribution
@@ -184,4 +184,4 @@ public extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.51]
+// FastlaneRunnerAPIVersion [0.9.52]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -1,5 +1,5 @@
 // Precheckfile.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 // This class is automatically included in FastlaneRunner during build
 
@@ -17,4 +17,4 @@ public class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.171.0
+// Generated with fastlane 2.172.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -1,5 +1,5 @@
 // PrecheckfileProtocol.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 public protocol PrecheckfileProtocol: class {
     /// Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)
@@ -52,4 +52,4 @@ public extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.50]
+// FastlaneRunnerAPIVersion [0.9.51]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -1,5 +1,5 @@
 // Scanfile.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 // This class is automatically included in FastlaneRunner during build
 
@@ -17,4 +17,4 @@ public class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.171.0
+// Generated with fastlane 2.172.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -1,5 +1,5 @@
 // ScanfileProtocol.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 public protocol ScanfileProtocol: class {
     /// Path to the workspace file
@@ -194,6 +194,12 @@ public protocol ScanfileProtocol: class {
     /// Sets a custom path for Swift Package Manager dependencies
     var clonedSourcePackagesPath: String? { get }
 
+    /// Skips resolution of Swift Package Manager dependencies
+    var skipPackageDependenciesResolution: Bool { get }
+
+    /// Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
+    var disablePackageAutomaticUpdates: Bool { get }
+
     /// Lets xcodebuild use system's scm configuration
     var useSystemScm: Bool { get }
 
@@ -266,10 +272,12 @@ public extension ScanfileProtocol {
     var customReportFileName: String? { return nil }
     var xcodebuildCommand: String { return "env NSUnbufferedIO=YES xcodebuild" }
     var clonedSourcePackagesPath: String? { return nil }
+    var skipPackageDependenciesResolution: Bool { return false }
+    var disablePackageAutomaticUpdates: Bool { return false }
     var useSystemScm: Bool { return false }
     var failBuild: Bool { return true }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.62]
+// FastlaneRunnerAPIVersion [0.9.63]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -1,5 +1,5 @@
 // Screengrabfile.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 // This class is automatically included in FastlaneRunner during build
 
@@ -17,4 +17,4 @@ public class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.171.0
+// Generated with fastlane 2.172.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -1,5 +1,5 @@
 // ScreengrabfileProtocol.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 public protocol ScreengrabfileProtocol: class {
     /// Path to the root of your Android SDK installation, e.g. ~/tools/android-sdk-macosx
@@ -96,4 +96,4 @@ public extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.52]
+// FastlaneRunnerAPIVersion [0.9.53]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -1,5 +1,5 @@
 // Snapshotfile.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 // This class is automatically included in FastlaneRunner during build
 
@@ -17,4 +17,4 @@ public class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.171.0
+// Generated with fastlane 2.172.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -1,5 +1,5 @@
 // SnapshotfileProtocol.swift
-// Copyright (c) 2020 FastlaneTools
+// Copyright (c) 2021 FastlaneTools
 
 public protocol SnapshotfileProtocol: class {
     /// Path the workspace file
@@ -119,6 +119,12 @@ public protocol SnapshotfileProtocol: class {
     /// Sets a custom path for Swift Package Manager dependencies
     var clonedSourcePackagesPath: String? { get }
 
+    /// Skips resolution of Swift Package Manager dependencies
+    var skipPackageDependenciesResolution: Bool { get }
+
+    /// Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
+    var disablePackageAutomaticUpdates: Bool { get }
+
     /// The testplan associated with the scheme that should be used for testing
     var testplan: String? { get }
 
@@ -133,6 +139,9 @@ public protocol SnapshotfileProtocol: class {
 
     /// Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path
     var suppressXcodeOutput: Bool? { get }
+
+    /// Lets xcodebuild use system's scm configuration
+    var useSystemScm: Bool { get }
 }
 
 public extension SnapshotfileProtocol {
@@ -175,13 +184,16 @@ public extension SnapshotfileProtocol {
     var concurrentSimulators: Bool { return true }
     var disableSlideToType: Bool { return false }
     var clonedSourcePackagesPath: String? { return nil }
+    var skipPackageDependenciesResolution: Bool { return false }
+    var disablePackageAutomaticUpdates: Bool { return false }
     var testplan: String? { return nil }
     var onlyTesting: String? { return nil }
     var skipTesting: String? { return nil }
     var disableXcpretty: Bool? { return nil }
     var suppressXcodeOutput: Bool? { return nil }
+    var useSystemScm: Bool { return false }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.46]
+// FastlaneRunnerAPIVersion [0.9.47]


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.171.0':**

* [frameit] add support for new iPhone 12-family devices and their new colors (#17940) via Nicolas Mauri
* [deliver][download_metadata] give precedence to generate metadata from edit version instead of live version (#17813) via Roger Oba
* [action] git_commit - skip commit if git status is clean for paths (#17913) via Pierre Felgines
* [spaceship][docs] update spaceship app store connect docs (#17938) via Roger Oba
[snapshot] fix snapshot not saving image files on Apple Silicon M1 (#17912) via Martin Albrecht
* [fastlane] add BUDDY environment variables (#17922) via Rafał Sztwiorok
* [spaceship] adding missing localizations attribute to AppStoreVersion (#17928) via gsavit
* Update sample issue from being an existing issue, to a fake one. (#17934) via Roger Oba
* [action] swiftlint - avoid throwing error for new types of reporters. (#17935) via Roger Oba
* [action] change 'platform' optionality since nil is not really a valid value. (#17936) via Roger Oba
* [gym] update gym's available export_methods to match xcodebuild's. (#17939) via Roger Oba
* [frameit] fix the screenshot size of iPhone 8 Plus (#17977) via Rhett Tuan
* [action] register_device - fix regression that was causing a crash when creating a device that already exists (#17799) via Roger Oba
* [spaceship] allow 2FA request only in interactive mode (#17854) via Oleg Kohtenko
* [action] new create_xcframework action (#17844) via José González
* [CI] support Ruby 2.7 on Circle CI (#17861) via Satoshi Namai
* [action] artifactory - add option to authenticate using an API key (#17835) via Florian Staine
* [gym] update identifier used to looked up the bundle ID when parsing provisioning profile (#17865) via John Britton
* [spaceship] allow for updating of beta groups (#17984) via Krish
* [snapshot] fix picking up 'SnapshotHelper'-files from DerivedData #17828 (#17833) via David Everlöf
* [gym] use unzip for IPA files that are too big (#17825) via Theodore Dubois
* [action] change username for register_devices action to optional (#17942) via Econa77
* [action] add api bearer to create pull request (#17972) via Thilek Silvadorai
* [scan] fix scan not failing when disable_xcpretty and fail_build are true (#17946) via Jean Mainguy
* [scan] fix scan regression caused by not setting `slack_default_payloads` option (#17923) via Roger Oba
* [gym][scan][snapshot] disable automatic SPM dependencies resolution or skip it entirely (#17916) via Roman Tysiachnik
* [gym][snapshot] fix gym `use_system_scm` option and add `use_system_scm` option to snapshot (#17832) via Roger Oba
