### PR TITLE
[pilot] clean-up - removed empty `tester_util` file

### DIFF
--- a/pilot/lib/pilot/tester_exporter.rb
+++ b/pilot/lib/pilot/tester_exporter.rb
@@ -1,5 +1,4 @@
 require 'spaceship/tunes/application'
-require_relative 'tester_util'
 require_relative 'module'
 require_relative 'manager'
 

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -1,7 +1,6 @@
 require 'terminal-table'
 
 require_relative 'manager'
-require_relative 'tester_util'
 
 module Pilot
   class TesterManager < Manager


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
- I was learning TestFlight beta testers code and notice this empty `tester_util` file
- I am suspecting, this might have happened due to some merge conflicts 🤷‍♂️

### Description
- Removed empty `tester_util` file
- Removed `require_relative 'tester_util'`

### Testing Steps
- Nothing really changed.
