### PR TITLE
[action][upload_symbols_to_crashlytics] Add a check for app_id before searching for gsp and api_token

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -5,8 +5,10 @@ module Fastlane
         require 'tmpdir'
 
         find_binary_path(params)
-        find_gsp_path(params)
-        find_api_token(params)
+        unless params[:app_id]
+          find_gsp_path(params)
+          find_api_token(params)
+        end
 
         if !params[:app_id] && !params[:gsp_path] && !params[:api_token]
           UI.user_error!('Either Firebase Crashlytics App ID, path to GoogleService-Info.plist or legacy Fabric API key must be given.')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
`upload_symbols_to_crashlytics` needs only one parameter of these: `app_id`, `gsp_path` and `api_token`. If only `app_id` was given no need to find the rest of those.
A issue what I have which requires this patch is that the fastlane searches for `api_token` in every `Info.plist` it can find. But not every `Info.plist` is a `utf-8` file 😃  (the derived data has a lot of `Info.plist` for storyboard files which are binary files). And when it tries to read that non-utf8 `Info.plist` it gives a lot of errors: `invalid byte sequence in UTF-8`. I don't see any value for fastlane to search `api_token` in `Info.plist` files when the `app_id` was already given.
<img height=500 src='https://user-images.githubusercontent.com/41613812/116226332-82028d80-a75b-11eb-8c0b-97921687ae90.png'>

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I've added a check for `app_id` before searching for `gsp_path` and `api_token`. If `app_id` was not given, it will try to find these, otherwise will not.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
