### PR TITLE
[docs] add match documentation on how to use basic authorization with GitHub tokens

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -99,14 +99,20 @@ If your machine is currently using SSH to authenticate with GitHub, you'll want 
 Using parameter:
 
 ```
-match(git_basic_authorization: '<YOUR KEY>')
+match(git_basic_authorization: '<YOUR BASE64 KEY>')
 ```
 
 Using environment variable:
 
 ```
-ENV['MATCH_GIT_BASIC_AUTHORIZATION'] = '<YOUR KEY>'
+ENV['MATCH_GIT_BASIC_AUTHORIZATION'] = '<YOUR BASE64 KEY>'
 match
+```
+
+To generate your base64 key [according to RFC 7617](https://tools.ietf.org/html/rfc7617), run this:
+
+```
+echo -n your_github_username:your_personal_access_token | base64
 ```
 
 You can find more information about GitHub basic authentication and personal token generation here: [https://developer.github.com/v3/auth/#basic-authentication](https://developer.github.com/v3/auth/#basic-authentication)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] (NOT APPLICABLE) I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] (NOT APPLICABLE) I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Currently it's really confusing how to use HTTPS Basic authentication with GitHub Personal Access Tokens. The most obvious way implied by [the docs](https://docs.fastlane.tools/actions/match/#git-storage-on-github), inserting the personal access token as MATCH_GIT_BASIC_AUTHORIZATION doesn't work and generates the following error in CI environments:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Other people have been bit by this, such as https://github.com/fastlane/fastlane/pull/17737#issuecomment-739965958 and potentially https://github.com/fastlane/fastlane/issues/17347.

I spent 15–30 minutes investigating this; reading the RFC, the GitHub documentation, and using `curl -v`. It would be helpful if we actually included documentation on how to do this for the next person.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Added instructions to the "Git Storage on GitHub" section of the `match` docs. I tested this with my own account.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

You can test this with your own account by creating a GitHub personal access token, running the base64 command as described, and providing it as the MATCH_GIT_BASIC_AUTHORIZATION environment variable or git_basic_authorization 
parameter.

I imagine whomever wrote this must have gone through this exact same process and just not documented the steps because they seemed obvious to them; or they glossed over the details without testing them, assuming they could paste in the personal access token as "&lt;YOUR KEY&gt;".
