### PR TITLE
[action] Add 'changelog' option to Appaloosa

### DIFF
--- a/fastlane/lib/fastlane/actions/appaloosa.rb
+++ b/fastlane/lib/fastlane/actions/appaloosa.rb
@@ -10,7 +10,7 @@ module Fastlane
         binary_url = get_binary_link(binary, api_key, store_id, params[:group_ids])
         return if binary_url.nil?
         screenshots_url = get_screenshots_links(api_key, store_id, params[:screenshots], params[:locale], params[:device])
-        upload_on_appaloosa(api_key, store_id, binary_url, screenshots_url, params[:group_ids], params[:description])
+        upload_on_appaloosa(api_key, store_id, binary_url, screenshots_url, params[:group_ids], params[:description], params[:changelog])
       end
 
       def self.get_binary_link(binary, api_key, store_id, group_ids)
@@ -101,7 +101,7 @@ module Fastlane
         end.compact
       end
 
-      def self.upload_on_appaloosa(api_key, store_id, binary_path, screenshots, group_ids, description)
+      def self.upload_on_appaloosa(api_key, store_id, binary_path, screenshots, group_ids, description, changelog)
         screenshots = all_screenshots_links(screenshots)
         uri = URI("#{APPALOOSA_SERVER}/#{store_id}/mobile_application_updates/upload")
         http = Net::HTTP.new(uri.host, uri.port)
@@ -111,6 +111,7 @@ module Fastlane
                      api_key: api_key,
                      mobile_application_update: {
                        description: description,
+                       changelog: changelog,
                        binary_path: binary_path,
                        screenshot1: screenshots[0],
                        screenshot2: screenshots[1],
@@ -218,6 +219,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :description,
                                        env_name: 'FL_APPALOOSA_DESCRIPTION',
                                        description: 'Your app description',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :changelog,
+                                       env_name: 'FL_APPALOOSA_CHANGELOG',
+                                       description: 'Your app changelog',
                                        optional: true)
         ]
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There is an "changelog" option in Appaloosa API which wasn't present in the Action.
I needed to make changelogs between application updates in Appaloosa.

### Description
`appaloosa.rb:104` add a `changelog` parameter in the method header.
`appaloosa.rb:114` add a `changelog` parameter in the HTTP request body.
`appaloosa.rb:223` add a `changelog` documentation.

### Testing Steps
I made my test locally -> the build is done with changelog section filled on the Appaloosa side.
