### PR TITLE
[action] ensure backup_xcarchive preserves symbolic links

### DIFF
--- a/fastlane/lib/fastlane/actions/backup_xcarchive.rb
+++ b/fastlane/lib/fastlane/actions/backup_xcarchive.rb
@@ -40,7 +40,7 @@ module Fastlane
                        end
 
             # Create zip
-            Actions.sh(%(cd "#{xcarchive_folder}" && zip -r -X "#{zip_file}" "#{xcarchive_file}" > /dev/null))
+            Actions.sh(%(cd "#{xcarchive_folder}" && zip -r -X -y "#{zip_file}" "#{xcarchive_file}" > /dev/null))
 
             # Moved to its final destination
             FileUtils.mv(zip_file, full_destination)

--- a/fastlane/spec/actions_specs/backup_xcarchive_spec.rb
+++ b/fastlane/spec/actions_specs/backup_xcarchive_spec.rb
@@ -76,7 +76,7 @@ describe Fastlane do
         end
 
         it "make zip with custom filename and copy to destination" do
-          allow(Fastlane::Actions).to receive(:sh).with("cd \"#{source_path}\" && zip -r -X \"#{tmp_path}/#{custom_zip_filename}.xcarchive.zip\" \"#{xcarchive_file}\" > /dev/null").and_return("")
+          allow(Fastlane::Actions).to receive(:sh).with("cd \"#{source_path}\" && zip -r -X -y \"#{tmp_path}/#{custom_zip_filename}.xcarchive.zip\" \"#{xcarchive_file}\" > /dev/null").and_return("")
           result = Fastlane::FastFile.new.parse("lane :test do
             backup_xcarchive(
               versioned: false,


### PR DESCRIPTION
Failing to do so can invalidate frameworks embedded in the app packages.

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

(still need to do some of those)

### Motivation and Context

When extracting archives created with `backup_xcarchive` and then importing them into Xcode for further use we noticed that we're getting validation errors during re-signing. 

<img width="897" alt="116429552-48f31780-a846-11eb-94d0-561e2c0f667a" src="https://user-images.githubusercontent.com/91322/116716765-6d7ef900-a9d8-11eb-8b20-5b842e13aa63.png">

This is because symlinks in embedded frameworks were replaced by file copies.

Expected (notice the links):

<img width="689" alt="116431662-e565eb80-a83f-11eb-90eb-0007e7569fca" src="https://user-images.githubusercontent.com/91322/116716977-a919c300-a9d8-11eb-9d40-27fe0dbb2cab.png">

Actual:

<img width="953" alt="116431328-98821500-a83f-11eb-8021-9fe365c69330" src="https://user-images.githubusercontent.com/91322/116717006-b20a9480-a9d8-11eb-8614-7962b5f17e8b.png">

### Description

The `zip` command can preserve links if the `-y` option is passed.

>-y
>--symlinks
>For UNIX and VMS (V8.3 and later), store symbolic links as such in the zip archive, instead of compressing and storing the file referred to by the link. This can avoid multiple copies of files being included in the archive as zip recurses the directory trees and accesses files directly and by links.

Source: https://linux.die.net/man/1/zip

This still needs to be tested but it looks like an obvious fix for the issue.
