### PR TITLE
[supply] upload native symbols for crash symbolication

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -327,12 +327,14 @@ module Supply
     def upload_mapping(path_to_mapping, apk_version_code)
       ensure_active_edit!
 
+      extension = File.extname(path_to_mapping).downcase
+
       call_google_api do
         client.upload_edit_deobfuscationfile(
           current_package_name,
           current_edit.id,
           apk_version_code,
-          "proguard",
+          extension == ".zip" ? "nativeCode" : "proguard",
           upload_source: path_to_mapping,
           content_type: "application/octet-stream"
         )

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -223,7 +223,7 @@ module Supply
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :mapping,
                                      env_name: "SUPPLY_MAPPING",
-                                     description: "Path to the mapping file to upload",
+                                     description: "Path to the mapping file to upload (mapping.txt or native-debug-symbols.zip alike)",
                                      short_option: "-d",
                                      conflicting_options: [:mapping_paths],
                                      optional: true,
@@ -235,7 +235,7 @@ module Supply
                                      conflicting_options: [:mapping],
                                      optional: true,
                                      type: Array,
-                                     description: "An array of paths to mapping files to upload",
+                                     description: "An array of paths to mapping files to upload (mapping.txt or native-debug-symbols.zip alike)",
                                      short_option: "-s",
                                      verify_block: proc do |value|
                                        UI.user_error!("Could not evaluate array from '#{value}'") unless value.kind_of?(Array)

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -304,6 +304,7 @@ module Supply
       mapping_paths = [Supply.config[:mapping]] unless (mapping_paths = Supply.config[:mapping_paths])
       mapping_paths.zip(apk_version_codes).each do |mapping_path, version_code|
         if mapping_path
+          UI.message("Preparing mapping at path '#{mapping_path}', version code #{version_code} for upload...")
           client.upload_mapping(mapping_path, version_code)
         end
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #17517, this allows uploading native symbols zip file in order for the Google Play Console to symbolicate crashes.

Google Documentation: https://support.google.com/googleplay/android-developer/answer/9848633#

### Description
It's a simple change, at the upload_mapping it looks for the file extensions and decide to use either the parameter `"proguard"` or `"nativeCode"` when it's a `.zip`.

It only can be uploaded together in the same edit as the `.apk` or `.abb` upload. 

I've tested to upload it alone after and  it says `"The Deobfuscation File can't be modified"`, however you can still do it manually via web later, but beware that any crash types that happened before won't be symbolicated.

### Testing Steps
- Generate your project zipped symbols following the format mentioned on Google's documentation.
- `bundler exec fastlane supply -f path/to/yourapp.aab -d path/to/symbols.zip --package_name "yourpackage.name" --skip_upload_metadata --skip_upload_images --skip_upload_screenshots`
- It should print something like `Preparing mapping at path...` after the app binary upload.
- You can check later at the Google Play Console if the symbols file are there:
![image](https://user-images.githubusercontent.com/1027847/114131346-de029080-98d8-11eb-8e23-dcb07b44db5e.png)