### PR TITLE
[Ruby 3.0] improve specs for Slack action 

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -4,49 +4,40 @@
 module Fastlane
   module Actions
     class SlackAction < Action
-      def self.is_supported?(platform)
-        true
-      end
-
-      # As there is a text limit in the notifications, we are
-      # usually interested in the last part of the message
-      # e.g. for tests
-      def self.trim_message(message)
-        # We want the last 7000 characters, instead of the first 7000, as the error is at the bottom
-        start_index = [message.length - 7000, 0].max
-        message = message[start_index..-1]
-        # We want line breaks to be shown on slack output so we replace
-        # input non-interpreted line break with interpreted line break
-        message.gsub('\n', "\n")
-      end
-
-      def self.run(options)
-        require 'slack-notifier'
-
-        options[:message] = self.trim_message(options[:message].to_s || '')
-        options[:message] = Slack::Notifier::Util::LinkFormatter.format(options[:message])
-
-        options[:pretext] = options[:pretext].gsub('\n', "\n") unless options[:pretext].nil?
-
-        if options[:channel].to_s.length > 0
-          channel = options[:channel]
-          channel = ('#' + options[:channel]) unless ['#', '@'].include?(channel[0]) # send message to channel by default
+      class Runner
+        def initialize(slack_url)
+          @notifier = Slack::Notifier.new(slack_url)
         end
 
-        username = options[:use_webhook_configured_username_and_icon] ? nil : options[:username]
+        def run(options)
+          options[:message] = self.trim_message(options[:message].to_s || '')
+          options[:message] = Slack::Notifier::Util::LinkFormatter.format(options[:message])
 
-        notifier = Slack::Notifier.new(options[:slack_url], channel: channel, username: username)
+          options[:pretext] = options[:pretext].gsub('\n', "\n") unless options[:pretext].nil?
 
-        link_names = options[:link_names]
+          if options[:channel].to_s.length > 0
+            channel = options[:channel]
+            channel = ('#' + options[:channel]) unless ['#', '@'].include?(channel[0]) # send message to channel by default
+          end
 
-        icon_url = options[:use_webhook_configured_username_and_icon] ? nil : options[:icon_url]
+          username = options[:use_webhook_configured_username_and_icon] ? nil : options[:username]
 
-        slack_attachment = generate_slack_attachments(options)
+          slack_attachment = generate_slack_attachments(options)
+          link_names = options[:link_names]
+          icon_url = options[:use_webhook_configured_username_and_icon] ? nil : options[:icon_url]
 
-        return [notifier, slack_attachment] if Helper.test? # tests will verify the slack attachments and other properties
+          post_message(
+            channel: channel,
+            username: username,
+            attachments: [slack_attachment],
+            link_names: link_names,
+            icon_url: icon_url,
+            fail_on_error: options[:fail_on_error]
+          )
+        end
 
-        begin
-          results = notifier.ping('', link_names: link_names, icon_url: icon_url, attachments: [slack_attachment])
+        def post_message(channel:, username:, attachments:, link_names:, icon_url:, fail_on_error:)
+          results = @notifier.ping('', channel: channel, username: username, link_names: link_names, icon_url: icon_url, attachments: attachments)
         rescue => exception
           UI.error("Exception: #{exception}")
         ensure
@@ -56,13 +47,129 @@ module Fastlane
           else
             UI.verbose(result) unless result.nil?
             message = "Error pushing Slack message, maybe the integration has no permission to post on this channel? Try removing the channel parameter in your Fastfile, this is usually caused by a misspelled or changed group/channel name or an expired SLACK_URL"
-            if options[:fail_on_error]
+            if fail_on_error
               UI.user_error!(message)
             else
               UI.error(message)
             end
           end
         end
+
+        # As there is a text limit in the notifications, we are
+        # usually interested in the last part of the message
+        # e.g. for tests
+        def trim_message(message)
+          # We want the last 7000 characters, instead of the first 7000, as the error is at the bottom
+          start_index = [message.length - 7000, 0].max
+          message = message[start_index..-1]
+          # We want line breaks to be shown on slack output so we replace
+          # input non-interpreted line break with interpreted line break
+          message.gsub('\n', "\n")
+        end
+
+        def generate_slack_attachments(options)
+          color = (options[:success] ? 'good' : 'danger')
+          should_add_payload = ->(payload_name) { options[:default_payloads].map(&:to_sym).include?(payload_name.to_sym) }
+
+          slack_attachment = {
+            fallback: options[:message],
+            text: options[:message],
+            pretext: options[:pretext],
+            color: color,
+            mrkdwn_in: ["pretext", "text", "fields", "message"],
+            fields: []
+          }
+
+          # custom user payloads
+          slack_attachment[:fields] += options[:payload].map do |k, v|
+            {
+              title: k.to_s,
+              value: Slack::Notifier::Util::LinkFormatter.format(v.to_s),
+              short: false
+            }
+          end
+
+          # Add the lane to the Slack message
+          # This might be nil, if slack is called as "one-off" action
+          if should_add_payload[:lane] && Actions.lane_context[Actions::SharedValues::LANE_NAME]
+            slack_attachment[:fields] << {
+              title: 'Lane',
+              value: Actions.lane_context[Actions::SharedValues::LANE_NAME],
+              short: true
+            }
+          end
+
+          # test_result
+          if should_add_payload[:test_result]
+            slack_attachment[:fields] << {
+              title: 'Result',
+              value: (options[:success] ? 'Success' : 'Error'),
+              short: true
+            }
+          end
+
+          # git branch
+          if Actions.git_branch && should_add_payload[:git_branch]
+            slack_attachment[:fields] << {
+              title: 'Git Branch',
+              value: Actions.git_branch,
+              short: true
+            }
+          end
+
+          # git_author
+          if Actions.git_author_email && should_add_payload[:git_author]
+            if FastlaneCore::Env.truthy?('FASTLANE_SLACK_HIDE_AUTHOR_ON_SUCCESS') && options[:success]
+            # We only show the git author if the build failed
+            else
+              slack_attachment[:fields] << {
+                title: 'Git Author',
+                value: Actions.git_author_email,
+                short: true
+              }
+            end
+          end
+
+          # last_git_commit
+          if Actions.last_git_commit_message && should_add_payload[:last_git_commit]
+            slack_attachment[:fields] << {
+              title: 'Git Commit',
+              value: Actions.last_git_commit_message,
+              short: false
+            }
+          end
+
+          # last_git_commit_hash
+          if Actions.last_git_commit_hash(true) && should_add_payload[:last_git_commit_hash]
+            slack_attachment[:fields] << {
+              title: 'Git Commit Hash',
+              value: Actions.last_git_commit_hash(short: true),
+              short: false
+            }
+          end
+
+          # merge additional properties
+          deep_merge(slack_attachment, options[:attachment_properties])
+        end
+
+        # Adapted from https://stackoverflow.com/a/30225093/158525
+        def deep_merge(a, b)
+          merger = proc do |key, v1, v2|
+            Hash === v1 && Hash === v2 ?
+              v1.merge(v2, &merger) : Array === v1 && Array === v2 ?
+                                        v1 | v2 : [:undefined, nil, :nil].include?(v2) ? v1 : v2
+          end
+          a.merge(b, &merger)
+        end
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.run(options)
+        require 'slack-notifier'
+        Runner.new(options[:slack_url]).run(options)
       end
 
       def self.description
@@ -179,105 +286,6 @@ module Fastlane
 
       def self.details
         "Create an Incoming WebHook and export this as `SLACK_URL`. Can send a message to **#channel** (by default), a direct message to **@username** or a message to a private group **group** with success (green) or failure (red) status."
-      end
-
-      #####################################################
-      # @!group Helper
-      #####################################################
-
-      def self.generate_slack_attachments(options)
-        color = (options[:success] ? 'good' : 'danger')
-        should_add_payload = ->(payload_name) { options[:default_payloads].map(&:to_sym).include?(payload_name.to_sym) }
-
-        slack_attachment = {
-          fallback: options[:message],
-          text: options[:message],
-          pretext: options[:pretext],
-          color: color,
-          mrkdwn_in: ["pretext", "text", "fields", "message"],
-          fields: []
-        }
-
-        # custom user payloads
-        slack_attachment[:fields] += options[:payload].map do |k, v|
-          {
-            title: k.to_s,
-            value: Slack::Notifier::Util::LinkFormatter.format(v.to_s),
-            short: false
-          }
-        end
-
-        # Add the lane to the Slack message
-        # This might be nil, if slack is called as "one-off" action
-        if should_add_payload[:lane] && Actions.lane_context[Actions::SharedValues::LANE_NAME]
-          slack_attachment[:fields] << {
-            title: 'Lane',
-            value: Actions.lane_context[Actions::SharedValues::LANE_NAME],
-            short: true
-          }
-        end
-
-        # test_result
-        if should_add_payload[:test_result]
-          slack_attachment[:fields] << {
-            title: 'Result',
-            value: (options[:success] ? 'Success' : 'Error'),
-            short: true
-          }
-        end
-
-        # git branch
-        if Actions.git_branch && should_add_payload[:git_branch]
-          slack_attachment[:fields] << {
-            title: 'Git Branch',
-            value: Actions.git_branch,
-            short: true
-          }
-        end
-
-        # git_author
-        if Actions.git_author_email && should_add_payload[:git_author]
-          if FastlaneCore::Env.truthy?('FASTLANE_SLACK_HIDE_AUTHOR_ON_SUCCESS') && options[:success]
-            # We only show the git author if the build failed
-          else
-            slack_attachment[:fields] << {
-              title: 'Git Author',
-              value: Actions.git_author_email,
-              short: true
-            }
-          end
-        end
-
-        # last_git_commit
-        if Actions.last_git_commit_message && should_add_payload[:last_git_commit]
-          slack_attachment[:fields] << {
-            title: 'Git Commit',
-            value: Actions.last_git_commit_message,
-            short: false
-          }
-        end
-
-        # last_git_commit_hash
-        if Actions.last_git_commit_hash(true) && should_add_payload[:last_git_commit_hash]
-          slack_attachment[:fields] << {
-            title: 'Git Commit Hash',
-            value: Actions.last_git_commit_hash(short: true),
-            short: false
-          }
-        end
-
-        # merge additional properties
-        deep_merge(slack_attachment, options[:attachment_properties])
-      end
-
-      # Adapted from https://stackoverflow.com/a/30225093/158525
-      def self.deep_merge(a, b)
-        merger = proc do |key, v1, v2|
-          Hash === v1 && Hash === v2 ?
-                 v1.merge(v2, &merger) : Array === v1 && Array === v2 ?
-                   v1 | v2 : [:undefined, nil, :nil].include?(v2) ? v1 : v2
-        end
-        a.merge(b, &merger)
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -10,7 +10,7 @@ module Fastlane
         end
 
         def run(options)
-          options[:message] = self.trim_message(options[:message].to_s || '')
+          options[:message] = self.class.trim_message(options[:message].to_s || '')
           options[:message] = Slack::Notifier::Util::LinkFormatter.format(options[:message])
 
           options[:pretext] = options[:pretext].gsub('\n', "\n") unless options[:pretext].nil?
@@ -22,7 +22,7 @@ module Fastlane
 
           username = options[:use_webhook_configured_username_and_icon] ? nil : options[:username]
 
-          slack_attachment = generate_slack_attachments(options)
+          slack_attachment = self.class.generate_slack_attachments(options)
           link_names = options[:link_names]
           icon_url = options[:use_webhook_configured_username_and_icon] ? nil : options[:icon_url]
 
@@ -58,7 +58,7 @@ module Fastlane
         # As there is a text limit in the notifications, we are
         # usually interested in the last part of the message
         # e.g. for tests
-        def trim_message(message)
+        def self.trim_message(message)
           # We want the last 7000 characters, instead of the first 7000, as the error is at the bottom
           start_index = [message.length - 7000, 0].max
           message = message[start_index..-1]
@@ -67,7 +67,7 @@ module Fastlane
           message.gsub('\n', "\n")
         end
 
-        def generate_slack_attachments(options)
+        def self.generate_slack_attachments(options)
           color = (options[:success] ? 'good' : 'danger')
           should_add_payload = ->(payload_name) { options[:default_payloads].map(&:to_sym).include?(payload_name.to_sym) }
 
@@ -153,7 +153,7 @@ module Fastlane
         end
 
         # Adapted from https://stackoverflow.com/a/30225093/158525
-        def deep_merge(a, b)
+        def self.deep_merge(a, b)
           merger = proc do |key, v1, v2|
             Hash === v1 && Hash === v2 ?
               v1.merge(v2, &merger) : Array === v1 && Array === v2 ?
@@ -286,6 +286,19 @@ module Fastlane
 
       def self.details
         "Create an Incoming WebHook and export this as `SLACK_URL`. Can send a message to **#channel** (by default), a direct message to **@username** or a message to a private group **group** with success (green) or failure (red) status."
+      end
+
+      #####################################################
+      # @!group Helper
+      #####################################################
+
+      def self.trim_message(message)
+        Runner.trim_message(message)
+      end
+
+      def self.generate_slack_attachments(options)
+        UI.deprecation('`Fastlane::Actions::Slack.generate_slack_attachments` is subject to be removed as Slack recommends migrating `attachments` to Block Kit. fastlane will also the same direction.')
+        Runner.generate_slack_attachments(options)
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -297,7 +297,7 @@ module Fastlane
       end
 
       def self.generate_slack_attachments(options)
-        UI.deprecation('`Fastlane::Actions::Slack.generate_slack_attachments` is subject to be removed as Slack recommends migrating `attachments` to Block Kit. fastlane will also the same direction.')
+        UI.deprecated('`Fastlane::Actions::Slack.generate_slack_attachments` is subject to be removed as Slack recommends migrating `attachments` to Block Kit. fastlane will also follow the same direction.')
         Runner.generate_slack_attachments(options)
       end
     end

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -3,11 +3,7 @@ require 'slack-notifier'
 describe Fastlane::Actions do
   describe Fastlane::Actions::SlackAction do
     describe Fastlane::Actions::SlackAction::Runner do
-      before :each do
-        ENV['SLACK_URL'] = 'https://127.0.0.1'
-      end
-
-      subject { Fastlane::Actions::SlackAction::Runner.new }
+      subject { Fastlane::Actions::SlackAction::Runner.new('https://127.0.0.1') }
 
       it "trims long messages to show the bottom of the messages" do
         long_text = "a" * 10_000

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions do
 
       it "trims long messages to show the bottom of the messages" do
         long_text = "a" * 10_000
-        expect(subject.trim_message(long_text).length).to eq(7000)
+        expect(described_class.trim_message(long_text).length).to eq(7000)
       end
 
       it "works so perfect, like Slack does" do

--- a/scan/spec/slack_poster_spec.rb
+++ b/scan/spec/slack_poster_spec.rb
@@ -2,6 +2,11 @@ require 'scan'
 require 'slack-notifier'
 
 describe Scan::SlackPoster do
+  before do
+    # mock the network request part
+    allow_any_instance_of(Fastlane::Actions::SlackAction::Runner).to receive(:post_message).with(any_args)
+  end
+
   describe "slack_url handling" do
     describe "without a slack_url set" do
       it "skips Slack posting", requires_xcodebuild: true do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

As per the plan #17931 for Ruby 3.0, I've been working on fixing Ruby 2.7's deprecation warnings which will crash on Ruby 3.0. There is an issue where one of the fastlane's dependencies `slack-notifier`, [which is not maintained any more](https://github.com/stevenosloan/slack-notifier/pull/119), keeps producing that warning.

There would be some options in solving that issue - 

1. Ping the maintainers and ask them to release a new version
2. Fork the repo and publish it as a different gem, like `fastlane-slack-notifier`
3. Replace the gem with our own one

In my opinion, 1 is too little hope and 2 would be too much. I would go with 3 as I've got this rewritten one tailored for fastlane's use-case within 60 LoC, which I think is fair to have its own implementation. https://github.com/fastlane/fastlane/pull/18537

So, in order to migrate the Slack action, I'd like to prepare for it by improving the testability of it. Prior to this PR, `slack_spec.rb` uses a hack that makes it return specific objects to verify instead of performing its process entirely. That pulls out `Slack::Notifier` object from the gem to unit tests. Meaning the unit tests will be completely broken when removing the dependency. This PR makes the test cases independent from the gem.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

There are two parts to this PR. The first one is to extract logic in `Fastlane::SlackAction.run` into a runner class that allows me to mock a network request to Slack by `expect(..).to receive(...).with(...)` in `rspec-mocks`.  It is a simpler approach than using the `Helper.test?` hack.  The second one is to use [argument matcher](https://github.com/rspec/rspec-mocks#argument-matchers) to describe what parameters are given to the method handling network requests without having to depend on `slack-notifier` gem.

```diff
-        notifier, attachments = Fastlane::Actions::SlackAction.run(options)
-
-        expect(notifier.config.defaults[:username]).to eq('fastlane')
-        expect(notifier.config.defaults[:channel]).to eq(channel)
-
-        expect(attachments[:color]).to eq('danger')
-        expect(attachments[:text]).to eq(message)
-        expect(attachments[:pretext]).to eq(nil)
-
-        fields = attachments[:fields]
-        expect(fields[1][:title]).to eq('Built by')
-        expect(fields[1][:value]).to eq('Jenkins')
-
-        expect(fields[2][:title]).to eq('Lane')
-        expect(fields[2][:value]).to eq(lane_name)
-
-        expect(fields[3][:title]).to eq('Result')
-        expect(fields[3][:value]).to eq('Error')
+        expected_args = {
+          attachments: [
+            hash_including(
+              color: 'danger',
+              pretext: nil,
+              text: message,
+              fields: array_including(
+                { title: 'Built by', value: 'Jenkins', short: false },
+                { title: 'Lane', value: lane_name, short: true },
+                { title: 'Result', value: 'Error', short: true },
+              )
+            )
+          ],
+          link_names: false,
+          icon_url: 'https://fastlane.tools/assets/img/fastlane_icon.png',
+          fail_on_error: true,
+        }
+        expect(subject).to receive(:post_message).with(expected_args)
+        subject.run(options)
```

Argument Matcher is much more descriptive than using many assertions to verify a big `Hash` object🙁 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Add a lane like below to `fastlane/Fastfile` in this repo's clone.

```ruby
lane :slack_test do
  slack(
    slack_url: 'https://hooks.slack.com/services/xxxxxxxxxxx',
    pretext: 'pretext test <@xxxxxx> #general',
    username: 'ainame-bot',
    channel: '#general',
    message: 'test <@xxxxxx> #general',
    link_names: true,
  )
end
```

<img width="652" alt="Screenshot 2021-04-07 at 02 41 16" src="https://user-images.githubusercontent.com/748949/113798274-c8f7f700-974a-11eb-9973-8d97041fd03c.png">
