### PR TITLE
[pilot] fix issue where build sometimes doesn't submit for review

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -428,7 +428,14 @@ module Pilot
 
         UI.important("Export compliance has been set to '#{uses_non_exempt_encryption}'. Need to wait for build to finishing processing again...")
         UI.important("Set 'ITSAppUsesNonExemptEncryption' in the 'Info.plist' to skip this step and speed up the submission")
-        return wait_for_build_processing_to_be_complete
+
+        loop do
+          build = Spaceship::ConnectAPI::Build.get(build_id: uploaded_build.id)
+          return build unless build.missing_export_compliance?
+
+          UI.message("Waiting for build #{uploaded_build.id} to process export compliance")
+          sleep(5)
+        end
       else
         return uploaded_build
       end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -258,7 +258,7 @@ describe "Build Manager" do
       end
 
       it "updates non-localized demo_account_required, notify_external_testers, beta_app_feedback_email, and beta_app_description and distributes" do
-        expect(ready_to_submit_mock_build).to receive(:build_beta_detail).and_return(build_beta_detail).exactly(6).times
+        expect(ready_to_submit_mock_build).to receive(:build_beta_detail).and_return(build_beta_detail).exactly(8).times
 
         options = distribute_options_non_localized
 
@@ -329,7 +329,7 @@ describe "Build Manager" do
         expect(Spaceship::ConnectAPI).to receive(:patch_builds).with({
           build_id: ready_to_submit_mock_build.id, attributes: { usesNonExemptEncryption: false }
         })
-        expect(fake_build_manager).to receive(:wait_for_build_processing_to_be_complete).and_return(ready_to_submit_mock_build)
+        expect(Spaceship::ConnectAPI::Build).to receive(:get).and_return(ready_to_submit_mock_build)
 
         # Expect beta groups fetched from app. This tests:
         # 1. app.get_beta_groups is called

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -87,6 +87,11 @@ module Spaceship
         return build_beta_detail.ready_for_beta_submission?
       end
 
+      def missing_export_compliance?
+        raise "No build_beta_detail included" unless build_beta_detail
+        return build_beta_detail.missing_export_compliance?
+      end
+
       # This is here temporarily until the removal of Spaceship::TestFlight
       def to_testflight_build
         h = {

--- a/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
@@ -56,6 +56,10 @@ module Spaceship
       def ready_for_beta_submission?
         return external_build_state == ExternalState::READY_FOR_BETA_SUBMISSION
       end
+
+      def missing_export_compliance?
+        return external_build_state == ExternalState::MISSING_EXPORT_COMPLIANCE
+      end
     end
   end
 end


### PR DESCRIPTION
### Motivation and Context
Fixes #17744

### Description
App Store Connect needs to reprocess build when export compliance is set via the App Store Connect API. The beta build detail will have a status of `MISSING_EXPORT_COMPLIANCE` until this processing hae been completed.  

Previously `pilot` just waited for processing to be done but it processing sometimes finished and return a build that still had a value of `MISSING_EXPORT_COMPLIANCE`. The fix now poll specifically for that value to be changed.

This bug only happened sometimes because the processing of changing export compliance was sometimes too instance and sometimes really slow.
