### PR TITLE
[Fastlane.Swift] Fix onError not being called

### DIFF
--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -17,20 +17,20 @@ public protocol LaneFileProtocol: class {
     func recordLaneDescriptions()
     func beforeAll(with lane: String)
     func afterAll(with lane: String)
-    func onError(currentLane: String, errorInfo: String)
+    func onError(currentLane: String, errorInfo: String, errorClass: String?, errorMessage: String?)
 }
 
 public extension LaneFileProtocol {
     var fastlaneVersion: String { return "" } // Defaults to "" because that means any is fine
     func beforeAll(with _: String) {} // No-op by default
     func afterAll(with _: String) {} // No-op by default
-    func onError(currentLane _: String, errorInfo _: String) {} // No-op by default
     func recordLaneDescriptions() {} // No-op by default
 }
 
 @objcMembers
 open class LaneFile: NSObject, LaneFileProtocol {
     private(set) static var fastfileInstance: LaneFile?
+    private static var onErrorCalled: [String: Bool] = [:]
 
     private static func trimLaneFromName(laneName: String) -> String {
         return String(laneName.prefix(laneName.count - 4))
@@ -38,6 +38,10 @@ open class LaneFile: NSObject, LaneFileProtocol {
 
     private static func trimLaneWithOptionsFromName(laneName: String) -> String {
         return String(laneName.prefix(laneName.count - 12))
+    }
+  
+    public func onError(currentLane: String, errorInfo: String, errorClass: String?, errorMessage: String?) {
+      LaneFile.onErrorCalled[currentLane] = true
     }
 
     private static var laneFunctionNames: [String] {
@@ -137,7 +141,9 @@ open class LaneFile: NSObject, LaneFileProtocol {
         _ = fastfileInstance.perform(NSSelectorFromString(laneMethod), with: parameters)
 
         // Call only on success.
-        fastfileInstance.afterAll(with: lane)
+        if !(Self.onErrorCalled[lane] ?? false) {
+          fastfileInstance.afterAll(with: lane)
+        }
 
         log(message: "Done running lane: \(lane) 🚀")
         return true

--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -30,7 +30,7 @@ public extension LaneFileProtocol {
 @objcMembers
 open class LaneFile: NSObject, LaneFileProtocol {
     private(set) static var fastfileInstance: LaneFile?
-    private static var onErrorCalled: [String: Bool] = [:]
+    private static var onErrorCalled = Set<String>()
 
     private static func trimLaneFromName(laneName: String) -> String {
         return String(laneName.prefix(laneName.count - 4))
@@ -39,9 +39,9 @@ open class LaneFile: NSObject, LaneFileProtocol {
     private static func trimLaneWithOptionsFromName(laneName: String) -> String {
         return String(laneName.prefix(laneName.count - 12))
     }
-  
-    public func onError(currentLane: String, errorInfo: String, errorClass: String?, errorMessage: String?) {
-      LaneFile.onErrorCalled[currentLane] = true
+
+    public func onError(currentLane: String, errorInfo _: String, errorClass _: String?, errorMessage _: String?) {
+        LaneFile.onErrorCalled.insert(currentLane)
     }
 
     private static var laneFunctionNames: [String] {
@@ -141,8 +141,8 @@ open class LaneFile: NSObject, LaneFileProtocol {
         _ = fastfileInstance.perform(NSSelectorFromString(laneMethod), with: parameters)
 
         // Call only on success.
-        if !(Self.onErrorCalled[lane] ?? false) {
-          fastfileInstance.afterAll(with: lane)
+        if !LaneFile.onErrorCalled.contains(lane) {
+            fastfileInstance.afterAll(with: lane)
         }
 
         log(message: "Done running lane: \(lane) 🚀")

--- a/fastlane/swift/SocketClient.swift
+++ b/fastlane/swift/SocketClient.swift
@@ -302,8 +302,9 @@ extension SocketClient: StreamDelegate {
                 self.closeSession(sendAbort: false)
             }
 
-        case let .failure(failureInformation):
-            socketDelegate?.commandExecuted(serverResponse: .serverError) {
+        case let .failure(failureInformation, failureClass, failureMessage):
+          LaneFile.fastfileInstance?.onError(currentLane: ArgumentProcessor(args: CommandLine.arguments).currentLane, errorInfo: failureInformation.joined(), errorClass: failureClass, errorMessage: failureMessage)
+          socketDelegate?.commandExecuted(serverResponse: .serverError) {
                 $0.writeSemaphore.signal()
                 self.handleFailure(message: failureInformation)
             }

--- a/fastlane/swift/SocketResponse.swift
+++ b/fastlane/swift/SocketResponse.swift
@@ -13,7 +13,7 @@ import Foundation
 struct SocketResponse {
     enum ResponseType {
         case parseFailure(failureInformation: [String])
-        case failure(failureInformation: [String])
+        case failure(failureInformation: [String], failureClass: String?, failureMessage: String?)
         case readyForNext(returnedObject: String?, closureArgumentValue: String?)
         case clientInitiatedCancel
 
@@ -35,12 +35,16 @@ struct SocketResponse {
                 return
 
             } else if status == "failure" {
-                guard let failureInformation = statusDictionary["failure_information"] as? [String] else {
+                guard
+                  let failureInformation = statusDictionary["failure_information"] as? [String],
+                  let failureClass = statusDictionary["failure_class"] as? String?,
+                  let failureMessage = statusDictionary["failure_message"] as? String?
+                else {
                     self = .parseFailure(failureInformation: ["Ruby server indicated failure but Swift couldn't receive it"])
                     return
                 }
 
-                self = .failure(failureInformation: failureInformation)
+                self = .failure(failureInformation: failureInformation, failureClass: failureClass, failureMessage: failureMessage)
                 return
             }
             self = .parseFailure(failureInformation: ["Message status: \(status) not a supported status"])

--- a/fastlane/swift/SocketResponse.swift
+++ b/fastlane/swift/SocketResponse.swift
@@ -35,15 +35,13 @@ struct SocketResponse {
                 return
 
             } else if status == "failure" {
-                guard
-                  let failureInformation = statusDictionary["failure_information"] as? [String],
-                  let failureClass = statusDictionary["failure_class"] as? String?,
-                  let failureMessage = statusDictionary["failure_message"] as? String?
-                else {
+                guard let failureInformation = statusDictionary["failure_information"] as? [String] else {
                     self = .parseFailure(failureInformation: ["Ruby server indicated failure but Swift couldn't receive it"])
                     return
                 }
 
+                let failureClass = statusDictionary["failure_class"] as? String
+                let failureMessage = statusDictionary["failure_message"] as? String
                 self = .failure(failureInformation: failureInformation, failureClass: failureClass, failureMessage: failureMessage)
                 return
             }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #17482

### Description
This fix an issue that never was initially implemented, the `onError` method call was never implemented, now it does. 

### Testing Steps
1. Checkout and install this fastlane version: `https://github.com/minuscorp/fastlane/tree/swift-on-error-call-fix`
2. Create a failing lane like for example:
```swift
func testLane() {
  sh(command: "exit -1")
}
```
3. Define and override the `onError` method and **don't forget to call the `super`** _(if you don't call the `super`, `afterAll` will be called)_:
![image](https://user-images.githubusercontent.com/3819883/112491126-4b161200-8d80-11eb-96b0-e7dd33572c41.png)
4. Check that `onError` is being called but `afterAll` doesn't (because an error occurred).