### PR TITLE
[git_branch][slack][ensure_git_branch] unify logic of `Actions.git_branch` helper and `git_branch` action

### DIFF
--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -1,16 +1,10 @@
 module Fastlane
   module Actions
-    module SharedValues
-      GIT_BRANCH_ENV_VARS = %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME CI_COMMIT_REF_NAME WERCKER_GIT_BRANCH BUILDKITE_BRANCH APPCENTER_BRANCH CIRCLE_BRANCH).reject do |branch|
-        # Removing because tests break on CircleCI
-        Helper.test? && branch == "CIRCLE_BRANCH"
-      end.freeze
-    end
-
     class GitBranchAction < Action
       def self.run(params)
-        env_name = SharedValues::GIT_BRANCH_ENV_VARS.find { |env_var| FastlaneCore::Env.truthy?(env_var) }
-        ENV.fetch(env_name.to_s) { `git symbolic-ref HEAD --short 2>/dev/null`.strip }
+        branch = Actions.git_branch
+        return "" if branch == "HEAD" # Backwards compatibility with the original (and documented) implementation
+        branch
       end
 
       #####################################################
@@ -22,7 +16,7 @@ module Fastlane
       end
 
       def self.details
-        "If no branch could be found, this action will return an empty string"
+        "If no branch could be found, this action will return an empty string. This is a wrapper for the internal action Actions.git_branch"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -2,6 +2,13 @@ module Fastlane
   module Actions
     GIT_MERGE_COMMIT_FILTERING_OPTIONS = [:include_merges, :exclude_merges, :only_include_merges].freeze
 
+    module SharedValues
+      GIT_BRANCH_ENV_VARS = %w(GIT_BRANCH BRANCH_NAME TRAVIS_BRANCH BITRISE_GIT_BRANCH CI_BUILD_REF_NAME CI_COMMIT_REF_NAME WERCKER_GIT_BRANCH BUILDKITE_BRANCH APPCENTER_BRANCH CIRCLE_BRANCH).reject do |branch|
+        # Removing because tests break on CircleCI
+        Helper.test? && branch == "CIRCLE_BRANCH"
+      end.freeze
+    end
+
     def self.git_log_between(pretty_format, from, to, merge_commit_filtering, date_format = nil, ancestry_path)
       command = %w(git log)
       command << "--pretty=#{pretty_format}"
@@ -112,14 +119,11 @@ module Fastlane
       return nil
     end
 
-    # Returns the current git branch - can be replaced using the environment variable `GIT_BRANCH`
+    # Returns the current git branch, or "HEAD" if it's not checked out to any branch
+    # Can be replaced using the environment variable `GIT_BRANCH`
     def self.git_branch
-      return ENV['GIT_BRANCH'] if ENV['GIT_BRANCH'].to_s.length > 0 # set by Jenkins
-      s = Actions.sh("git rev-parse --abbrev-ref HEAD", log: false).chomp
-      return s.to_s.strip if s.to_s.length > 0
-      nil
-    rescue
-      nil
+      env_name = SharedValues::GIT_BRANCH_ENV_VARS.find { |env_var| FastlaneCore::Env.truthy?(env_var) }
+      ENV.fetch(env_name.to_s) { Actions.sh("git rev-parse --abbrev-ref HEAD", log: false).chomp }
     end
 
     private_class_method

--- a/fastlane/spec/actions_specs/git_branch_spec.rb
+++ b/fastlane/spec/actions_specs/git_branch_spec.rb
@@ -15,15 +15,27 @@ describe Fastlane::Actions::GitBranchAction do
 
   describe "with no CI set ENV values" do
     it "gets the value from Git directly" do
-      expect(Fastlane::Actions::GitBranchAction).to receive(:`)
-        .with('git symbolic-ref HEAD --short 2>/dev/null')
-        .and_return('branch-name')
+      expect(Fastlane::Actions).to receive(:sh)
+        .with("git rev-parse --abbrev-ref HEAD", log: false)
+        .and_return("branch-name")
 
       result = Fastlane::FastFile.new.parse("lane :test do
         git_branch
       end").runner.execute(:test)
 
       expect(result).to eq("branch-name")
+    end
+
+    it "returns empty string if git is at HEAD" do
+      expect(Fastlane::Actions).to receive(:sh)
+        .with("git rev-parse --abbrev-ref HEAD", log: false)
+        .and_return("HEAD")
+
+      result = Fastlane::FastFile.new.parse("lane :test do
+        git_branch
+      end").runner.execute(:test)
+
+      expect(result).to eq("")
     end
   end
 end

--- a/fastlane/spec/fixtures/plist/Info.plist
+++ b/fastlane/spec/fixtures/plist/Info.plist
@@ -40,7 +40,7 @@
 	<key>CFBundleVersion</key>
 	<string>0.9.14</string>
 	<key>LSApplicationCategoryType</key>
-	<string></string>
+	<string/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Supersedes #15035
Resolves #13346
Resolves #15034
Closes #17527

Timeline:
- #13346 issue was open in September 2018 and closed in December 2018 due to inactivity
- #15034 issue and #15035 PR were open in July 2019 to fix the issue above
- The PR above was closed in July 2020 probably because the PR had a lot of back and forth and took too long. The author decided to close it without an explanation 🤷 
- #17527 was open by @revolter in October 2020 to fix just `slack` action, in another simpler (and less generic) way. It was just a proposal though, it didn't fix the existing specs at that time.
- This PR aims to fix the root cause of the issue rather than just fix `slack` action specifically. It also fixes e.g. `ensure_git_branch` action, for instance. 

----

`Actions.git_branch` and `git_branch` have slightly different implementations, even though their behavior should probably be very similar.

`Actions.git_branch` looks up the `GIT_BRANCH` env var and falls back to `git rev-parse --abbrev-ref HEAD`, which results in either a branch name or "HEAD". (note: AFAICT it's not possible to have it return `nil` as the code suggests. Tested in the field)
`git_branch` looks up a bunch of CI-specific env vars for git branch detection, and falls back to `git symbolic-ref HEAD --short 2>/dev/null`, which results in either a branch name or an empty string, as documented.

It has been expressed by users that other _fastlane_ tools that make use of `Actions.git_branch` have been unable to detect the right branch because the action wouldn't take into account all the CI env vars that `git_branch` action does. Since CI checks out the repo under no branch (i.e. "HEAD" ref.), those actions (e.g. `slack` and `ensure_git_branch `) do not work properly.

### Description
This PR unifies both utilities to look up the same information: first env vars that represent git branches in multiple CI envs (starting with `GIT_BRANCH` for backwards compatibility), and falling back to `git rev-parse --abbrev-ref HEAD`. The decision to use this git command to print the branch is because it never fails and it prints either the branch name or HEAD. Since the `git_branch` action documents that it returns an empty string when a branch can't be located (and it's not only documented, it currently does behave like that), then when `Actions.git_branch` returns "HEAD" (which means no branch was found), then it will translate that into an empty string.

By moving away from `git symbolic-ref HEAD --short 2>/dev/null` to `git rev-parse --abbrev-ref HEAD`, it also implicitly fixed Windows environments running `git_branch` action.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan/unify-git-branch-utilities"
```

And run `bundle install` to apply the changes.