### PR TITLE
[pilot] also wait for build processing when only distributing

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -22,7 +22,7 @@ module Fastlane
         return values if Helper.test?
 
         if distribute_only
-          Pilot::BuildManager.new.wait_for_build_processing_to_be_complete(values) unless values[:skip_waiting_for_build_processing]
+          Pilot::BuildManager.new.wait_for_build_processing_to_be_complete(false) unless values[:skip_waiting_for_build_processing]
           Pilot::BuildManager.new.distribute(values) # we already have the finished config
         else
           Pilot::BuildManager.new.upload(values) # we already have the finished config

--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -22,6 +22,7 @@ module Fastlane
         return values if Helper.test?
 
         if distribute_only
+          Pilot::BuildManager.new.wait_for_build_processing_to_be_complete(values) unless values[:skip_waiting_for_build_processing]
           Pilot::BuildManager.new.distribute(values) # we already have the finished config
         else
           Pilot::BuildManager.new.upload(values) # we already have the finished config

--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -22,8 +22,11 @@ module Fastlane
         return values if Helper.test?
 
         if distribute_only
-          Pilot::BuildManager.new.wait_for_build_processing_to_be_complete(false) unless values[:skip_waiting_for_build_processing]
-          Pilot::BuildManager.new.distribute(values) # we already have the finished config
+          build_manager = Pilot::BuildManager.new
+          should_login_in_start = values[:apple_id].nil?
+          build_manager.start(values, should_login: should_login_in_start)
+          build_manager.wait_for_build_processing_to_be_complete(false) unless values[:skip_waiting_for_build_processing]
+          build_manager.distribute(values) # we already have the finished config
         else
           Pilot::BuildManager.new.upload(values) # we already have the finished config
         end

--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -23,8 +23,8 @@ module Fastlane
 
         if distribute_only
           build_manager = Pilot::BuildManager.new
-          should_login_in_start = values[:apple_id].nil?
-          build_manager.start(values, should_login: should_login_in_start)
+          build_manager.start(values, should_login: true)
+
           build_manager.wait_for_build_processing_to_be_complete(false) unless values[:skip_waiting_for_build_processing]
           build_manager.distribute(values) # we already have the finished config
         else

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -89,12 +89,11 @@ module Pilot
     end
 
     def wait_for_build_processing_to_be_complete(return_when_build_appears = false)
+      platform = fetch_app_platform
       if config[:ipa]
-        platform = fetch_app_platform
         app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
         app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
       else
-        platform = config[:app_platform]
         app_version = config[:app_version]
         app_build = config[:build_number]
       end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -96,7 +96,7 @@ module Pilot
       else
         platform = config[:app_platform]
         app_version = config[:app_version]
-        build = config[:build_number]
+        app_build = config[:build_number]
       end
 
       latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -89,9 +89,15 @@ module Pilot
     end
 
     def wait_for_build_processing_to_be_complete(return_when_build_appears = false)
-      platform = fetch_app_platform
-      app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
-      app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
+      if config[:ipa]
+        platform = fetch_app_platform
+        app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
+        app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
+      else
+        platform = config[:app_platform]
+        app_version = config[:app_version]
+        build = config[:build_number]
+      end
 
       latest_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(
         app_id: app.id,

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -217,7 +217,7 @@ describe "Build Manager" do
       end
 
       it "updates non-localized changelog and doesn't distribute" do
-        allow(ready_to_submit_mock_build).to receive(:build_beta_detail).and_return(build_beta_detail_still_processing)
+        expect(ready_to_submit_mock_build).to receive(:build_beta_detail).and_return(build_beta_detail_still_processing).exactly(4).times
 
         options = distribute_options_skip_waiting_non_localized_changelog
 
@@ -258,7 +258,7 @@ describe "Build Manager" do
       end
 
       it "updates non-localized demo_account_required, notify_external_testers, beta_app_feedback_email, and beta_app_description and distributes" do
-        allow(ready_to_submit_mock_build).to receive(:build_beta_detail).and_return(build_beta_detail)
+        expect(ready_to_submit_mock_build).to receive(:build_beta_detail).and_return(build_beta_detail).exactly(6).times
 
         options = distribute_options_non_localized
 
@@ -365,6 +365,66 @@ describe "Build Manager" do
     end
   end
 
+  describe "#wait_for_build_processing_to_be_complete" do
+    let(:fake_build_manager) { Pilot::BuildManager.new }
+    let(:app) do
+      Spaceship::ConnectAPI::App.new("123-123-123-123", {
+        name: "Mock App"
+      })
+    end
+
+    before(:each) do
+      allow(fake_build_manager).to receive(:login)
+      allow(fake_build_manager).to receive(:app).and_return(app)
+    end
+
+    it "wait given :ipa" do
+      options = { ipa: "some_path.ipa" }
+      fake_build_manager.instance_variable_set(:@config, options)
+
+      expect(fake_build_manager).to receive(:fetch_app_platform)
+      expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version).and_return("1.2.3")
+      expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build).and_return("123")
+
+      fake_build = double
+      expect(fake_build).to receive(:app_version).and_return("1.2.3")
+      expect(fake_build).to receive(:version).and_return("123")
+      expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+      fake_build_manager.wait_for_build_processing_to_be_complete
+    end
+
+    it "wait given :app_version and :build_number" do
+      options = { app_version: "1.2.3", build_number: "123" }
+      fake_build_manager.instance_variable_set(:@config, options)
+
+      expect(fake_build_manager).to receive(:fetch_app_platform)
+
+      fake_build = double
+      expect(fake_build).to receive(:app_version).and_return("1.2.3")
+      expect(fake_build).to receive(:version).and_return("123")
+      expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+      fake_build_manager.wait_for_build_processing_to_be_complete
+    end
+
+    it "wait given :ipa, :app_version and :build_number" do
+      options = { app_version: "4.5.6", build_number: "456", ipa: "some_path.ipa" }
+      fake_build_manager.instance_variable_set(:@config, options)
+
+      expect(fake_build_manager).to receive(:fetch_app_platform)
+      expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version).and_return("1.2.3")
+      expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build).and_return("123")
+
+      fake_build = double
+      expect(fake_build).to receive(:app_version).and_return("1.2.3")
+      expect(fake_build).to receive(:version).and_return("123")
+      expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+      fake_build_manager.wait_for_build_processing_to_be_complete
+    end
+  end
+
   describe "#upload" do
     describe "uses Manager.login (which does spaceship login)" do
       let(:fake_build_manager) { Pilot::BuildManager.new }
@@ -405,21 +465,20 @@ describe "Build Manager" do
 
         # other stuff required to let `upload` work:
 
-        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_identifier).and_return("com.fastlane")
-        allow(fake_build_manager).to receive(:fetch_app_id).and_return(123)
-        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
-        allow(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
+        expect(fake_build_manager).to receive(:fetch_app_id).and_return(123).exactly(3).times
+        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
+        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
 
         fake_app = double
-        allow(fake_app).to receive(:id).and_return(123)
-        allow(fake_build_manager).to receive(:app).and_return(fake_app)
+        expect(fake_app).to receive(:id).and_return(123)
+        expect(fake_build_manager).to receive(:app).and_return(fake_app)
 
         fake_build = double
-        allow(fake_build).to receive(:app_version)
-        allow(fake_build).to receive(:version)
-        allow(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+        expect(fake_build).to receive(:app_version)
+        expect(fake_build).to receive(:version)
+        expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
 
-        allow(fake_build_manager).to receive(:distribute)
+        expect(fake_build_manager).to receive(:distribute)
 
         fake_build_manager.upload(upload_options)
       end


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #18072 

### Description
I'm already on my personal machine, so I couldn't test it and I'll be AFK for a week. I don't usually use ruby, so the syntax might need fixing but the general idea should be correct.

### Testing Steps
First only upload the ipa with `fastlane pilot` (skip waiting for processing and don't set changelog)
`fastlane pilot distribute_only`
