### PR TITLE
[action] import_from_git - Add caching support for branch

### DIFF
--- a/fastlane/lib/fastlane/actions/import_from_git.rb
+++ b/fastlane/lib/fastlane/actions/import_from_git.rb
@@ -43,7 +43,7 @@ module Fastlane
                                        is_string: false,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :cache_path,
-                                       description: "The path to a directory where the repository should be cloned into. This is ignored if `version` is not specified. Defaults to `nil`, which causes the repository to be cloned on every call, to a temporary directory",
+                                       description: "The path to a directory where the repository should be cloned into. Defaults to `nil`, which causes the repository to be cloned on every call, to a temporary directory",
                                        default_value: nil,
                                        optional: true)
         ]

--- a/fastlane/lib/fastlane/actions/import_from_git.rb
+++ b/fastlane/lib/fastlane/actions/import_from_git.rb
@@ -61,14 +61,14 @@ module Fastlane
         [
           'import_from_git(
             url: "git@github.com:fastlane/fastlane.git", # The URL of the repository to import the Fastfile from.
-            branch: "HEAD", # The branch to checkout on the repository
-            path: "fastlane/Fastfile", # The path of the Fastfile in the repository
+            branch: "HEAD", # The branch to checkout on the repository.
+            path: "fastlane/Fastfile", # The path of the Fastfile in the repository.
             version: "~> 1.0.0" # The version to checkout on the repository. Optimistic match operator can be used to select the latest version within constraints.
           )',
           'import_from_git(
             url: "git@github.com:fastlane/fastlane.git", # The URL of the repository to import the Fastfile from.
-            branch: "HEAD", # The branch to checkout on the repository
-            path: "fastlane/Fastfile", # The path of the Fastfile in the repository
+            branch: "HEAD", # The branch to checkout on the repository.
+            path: "fastlane/Fastfile", # The path of the Fastfile in the repository.
             version: [">= 1.1.0", "< 2.0.0"], # The version to checkout on the repository. Multiple conditions can be used to select the latest version within constraints.
             cache_path: "~/.cache/fastlane/imported" # A directory in which the repository will be added, which means that it will not be cloned again on subsequent calls.
           )'

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -342,7 +342,7 @@ module Fastlane
             # Update the repo if it's eligible for caching but the version isn't specified
             UI.message("Fetching remote git branches and updating git repo...")
             Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
-              Actions.sh("cd #{clone_folder.shellescape} && git fetch --all -q && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard && git merge")
+              Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard && git merge")
             end
           else
             Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -284,7 +284,7 @@ module Fastlane
 
         action_launched('import_from_git')
 
-        is_eligible_for_caching = !version.nil? && !cache_path.nil?
+        is_eligible_for_caching = !cache_path.nil?
 
         UI.message("Eligible for caching") if is_eligible_for_caching
 
@@ -338,7 +338,15 @@ module Fastlane
             UI.user_error!("No tag found matching #{version.inspect}") if checkout_param.nil?
           end
 
-          Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")
+          if is_eligible_for_caching && version.nil?
+            # Update the repo if it's eligible for caching but the version isn't specified
+            UI.message("Fetching remote git branches and updating git repo...")
+            Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+              Actions.sh("cd #{clone_folder.shellescape} && git fetch --all -q && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard && git merge")
+            end
+          else
+            Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")
+          end
 
           # Knowing that we check out all the files and directories when the
           # current call is eligible for caching, we don't need to also

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -342,7 +342,7 @@ module Fastlane
             # Update the repo if it's eligible for caching but the version isn't specified
             UI.message("Fetching remote git branches and updating git repo...")
             Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
-              Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard && git merge")
+              Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard && git rebase")
             end
           else
             Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -234,7 +234,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end
 
-        # Respects the specified version even if the branch is specified
+        # Respects the specified version even if the branch is specified.
         it "works with new tags and branch" do
           Dir.chdir(source_directory_path) do
             `git checkout "master" 2>&1`

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -209,7 +209,8 @@ describe Fastlane do
           end").runner.execute(:test)
         end
 
-        # Meaning, a `git pull` is performed when caching is eligible and the version isn't specified
+        # Meaning, `git fetch` and `git merge` are performed when caching is eligible
+        # and the version isn't specified in the local clone.
         it "works with updated branch" do
           Dir.chdir(source_directory_path) do
             `git checkout "version-2.1" 2>&1`

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -210,7 +210,7 @@ describe Fastlane do
         end
 
         # Meaning, `git fetch` and `git merge` are performed when caching is eligible
-        # and the version isn't specified in the local clone.
+        # and the version isn't specified.
         it "works with updated branch" do
           Dir.chdir(source_directory_path) do
             `git checkout "version-2.1" 2>&1`

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -197,8 +197,9 @@ describe Fastlane do
           end.not_to raise_error
         end
 
-        it "ignores it when branch is specified" do
-          expect(UI).not_to receive(:message).with(caching_message)
+        it "works with branch" do
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works since v2.1')
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -208,26 +209,52 @@ describe Fastlane do
           end").runner.execute(:test)
         end
 
-        # Because we don't know if the specified value represents a branch or a
-        # tag. And knowing that it doesn't make sense to cache a branch, that
-        # points to a different commit when one is added, as opposed to a tag,
-        # we decided to enable caching only when used with the `version` param.
-        it "ignores it when tag is specified via branch param" do
-          expect(UI).not_to receive(:message).with(caching_message)
-          expect(UI).to receive(:important).with('Works since v1')
+        # Meaning, a `git pull` is performed when caching is eligible and the version isn't specified
+        it "works with updated branch" do
+          Dir.chdir(source_directory_path) do
+            `git checkout "version-2.1" 2>&1`
+            File.write('fastlane/Fastfile', <<-FASTFILE)
+              lane :works do
+                UI.important('Works until v5')
+              end
+            FASTFILE
+            `git add .`
+            `git commit --message "Version 5"`
+          end
+
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
+          expect(UI).to receive(:important).with('Works until v5')
 
           Fastlane::FastFile.new.parse("lane :test do
-            import_from_git(url: '#{source_directory_path}', branch: '3', cache_path: '#{cache_directory_path}')
+            import_from_git(url: '#{source_directory_path}', branch: 'version-2.1', cache_path: '#{cache_directory_path}')
 
             works
           end").runner.execute(:test)
         end
 
-        it "ignores it when version is not specified" do
-          expect(UI).not_to receive(:message).with(caching_message)
+        # Respects the specified version even if the branch is specified
+        it "works with new tags and branch" do
+          Dir.chdir(source_directory_path) do
+            `git checkout "master" 2>&1`
+            File.write('fastlane/Fastfile', <<-FASTFILE)
+              lane :works do
+                UI.important('Works until v6')
+              end
+            FASTFILE
+            `git add .`
+            `git commit --message "Version 6"`
+            `git tag "6"`
+          end
+
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
+          expect(UI).to receive(:important).with('Works until v6')
 
           Fastlane::FastFile.new.parse("lane :test do
-            import_from_git(url: '#{source_directory_path}', cache_path: '#{cache_directory_path}')
+            import_from_git(url: '#{source_directory_path}', branch: 'version-2.1', version: '6', cache_path: '#{cache_directory_path}')
+
+            works
           end").runner.execute(:test)
         end
 

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -209,7 +209,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end
 
-        # Meaning, `git fetch` and `git merge` are performed when caching is eligible
+        # Meaning, `git fetch` and `git rebase` are performed when caching is eligible
         # and the version isn't specified.
         it "works with updated branch" do
           Dir.chdir(source_directory_path) do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

> I've run bundle exec rspec from the root directory to see all new and existing tests pass

I have seen so many errors on this, but I have run `bundle exec rspec ./fastlane/spec/actions_specs/import_from_git_spec.rb` to make sure the tests for the change pass.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

First of all, I referred to [[action] import_from_git - Add caching support](https://github.com/fastlane/fastlane/pull/17412) to better understand the context.

With this in mind, the current caching support for `import_from_git` is eligible only if the version is specified, but adding caching support for a branch could be useful when you don't manage versions in a remote git repository, but need to point to the latest commit.

As additional benefits,
- This also prevents us from cloning the repository every time on subsequent calls. For example, on CI, it's likely that you call multiple different lanes as a different step, which could lead to the fact that it clones the repo again and again.
- This makes the usage of `import_from_git` straightforward in that caching support becomes eligible when `cache_path` is specified. Currently, we had to specify `version` to make use of caching support.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

- Update the repo if it's eligible for caching but the version isn't specified.
- Removed `This is ignored if version is not specified.` from the description.
- Added punctuation marks to example code of `import_from_git`.
- Tested this local fastlane code base with my sample project.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
