### PR TITLE
[fastlane][action] fix git_branch when not in a git repo

### DIFF
--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class GitBranchAction < Action
       def self.run(params)
-        branch = Actions.git_branch
+        branch = Actions.git_branch || ""
         return "" if branch == "HEAD" # Backwards compatibility with the original (and documented) implementation
         branch
       end

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -123,7 +123,15 @@ module Fastlane
     # Can be replaced using the environment variable `GIT_BRANCH`
     def self.git_branch
       env_name = SharedValues::GIT_BRANCH_ENV_VARS.find { |env_var| FastlaneCore::Env.truthy?(env_var) }
-      ENV.fetch(env_name.to_s) { Actions.sh("git rev-parse --abbrev-ref HEAD", log: false).chomp }
+      ENV.fetch(env_name.to_s) do
+        # Rescues if not a git repo or no commits in a git repo
+        begin
+          Actions.sh("git rev-parse --abbrev-ref HEAD", log: false).chomp
+        rescue => err
+          UI.verbose("Error getting git branch: #{err.message}")
+          nil
+        end
+      end
     end
 
     private_class_method


### PR DESCRIPTION
### Motivation and Context
I noticed when running _fastlane_ in a folder that was not a git repo, that things would fail. There are some actions that use `Actions.git_branch` a dynamic default value that would error out. This will add safety for when there is no git repo.

Resolves #18467

### Description
This solution wraps the shell command that `Actions.git_branch` executes in a begin/rescue and returns `nil` if an error is caught.
