### PR TITLE
[action] app_store_connect_api_key - add validation to the session duration (that can't be greater than 20 minutes)

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -76,7 +76,10 @@ module Fastlane
                                        description: "The token session duration",
                                        optional: true,
                                        default_value: Spaceship::ConnectAPI::Token::MAX_TOKEN_DURATION,
-                                       type: Integer),
+                                       type: Integer,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The duration can't be more than 1200 (20 minutes) and the value entered was '#{value}'") unless value <= 1200
+                                       end),
           FastlaneCore::ConfigItem.new(key: :in_house,
                                        env_name: "APP_STORE_CONNECT_API_KEY_IN_HOUSE",
                                        description: "Is App Store or Enterprise (in house) team? App Store Connect API cannot determine this on its own (yet)",

--- a/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
@@ -91,6 +91,19 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error(/:key_content or :key_filepath is required/)
       end
+
+      it "raise error when duration is higher than 20 minutes" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            app_store_connect_api_key(
+              key_id: 'foo',
+              issuer_id: 'bar',
+              key_content: 'derp',
+              duration: 1300
+            )
+          end").runner.execute(:test)
+        end.to raise_error("The duration can't be more than 1200 (20 minutes) and the value entered was '1300'")
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This came up in https://github.com/fastlane/docs/pull/1029

### Description

The session max duration is 20 minutes, as per the Apple documentation: https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests

After updating the documentation in https://github.com/fastlane/docs/pull/1029, I thought we should actually validate this field directly in the user's input.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan/validate-app-store-connect-session-duration"
```

And run `bundle install` to apply the changes.

To test this issue, try to run `app_store_connect_api_key` lane using a duration greater than 1200.