### PR TITLE
Fix typo in queue_worker.rb

### DIFF
--- a/fastlane_core/lib/fastlane_core/queue_worker.rb
+++ b/fastlane_core/lib/fastlane_core/queue_worker.rb
@@ -16,12 +16,12 @@ module FastlaneCore
       @queue = Queue.new
     end
 
-    # @param job (Object) - An arbitary object that keeps parameters
+    # @param job (Object) - An arbitrary object that keeps parameters
     def enqueue(job)
       @queue.push(job)
     end
 
-    # @param jobs (Array<Object>) - An array of arbitary object that keeps parameters
+    # @param jobs (Array<Object>) - An array of arbitrary object that keeps parameters
     def batch_enqueue(jobs)
       raise(ArgumentError, "Enqueue Array instead of #{jobs.class}") unless jobs.kind_of?(Array)
       jobs.each { |job| enqueue(job) }


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
Fixed typo.
arbitary -> arbitrary
