### PR TITLE
[action][ensure_env_vars] efficiency improvement

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_env_vars.rb
+++ b/fastlane/lib/fastlane/actions/ensure_env_vars.rb
@@ -5,8 +5,7 @@ module Fastlane
         variables = params[:env_vars]
         missing_variables = variables.select { |variable| ENV[variable].to_s.strip.empty? }
 
-        is_one = missing_variables.length == 1
-        UI.user_error!("Missing environment variable#{is_one ? '' : 's'} '#{missing_variables.join('\', \'')}'") unless missing_variables.empty?
+        UI.user_error!("Missing environment variable(s) '#{missing_variables.join('\', \'')}'") unless missing_variables.empty?
 
         is_one = variables.length == 1
         UI.success("Environment variable#{is_one ? '' : 's'} '#{variables.join('\', \'')}' #{is_one ? 'is' : 'are'} set!")

--- a/fastlane/lib/fastlane/actions/ensure_env_vars.rb
+++ b/fastlane/lib/fastlane/actions/ensure_env_vars.rb
@@ -3,11 +3,7 @@ module Fastlane
     class EnsureEnvVarsAction < Action
       def self.run(params)
         variables = params[:env_vars]
-        missing_variables = []
-
-        variables.each do |variable|
-          missing_variables << variable if ENV[variable].to_s.strip.empty?
-        end
+        missing_variables = variables.select { |variable| ENV[variable].to_s.strip.empty? }
 
         is_one = missing_variables.length == 1
         UI.user_error!("Missing environment variable#{is_one ? '' : 's'} '#{missing_variables.join('\', \'')}'") unless missing_variables.empty?

--- a/fastlane/lib/fastlane/actions/ensure_env_vars.rb
+++ b/fastlane/lib/fastlane/actions/ensure_env_vars.rb
@@ -3,15 +3,16 @@ module Fastlane
     class EnsureEnvVarsAction < Action
       def self.run(params)
         variables = params[:env_vars]
+        missing_variables = []
 
         variables.each do |variable|
-          next unless ENV[variable].to_s.strip.empty?
-
-          UI.user_error!("Missing environment variable '#{variable}'")
+          missing_variables << variable if ENV[variable].to_s.strip.empty?
         end
 
-        is_one = variables.length == 1
+        is_one = missing_variables.length == 1
+        UI.user_error!("Missing environment variable#{is_one ? '' : 's'} '#{missing_variables.join('\', \'')}'") unless missing_variables.empty?
 
+        is_one = variables.length == 1
         UI.success("Environment variable#{is_one ? '' : 's'} '#{variables.join('\', \'')}' #{is_one ? 'is' : 'are'} set!")
       end
 

--- a/fastlane/spec/actions_specs/ensure_env_vars_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_env_vars_spec.rb
@@ -46,6 +46,18 @@ describe Fastlane do
           end
         end
 
+        context 'and multiple env vars are not set' do
+          it 'outputs error message' do
+            expect do
+              Fastlane::FastFile.new.parse('lane :test do
+                ensure_env_vars(env_vars: [\'MISSING_FIRST\', \'MISSING_SECOND\'])
+              end').runner.execute(:test)
+            end.to raise_error(FastlaneCore::Interface::FastlaneError) do |error|
+              expect(error.message).to eq('Missing environment variables \'MISSING_FIRST\', \'MISSING_SECOND\'')
+            end
+          end
+        end
+
         context 'and env var is empty' do
           before :each do
             allow(ENV).to receive(:[]).and_return(' ')

--- a/fastlane/spec/actions_specs/ensure_env_vars_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_env_vars_spec.rb
@@ -41,7 +41,7 @@ describe Fastlane do
                 ensure_env_vars(env_vars: [\'MISSING\'])
               end').runner.execute(:test)
             end.to raise_error(FastlaneCore::Interface::FastlaneError) do |error|
-              expect(error.message).to eq('Missing environment variable \'MISSING\'')
+              expect(error.message).to eq('Missing environment variable(s) \'MISSING\'')
             end
           end
         end
@@ -53,7 +53,7 @@ describe Fastlane do
                 ensure_env_vars(env_vars: [\'MISSING_FIRST\', \'MISSING_SECOND\'])
               end').runner.execute(:test)
             end.to raise_error(FastlaneCore::Interface::FastlaneError) do |error|
-              expect(error.message).to eq('Missing environment variables \'MISSING_FIRST\', \'MISSING_SECOND\'')
+              expect(error.message).to eq('Missing environment variable(s) \'MISSING_FIRST\', \'MISSING_SECOND\'')
             end
           end
         end
@@ -69,7 +69,7 @@ describe Fastlane do
                 ensure_env_vars(env_vars: [\'MISSING\'])
               end').runner.execute(:test)
             end.to raise_error(FastlaneCore::Interface::FastlaneError) do |error|
-              expect(error.message).to eq('Missing environment variable \'MISSING\'')
+              expect(error.message).to eq('Missing environment variable(s) \'MISSING\'')
             end
           end
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- **Problem:** If multiple ENV variables are missing then the user has to run `ensure_env_vars` multiple times because it always EXIT after found the first missing ENV variable. 
- This is slightly inconvenience because Fastlane uses lots of ENV variables and good to report **all expected** missing ENV variables after one run itself to save time and to avoid Fastlane run `ensure_env_vars` multiple times 😇

### Description
- Made `ensure_env_vars` more efficient, now it will report all missing ENV variables after one run itself.
- Please see the screenshot for more details

### Testing Steps
- Update Gemfile and run `bundle install` with
```
gem "fastlane", :git => "git@github.com:crazymanish/fastlane.git", :branch => "ensure-env-vars-improvement"
```
- With the below test lane, run `bundle exec fastlane test`

```
lane :test do
    #ENV["GITHUB_API_TOKEN_MISSING_EXAMPLE"] = 'xxxxx-xxxxxxx-xxxxxxx'
    ENV["GYM_SCHEME"] = "MyApp"
    ENV["GYM_EXPORT_METHOD"] = 'app-store'
    #ENV["GYM_CLEAN"] = 'true'
    ENV["GYM_SILENT"] = 'true'
    #ENV["SLACK_API_TOKEN_MISSING_EXAMPLE"] = 'xxxxx-xxxxxxx-xxxxxxx'

    ensure_env_vars(
      env_vars: [
        'GITHUB_API_TOKEN_MISSING_EXAMPLE',
        'GYM_SCHEME',
        'GYM_EXPORT_METHOD',
        'GYM_CLEAN',
        'GYM_SILENT',
        'SLACK_API_TOKEN_MISSING_EXAMPLE'
      ]
    )
  end
```

### Screenshot
<img width="1670" alt="Screenshot 2021-04-08 at 20 26 22" src="https://user-images.githubusercontent.com/5364500/114079743-da581500-98aa-11eb-9861-f58166861a32.png">
