### PR TITLE
[app store connect] update App Store Connect API token generation documentation

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -75,6 +75,7 @@ module Fastlane
                                        env_name: "APP_STORE_CONNECT_API_KEY_DURATION",
                                        description: "The token session duration",
                                        optional: true,
+                                       default_value: Spaceship::ConnectAPI::Token::MAX_TOKEN_DURATION,
                                        type: Integer),
           FastlaneCore::ConfigItem.new(key: :in_house,
                                        env_name: "APP_STORE_CONNECT_API_KEY_IN_HOUSE",

--- a/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
@@ -22,7 +22,7 @@ describe Fastlane do
           issuer_id: issuer_id,
           key: File.binread(fake_api_key_p8_path),
           is_key_content_base64: false,
-          duration: nil,
+          duration: 1200,
           in_house: nil
         }
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I was trying to troubleshoot why our release notes were not able to be uploaded to App Store Connect after uploading a build. Part of that troubleshooting was determining when the API key token expired to see if that could be the cause of the issue.

### Description

This change adds the default value for the `duration` property to the documentation so folks who use the `app_store_connect_api_key` lane don't have to go searching through the source code to find it.

### Testing Steps

None, this is a documentation change.
