### PR TITLE
[action][app_store_connect_api_key] Updated `is_supported` platform 

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -99,7 +99,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include?(platform)
+        [:ios, :mac, :tvos].include?(platform)
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -99,7 +99,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        true
+        [:ios, :mac].include?(platform)
       end
 
       def self.details


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- I was going through the documentation https://docs.fastlane.tools/actions/
- Notice that: `app_store_connect_api_key` was showing support for all platforms `ios, android, mac` (please see attached screenshot)

### Description
- Updated the `is_supported` and make it for `ios, mac` platforms only

### Testing Steps
- 🤪

<img width="957" alt="Screenshot 2021-03-28 at 14 44 19" src="https://user-images.githubusercontent.com/5364500/112753438-f66cd400-8fd7-11eb-973b-c3147b7bc6b8.png">
