### PR TITLE
[ci] bump CI jobs to use Ruby 2.5 since some dependencies now require 2.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,10 +254,10 @@ workflows:
           ruby_version: '2.5'
       - validate_documentation:
           name: 'Validate Documentation'
-          ruby_version: 'circleci/ruby:2.4'
+          ruby_version: 'circleci/ruby:2.5'
       - lint_source_code:
           name: 'Lint source code'
           ruby_version: 'circleci/ruby:2.5'
       - modules_load_up_tests:
           name: 'Modules load up tests'
-          ruby_version: '2.5'
+          ruby_version: 'circleci/ruby:2.5'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,4 +260,4 @@ workflows:
           ruby_version: 'circleci/ruby:2.5'
       - modules_load_up_tests:
           name: 'Modules load up tests'
-          ruby_version: 'circleci/ruby:2.4'
+          ruby_version: '2.5'

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,6 +97,7 @@ Gem::Specification.new do |spec|
   # If you upgrade this gem, make sure to upgrade the users of it as well.
   spec.add_dependency('google-api-client', '>= 0.37.0', '< 0.39.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
+  spec.add_dependency('signet', '>= 0.14.0') # Signet 0.14.0 is needed for Ruby 2.4
 
   spec.add_dependency('emoji_regex', '>= 0.1', '< 4.0') # Used to scan for Emoji in the changelog
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -58,14 +58,13 @@ Gem::Specification.new do |spec|
 
   # need to lock under 0.15 using less than Ruby 2.5 to prevent install issues when using 'gem install'
   # 'gem install' does not respect Ruby versions and would try installing 0.15 on Ruby 2.4 or less
-  # signet - https://github.com/googleapis/signet/commit/bd6fe87948f8fc7702720dae651e82f4fd348b5d#diff-cd03b1ea000c03b6c5c89bccd9d04486b36976aef245f00ea92aaef2bd98ebb7
-  spec.add_dependency('signet', '<= 0.14.1')
-  spec.add_dependency('googleauth', '<= 0.15.1')
-#  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
-#    spec.add_dependency('signet', '<= 0.14.1')
-#    spec.add_dependency('googleauth', '<= 0.9')
-#    STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet' and 'googleauth' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.5 or later")
-#  end
+  # signet - https://github.com/googleapis/signet/commit/bd6fe87948f8fc7702720dae651e82f4fd348b5d
+  # googleauth - https://github.com/googleapis/google-auth-library-ruby/commit/6644806ab47cea6d08e1901c2ed808e53a579bc3
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
+    spec.add_dependency('signet', '<= 0.14.1')
+    spec.add_dependency('googleauth', '<= 0.15.1')
+    STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet' and 'googleauth' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.5 or later")
+  end
 
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
   spec.add_dependency('xcodeproj', '>= 1.13.0', '< 2.0.0') # Modify Xcode projects

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -56,6 +56,15 @@ Gem::Specification.new do |spec|
   # spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = Dir["*/lib"]
 
+  # need to lock under 0.15 using less than Ruby 2.5 to prevent install issues when using 'gem install'
+  # 'gem install' does not respect Ruby versions and would try installing 0.15 on Ruby 2.4 or less
+  # signet - https://github.com/googleapis/signet/commit/bd6fe87948f8fc7702720dae651e82f4fd348b5d#diff-cd03b1ea000c03b6c5c89bccd9d04486b36976aef245f00ea92aaef2bd98ebb7
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
+    spec.add_dependency('signet', '< 0.15')
+    spec.add_dependency('googleauth', '< 0.10')
+    STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet' and 'googleauth' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.5 or later")
+  end
+
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
   spec.add_dependency('xcodeproj', '>= 1.13.0', '< 2.0.0') # Modify Xcode projects
   spec.add_dependency('xcpretty', '~> 0.3.0') # prettify xcodebuild output
@@ -97,14 +106,6 @@ Gem::Specification.new do |spec|
   # If you upgrade this gem, make sure to upgrade the users of it as well.
   spec.add_dependency('google-api-client', '>= 0.37.0', '< 0.39.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
-
-  # need to lock under 0.15 using less than Ruby 2.5 to prevent install issues when using 'gem install'
-  # 'gem install' does not respect Ruby versions and would try installing 0.15 on Ruby 2.4 or less
-  # signet - https://github.com/googleapis/signet/commit/bd6fe87948f8fc7702720dae651e82f4fd348b5d#diff-cd03b1ea000c03b6c5c89bccd9d04486b36976aef245f00ea92aaef2bd98ebb7
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
-    spec.add_dependency('signet', '< 0.15')
-    STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet'  because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.5 or later")
-  end
 
   spec.add_dependency('emoji_regex', '>= 0.1', '< 4.0') # Used to scan for Emoji in the changelog
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -59,11 +59,12 @@ Gem::Specification.new do |spec|
   # need to lock under 0.15 using less than Ruby 2.5 to prevent install issues when using 'gem install'
   # 'gem install' does not respect Ruby versions and would try installing 0.15 on Ruby 2.4 or less
   # signet - https://github.com/googleapis/signet/commit/bd6fe87948f8fc7702720dae651e82f4fd348b5d#diff-cd03b1ea000c03b6c5c89bccd9d04486b36976aef245f00ea92aaef2bd98ebb7
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
-    spec.add_dependency('signet', '<= 0.14.1')
-    spec.add_dependency('googleauth', '<= 0.9')
-    STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet' and 'googleauth' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.5 or later")
-  end
+  spec.add_dependency('signet', '<= 0.14.1')
+#  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
+#    spec.add_dependency('signet', '<= 0.14.1')
+#    spec.add_dependency('googleauth', '<= 0.9')
+#    STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet' and 'googleauth' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.5 or later")
+#  end
 
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
   spec.add_dependency('xcodeproj', '>= 1.13.0', '< 2.0.0') # Modify Xcode projects

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -99,6 +99,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
   spec.add_dependency('signet', '>= 0.14.0') # Signet 0.14.0 is needed for Ruby 2.4
 
+  # need to lock under 0.15 using less than Ruby 2.5 to prevent install issues when using 'gem install'
+  # 'gem install' does not respect Ruby versions and would try installing 0.15 on Ruby 2.4 or less
+  # signet - https://github.com/googleapis/signet/commit/bd6fe87948f8fc7702720dae651e82f4fd348b5d#diff-cd03b1ea000c03b6c5c89bccd9d04486b36976aef245f00ea92aaef2bd98ebb7
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
+    spec.add_dependency('signet', '< 0.15')
+    STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet'  because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.5 or later")
+  end
+
   spec.add_dependency('emoji_regex', '>= 0.1', '< 4.0') # Used to scan for Emoji in the changelog
 
   spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used for S3 storage in fastlane match

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -97,7 +97,6 @@ Gem::Specification.new do |spec|
   # If you upgrade this gem, make sure to upgrade the users of it as well.
   spec.add_dependency('google-api-client', '>= 0.37.0', '< 0.39.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
-  spec.add_dependency('signet', '>= 0.14.0') # Signet 0.14.0 is needed for Ruby 2.4
 
   # need to lock under 0.15 using less than Ruby 2.5 to prevent install issues when using 'gem install'
   # 'gem install' does not respect Ruby versions and would try installing 0.15 on Ruby 2.4 or less

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -60,6 +60,7 @@ Gem::Specification.new do |spec|
   # 'gem install' does not respect Ruby versions and would try installing 0.15 on Ruby 2.4 or less
   # signet - https://github.com/googleapis/signet/commit/bd6fe87948f8fc7702720dae651e82f4fd348b5d#diff-cd03b1ea000c03b6c5c89bccd9d04486b36976aef245f00ea92aaef2bd98ebb7
   spec.add_dependency('signet', '<= 0.14.1')
+  spec.add_dependency('googleauth', '<= 0.15.1')
 #  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
 #    spec.add_dependency('signet', '<= 0.14.1')
 #    spec.add_dependency('googleauth', '<= 0.9')

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -60,8 +60,8 @@ Gem::Specification.new do |spec|
   # 'gem install' does not respect Ruby versions and would try installing 0.15 on Ruby 2.4 or less
   # signet - https://github.com/googleapis/signet/commit/bd6fe87948f8fc7702720dae651e82f4fd348b5d#diff-cd03b1ea000c03b6c5c89bccd9d04486b36976aef245f00ea92aaef2bd98ebb7
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
-    spec.add_dependency('signet', '< 0.15')
-    spec.add_dependency('googleauth', '< 0.10')
+    spec.add_dependency('signet', '<= 0.14.1')
+    spec.add_dependency('googleauth', '<= 0.9')
     STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet' and 'googleauth' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.5 or later")
   end
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -56,16 +56,6 @@ Gem::Specification.new do |spec|
   # spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = Dir["*/lib"]
 
-  # need to lock under 0.15 using less than Ruby 2.5 to prevent install issues when using 'gem install'
-  # 'gem install' does not respect Ruby versions and would try installing 0.15 on Ruby 2.4 or less
-  # signet - https://github.com/googleapis/signet/commit/bd6fe87948f8fc7702720dae651e82f4fd348b5d
-  # googleauth - https://github.com/googleapis/google-auth-library-ruby/commit/6644806ab47cea6d08e1901c2ed808e53a579bc3
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
-    spec.add_dependency('signet', '<= 0.14.1')
-    spec.add_dependency('googleauth', '<= 0.15.1')
-    STDERR.puts("WARNING: Locking to a potentially insecure version of 'signet' and 'googleauth' because you are using a version of Ruby which is marked as End-Of-Life. Please upgrade your Ruby installation to 2.5 or later")
-  end
-
   spec.add_dependency('slack-notifier', '>= 2.0.0', '< 3.0.0') # Slack notifications
   spec.add_dependency('xcodeproj', '>= 1.13.0', '< 2.0.0') # Modify Xcode projects
   spec.add_dependency('xcpretty', '~> 0.3.0') # prettify xcodebuild output


### PR DESCRIPTION
### Motivation and Context
CI broke in #18328 because `signet` updated 0.15.0 to require Ruby 2.5+

### Description
Updating CI jobs to use Ruby 2.5