### PR TITLE
[action] carthage - add archive option

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -33,7 +33,7 @@ module Fastlane
         cmd << "--cache-builds" if params[:cache_builds]
         cmd << "--new-resolver" if params[:new_resolver]
         cmd << "--log-path #{params[:log_path]}" if params[:log_path]
-        cmd << "--archive #{params[:archive]}" if params[:archive]
+        cmd << "--archive" if params[:archive]
 
         Actions.sh(cmd.join(' '))
       end

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -33,6 +33,7 @@ module Fastlane
         cmd << "--cache-builds" if params[:cache_builds]
         cmd << "--new-resolver" if params[:new_resolver]
         cmd << "--log-path #{params[:log_path]}" if params[:log_path]
+        cmd << "--archive #{params[:archive]}" if params[:archive]
 
         Actions.sh(cmd.join(' '))
       end
@@ -49,6 +50,10 @@ module Fastlane
 
         if params[:log_path] && !%w(build bootstrap update).include?(command_name)
           UI.user_error!("Log path option is available only for 'build', 'bootstrap', and 'update' command.")
+        end
+
+        if command_name != "build" && params[:archive]
+          UI.user_error!("Archive option is available only for 'build' command.")
         end
       end
 
@@ -183,6 +188,11 @@ module Fastlane
                                        env_name: "FL_CARTHAGE_LOG_PATH",
                                        description: "Path to the xcode build output",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :archive,
+                                       env_name: "FL_CARTHAGE_ARCHIVE",
+                                       description: "Archive built frameworks from the current project",
+                                       is_string: false,
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :executable,
                                        env_name: "FL_CARTHAGE_EXECUTABLE",
                                        description: "Path to the `carthage` executable on your machine",

--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -192,6 +192,7 @@ module Fastlane
                                        env_name: "FL_CARTHAGE_ARCHIVE",
                                        description: "Archive built frameworks from the current project",
                                        is_string: false,
+                                       type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :executable,
                                        env_name: "FL_CARTHAGE_EXECUTABLE",

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -349,6 +349,28 @@ describe Fastlane do
         expect(result).to eq("carthage bootstrap --cache-builds")
       end
 
+      it "does not add a archive flag to command if archive is set to false" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'build',
+              archive: false
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage build")
+      end
+
+      it "add a archive flag to command if archive is set to true" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+            carthage(
+              command: 'build',
+              archive: true
+            )
+          end").runner.execute(:test)
+
+        expect(result).to eq("carthage build --archive")
+      end
+
       it "does not set the project directory if none is provided" do
         result = Fastlane::FastFile.new.parse("lane :test do
           carthage
@@ -663,6 +685,55 @@ describe Fastlane do
               end").runner.execute(:test)
               expect(result).to eq("carthage archive")
             end
+          end
+        end
+      end
+
+      context "when specify archive" do
+        context "when command is archive" do
+          let(:command) { 'archive' }
+
+          it "raises an exception" do
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                  carthage(command: '#{command}', archive: true)
+                end").runner.execute(:test)
+            end.to raise_error("Archive option is available only for 'build' command.")
+          end
+        end
+
+        context "when command is update" do
+          let(:command) { 'update' }
+
+          it "raises an exception" do
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                  carthage(command: '#{command}', archive: true)
+                end").runner.execute(:test)
+            end.to raise_error("Archive option is available only for 'build' command.")
+          end
+        end
+
+        context "when command is build" do
+          let(:command) { 'build' }
+
+          it "adds the archive option" do
+            result = Fastlane::FastFile.new.parse("lane :test do
+                carthage(command: '#{command}', archive: true)
+              end").runner.execute(:test)
+            expect(result).to eq("carthage build --archive")
+          end
+        end
+
+        context "when command is bootstrap" do
+          let(:command) { 'bootstrap' }
+
+          it "raises an exception" do
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                  carthage(command: '#{command}', archive: true)
+                end").runner.execute(:test)
+            end.to raise_error("Archive option is available only for 'build' command.")
           end
         end
       end

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -690,30 +690,6 @@ describe Fastlane do
       end
 
       context "when specify archive" do
-        context "when command is archive" do
-          let(:command) { 'archive' }
-
-          it "raises an exception" do
-            expect do
-              Fastlane::FastFile.new.parse("lane :test do
-                  carthage(command: '#{command}', archive: true)
-                end").runner.execute(:test)
-            end.to raise_error("Archive option is available only for 'build' command.")
-          end
-        end
-
-        context "when command is update" do
-          let(:command) { 'update' }
-
-          it "raises an exception" do
-            expect do
-              Fastlane::FastFile.new.parse("lane :test do
-                  carthage(command: '#{command}', archive: true)
-                end").runner.execute(:test)
-            end.to raise_error("Archive option is available only for 'build' command.")
-          end
-        end
-
         context "when command is build" do
           let(:command) { 'build' }
 
@@ -725,15 +701,15 @@ describe Fastlane do
           end
         end
 
-        context "when command is bootstrap" do
-          let(:command) { 'bootstrap' }
-
+        context "when archive option is present with invalid command" do
           it "raises an exception" do
-            expect do
-              Fastlane::FastFile.new.parse("lane :test do
-                  carthage(command: '#{command}', archive: true)
-                end").runner.execute(:test)
-            end.to raise_error("Archive option is available only for 'build' command.")
+            ['archive', 'update', 'bootstrap'].each do |command|
+              expect do
+                Fastlane::FastFile.new.parse("lane :test do
+                    carthage(command: '#{command}', archive: true)
+                  end").runner.execute(:test)
+              end.to raise_error("Archive option is available only for 'build' command.")
+            end
           end
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carthage has archive option for build command.
So, I also added the option to CarthageAction.

```
❯ carthage help build
Build the project's dependencies

[--configuration (string)]
	the Xcode configuration to build

...

[--archive]
	archive built frameworks from the current project (implies --no-skip-current)

...
```
