### PR TITLE
[Fastlane.Swift] Add some missing return types

### DIFF
--- a/fastlane/lib/fastlane/actions/build_app.rb
+++ b/fastlane/lib/fastlane/actions/build_app.rb
@@ -120,6 +120,10 @@ module Fastlane
         "The absolute path to the generated ipa file"
       end
 
+      def self.return_type
+        :string
+      end
+
       def self.author
         "KrauseFx"
       end

--- a/fastlane/lib/fastlane/actions/check_app_store_metadata.rb
+++ b/fastlane/lib/fastlane/actions/check_app_store_metadata.rb
@@ -28,6 +28,10 @@ module Fastlane
         return "true if precheck passes, else, false"
       end
 
+      def self.return_type
+        :bool
+      end
+
       def self.authors
         ["taquitos"]
       end

--- a/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/get_provisioning_profile.rb
@@ -68,6 +68,10 @@ module Fastlane
         "The UUID of the profile sigh just fetched/generated"
       end
 
+      def self.return_type
+        :string
+      end
+
       def self.details
         "**Note**: It is recommended to use [match](https://docs.fastlane.tools/actions/match/) according to the [codesigning.guide](https://codesigning.guide) for generating and maintaining your provisioning profiles. Use _sigh_ directly only if you want full control over what's going on and know more about codesigning."
       end

--- a/fastlane/lib/fastlane/actions/git_tag_exists.rb
+++ b/fastlane/lib/fastlane/actions/git_tag_exists.rb
@@ -45,6 +45,10 @@ module Fastlane
         "Boolean value whether the tag exists or not"
       end
 
+      def self.return_type
+        :bool
+      end
+
       def self.output
         [
         ]

--- a/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
+++ b/fastlane/lib/fastlane/actions/install_provisioning_profile.rb
@@ -48,6 +48,10 @@ module Fastlane
         "The absolute path to the installed provisioning profile"
       end
 
+      def self.return_type
+        :string
+      end
+
       def self.example_code
         [
           'install_provisioning_profile(path: "profiles/profile.mobileprovision")'

--- a/fastlane/lib/fastlane/actions/spaceship_logs.rb
+++ b/fastlane/lib/fastlane/actions/spaceship_logs.rb
@@ -124,7 +124,7 @@ module Fastlane
       end
 
       def self.return_type
-        :array
+        :array_of_strings
       end
 
       def self.author


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #18393
Have checked most of the actions but maybe I missed some, so a review is appreciated 😄.

### Description
Adds the `action` class method `return_type` for Fastlane.Swift to return a proper result value.
 
### Testing Steps
1. Install from `https://github.com/minuscorp/fastlane/tree/swift-add-missing-return-types`
2. Create your Fastfile.swift with your favorite returning type action.
3. See the proper return type from it.