### PR TITLE
[action] - cocoapods - add allow_root option

### DIFF
--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -20,8 +20,8 @@ module Fastlane
 
         cmd << '--no-clean' unless params[:clean]
         cmd << '--no-integrate' unless params[:integrate]
-        cmd << '--clean-install' if params[:clean_install] && pod_version(params).to_f >= 1.7
-        cmd << '--allow-root' if params[:allow_root] && pod_version(params).to_f >= 1.10
+        cmd << '--clean-install' if params[:clean_install] && pod_version_at_least("1.7", params)
+        cmd << '--allow-root' if params[:allow_root] && pod_version_at_least("1.10", params)
         cmd << '--repo-update' if params[:repo_update]
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]
@@ -46,6 +46,11 @@ module Fastlane
 
       def self.pod_version(params)
         use_bundle_exec?(params) ? `bundle exec pod --version` : `pod --version`
+      end
+
+      def self.pod_version_at_least(at_least_version, params)
+        version = pod_version(params)
+        return Gem::Version.new(version) >= Gem::Version.new(at_least_version)
       end
 
       def self.call_error_callback(params, result)

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -20,6 +20,7 @@ module Fastlane
         cmd << '--no-clean' unless params[:clean]
         cmd << '--no-integrate' unless params[:integrate]
         cmd << '--clean-install' if params[:clean_install] && pod_version(params).to_f >= 1.7
+        cmd << '--allow-root' if params[:allow_root] && pod_version(params).to_f >= 1.10
         cmd << '--repo-update' if params[:repo_update]
         cmd << '--silent' if params[:silent]
         cmd << '--verbose' if params[:verbose]
@@ -120,6 +121,13 @@ module Fastlane
                                        is_string: false,
                                        default_value: false,
                                        type: Boolean),
+           FastlaneCore::ConfigItem.new(key: :allow_root,
+                                        env_name: "FL_COCOAPODS_ALLOW_ROOT",
+                                        description: 'Allows CocoaPods to run as root',
+                                        optional: true,
+                                        is_string: false,
+                                        default_value: false,
+                                        type: Boolean),
 
           # Deprecated
           FastlaneCore::ConfigItem.new(key: :clean,

--- a/fastlane/lib/fastlane/actions/cocoapods.rb
+++ b/fastlane/lib/fastlane/actions/cocoapods.rb
@@ -1,6 +1,7 @@
 module Fastlane
   module Actions
     class CocoapodsAction < Action
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         Actions.verify_gem!('cocoapods')
         cmd = []
@@ -121,13 +122,13 @@ module Fastlane
                                        is_string: false,
                                        default_value: false,
                                        type: Boolean),
-           FastlaneCore::ConfigItem.new(key: :allow_root,
-                                        env_name: "FL_COCOAPODS_ALLOW_ROOT",
-                                        description: 'Allows CocoaPods to run as root',
-                                        optional: true,
-                                        is_string: false,
-                                        default_value: false,
-                                        type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :allow_root,
+                                       env_name: "FL_COCOAPODS_ALLOW_ROOT",
+                                       description: 'Allows CocoaPods to run as root',
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: false,
+                                       type: Boolean),
 
           # Deprecated
           FastlaneCore::ConfigItem.new(key: :clean,

--- a/fastlane/spec/actions_specs/cocoapods_spec.rb
+++ b/fastlane/spec/actions_specs/cocoapods_spec.rb
@@ -63,6 +63,18 @@ describe Fastlane do
         expect(result).to eq("bundle exec pod install --clean-install")
       end
 
+      it "add allow_root to command if allow_root is set to true, and  pod version is 1.10 and over" do
+        allow(Fastlane::Actions::CocoapodsAction).to receive(:pod_version).and_return('1.10')
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          cocoapods(
+            allow_root: true
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod install --allow-root")
+      end
+
       it "does not add clean_install to command if clean_install is set to true, and pod version is less than 1.7" do
         allow(Fastlane::Actions::CocoapodsAction).to receive(:pod_version).and_return('1.6')
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

CocoaPods has --allow-root option since version 1.10.
I also added the option to CocoapodsAction.

https://github.com/CocoaPods/CocoaPods/releases
https://github.com/CocoaPods/CocoaPods/issues/8929

