### PR TITLE
[action] push_to_git_remote - Remove useless `pwd`

### DIFF
--- a/fastlane/lib/fastlane/actions/push_to_git_remote.rb
+++ b/fastlane/lib/fastlane/actions/push_to_git_remote.rb
@@ -36,7 +36,6 @@ module Fastlane
         params[:push_options].each { |push_option| command << "--push-option=#{push_option}" } if params[:push_options]
 
         # execute our command
-        Actions.sh('pwd')
         return command.join(' ') if Helper.test?
 
         Actions.sh(command.join(' '))


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Removes a needless shell execution of `pwd`, which appears to have been put in as a test during the initial development of this action.

Although not Fastlane's main target audience, it is possible to run Fastlane for Android development on Windows, and it actually works quite well. However, this call to `pwd` makes the `push_to_git_remote` action crash on Windows. Since there seems to be no reason to keep this `pwd` (it isn't required to make the action work and no other action has it that I could find), it makes sense to remove it.

References https://github.com/fastlane/fastlane/discussions/18231

### Description

Removed a call to `Actions.sh('pwd')` in `fastlane/lib/fastlane/actions/push_to_git_remote.rb`

### Testing Steps

The RSpec tests for this action still pass, and now it does not crash on Windows.