### PR TITLE
[gym] fix in the gym/runner. When moving mac 'app' silently fails if file already exist in that location.

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -245,11 +245,10 @@ module Gym
     def move_pkg
       binary_path = File.expand_path(File.join(Gym.config[:output_directory], File.basename(PackageCommandGenerator.binary_path)))
       if File.exist?(binary_path)
-          UI.important(" Removing #{File.basename(binary_path)}") if FastlaneCore::Globals.verbose?
-          FileUtils.rm_rf(binary_path)
+        UI.important(" Removing #{File.basename(binary_path)}") if FastlaneCore::Globals.verbose?
+        FileUtils.rm_rf(binary_path)
       end
       FileUtils.mv(PackageCommandGenerator.binary_path, File.expand_path(Gym.config[:output_directory]), force: true)
-      
 
       UI.success("Successfully exported and signed the pkg file:")
       UI.message(binary_path)

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -243,8 +243,13 @@ module Gym
     # Moves over the binary and dsym file to the output directory
     # @return (String) The path to the resulting pkg file
     def move_pkg
-      FileUtils.mv(PackageCommandGenerator.binary_path, File.expand_path(Gym.config[:output_directory]), force: true)
       binary_path = File.expand_path(File.join(Gym.config[:output_directory], File.basename(PackageCommandGenerator.binary_path)))
+      if File.exist?(binary_path)
+          UI.important(" Removing #{File.basename(binary_path)}") if FastlaneCore::Globals.verbose?
+          FileUtils.rm_rf(binary_path)
+      end
+      FileUtils.mv(PackageCommandGenerator.binary_path, File.expand_path(Gym.config[:output_directory]), force: true)
+      
 
       UI.success("Successfully exported and signed the pkg file:")
       UI.message(binary_path)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.


### Motivation and Context

I've found a bug in the export of the mac app using `developer-id`. Looks like the app file generated by fastlane did not contain valid entitlements. After investigation, it looks like the exported app is the one from Xcode archive, and not the one from exporter tool. 


### Description

I've used the following config:

```
build_mac_app(
    workspace: 'Journal.xcworkspace',
    scheme: 'Diarly_Setapp',
    configuration: 'Release',
    export_options: {
      iCloudContainerEnvironment: 'Production',
      provisioningProfiles: specifiers
    },
    export_method: 'developer-id',
    output_directory: 'build/setapp',
  )
```

When I verified created App file with: 

``` 
codesign -d --entitlements :entitlements.plist Diarly.app
```

I've noticed that the `iCloudContainerEnvironment` was not set correctly. After applying the fix (removing existing app file) everything worked ok.

What's interesting / off the topic, when I use skip-package option the export options are ignored (not sure if it's expected behavior). Was expecting even the app without package to be exported. 

### Testing Steps

I've used the following action to verify if the iCloudContainerEnvironment is set after export is done

```
module Fastlane
  module Actions

    class VerifyIcloudEnvironmentAction < Action
      def self.run(params)
        UI.message "Verifying if the app is set to correct icloud-container-environment"

        entitlements_path = "entitlements.plist"
        sh("codesign -d --entitlements :#{entitlements_path} #{params[:path]}")

        entitlements = File.open(entitlements_path) { |f| Plist.parse_xml(f) }

        value = entitlements['com.apple.developer.icloud-container-environment']
        if value != "Production"
          UI.abort_with_message! "iCloud container was not set to production!"
        end
      end


      def self.description
        "Verifies the app is using correct icloud-container-environment"
      end

      def self.available_options
        [
          FastlaneCore::ConfigItem.new(key: :path,
                                       description: "path to the .app file to verify",
                                       is_string: true),
        ]
      end

      def self.authors
        ["krzysztof"]
      end

      def self.is_supported?(platform)
        true
      end
    end
  end
end
```
