### PR TITLE
[spaceship][spaceauth] fix SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER forcing 'sms' push mode

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -235,9 +235,7 @@ module Spaceship
 
     def phone_id_from_number(phone_numbers, phone_number)
       phone_numbers.each do |phone|
-
         return phone['id'] if match_phone_to_masked_phone(phone_number, phone['numberWithDialCode'])
-        # +491621234585 matches /^\+49([0-9]{8})85$/
       end
 
       # Handle case of phone_number not existing in phone_numbers because ENV var is wrong or matcher is broken
@@ -284,6 +282,7 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
       # => /^\+49([0-9]{8})85$/ or /^\+1([0-9]{7,8})66$/
 
       return phone_number =~ number_with_dialcode_regex
+      # +491621234585 matches /^\+49([0-9]{8})85$/
     end
 
     def phone_id_from_masked_number(phone_numbers, masked_number)

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -249,6 +249,15 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
 )
     end
 
+    def push_mode_from_number(phone_numbers, phone_number)
+      phone_numbers.each do |phone|
+        return phone['pushMode'] if match_phone_to_masked_phone(phone_number, phone['numberWithDialCode'])
+      end
+
+      # If no pushMode was supplied, assume sms
+      return "sms"
+    end
+
     def match_phone_to_masked_phone(phone_number, masked_number)
       characters_to_remove_from_phone_numbers = ' \-()"'
 

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -135,7 +135,7 @@ module Spaceship
 
         phone_number = env_2fa_sms_default_phone_number
         phone_id = phone_id_from_number(response.body["trustedPhoneNumbers"], phone_number)
-        push_mode = push_mode_from_masked_number(response.body["trustedPhoneNumbers"], phone_number)
+        push_mode = push_mode_from_number(response.body["trustedPhoneNumbers"], phone_number)
         # don't request sms if no trusted devices and env default is the only trusted number,
         # code was automatically sent
         should_request_code = !sms_automatically_sent(response)
@@ -235,7 +235,6 @@ module Spaceship
 
     def phone_id_from_number(phone_numbers, phone_number)
       phone_numbers.each do |phone|
-
 
         return phone['id'] if match_phone_to_masked_phone(phone_number, phone['numberWithDialCode'])
         # +491621234585 matches /^\+49([0-9]{8})85$/

--- a/spaceship/spec/fixtures/client_appleauth_auth_2fa_response.json
+++ b/spaceship/spec/fixtures/client_appleauth_auth_2fa_response.json
@@ -9,6 +9,11 @@
 		"pushMode": "sms",
 		"obfuscatedNumber": "••••• •••••81",
 		"id": 2
+	}, {
+		"numberWithDialCode": "+49 ••••• •••••80",
+		"pushMode": "voice",
+		"obfuscatedNumber": "••••• •••••80",
+		"id": 3
 	}],
 	"securityCode": {
 		"length": 6,

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -55,6 +55,15 @@ class TunesStubbing
           to_return(status: 200, body: "", headers: {})
       end
 
+      # 2FA: Request and Submit code via voice
+      stub_request(:put, "https://idmsa.apple.com/appleauth/auth/verify/phone").
+        with(body: "{\"phoneNumber\":{\"id\":3},\"mode\":\"voice\"}").
+        to_return(status: 200, body: "", headers: {})
+
+      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode").
+        with(body: "{\"securityCode\":{\"code\":\"123\"},\"phoneNumber\":{\"id\":3},\"mode\":\"voice\"}").
+        to_return(status: 200, body: "", headers: {})
+
       # 2FA: Submit security code from trusted phone with voice for verification
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode").
         with(body: "{\"securityCode\":{\"code\":\"123\"},\"phoneNumber\":{\"id\":1},\"mode\":\"voice\"}").

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -235,6 +235,21 @@ describe Spaceship::Client do
         end.to raise_error(Spaceship::Tunes::Error)
       end
 
+      context 'and pushMode is voice' do
+        let(:phone_number) { '+49 123 4567880' }
+        let(:phone_id) { 3 }
+
+        it 'requests voice code' do
+          bool = subject.handle_two_factor(response)
+          expect(bool).to eq(true)
+  
+          # expected requests
+          expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: phone_id }, mode: "voice" }).once
+          expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: phone_id }, mode: "voice" })
+          expect(WebMock).to have_requested(:get, 'https://idmsa.apple.com/appleauth/auth/2sv/trust')
+        end
+      end
+
       context 'with trusted devices' do
         # make sure sms overrides device verification when env var is set
         it 'requests sms code, and submits code correctly' do

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -242,7 +242,7 @@ describe Spaceship::Client do
         it 'requests voice code' do
           bool = subject.handle_two_factor(response)
           expect(bool).to eq(true)
-  
+
           # expected requests
           expect(WebMock).to have_requested(:put, 'https://idmsa.apple.com/appleauth/auth/verify/phone').with(body: { phoneNumber: { id: phone_id }, mode: "voice" }).once
           expect(WebMock).to have_requested(:post, 'https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode').with(body: { securityCode: { code: "123" }, phoneNumber: { id: phone_id }, mode: "voice" })


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When running fastlane spaceauth with SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER set, because the `push_mode_from_masked_number` compares the full phone number with the masked phone number from the response from apple, it doesn't find a matching trusted phone number and defauts to pushMode = "sms".

### Description
The code handling the case of the environment variable being set was correctly handling the masked vs unmasked phone numbers, so this logic was refactored out to a method `match_phone_to_masked_phone` so that it could be shared for both the `phone_id_from_number` and the new `push_mode_from_number` methods.
### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Set up a phone on the apple account with the "Phone Call" option, then run
```
SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER="phone with voice" bundle exec fastlane spaceauth -u email@email.com
```
