### PR TITLE
[CI] Fix CI checks passing successfully when actually failing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ task(:test_all) do
     # Mix stderr into stdout to let handle `tee` it and then collect warnings by filtering stdout out
     command += " 2>&1 | tee >(grep 'warning:' > #{File.join(ENV['CIRCLE_TEST_REPORTS'], 'ruby_warnings.txt')})" if ENV["CIRCLE_TEST_REPORTS"]
     # tee >(...) occurs syntax error with `sh` helper which uses /bin/sh by default.
-    sh("/bin/bash -c \"#{command}\"")
+    sh("/bin/bash -o pipefail -c \"#{command}\"")
   end
 end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

In #18021, I've updated `Rakefile` to collect deprecation warnings from RSpec's output for Ruby 3.0 migration but it was implemented wrong slightly. Due to the syntax issue, I used `/bin/bash -c "rspec ..."` form to call `rspec` command but it didn't enable `pipefail` option in the new bash process. 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I added `-o pipefail` to make the rspec command (with pipe) fail when failing!

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I added [a temporary commit](https://github.com/ainame/fastlane/commit/e9666bd7e86de2345fd23475b3a8c438c6a59c9a) to make CI fail to confirm https://app.circleci.com/pipelines/github/fastlane/fastlane?branch=pull%2F18398
