### PR TITLE
[spaceship] Add `fetch_all_certificates` method

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -92,6 +92,12 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
+      def fetch_all_certificates(client: nil, filter: {}, includes: nil, sort: nil)
+        client ||= Spaceship::ConnectAPI
+        resps = client.get_certificates(profile_id: id, filter: filter, includes: includes).all_pages
+        return resps.flat_map(&:to_models)
+      end
+
       def delete!(client: nil)
         client ||= Spaceship::ConnectAPI
         return client.delete_profile(profile_id: id)

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -84,9 +84,13 @@ module Spaceship
         # certificates
         #
 
-        def get_certificates(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_certificates(profile_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = provisioning_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          provisioning_request_client.get("certificates", params)
+          if profile_id.nil?
+            provisioning_request_client.get("certificates", params)
+          else
+            provisioning_request_client.get("profiles/#{profile_id}/certificates", params)
+          end
         end
 
         def get_certificate(certificate_id: nil, includes: nil)

--- a/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
@@ -77,7 +77,7 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
           params = {}
           req_mock = test_request_body(path, params)
           expect(client).to receive(:request).with(:post).and_yield(req_mock)
-          client.get_certificates(profile_id: 123456789)
+          client.get_certificates(profile_id: '123456789')
         end
       end
     end

--- a/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
@@ -69,6 +69,17 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
           client.get_certificates
         end
       end
+
+      context 'get_certificates_for_profile' do
+        let(:path) { "profiles/123456789/certificates" }
+
+        it 'succeeds' do
+          params = {}
+          req_mock = test_request_body(path, params)
+          expect(client).to receive(:request).with(:post).and_yield(req_mock)
+          client.get_certificates(profile_id: 123456789)
+        end
+      end
     end
 
     describe "devices" do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The task I work on in my organisation requires fetching and modifying profiles and certificates.
I modified `get_certificates` method following the example of `get_devices`.

### Description
The code is almost the same as `get_devices` method.
I checked if the changes are working as was described in [RespondingToIssuesAndPullRequests.md](https://github.com/fastlane/fastlane/blob/master/RespondingToIssuesAndPullRequests.md)

### Testing Steps
```ruby
Spaceship::ConnectAPI::Profile.all.first.fetch_all_certificates # returns list of certificates for the profile
```
