### PR TITLE
[Match] Fix change password argument error

### DIFF
--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -40,7 +40,7 @@ module Match
       encryption.store_password(new_password)
 
       message = "[fastlane] Changed passphrase"
-      files_to_commit = encryption.encrypt_files(new_password)
+      files_to_commit = encryption.encrypt_files(password: new_password)
       storage.save_changes!(files_to_commit: files_to_commit, custom_message: message)
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:

-->
Resolves #18509

### Description
The encrypt_files method accepts named parameters and was called without. This bug was introduced in https://github.com/fastlane/fastlane/pull/18389

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
To test this branch, modify your Gemfile as:
```
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "fix/change_password-fix-wrong-number-of-arguments-error"
```