### PR TITLE
[Ruby 3.0] Replace Kernel.open overridden by open-uri with URI.open

### DIFF
--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -68,7 +68,7 @@ module Deliver
           end
 
           path = File.join(containing_folder, file_name)
-          File.binwrite(path, open(url).read)
+          File.binwrite(path, URI.open(url).read)
         end
       end
     end

--- a/deliver/lib/deliver/setup.rb
+++ b/deliver/lib/deliver/setup.rb
@@ -1,4 +1,3 @@
-require 'open-uri'
 require 'spaceship/tunes/tunes'
 
 require_relative 'module'

--- a/fastlane/actions/plugin_scores.rb
+++ b/fastlane/actions/plugin_scores.rb
@@ -24,7 +24,7 @@ module Fastlane
         loop do
           url = "https://rubygems.org/api/v1/search.json?query=fastlane-plugin-&page=#{page}"
           puts("RubyGems API Request: #{url}")
-          results = JSON.parse(open(url).read)
+          results = JSON.parse(URI.open(url).read)
           break if results.count == 0
 
           plugins += results.collect do |current|

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -23,7 +23,7 @@ module Fastlane
           UI.message("Downloading root certificate from (#{ROOT_CERTIFICATE_URL}) to path '#{params[:certificate]}'")
           require 'open-uri'
           File.open(params[:certificate], "w:ASCII-8BIT") do |file|
-            file.write(open(ROOT_CERTIFICATE_URL, "rb").read)
+            file.write(URI.open(ROOT_CERTIFICATE_URL, "rb").read)
           end
         end
 

--- a/fastlane/lib/fastlane/plugins/plugin_fetcher.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_fetcher.rb
@@ -14,7 +14,7 @@ module Fastlane
       loop do
         url = "https://rubygems.org/api/v1/search.json?query=#{PluginManager.plugin_prefix}&page=#{page}"
         FastlaneCore::UI.verbose("RubyGems API Request: #{url}")
-        results = JSON.parse(open(url).read)
+        results = JSON.parse(URI.open(url).read)
         break if results.count == 0
 
         plugins += results.collect do |current|

--- a/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
@@ -68,7 +68,7 @@ module Fastlane
       require 'open-uri'
       require 'json'
       url = "https://rubygems.org/api/v1/gems/#{name}.json"
-      response = JSON.parse(open(url).read)
+      response = JSON.parse(URI.open(url).read)
       return !!response['version']
     rescue
       false


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Prior to this PR, I've fixed most issues about Ruby 2.7 deprecation warnings at least within fastlane/fastlane's codebase #18021 as per plan #17931. There are some left in its dependencies. While working on this PR https://github.com/fastlane/fastlane/pull/18278 that randomises the order of execution of test cases, I found that there are more issues that I missed last time due to the code path in unit testing which is always the same unless using `--order random` like #18278. (In other words, #18278 will be quite handy to reveal undiscovered issues😄)

https://app.circleci.com/pipelines/github/fastlane/fastlane/2446/workflows/604cf165-0e95-4227-8088-732c3957d62c/jobs/64390/parallel-runs/0/steps/0-115

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

`Kernel#open` which is overridden by `require 'open-uri'` is deprecated in Ruby 2.7 and removed in Ruby 3.0. For some reasons, it wasn't detected in fastlane's codebase. So this PR replace `Kernel#open` that appears as `open(url)` with `URI.open` which remains available in Ruby 3.0. 
https://github.com/ruby/ruby/commit/a73b5cc556bd131fe924ed6bb02b3c5bdf1593e8


### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
