### PR TITLE
[swiftlint] fix syntactic issue when validating swiftlint reporters

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -145,7 +145,7 @@ module Fastlane
                                        optional: true,
                                        verify_block: proc do |value|
                                          available = ['xcode', 'json', 'csv', 'checkstyle', 'codeclimate', 'junit', 'html', 'emoji', 'sonarqube', 'markdown', 'github-actions-logging']
-                                         UI.warning("Known 'reporter' values are '#{available.join("', '")}'. If you're receiving errors from swiftlint related to the reporter, make sure the reporter identifier you're using is correct and it's supported by your version of swiftlint.") unless available.include?(value)
+                                         UI.important("Known 'reporter' values are '#{available.join("', '")}'. If you're receiving errors from swiftlint related to the reporter, make sure the reporter identifier you're using is correct and it's supported by your version of swiftlint.") unless available.include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :quiet,
                                        env_name: "FL_SWIFTLINT_QUIET",


### PR DESCRIPTION
### Motivation and Context
Resolves #18027

### Description
Simple oversight 🤦 `warning` → ` important`
Note that this error should only be seen if passing an invalid value for `reporter` option.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-fix-swiftlint-validation-block"
```

And run `bundle install` to apply the changes.

Proof of tests (before → after):

<img width="962" alt="image" src="https://user-images.githubusercontent.com/8419048/105490169-2673c000-5c93-11eb-91d2-ab70eed4708e.png">
