### PR TITLE
[jazzy] add module_version option

### DIFF
--- a/fastlane/lib/fastlane/actions/jazzy.rb
+++ b/fastlane/lib/fastlane/actions/jazzy.rb
@@ -5,6 +5,7 @@ module Fastlane
         Actions.verify_gem!('jazzy')
         command = "jazzy"
         command << " --config #{params[:config]}" if params[:config]
+        command << " --module-version #{params[:module_version]}" if params[:module_version]
         Actions.sh(command)
       end
 
@@ -22,6 +23,13 @@ module Fastlane
             key: :config,
             env_name: 'FL_JAZZY_CONFIG',
             description: 'Path to jazzy config file',
+            is_string: true,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :module_version,
+            env_name: 'FL_JAZZY_MODULE_VERSION',
+            description: 'Version string to use as part of the the default docs title and inside the docset',
             is_string: true,
             optional: true
           )
@@ -44,7 +52,8 @@ module Fastlane
 
       def self.example_code
         [
-          'jazzy'
+          'jazzy',
+          'jazzy(config: ".jazzy.yaml", module_version: "2.1.37")'
         ]
       end
 

--- a/fastlane/spec/actions_specs/jazzy_spec.rb
+++ b/fastlane/spec/actions_specs/jazzy_spec.rb
@@ -18,6 +18,16 @@ describe Fastlane do
 
         expect(result).to eq("jazzy --config .jazzy.yaml")
       end
+
+      it "add module_version option" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          jazzy(
+            module_version: '1.2.6'
+          )
+        end").runner.execute(:test)
+
+        expect(result).to eq("jazzy --module-version 1.2.6")
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently, if we want to use jazzy from fastlane we need to keep every parameter in the config file. With `module_version` option is possible to set this parameter dynamically during lane without changing the file.

### Description
Add `module_version` optional parameter to jazzy action. This is a version string to use as part of the default docs title and inside the docset.

### Testing Steps
Proper test was added to `jazzy_spec.rb`, you can check if the runned script is compatible with jazzy (https://github.com/realm/jazzy).