### PR TITLE
[action] fix download dsyms with zero prefixed versions

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -163,7 +163,8 @@ module Fastlane
 
       def self.get_latest_build!(app_id: nil, version: nil, platform: nil)
         filter = { app: app_id }
-        filter["preReleaseVersion.version"] = version
+        # The version filter seems to ignore zero prefixes in versions (e.g. 21.01)
+        filter["preReleaseVersion.version"] = version.split(".").map(&:to_i).join(".")
         filter["preReleaseVersion.platform"] = platform
         latest_build = Spaceship::ConnectAPI.get_builds(filter: filter, sort: "-uploadedDate", includes: "preReleaseVersion").first
 

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -59,11 +59,6 @@ module Fastlane
           build_number = live_version.build.version
         end
 
-        # Remove leading zeros from version string (eg. 1.02 -> 1.2)
-        if version
-          version = version.split(".").map(&:to_i).join(".")
-        end
-
         # Make sure output_directory has a slash on the end
         if output_directory && !output_directory.end_with?('/')
           output_directory += '/'

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -99,7 +99,7 @@ describe Fastlane do
         it 'downloads all dsyms of all builds in train 1.07.0' do
           expect(build_resp).to receive(:to_models).and_return([build1])
 
-          [[build1, '1.7.0', '3', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
+          [[build1, '1.07.0', '3', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
             expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The the `preReleaseVersion.version` filter in the [App Store Connect API to list builds](https://developer.apple.com/documentation/appstoreconnectapi/list_builds) seems to be comparing major/minor/subminor versions as integers not as verbatim strings and fails to retrieve builds when the version includes leading zeros (e.g. `21.01.1`).

Also the version number in the build info returned by the App Store Connect API includes the version as strings (with leading zeros) but as the existing `download_dsyms` code is stripping out leading zeros prior to comparing the version specified and the versions returned from the API, it **fails to download the corresponding dSYMs** thinking that none of the versions match.

### Description

This change  deals with the two issues above by 1) stripping out leading zeros before setting it to the `preReleaseVersion.version` filter, 2) removes the leading zero stripping when comparing the versions.

I have tested by uploading and releasing an iPhone app with a leading zero in its minor version (e.g. `21.01.1`), running both
`download_dsyms(version: "live")` and `download_dsyms(version: "latest")` and confirmed that both have successfully downloaded the dSYM.

### Testing Steps

Please see above Description for testing steps.