### PR TITLE
[scan] fix tests for ruby 2.4

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -123,7 +123,7 @@ module Scan
         suite_name = suite.match(/\s*([\w\s]+):/).captures.first
 
         test_cases = suite.split(":\n").fetch(1, []).split("\n").each
-                          .select { |line| line.start_with?(/\s+/) }
+                          .select { |line| line.match?(/^\s+/) }
                           .map { |line| line.strip.gsub(".", "/").gsub("()", "") }
                           .map { |line| suite_name + "/" + line }
 


### PR DESCRIPTION
### Motivation and Context
- Fix failing tests for Ruby 2.4

### Description
- Fix failing tests for Ruby 2.4 by using `match?` instead of `starts_with?`
