### PR TITLE
[spaceship] added missing create method for UserInvitation model

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -53,6 +53,19 @@ module Spaceship
         return all(client: client, filter: { email: email }, includes: includes)
       end
 
+      def self.create(client: nil, email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil)
+        client ||= Spaceship::ConnectAPI
+        resp = client.post_user_invitation(
+          email: email,
+          first_name: first_name,
+          last_name: last_name,
+          roles: roles,
+          provisioning_allowed: provisioning_allowed,
+          all_apps_visible: all_apps_visible
+        )
+        return resp.to_models.first
+      end
+
       def delete!(client: nil)
         client ||= Spaceship::ConnectAPI
         client.delete_user_invitation(user_invitation_id: id)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
🔑
### Checklist 
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
As mention in this discussion https://github.com/fastlane/fastlane/discussions/18029, the user_invitation model is missing a create method to call the already added post_user_invitation in Users module.


### Description
I just added the create method like it's added in all other models for ConnectAPI.
I tested the method in the Rakefile to verify the create method was working.

### Testing Steps
I used the following in the Rakefile and run it with `bundle exec rake debug --trace`
```ruby
task(:debug) do
  require 'spaceship'

  token = Spaceship::ConnectAPI::Token.from_json_file(File.expand_path("fastlane.json"))
  Spaceship::ConnectAPI.token = token

  resp = Spaceship::ConnectAPI::UserInvitation.create(email: "brian@brian.dk", first_name: "Brian", last_name: "Dinsen Test", roles: ["DEVELOPER"], provisioning_allowed: false, all_apps_visible: true)

  puts(resp.to_yaml)
end

```
