### PR TITLE
[spaceship] expose error also from source

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -247,8 +247,23 @@ module Spaceship
         # ]
         # }
 
+        # Detail is missing in this response making debugging super hard
+        # {"errors" =>
+        #   [
+        #     {
+        #       "id"=>"80ea6cff-0043-4543-9cd1-3e26b0fce383",
+        #       "status"=>"409",
+        #       "code"=>"ENTITY_ERROR.RELATIONSHIP.INVALID",
+        #       "title"=>"The provided entity includes a relationship with an invalid value",
+        #       "source"=>{
+        #         "pointer"=>"/data/relationships/primarySubcategoryOne"
+        #       }
+        #     }
+        #   ]
+        # }
+
         return response.body['errors'].map do |error|
-          messages = [[error['title'], error['detail']].compact.join(" - ")]
+          messages = [[error['title'], error['detail'], error.dig("source", "pointer")].compact.join(" - ")]
 
           meta = error["meta"] || {}
           associated_errors = meta["associatedErrors"] || {}


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Primary first sub category inside metadata txt file looks like had typo and error
provided to developers was confusing since error was missing an important
attribute detail but source -> pointer had at least showing where the issue was.

<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
