### PR TITLE
[fastlane_core] env_names - new config item option

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -21,7 +21,7 @@ module Deliver
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "DELIVER_API_KEY",
+                                     env_names: ["DELIVER_API_KEY", "FASTLANE_API_KEY"],
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -21,7 +21,7 @@ module Deliver
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_names: ["DELIVER_API_KEY", "FASTLANE_API_KEY"],
+                                     env_name: "DELIVER_API_KEY",
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/fastlane/lib/fastlane/documentation/actions_list.rb
+++ b/fastlane/lib/fastlane/documentation/actions_list.rb
@@ -135,7 +135,7 @@ module Fastlane
       if options
         puts(Terminal::Table.new(
                title: "#{name} Options".green,
-               headings: ['Key', 'Description', 'Env Var', 'Default'],
+               headings: ['Key', 'Description', 'Env Var(s)', 'Default'],
                rows: FastlaneCore::PrintTable.transform_output(options)
         ))
       else
@@ -197,7 +197,7 @@ module Fastlane
       if options.kind_of?(Array)
         options.each do |current|
           if current.kind_of?(FastlaneCore::ConfigItem)
-            rows << [current.key.to_s.yellow, current.deprecated ? current.description.red : current.description, current.env_name, current.help_default_value]
+            rows << [current.key.to_s.yellow, current.deprecated ? current.description.red : current.description, current.env_names.join(", "), current.help_default_value]
           elsif current.kind_of?(Array)
             # Legacy actions that don't use the new config manager
             UI.user_error!("Invalid number of elements in this row: #{current}. Must be 2 or 3") unless [2, 3].include?(current.count)

--- a/fastlane/swift/formatting/Brewfile.lock.json
+++ b/fastlane/swift/formatting/Brewfile.lock.json
@@ -31,9 +31,9 @@
   "system": {
     "macos": {
       "catalina": {
-        "HOMEBREW_VERSION": "3.0.0-57-g59dd425",
+        "HOMEBREW_VERSION": "3.0.0-59-g4695220",
         "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "637196b33ecd885dc057c16fc5cb652a4561f632",
+        "Homebrew/homebrew-core": "7fd600e6644b774e47e12b13ba1ccf2f2ede6c67",
         "CLT": "11.0.33.12",
         "Xcode": "12.2",
         "macOS": "10.15.7"

--- a/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb
@@ -67,7 +67,7 @@ module FastlaneCore
         long_switch = "--#{option.key} #{value_appendix}"
 
         description = option.description
-        description += " (#{option.env_name})" unless option.env_name.to_s.empty?
+        description += " (#{option.env_names.join(', ')})" unless option.env_names.empty?
 
         # We compact this array here to remove the short_switch variable if it is nil.
         # Passing a nil value to global_option has been shown to create problems with

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -12,6 +12,9 @@ module FastlaneCore
     # [String] the name of the environment variable, which is only used if no other values were found
     attr_accessor :env_name
 
+    # [Array] the names of the environment variables, which is only used if no other values were found
+    attr_accessor :env_names
+
     # [String] A description shown to the user
     attr_accessor :description
 
@@ -71,6 +74,7 @@ module FastlaneCore
     # Creates a new option
     # @param key (Symbol) the key which is used as command parameters or key in the fastlane tools
     # @param env_name (String) the name of the environment variable, which is only used if no other values were found
+    # @param env_names (Array) the names of the environment variables, which is only used if no other values were found
     # @param description (String) A description shown to the user
     # @param short_option (String) A string of length 1 which is used for the command parameters (e.g. -f)
     # @param default_value the value which is used if there was no given values and no environment values
@@ -88,8 +92,10 @@ module FastlaneCore
     # @param sensitive (Boolean) Set if the variable is sensitive, such as a password or API token, to prevent echoing when prompted for the parameter
     # @param display_in_shell (Boolean) Set if the variable can be used from shell
     # rubocop:disable Metrics/ParameterLists
+    # rubocop:disable Metrics/PerceivedComplexity
     def initialize(key: nil,
                    env_name: nil,
+                   env_names: nil,
                    description: nil,
                    short_option: nil,
                    default_value: nil,
@@ -108,6 +114,11 @@ module FastlaneCore
                    display_in_shell: true)
       UI.user_error!("key must be a symbol") unless key.kind_of?(Symbol)
       UI.user_error!("env_name must be a String") unless (env_name || '').kind_of?(String)
+
+      UI.user_error!("env_names must be an Array") unless (env_names || []).kind_of?(Array)
+      (env_names || []).each do |name|
+        UI.user_error!("env_names must only contain String") unless (name || '').kind_of?(String)
+      end
 
       if short_option
         UI.user_error!("short_option for key :#{key} must of type String") unless short_option.kind_of?(String)
@@ -138,6 +149,7 @@ module FastlaneCore
 
       @key = key
       @env_name = env_name
+      @env_names = env_names
       @description = description
       @short_option = short_option
       @default_value = default_value
@@ -160,6 +172,7 @@ module FastlaneCore
 
       update_code_gen_default_value_if_able!
     end
+    # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/ParameterLists
 
     # if code_gen_default_value is nil, use the default value if it isn't a `code_gen_sensitive` value
@@ -226,6 +239,18 @@ module FastlaneCore
       end
 
       true
+    end
+
+    def fetch_env_value
+      all_env_names = [env_name].compact + (env_names || [])
+
+      all_env_names.each do |name|
+        next if ENV[name].nil?
+        # verify! before using (see https://github.com/fastlane/fastlane/issues/14449)
+        return ENV[name].dup if verify!(auto_convert_value(ENV[name]))
+      end
+
+      return nil
     end
 
     # rubocop:disable Metrics/PerceivedComplexity

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -149,7 +149,7 @@ module FastlaneCore
 
       @key = key
       @env_name = env_name
-      @env_names = env_names
+      @env_names = [env_name].compact + (env_names || [])
       @description = description
       @short_option = short_option
       @default_value = default_value
@@ -242,9 +242,7 @@ module FastlaneCore
     end
 
     def fetch_env_value
-      all_env_names = [env_name].compact + (env_names || [])
-
-      all_env_names.each do |name|
+      env_names.each do |name|
         next if ENV[name].nil?
         # verify! before using (see https://github.com/fastlane/fastlane/issues/14449)
         return ENV[name].dup if verify!(auto_convert_value(ENV[name]))

--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -209,7 +209,6 @@ module FastlaneCore
 
     # Returns the value for a certain key. fastlane_core tries to fetch the value from different sources
     # if 'ask' is true and the value is not present, the user will be prompted to provide a value
-    # rubocop:disable Metrics/PerceivedComplexity
     def fetch(key, ask: true)
       UI.crash!("Key '#{key}' must be a symbol. Example :app_id.") unless key.kind_of?(Symbol)
 
@@ -218,9 +217,8 @@ module FastlaneCore
       # Same order as https://docs.fastlane.tools/advanced/#priorities-of-parameters-and-options
       value = if @values.key?(key) && !@values[key].nil?
                 @values[key]
-              elsif option.env_name && !ENV[option.env_name].nil?
-                # verify! before using (see https://github.com/fastlane/fastlane/issues/14449)
-                ENV[option.env_name].dup if option.verify!(option.auto_convert_value(ENV[option.env_name]))
+              elsif (env_value = option.fetch_env_value)
+                env_value
               elsif self.config_file_options.key?(key)
                 self.config_file_options[key]
               else

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -794,7 +794,7 @@ describe FastlaneCore do
             ENV.delete("abc")
           end
 
-          it "prioritizes ENV values after CLI" do
+          it "prioritizes env_name after CLI" do
             ENV["abc"] = "val env"
             config_item = FastlaneCore::ConfigItem.new(key: :item, env_name: "abc", default_value: "val default")
             config = FastlaneCore::Configuration.create([config_item], {})
@@ -804,8 +804,38 @@ describe FastlaneCore do
             ENV.delete("abc")
           end
 
-          it "prioritizes config file values after ENV" do
+          it "prioritizes env_names after CLI" do
+            ENV["abc"] = "val env"
+            config_item = FastlaneCore::ConfigItem.new(key: :item, env_names: ["abc"], default_value: "val default")
+            config = FastlaneCore::Configuration.create([config_item], {})
+            config.config_file_options = { item: "val config" }
+
+            expect(config[:item]).to eq("val env")
+            ENV.delete("abc")
+          end
+
+          it "prioritizes env_names after env_name" do
+            ENV["abc"] = "val env"
+            ENV["def"] = "val env wrong"
+            config_item = FastlaneCore::ConfigItem.new(key: :item, env_name: "abc", "env_names": ["def"], default_value: "val default")
+            config = FastlaneCore::Configuration.create([config_item], {})
+            config.config_file_options = { item: "val config" }
+
+            expect(config[:item]).to eq("val env")
+            ENV.delete("abc")
+            ENV.delete("def")
+          end
+
+          it "prioritizes config file values after env_name" do
             config_item = FastlaneCore::ConfigItem.new(key: :item, env_name: "abc", default_value: "val default")
+            config = FastlaneCore::Configuration.create([config_item], {})
+            config.config_file_options = { item: "val config" }
+
+            expect(config[:item]).to eq("val config")
+          end
+
+          it "prioritizes config file values after env_names" do
+            config_item = FastlaneCore::ConfigItem.new(key: :item, env_names: ["abc"], default_value: "val default")
             config = FastlaneCore::Configuration.create([config_item], {})
             config.config_file_options = { item: "val config" }
 


### PR DESCRIPTION
### Motivation and Context
This is the first PR for #18145 for consolidating the App Store Connect API Key across multiple tools/actions.
Currently, each tool/action has its own environment variable. This will allow one variable to be set an used by all.

There will be a follow up PR that will actually modify all the tools/actions with this new option

### Description
- Adds optional `env_names` option to `FastlaneCore::ConfigItem` 
- Moves fetching of `ENV` value from `FastlaneCore::Configuration` to `FastlaneCore::ConfigItem`
  - New `fetch_env_value` method first looks for `env_name` and then looks for `env_names`
- Updated action list to show all environment variables
- Updated command help to show all environment variables

#### Action List
![AF35996B-F14B-43F8-96B1-98014DDE5C3D](https://user-images.githubusercontent.com/401294/107516677-603d3580-6b72-11eb-9239-f40dda746a91.jpeg)

#### Command Help
![23EC166A-8484-46DA-8DE0-9A8FBAB1FEB9](https://user-images.githubusercontent.com/401294/107516685-616e6280-6b72-11eb-9bc6-acfed9b78885.jpeg)
