### PR TITLE
Version bump to 2.180.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane (2.179.0)
+    fastlane (2.180.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       artifactory (~> 3.0)
@@ -50,8 +50,8 @@ GEM
     ast (2.4.2)
     atomos (0.1.3)
     aws-eventstream (1.1.1)
-    aws-partitions (1.434.0)
-    aws-sdk-core (3.113.0)
+    aws-partitions (1.441.0)
+    aws-sdk-core (3.113.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)

--- a/README.md
+++ b/README.md
@@ -35,87 +35,11 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <!-- This table is regenerated and resorted on each release -->
 <table id='team'>
 <tr>
-<td id='joshua-liebowitz'>
-<a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
-</td>
-<td id='manu-wallner'>
-<a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
-</td>
-<td id='josh-holtz'>
-<a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
-</td>
-<td id='stefan-natchev'>
-<a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
-</td>
-<td id='satoshi-namai'>
-<a href='https://github.com/ainame'>
-<img src='https://github.com/ainame.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/ainame'>Satoshi Namai</a></h4>
-</td>
-</tr>
-<tr>
-<td id='jérôme-lacoste'>
-<a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
-</td>
-<td id='matthew-ellis'>
-<a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
-</td>
-<td id='aaron-brager'>
-<a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
-</td>
-<td id='iulian-onofrei'>
-<a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
-</td>
 <td id='jimmy-dee'>
 <a href='https://github.com/jdee'>
 <img src='https://github.com/jdee.png?size=140'>
 </a>
 <h4 align='center'>Jimmy Dee</h4>
-</td>
-</tr>
-<tr>
-<td id='jan-piotrowski'>
-<a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
-</td>
-<td id='helmut-januschka'>
-<a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
-</td>
-<td id='maksym-grebenets'>
-<a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/endocrimes'>
@@ -123,25 +47,17 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
-<td id='fumiya-nakamura'>
-<a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<td id='andrew-mcburney'>
+<a href='https://github.com/armcburney'>
+<img src='https://github.com/armcburney.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
+<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
-</tr>
-<tr>
-<td id='jorge-revuelta-h'>
-<a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<td id='manu-wallner'>
+<a href='https://github.com/milch'>
+<img src='https://github.com/milch.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
-</td>
-<td id='felix-krause'>
-<a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+<h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 <td id='roger-oba'>
 <a href='https://github.com/rogerluan'>
@@ -149,11 +65,95 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </a>
 <h4 align='center'><a href='https://twitter.com/rogerluan_'>Roger Oba</a></h4>
 </td>
+</tr>
+<tr>
+<td id='iulian-onofrei'>
+<a href='https://github.com/revolter'>
+<img src='https://github.com/revolter.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
+</td>
+<td id='luka-mirosevic'>
+<a href='https://github.com/lmirosevic'>
+<img src='https://github.com/lmirosevic.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
+</td>
+<td id='aaron-brager'>
+<a href='https://github.com/getaaron'>
+<img src='https://github.com/getaaron.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
+</td>
+<td id='jorge-revuelta-h'>
+<a href='https://github.com/minuscorp'>
+<img src='https://github.com/minuscorp.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
+</td>
+<td id='jérôme-lacoste'>
+<a href='https://github.com/lacostej'>
+<img src='https://github.com/lacostej.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
+</td>
+</tr>
+<tr>
+<td id='matthew-ellis'>
+<a href='https://github.com/matthewellis'>
+<img src='https://github.com/matthewellis.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
+</td>
+<td id='joshua-liebowitz'>
+<a href='https://github.com/taquitos'>
+<img src='https://github.com/taquitos.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
+</td>
 <td id='daniel-jankowski'>
 <a href='https://github.com/mollyIV'>
 <img src='https://github.com/mollyIV.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
+</td>
+<td id='jan-piotrowski'>
+<a href='https://github.com/janpio'>
+<img src='https://github.com/janpio.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
+</td>
+<td id='felix-krause'>
+<a href='https://github.com/KrauseFx'>
+<img src='https://github.com/KrauseFx.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
+</td>
+</tr>
+<tr>
+<td id='satoshi-namai'>
+<a href='https://github.com/ainame'>
+<img src='https://github.com/ainame.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ainame'>Satoshi Namai</a></h4>
+</td>
+<td id='maksym-grebenets'>
+<a href='https://github.com/mgrebenets'>
+<img src='https://github.com/mgrebenets.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
+</td>
+<td id='max-ott'>
+<a href='https://github.com/max-ott'>
+<img src='https://github.com/max-ott.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
+</td>
+<td id='fumiya-nakamura'>
+<a href='https://github.com/nafu'>
+<img src='https://github.com/nafu.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
@@ -163,29 +163,29 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 </td>
 </tr>
 <tr>
+<td id='helmut-januschka'>
+<a href='https://github.com/hjanuschka'>
+<img src='https://github.com/hjanuschka.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
+</td>
+<td id='josh-holtz'>
+<a href='https://github.com/joshdholtz'>
+<img src='https://github.com/joshdholtz.png?size=140'>
+</a>
+<h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
+</td>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
 <img src='https://github.com/giginet.png?size=140'>
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
-<td id='max-ott'>
-<a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
+<td id='stefan-natchev'>
+<a href='https://github.com/snatchev'>
+<img src='https://github.com/snatchev.png?size=140'>
 </a>
-<h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
-</td>
-<td id='luka-mirosevic'>
-<a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
-</td>
-<td id='andrew-mcburney'>
-<a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
-</a>
-<h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
+<h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 </table>
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,30 +15,30 @@ Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
   # list of authors is regenerated and resorted on each release
-  spec.authors       = ["Luka Mirosevic",
-                        "Max Ott",
-                        "Joshua Liebowitz",
-                        "Jérôme Lacoste",
-                        "Manu Wallner",
-                        "Stefan Natchev",
-                        "Andrew McBurney",
+  spec.authors       = ["Jimmy Dee",
                         "Roger Oba",
                         "Daniel Jankowski",
                         "Satoshi Namai",
-                        "Jimmy Dee",
-                        "Kohki Miki",
-                        "Iulian Onofrei",
-                        "Fumiya Nakamura",
-                        "Josh Holtz",
-                        "Helmut Januschka",
+                        "Joshua Liebowitz",
+                        "Max Ott",
+                        "Manu Wallner",
                         "Felix Krause",
-                        "Jan Piotrowski",
+                        "Fumiya Nakamura",
                         "Aaron Brager",
                         "Maksym Grebenets",
                         "Jorge Revuelta H",
+                        "Helmut Januschka",
+                        "Olivier Halligon",
+                        "Iulian Onofrei",
+                        "Stefan Natchev",
+                        "Andrew McBurney",
+                        "Josh Holtz",
                         "Danielle Tomlinson",
-                        "Matthew Ellis",
-                        "Olivier Halligon"]
+                        "Kohki Miki",
+                        "Jan Piotrowski",
+                        "Jérôme Lacoste",
+                        "Luka Mirosevic",
+                        "Matthew Ellis"]
 
   spec.email         = ["fastlane@krausefx.com"]
   spec.summary       = Fastlane::DESCRIPTION

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.179.0'.freeze
+  VERSION = '2.180.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '0.49.1'.freeze

--- a/fastlane/swift/Deliverfile.swift
+++ b/fastlane/swift/Deliverfile.swift
@@ -17,4 +17,4 @@ public class Deliverfile: DeliverfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.179.0
+// Generated with fastlane 2.180.0

--- a/fastlane/swift/DeliverfileProtocol.swift
+++ b/fastlane/swift/DeliverfileProtocol.swift
@@ -256,4 +256,4 @@ public extension DeliverfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.62]
+// FastlaneRunnerAPIVersion [0.9.63]

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -4705,30 +4705,36 @@ public func jazzy(config: String? = nil,
 }
 
 /**
- Leave a comment on JIRA tickets
+  Leave a comment on a Jira ticket
 
- - parameters:
-   - url: URL for Jira instance
-   - contextPath: Appends to the url (ex: "/jira")
-   - username: Username for JIRA instance
-   - password: Password for Jira
-   - ticketId: Ticket ID for Jira, i.e. IOS-123
-   - commentText: Text to add to the ticket as a comment
+  - parameters:
+    - url: URL for Jira instance
+    - contextPath: Appends to the url (ex: "/jira")
+    - username: Username for Jira instance
+    - password: Password or API token for Jira
+    - ticketId: Ticket ID for Jira, i.e. IOS-123
+    - commentText: Text to add to the ticket as a comment
+    - failOnError: Should an error adding the Jira comment cause a failure?
+
+  - returns: A hash containing all relevant information of the Jira comment
+ Access Jira comment 'id', 'author', 'body', and more
  */
-public func jira(url: String,
-                 contextPath: String = "",
-                 username: String,
-                 password: String,
-                 ticketId: String,
-                 commentText: String)
+@discardableResult public func jira(url: String,
+                                    contextPath: String = "",
+                                    username: String,
+                                    password: String,
+                                    ticketId: String,
+                                    commentText: String,
+                                    failOnError: Bool = true) -> [String: Any]
 {
     let command = RubyCommand(commandID: "", methodName: "jira", className: nil, args: [RubyCommand.Argument(name: "url", value: url),
                                                                                         RubyCommand.Argument(name: "context_path", value: contextPath),
                                                                                         RubyCommand.Argument(name: "username", value: username),
                                                                                         RubyCommand.Argument(name: "password", value: password),
                                                                                         RubyCommand.Argument(name: "ticket_id", value: ticketId),
-                                                                                        RubyCommand.Argument(name: "comment_text", value: commentText)])
-    _ = runner.executeCommand(command)
+                                                                                        RubyCommand.Argument(name: "comment_text", value: commentText),
+                                                                                        RubyCommand.Argument(name: "fail_on_error", value: failOnError)])
+    return parseDictionary(fromString: runner.executeCommand(command))
 }
 
 /**
@@ -5302,14 +5308,16 @@ public func nexusUpload(file: String,
    - ascProvider: Provider short name for accounts associated with multiple providers
    - printLog: Whether to print notarization log file, listing issues on failure and warnings on success
    - verbose: Whether to log requests
+   - apiKeyPath: Path to AppStore Connect API key
  */
 public func notarize(package: String,
                      tryEarlyStapling: Bool = false,
                      bundleId: String? = nil,
-                     username: String,
+                     username: String? = nil,
                      ascProvider: String? = nil,
                      printLog: Bool = false,
-                     verbose: Bool = false)
+                     verbose: Bool = false,
+                     apiKeyPath: String? = nil)
 {
     let command = RubyCommand(commandID: "", methodName: "notarize", className: nil, args: [RubyCommand.Argument(name: "package", value: package),
                                                                                             RubyCommand.Argument(name: "try_early_stapling", value: tryEarlyStapling),
@@ -5317,7 +5325,8 @@ public func notarize(package: String,
                                                                                             RubyCommand.Argument(name: "username", value: username),
                                                                                             RubyCommand.Argument(name: "asc_provider", value: ascProvider),
                                                                                             RubyCommand.Argument(name: "print_log", value: printLog),
-                                                                                            RubyCommand.Argument(name: "verbose", value: verbose)])
+                                                                                            RubyCommand.Argument(name: "verbose", value: verbose),
+                                                                                            RubyCommand.Argument(name: "api_key_path", value: apiKeyPath)])
     _ = runner.executeCommand(command)
 }
 
@@ -6411,6 +6420,7 @@ public func rubyVersion() {
    - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
    - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - useSystemScm: Lets xcodebuild use system's scm configuration
+   - numberOfRetries: The number of times a test can fail before scan should stop retrying
    - failBuild: Should this step stop the build if the tests fail? Set this to false if you're using trainer
 
  More information: https://docs.fastlane.tools/actions/scan/
@@ -6484,6 +6494,7 @@ public func runTests(workspace: String? = nil,
                      skipPackageDependenciesResolution: Bool = false,
                      disablePackageAutomaticUpdates: Bool = false,
                      useSystemScm: Bool = false,
+                     numberOfRetries: Int = 0,
                      failBuild: Bool = true)
 {
     let command = RubyCommand(commandID: "", methodName: "run_tests", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
@@ -6555,6 +6566,7 @@ public func runTests(workspace: String? = nil,
                                                                                              RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
                                                                                              RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                              RubyCommand.Argument(name: "use_system_scm", value: useSystemScm),
+                                                                                             RubyCommand.Argument(name: "number_of_retries", value: numberOfRetries),
                                                                                              RubyCommand.Argument(name: "fail_build", value: failBuild)])
     _ = runner.executeCommand(command)
 }
@@ -6708,6 +6720,7 @@ public func say(text: Any,
    - skipPackageDependenciesResolution: Skips resolution of Swift Package Manager dependencies
    - disablePackageAutomaticUpdates: Prevents packages from automatically being resolved to versions other than those recorded in the `Package.resolved` file
    - useSystemScm: Lets xcodebuild use system's scm configuration
+   - numberOfRetries: The number of times a test can fail before scan should stop retrying
    - failBuild: Should this step stop the build if the tests fail? Set this to false if you're using trainer
 
  More information: https://docs.fastlane.tools/actions/scan/
@@ -6781,6 +6794,7 @@ public func scan(workspace: Any? = scanfile.workspace,
                  skipPackageDependenciesResolution: Bool = scanfile.skipPackageDependenciesResolution,
                  disablePackageAutomaticUpdates: Bool = scanfile.disablePackageAutomaticUpdates,
                  useSystemScm: Bool = scanfile.useSystemScm,
+                 numberOfRetries: Int = scanfile.numberOfRetries,
                  failBuild: Bool = scanfile.failBuild)
 {
     let command = RubyCommand(commandID: "", methodName: "scan", className: nil, args: [RubyCommand.Argument(name: "workspace", value: workspace),
@@ -6852,6 +6866,7 @@ public func scan(workspace: Any? = scanfile.workspace,
                                                                                         RubyCommand.Argument(name: "skip_package_dependencies_resolution", value: skipPackageDependenciesResolution),
                                                                                         RubyCommand.Argument(name: "disable_package_automatic_updates", value: disablePackageAutomaticUpdates),
                                                                                         RubyCommand.Argument(name: "use_system_scm", value: useSystemScm),
+                                                                                        RubyCommand.Argument(name: "number_of_retries", value: numberOfRetries),
                                                                                         RubyCommand.Argument(name: "fail_build", value: failBuild)])
     _ = runner.executeCommand(command)
 }
@@ -7737,6 +7752,57 @@ public func sonar(projectConfigurationPath: String? = nil,
                                                                                          RubyCommand.Argument(name: "pull_request_branch", value: pullRequestBranch),
                                                                                          RubyCommand.Argument(name: "pull_request_base", value: pullRequestBase),
                                                                                          RubyCommand.Argument(name: "pull_request_key", value: pullRequestKey)])
+    _ = runner.executeCommand(command)
+}
+
+/**
+ Generate docs using SourceDocs
+
+ - parameters:
+   - allModules: Generate documentation for all modules in a Swift package
+   - spmModule: Generate documentation for Swift Package Manager module
+   - moduleName: Generate documentation for a Swift module
+   - linkBeginning: The text to begin links with
+   - linkEnding: The text to end links with (default: .md)
+   - outputFolder: Output directory to clean (default: Documentation/Reference)
+   - minAcl: Access level to include in documentation [private, fileprivate, internal, public, open] (default: public)
+   - moduleNamePath: Include the module name as part of the output folder path
+   - clean: Delete output folder before generating documentation
+   - collapsible: Put methods, properties and enum cases inside collapsible blocks
+   - tableOfContents: Generate a table of contents with properties and methods for each type
+   - reproducible: Generate documentation that is reproducible: only depends on the sources
+   - scheme: Create documentation for specific scheme
+   - sdkPlatform: Create documentation for specific sdk platform
+ */
+public func sourcedocs(allModules: Bool? = nil,
+                       spmModule: String? = nil,
+                       moduleName: String? = nil,
+                       linkBeginning: String? = nil,
+                       linkEnding: String? = nil,
+                       outputFolder: String,
+                       minAcl: String? = nil,
+                       moduleNamePath: Bool? = nil,
+                       clean: Bool? = nil,
+                       collapsible: Bool? = nil,
+                       tableOfContents: Bool? = nil,
+                       reproducible: Bool? = nil,
+                       scheme: String? = nil,
+                       sdkPlatform: String? = nil)
+{
+    let command = RubyCommand(commandID: "", methodName: "sourcedocs", className: nil, args: [RubyCommand.Argument(name: "all_modules", value: allModules),
+                                                                                              RubyCommand.Argument(name: "spm_module", value: spmModule),
+                                                                                              RubyCommand.Argument(name: "module_name", value: moduleName),
+                                                                                              RubyCommand.Argument(name: "link_beginning", value: linkBeginning),
+                                                                                              RubyCommand.Argument(name: "link_ending", value: linkEnding),
+                                                                                              RubyCommand.Argument(name: "output_folder", value: outputFolder),
+                                                                                              RubyCommand.Argument(name: "min_acl", value: minAcl),
+                                                                                              RubyCommand.Argument(name: "module_name_path", value: moduleNamePath),
+                                                                                              RubyCommand.Argument(name: "clean", value: clean),
+                                                                                              RubyCommand.Argument(name: "collapsible", value: collapsible),
+                                                                                              RubyCommand.Argument(name: "table_of_contents", value: tableOfContents),
+                                                                                              RubyCommand.Argument(name: "reproducible", value: reproducible),
+                                                                                              RubyCommand.Argument(name: "scheme", value: scheme),
+                                                                                              RubyCommand.Argument(name: "sdk_platform", value: sdkPlatform)])
     _ = runner.executeCommand(command)
 }
 
@@ -9821,4 +9887,4 @@ public let snapshotfile = Snapshotfile()
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.115]
+// FastlaneRunnerAPIVersion [0.9.116]

--- a/fastlane/swift/Gymfile.swift
+++ b/fastlane/swift/Gymfile.swift
@@ -17,4 +17,4 @@ public class Gymfile: GymfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.179.0
+// Generated with fastlane 2.180.0

--- a/fastlane/swift/GymfileProtocol.swift
+++ b/fastlane/swift/GymfileProtocol.swift
@@ -196,4 +196,4 @@ public extension GymfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.65]
+// FastlaneRunnerAPIVersion [0.9.66]

--- a/fastlane/swift/Matchfile.swift
+++ b/fastlane/swift/Matchfile.swift
@@ -17,4 +17,4 @@ public class Matchfile: MatchfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.179.0
+// Generated with fastlane 2.180.0

--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -184,4 +184,4 @@ public extension MatchfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.59]
+// FastlaneRunnerAPIVersion [0.9.60]

--- a/fastlane/swift/Precheckfile.swift
+++ b/fastlane/swift/Precheckfile.swift
@@ -17,4 +17,4 @@ public class Precheckfile: PrecheckfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.179.0
+// Generated with fastlane 2.180.0

--- a/fastlane/swift/PrecheckfileProtocol.swift
+++ b/fastlane/swift/PrecheckfileProtocol.swift
@@ -52,4 +52,4 @@ public extension PrecheckfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.58]
+// FastlaneRunnerAPIVersion [0.9.59]

--- a/fastlane/swift/Scanfile.swift
+++ b/fastlane/swift/Scanfile.swift
@@ -17,4 +17,4 @@ public class Scanfile: ScanfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.179.0
+// Generated with fastlane 2.180.0

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -209,6 +209,9 @@ public protocol ScanfileProtocol: class {
     /// Lets xcodebuild use system's scm configuration
     var useSystemScm: Bool { get }
 
+    /// The number of times a test can fail before scan should stop retrying
+    var numberOfRetries: Int { get }
+
     /// Should this step stop the build if the tests fail? Set this to false if you're using trainer
     var failBuild: Bool { get }
 }
@@ -283,9 +286,10 @@ public extension ScanfileProtocol {
     var skipPackageDependenciesResolution: Bool { return false }
     var disablePackageAutomaticUpdates: Bool { return false }
     var useSystemScm: Bool { return false }
+    var numberOfRetries: Int { return 0 }
     var failBuild: Bool { return true }
 }
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.70]
+// FastlaneRunnerAPIVersion [0.9.71]

--- a/fastlane/swift/Screengrabfile.swift
+++ b/fastlane/swift/Screengrabfile.swift
@@ -17,4 +17,4 @@ public class Screengrabfile: ScreengrabfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.179.0
+// Generated with fastlane 2.180.0

--- a/fastlane/swift/ScreengrabfileProtocol.swift
+++ b/fastlane/swift/ScreengrabfileProtocol.swift
@@ -96,4 +96,4 @@ public extension ScreengrabfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.60]
+// FastlaneRunnerAPIVersion [0.9.61]

--- a/fastlane/swift/Snapshotfile.swift
+++ b/fastlane/swift/Snapshotfile.swift
@@ -17,4 +17,4 @@ public class Snapshotfile: SnapshotfileProtocol {
     // during the `init` process, and you won't see this message
 }
 
-// Generated with fastlane 2.179.0
+// Generated with fastlane 2.180.0

--- a/fastlane/swift/SnapshotfileProtocol.swift
+++ b/fastlane/swift/SnapshotfileProtocol.swift
@@ -196,4 +196,4 @@ public extension SnapshotfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.54]
+// FastlaneRunnerAPIVersion [0.9.55]

--- a/fastlane/swift/SocketClient.swift
+++ b/fastlane/swift/SocketClient.swift
@@ -303,8 +303,8 @@ extension SocketClient: StreamDelegate {
             }
 
         case let .failure(failureInformation, failureClass, failureMessage):
-          LaneFile.fastfileInstance?.onError(currentLane: ArgumentProcessor(args: CommandLine.arguments).currentLane, errorInfo: failureInformation.joined(), errorClass: failureClass, errorMessage: failureMessage)
-          socketDelegate?.commandExecuted(serverResponse: .serverError) {
+            LaneFile.fastfileInstance?.onError(currentLane: ArgumentProcessor(args: CommandLine.arguments).currentLane, errorInfo: failureInformation.joined(), errorClass: failureClass, errorMessage: failureMessage)
+            socketDelegate?.commandExecuted(serverResponse: .serverError) {
                 $0.writeSemaphore.signal()
                 self.handleFailure(message: failureInformation)
             }

--- a/fastlane/swift/formatting/Brewfile.lock.json
+++ b/fastlane/swift/formatting/Brewfile.lock.json
@@ -33,10 +33,10 @@
   "system": {
     "macos": {
       "catalina": {
-        "HOMEBREW_VERSION": "3.0.9-4-g9308a25",
+        "HOMEBREW_VERSION": "3.0.11-37-g6d0275f",
         "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "2e6c683b1705308ab02e71f996733b1ad05942d0",
-        "CLT": "11.0.33.12",
+        "Homebrew/homebrew-core": "ef0489237f06f73c1148f10ea1001def194b6808",
+        "CLT": "11.0.0.33.12",
         "Xcode": "12.2",
         "macOS": "10.15.7"
       },


### PR DESCRIPTION
Auto-generated by fastlane 🤖

**Changes since release '2.179.0':**

* [action][jira] API response improvement (#18504) via Manish Rathi
* [scan] fix tests for ruby 2.4 (#18513) via Josh Holtz
* [action] fix "sh" broken when output is in encoding other than UTF-8 (#18075) via Stuart McHattie
* [scan] retry after failure (#17765) via Xavier Lowmiller
* [Fastlane.Swift] fix onError not being called (#18452) via Jorge
* [match] fix match change password argument error (#18510) via Bob Smits
* [action] notarize: add support for AppStore Connect API Key (#18364) via Paul Niezborala
* [Fastlane.Swift] Restore 'swift' directory if it is deleted before running a lane (#18496) via Tim Oliver
* [action][app_store_connect_api_key] Updated `is_supported` platform  (#18462) via Manish Rathi
* [snapshot] bump SnapshotHelper.swift's version. (#18503) via Yilei "Dolee" Yang
* [Fastlane.Swift] Fix array-typed RubyCommand arguments (#18458) via Jorge
* [fastlane_core] fix typo in queue_worker.rb (#18460) via Ikko Ashimine
* [action] new sourcedocs action (#18464) via Nemanja Filipovic
* [spaceship] Fix typo in app_screenshot.rb (#18475) via Ikko Ashimine
