### PR TITLE
[Ruby 3.0] fix failing CI checks by supporting open-uri on Ruby 2.4 

### DIFF
--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -1,6 +1,5 @@
 require_relative 'module'
 require 'spaceship'
-require 'open-uri'
 
 module Deliver
   class DownloadScreenshots
@@ -68,7 +67,7 @@ module Deliver
           end
 
           path = File.join(containing_folder, file_name)
-          File.binwrite(path, URI.open(url).read)
+          File.binwrite(path, FastlaneCore::Helper.open_uri(url).read)
         end
       end
     end

--- a/fastlane/actions/plugin_scores.rb
+++ b/fastlane/actions/plugin_scores.rb
@@ -24,7 +24,7 @@ module Fastlane
         loop do
           url = "https://rubygems.org/api/v1/search.json?query=fastlane-plugin-&page=#{page}"
           puts("RubyGems API Request: #{url}")
-          results = JSON.parse(URI.open(url).read)
+          results = JSON.parse(FastlaneCore::Helper.open_uri(url).read)
           break if results.count == 0
 
           plugins += results.collect do |current|

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -21,9 +21,8 @@ module Fastlane
         # download certificate
         unless File.exist?(params[:certificate])
           UI.message("Downloading root certificate from (#{ROOT_CERTIFICATE_URL}) to path '#{params[:certificate]}'")
-          require 'open-uri'
           File.open(params[:certificate], "w:ASCII-8BIT") do |file|
-            file.write(URI.open(ROOT_CERTIFICATE_URL, "rb").read)
+            file.write(FastlaneCore::Helper.open_uri(ROOT_CERTIFICATE_URL, "rb").read)
           end
         end
 

--- a/fastlane/lib/fastlane/plugins/plugin_fetcher.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_fetcher.rb
@@ -7,14 +7,13 @@ module Fastlane
     # Returns an array of FastlanePlugin objects
     def self.fetch_gems(search_query: nil)
       require 'json'
-      require 'open-uri'
 
       page = 1
       plugins = []
       loop do
         url = "https://rubygems.org/api/v1/search.json?query=#{PluginManager.plugin_prefix}&page=#{page}"
         FastlaneCore::UI.verbose("RubyGems API Request: #{url}")
-        results = JSON.parse(URI.open(url).read)
+        results = JSON.parse(FastlaneCore::Helper.open_uri(url).read)
         break if results.count == 0
 
         plugins += results.collect do |current|

--- a/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
@@ -65,10 +65,9 @@ module Fastlane
 
     # Checks if the gem name is still free on RubyGems
     def gem_name_taken?(name)
-      require 'open-uri'
       require 'json'
       url = "https://rubygems.org/api/v1/gems/#{name}.json"
-      response = JSON.parse(URI.open(url).read)
+      response = JSON.parse(FastlaneCore::Helper.open_uri(url).read)
       return !!response['version']
     rescue
       false

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -155,11 +155,10 @@ module Fastlane
     #####################################################
 
     def self.fetch_gem_info_from_rubygems(gem_name)
-      require 'open-uri'
       require 'json'
       url = "https://rubygems.org/api/v1/gems/#{gem_name}.json"
       begin
-        JSON.parse(URI.open(url).read)
+        JSON.parse(FastlaneCore::Helper.open_uri(url).read)
       rescue
         nil
       end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -462,5 +462,20 @@ module FastlaneCore
         UI.error("Your entries do not match. Please try again")
       end
     end
+
+    # URI.open added by `require 'open-uri'` is not available in Ruby 2.4. This helper lets you open a URI
+    # by choosing appropriate interface to do so depending on Ruby version. This helper is subject to be removed
+    # when fastlane drops Ruby 2.4 support.
+    def self.open_uri(*rest, &block)
+      require 'open-uri'
+
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
+        dup = rest.dup
+        uri = dup.shift
+        URI.parse(uri).open(*dup, &block)
+      else
+        URI.open(*rest, &block)
+      end
+    end
   end
 end

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -222,5 +222,28 @@ describe FastlaneCore do
         expect(FastlaneCore::Helper.fastlane_enabled?).to be(true)
       end
     end
+
+    describe '#open_uri' do
+      before do
+        stub_request(:get, 'https://fastlane.tools').to_return(body: 'SOME_TEXT', status: 200)
+      end
+
+      it 'performs URI.open and return IO like object that can be read' do
+        expect(FastlaneCore::Helper.open_uri('https://fastlane.tools')).to respond_to(:read)
+      end
+
+      it 'performs URI.open with block' do
+        is_called_block = false
+        FastlaneCore::Helper.open_uri('https://fastlane.tools') do |content|
+          expect(content).to respond_to(:read)
+          is_called_block = true
+        end
+        expect(is_called_block).to be(true)
+      end
+
+      it 'performs URI.open with options' do
+        expect(FastlaneCore::Helper.open_uri('https://fastlane.tools', 'rb')).to respond_to(:read)
+      end
+    end
   end
 end

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -247,7 +247,7 @@ describe FastlaneCore do
 
       it 'performs URI.open with options and block' do
         is_block_called = false
-        FastlaneCore::Helper.open_uri('https://fastlane.tools', 'rb') do |content| 
+        FastlaneCore::Helper.open_uri('https://fastlane.tools', 'rb') do |content|
           expect(content).to respond_to(:read)
           is_block_called = true
         end

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -233,16 +233,25 @@ describe FastlaneCore do
       end
 
       it 'performs URI.open with block' do
-        is_called_block = false
+        is_block_called = false
         FastlaneCore::Helper.open_uri('https://fastlane.tools') do |content|
           expect(content).to respond_to(:read)
-          is_called_block = true
+          is_block_called = true
         end
-        expect(is_called_block).to be(true)
+        expect(is_block_called).to be(true)
       end
 
       it 'performs URI.open with options' do
         expect(FastlaneCore::Helper.open_uri('https://fastlane.tools', 'rb')).to respond_to(:read)
+      end
+
+      it 'performs URI.open with options and block' do
+        is_block_called = false
+        FastlaneCore::Helper.open_uri('https://fastlane.tools', 'rb') do |content| 
+          expect(content).to respond_to(:read)
+          is_block_called = true
+        end
+        expect(is_block_called).to be(true)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Prior to this PR, I fixed deprecation warnings around the usage of `open-uri` in #18395 (as a part of #17931). However the alternative `URI.open` isn't supported on Ruby 2.4 apparently😢 So this PR is adding a helper method that chose either `URI.open` or `URI.parse(...).open` depending on Ruby version.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

It's a simple helper method. I added tests to make sure all of the Ruby versions we support can perform `FastlaneCore::Helper.open_uri`.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

It's done by RSpec.