### PR TITLE
[spaceship] opt-in to skipping 2FA upgrade with SPACESHIP_SKIP_2FA_UPGRADE=1

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -516,9 +516,9 @@ module Spaceship
 
           # Need to acknowledge Apple ID and Privacy statement - https://github.com/fastlane/fastlane/issues/12577
           # Looking for status of 412 might be enough but might be safer to keep looking only at what is being reported
-          raise AppleIDAndPrivacyAcknowledgementNeeded.new, "Need to acknowledge to Apple's Apple ID and Privacy statement." \
+          raise AppleIDAndPrivacyAcknowledgementNeeded.new, "Need to acknowledge to Apple's Apple ID and Privacy statement. " \
                                                             "Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement. " \
-                                                            "Your account might also be asked to upgrade to 2FA." \
+                                                            "Your account might also be asked to upgrade to 2FA. " \
                                                             "Set SPACESHIP_SKIP_2FA_UPGRADE=1 for fastlane to automaticaly bypass 2FA upgrade if possible."
         elsif (response['Set-Cookie'] || "").include?("itctx")
           raise "Looks like your Apple ID is not enabled for App Store Connect, make sure to be able to login online"

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -403,6 +403,7 @@ module Spaceship
     # This will also handle 2 step verification and 2 factor authentication
     #
     # It is called in `send_login_request` of sub classes (which the method `login`, above, transferred over to via `do_login`)
+    # rubocop:disable Metrics/PerceivedComplexity
     def send_shared_login_request(user, password)
       # Check if we have a cached/valid session
       #
@@ -506,9 +507,19 @@ module Spaceship
           # User Credentials are wrong
           raise InvalidUserCredentialsError.new, "Invalid username and password combination. Used '#{user}' as the username."
         elsif response.status == 412 && AUTH_TYPES.include?(response.body["authType"])
+
+          if try_upgrade_2fa_later(response)
+            store_cookie
+            fetch_olympus_session
+            return true
+          end
+
           # Need to acknowledge Apple ID and Privacy statement - https://github.com/fastlane/fastlane/issues/12577
           # Looking for status of 412 might be enough but might be safer to keep looking only at what is being reported
-          raise AppleIDAndPrivacyAcknowledgementNeeded.new, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement."
+          raise AppleIDAndPrivacyAcknowledgementNeeded.new, "Need to acknowledge to Apple's Apple ID and Privacy statement." \
+                                                            "Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement. " \
+                                                            "Your account might also be asked to upgrade to 2FA." \
+                                                            "Set SPACESHIP_SKIP_2FA_UPGRADE=1 for fastlane to automaticaly bypass 2FA upgrade if possible."
         elsif (response['Set-Cookie'] || "").include?("itctx")
           raise "Looks like your Apple ID is not enabled for App Store Connect, make sure to be able to login online"
         else
@@ -517,6 +528,7 @@ module Spaceship
         end
       end
     end
+    # rubocop:enable Metrics/PerceivedComplexity
 
     # Get the `itctx` from the new (22nd May 2017) API endpoint "olympus"
     # Update (29th March 2019) olympus migrates to new appstoreconnect API
@@ -925,3 +937,4 @@ module Spaceship
 end
 
 require 'spaceship/two_step_or_factor_client'
+require 'spaceship/upgrade_2fa_later_client'

--- a/spaceship/lib/spaceship/upgrade_2fa_later_client.rb
+++ b/spaceship/lib/spaceship/upgrade_2fa_later_client.rb
@@ -1,0 +1,91 @@
+require_relative 'globals'
+require_relative 'tunes/tunes_client'
+
+module Spaceship
+  class Client
+    def try_upgrade_2fa_later(response)
+      if ENV['SPACESHIP_SKIP_2FA_UPGRADE'].nil?
+        puts("Skipping automatic bypass of 2FA upgrade")
+        return false
+      end
+
+      puts("This account is being prompted to upgrade to 2FA")
+      puts("Attempting to automatically bypass the upgrade until a later date")
+      puts("To disable this, remove SPACESHIP_SKIP_2FA_UPGRADE=1 environment variable")
+
+      # Get URL that requests a repair and gets the widget key
+      widget_key_location = response.headers['location']
+      uri    = URI.parse(widget_key_location)
+      params = CGI.parse(uri.query)
+
+      widget_key = (params['widgetKey'] || []).first
+      if widget_key.nil?
+        STDERR.puts("Couldn't find widgetKey to continue with requests")
+        return false
+      end
+
+      # Step 1 - Request repair
+      response_repair = request(:get) do |req|
+        req.url(widget_key_location)
+      end
+
+      # Step 2 - Request repair options
+      response_repair_options = request(:get) do |req|
+        req.url("https://appleid.apple.com/account/manage/repair/options")
+
+        req.headers['scnt'] = response_repair.headers['scnt']
+        req.headers['X-Apple-Id-Session-Id'] = response.headers['X-Apple-Id-Session-Id']
+        req.headers['X-Apple-Session-Token'] = response.headers['X-Apple-Repair-Session-Token']
+
+        req.headers['X-Apple-Skip-Repair-Attributes'] = '[]'
+        req.headers['X-Apple-Widget-Key'] = widget_key
+
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['X-Requested-With'] = 'XMLHttpRequest'
+        req.headers['Accept'] = 'application/json, text/javascript'
+      end
+
+      # Step 3 - Request setup later
+      request(:get) do |req|
+        req.url("https://appleid.apple.com/account/security/upgrade/setuplater")
+
+        req.headers['scnt'] = response.headers['scnt']
+        req.headers['X-Apple-Id-Session-Id'] = response.headers['X-Apple-Id-Session-Id']
+        req.headers['X-Apple-Session-Token'] = response_repair_options.headers['x-apple-session-token']
+        req.headers['X-Apple-Skip-Repair-Attributes'] = '[]'
+        req.headers['X-Apple-Widget-Key'] = widget_key
+
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['X-Requested-With'] = 'XMLHttpRequest'
+        req.headers['Accept'] = 'application/json, text/javascript'
+      end
+
+      # Step 4 - Post complete
+      response_repair_complete = request(:post) do |req|
+        req.url("https://idmsa.apple.com/appleauth/auth/repair/complete")
+
+        req.body = ''
+        req.headers['scnt'] = response.headers['scnt']
+        req.headers['X-Apple-Id-Session-Id'] = response.headers['X-Apple-Id-Session-Id']
+        req.headers['X-Apple-Repair-Session-Token'] = response_repair_options.headers['X-Apple-Session-Token']
+
+        req.headers['X-Apple-Widget-Key'] = widget_key
+
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['X-Requested-With'] = 'XMLHttpRequest'
+        req.headers['Accept'] = 'application/json;charset=utf-8'
+      end
+
+      if response_repair_complete.status == 204
+        return true
+      else
+        return false
+      end
+    rescue => error
+      STDERR.puts(error.backtrace)
+      STDERR.puts("Failed to bypass 2FA upgrade")
+      STDERR.puts("To disable this from trying again, set SPACESHIP_SKIP_UPGRADE_2FA_LATER=1")
+      return false
+    end
+  end
+end

--- a/spaceship/lib/spaceship/upgrade_2fa_later_client.rb
+++ b/spaceship/lib/spaceship/upgrade_2fa_later_client.rb
@@ -18,7 +18,7 @@ module Spaceship
       uri    = URI.parse(widget_key_location)
       params = CGI.parse(uri.query)
 
-      widget_key = (params['widgetKey'] || []).first
+      widget_key = params.dig('widgetKey', 0)
       if widget_key.nil?
         STDERR.puts("Couldn't find widgetKey to continue with requests")
         return false
@@ -49,7 +49,7 @@ module Spaceship
       request(:get) do |req|
         req.url("https://appleid.apple.com/account/security/upgrade/setuplater")
 
-        req.headers['scnt'] = response.headers['scnt']
+        req.headers['scnt'] = response_repair_options.headers['scnt']
         req.headers['X-Apple-Id-Session-Id'] = response.headers['X-Apple-Id-Session-Id']
         req.headers['X-Apple-Session-Token'] = response_repair_options.headers['x-apple-session-token']
         req.headers['X-Apple-Skip-Repair-Attributes'] = '[]'

--- a/spaceship/lib/spaceship/upgrade_2fa_later_client.rb
+++ b/spaceship/lib/spaceship/upgrade_2fa_later_client.rb
@@ -5,7 +5,6 @@ module Spaceship
   class Client
     def try_upgrade_2fa_later(response)
       if ENV['SPACESHIP_SKIP_2FA_UPGRADE'].nil?
-        puts("Skipping automatic bypass of 2FA upgrade")
         return false
       end
 
@@ -79,6 +78,7 @@ module Spaceship
       if response_repair_complete.status == 204
         return true
       else
+        STDERR.puts("Failed with status code of #{response_repair_complete.status}")
         return false
       end
     rescue => error

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -30,7 +30,8 @@ describe Spaceship::TunesClient do
 
       expect do
         Spaceship::Tunes.login(username, password)
-      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement.")
+      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement. " \
+                             "Your account might also be asked to upgrade to 2FA. Set SPACESHIP_SKIP_2FA_UPGRADE=1 for fastlane to automaticaly bypass 2FA upgrade if possible.")
     end
 
     it 'has authType of hsa' do
@@ -41,7 +42,8 @@ describe Spaceship::TunesClient do
 
       expect do
         Spaceship::Tunes.login(username, password)
-      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement.")
+      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement. " \
+                             "Your account might also be asked to upgrade to 2FA. Set SPACESHIP_SKIP_2FA_UPGRADE=1 for fastlane to automaticaly bypass 2FA upgrade if possible.")
     end
 
     it 'has authType of non-sa' do
@@ -52,7 +54,8 @@ describe Spaceship::TunesClient do
 
       expect do
         Spaceship::Tunes.login(username, password)
-      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement.")
+      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement. " \
+                             "Your account might also be asked to upgrade to 2FA. Set SPACESHIP_SKIP_2FA_UPGRADE=1 for fastlane to automaticaly bypass 2FA upgrade if possible.")
     end
 
     it 'has authType of hsa2' do
@@ -63,7 +66,8 @@ describe Spaceship::TunesClient do
 
       expect do
         Spaceship::Tunes.login(username, password)
-      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement.")
+      end.to raise_exception(Spaceship::AppleIDAndPrivacyAcknowledgementNeeded, "Need to acknowledge to Apple's Apple ID and Privacy statement. Please manually log into https://appleid.apple.com (or https://appstoreconnect.apple.com) to acknowledge the statement. " \
+                             "Your account might also be asked to upgrade to 2FA. Set SPACESHIP_SKIP_2FA_UPGRADE=1 for fastlane to automaticaly bypass 2FA upgrade if possible.")
     end
   end
 


### PR DESCRIPTION
### Motivation and Context
Fixes #18098
Spaceship Apple ID login fails due to Apple ID prompting to be upgraded to 2FA. 

### Description
Web allows Apple ID login to skip the upgrade but requires a handful of requests to tell the session that this will be skipped. Attempts to do this on a 412 status code if `SPACESHIP_SKIP_2FA_UPGRADE=1` is set.

⚠️ This _may_ not work into the future when 2FA is hard forced on everyone

#### Steps
Below are the steps that are done to skip the 2FA upgrade. This was all done with trial and error and matching up request and response headers from web inspector 😇 

1. Get widget key - From `location` header from signing request
2 Gets repair options - https://appleid.apple.com/account/manage/repair/options
3. Do upgrade later - https://appleid.apple.com/account/security/upgrade/setuplater
4. Post complete - https://idmsa.apple.com/appleauth/auth/repair/complete
5. Store cookie
6. Fetch olympus session

### Testing Steps
Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-skip-2fa-upgrade"
```
