### PR TITLE
[pilot] fix default value of `demo_account_required` to nil instead of false

### DIFF
--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -88,7 +88,7 @@ module Pilot
                                      type: Boolean,
                                      env_name: "DEMO_ACCOUNT_REQUIRED",
                                      description: "Do you need a demo account when Apple does review?",
-                                     default_value: false),
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :beta_app_review_info,
                                      type: Hash,
                                      env_name: "PILOT_BETA_APP_REVIEW_INFO",

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -425,6 +425,40 @@ describe "Build Manager" do
     end
   end
 
+  describe "#update_beta_app_meta" do
+    let(:fake_build_manager) { Pilot::BuildManager.new }
+    let(:fake_build) { double("fake build") }
+
+    it "does not attempt to set demo account required" do
+      options = {}
+
+      expect(fake_build_manager).to receive(:update_build_beta_details)
+      fake_build_manager.update_beta_app_meta(options, fake_build)
+    end
+
+    it "sets demo account required to false" do
+      options = { demo_account_required: false }
+
+      expect(fake_build_manager).to receive(:update_review_detail)
+      expect(fake_build_manager).to receive(:update_build_beta_details)
+
+      fake_build_manager.update_beta_app_meta(options, fake_build)
+
+      expect(options[:beta_app_review_info][:demo_account_required]).to be(false)
+    end
+
+    it "sets demo account required to true" do
+      options = { demo_account_required: true }
+
+      expect(fake_build_manager).to receive(:update_review_detail)
+      expect(fake_build_manager).to receive(:update_build_beta_details)
+
+      fake_build_manager.update_beta_app_meta(options, fake_build)
+
+      expect(options[:beta_app_review_info][:demo_account_required]).to be(true)
+    end
+  end
+
   describe "#upload" do
     describe "uses Manager.login (which does spaceship login)" do
       let(:fake_build_manager) { Pilot::BuildManager.new }


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
As discussed in #17910 pilot seems to be unable to work with an api_key with just the Developer permissions, needing App Manager permissions instead. However, it should work with the Developer permissions if no distribution of the uploaded binary is performed. This is the first in a series of patches.

### Description
The `demo_account_required` has a default value of `false` but then on the code that chacks for its presence https://github.com/fastlane/fastlane/blob/832e3e4a19d9cff5d5a14a61e9614b5659327427/pilot/lib/pilot/build_manager.rb#L217 it performs a null check that always evaluates to true (`false` is not `nil`) and that causes an API call that needs the said App Manager permissions. 

With this patch, I propose that option be made optional (and thus nil if not set) so that only when an explicit value is set, the API call is performed, avoiding the need for App Manager permissions.

### Testing Steps
Before: If the option was not set, the `false` default would also trigger an API call
Now: If the option is not set, the `nil` value will prevent an API call.
