### PR TITLE
[action] notarize: add support for AppStore Connect API Key

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -38,7 +38,7 @@ module Fastlane
           # From xcrun altool for --apiKey:
           # This option will search the following directories in sequence for a private key file with the name of 'AuthKey_<api_key>.p8':  './private_keys', '~/private_keys', '~/.private_keys', and '~/.appstoreconnect/private_keys'.
           api_key = JSON.parse(File.read(api_key_path))
-          api_key_folder_path = 'private_keys'
+          api_key_folder_path = '~/.appstoreconnect/private_keys'
           api_key_file_path = File.join(api_key_folder_path, "AuthKey_#{api_key['key_id']}.p8")
           directory_exists = File.directory?(api_key_folder_path)
           file_exists = File.exist?(api_key_file_path)

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -88,11 +88,11 @@ module Fastlane
                 UI.error("Error polling for notarization info: #{msg}")
               }
             )
-          end
 
-          unless error
-            notarization_info_plist = Plist.parse_xml(notarization_info_response)
-            notarization_info = notarization_info_plist['notarization-info']
+            unless error
+              notarization_info_plist = Plist.parse_xml(notarization_info_response)
+              notarization_info = notarization_info_plist['notarization-info']
+            end
           end
         end
 

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -33,6 +33,7 @@ module Fastlane
 
         notarization_upload_command = "xcrun altool --notarize-app -t osx -f \"#{compressed_package_path || package_path}\" --primary-bundle-id #{bundle_id} --output-format xml"
 
+        notarization_info = {}
         with_notarize_authenticator(api_key_path) do |notarize_authenticator|
           notarization_upload_command << " --asc-provider \"#{params[:asc_provider]}\"" if params[:asc_provider] and api_key_path.nil?
 
@@ -55,7 +56,6 @@ module Fastlane
 
           UI.success("Successfully uploaded package to notarization service with request identifier #{notarization_request_id}")
 
-          notarization_info = {}
           while notarization_info.empty? || (notarization_info['Status'] == 'in progress')
             if notarization_info.empty?
               UI.message('Waiting to query request status')

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -35,7 +35,7 @@ module Fastlane
 
         notarization_info = {}
         with_notarize_authenticator(api_key_path) do |notarize_authenticator|
-          notarization_upload_command << " --asc-provider \"#{params[:asc_provider]}\"" if params[:asc_provider] and api_key_path.nil?
+          notarization_upload_command << " --asc-provider \"#{params[:asc_provider]}\"" if params[:asc_provider] && api_key_path.nil?
 
           notarization_upload_response = Actions.sh(
             notarize_authenticator.call(notarization_upload_command),
@@ -46,9 +46,9 @@ module Fastlane
 
           notarization_upload_plist = Plist.parse_xml(notarization_upload_response)
 
-          if notarization_upload_plist.has_key?('product-errors') && notarization_upload_plist['product-errors'].any?
+          if notarization_upload_plist.key?('product-errors') && notarization_upload_plist['product-errors'].any?
             UI.important("🚫 Could not upload package to notarization service! Here are the reasons:")
-            notarization_upload_plist['product-errors'].each { |product_error| UI.error "#{product_error['message']} (#{product_error['code']})" }
+            notarization_upload_plist['product-errors'].each { |product_error| UI.error("#{product_error['message']} (#{product_error['code']})") }
             UI.user_error!("Package upload to notarization service cancelled. Please check the error messages above.")
           end
 
@@ -139,9 +139,9 @@ module Fastlane
           file_exists = File.exist?(api_key_file_path)
           begin
             FileUtils.mkdir_p(api_key_folder_path) unless directory_exists
-            File.open(api_key_file_path, 'w') {|f| f.write api_key['key'] } unless file_exists
+            File.open(api_key_file_path, 'w') { |f| f.write(api_key['key']) } unless file_exists
 
-            yield Proc.new { |command| "#{command} --apiKey #{api_key['key_id']} --apiIssuer #{api_key['issuer_id']}" }
+            yield(proc { |command| "#{command} --apiKey #{api_key['key_id']} --apiIssuer #{api_key['issuer_id']}" })
           ensure
             FileUtils.rm(api_key_file_path) unless file_exists
             FileUtils.rm_r(api_key_folder_path) unless directory_exists
@@ -153,7 +153,7 @@ module Fastlane
           # Use app specific password if specified.
           ENV['FL_NOTARIZE_PASSWORD'] = ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'] || apple_id_account.password
 
-          yield Proc.new { |command| "#{command} -u #{apple_id_account.user} -p @env:FL_NOTARIZE_PASSWORD" }
+          yield(proc { |command| "#{command} -u #{apple_id_account.user} -p @env:FL_NOTARIZE_PASSWORD" })
         end
       end
 

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -1,6 +1,7 @@
 module Fastlane
   module Actions
     class NotarizeAction < Action
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         package_path = params[:package]
         bundle_id = params[:bundle_id]
@@ -95,6 +96,7 @@ module Fastlane
             end
           end
         end
+        # rubocop:enable Metrics/PerceivedComplexity
 
         log_url = notarization_info['LogFileURL']
         ENV['FL_NOTARIZE_LOG_FILE_URL'] = log_url

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -196,6 +196,8 @@ module Fastlane
                                        env_name: 'FL_NOTARIZE_USERNAME',
                                        description: 'Apple ID username',
                                        default_value: username,
+                                       optional: true,
+                                       conflicting_options: [:api_key_path],
                                        default_value_dynamic: true),
           FastlaneCore::ConfigItem.new(key: :asc_provider,
                                        env_name: 'FL_NOTARIZE_ASC_PROVIDER',
@@ -218,6 +220,7 @@ module Fastlane
                                        env_name: 'FL_NOTARIZE_API_KEY_PATH',
                                        description: 'Path to AppStore Connect API key',
                                        optional: true,
+                                       conflicting_options: [:username],
                                        is_string: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("API Key not found at '#{value}'") unless File.exist?(value)

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -47,6 +47,13 @@ module Fastlane
         FileUtils.rm_rf(compressed_package_path) if compressed_package_path
 
         notarization_upload_plist = Plist.parse_xml(notarization_upload_response)
+
+        if notarization_upload_plist.has_key?('product-errors') && notarization_upload_plist['product-errors'].any?
+          UI.important("🚫 Could not upload package to notarization service! Here are the reasons:")
+          notarization_upload_plist['product-errors'].each { |product_error| UI.error "#{product_error['message']} (#{product_error['code']})" }
+          UI.user_error!("Package upload to notarization service cancelled. Please check the error messages above.")
+        end
+
         notarization_request_id = notarization_upload_plist['notarization-upload']['RequestUUID']
 
         UI.success("Successfully uploaded package to notarization service with request identifier #{notarization_request_id}")

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -134,16 +134,16 @@ module Fastlane
         if api_key_path
           # From xcrun altool for --apiKey:
           # This option will search the following directories in sequence for a private key file with the name of 'AuthKey_<api_key>.p8':  './private_keys', '~/private_keys', '~/.private_keys', and '~/.appstoreconnect/private_keys'.
-          api_key = JSON.parse(File.read(api_key_path))
+          api_key = Spaceship::ConnectAPI::Token.from_json_file(api_key_path)
           api_key_folder_path = '~/.appstoreconnect/private_keys'
-          api_key_file_path = File.join(api_key_folder_path, "AuthKey_#{api_key['key_id']}.p8")
+          api_key_file_path = File.join(api_key_folder_path, "AuthKey_#{api_key.key_id}.p8")
           directory_exists = File.directory?(api_key_folder_path)
           file_exists = File.exist?(api_key_file_path)
           begin
             FileUtils.mkdir_p(api_key_folder_path) unless directory_exists
-            File.open(api_key_file_path, 'w') { |f| f.write(api_key['key']) } unless file_exists
+            api_key.write_key_to_file(api_key_file_path) unless file_exists
 
-            yield(proc { |command| "#{command} --apiKey #{api_key['key_id']} --apiIssuer #{api_key['issuer_id']}" })
+            yield(proc { |command| "#{command} --apiKey #{api_key.key_id} --apiIssuer #{api_key.issuer_id}" })
           ensure
             FileUtils.rm(api_key_file_path) unless file_exists
             FileUtils.rm_r(api_key_folder_path) unless directory_exists

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -58,9 +58,8 @@ module Fastlane
           ENV['FL_NOTARIZE_PASSWORD'] = ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'] || apple_id_account.password
 
           notarization_upload_command << " -u #{apple_id_account.user} -p @env:FL_NOTARIZE_PASSWORD"
+          notarization_upload_command << " --asc-provider \"#{params[:asc_provider]}\"" if params[:asc_provider]
         end
-
-        notarization_upload_command << " --asc-provider \"#{params[:asc_provider]}\"" if params[:asc_provider]
 
         notarization_upload_response = Actions.sh(
           notarization_upload_command,

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -35,7 +35,7 @@ module Fastlane
         notarization_upload_command = "xcrun altool --notarize-app -t osx -f \"#{compressed_package_path || package_path}\" --primary-bundle-id #{bundle_id} --output-format xml"
 
         notarization_info = {}
-        with_notarize_authenticator(api_key_path) do |notarize_authenticator|
+        with_notarize_authenticator(params, api_key_path) do |notarize_authenticator|
           notarization_upload_command << " --asc-provider \"#{params[:asc_provider]}\"" if params[:asc_provider] && api_key_path.nil?
 
           notarization_upload_response = Actions.sh(
@@ -130,7 +130,7 @@ module Fastlane
         )
       end
 
-      def self.with_notarize_authenticator(api_key_path)
+      def self.with_notarize_authenticator(params, api_key_path)
         if api_key_path
           # From xcrun altool for --apiKey:
           # This option will search the following directories in sequence for a private key file with the name of 'AuthKey_<api_key>.p8':  './private_keys', '~/private_keys', '~/.private_keys', and '~/.appstoreconnect/private_keys'.

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -135,7 +135,7 @@ module Fastlane
           # From xcrun altool for --apiKey:
           # This option will search the following directories in sequence for a private key file with the name of 'AuthKey_<api_key>.p8':  './private_keys', '~/private_keys', '~/.private_keys', and '~/.appstoreconnect/private_keys'.
           api_key = Spaceship::ConnectAPI::Token.from_json_file(api_key_path)
-          api_key_folder_path = '~/.appstoreconnect/private_keys'
+          api_key_folder_path = File.expand_path('~/.appstoreconnect/private_keys')
           api_key_file_path = File.join(api_key_folder_path, "AuthKey_#{api_key.key_id}.p8")
           directory_exists = File.directory?(api_key_folder_path)
           file_exists = File.exist?(api_key_file_path)

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -97,6 +97,10 @@ module Spaceship
       def expired?
         @expiration < Time.now
       end
+
+      def write_key_to_file(path)
+        File.open(path, 'w') { |f| f.write(@key) }
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -60,14 +60,16 @@ module Spaceship
           key_id: key_id,
           issuer_id: issuer_id,
           key: OpenSSL::PKey::EC.new(key),
+          key_raw: key,
           duration: duration,
           in_house: in_house
         )
       end
 
-      def initialize(key_id: nil, issuer_id: nil, key: nil, duration: nil, in_house: nil)
+      def initialize(key_id: nil, issuer_id: nil, key: nil, key_raw: nil, duration: nil, in_house: nil)
         @key_id = key_id
         @key = key
+        @key_raw = key_raw
         @issuer_id = issuer_id
         @duration = duration
         @in_house = in_house
@@ -99,7 +101,7 @@ module Spaceship
       end
 
       def write_key_to_file(path)
-        File.open(path, 'w') { |f| f.write(@key) }
+        File.open(path, 'w') { |f| f.write(@key_raw) }
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Following Apple's incentives towards using AppStore Connect API keys instead of passwords, my team is trying to move to this new system. `notarize`, which is a critical component in our Mac builds pipeline does not seem to support it however, which is what this pull request aims to solve.

### Description

The biggest change in the interface of `notarize` this PR suggests is the addition of a new parameter, `api_key_path`, which would be the path to an API key file.

On a purely black box perspective, the only change there is the support for this new authentication method. I made this backwards compatibility in mind, so this change should not change anything for users that do not use API keys.

On a more technical level, I've done a few things:
- make notarize calls authentication abstract of which mean of authentication is used
- select authentication method based on the absence or presence of api_key_path
- support API key parameters
- I took the liberty of making `self.run` ignore rubocop Perceived Complexity metric, because addressing it would have me change more than what I was comfortable with for this specific PR

One important specificity of notarize (which I believe is not present in other apple tools) is that in order to be able to use the key, it must be present on the file system in a specific location, which means that I had to actually write the content of the token on the file system.