### PR TITLE
[fastlane] fix fastlane_require to work with RubyGems 3.2.0 and up

### DIFF
--- a/fastlane/lib/fastlane/fastlane_require.rb
+++ b/fastlane/lib/fastlane/fastlane_require.rb
@@ -59,8 +59,14 @@ module Fastlane
 
       def find_gem_name(user_supplied_name)
         fetcher = Gem::SpecFetcher.fetcher
-        gems = fetcher.suggest_gems_from_name(user_supplied_name)
 
+        # RubyGems 3.2.0 changed behavior of suggest_gems_from_name to no longer return user supplied name (only similar suggestions)
+        # First search for exact gem with detect then use suggest_gems_from_name
+        if (detected_gem = fetcher.detect(:latest) { |nt| nt.name == user_supplied_name }.first)
+          return detected_gem[0].name
+        end
+
+        gems = fetcher.suggest_gems_from_name(user_supplied_name)
         return gems.first
       end
 


### PR DESCRIPTION
### Motivation and Context
Fixes #18517

### Description
`suggest_gems_from_name` stopped returning the gem if the user supplied name matched exactly in RubyGems 3.2.0. Example: searching for 'cocoapods' would return only suggetions but not the actual 'cocoapod' gem. To fix this, we now first search using the `detect` method.

https://github.com/rubygems/rubygems/commit/e344582a1c50f228ea1c064d85ab28011c737493#diff-bfff887b3ff2da28c9a511379d64b521525a5cf21408f7959fbc2f07afd26329
