### PR TITLE
[action] appetize add timeout support

### DIFF
--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -31,6 +31,10 @@ module Fastlane
 
         params[:note] = options[:note] if options[:note].to_s.length > 0
 
+        if options[:timeout]
+          params[:timeout] = options[:timeout]
+        end
+
         uri = URI.parse(appetize_url(options))
         req = create_request(uri, params)
         req.basic_auth(options[:api_token], nil)
@@ -147,7 +151,15 @@ module Fastlane
                                        env_name: "APPETIZE_NOTE",
                                        description: "Notes you wish to add to the uploaded app",
                                        is_string: true,
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+                                       env_name: "APPETIZE_TIMEOUT",
+                                       description: "The number of seconds to wait until automatically ending the session due to user inactivity. Must be 30, 60, 90, 120, 180, 300, 600, 1800, 3600 or 7200. Default is 120",
+                                       is_string: false,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                          UI.user_error!("The value provided doesn't match any of the supported options.") unless [30, 60, 90, 120, 180, 300, 600, 1800, 3600, 7200].include?(value)
+                                       end),
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -155,11 +155,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :timeout,
                                        env_name: "APPETIZE_TIMEOUT",
                                        description: "The number of seconds to wait until automatically ending the session due to user inactivity. Must be 30, 60, 90, 120, 180, 300, 600, 1800, 3600 or 7200. Default is 120",
-                                       is_string: false,
+                                       type: Integer,
                                        optional: true,
                                        verify_block: proc do |value|
-                                          UI.user_error!("The value provided doesn't match any of the supported options.") unless [30, 60, 90, 120, 180, 300, 600, 1800, 3600, 7200].include?(value)
-                                       end),
+                                         UI.user_error!("The value provided doesn't match any of the supported options.") unless [30, 60, 90, 120, 180, 300, 600, 1800, 3600, 7200].include?(value)
+                                       end)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
+++ b/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
@@ -77,7 +77,14 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :note,
                                        description: "Notes you wish to add to the uploaded app",
                                        is_string: true,
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+                                       description: "The number of seconds to wait until automatically ending the session due to user inactivity. Must be 30, 60, 90, 120, 180, 300, 600, 1800, 3600 or 7200. Default is 120",
+                                       type: Integer,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The value provided doesn't match any of the supported options.") unless [30, 60, 90, 120, 180, 300, 600, 1800, 3600, 7200].include?(value)
+                                       end)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
+++ b/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
@@ -21,7 +21,8 @@ module Fastlane
         other_action.appetize(path: zipped_bundle,
                               api_token: params[:api_token],
                               public_key: params[:public_key],
-                              note: params[:note])
+                              note: params[:note],
+                              timeout: params[:timeout])
 
         public_key = Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY]
         UI.success("Generated Public Key: #{Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY]}")

--- a/fastlane/spec/actions_specs/appetize_spec.rb
+++ b/fastlane/spec/actions_specs/appetize_spec.rb
@@ -85,6 +85,18 @@ describe Fastlane do
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APPETIZE_API_HOST]).to eql(api_host)
       end
+
+      it "raises an error if an invalid timeout was given" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            appetize({
+              api_token: '#{api_token}',
+              url: '#{url}',
+              timeout: 9999
+            })
+          end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, /value provided doesn't match any of the supported options/)
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adding support for the `timeout` option in Appetize, as seen in their documentation https://docs.appetize.io/api/update-existing-app it would be ideal to support more than the default 2mins.

### Description
Expanded the `appetize` and `build_and_upload_to_appetize` actions to include this parameter. Also included the appropriate validations and test to make sure we always submit the values specified by Apptize themselves.

### Testing Steps
Running `bundle exec rspec ./fastlane/spec/actions_specs/appetize_spec.rb ` will result in green tests.
