### PR TITLE
[action] app_store_connect_api_key - fixed issue with ApiKey in home directory

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -29,7 +29,7 @@ module Fastlane
         key = {
           key_id: key_id,
           issuer_id: issuer_id,
-          key: key_content || File.binread(key_filepath),
+          key: key_content || File.binread(File.expand_path(key_filepath)),
           is_key_content_base64: is_key_content_base64,
           duration: duration,
           in_house: in_house
@@ -58,7 +58,7 @@ module Fastlane
                                        optional: true,
                                        conflicting_options: [:key_content],
                                        verify_block: proc do |value|
-                                         UI.user_error!("Couldn't find key p8 file at path '#{value}'") unless File.exist?(value)
+                                         UI.user_error!("Couldn't find key p8 file at path '#{value}'") unless File.exist?(File.expand_path(value))
                                        end),
           FastlaneCore::ConfigItem.new(key: :key_content,
                                        env_name: "APP_STORE_CONNECT_API_KEY_KEY",


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

* I cannot run the rspec and rubocop on M1 somehow... 

### Motivation and Context
If you want to specify where the api key is stored, you are not able to use home directory. Ruby by default does not expand path of `~/` to `/Users/username/`

<img width="800" alt="CleanShot 2021-03-15 at 19 49 19@2x" src="https://user-images.githubusercontent.com/1025588/111205966-1b207f00-85c8-11eb-9168-1a122f69dc74.png">


### Description
When checking if the file exists, we need to first expand the path.
Not sure if this is correct solution and I don't have an idea how to add a testcase for this scenario (due to zero knowledge about CI runners fastlane uses) so would love to get some feedback.

### Testing Steps

