### PR TITLE
[spaceship] use new analytics endpoint

### DIFF
--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -579,10 +579,10 @@ module Spaceship
       }
 
       r = request(:post) do |req|
-        req.url("https://analytics.itunes.apple.com/analytics/api/v1/data/time-series")
+        req.url("https://appstoreconnect.apple.com/analytics/api/v1/data/time-series")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['X-Requested-By'] = 'analytics.itunes.apple.com'
+        req.headers['X-Requested-By'] = 'appstoreconnect.apple.com'
       end
 
       data = parse_response(r)

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -606,52 +606,52 @@ class TunesStubbing
     end
 
     def itc_stub_analytics(start_time, end_time)
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["units"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_units.json"),
                   headers: { "Content-Type" => "application/json" })
 
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["pageViewCount"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_views.json"),
                   headers: { "Content-Type" => "application/json" })
 
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["iap"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_in_app_purchases.json"),
                   headers: { "Content-Type" => "application/json" })
 
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["sales"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_sales.json"),
                   headers: { "Content-Type" => "application/json" })
 
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["payingUsers"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_paying_users.json"),
                   headers: { "Content-Type" => "application/json" })
 
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["installs"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_installs.json"),
                   headers: { "Content-Type" => "application/json" })
 
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["sessions"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_sessions.json"),
                   headers: { "Content-Type" => "application/json" })
 
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["activeDevices"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_active_devices.json"),
                   headers: { "Content-Type" => "application/json" })
 
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => nil, "measures" => ["crashes"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_crashes.json"),
                   headers: { "Content-Type" => "application/json" })
 
-      stub_request(:post, "https://analytics.itunes.apple.com/analytics/api/v1/data/time-series").
+      stub_request(:post, "https://appstoreconnect.apple.com/analytics/api/v1/data/time-series").
         with(body: { "adamId" => ["898536088"], "dimensionFilters" => [], "endTime" => end_time, "frequency" => "DAY", "group" => { metric: "installs", dimension: "source", rank: "DESCENDING", limit: 3 }, "measures" => ["installs"], "startTime" => start_time }.to_json).
         to_return(status: 200, body: itc_read_fixture_file("app_analytics_installs_by_source.json"),
                   headers: { "Content-Type" => "application/json" })


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #18203

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Apple changed the domain of their analytics endpoint from [analytics.itunes.apple.com](analytics.itunes.apple.com) to [appstoreconnect.apple.com](appstoreconnect.apple.com). Since the format of the response is the same, changing the domain in the codebase is enough to restore functionality. Note that the old domain is still up, but every call to that domain returns an empty response. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
The change has been tested live with a script.