### PR TITLE
[docs] fix typo in update_code_signing_settings documentation

### DIFF
--- a/fastlane/lib/fastlane/actions/update_code_signing_settings.rb
+++ b/fastlane/lib/fastlane/actions/update_code_signing_settings.rb
@@ -140,7 +140,7 @@ module Fastlane
                                        env_name: "FL_PROJECT_SIGNING_BUILD_CONFIGURATIONS",
                                        optional: true,
                                        type: Array,
-                                       description: "Specify build_configurations you want to toggle the signing mech. (default to all targets)",
+                                       description: "Specify build_configurations you want to toggle the signing mech. (default to all configurations)",
                                        is_string: false),
           FastlaneCore::ConfigItem.new(key: :code_sign_identity,
                                        env_name: "FL_CODE_SIGN_IDENTITY",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

There is a small typo in the `update_code_signing_settings` [documentation](https://docs.fastlane.tools/actions/update_code_signing_settings/#parameters).

Under the key `build_configurations`, by default all *configurations* are updated (not the *targets*)
