### PR TITLE
[action][match] match_nuke action - Nuke your certificate and provisioning profiles (via match)

### DIFF
--- a/fastlane/lib/fastlane/actions/match_nuke.rb
+++ b/fastlane/lib/fastlane/actions/match_nuke.rb
@@ -1,6 +1,5 @@
 module Fastlane
   module Actions
-
     class MatchNukeAction < Action
       def self.run(params)
         require 'match'

--- a/fastlane/lib/fastlane/actions/match_nuke.rb
+++ b/fastlane/lib/fastlane/actions/match_nuke.rb
@@ -1,0 +1,60 @@
+module Fastlane
+  module Actions
+
+    class MatchNukeAction < Action
+      def self.run(params)
+        require 'match'
+
+        params.load_configuration_file("Matchfile")
+        params[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
+
+        cert_type = Match.cert_type_sym(params[:type])
+        UI.important("Going to revoke your '#{cert_type}' certificate type and provisioning profiles")
+
+        Match::Nuke.new.run(params, type: cert_type)
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Easily nuke your certificate and provisioning profiles (via _match_)"
+      end
+
+      def self.details
+        [
+          "Use the match_nuke action to revoke your certificates and provisioning profiles.",
+          "Don't worry, apps that are already available in the App Store / TestFlight will still work.",
+          "Builds distributed via Ad Hoc or Enterprise will be disabled after nuking your account, so you'll have to re-upload a new build.",
+          "After clearing your account you'll start from a clean state, and you can run match to generate your certificates and profiles again.",
+          "More information: https://docs.fastlane.tools/actions/match/"
+        ].join("\n")
+      end
+
+      def self.available_options
+        require 'match'
+        Match::Options.available_options
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.example_code
+        [
+          'match_nuke(type: "development")', # See all other options https://github.com/fastlane/fastlane/blob/master/match/lib/match/module.rb#L23
+          'match_nuke(type: "development", api_key: app_store_connect_api_key)'
+        ]
+      end
+
+      def self.authors
+        ["crazymanish"]
+      end
+
+      def self.category
+        :code_signing
+      end
+    end
+  end
+end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -71,6 +71,7 @@ describe Fastlane do
           validate_play_store_json_key
           update_fastlane
           s3
+          match_nuke
         )
       end
 

--- a/match/lib/match/module.rb
+++ b/match/lib/match/module.rb
@@ -21,6 +21,7 @@ module Match
   end
 
   def self.cert_type_sym(type)
+    type = type.to_s
     return :mac_installer_distribution if type == "mac_installer_distribution"
     return :developer_id_installer if type == "developer_id_installer"
     return :developer_id_application if type == "developer_id"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
#### Motivation
Allow user to use `api_key` / `api_key_path` to `match nuke` to use App Store Connect JWT Auth

#### Context
Problem1: Nuke certificate and provisioning profiles using match nuke CLI command is crazy 
```ruby 
fastlane match nuke development --passing here AppStoreConnect API key details 
```
Problem2: match nuke CLI command with `app_store_connect_api_key` (@joshdholtz's lovely action) is almost impossible 

### Description
- Introduce a new action `match_nuke` to easily nuke certificate and provisioning profiles (via _match_)

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
```ruby
lane :renew_certificate do
   ENV["MATCH_TYPE"] = "development"
   
  app_store_connect_api_key(
    key_id: "D383SF739",
    issuer_id: "6053b7fe-68a8-4acb-89be-165aa6465141",
    key_filepath: "./AuthKey_D383SF739.p8",
    in_house: false
  )

  # Automatically loads Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
  match_nuke
  match
end
```

<img width="912" alt="Screenshot 2021-03-12 at 23 14 22" src="https://user-images.githubusercontent.com/5364500/111008331-2473d680-8391-11eb-9437-b6e10f517243.png">
