### PR TITLE
[xcov] fix compatibility issues for plugins depending on FastlaneCore::Project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane (2.172.0)
+    fastlane (2.171.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       artifactory (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane (2.171.0)
+    fastlane (2.172.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       artifactory (~> 3.0)

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -1,5 +1,6 @@
 require_relative 'helper'
 require 'xcodeproj'
+require_relative './configuration/configuration'
 require 'fastlane_core/command_executor'
 
 module FastlaneCore
@@ -67,9 +68,6 @@ module FastlaneCore
     # Is this project a workspace?
     attr_accessor :is_workspace
 
-    # The config object containing the scheme, configuration, etc.
-    attr_accessor :options
-
     # Should the output of xcodebuild commands be silenced?
     attr_accessor :xcodebuild_list_silent
 
@@ -78,7 +76,7 @@ module FastlaneCore
     attr_accessor :xcodebuild_suppress_stderr
 
     def initialize(options, xcodebuild_list_silent: false, xcodebuild_suppress_stderr: false)
-      self.options = options
+      @options = options
       self.path = File.expand_path(options[:workspace] || options[:project])
       self.is_workspace = (options[:workspace].to_s.length > 0)
       self.xcodebuild_list_silent = xcodebuild_list_silent
@@ -87,6 +85,14 @@ module FastlaneCore
       if !path || !File.directory?(path)
         UI.user_error!("Could not find project at path '#{path}'")
       end
+    end
+
+    # @return [Hash] a hash object containing project, workspace, scheme, any configuration related to xcodebuild, or etc...
+    def options
+      # To keep compatibility with actions using this class from outside of `fastlane` gem; i.e. `xcov`,
+      # converts `options` to a plain Hash. Otherwise, it might crash when a new option's key is added
+      # due to `FastlaneCore::Configuration` to validate valid keys defined.
+      @options.kind_of?(FastlaneCore::Configuration) ? @options.values : @options
     end
 
     def workspace?

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -75,6 +75,9 @@ module FastlaneCore
     # Gets rid of annoying plugin info warnings.
     attr_accessor :xcodebuild_suppress_stderr
 
+    # @param options [FastlaneCore::Configuration|Hash] a set of configuration to run xcodebuild to work out build settings
+    # @param xcodebuild_list_silent [Boolean] a flag to silent xcodebuild command's output
+    # @param xcodebuild_suppress_stderr [Boolean] a flag to supress output to stderr from xcodebuild
     def initialize(options, xcodebuild_list_silent: false, xcodebuild_suppress_stderr: false)
       @options = options
       @path = File.expand_path(self.options[:workspace] || self.options[:project])

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -77,10 +77,10 @@ module FastlaneCore
 
     def initialize(options, xcodebuild_list_silent: false, xcodebuild_suppress_stderr: false)
       @options = options
-      self.path = File.expand_path(options[:workspace] || options[:project])
-      self.is_workspace = (options[:workspace].to_s.length > 0)
-      self.xcodebuild_list_silent = xcodebuild_list_silent
-      self.xcodebuild_suppress_stderr = xcodebuild_suppress_stderr
+      @path = File.expand_path(options[:workspace] || options[:project])
+      @is_workspace = (options[:workspace].to_s.length > 0)
+      @xcodebuild_list_silent = xcodebuild_list_silent
+      @xcodebuild_suppress_stderr = xcodebuild_suppress_stderr
 
       if !path || !File.directory?(path)
         UI.user_error!("Could not find project at path '#{path}'")

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -77,8 +77,8 @@ module FastlaneCore
 
     def initialize(options, xcodebuild_list_silent: false, xcodebuild_suppress_stderr: false)
       @options = options
-      @path = File.expand_path(options[:workspace] || options[:project])
-      @is_workspace = (options[:workspace].to_s.length > 0)
+      @path = File.expand_path(self.options[:workspace] || self.options[:project])
+      @is_workspace = (self.options[:workspace].to_s.length > 0)
       @xcodebuild_list_silent = xcodebuild_list_silent
       @xcodebuild_suppress_stderr = xcodebuild_suppress_stderr
 

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -95,6 +95,11 @@ module FastlaneCore
       @options.kind_of?(FastlaneCore::Configuration) ? @options.values : @options
     end
 
+    def options=(new_value)
+      UI.deprecated('Update `options` is not worth doing since it can change behavior of this object entirely. Consider re-creating FastlaneCore::Project.')
+      @options = new_value
+    end
+
     def workspace?
       self.is_workspace
     end

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -587,6 +587,20 @@ describe FastlaneCore do
         command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
         expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
       end
+
+      it 'generates even if given options do not support skip_package_dependencies_resolution' do
+        config = FastlaneCore::Configuration.create(
+          [
+            FastlaneCore::ConfigItem.new(key: :workspace, optional: true),
+            FastlaneCore::ConfigItem.new(key: :project, optional: true)
+          ], {
+            project: './fastlane_core/spec/fixtures/projects/Example.xcodeproj'
+          }
+        )
+        project = FastlaneCore::Project.new(config)
+        expect(project.build_xcodebuild_resolvepackagedependencies_command).to_not(be_nil)
+        expect { project.build_xcodebuild_resolvepackagedependencies_command }.to_not(raise_error)
+      end
     end
 
     describe "#project_paths" do

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -6,7 +6,7 @@ describe Gym do
   end
 
   before(:each) do
-    @project.options.values.delete(:use_system_scm)
+    @project.options.delete(:use_system_scm)
     allow(Gym).to receive(:project).and_return(@project)
   end
 

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -76,7 +76,7 @@ describe Scan do
   describe Scan::TestCommandGenerator do
     before(:each) do
       @test_command_generator = Scan::TestCommandGenerator.new
-      @project.options.values.delete(:use_system_scm)
+      @project.options.delete(:use_system_scm)
     end
 
     it "raises an exception when project path wasn't found" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Closes https://github.com/fastlane/fastlane/issues/18047

Prior to this PR, https://github.com/fastlane/fastlane/pull/17916 got merged but it appears to cause a regression in `xcov` https://github.com/fastlane/fastlane/issues/18047 https://github.com/fastlane-community/xcov/issues/189  

This is due to the fact https://github.com/fastlane/fastlane/pull/17916 changed what `FastlaneCore::Project` requires its consumers to pass.  Now all the consumers need to pass `disable_package_automatic_updates` and `cloned_source_packages_path` by `options` argument. It's not clearly documented but from the use-cases of `FastlaneCore::Project` `options` is `FastlaneCore::Configuration` object in reality whilst `Hash` is used in unit test cases. So when it comes to fetching a value with a key `FastlaneCore::Configuration` can fail if the key is *not* defined within its available options. That's what reported in those issues.

``` 
Could not find option 'skip_package_dependencies_resolution' in the list of available options: workspace, project, scheme, configuration, source_directory, derived_data_path, xccov_file_direct_path, output_directory, cloned_source_packages_path, html_report, markdown_report, json_report, minimum_coverage_percentage, slack_url, slack_channel, skip_slack, slack_username, slack_message, ignore_file_path, include_test_targets, exclude_targets, include_targets, only_project_targets, disable_coveralls, coveralls_service_name, coveralls_service_job_id, coveralls_repo_token, xcconfig, ideFoundationPath, legacy_support
```

It was no problem in `fastlane` gem itself because in https://github.com/fastlane/fastlane/pull/17916 did cover all the modules that depend on `FastlaneCore::Project` by adding new keys to remain working. However, `xocv` or possibly other gems that depend on `FastlaneCore::Project` is now broken with that reason.

I would say this is very fragile. To remove future regressions with similar reasons, I decided to fix `FastlaneCore::Proejct` rather than `xcov` or others one by one.  

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I didn't want to introduce breaking changes to `FastlaneCore::Project` itself because it may cause another bug😅 What I did is to workaround the validation in `FastlaneCore::Project` when fetching values with `.[]` by temporarily converting `options` to `Hash` each time.  This way we still can expect `FastlaneCore::Configuration` to be passed but we can safely fetch any additional value with a new key in future within `FastlaneCore::Project`.
 
### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

See CI passes unit tests. I added a test case to replicate the previously failing situation.