### PR TITLE
[deliver] don't update review information if empty hash

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -592,8 +592,9 @@ module Deliver
     end
 
     def set_review_information(version, options)
-      return unless options[:app_review_information]
       info = options[:app_review_information]
+      return if info.nil? || info.empty?
+
       info = info.collect { |k, v| [k.to_sym, v] }.to_h
       UI.user_error!("`app_review_information` must be a hash", show_github_issues: true) unless info.kind_of?(Hash)
 

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -80,7 +80,12 @@ describe Deliver::UploadMetadata do
           notes: "This is a note" }
       end
 
-      it "set review information" do
+      it "skips review information with empty app_review_information" do
+        expect(FastlaneCore::UI).not_to receive(:message).with("Uploading app review information to App Store Connect")
+        uploader.send("set_review_information", version, { app_review_information: {} })
+      end
+
+      it "successfully set review information" do
         expect(version).to receive(:fetch_app_store_review_detail).and_return(app_store_review_detail)
         expect(app_store_review_detail).to receive(:update).with(attributes: {
           "contact_first_name" => app_review_information[:first_name],
@@ -92,6 +97,8 @@ describe Deliver::UploadMetadata do
           "demo_account_required" => true,
           "notes" => app_review_information[:notes]
         })
+
+        expect(FastlaneCore::UI).to receive(:message).with("Uploading app review information to App Store Connect")
 
         uploader.send("set_review_information", version, options)
       end


### PR DESCRIPTION
### Motivation and Context
Fixes #18413

### Description
Return early out of method that updates review information if nil or empty
