### PR TITLE
[app store connect] unified ENV vars for App Store Connect API Key

### DIFF
--- a/cert/lib/cert/options.rb
+++ b/cert/lib/cert/options.rb
@@ -38,7 +38,7 @@ module Cert
 
         # App Store Connect API
         FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                     env_name: "DELIVER_API_KEY_PATH",
+                                     env_names: ["CERT_API_KEY_PATH", "DELIVER_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:api_key],
@@ -46,7 +46,7 @@ module Cert
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "DELIVER_API_KEY",
+                                     env_names: ["CERT_API_KEY", "DELIVER_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -13,7 +13,7 @@ module Deliver
 
       [
         FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                     env_name: "DELIVER_API_KEY_PATH",
+                                     env_names: ["DELIVER_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:api_key],
@@ -21,7 +21,7 @@ module Deliver
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "DELIVER_API_KEY",
+                                     env_names: ["DELIVER_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -21,7 +21,7 @@ module Deliver
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "DELIVER_API_KEY",
+                                     env_names: ["DELIVER_API_KEY", "FASTLANE_API_KEY"],
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -21,7 +21,7 @@ module Deliver
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_names: ["DELIVER_API_KEY", "FASTLANE_API_KEY"],
+                                     env_name: "DELIVER_API_KEY",
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -118,7 +118,7 @@ module Fastlane
         user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
         [
           FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                       env_name: "APPSTORE_BUILD_NUMBER_API_KEY_PATH",
+                                       env_names: ["APPSTORE_BUILD_NUMBER_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                        description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                        optional: true,
                                        conflicting_options: [:api_key],
@@ -126,7 +126,7 @@ module Fastlane
                                          UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_key,
-                                       env_name: "APPSTORE_BUILD_NUMBER_API_KEY",
+                                       env_names: ["APPSTORE_BUILD_NUMBER_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                        description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                        type: Hash,
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -38,7 +38,7 @@ module Fastlane
 
         [
           FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                       env_name: "APPSTORE_BUILD_NUMBER_API_KEY_PATH",
+                                       env_names: ["APPSTORE_BUILD_NUMBER_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                        description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                        optional: true,
                                        conflicting_options: [:api_key],
@@ -46,7 +46,7 @@ module Fastlane
                                          UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_key,
-                                       env_name: "APPSTORE_BUILD_NUMBER_API_KEY",
+                                       env_names: ["APPSTORE_BUILD_NUMBER_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                        description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                        type: Hash,
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/register_device.rb
+++ b/fastlane/lib/fastlane/actions/register_device.rb
@@ -69,7 +69,7 @@ module Fastlane
                                        env_name: "FL_REGISTER_DEVICE_UDID",
                                        description: "Provide the UDID of the device to register as"),
           FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                       env_name: "FL_REGISTER_DEVICE_API_KEY_PATH",
+                                       env_names: ["FL_REGISTER_DEVICE_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                        description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                        optional: true,
                                        conflicting_options: [:api_key],
@@ -77,7 +77,7 @@ module Fastlane
                                          UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_key,
-                                       env_name: "FL_REGISTER_DEVICE_API_KEY",
+                                       env_names: ["FL_REGISTER_DEVICE_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                        description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                        type: Hash,
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -118,7 +118,7 @@ module Fastlane
                                          UI.user_error!("Could not find file '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                       env_name: "FL_REGISTER_DEVICES_API_KEY_PATH",
+                                       env_names: ["FL_REGISTER_DEVICES_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                        description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                        optional: true,
                                        conflicting_options: [:api_key],
@@ -126,7 +126,7 @@ module Fastlane
                                          UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :api_key,
-                                       env_name: "FL_REGISTER_DEVICES_API_KEY",
+                                       env_names: ["FL_REGISTER_DEVICES_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                        description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                        type: Hash,
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -111,7 +111,7 @@ module Fastlane
 
         [
           FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                     env_name: "FL_SET_CHANGELOG_API_KEY_PATH",
+                                     env_names: ["FL_SET_CHANGELOG_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:api_key],
@@ -119,7 +119,7 @@ module Fastlane
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
           FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "FL_SET_CHANGELOG_API_KEY",
+                                     env_names: ["FL_SET_CHANGELOG_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -74,7 +74,7 @@ module Match
 
         # App Store Connect API
         FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                     env_name: "SIGH_API_KEY_PATH",
+                                     env_names: ["SIGH_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:api_key],
@@ -82,7 +82,7 @@ module Match
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "SIGH_API_KEY",
+                                     env_names: ["SIGH_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -11,7 +11,7 @@ module Pilot
 
       [
         FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                     env_name: "PILOT_API_KEY_PATH",
+                                     env_names: ["PILOT_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:username],
@@ -19,7 +19,7 @@ module Pilot
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "PILOT_API_KEY",
+                                     env_names: ["PILOT_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -26,7 +26,7 @@ module Precheck
 
       [
         FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                     env_name: "PRECHECK_API_KEY_PATH",
+                                     env_names: ["PRECHECK_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:username],
@@ -34,7 +34,7 @@ module Precheck
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "PRECHECK_API_KEY",
+                                     env_names: ["PRECHECK_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -57,7 +57,7 @@ module Sigh
 
         # App Store Connect API
         FastlaneCore::ConfigItem.new(key: :api_key_path,
-                                     env_name: "SIGH_API_KEY_PATH",
+                                     env_names: ["SIGH_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
                                      description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                      optional: true,
                                      conflicting_options: [:api_key],
@@ -65,7 +65,7 @@ module Sigh
                                        UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :api_key,
-                                     env_name: "SIGH_API_KEY",
+                                     env_names: ["SIGH_API_KEY", "APP_STORE_CONNECT_API_KEY"],
                                      description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
                                      type: Hash,
                                      optional: true,


### PR DESCRIPTION
### Motivation and Context
Adds on to #18173
Partly resolves #18145

Adds new unified ENV vars to all tools/actions using App Store Connect API Key


### Description
- Adds new unified ENV vars to all tools/actions using App Store Connect API Key
  - `APP_STORE_CONNECT_API_KEY_PATH`
  - `APP_STORE_CONNECT_API_KEY` 

#### Tools
- cert
- deliver
- match
- pilot
- precheck
- sigh

#### Actions 
- `app_store_build_number`
- `latest_testflight_build_number`
- `register_device`
- `register_devices`
- `set_changelog`