### PR TITLE
[snapshot] added iPhone 12 models to snapshot reports generator

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -84,6 +84,10 @@ module Snapshot
       {
         # snapshot in Xcode 9 saves screenshots with the SIMULATOR_DEVICE_NAME
         # which includes spaces
+        'iPhone 12 Pro Max' => "iPhone 12 Pro Max",
+        'iPhone 12 Pro' => "iPhone 12 Pro",
+        'iPhone 12 mini' => "iPhone 12 mini",
+        'iPhone 12' => "iPhone 12",
         'iPhone 11 Pro Max' => "iPhone 11 Pro Max",
         'iPhone 11 Pro' => "iPhone 11 Pro",
         'iPhone 11' => "iPhone 11",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The `snapshot` command generates iPhone 12 screenshot correctly, but the screenshot are not inserted in the `screenshots.html` file. 
After some googling I found out a similar issue, https://github.com/fastlane/fastlane/issues/6690.
This issue, now solved, was related to iPhone SE. After inspecting `snapshot/lib/snapshot/reports_generator.rb` I realized iPhone 12 models were completely missing.

### Description
I added the four models of iPhone 12 to the hash returned by `xcode_9_and_above_device_name_mappings`.

<!-- Please describe in detail how you tested your changes. -->
I then tested the feature by adding the four devices to my app snapfile.
Screenshots were generated correctly.
I also did some tests to make the change worked also with a single device, or a couple.

### Testing Steps
Test with a project setup for fast lane snapshots.
Modify your Snapfile to include the four iPhone 12 models, like this:

```
 devices([
    "iPhone 12",
   "iPhone 12 mini",
    "iPhone 12 Pro",
    "iPhone 12 Pro Max"
 ])

```

Run `bundle exec fastlane snapshot` 
Verify. the four iPhone 12 models are added to the `snapshot.html` file.
