### PR TITLE
[fastlane_core] improve config item validation conversion and use UI.error instead of puts to report validation exception

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -243,6 +243,12 @@ module FastlaneCore
       while value.nil?
         UI.important("To not be asked about this value, you can specify it using '#{option.key}'") if ENV["FASTLANE_ONBOARDING_IN_PROCESS"].to_s.length == 0
         value = option.sensitive ? UI.password("#{option.description}: ") : UI.input("#{option.description}: ")
+
+        # ConfigItem allows to specify a type for the item but UI.password and
+        # UI.input return String values. Try to convert the String input to
+        # the option's type before passing it along.
+        value = option.auto_convert_value(value)
+
         # Also store this value to use it from now on
         begin
           set(key, value)

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -247,7 +247,7 @@ module FastlaneCore
         begin
           set(key, value)
         rescue => ex
-          puts(ex)
+          UI.error(ex)
           value = nil
         end
       end

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -718,14 +718,24 @@ describe FastlaneCore do
               expect(config[:item]).to eq(123)
             end
 
-            # It would be good to have a test for the scenario where the user
-            # inserts a value that doesn't match the expected type to verify
-            # we show an error. Unfortunately, because after showing the error
-            # we ask for the value again, we'd be stuck into an infinite loop
-            # in the tests.
-            #
-            # Note that using `.to receive(:input).once` like above is not an
-            # option because that would fail the test in this case.
+            it "shows an error after user inputs value that doesn't match type (the first time) and works the second time" do
+              config_item = FastlaneCore::ConfigItem.new(key: :item,
+                                                         short_option: "-i",
+                                                         env_name: "ITEM_ENV_VAR",
+                                                         description: "a description",
+                                                         is_string: false,
+                                                         type: Integer,
+                                                         # false is the default, but let's be explicit
+                                                         skip_type_validation: false)
+              config = FastlaneCore::Configuration.create([config_item], {})
+
+              config.set(:item, nil)
+              expect(FastlaneCore::UI).to receive(:input).once.and_return("123abc")
+              expect(FastlaneCore::UI).to receive(:input).once.and_return("123")
+              expect(FastlaneCore::UI).to(receive(:error)).once
+              expect(config[:item].class).to eq(Integer)
+              expect(config[:item]).to eq(123)
+            end
 
             it "doesn't show an error when skipping type validation" do
               # Taken from match/options.rb


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

At [Automattic](https://automattic.com), we use Fastlane to automate the release process for our mobile app 💪 ✨ We built [a suite of custom actions](github.com/wordpress-mobile/release-toolkit) to help us with that.

While running one of our actions, I passed a string to the interactive prompt for a parameter that was supposed to only ever be an integer. I was happy to see that Fastlane allows to specify the type of the parameters 😍 I went and changed the type from `String` to `Integer` but when I tried to verify my fix, Fastlane kept telling me that my `123` input wasn't an `Integer`.

To recap, if you build a custom action and configure a parameter like:

```ruby
FastlaneCore::ConfigItem.new(
  key: :int_param,
  env_name: "INTEGER_PARAM_DEMO_YOUR_OPTION",
  description: "A non optional Integer parameter",
  optional: false,
  type: Integer
)
```

When you run your action without passing the value at the call-site (i.e. `bundle exec fastlane run my_action` instead of `bundle exec fastlane run my_action int_param:123`) and Fastlane prompts you for the value, even if you pass a correct value (in the case of `type: Integer`, you type only digits), Fastlane will consider the input a `String` and ask you to pass it again.

```
➜ bf run integer_param_demo
[✔] 🚀
+------------------------------------+---------+--------------------+
|                           Used plugins                            |
+------------------------------------+---------+--------------------+
| Plugin                             | Version | Action             |
+------------------------------------+---------+--------------------+
| fastlane-plugin-integer_param_demo | 0.1.0   | integer_param_demo |
+------------------------------------+---------+--------------------+

[15:08:09]: --------------------------------
[15:08:09]: --- Step: integer_param_demo ---
[15:08:09]: --------------------------------
[15:08:09]: To not be asked about this value, you can specify it using 'int_param'
[15:08:09]: A non optional Integer parameter: 123
'int_param' value must be a Integer! Found String instead.
[15:08:15]: To not be asked about this value, you can specify it using 'int_param'
[15:08:15]: A non optional Integer parameter:
```

I reproduced the issue in [this isolated repository](https://github.com/mokagio/fastlane_plugin_test/). There are detailed instructions on how to install and reproduce in the README and a PR that points Fastlane to this fix to show its effectiveness.

### Description

To ensure that parameters provided via UI input are converted to their desired `type`, I added a call to `auto_convert_value` after reading the user input. More details in the inline comments.

### Testing Steps

Please refer to in the demo repo. I also added a unit test for this.
