### PR TITLE
Don't fallback to user password if app-specific password is not available in notarize

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -8,6 +8,10 @@ module Fastlane
         print_log = params[:print_log]
         verbose = params[:verbose]
 
+        # Add password as a temporary environment variable for altool.
+        # Use app specific password if specified.
+        ENV['FL_NOTARIZE_PASSWORD'] = ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'] || apple_id_account.password
+
         # Compress and read bundle identifier only for .app bundle.
         compressed_package_path = nil
         if File.extname(package_path) == '.app'
@@ -29,10 +33,6 @@ module Fastlane
         UI.user_error!('Could not read bundle identifier, provide as a parameter') unless bundle_id
 
         apple_id_account = CredentialsManager::AccountManager.new(user: params[:username])
-
-        # Add password as a temporary environment variable for altool.
-        # Use app specific password if specified.
-        ENV['FL_NOTARIZE_PASSWORD'] = ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'] || apple_id_account.password
 
         UI.message('Uploading package to notarization service, might take a while')
 

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -10,7 +10,17 @@ module Fastlane
 
         # Add password as a temporary environment variable for altool.
         # Use app specific password if specified.
-        ENV['FL_NOTARIZE_PASSWORD'] = ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'] || apple_id_account.password
+        app_specific_password_key = 'FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'
+        password = ENV[app_specific_password_key] || apple_id_account.password
+
+        message = %{Please specify an app specific password to access App Store Connect for the notarization process.
+          You can do so via the #{app_specific_password_key} environment variable.
+          More information at https://docs.fastlane.tools/best-practices/continuous-integration/#application-specific-passwords.
+        }
+
+        UI.user_error!(message) if password.nil? || password.empty?
+
+        ENV['FL_NOTARIZE_PASSWORD'] = password
 
         # Compress and read bundle identifier only for .app bundle.
         compressed_package_path = nil

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -10,10 +10,10 @@ module Fastlane
         print_log = params[:print_log]
         verbose = params[:verbose]
 
-        # Add password as a temporary environment variable for altool.
-        # Use app specific password if specified.
+        # Add the app-specific password as a temporary environment variable for
+        # altool.
         app_specific_password_key = 'FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'
-        password = ENV[app_specific_password_key] || apple_id_account.password
+        password = ENV[app_specific_password_key]
 
         message = %{Please specify an app specific password to access App Store Connect for the notarization process.
           You can do so via the #{app_specific_password_key} environment variable.


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While working on automating the build and notarization for the beta version of [Simplenote for macOS](https://github.com/Automattic/simplenote-macos/), which we distribute using [Sparkle](https://sparkle-project.org/), my system ended up in a state such that the `altool` upload would hang. I did a bit of investigation and I thought it was due to the password value not being set by `notarize`. 

That lead me through more investigation and I discovered that ASC now rejects notarization attempts that are not done with an app-specific password.

```
Sign in with the app-specific password you generated. If you forgot the app-specific password or need to create a new one, go to appleid.apple.com
```

### Description

This PR:

- Removes the fallback to the user's account password if no `FL_APP_SPECIFIC_PASSWORD` is set
- Makes the action fail if early if no `FL_APP_SPECIFIC_PASSWORD` is set

### Testing Steps
Unfortunately, there were no tests for `notarize` in which I could hook up into.

And idea I have would be to extract the logic that generates the `altool` commands in a dedicated object that can be tested in isolation. @joshdholtz let me know what you think of this approach. Although, I do wonder if it's out of scope for a PR like this.

`altool` does support using the ASC API key. From `man altool`:

```
xcrun altool --notarize-app  -f  file  --primary-bundle-id  bundle_id  {-u
       username  [-p  password] | --apiKey api_key --apiIssuer issuer_id} [--asc-
       provider provider_shortname | --team-id wwdr_team_id]
```

I would prefer to use that approach in the long run for my app, so I might be able to work on it. That might be a good occasion to make the refactor to enable more testability happen.

I manually tested it as part of my work on Simplenote, although I don't have a PR for it yet.