### PR TITLE
[action] restore multi-threading uploads in upload_symbols_to_crashlytics

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -1,7 +1,7 @@
 require 'spaceship'
+require 'fastlane_core/queue_worker'
 
 require_relative 'module'
-require_relative 'queue_worker'
 
 module Deliver
   # upload description, rating, etc.
@@ -200,7 +200,7 @@ module Deliver
       sleep(1)
 
       # Update app store version localizations
-      store_version_worker = Deliver::QueueWorker.new do |app_store_version_localization|
+      store_version_worker = FastlaneCore::QueueWorker.new do |app_store_version_localization|
         attributes = localized_version_attributes_by_locale[app_store_version_localization.locale]
         if attributes
           UI.message("Uploading metadata to App Store Connect for localized version '#{app_store_version_localization.locale}'")
@@ -211,7 +211,7 @@ module Deliver
       store_version_worker.start
 
       # Update app info localizations
-      app_info_worker = Deliver::QueueWorker.new do |app_info_localization|
+      app_info_worker = FastlaneCore::QueueWorker.new do |app_info_localization|
         attributes = localized_info_attributes_by_locale[app_info_localization.locale]
         if attributes
           UI.message("Uploading metadata to App Store Connect for localized info '#{app_info_localization.locale}'")

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -1,5 +1,5 @@
+require 'fastlane_core'
 require 'spaceship'
-require 'fastlane_core/queue_worker'
 
 require_relative 'module'
 

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -1,6 +1,6 @@
+require 'fastlane_core'
 require 'spaceship/tunes/tunes'
 require 'digest/md5'
-require 'fastlane_core/queue_worker'
 
 require_relative 'app_screenshot'
 require_relative 'module'

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -1,10 +1,10 @@
 require 'spaceship/tunes/tunes'
 require 'digest/md5'
+require 'fastlane_core/queue_worker'
 
 require_relative 'app_screenshot'
 require_relative 'module'
 require_relative 'loader'
-require_relative 'queue_worker'
 require_relative 'app_screenshot_iterator'
 
 module Deliver
@@ -67,7 +67,7 @@ module Deliver
     def delete_screenshots(localizations, screenshots_per_language, tries: 5)
       tries -= 1
 
-      worker = QueueWorker.new do |job|
+      worker = FastlaneCore::QueueWorker.new do |job|
         start_time = Time.now
         target = "#{job.localization.locale} #{job.app_screenshot_set.screenshot_display_type} #{job.app_screenshot.id}"
         begin
@@ -113,7 +113,7 @@ module Deliver
       tries -= 1
 
       # Upload screenshots
-      worker = QueueWorker.new do |job|
+      worker = FastlaneCore::QueueWorker.new do |job|
         begin
           UI.verbose("Uploading '#{job.path}'...")
           start_time = Time.now
@@ -235,7 +235,7 @@ module Deliver
       iterator = AppScreenshotIterator.new(localizations)
 
       # Re-order screenshots within app_screenshot_set
-      worker = QueueWorker.new do |app_screenshot_set|
+      worker = FastlaneCore::QueueWorker.new do |app_screenshot_set|
         original_ids = app_screenshot_set.app_screenshots.map(&:id)
         sorted_ids = Naturally.sort(app_screenshot_set.app_screenshots, by: :file_name).map(&:id)
         if original_ids != sorted_ids

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -1,5 +1,3 @@
-require 'thread'
-
 module Fastlane
   module Actions
     class UploadSymbolsToCrashlyticsAction < Action
@@ -35,10 +33,11 @@ module Fastlane
           UI.message("Using #{max_worker_threads} threads for Crashlytics dSYM upload 🏎")
         end
 
-        dsym_paths.each do |current_path|
-          handle_dsym(params, current_path, max_worker_threads)
+        worker = FastlaneCore::QueueWorker.new(max_worker_threads) do |dsym_path|
+          handle_dsym(params, dsym_path, max_worker_threads)
         end
-
+        worker.batch_enqueue(dsym_paths)
+        worker.start
         UI.success("Successfully uploaded dSYM files to Crashlytics 💯")
       end
 

--- a/fastlane_core/lib/fastlane_core.rb
+++ b/fastlane_core/lib/fastlane_core.rb
@@ -35,6 +35,7 @@ require_relative 'fastlane_core/analytics/analytics_ingester_client'
 require_relative 'fastlane_core/analytics/analytics_session'
 require_relative 'fastlane_core/tag_version'
 require_relative 'fastlane_core/fastlane_pty'
+require_relative 'fastlane_core/queue_worker'
 
 # Third Party code
 require 'colored'

--- a/fastlane_core/lib/fastlane_core/queue_worker.rb
+++ b/fastlane_core/lib/fastlane_core/queue_worker.rb
@@ -1,12 +1,12 @@
 require 'thread'
 
-module Deliver
+module FastlaneCore
   # This dispatches jobs to worker threads and make it work in parallel.
   # It's suitable for I/O bounds works and not for CPU bounds works.
   # Use this when you have all the items that you'll process in advance.
   # Simply enqueue them to this and call `QueueWorker#start`.
   class QueueWorker
-    NUMBER_OF_THREADS = Helper.test? ? 1 : [ENV.fetch("DELIVER_NUMBER_OF_THREADS", 10).to_i, 10].min
+    NUMBER_OF_THREADS = FastlaneCore::Helper.test? ? 1 : [(ENV["DELIVER_NUMBER_OF_THREADS"] || ENV.fetch("FL_NUMBER_OF_THREADS", 10)).to_i, 10].min
 
     # @param concurrency (Numeric) - A number of threads to be created
     # @param block (Proc) - A task you want to execute with enqueued items

--- a/fastlane_core/spec/queue_worker_spec.rb
+++ b/fastlane_core/spec/queue_worker_spec.rb
@@ -1,6 +1,4 @@
-require 'deliver/queue_worker'
-
-describe Deliver::QueueWorker do
+describe FastlaneCore::QueueWorker do
   describe '#new' do
     it 'should initialize an instance' do
       expect(described_class.new { |_| }).to be_kind_of(described_class)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

I noticed that for some reasons, the ability to upload dSYM.zip files with multiple-threads was removed (accidentally) in https://github.com/fastlane/fastlane/pull/16551
This is to restore that lost ability by leveraging `Deliver::QueueWorker` implemented before as well as moving it to `FastlaneCore`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

1. Move `Deliver::QueueWorker`'s namespace to `FastlaneCore`
2. Use it in `upload_symbols_to_crashlytics`

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I've tested with the below lane with my project at work.

```ruby
lane :sync_dsym do
  last_month = DateTime.now.prev_month.to_s
  download_dsyms(after_uploaded_date: last_month)
  upload_symbols_to_crashlytics(dsym_worker_threads: 5)
end
```