### PR TITLE
[spaceship] make ensure_version pass the client to get_edit_app_store_version

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -203,7 +203,7 @@ module Spaceship
       # @return (Bool) Was something changed?
       def ensure_version!(version_string, platform: nil, client: nil)
         client ||= Spaceship::ConnectAPI
-        app_store_version = get_edit_app_store_version(platform: platform)
+        app_store_version = get_edit_app_store_version(client:client,platform: platform)
 
         if app_store_version
           if version_string != app_store_version.version_string

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -203,7 +203,7 @@ module Spaceship
       # @return (Bool) Was something changed?
       def ensure_version!(version_string, platform: nil, client: nil)
         client ||= Spaceship::ConnectAPI
-        app_store_version = get_edit_app_store_version(client:client,platform: platform)
+        app_store_version = get_edit_app_store_version(client: client, platform: platform)
 
         if app_store_version
           if version_string != app_store_version.version_string


### PR DESCRIPTION
Without this you will get a nil exception if you supply a client instead of relying on Spaceship::ConnectAPI

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Because you get a nil exception when supplying a client otherwise
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #18288
-->

### Description
<!-- Describe your changes in detail. -->
Pass the given client to get_edit_app_store_version instead of the default value
<!-- Please describe in detail how you tested your changes. -->
I ran my existing fastlane project

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
