### PR TITLE
[fastlane_core] fix 2FA in CI environments by correctly evaluating falsey values of CI identifier env vars

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -75,7 +75,7 @@ module FastlaneCore
 
       # Check for Jenkins, Travis CI, ... environment variables
       ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CI', 'APPCENTER_BUILD_ID', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS', 'TF_BUILD', 'GITHUB_ACTION', 'GITHUB_ACTIONS', 'BITRISE_IO', 'BUDDY'].each do |current|
-        return true if ENV.key?(current)
+        return true if FastlaneCore::Env.truthy?(current)
       end
       return false
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
With mandatory 2fa sometimes it's necessary to generate and save `FASTLANE_SESSION` on remote machine. However it can't be done if `CI` variable is defined in current environments, regardless of it's value.

### Description
When defining `CI` var as untruthy (i.e. false or 0) and running `fastlane spaceauth` fastlane will ask for username and password but will crash with `2FA can only be performed in interactive mode` error when required to enter 2fa code.
```bash
export CI=1 # somewhere in .bash_profile
CI=0 fastlane spaceauth # crashes with "2FA can only be performed in interactive mode" error
unset CI && fastlane spaceauth # works fine
```
### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
