### PR TITLE
[match][change_password] re-encrypt using new password instead of MATCH_PASSWORD env var

### DIFF
--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -16,7 +16,7 @@ module Match
 
       ensure_ui_interactive
 
-      to = FastlaneCore::Helper.ask_password(message: "New passphrase for Git Repo: ", confirm: true)
+      new_password = FastlaneCore::Helper.ask_password(message: "New passphrase for Git Repo: ", confirm: true)
 
       # Choose the right storage and encryption implementations
       storage = Storage.for_mode(params[:storage_mode], {
@@ -37,10 +37,10 @@ module Match
       encryption.decrypt_files
 
       encryption.clear_password
-      encryption.store_password(to)
+      encryption.store_password(new_password)
 
       message = "[fastlane] Changed passphrase"
-      files_to_commit = encryption.encrypt_files
+      files_to_commit = encryption.encrypt_files(new_password)
       storage.save_changes!(files_to_commit: files_to_commit, custom_message: message)
     end
 

--- a/match/lib/match/encryption/interface.rb
+++ b/match/lib/match/encryption/interface.rb
@@ -3,7 +3,7 @@ module Match
     class Interface
       # Call this method to trigger the actual
       # encryption
-      def encrypt_files
+      def encrypt_files(password: nil)
         not_implemented(__method__)
       end
 

--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -28,9 +28,9 @@ module Match
         self.working_directory = working_directory
       end
 
-      def encrypt_files
+      def encrypt_files(password: nil)
         files = []
-        password = fetch_password!
+        password ||= fetch_password!
         iterate(self.working_directory) do |current|
           files << current
           encrypt_specific_file(path: current, password: password)

--- a/match/spec/encryption/openssl_spec.rb
+++ b/match/spec/encryption/openssl_spec.rb
@@ -8,7 +8,7 @@ describe Match do
       @content = File.binread(@full_path)
       @git_url = "https://github.com/fastlane/fastlane/tree/master/so_random"
       allow(Dir).to receive(:mktmpdir).and_return(@directory)
-      ENV["MATCH_PASSWORD"] = '2"QAHg@v(Qp{=*n^'
+      stub_const('ENV', { "MATCH_PASSWORD" => '2"QAHg@v(Qp{=*n^' })
 
       @e = Match::Encryption::OpenSSL.new(
         keychain_name: @git_url,
@@ -28,33 +28,33 @@ describe Match do
       @e.encrypt_files
       expect(File.read(@full_path)).to_not(eq(@content))
 
-      ENV["MATCH_PASSWORD"] = "invalid"
+      stub_const('ENV', { "MATCH_PASSWORD" => "invalid" })
       expect do
         @e.decrypt_files
       end.to raise_error("Invalid password passed via 'MATCH_PASSWORD'")
     end
 
     it "raises an exception if no password is supplied" do
-      ENV["MATCH_PASSWORD"] = ""
+      stub_const('ENV', { "MATCH_PASSWORD" => "" })
       expect do
         @e.encrypt_files
       end.to raise_error("No password supplied")
     end
 
     it "doesn't raise an exception if no env var is supplied but custom password is" do
-      ENV["MATCH_PASSWORD"] = ""
+      stub_const('ENV', { "MATCH_PASSWORD" => "" })
       expect do
         @e.encrypt_files(password: "some custom password")
       end.to_not(raise_error)
     end
 
     it "given a custom password argument, then it should be given precedence when encrypting file, even when MATCH_PASSWORD is set" do
-      ENV["MATCH_PASSWORD"] = "something else"
+      stub_const('ENV', { "MATCH_PASSWORD" => "something else" })
       new_password = '2"QAHg@v(Qp{=*n^'
       @e.encrypt_files(password: new_password)
       expect(File.binread(@full_path)).to_not(eq(@content))
 
-      ENV["MATCH_PASSWORD"] = new_password
+      stub_const('ENV', { "MATCH_PASSWORD" => new_password })
       @e.decrypt_files
       expect(File.binread(@full_path)).to eq(@content)
     end

--- a/match/spec/encryption/openssl_spec.rb
+++ b/match/spec/encryption/openssl_spec.rb
@@ -40,5 +40,23 @@ describe Match do
         @e.encrypt_files
       end.to raise_error("No password supplied")
     end
+
+    it "doesn't raise an exception if no env var is supplied but custom password is" do
+      ENV["MATCH_PASSWORD"] = ""
+      expect do
+        @e.encrypt_files(password: "some custom password")
+      end.to_not(raise_error)
+    end
+
+    it "given a custom password argument, then it should be given precedence when encrypting file, even when MATCH_PASSWORD is set" do
+      ENV["MATCH_PASSWORD"] = "something else"
+      new_password = '2"QAHg@v(Qp{=*n^'
+      @e.encrypt_files(password: new_password)
+      expect(File.binread(@full_path)).to_not(eq(@content))
+
+      ENV["MATCH_PASSWORD"] = new_password
+      @e.decrypt_files
+      expect(File.binread(@full_path)).to eq(@content)
+    end
   end
 end

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -18,6 +18,8 @@ describe Match do
         before do
           allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
           allow(FastlaneCore::Helper).to receive(:xcode_version).and_return(xcode_version)
+
+          stub_const('ENV', { "MATCH_PASSWORD" => '2"QAHg@v(Qp{=*n^' })
         end
 
         it "creates a new profile and certificate if it doesn't exist yet", requires_security: true do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves #15942
Resolves #17968
Resolves #17909

### Description

`encrypt_files` was being called without informing the new password as an argument. As a result, it would invoke `fetch_password` which reads the password from the env var. Worst case scenario, if the env var is not set, it either asks the user for the password again (if interactive) or crashes.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan/fix-change-password-new-password"
```

And run `bundle install` to apply the changes.

The test scenario is: call `change_password` with an env var `MATCH_PASSWORD` set. After re-encrypting the files, check if the encrypted files can be decrypted using the password you provided in `change_password`