### PR TITLE
[deliver] sort screenshots naturally, in a human-friendly way

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ PATH
       jwt (>= 2.1.0, < 3)
       mini_magick (>= 4.9.4, < 5.0.0)
       multipart-post (~> 2.0.0)
+      naturally (~> 2.2)
       plist (>= 3.1.0, < 4.0.0)
       rubyzip (>= 2.0.0, < 3.0.0)
       security (= 0.1.3)
@@ -381,4 +382,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   2.2.8
+   2.2.9

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -231,12 +231,13 @@ module Deliver
     end
 
     def sort_screenshots(localizations)
+      require 'naturally'
       iterator = AppScreenshotIterator.new(localizations)
 
       # Re-order screenshots within app_screenshot_set
       worker = QueueWorker.new do |app_screenshot_set|
         original_ids = app_screenshot_set.app_screenshots.map(&:id)
-        sorted_ids = app_screenshot_set.app_screenshots.sort_by(&:file_name).map(&:id)
+        sorted_ids = Naturally.sort(app_screenshot_set.app_screenshots, by: :file_name).map(&:id)
         if original_ids != sorted_ids
           app_screenshot_set.reorder_screenshots(app_screenshot_ids: sorted_ids)
         end

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -415,5 +415,21 @@ describe Deliver::UploadScreenshots do
         described_class.new.sort_screenshots([localization])
       end
     end
+
+    context 'when localization has screenshots uploaded in wrong order with trailing numbers up to 10' do
+      it 'should reoder screenshots' do
+        app_screenshot1 = make_app_screenshot(id: '1', file_name: '6.5_1.jpg')
+        app_screenshot2 = make_app_screenshot(id: '2', file_name: '6.5_2.jpg')
+        app_screenshot10 = make_app_screenshot(id: '10', file_name: '6.5_10.jpg')
+        app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
+                                    screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55,
+                                    app_screenshots: [app_screenshot10, app_screenshot2, app_screenshot1])
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization',
+                              locale: 'en-US',
+                              get_app_screenshot_sets: [app_screenshot_set])
+        expect(app_screenshot_set).to receive(:reorder_screenshots).with(app_screenshot_ids: ['1', '2', '10'])
+        described_class.new.sort_screenshots([localization])
+      end
+    end
   end
 end

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -84,6 +84,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('highline', '>= 1.7.2', '< 2.0.0') # user inputs (e.g. passwords)
   spec.add_dependency('json', '< 3.0.0') # Because sometimes it's just not installed
   spec.add_dependency('mini_magick', '>= 4.9.4', '< 5.0.0') # To open, edit and export PSD files
+  spec.add_dependency('naturally', '~> 2.2') # Used to sort strings with numbers in a human-friendly way
   spec.add_dependency('rubyzip', '>= 2.0.0', '< 3.0.0') # fix swift/ipa in gym
   spec.add_dependency('security', '= 0.1.3') # macOS Keychain manager, a dead project, no updates expected
   spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3')


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #15959

After reading the OP's issue, there's this thorough examination of the issue in this comment, please read it for full context: https://github.com/fastlane/fastlane/issues/15959#issuecomment-722150542

### Description
Implementation decisions:
- I decided to add the dependency mentioned in the ticket, [`naturally`](https://github.com/dogweather/naturally). However, notice that this dependency is already a transient dependency from another gem (I didn't bother to check which one(s)'s), so there's not much of a difference. Plus, this gem is so so tiny that I didn't see harm 😊 
- I decided that it wasn't worth adding an option for this underlying change, as probably no one is using this "unnatural" - or counterintuitive - sorting behavior intentionally. However, this _may_ characterize as a regression for some, so we may want to highlight this in the release notes.

I'm open to discuss and reconsider those decisions, just let me know your thoughts 🤗 

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-sort-screenshots-naturally"
```

And run `bundle install` to apply the changes.

[This comment](https://github.com/fastlane/fastlane/issues/15959#issuecomment-722150542) contains an `irb` test showing the old and new sorting algorithms in action. This PR contains a unit test for the specific change, to make sure the expected behavior is being met.