### PR TITLE
[snapshot] bump SnapshotHelper.swift's version

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -302,4 +302,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.24]
+// SnapshotHelperVersion [1.25]


### PR DESCRIPTION
There are a few recent fixes in the helper but the version wasn't increased. I was debugging why my screenshots generation failed, turns out it was because of M1. The issue has already been fixed, but I didn't realize the helper is out of dated.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There are a few recent fixes in the helper but the version wasn't increased. I was debugging why my screenshots generation failed, turns out it was because of M1. The issue has already been fixed a few month ago, but I didn't realize the helper is out of dated.

### Description
Bump SnapshotHelper.swift's version to reflect a few recent changes.

### Testing Steps
`bundle exec rspec`