### PR TITLE
[fastlane_core][pilot][deliver] fix when polling for build processing to poll for X.Y and X.Y.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
+            bundle update
       - *bundle_install
       - *cache_save_bundler
       - run: bundle exec fastlane generate_swift_api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 ---
 
 version: 2.1
+orbs:
+    shellcheck: circleci/shellcheck@2.2.2
 
 aliases:
   # common - cache
@@ -94,7 +96,6 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            brew install shellcheck
       - *bundle_install
       - *cache_save_bundler
       - run:
@@ -178,7 +179,6 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            brew install shellcheck
       - *bundle_install
       - *cache_save_bundler
       - run: bundle exec fastlane generate_swift_api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            bundle update
+            brew update
       - *bundle_install
       - *cache_save_bundler
       - run: bundle exec fastlane generate_swift_api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 
 version: 2.1
 orbs:
-    shellcheck: circleci/shellcheck@2.2.2
+    shellcheck: circleci/shellcheck@2.2.2 # brew install shellcheck stopped working so using this
 
 aliases:
   # common - cache
@@ -179,7 +179,7 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-            brew update
+            brew update # Needed because this lane uses "brew bundle" and CircleCI's brew install is too old for that
       - *bundle_install
       - *cache_save_bundler
       - run: bundle exec fastlane generate_swift_api

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -4,6 +4,8 @@ require_relative 'ui/ui'
 
 module FastlaneCore
   class BuildWatcher
+    VersionMatches = Struct.new(:version, :builds)
+
     class << self
       # @return The build we waited for. This method will always return a build
       def wait_for_build_processing_to_be_complete(app_id: nil, platform: nil, train_version: nil, app_version: nil, build_version: nil, poll_interval: 10, strict_build_watch: false, return_when_build_appears: false, return_spaceship_testflight_build: true, select_latest: false)
@@ -23,7 +25,7 @@ module FastlaneCore
 
         showed_info = false
         loop do
-          matched_build = matching_build(watched_app_version: app_version, watched_build_version: build_version, app_id: app_id, platform: platform, select_latest: select_latest)
+          matched_build, app_version_queried = matching_build(watched_app_version: app_version, watched_build_version: build_version, app_id: app_id, platform: platform, select_latest: select_latest)
 
           if matched_build.nil? && !showed_info
             UI.important("Read more information on why this build isn't showing up yet - https://github.com/fastlane/fastlane/issues/14997")
@@ -37,6 +39,13 @@ module FastlaneCore
           # having a build resource appear in AppStoreConnect (matched_build) may be enough (i.e. setting a changelog)
           # so here we may choose to skip the full processing of the build if return_when_build_appears is true
           if matched_build && (return_when_build_appears || matched_build.processed?)
+
+            if !app_version.nil? && app_version != app_version_queried
+              UI.important("App version is #{app_version} but build was found while querying #{app_version_queried}")
+              UI.important("This shouldn't be an issue as Apple sees #{app_version} and #{app_version_queried} as equal")
+              UI.important("See docs for more info - https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364")
+            end
+
             if return_spaceship_testflight_build
               return matched_build.to_testflight_build
             else
@@ -60,15 +69,31 @@ module FastlaneCore
         watched_app_version = remove_version_leading_zeros(version: watched_app_version)
         watched_build_version = remove_version_leading_zeros(version: watched_build_version)
 
-        matched_builds = Spaceship::ConnectAPI::Build.all(
-          app_id: app_id,
-          version: watched_app_version,
-          build_number: watched_build_version,
-          platform: platform
-        )
+        # App Store Connect will allow users to upload  X.Y is the same as X.Y.0 and treat them as the same version
+        # However, only the first uploaded version format will be the one that is queryable
+        # This could lead to BuildWatcher never finding X.Y.0 if X.Y was upoaded first as X.Y will only yield results
+        #
+        # This will add an additional request to search for both X.Y and X.Y.0 but
+        # will give preference to the version format specified passed in
+        watched_app_version_alternate = alternate_version(watched_app_version)
+        versions = [watched_app_version, watched_app_version_alternate].compact
+
+        version_matches = versions.map do |version|
+          match = VersionMatches.new
+          match.version = version
+          match.builds = Spaceship::ConnectAPI::Build.all(
+            app_id: app_id,
+            version: version,
+            build_number: watched_build_version,
+            platform: platform
+          )
+
+          match
+        end.flatten
 
         # Raise error if more than 1 build is returned
         # This should never happen but need to inform the user if it does
+        matched_builds = version_matches.map(&:builds).flatten
         if matched_builds.size > 1 && !select_latest
           error_builds = matched_builds.map do |build|
             "#{build.app_version}(#{build.version}) for #{build.platform} - #{build.processing_state}"
@@ -77,9 +102,25 @@ module FastlaneCore
           UI.crash!(error_message)
         end
 
-        matched_build = matched_builds.first
+        version_match = version_matches.reject do |match|
+          match.builds.empty?
+        end.first
+        matched_build = version_match&.builds&.first
 
-        return matched_build
+        return matched_build, version_match&.version
+      end
+
+      def alternate_version(version)
+        return nil if version.nil?
+
+        version_info = Gem::Version.new(version)
+        if version_info.segments.size == 3 && version_info.segments[2] == 0
+          return version_info.segments[0..1].join(".")
+        elsif version_info.segments.size == 2
+          return "#{version}.0"
+        end
+
+        return nil
       end
 
       def report_status(build: nil)

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -23,6 +23,13 @@ describe FastlaneCore::BuildWatcher do
 
     let(:mock_base_api_client) { "fake api base client" }
 
+    let(:options_1_0) do
+      { app_id: 'some-app-id', version: '1.0', build_number: '1', platform: 'IOS' }
+    end
+    let(:options_1_0_0) do
+      { app_id: 'some-app-id', version: '1.0.0', build_number: '1', platform: 'IOS' }
+    end
+
     before(:each) do
       allow(Spaceship::ConnectAPI::TestFlight::Client).to receive(:instance).and_return(mock_base_api_client)
     end
@@ -57,9 +64,11 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'waits when a build is still processing' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([processing_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
       expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
       expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{ready_build.platform}")
@@ -70,9 +79,11 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'waits when the build disappears' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
       expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
       expect(UI).to receive(:message).with("Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)")
@@ -83,7 +94,8 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'watches the latest build when no builds are processing' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
       found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false)
@@ -94,9 +106,11 @@ describe FastlaneCore::BuildWatcher do
     it 'raises error when multiple builds found' do
       builds = [ready_build, ready_build]
 
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return(builds)
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return(builds)
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
       expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
       expect(UI).to receive(:message).with("Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)")
@@ -109,9 +123,11 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'sleeps 10 seconds by default' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([processing_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep).with(10)
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
       allow(UI).to receive(:message)
       allow(UI).to receive(:success)
@@ -119,9 +135,11 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'sleeps for the amount of time specified in poll_interval' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([processing_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep).with(123)
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
       allow(UI).to receive(:message)
       allow(UI).to receive(:success)


### PR DESCRIPTION
### Motivation and Context
Apple sees versions with as `X.Y` and `X.Y.0` as the same. This can lead to issues when waiting for build processing as the queryable version format is the type that was first uploaded.

Example: If first version was `X.Y` and next uploads were `X.Y.0`, the API returns nothing when querying for `X.Y.0` but will for `X.Y`

This will lead to an infinite poll as nothing will ever appear for `X.Y.0`.

### Description

A few changes have been made to `FastlaneCore::BuildWatcher`

1. If patch version is `0`, an extra API call will be made with the major and minor versions
2. If no patch version, an extra API call will be made with a `0` patch version

If watched app version will be given preference if a build exists in that one. Otherwise the build will be taken from the secondary API request.

New logs have also been added when a build is found in the adjusted version 👇 

#### Sample of new log

```sh
[09:10:40]: App version is 0.1 but build was found while querying 0.1.0                                                                                                  
[09:10:40]: This shouldn't be an issue as Apple sees 0.1 and 0.1.0 as equal                                                                                              
[09:10:40]: See docs for more info - https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#/
/apple_ref/doc/uid/20001431-102364   
```

#### Full log with addition

```sh
[09:08:01]: Waiting for processing on... app_id: 1517717965, app_version: 0.1, build_version: 1618322818, platform: IOS                                                  
[09:08:02]: Read more information on why this build isn't showing up yet - https://github.com/fastlane/fastlane/issues/14997                                             
[09:08:02]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)                  
[09:08:33]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)                  
[09:09:04]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)                  
[09:09:37]: Waiting for App Store Connect to finish processing the new build (0.1 - 1618322818) for IOS                                                                  
[09:10:09]: Waiting for App Store Connect to finish processing the new build (0.1 - 1618322818) for IOS                                                                  
[09:10:40]: Successfully finished processing the build 0.1 - 1618322818 for IOS                                                                                          
[09:10:40]: App version is 0.1 but build was found while querying 0.1.0                                                                                                  
[09:10:40]: This shouldn't be an issue as Apple sees 0.1 and 0.1.0 as equal                                                                                              
[09:10:40]: See docs for more info - https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#/
/apple_ref/doc/uid/20001431-102364                                                                                                                                       
[09:10:40]: Using App Store Connect's default for notifying external testers (which is true) - set `notify_external_testers` for full control                            
[09:10:40]: Distributing new build to testers: 0.1 - 1618322818                                                                                                          
[09:10:41]: Export compliance has been set to 'false'. Need to wait for build to finishing processing again...                                                           
[09:10:41]: Set 'ITSAppUsesNonExemptEncryption' in the 'Info.plist' to skip this step and speed up the submission                                                        
[09:10:42]: Successfully distributed build to Internal testers 🚀                 
```
