### PR TITLE
[screengrab] Fix screenshots on Android Q and above

### DIFF
--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -1,6 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "adb" do
+      before(:each) do
+        allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
+      end
+
       it "generates a valid command" do
         result = Fastlane::FastFile.new.parse("lane :test do
           adb(command: 'test', adb_path: './README.md')
@@ -68,6 +72,81 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(result).to eq("#{File.expand_path('/usr/local/android-sdk/platform-tools/adb')} test")
+      end
+    end
+
+    describe "adb on Windows" do
+      before(:each) do
+        allow(FastlaneCore::Helper).to receive(:windows?).and_return(true)
+      end
+
+      it "generates a valid command" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test', adb_path: './README.md')
+        end").runner.execute(:test)
+
+        expect(result).to eq("#{File.expand_path('./fastlane/README.md').gsub('/', '\\')} test")
+      end
+
+      it "generates a valid command for commands with multiple parts" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test command with multiple parts', adb_path: './README.md')
+        end").runner.execute(:test)
+
+        expect(result).to eq("#{File.expand_path('./fastlane/README.md').gsub('/', '\\')} test command with multiple parts")
+      end
+
+      it "generates a valid command when a non-empty serial is passed" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test command with non-empty serial', adb_path: './README.md', serial: 'emulator-1234')
+        end").runner.execute(:test)
+
+        expect(result).to eq("ANDROID_SERIAL=emulator-1234 #{File.expand_path('./fastlane/README.md').gsub('/', '\\')} test command with non-empty serial")
+      end
+
+      it "generates a valid command when an empty serial is passed" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test command with empty serial', adb_path: './README.md', serial: '')
+        end").runner.execute(:test)
+
+        expect(result).to eq("#{File.expand_path('./fastlane/README.md').gsub('/', '\\')} test command with empty serial")
+      end
+
+      it "picks up path from ANDROID_HOME environment variable" do
+        stub_const('ENV', { 'ANDROID_HOME' => '/Users\\SomeUser\\AppData\\Local\\Android\\Sdk' })
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test')
+        end").runner.execute(:test)
+
+        expect(result).to eq("#{File.expand_path('/Users\\SomeUser\\AppData\\Local\\Android\\Sdk\\platform-tools\\adb').gsub('/', '\\')} test")
+      end
+
+      it "picks up path from ANDROID_HOME environment variable and handles path that has to be made safe" do
+        stub_const('ENV', { 'ANDROID_HOME' => '/Users\\Some User With Space\\AppData\\Local\\Android\\Sdk' })
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test')
+        end").runner.execute(:test)
+
+        path = File.expand_path("/Users\\Some User With Space\\AppData\\Local\\Android\\Sdk\\platform-tools\\adb").shellescape.gsub('/', '\\')
+        expect(result).to eq("#{path} test")
+      end
+
+      it "picks up path from ANDROID_SDK_ROOT environment variable" do
+        stub_const('ENV', { 'ANDROID_SDK_ROOT' => '/Users\\SomeUser\\AppData\\Local\\Android\\Sdk' })
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test')
+        end").runner.execute(:test)
+
+        expect(result).to eq("#{File.expand_path('/Users\\SomeUser\\AppData\\Local\\Android\\Sdk\\platform-tools\\adb').gsub('/', '\\')} test")
+      end
+
+      it "picks up path from ANDROID_SDK environment variable" do
+        stub_const('ENV', { 'ANDROID_SDK' => '/Users\\SomeUser\\AppData\\Local\\Android\\Sdk' })
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'test')
+        end").runner.execute(:test)
+
+        expect(result).to eq("#{File.expand_path('/Users\\SomeUser\\AppData\\Local\\Android\\Sdk\\platform-tools\\adb').gsub('/', '\\')} test")
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -377,6 +377,8 @@ module FastlaneCore
 
     # returns the path of the executable with the correct extension on Windows
     def self.get_executable_path(cmd_path)
+      cmd_path = localize_file_path(cmd_path)
+
       if self.windows?
         # PATHEXT contains the list of file extensions that Windows considers executable, semicolon separated.
         # e.g. ".COM;.EXE;.BAT;.CMD"
@@ -391,6 +393,12 @@ module FastlaneCore
       end
 
       return cmd_path
+    end
+
+    # returns the path with the platform-specific path separator (`/` on UNIX, `\` on Windows)
+    def self.localize_file_path(path)
+      # change `/` to `\` on Windows
+      return self.windows? ? path.gsub('/', '\\') : path
     end
 
     # checks if given file is a valid json file

--- a/screengrab/lib/screengrab/android_environment.rb
+++ b/screengrab/lib/screengrab/android_environment.rb
@@ -34,22 +34,22 @@ module Screengrab
     def find_platform_tools(android_home)
       return nil unless android_home
 
-      platform_tools_path = File.join(android_home, 'platform-tools')
+      platform_tools_path = Helper.localize_file_path(File.join(android_home, 'platform-tools'))
       File.directory?(platform_tools_path) ? platform_tools_path : nil
     end
 
     def find_build_tools(android_home, build_tools_version)
       return nil unless android_home
 
-      build_tools_dir = File.join(android_home, 'build-tools')
+      build_tools_dir = Helper.localize_file_path(File.join(android_home, 'build-tools'))
 
       return nil unless build_tools_dir && File.directory?(build_tools_dir)
 
-      return File.join(build_tools_dir, build_tools_version) if build_tools_version
+      return Helper.localize_file_path(File.join(build_tools_dir, build_tools_version)) if build_tools_version
 
       version = select_build_tools_version(build_tools_dir)
 
-      return version ? File.join(build_tools_dir, version) : nil
+      return version ? Helper.localize_file_path(File.join(build_tools_dir, version)) : nil
     end
 
     def select_build_tools_version(build_tools_dir)
@@ -74,6 +74,7 @@ module Screengrab
       return FastlaneCore::CommandExecutor.which('adb') unless platform_tools_path
 
       adb_path = Helper.get_executable_path(File.join(platform_tools_path, 'adb'))
+      adb_path = Helper.localize_file_path(adb_path)
       return executable_command?(adb_path) ? adb_path : nil
     end
 
@@ -81,6 +82,7 @@ module Screengrab
       return FastlaneCore::CommandExecutor.which('aapt') unless build_tools_path
 
       aapt_path = Helper.get_executable_path(File.join(build_tools_path, 'aapt'))
+      aapt_path = Helper.localize_file_path(aapt_path)
       return executable_command?(aapt_path) ? aapt_path : nil
     end
 

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -308,7 +308,7 @@ module Screengrab
             if out =~ /Permission denied/
               dir = File.dirname(path)
               base = File.basename(path)
-              run_adb_command("-s #{device_serial} shell run-as #{@config[:app_package_name]} 'tar -cC #{dir} #{base}' | tar -xvC #{tempdir}",
+              run_adb_command("-s #{device_serial} shell run-as #{@config[:app_package_name]} \"tar -cC #{dir} #{base}\" | tar -xv -f- -C #{tempdir}",
                               print_all: false,
                               print_command: true)
             end

--- a/screengrab/spec/android_environment_spec.rb
+++ b/screengrab/spec/android_environment_spec.rb
@@ -1,5 +1,9 @@
 describe Screengrab do
   describe Screengrab::AndroidEnvironment do
+    before(:each) do
+      allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
+    end
+
     describe "with an empty ANDROID_HOME and an empty PATH" do
       it "finds no useful values" do
         FastlaneSpec::Env.with_env_values('PATH' => 'screengrab/spec/fixtures/empty_home_empty_path/path') do
@@ -61,37 +65,48 @@ describe Screengrab do
     end
   end
 
-  describe "on windows" do
-    before(:each) do
-      allow(FastlaneCore::Helper).to receive(:windows?).and_return(true)
-    end
-
+  describe "on windows", if: FastlaneCore::Helper.windows? do
     describe "with an empty ANDROID_HOME and a complete PATH" do
       it "finds commands on the PATH" do
-        FastlaneSpec::Env.with_env_values('PATH' => 'screengrab/spec/fixtures/empty_home_complete_path_windows/path', 'PATHEXT' => ".EXE") do
-          android_env = Screengrab::AndroidEnvironment.new('screengrab/spec/fixtures/empty_home_complete_path_windows/android_home', nil)
+        FastlaneSpec::Env.with_env_values('PATH' => 'screengrab\\spec\\fixtures\\empty_home_complete_path_windows\\path', 'PATHEXT' => ".EXE") do
+          android_env = Screengrab::AndroidEnvironment.new('screengrab\\spec\\fixtures\\empty_home_complete_path_windows\\android_home', nil)
 
-          expect(android_env.android_home).to eq('screengrab/spec/fixtures/empty_home_complete_path_windows/android_home')
+          expect(android_env.android_home).to eq('screengrab\\spec\\fixtures\\empty_home_complete_path_windows\\android_home')
           expect(android_env.build_tools_version).to be_nil
           expect(android_env.build_tools_path).to be_nil
           expect(android_env.platform_tools_path).to be_nil
-          expect(android_env.adb_path).to eq('screengrab/spec/fixtures/empty_home_complete_path_windows/path/adb.exe')
-          expect(android_env.aapt_path).to eq('screengrab/spec/fixtures/empty_home_complete_path_windows/path/aapt.exe')
+          expect(android_env.adb_path).to eq('screengrab\\spec\\fixtures\\empty_home_complete_path_windows\\path\\adb.exe')
+          expect(android_env.aapt_path).to eq('screengrab\\spec\\fixtures\\empty_home_complete_path_windows\\path\\aapt.exe')
         end
       end
     end
 
     describe "with a complete ANDROID_HOME and a complete PATH and no build tools version specified" do
       it "finds adb.exe in platform-tools and aapt in the highest version build tools dir" do
-        FastlaneSpec::Env.with_env_values('PATH' => 'screengrab/spec/fixtures/complete_home_complete_path_windows/path', 'PATHEXT' => ".EXE") do
-          android_env = Screengrab::AndroidEnvironment.new('screengrab/spec/fixtures/complete_home_complete_path_windows/android_home', nil)
+        FastlaneSpec::Env.with_env_values('PATH' => 'screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\path', 'PATHEXT' => ".EXE") do
+          android_env = Screengrab::AndroidEnvironment.new('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home', nil)
 
-          expect(android_env.android_home).to eq('screengrab/spec/fixtures/complete_home_complete_path_windows/android_home')
+          expect(android_env.android_home).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home')
           expect(android_env.build_tools_version).to be_nil
-          expect(android_env.build_tools_path).to eq('screengrab/spec/fixtures/complete_home_complete_path_windows/android_home/build-tools/23.0.2')
-          expect(android_env.platform_tools_path).to eq('screengrab/spec/fixtures/complete_home_complete_path_windows/android_home/platform-tools')
-          expect(android_env.adb_path).to eq('screengrab/spec/fixtures/complete_home_complete_path_windows/android_home/platform-tools/adb.exe')
-          expect(android_env.aapt_path).to eq('screengrab/spec/fixtures/complete_home_complete_path_windows/android_home/build-tools/23.0.2/aapt.exe')
+          expect(android_env.build_tools_path).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home\\build-tools\\23.0.2')
+          expect(android_env.platform_tools_path).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home\\platform-tools')
+          expect(android_env.adb_path).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home\\platform-tools\\adb.exe')
+          expect(android_env.aapt_path).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home\\build-tools\\23.0.2\\aapt.exe')
+        end
+      end
+    end
+
+    describe "with a complete ANDROID_HOME and a complete PATH and no build tools version specified" do
+      it "finds adb in platform-tools and aapt in the highest version build tools dir" do
+        FastlaneSpec::Env.with_env_values('PATH' => 'screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\path', 'PATHEXT' => ".EXE") do
+          android_env = Screengrab::AndroidEnvironment.new('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home', nil)
+
+          expect(android_env.android_home).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home')
+          expect(android_env.build_tools_version).to be_nil
+          expect(android_env.build_tools_path).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home\\build-tools\\23.0.2')
+          expect(android_env.platform_tools_path).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home\\platform-tools')
+          expect(android_env.adb_path).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home\\platform-tools\\adb.exe')
+          expect(android_env.aapt_path).to eq('screengrab\\spec\\fixtures\\complete_home_complete_path_windows\\android_home\\build-tools\\23.0.2\\aapt.exe')
         end
       end
     end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Trying to capture screenshots with `screengrab` on Android versions >= Android Q (v10, API version 29) fails on Windows.
Resolves #18335

### Description
`FastlaneCore::Helper.which` uses the platform-specific path separator (`/` on UNIX, `\` on Windows).  
Adds a new method, `FastlaneCore::Helper.localize_file_path(path)` that fixes the path separator.

Fixes the command used to extract the screenshots as described in [the issue](https://github.com/fastlane/fastlane/issues/18335#issuecomment-790676320)
<blockquote>
Microsoft is including some UNIX commands like `tar` and `curl` in the standard install of Windows ([source](https://docs.microsoft.com/en-us/virtualization/community/team-blog/2017/20171219-tar-and-curl-come-to-windows)).

```batch
> where tar
C:\Windows\System32\tar.exe
```

The bundled `tar` is a version of `bsdtar`
```batch
> tar --version
bsdtar 3.3.2 - libarchive 3.3.2 zlib/1.2.5.f-ipp
```

Piping the output directly doesn't work
```batch
> type archive.tar | tar -xvC folder
tar: Error opening archive: Failed to open '\\.\tape0'
The process tried to write to a nonexistent pipe.
```

Fortunately, specifying the input file with `-f-` works
```batch
> type archive.tar | tar -f- -xvC folder
```
</blockquote>

### Testing Steps
On a Windows PC:
- Create an Android Emulator running Android Q or higher
- Setup Fastlane and Screengrab for an Android Project
- Run `fastlane screengrab` for the project
