### PR TITLE
[spaceship] allow extra fields in API Key JSON file

### DIFF
--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -40,7 +40,7 @@ module Spaceship
         self.create(json)
       end
 
-      def self.create(key_id: nil, issuer_id: nil, filepath: nil, key: nil, is_key_content_base64: false, duration: nil, in_house: nil)
+      def self.create(key_id: nil, issuer_id: nil, filepath: nil, key: nil, is_key_content_base64: false, duration: nil, in_house: nil, **)
         key_id ||= ENV['SPACESHIP_CONNECT_API_KEY_ID']
         issuer_id ||= ENV['SPACESHIP_CONNECT_API_ISSUER_ID']
         filepath ||= ENV['SPACESHIP_CONNECT_API_KEY_FILEPATH']

--- a/spaceship/spec/connect_api/fixtures/asc_key_extra_fields.json
+++ b/spaceship/spec/connect_api/fixtures/asc_key_extra_fields.json
@@ -1,0 +1,6 @@
+{
+  "key_id": "D485S484",
+  "issuer_id": "061966a2-5f3c-4185-af13-70e66d2263f5",
+  "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIOChdk7KmY4kakEbpQzG6h7/FpsLviYzsG8VIAY8dQNPoAoGCCqGSM49\nAwEHoUQDQgAEYrwrM8lljj4upX7lb4YwjsnrD9CDYrMqKRH34GHPc6mMSLmXPqFr\nTdWWgfn6fee6YcJhvdGZliO08CbpjMPY2Q==\n-----END EC PRIVATE KEY-----\n",
+  "comment": "something extra"
+}

--- a/spaceship/spec/connect_api/token_spec.rb
+++ b/spaceship/spec/connect_api/token_spec.rb
@@ -5,12 +5,21 @@ describe Spaceship::ConnectAPI::Token do
   let(:issuer_id) { '693fbb20-54a0-4d94-88ce-8a6caf875439' }
 
   let(:fake_api_key_json_path) { "./spaceship/spec/connect_api/fixtures/asc_key.json" }
+  let(:fake_api_key_extra_fields_json_path) { "./spaceship/spec/connect_api/fixtures/asc_key_extra_fields.json" }
   let(:fake_api_key_base64_json_path) { "./spaceship/spec/connect_api/fixtures/asc_key_base64.json" }
   let(:fake_api_key_in_house_json_path) { "./spaceship/spec/connect_api/fixtures/asc_key_in_house.json" }
 
   context '#from_json_file' do
     it 'successfully creates token' do
       token = Spaceship::ConnectAPI::Token.from_json_file(fake_api_key_json_path)
+
+      expect(token.key_id).to eq("D485S484")
+      expect(token.issuer_id).to eq("061966a2-5f3c-4185-af13-70e66d2263f5")
+      expect(token.in_house).to be_nil
+    end
+
+    it 'successfully creates token with extra fields' do
+      token = Spaceship::ConnectAPI::Token.from_json_file(fake_api_key_extra_fields_json_path)
 
       expect(token.key_id).to eq("D485S484")
       expect(token.issuer_id).to eq("061966a2-5f3c-4185-af13-70e66d2263f5")


### PR DESCRIPTION

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently `Spaceship::ConnectAPI::Token.from_json_file` passes all json fields to `Spaceship::ConnectAPI::Token.create`. When managing multiple teams API key json is convenient place to store some extra information like `dev_team_id`, `itc_team_id` or similar. But in case if json contains extra fields `.create` will fail with `ArgumentError (unknown keywords: dev_team_id, itc_team_id)`
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
By adding vararg `**` to arguments of `.create` we can ignore any extra fields that are present. Worth noting that similar result may be achieved by filtering json output before passing to `.create`. 
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
Extra fields in API key json are not causing `ArgumentError`.
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
