### PR TITLE
[spaceship] fix case sensitive email issue for Spaceship::Members.find

### DIFF
--- a/spaceship/lib/spaceship/tunes/members.rb
+++ b/spaceship/lib/spaceship/tunes/members.rb
@@ -15,7 +15,7 @@ module Spaceship
 
         def find(email)
           all.each do |member|
-            if member.email_address == email
+            if member.email_address.downcase == email
               return member
             end
           end

--- a/spaceship/lib/spaceship/tunes/members.rb
+++ b/spaceship/lib/spaceship/tunes/members.rb
@@ -15,7 +15,7 @@ module Spaceship
 
         def find(email)
           all.each do |member|
-            if member.email_address.downcase == email
+            if member.email_address.casecmp?(email)
               return member
             end
           end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Apple treats emails case sensitive. Sample: `Spaceship::Members.all` => `"emil.dvorjak@acme.com", "Stacy.Hammilton@acme.com", "samual.Ethan@acme.com"` 

If you search for `Spaceship::Members.find("stacy.hammilton@acme.com")`, the call will fail, because there is no match. This PR tries to fix the issue.

#edgecase
