### PR TITLE
[Fastlane.Swift] Fix Fastlane.Swift point values default value

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -116,6 +116,7 @@ module Fastlane
     end
 
     def get_type(param: nil, default_value: nil, optional: nil, param_type_override: nil, is_string: true)
+      require 'bigdecimal'
       unless param_type_override.nil?
         type = determine_type_from_override(type_override: param_type_override)
       end
@@ -168,6 +169,8 @@ module Fastlane
             default_value = "[:]"
           elsif type != "Bool" && type != "[String]" && type != "Int" && type != "@escaping ((String) -> Void)" && type != "Float" && type != "Double"
             default_value = "\"#{default_value}\""
+          elsif type == "Float" || type == "Double"
+            default_value =  BigDecimal(default_value).to_s
           end
         end
 

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -170,7 +170,8 @@ module Fastlane
           elsif type != "Bool" && type != "[String]" && type != "Int" && type != "@escaping ((String) -> Void)" && type != "Float" && type != "Double"
             default_value = "\"#{default_value}\""
           elsif type == "Float" || type == "Double"
-            default_value =  BigDecimal(default_value).to_s
+            require 'bigdecimal'
+            default_value = BigDecimal(default_value).to_s
           end
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #18433 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Make sure that when a `ConfigItem`'s `type` is set to a decimal point type take the default value and get its decimal point representation in case it is not yet valid.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

1. Checkout: `https://github.com/minuscorp/fastlane/tree/swift-fix-decimal-precission-values`
2. Install it
3. Run `fastlane generate_swift_api`
4. Verify that floating point variables have a floating point default value:

<img width="503" alt="image" src="https://user-images.githubusercontent.com/8419048/112400006-1e152100-8ce6-11eb-820f-cd98e72cb613.png">
