### PR TITLE
Fixed the Gym move_pkg failing if output binary already exists

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -243,8 +243,13 @@ module Gym
     # Moves over the binary and dsym file to the output directory
     # @return (String) The path to the resulting pkg file
     def move_pkg
-      FileUtils.mv(PackageCommandGenerator.binary_path, File.expand_path(Gym.config[:output_directory]), force: true)
       binary_path = File.expand_path(File.join(Gym.config[:output_directory], File.basename(PackageCommandGenerator.binary_path)))
+      if File.exist?(binary_path)
+          UI.important(" Removing #{File.basename(binary_path)}") if FastlaneCore::Globals.verbose?
+          FileUtils.rm_rf(binary_path)
+      end
+      FileUtils.mv(PackageCommandGenerator.binary_path, File.expand_path(Gym.config[:output_directory]), force: true)
+      
 
       UI.success("Successfully exported and signed the pkg file:")
       UI.message(binary_path)


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
This PR contains fix for `build_mac_app`. Where the exported  app contains wrong entitlements.

### Description

When exporting Mac app using the `developer-id` export method as follow:

```
 path = build_mac_app(
    workspace: 'Journal.xcworkspace',
    scheme: 'Diarly_Setapp',
    configuration: 'Release',
    export_options: {
      iCloudContainerEnvironment: 'Production',
      provisioningProfiles: specifiers
    },
    export_method: 'developer-id',
    output_directory: 'build/setapp',
    silent: false,
    verbose: false,
    suppress_xcode_output: true,
  )
```

I've noticed that the exported app does not contain the proper entitlements. I have verified it with:
```
codesign -d --entitlements :entitlements.plist Diarly.app
```

And noticed that the entitlements do not have `iCloudContainerEnvironment` set.

After debugging it on my local computer I was able to fix it by first removing the 'app' file in build directory. 
The setup I have causes `app` to be there before the export happens, because it does not create pkg there is a conflict of the file names.
What's strange, if I used skip-package, there is no process of exporting at all, the export_options are ignored.




### Testing Steps

Build mac app by using `developer-id` export method, with `iCloudContainerEnvironment` is set to Production.
Next check if the entitlements of the exported app do have the environment set. 


I've created action to verify the environment:

```
module Fastlane
  module Actions

    class VerifyIcloudEnvironmentAction < Action
      def self.run(params)
        UI.message "Verifying if the app is set to correct icloud-container-environment"

        entitlements_path = "entitlements.plist"
        sh("codesign -d --entitlements :#{entitlements_path} #{params[:path]}")

        entitlements = File.open(entitlements_path) { |f| Plist.parse_xml(f) }

        value = entitlements['com.apple.developer.icloud-container-environment']
        if value != "Production"
          UI.abort_with_message! "iCloud container was not set to production!"
        end
      end


      def self.description
        "Verifies the app is using correct iCloud-container-environment"
      end

      def self.available_options
        [
          FastlaneCore::ConfigItem.new(key: :path,
                                       description: "path to the .app file to verify",
                                       is_string: true),
        ]
      end

      def self.authors
        ["krzysztof"]
      end

      def self.is_supported?(platform)
        true
      end
    end
  end
end
```


