### PR TITLE
[snapshot] fixed logic calling uninstall_app

### DIFF
--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -69,7 +69,8 @@ module Snapshot
           unless launcher_config.dark_mode.nil?
             interface_style(type, launcher_config.dark_mode)
           end
-        elsif launcher_config.reinstall_app
+        end
+        if launcher_config.reinstall_app && !launcher_config.erase_simulator
           # no need to reinstall if device has been erased
           uninstall_app(type)
         end


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #18296

### Description
The check if an app needs to be uninstalled is now moved out of an if statement which does not only test if `erase_simulator` is true but also tests for `localize_simulator` and `dark_mode`. While an app doesn't need to be uninstalled if the simulator is erased, it needs to be uninstalled in all other situations.

### Testing Steps
Please have a look at the issue.