### PR TITLE
[Fastlane.Swift] Restore 'swift' directory if it is deleted before running a lane

### DIFF
--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -35,13 +35,24 @@ module Fastlane
     # rubocop:disable Metrics/BlockNesting
     def self.start(user: nil, is_swift_fastfile: false)
       if FastlaneCore::FastlaneFolder.setup? && !Helper.test?
+        
+        setup_ios = self.new
+
+        # If Fastfile.swift exists, but the swift sources folder does not, rebuild it
+        swift_folder_path = File.expand_path('swift', FastlaneCore::FastlaneFolder.path)
+        if is_swift_fastfile && !File.exists?(swift_folder_path)
+          spinner = TTY::Spinner.new("[:spinner] Restoring Swift classes and FastlaneSwiftRunner.xcodeproj...", format: :dots)
+          spinner.auto_spin
+          setup_ios.setup_swift_support
+          spinner.success
+        end
+
         require 'fastlane/lane_list'
         Fastlane::LaneList.output(FastlaneCore::FastlaneFolder.fastfile_path)
         UI.important("------------------")
         UI.important("fastlane is already set up at path `#{FastlaneCore::FastlaneFolder.path}`, see the available lanes above")
         UI.message("")
 
-        setup_ios = self.new
         setup_ios.add_or_update_gemfile(update_gemfile_if_needed: false)
         setup_ios.suggest_next_steps
         return

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -35,12 +35,12 @@ module Fastlane
     # rubocop:disable Metrics/BlockNesting
     def self.start(user: nil, is_swift_fastfile: false)
       if FastlaneCore::FastlaneFolder.setup? && !Helper.test?
-        
+
         setup_ios = self.new
 
         # If Fastfile.swift exists, but the swift sources folder does not, rebuild it
         swift_folder_path = File.expand_path('swift', FastlaneCore::FastlaneFolder.path)
-        if is_swift_fastfile && !File.exists?(swift_folder_path)
+        if is_swift_fastfile && !File.exist?(swift_folder_path)
           spinner = TTY::Spinner.new("[:spinner] Restoring Swift classes and FastlaneSwiftRunner.xcodeproj...", format: :dots)
           spinner.auto_spin
           setup_ios.setup_swift_support

--- a/fastlane/lib/fastlane/swift_runner_upgrader.rb
+++ b/fastlane/lib/fastlane/swift_runner_upgrader.rb
@@ -29,6 +29,11 @@ module Fastlane
       @source_swift_code_file_folder_path = File.expand_path(File.join(Fastlane::ROOT, "/swift"))
       @target_swift_code_file_folder_path = FastlaneCore::FastlaneFolder.swift_folder_path
 
+      if !File.exists?(target_swift_code_file_folder_path)
+        UI.verbose("FastlaneRunner project cannot be found. Making a new copy.")
+        restore_swift_setup
+      end
+
       manifest_file = File.join(@source_swift_code_file_folder_path, "/upgrade_manifest.json")
       UI.success("loading manifest: #{manifest_file}")
       @manifest_hash = JSON.parse(File.read(manifest_file))
@@ -40,6 +45,14 @@ module Fastlane
       @root_group = @target_project.groups.select { |group| group.name == "Fastlane Runner" }.first
 
       @fastlane_runner_target = @target_project.targets.select { |target| target.name == "FastlaneRunner" }.first
+    end
+
+    def restore_swift_setup
+      runner_source_resources = "#{Fastlane::ROOT}/swift/."
+      destination_path = File.expand_path('swift', FastlaneCore::FastlaneFolder.path)
+      FileUtils.cp_r(runner_source_resources, destination_path)
+      UI.success("Copied Swift fastlane runner project to '#{destination_path}'.")
+      Fastlane::SwiftLaneManager.first_time_setup
     end
 
     def upgrade_if_needed!(dry_run: false)

--- a/fastlane/lib/fastlane/swift_runner_upgrader.rb
+++ b/fastlane/lib/fastlane/swift_runner_upgrader.rb
@@ -29,7 +29,7 @@ module Fastlane
       @source_swift_code_file_folder_path = File.expand_path(File.join(Fastlane::ROOT, "/swift"))
       @target_swift_code_file_folder_path = FastlaneCore::FastlaneFolder.swift_folder_path
 
-      restore_swift_setup unless File.exist?(target_swift_code_file_folder_path)
+      Fastlane::Setup.setup_swift_support
 
       manifest_file = File.join(@source_swift_code_file_folder_path, "/upgrade_manifest.json")
       UI.success("loading manifest: #{manifest_file}")
@@ -42,15 +42,6 @@ module Fastlane
       @root_group = @target_project.groups.select { |group| group.name == "Fastlane Runner" }.first
 
       @fastlane_runner_target = @target_project.targets.select { |target| target.name == "FastlaneRunner" }.first
-    end
-
-    def restore_swift_setup
-      UI.verbose("FastlaneRunner project cannot be found. Making a new copy.")
-      runner_source_resources = "#{Fastlane::ROOT}/swift/."
-      destination_path = File.expand_path('swift', FastlaneCore::FastlaneFolder.path)
-      FileUtils.cp_r(runner_source_resources, destination_path)
-      UI.success("Copied Swift fastlane runner project to '#{destination_path}'.")
-      Fastlane::SwiftLaneManager.first_time_setup
     end
 
     def upgrade_if_needed!(dry_run: false)

--- a/fastlane/lib/fastlane/swift_runner_upgrader.rb
+++ b/fastlane/lib/fastlane/swift_runner_upgrader.rb
@@ -29,10 +29,7 @@ module Fastlane
       @source_swift_code_file_folder_path = File.expand_path(File.join(Fastlane::ROOT, "/swift"))
       @target_swift_code_file_folder_path = FastlaneCore::FastlaneFolder.swift_folder_path
 
-      if !File.exists?(target_swift_code_file_folder_path)
-        UI.verbose("FastlaneRunner project cannot be found. Making a new copy.")
-        restore_swift_setup
-      end
+      restore_swift_setup unless File.exist?(target_swift_code_file_folder_path)
 
       manifest_file = File.join(@source_swift_code_file_folder_path, "/upgrade_manifest.json")
       UI.success("loading manifest: #{manifest_file}")
@@ -48,6 +45,7 @@ module Fastlane
     end
 
     def restore_swift_setup
+      UI.verbose("FastlaneRunner project cannot be found. Making a new copy.")
       runner_source_resources = "#{Fastlane::ROOT}/swift/."
       destination_path = File.expand_path('swift', FastlaneCore::FastlaneFolder.path)
       FileUtils.cp_r(runner_source_resources, destination_path)


### PR DESCRIPTION
G'day folks! Thanks again so much for all the work you do on fastlane! Here's my first ever PR for something in Ruby!
 
I tried to design and inline with fastlane's style, but I'm happy to modify the flow or usability if anyone can see a better way of achieving this functionality. Thanks again! :)

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Addresses [#18483](https://github.com/fastlane/fastlane/discussions/18483) in Discussions.

I'm looking at using Fastlane Swift in an iOS project, but I would like to avoid checking in all of the sources and Xcode project files in `fastlane/swift` into my GitHub repo. So ideally, I'd like to only check-in `fastlane/Fastfile.swift` and put the rest in `.gitignore`. Then, whenever I do fresh clone, I can just run `fastlane swift init` again and have the `fastlane/swift` folder restored. Or conversely, whenever I get my CI to run an action, it'll restore the `swift` folder just-in-time then too.

At the moment, Fastlane Swift doesn't properly handle having the `swift` folder deleted. Running `fastlane swift init` after deleting it will simply return a message stating there is already a `Fastfile.swift` file. But when I go to execute a lane after that, it will throw an exception saying it cannot find the `FastlaneSwiftRunner.xcodeproj` file.

My goal with this PR is to enable the ability of letting Fastlane Swift recover from having the `swift` folder deleted and automatically restore itself. I think this is valuable in two places:

1. When running `fastlane swift init` a second time, when wanting to restore the `swift` folder, but not run any lanes yet.
2. When trying to run a lane, and it's discovered the `swift` folder is missing (eg, if a CI automation tries to run it from scratch).

### Description

* In `setup.rb`, when the user starts a new `init` command and Swift is enabled, I added a check to see if the `fastlane/swift` folder exists or not. If it doesn't exist, it prints a message saying it's restoring the Swift files, and then restores the Swift files using the same codepath as when creating a new Fastlane Swift project from scratch. When it is done, it continues on with the regular execution, where it will list the available lanes.
* In `swift_runner_upgrader.rb`, I added similar logic above the code that would crash when `FastlaneSwiftRunner.xcodeproj` couldn't be found. It checks to see if the `swift` folder is missing and restores it if it is. It then continues regular execution of the lane. I couldn't work out how to call the original method from `setup.rb` (Admittedly I'm still quite new to Ruby), so I copied the code. If there's a better way to do this, I'm happy to modify as needed.

### Testing Steps
1. Create a new Fastlane Swift project by navigating to a project and running `fastlane swift init`.
2. Set up Fastlane for any type of project configuration.
3. Run one of the sample lanes to confirm lanes regularly run.
4. Navigate to the `fastlane` directory and delete the `swift` folder.
5. Try and run the same lane again. It should succeed.
6. Delete `swift` again.
7. Try and run `fastlane swift init`. It should still report the Fastfile existing, but `swift` is also restored.
