### PR TITLE
[spaceship] resolve issue with current team_id being incorrectly reported

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -134,7 +134,7 @@ module Spaceship
       if teams.count > 1
         puts("The current user is in #{teams.count} teams. Pass a team ID or call `select_team` to choose a team. Using the first one for now.")
       end
-      @current_team_id ||= teams[0]['contentProvider']['contentProviderId']
+      @current_team_id ||= user_details_data['sessionToken']['contentProviderId']
     end
 
     # Set a new team ID which will be used from now on
@@ -170,6 +170,9 @@ module Spaceship
       end
 
       handle_itc_response(response.body)
+
+      # clear user_details_data cache, as session switch will have changed sessionToken attribute
+      @_cached_user_details = nil
 
       @current_team_id = team_id
     end

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -110,21 +110,29 @@ describe Spaceship::TunesClient do
     end
 
     describe "associated to multiple teams" do
-      let(:associated_teams) { [{ 'contentProvider' => { 'name' => 'Tom', 'contentProviderId' => '1234' } }, { 'contentProvider' => { 'name' => 'Harry', 'contentProviderId' => '5678' } }] }
+      let(:user_details_data) do
+        {
+          'associatedAccounts' => [
+            { 'contentProvider' => { 'name' => 'Tom', 'contentProviderId' => 1234 } },
+            { 'contentProvider' => { 'name' => 'Harry', 'contentProviderId' => 5678 } }
+          ],
+          'sessionToken' => { 'contentProviderId' => 1234 }
+        }
+      end
 
-      it "#team_id picks the first team if select_team not called" do
-        allow(subject).to receive(:teams).and_return(associated_teams)
-        expect(subject.team_id).to eq('1234')
+      it "#team_id picks team indicated by the sessionToken if select_team not called" do
+        allow(subject).to receive(:user_details_data).and_return(user_details_data)
+        expect(subject.team_id).to eq(1234)
       end
 
       it "returns team_id from legitimate team_name parameter" do
-        allow(subject).to receive(:teams).and_return(associated_teams)
+        allow(subject).to receive(:user_details_data).and_return(user_details_data)
         expect(subject.select_team(team_name: 'Harry')).to eq('5678')
       end
 
       it "returns team_id from environment variable" do
         stub_const('ENV', { 'FASTLANE_ITC_TEAM_NAME' => 'Harry' })
-        allow(subject).to receive(:teams).and_return(associated_teams)
+        allow(subject).to receive(:user_details_data).and_return(user_details_data)
         expect(subject.select_team).to eq('5678')
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The team_id method currently uses `teams[0]['contentProvider']['contentProviderId']` to determine the team ID that is in use.
`teams` ultimately derives from the `user_details_data` session information, but critically, it is manually sorted by name before being returned.
This means that the first element in `teams` does not have a semantic meaning, and may only by chance reflect the currently selected team.

`git blame` suggests this bug may have been present since the initial implementation of this code in 3ffaaf2d0. It makes sense that it may not have been detected, as I doubt many users use the team switching functionality, and you still have a 50:50 chance of it selecting the right one out of the box if you only have two teams, as it just depends on their alphabetical sorting.

### Description
This fix uses the `user_details_data['sessionToken']['contentProviderId']` directly to determine the current team, as this attribute always reflects the ID of the current team.
The `user_details_data` is typically cached for performance, but this data changes when switching team.
To prevent potential confusion and stale info this cache is cleared on manual team switch with `team_id=`.

### Testing Steps
You will need an Apple account with two teams joined, where the alphabetical team names don't happen to line up with the account selected by default.

Updated specs fail with old code and succeed with new one. Because they were directly mocking `teams`, they weren't testing how the sorting impacts the selection of the first element, thus masking this bug, which actually causes the example data already present to fail, as "Harry" sorts before "Tom".

Basic testing on our system indicates this fixes the issue, but I will be deploying this patch to our prod to verify the fix works more extensively in the coming days.