### PR TITLE
[scan] Keep initial xcresult

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -55,6 +55,8 @@ module Scan
     end
 
     def execute(retries: 0)
+      Scan.cache[:retry_attempt] = Scan.config[:number_of_retries] - retries
+
       command = @test_command_generator.generate
 
       prefix_hash = [

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -164,8 +164,9 @@ module Scan
 
     # The path to the result bundle
     def result_bundle_path
+      attempt = Scan.cache[:retry_attempt] > 0 ? "-#{Scan.cache[:retry_attempt]}" : ""
       ext = FastlaneCore::Helper.xcode_version.to_i >= 11 ? '.xcresult' : '.test_result'
-      path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + ext
+      path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + attempt + ext
       if File.directory?(path)
         FileUtils.remove_dir(path)
       end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -164,7 +164,8 @@ module Scan
 
     # The path to the result bundle
     def result_bundle_path
-      attempt = Scan.cache[:retry_attempt] > 0 ? "-#{Scan.cache[:retry_attempt]}" : ""
+      retry_count = Scan.cache[:retry_attempt] || 0
+      attempt = retry_count > 0 ? "-#{retry_count}" : ""
       ext = FastlaneCore::Helper.xcode_version.to_i >= 11 ? '.xcresult' : '.test_result'
       path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + attempt + ext
       if File.directory?(path)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Scan has a `number_of_retries` parameter which upon retry, will delete an existing `xcresult` file and create a new one. The issue with this is the new file will only contain the previous tests that failed. The reason this is an issue is because the `xcresult` file is used for code coverage.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This PR is building on top of the `number_of_retries` feature. Instead of removing the `xcresult` file for each retry, it will create a new file with an appending number. The first attempt will not append a number to the `xcresult` file. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

This involves enabling `result_bundle` along with setting `number_of_retries` greater than 0. When performing scan make sure one of your tests is failing. You will see inside the `output_directory` path that the first `xcresult` has the whole test suite and is not removed upon retry attempts.
