### PR TITLE
[screengrab] fix regression: incorrect executable name on Windows

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -392,13 +392,12 @@ module Screengrab
     end
 
     def run_adb_command(command, print_all: false, print_command: false, raise_errors: true)
-      adb_path = @android_env.adb_path.chomp("adb")
       adb_host = @config[:adb_host]
       host = adb_host.nil? ? '' : "-H #{adb_host} "
       output = ''
       begin
         errout = nil
-        cmdout = @executor.execute(command: adb_path + "adb " + host + command,
+        cmdout = @executor.execute(command: @android_env.adb_path + " " + host + command,
                                   print_all: print_all,
                                   print_command: print_command,
                                   error: raise_errors ? nil : proc { |out, status| errout = out }) || ''


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #18240

Fixes the executable name used in `executor.execute` on Windows.