### PR TITLE
[Fastlane.Swift] Fix array-typed RubyCommand arguments

### DIFF
--- a/fastlane/swift/RubyCommand.swift
+++ b/fastlane/swift/RubyCommand.swift
@@ -51,7 +51,7 @@ struct RubyCommand: RubyCommandable {
                 if type == .stringClosure {
                     return "{\"name\" : \"\(name)\", \"value\" : \"ignored_for_closure\"\(typeJson)}"
                 } else if let array = someValue as? [String] {
-                    return "{\"name\" : \"\(name)\", \"value\" : \"\(array.joined(separator: ","))\"\(typeJson)}"
+                    return "{\"name\" : \"\(name)\", \"value\" : \(array)\(typeJson)}"
                 } else if let hash = someValue as? [String: Any] {
                     let jsonData = try! JSONSerialization.data(withJSONObject: hash, options: [])
                     let jsonString = String(data: jsonData, encoding: .utf8)!


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #18085

### Description
Array-typed `RubyCommand`s where wrongly converted to json, using a comma separated format instead of an array string representation

### Testing Steps
1. Checkout and install the following branch: `https://github.com/minuscorp/fastlane/tree/swift-fix-array-type-commands`
2. Use a lane that calls some array parameter, like for example:
```swift
func testLane() {
    updateAppGroupIdentifiers(
        entitlementsFile: "/Users/minuscorp/example.entitlements",
        appGroupIdentifiers: ["group.com.company.MyApp"]
    )
}
```
3. Run the lane and check in the logs that the command is correctly encoded:
```json
{ "commandType": "action", "command": {"commandID" : "","methodName" : "update_app_group_identifiers","args" : [{"value":"\/Users\/minuscorp\/example.entitlements","name":"entitlements_file"},{"name" : "app_group_identifiers", "value" : ["group.com.company.MyApp"]}]} }
```
4. Check that the expected validation in Ruby is correctly parsed.
```ruby
verify_block: proc do |value|
    UI.user_error!("The parameter app_group_identifiers need to be an Array.") unless value.kind_of?(Array)
end
```
