### PR TITLE
[pilot] do not update app beta details if not needed

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -253,9 +253,11 @@ module Pilot
         end
       end
 
-      update_build_beta_details(build, {
-        auto_notify_enabled: options[:notify_external_testers]
-      })
+      if options[:notify_external_testers]
+        update_build_beta_details(build, {
+          auto_notify_enabled: options[:notify_external_testers]
+        })
+      end
     end
 
     def self.truncate_changelog(changelog)

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -253,7 +253,9 @@ module Pilot
         end
       end
 
-      if options[:notify_external_testers]
+      if options[:notify_external_testers].nil?
+        UI.important("Using App Store Connect's default for notifying external testers (which is true) - set `notify_external_testers` for full control")
+      else
         update_build_beta_details(build, {
           auto_notify_enabled: options[:notify_external_testers]
         })

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -182,7 +182,7 @@ module Pilot
         FastlaneCore::ConfigItem.new(key: :notify_external_testers,
                                     is_string: false,
                                     env_name: "PILOT_NOTIFY_EXTERNAL_TESTERS",
-                                    description: "Should notify external testers?",
+                                    description: "Should notify external testers? (Not setting a value will use App Store Connect's default which is to notify)",
                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :app_version,
                                      env_name: "PILOT_APP_VERSION",

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -183,7 +183,7 @@ module Pilot
                                     is_string: false,
                                     env_name: "PILOT_NOTIFY_EXTERNAL_TESTERS",
                                     description: "Should notify external testers?",
-                                    default_value: true),
+                                    optional: true),
         FastlaneCore::ConfigItem.new(key: :app_version,
                                      env_name: "PILOT_APP_VERSION",
                                      description: "The version number of the application build to distribute. If the version number is not specified, then the most recent build uploaded to TestFlight will be distributed. If specified, the most recent build for the version number will be distributed",

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -441,6 +441,15 @@ describe "Build Manager" do
     it "does not attempt to set demo account required" do
       options = {}
 
+      expect(fake_build_manager).not_to receive(:update_review_detail)
+      expect(fake_build_manager).not_to receive(:update_build_beta_details)
+      fake_build_manager.update_beta_app_meta(options, fake_build)
+    end
+
+    it "does not attempt to set demo account required" do
+      options = { notify_external_testers: true }
+
+      expect(fake_build_manager).not_to receive(:update_review_detail)
       expect(fake_build_manager).to receive(:update_build_beta_details)
       fake_build_manager.update_beta_app_meta(options, fake_build)
     end
@@ -449,7 +458,7 @@ describe "Build Manager" do
       options = { demo_account_required: false }
 
       expect(fake_build_manager).to receive(:update_review_detail)
-      expect(fake_build_manager).to receive(:update_build_beta_details)
+      expect(fake_build_manager).not_to receive(:update_build_beta_details)
 
       fake_build_manager.update_beta_app_meta(options, fake_build)
 
@@ -460,7 +469,7 @@ describe "Build Manager" do
       options = { demo_account_required: true }
 
       expect(fake_build_manager).to receive(:update_review_detail)
-      expect(fake_build_manager).to receive(:update_build_beta_details)
+      expect(fake_build_manager).not_to receive(:update_build_beta_details)
 
       fake_build_manager.update_beta_app_meta(options, fake_build)
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

As discussed in #17910 pilot seems to be unable to work with an api_key with just the Developer permissions, needing App Manager permissions instead. However, it should work with the Developer permissions if no distribution of the uploaded binary is performed. This is the second patch after #18158

### Description
If the `notify_external_testers` option is false there's no need to make the update build beta details API call. It's an API call that requires App Manager permissions. Following this patch, pilot can be used with just Developer permissions and have it wait for the build to finish uploading & processing using the following config:

`upload_to_testflight(skip_submission: true)`

### Testing Steps
Before the patch: the API call is always performed, despite not having any effects if `notify_external_testers` is false
After the patch: the API call is only performed when `notify_external_testers` is true (which is the default behaviour)
