### PR TITLE
[action][jira] API response improvement

### DIFF
--- a/fastlane/lib/fastlane/actions/jira.rb
+++ b/fastlane/lib/fastlane/actions/jira.rb
@@ -43,7 +43,12 @@ module Fastlane
             return json_response
           end
         rescue => exception
-          UI.error("Exception: #{exception}")
+          message = "Received exception when adding a JIRA comment: #{exception}"
+          if params[:fail_on_error]
+            UI.user_error!(message)
+          else
+            UI.error(message)
+          end
         end
       end
 
@@ -92,13 +97,19 @@ module Fastlane
                                        description: "Text to add to the ticket as a comment",
                                        verify_block: proc do |value|
                                          UI.user_error!("No comment specified") if value.to_s.length == 0
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :fail_on_error,
+                                       env_name: "FL_JIRA_FAIL_ON_ERROR",
+                                       description: "Should an error adding the JIRA comment cause a failure?",
+                                       type: Boolean,
+                                       optional: true,
+                                       default_value: true) # Default value is true for 'Backward compatibility'
         ]
       end
 
       def self.output
         [
-          ['JIRA_JSON', 'The whole JIRA api JSON object']
+          ['JIRA_JSON', 'The whole JIRA API JSON object']
         ]
       end
 
@@ -137,6 +148,11 @@ module Fastlane
             password: "Your password or API token",
             ticket_id: "IOS-123",
             comment_text: "Text to post as a comment"
+          )',
+          'jira(
+            ticket_id: "IOS-123",
+            comment_text: "Text to post as a comment",
+            fail_on_error: false
           )'
         ]
       end

--- a/fastlane/lib/fastlane/actions/jira.rb
+++ b/fastlane/lib/fastlane/actions/jira.rb
@@ -34,16 +34,13 @@ module Fastlane
           # An exact representation of the JSON returned from the JIRA API
           # https://github.com/sumoheavy/jira-ruby/blob/master/lib/jira/base.rb#L67
           json_response = comment.attrs
-          if json_response.nil?
-            UI.error('Failed to add a comment on JIRA ticket')
-            return nil
-          else
-            Actions.lane_context[SharedValues::JIRA_JSON] = json_response
-            UI.success('Successfully added a comment on JIRA ticket')
-            return json_response
-          end
+          raise 'Failed to add a comment on Jira ticket' if json_response.nil?
+
+          Actions.lane_context[SharedValues::JIRA_JSON] = json_response
+          UI.success('Successfully added a comment on Jira ticket')
+          return json_response
         rescue => exception
-          message = "Received exception when adding a JIRA comment: #{exception}"
+          message = "Received exception when adding a Jira comment: #{exception}"
           if params[:fail_on_error]
             UI.user_error!(message)
           else
@@ -57,7 +54,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Leave a comment on JIRA ticket"
+        "Leave a comment on a Jira ticket"
       end
 
       def self.available_options
@@ -75,7 +72,7 @@ module Fastlane
                                       default_value: ""),
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: "FL_JIRA_USERNAME",
-                                       description: "Username for JIRA instance",
+                                       description: "Username for Jira instance",
                                        verify_block: proc do |value|
                                          UI.user_error!("No username") if value.to_s.length == 0
                                        end),
@@ -100,7 +97,7 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :fail_on_error,
                                        env_name: "FL_JIRA_FAIL_ON_ERROR",
-                                       description: "Should an error adding the JIRA comment cause a failure?",
+                                       description: "Should an error adding the Jira comment cause a failure?",
                                        type: Boolean,
                                        optional: true,
                                        default_value: true) # Default value is true for 'Backward compatibility'
@@ -109,14 +106,14 @@ module Fastlane
 
       def self.output
         [
-          ['JIRA_JSON', 'The whole JIRA API JSON object']
+          ['JIRA_JSON', 'The whole Jira API JSON object']
         ]
       end
 
       def self.return_value
         [
-          "A hash containing all relevant information of the JIRA comment",
-          "Access things like JIRA comment 'id', 'author', 'body'"
+          "A hash containing all relevant information of the Jira comment",
+          "Access Jira comment 'id', 'author', 'body', and more"
         ].join("\n")
       end
 

--- a/fastlane/lib/fastlane/actions/jira.rb
+++ b/fastlane/lib/fastlane/actions/jira.rb
@@ -34,9 +34,6 @@ module Fastlane
           # An exact representation of the JSON returned from the JIRA API
           # https://github.com/sumoheavy/jira-ruby/blob/master/lib/jira/base.rb#L67
           json_response = comment.attrs
-        rescue => exception
-          UI.error("Exception: #{exception}")
-        ensure
           if json_response.nil?
             UI.error('Failed to add a comment on JIRA ticket')
             return nil
@@ -45,6 +42,8 @@ module Fastlane
             UI.success('Successfully added a comment on JIRA ticket')
             return json_response
           end
+        rescue => exception
+          UI.error("Exception: #{exception}")
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There were two problems in JIRA action.
**Problem1: OnSuccess:** After adding a JIRA comment, it was not returning the JIRA API JSON response.
**Problem2: OnError:** After getting an Error, it was not handling the exception, resulting in the entire Fastlane failed with errors.

### Description
- To solve the problem1, now this action will return the exact JSON returned from the JIRA API
- To solve the problem2, now this action will not fail the entire Fastlane, added begin-rescue block
- Please see attached image for more details. **Earlier v/s Now**

### Testing Steps
Nothing change here.
```ruby
jira(
            url: "https://bugs.yourdomain.com",
            ticket_id: "IOS-123",
            comment_text: "Text to post as a comment"
          )
```

<img width="1231" alt="Screenshot 2021-04-03 at 10 25 27" src="https://user-images.githubusercontent.com/5364500/113473210-5d6f0a80-9468-11eb-950d-ba9d68c25ad9.png">

.

<img width="812" alt="Screenshot 2021-04-03 at 10 09 34" src="https://user-images.githubusercontent.com/5364500/113473215-68299f80-9468-11eb-9b13-6eb3447752ac.png">

