### PR TITLE
[Fastlane.Swift] Sanitize Swift document comments

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -232,7 +232,7 @@ module Fastlane
       # Adds newlines between each documentation element.
       documentation = documentation_elements.flat_map { |element| [element, separator] }.tap(&:pop).join("\n")
 
-      return "/**\n#{documentation}\n*/\n"
+      return "/**\n#{documentation.gsub('/*', '/\\*')}\n*/\n"
     end
 
     def swift_parameter_documentation


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When generating the documentation for Swift functions, it could occur that a `/*` might appear and comment out all the code below it. This PR resolves #18561.

### Description
In the last step of `swift_documentation` it is needed to replace appearances of `/*` with `/\*`.

### Testing Steps
1. Install the branch:
```ruby
gem 'fastlane', :branch => 'https://github.com/minuscorp/fastlane/swift-sanitize-documents'
```
2. Add a failing plugin, like `lizard`
3. Run `bundle exec fastlane update_plugins`
4. Check `Plugins.swift` source code for the correct codedocs.
5. 🚀 
