### PR TITLE
[download_dsyms] fix build lookup when using option 'latest' for the version

### DIFF
--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -135,9 +135,6 @@ describe Fastlane do
 
       context 'when version is latest' do
         it 'downloads only dsyms of latest build in latest train' do
-          expect(app).to receive(:get_edit_app_store_version).and_return(version)
-          expect(version).to receive(:version_string).and_return('2.0.0')
-
           expect(Spaceship::ConnectAPI).to receive(:get_builds).and_return([build2, build1])
 
           expect(build_resp).to receive(:to_models).and_return([build1, build2])


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17474
This PR fixes a regression introduced in #17148

### Description

After https://github.com/fastlane/fastlane/pull/17148, the `download_dsyms` action started handling the `'latest'` option for the `version` a bit differently: it would first find the latest "app version" created, and then find the latest build associated with that version only. However, the point of 'latest' is to download the dsyms for the latest _build_, which may not necessarily have an app version yet (for instance, in the scenario described by the OP in the original ticket). 
This PR resolves this issue by ignoring the app version completely and looking only at the builds submitted. It uses the latest build submitted (sorted by creation date).

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-sort-screenshots-naturally"
```

And run `bundle install` to apply the changes.

The way I test this was with an app which had an app version `1.0`, but the latest build sent to the app store connect was `2.35.9002`.
In master, it would print `Looking for dSYM files for 'my-bundle-identifier' on platform IOS v1.0 (1960)`
In this PR, it selects the right build `Looking for dSYM files for 'my-bundle-identifier' on platform IOS v2.35.9002 (296110.325651620)`