### PR TITLE
[carthage] Add xcode_warnings option

### DIFF
--- a/fastlane/lib/fastlane/actions/carthage.rb
+++ b/fastlane/lib/fastlane/actions/carthage.rb
@@ -33,6 +33,7 @@ module Fastlane
         cmd << "--cache-builds" if params[:cache_builds]
         cmd << "--new-resolver" if params[:new_resolver]
         cmd << "--log-path #{params[:log_path]}" if params[:log_path]
+        cmd << "--xcode-warnings" if params[:xcode_warnings]
 
         Actions.sh(cmd.join(' '))
       end
@@ -49,6 +50,10 @@ module Fastlane
 
         if params[:log_path] && !%w(build bootstrap update).include?(command_name)
           UI.user_error!("Log path option is available only for 'build', 'bootstrap', and 'update' command.")
+        end
+
+        if command_name != "outdated" && params[:xcode_warnings]
+          UI.user_error!("Xcode warnings option is available only for 'outdated' command.")
         end
       end
 
@@ -183,6 +188,12 @@ module Fastlane
                                        env_name: "FL_CARTHAGE_LOG_PATH",
                                        description: "Path to the xcode build output",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :xcode_warnings,
+                                       env_name: "FL_CARTHAGE_XCODE_WARNINGS",
+                                       description: "Output Xcode compatible warning messages",
+                                       is_string: false,
+                                       type: Boolean,
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :executable,
                                        env_name: "FL_CARTHAGE_EXECUTABLE",
                                        description: "Path to the `carthage` executable on your machine",

--- a/fastlane/spec/actions_specs/carthage_spec.rb
+++ b/fastlane/spec/actions_specs/carthage_spec.rb
@@ -708,7 +708,7 @@ describe Fastlane do
                 Fastlane::FastFile.new.parse("lane :test do
                     carthage(command: '#{command}', archive: true)
                   end").runner.execute(:test)
-              end.to raise_error("Archive option is available only for 'build' command.")
+              end.to raise_error("Xcode warnings option is available only for 'outdated' command.")
             end
           end
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Carthage has xcode warnings option for outdated command.
So, I also added the option to CarthageAction.
