### PR TITLE
[fastlane_core] `xcode_at_least` method improvements

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -167,11 +167,11 @@ module FastlaneCore
       @xcode_version
     end
 
-    # @return true if Xcode version is higher than 8.3
+    # @return true if installed Xcode version is 'greater than or equal to' the input parameter version
     def self.xcode_at_least?(version)
-      FastlaneCore::UI.user_error!("Unable to locate Xcode. Please make sure to have Xcode installed on your machine") if xcode_version.nil?
-      v = xcode_version
-      Gem::Version.new(v) >= Gem::Version.new(version)
+      installed_xcode_version = xcode_version
+      UI.user_error!("Unable to locate Xcode. Please make sure to have Xcode installed on your machine") if installed_xcode_version.nil?
+      Gem::Version.new(installed_xcode_version) >= Gem::Version.new(version)
     end
 
     # iTMSTransporter


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
- I was learning Fastlane-Core's helper class and notice that the `xcode_at_least` method was slightly off/incorrect (in the documentation) 😇

### Description
- Updated the method documentation
- Replaced `FastlaneCore::UI.user_error!("xxxx")` with `UI.user_error!("xxxx")` message
- Improved naming and calling `xcode_version` only once now, earlier it was getting called 2 times (2times calling doesn't really matter in terms of performance, but still why call two times if not required 😊)

### Testing Steps
- Nothing changed in functionality.
- All existing unit tests are passing.