### PR TITLE
[spaceship] Explicitly allow to continue 2FA in non-interactive mode

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -4,7 +4,7 @@ require_relative 'tunes/tunes_client'
 module Spaceship
   class Client
     def handle_two_step_or_factor(response)
-      raise "2FA can only be performed in interactive mode" if ENV["FASTLANE_IS_INTERACTIVE"] == "false" && ENV["SPACESHIP_ALLOW_NON_INTERACTIVE_2FA"] != "true"
+      raise "2FA can only be performed in interactive mode" if ENV["SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA"] == "true" && ENV["FASTLANE_IS_INTERACTIVE"] == "false"
       # extract `x-apple-id-session-id` and `scnt` from response, to be used by `update_request_headers`
       @x_apple_id_session_id = response["x-apple-id-session-id"]
       @scnt = response["scnt"]

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -4,7 +4,7 @@ require_relative 'tunes/tunes_client'
 module Spaceship
   class Client
     def handle_two_step_or_factor(response)
-      raise "2FA can only be performed in interactive mode" if ENV["FASTLANE_IS_INTERACTIVE"] == "false"
+      raise "2FA can only be performed in interactive mode" if ENV["FASTLANE_IS_INTERACTIVE"] == "false" && ENV["SPACESHIP_ALLOW_NON_INTERACTIVE_2FA"] != "true"
       # extract `x-apple-id-session-id` and `scnt` from response, to be used by `update_request_headers`
       @x_apple_id_session_id = response["x-apple-id-session-id"]
       @scnt = response["scnt"]

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -77,6 +77,17 @@ describe Spaceship::Client do
       end
     end
 
+    context 'when running non-interactive and force 2FA to continue' do
+      it 'raises an error' do
+        ENV["FASTLANE_IS_INTERACTIVE"] = "false"
+        ENV["SPACESHIP_ALLOW_NON_INTERACTIVE_2FA"] = "true"
+        expect(subject).to receive(:handle_two_factor)
+        stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
+        subject.handle_two_step_or_factor("response")
+        ENV.delete('SPACESHIP_ALLOW_NON_INTERACTIVE_2FA')
+      end
+    end
+
     context 'when running interactive' do
       it 'does not raise an error' do
         ENV["FASTLANE_IS_INTERACTIVE"] = "true"


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves: https://github.com/fastlane/fastlane/issues/18094
### Description
Add an opportunity to explicitly allow running 2FA in non-interactive mode.
Updated documentation https://github.com/fastlane/docs/pull/1019

### Testing Steps
run in non-interactive mode
```
$ export SPACESHIP_ALLOW_NON_INTERACTIVE_2FA='true'
$ bundle exec fastlane spaceauth
```