### PR TITLE
[action] add skip_info_plist parameter to increment_build_number to avoid updating Info.plist

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -33,11 +33,11 @@ module Fastlane
         agv_disabled = !system([command_prefix, 'agvtool what-version', command_suffix].join(' '))
         raise "Apple Generic Versioning is not enabled." if agv_disabled && params[:build_number].nil?
 
-        mode = params[:skip_info_plist] ? '' : '-all'
+        mode = params[:skip_info_plist] ? '' : ' -all'
         command = [
           command_prefix,
           'agvtool',
-          params[:build_number] ? "new-version #{mode} #{params[:build_number].to_s.strip}" : "next-version #{mode}",
+          params[:build_number] ? "new-version#{mode} #{params[:build_number].to_s.strip}" : "next-version#{mode}",
           command_suffix
         ].join(' ')
 

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -33,10 +33,11 @@ module Fastlane
         agv_disabled = !system([command_prefix, 'agvtool what-version', command_suffix].join(' '))
         raise "Apple Generic Versioning is not enabled." if agv_disabled && params[:build_number].nil?
 
+        mode = params[:skip_info_plist] ? '' : '-all'
         command = [
           command_prefix,
           'agvtool',
-          params[:build_number] ? "new-version -all #{params[:build_number].to_s.strip}" : 'next-version -all',
+          params[:build_number] ? "new-version #{mode} #{params[:build_number].to_s.strip}" : "next-version #{mode}",
           command_suffix
         ].join(' ')
 
@@ -66,6 +67,12 @@ module Fastlane
                                        description: "Change to a specific version. When you provide this parameter, Apple Generic Versioning does not have to be enabled",
                                        optional: true,
                                        is_string: false),
+          FastlaneCore::ConfigItem.new(key: :skip_info_plist,
+                                       env_name: "FL_BUILD_NUMBER_SKIP_INFO_PLIST",
+                                       description: "Don't update Info.plist files when updating the build version",
+                                       is_string: false,
+                                       type: Boolean,
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
                                        env_name: "FL_BUILD_NUMBER_PROJECT",
                                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",

--- a/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_build_number_action_spec.rb
@@ -39,6 +39,19 @@ describe Fastlane do
           expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('24')
         end
 
+        it "skips info plist updating" do
+          expect(Fastlane::Actions).to receive(:sh)
+            .with(/agvtool new[-]version 24 && cd [-]/)
+            .once
+            .and_return("")
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            increment_build_number(build_number: 24, xcodeproj: '.xcproject', skip_info_plist: true)
+          end").runner.execute(:test)
+
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq('24')
+        end
+
         it "displays error when $(SRCROOT) detected" do
           expect(Fastlane::Actions).to receive(:sh)
             .with(/agvtool new[-]version [-]all 24 && cd [-]/)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This is important when Info.plist is configured to reference $(CURRENT_PROJECT_VERSION).

Fixes #18367

### Description
The issue is caused by passing `-all` to `agvtool`. This change makes `-all` optional by allowing the developer to turn it off.
