### PR TITLE
[docs] Remove "sudo" from instructions in code

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
@@ -21,7 +21,7 @@ _screengrab_ generates localized screenshots of your Android app for different d
 Install the gem
 
 ```no-highlight
-sudo gem install fastlane
+gem install fastlane
 ```
 
 ##### Gradle dependency

--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -345,5 +345,5 @@ brew install imagemagick
 
 ## Uninstall
 
-- `sudo gem uninstall fastlane`
+- `gem uninstall fastlane`
 - `rm -rf ~/.frameit`

--- a/fastlane/lib/fastlane/helper/gem_helper.rb
+++ b/fastlane/lib/fastlane/helper/gem_helper.rb
@@ -10,8 +10,8 @@ module Fastlane
       rescue Gem::LoadError
         UI.error("Could not find gem '#{gem_name}'")
         UI.error("")
-        UI.error("If you installed fastlane using `sudo gem install fastlane` run")
-        UI.command("sudo gem install #{gem_name}")
+        UI.error("If you installed fastlane using `gem install fastlane` run")
+        UI.command("gem install #{gem_name}")
         UI.error("to install the missing gem")
         UI.error("")
         UI.error("If you use a Gemfile add this to your Gemfile:")

--- a/fastlane/spec/actions_specs/min_fastlane_version_spec.rb
+++ b/fastlane/spec/actions_specs/min_fastlane_version_spec.rb
@@ -21,7 +21,7 @@ describe Fastlane do
         expect do
           # We have to clean ENV to be sure that Bundler environement is not defined.
           stub_const('ENV', {})
-          expect(FastlaneCore::Changelog).to receive(:show_changes).with("fastlane", Fastlane::VERSION, update_gem_command: "sudo gem install fastlane")
+          expect(FastlaneCore::Changelog).to receive(:show_changes).with("fastlane", Fastlane::VERSION, update_gem_command: "gem install fastlane")
 
           Fastlane::FastFile.new.parse("lane :test do
             min_fastlane_version '9999'

--- a/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
+++ b/fastlane_core/lib/fastlane_core/update_checker/update_checker.rb
@@ -63,7 +63,7 @@ module FastlaneCore
       if !Helper.bundler? && !Helper.contained_fastlane? && Random.rand(5) == 1
         # We want to show this message from time to time, if the user doesn't use bundler, nor bundled fastlane
         puts('#######################################################################')
-        puts("# Run `sudo gem cleanup` from time to time to speed up fastlane")
+        puts("# Run `gem cleanup` from time to time to speed up fastlane")
       end
       puts('#######################################################################')
       Changelog.show_changes(gem_name, current_version, update_gem_command: UpdateChecker.update_command(gem_name: gem_name)) unless FastlaneCore::Env.truthy?("FASTLANE_HIDE_CHANGELOG")
@@ -80,7 +80,7 @@ module FastlaneCore
       elsif Helper.mac_app?
         "the Fabric app. Launch the app and navigate to the fastlane tab to get the most recent version."
       else
-        "sudo gem install #{gem_name.downcase}"
+        "gem install #{gem_name.downcase}"
       end
     end
 

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -43,11 +43,11 @@ describe FastlaneCore do
       end
 
       it "works a custom gem name" do
-        expect(FastlaneCore::UpdateChecker.update_command(gem_name: "gym")).to eq("sudo gem install gym")
+        expect(FastlaneCore::UpdateChecker.update_command(gem_name: "gym")).to eq("gem install gym")
       end
 
       it "works with system ruby" do
-        expect(FastlaneCore::UpdateChecker.update_command).to eq("sudo gem install fastlane")
+        expect(FastlaneCore::UpdateChecker.update_command).to eq("gem install fastlane")
       end
 
       it "works with bundler" do

--- a/snapshot/MigrationGuide.md
+++ b/snapshot/MigrationGuide.md
@@ -27,6 +27,6 @@ Option     | Note
 
 How to migrate:
 
-- Update to the new version using `sudo gem update snapshot`
+- Update to the new version using `gem update snapshot`
 - Delete `snapshot.js`, `SnapshotHelper.js` and `Snapfile` and any other files you were using
 - Follow the [Quick Start Guide](https://docs.fastlane.tools/actions/snapshot/#quick-start)

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -83,7 +83,7 @@ Using spaceship, the execution time of [_sigh_](https://docs.fastlane.tools/acti
 
 _spaceship_ is part of _fastlane_:
 
-    sudo gem install fastlane
+    gem install fastlane
 
 # Usage
 
@@ -93,7 +93,7 @@ To try _spaceship_, just run `fastlane spaceship`. It will automatically start t
 
 ![assets/docs/Playground.png](assets/docs/Playground.png)
 
-This requires you to install `pry` using `sudo gem install pry`. `pry` is not installed by default, as most [_fastlane_](https://fastlane.tools) users won't need the `spaceship playground`. You can add the `pry` dependency to your `Gemfile`.
+This requires you to install `pry` using `gem install pry`. `pry` is not installed by default, as most [_fastlane_](https://fastlane.tools) users won't need the `spaceship playground`. You can add the `pry` dependency to your `Gemfile`.
 
 ## Apple Developer Portal API
 

--- a/spaceship/lib/spaceship/playground.rb
+++ b/spaceship/lib/spaceship/playground.rb
@@ -13,8 +13,8 @@ module Spaceship
       rescue Gem::LoadError
         puts("Could not find gem 'pry'".red)
         puts("")
-        puts("If you installed spaceship using `sudo gem install spaceship` run")
-        puts("  sudo gem install pry".yellow)
+        puts("If you installed spaceship using `gem install spaceship` run")
+        puts("  gem install pry".yellow)
         puts("to install the missing gem")
         puts("")
         puts("If you use a Gemfile add this to your Gemfile:")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

https://github.com/fastlane/fastlane/issues/17931

Prior to this PR, I've updated https://docs.fastlane.tools/getting-started/ios/setup/ page to not recommend "sudo gem install" habit officially. 
https://github.com/fastlane/docs/pull/1022

This PR removes hardcoded instructions displaying "sudo gem install" in order to match the document. Although I feel like some of them need to be revised due to the fact we now recommend "Bundler" as the first option, I guess there would be no harm to get rid of "sudo" from the code.

I might work on improving how the instructions are later on. For example,  we might need to guide users to use `bundle update xxx` instead of `gem update xxx`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
