### PR TITLE
[Fastlane.Swift] Fix Fastfile.swift template syntax error

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -149,7 +149,7 @@ module Fastlane
         if include_metadata
           lane << "\tuploadToAppStore(username: \"#{self.user}\", app: \"#{self.app_identifier}\")"
         else
-          lane << "\tuploadToAppStore(username: \"#{self.user}\", app: \"#{self.app_identifier}\", skipScreenshots: true, skipMetadata: true)"
+          lane << "\tuploadToAppStore(username: \"#{self.user}\", skipScreenshots: true, skipMetadata: true, app: \"#{self.app_identifier}\")"
         end
         lane << "}"
       else
@@ -219,7 +219,7 @@ module Fastlane
                 "\tcaptureScreenshots(#{project_prefix}scheme: \"#{ui_testing_scheme}\")"]
 
         if automatic_upload
-          lane << "\tuploadToAppStore(username: \"#{self.user}\", app: \"#{self.app_identifier}\", skipBinaryUpload: true, skipMetadata: true)"
+          lane << "\tuploadToAppStore(username: \"#{self.user}\", skipBinaryUpload: true, skipMetadata: true, app: \"#{self.app_identifier}\")"
         end
         lane << "}"
       else

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -147,9 +147,9 @@ module Fastlane
                 increment_build_number_if_applicable,
                 "\tbuildApp(#{project_prefix}scheme: \"#{self.scheme}\")"]
         if include_metadata
-          lane << "\tuploadToAppStore(username: \"#{self.user}\", app: \"#{self.app_identifier}\")"
+          lane << "\tuploadToAppStore(username: \"#{self.user}\", appIdentifier: \"#{self.app_identifier}\")"
         else
-          lane << "\tuploadToAppStore(username: \"#{self.user}\", skipScreenshots: true, skipMetadata: true, app: \"#{self.app_identifier}\")"
+          lane << "\tuploadToAppStore(username: \"#{self.user}\", appIdentifier: \"#{self.app_identifier}\", skipScreenshots: true, skipMetadata: true)"
         end
         lane << "}"
       else
@@ -219,7 +219,7 @@ module Fastlane
                 "\tcaptureScreenshots(#{project_prefix}scheme: \"#{ui_testing_scheme}\")"]
 
         if automatic_upload
-          lane << "\tuploadToAppStore(username: \"#{self.user}\", skipBinaryUpload: true, skipMetadata: true, app: \"#{self.app_identifier}\")"
+          lane << "\tuploadToAppStore(username: \"#{self.user}\", appIdentifier: \"#{self.app_identifier}\", skipBinaryUpload: true, skipMetadata: true)"
         end
         lane << "}"
       else


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
While I was applying fastlane to project I faced issue that default Fastfile.swift template has syntax error.
I noticed this syntax error occurred when I select option not to upload metadata to App Store Connect.

My goal with this PR is to resolve syntax error in Fastfile.swift template.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
- Replaced `app` argument of `uploadToAppStore` method to be placed at the end in default swift Fastfile template.