### PR TITLE
[Ruby 3.0] Replace obsolete URI.escape with alternatives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,8 @@ jobs:
           name: Check compatibility with Ruby 3.0
           command: |
             touch ~/test-reports/ruby_warnings.txt
-            # TODO remove 'grep -v ".bundle"' once 3rd party dependencies support Ruby 3.0
-            ! cat ~/test-reports/ruby_warnings.txt | grep -v ".bundle" | grep -E "warning:\s.*(deprecated).*$" && echo "No deprecation message found."
+            ! cat ~/test-reports/ruby_warnings.txt | grep -E "warning:\s.*(deprecated).*$" && echo "No deprecation message found."
+            ! cat ~/test-reports/ruby_warnings.txt | grep -E "warning:\s.*(obsolete).*$" && echo "No obsolete message found."
       - store_test_results:
           path: ~/test-reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,13 @@ jobs:
           name: debug | brew version
           command: |
             brew -v
+      - run:
+          name: brew update
+          command: |
+            # temporary solution for this https://discuss.circleci.com/t/macos-image-users-homebrew-brownout-2021-04-26/39872/2
+            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
+            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
+            brew update
       - run: bundle exec fastlane generate_swift_api
 
   validate_documentation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,11 +178,11 @@ jobs:
           command: |
             brew -v
       - run:
-          name: brew update
+          name: brew update if needed # temporary solution for this https://discuss.circleci.com/t/macos-image-users-homebrew-brownout-2021-04-26/39872/2
           command: |
-            # temporary solution for this https://discuss.circleci.com/t/macos-image-users-homebrew-brownout-2021-04-26/39872/2
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
+            ruby -e 'exit(1) if `brew -v` =~ /2\.\d+\.\d+/' ||\
+            brew update || \
+            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow && \
             brew update
       - run: bundle exec fastlane generate_swift_api
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,8 +180,10 @@ jobs:
       - run:
           name: brew update if needed # temporary solution for this https://discuss.circleci.com/t/macos-image-users-homebrew-brownout-2021-04-26/39872/2
           command: |
+            # if the version is not 3.x.x, try brew update
             ruby -e 'exit(1) if `brew -v` =~ /2\.\d+\.\d+/' ||\
             brew update || \
+            # if brew update fails due to shallow clone, try unshallowing and then brew update again
             git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow && \
             brew update
       - run: bundle exec fastlane generate_swift_api

--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -91,7 +91,7 @@
 
           .app-changelog-list {
               list-style-type: square;
-              
+
               font-weight: 300;
           }
 
@@ -137,10 +137,10 @@
           }
         </style>
     </head>
-    
+
     <body>
       <div class="app-icons">
-        
+
         <% if @options[:app_icon] %>
         <div class="app-icon">
           Large App Icon:<br>
@@ -182,7 +182,7 @@
             <% end %>
           <% end %>
         </div>
-        
+
         <% if @options[:keywords] and @options[:keywords][language] %>
           <div class="app-keyword">
               <div class="cat-headline">Keywords</div>
@@ -193,7 +193,7 @@
               </ul>
           </div>
         <% end %>
-        
+
         <% if @options[:description] %>
           <div class="app-description">
                <div class="cat-headline">Description</div>
@@ -202,7 +202,7 @@
                </div>
           </div>
         <% end %>
-        
+
         <% if @options[:release_notes] %>
           <div class="app-changelog">
               <div class="cat-headline">Changelog</div>
@@ -216,7 +216,7 @@
               <%= (@options[:promotional_text][language] || '').gsub("\n", "<br />") %>
           </div>
         <% end %>
-        
+
         <div class="app-screenshots">
           <div class="cat-headline">Screenshots</div>
 
@@ -237,7 +237,7 @@
               <div class="app-screenshot-row">
 
               <% screenshots.each_with_index do |screenshot, index| %>
-                <a href="<%= URI.escape(screenshot.path) %>" target="_blank"><img class="app-screenshot" src="<%= render_relative_path(@export_path, URI.escape(screenshot.path)) %>" title="Screenshot #<%=index%> for <%=language%>"></a>
+                <a href="<%= Addressable::URI.encode(screenshot.path) %>" target="_blank"><img class="app-screenshot" src="<%= render_relative_path(@export_path, Addressable::URI.encode(screenshot.path)) %>" title="Screenshot #<%=index%> for <%=language%>"></a>
               <% end %>
               </div>
             <% end %>
@@ -250,7 +250,7 @@
                 <% if options[:overwrite_screenshots] %>
                   <b>--overwrite_screenshots</b> is set, existing screenshots will be removed, but none will be uploaded.
                 <% else %>
-                  The existing screenshots on App Store Connect will be kept. 
+                  The existing screenshots on App Store Connect will be kept.
                   if you want to remove them you have to use the <i>--overwrite_screenshots</i> flag.
                 <% end %>
               <p>
@@ -259,7 +259,7 @@
             </div>
           <% end %>
           </div>
-        
+
         <hr />
       <% end # end data
       %>

--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -237,7 +237,7 @@
               <div class="app-screenshot-row">
 
               <% screenshots.each_with_index do |screenshot, index| %>
-                <a href="<%= Addressable::URI.encode(screenshot.path) %>" target="_blank"><img class="app-screenshot" src="<%= render_relative_path(@export_path, Addressable::URI.encode(screenshot.path)) %>" title="Screenshot #<%=index%> for <%=language%>"></a>
+                <a href="<%= render_relative_path(@export_path, Addressable::URI.encode(screenshot.path)) %>" target="_blank"><img class="app-screenshot" src="<%= render_relative_path(@export_path, Addressable::URI.encode(screenshot.path)) %>" title="Screenshot #<%=index%> for <%=language%>"></a>
               <% end %>
               </div>
             <% end %>

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -26,7 +26,9 @@ module Fastlane
         # Login
         credentials = JSON.parse(json_key_data)
         callback_uri = 'https://fastlane.github.io/managed_google_play-callback/callback.html'
-        uri = "https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{credentials['client_email']}&continueUrl=#{URI.encode_www_form_component(callback_uri)}"
+        require 'addressable/uri'
+        continueUrl = Addressable::URI.encode(callback_uri)
+        uri = "https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{credentials['client_email']}&continueUrl=#{continueUrl}"
 
         UI.message("To obtain publishing rights for custom apps on Managed Play Store, open the following URL and log in:")
         UI.message("")

--- a/fastlane/lib/fastlane/actions/hipchat.rb
+++ b/fastlane/lib/fastlane/actions/hipchat.rb
@@ -49,7 +49,8 @@ module Fastlane
           # Escape channel's name to guarantee it is a valid URL resource.
           # First of all we verify that the value is not already escaped,
           # escaping an escaped value will produce a wrong channel name.
-          escaped_channel = URI.unescape(channel) == channel ? URI.escape(channel) : channel
+          require 'addressable/uri'
+          escaped_channel = Addressable::URI.encode(channel) == channel ? Addressable::URI.encode(channel) : channel
           if user?(channel)
             params = { 'message' => message, 'message_format' => message_format }
             json_headers = { 'Content-Type' => 'application/json',

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -305,12 +305,12 @@ module Fastlane
 
           # Normalize some values
           export_options[:teamID] = CredentialsManager::AppfileConfig.try_fetch_value(:team_id) if !export_options[:teamID] && CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
-          export_options[:onDemandResourcesAssetPacksBaseURL] = URI.escape(export_options[:onDemandResourcesAssetPacksBaseURL]) if export_options[:onDemandResourcesAssetPacksBaseURL]
+          export_options[:onDemandResourcesAssetPacksBaseURL] = Addressable::URI.encode(export_options[:onDemandResourcesAssetPacksBaseURL]) if export_options[:onDemandResourcesAssetPacksBaseURL]
           if export_options[:manifest]
-            export_options[:manifest][:appURL] = URI.encode_www_form_component(export_options[:manifest][:appURL]) if export_options[:manifest][:appURL]
-            export_options[:manifest][:displayImageURL] = URI.encode_www_form_component(export_options[:manifest][:displayImageURL]) if export_options[:manifest][:displayImageURL]
-            export_options[:manifest][:fullSizeImageURL] = URI.encode_www_form_component(export_options[:manifest][:fullSizeImageURL]) if export_options[:manifest][:fullSizeImageURL]
-            export_options[:manifest][:assetPackManifestURL] = URI.encode_www_form_component(export_options[:manifest][:assetPackManifestURL]) if export_options[:manifest][:assetPackManifestURL]
+            export_options[:manifest][:appURL] = Addressable::URI.encode(export_options[:manifest][:appURL]) if export_options[:manifest][:appURL]
+            export_options[:manifest][:displayImageURL] = Addressable::URI.encode(export_options[:manifest][:displayImageURL]) if export_options[:manifest][:displayImageURL]
+            export_options[:manifest][:fullSizeImageURL] = Addressable::URI.encode(export_options[:manifest][:fullSizeImageURL]) if export_options[:manifest][:fullSizeImageURL]
+            export_options[:manifest][:assetPackManifestURL] = Addressable::URI.encode(export_options[:manifest][:assetPackManifestURL]) if export_options[:manifest][:assetPackManifestURL]
           end
 
           # Saves options to plist

--- a/fastlane/spec/actions_specs/get_managed_play_store_publishing_rights_spec.rb
+++ b/fastlane/spec/actions_specs/get_managed_play_store_publishing_rights_spec.rb
@@ -21,7 +21,7 @@ describe Fastlane do
         it "found file" do
           expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'").once
           expect(UI).to receive(:input).with(anything).and_return(json_key_path)
-          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
+          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https://fastlane.github.io/managed_google_play-callback/callback.html")
 
           Fastlane::FastFile.new.parse("lane :test do
             get_managed_play_store_publishing_rights()
@@ -31,7 +31,7 @@ describe Fastlane do
 
       describe "with options" do
         it "with :json_key" do
-          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
+          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https://fastlane.github.io/managed_google_play-callback/callback.html")
 
           Fastlane::FastFile.new.parse("lane :test do
             get_managed_play_store_publishing_rights(
@@ -41,7 +41,7 @@ describe Fastlane do
         end
 
         it "with :json_key_data" do
-          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https%3A%2F%2Ffastlane.github.io%2Fmanaged_google_play-callback%2Fcallback.html")
+          expect(UI).to receive(:important).with("https://play.google.com/apps/publish/delegatePrivateApp?service_account=#{json_key_client_email}&continueUrl=https://fastlane.github.io/managed_google_play-callback/callback.html")
 
           Fastlane::FastFile.new.parse("lane :test do
             get_managed_play_store_publishing_rights(

--- a/frameit/lib/frameit/frame_downloader.rb
+++ b/frameit/lib/frameit/frame_downloader.rb
@@ -71,8 +71,9 @@ module Frameit
     def download_file(path, txt: "file")
       require 'uri'
       require 'excon'
+      require 'addressable/uri'
 
-      url = File.join(HOST_URL, Frameit.frames_version, URI.escape(path))
+      url = File.join(HOST_URL, Frameit.frames_version, Addressable::URI.encode(path))
       UI.message("Downloading #{txt} from '#{url}' ...")
       body = Excon.get(url).body
       raise body if body.include?("<Error>")

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -4,6 +4,7 @@
 # because of
 # `incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string) (Encoding::CompatibilityError)`
 
+require 'addressable/uri'
 require 'tempfile'
 require 'xcodeproj'
 
@@ -154,12 +155,12 @@ module Gym
 
       def normalize_export_options(hash)
         # Normalize some values
-        hash[:onDemandResourcesAssetPacksBaseURL] = URI.escape(hash[:onDemandResourcesAssetPacksBaseURL]) if hash[:onDemandResourcesAssetPacksBaseURL]
+        hash[:onDemandResourcesAssetPacksBaseURL] = Addressable::URI.encode(hash[:onDemandResourcesAssetPacksBaseURL]) if hash[:onDemandResourcesAssetPacksBaseURL]
         if hash[:manifest]
-          hash[:manifest][:appURL] = URI.escape(hash[:manifest][:appURL]) if hash[:manifest][:appURL]
-          hash[:manifest][:displayImageURL] = URI.escape(hash[:manifest][:displayImageURL]) if hash[:manifest][:displayImageURL]
-          hash[:manifest][:fullSizeImageURL] = URI.escape(hash[:manifest][:fullSizeImageURL]) if hash[:manifest][:fullSizeImageURL]
-          hash[:manifest][:assetPackManifestURL] = URI.escape(hash[:manifest][:assetPackManifestURL]) if hash[:manifest][:assetPackManifestURL]
+          hash[:manifest][:appURL] = Addressable::URI.encode(hash[:manifest][:appURL]) if hash[:manifest][:appURL]
+          hash[:manifest][:displayImageURL] = Addressable::URI.encode(hash[:manifest][:displayImageURL]) if hash[:manifest][:displayImageURL]
+          hash[:manifest][:fullSizeImageURL] = Addressable::URI.encode(hash[:manifest][:fullSizeImageURL]) if hash[:manifest][:fullSizeImageURL]
+          hash[:manifest][:assetPackManifestURL] = Addressable::URI.encode(hash[:manifest][:assetPackManifestURL]) if hash[:manifest][:assetPackManifestURL]
         end
         hash
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

As per #17931, I've been working on Ruby 3.0 support. Prior to this, I've fixed most deprecation warnings from Ruby 2.7 #18021. It now prevents PRs from making new warnings by checking them in CircleCI.

https://github.com/fastlane/fastlane/blob/72ff4fc82c0cb57c63204eaa4c6d2b9ca33a1bb5/.circleci/config.yml#L106-L111

However, there is still another type of deprecation warning introduced in Ruby 1.9; `warning: URI.escape is obsolete`. This message bypassed the above check😂 I recognised this warning before but didn't know `URI.escape` was finally removed in Ruby 3.0 until I run fastlane on Ruby 3.0, which became possible after #18599.

This PR replace `URI.escape` with some alternatives. Some of them were fixed in this PR previously https://github.com/fastlane/fastlane/pull/16409 but it had some defects that the PR changed results. This PR also restores previous results.

You can read some history in blog posts; for example 
https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

There's no 100% equivalent to `URI.escape`. So we need to use alternatives case by case.

1. `URI.encode_www_form_component` - can be used where you encode a part of URI query parameter 
2. `URI.encode_www_form` - can be used with query parameters in Array on Hash
3. `CGI.escape` - similar to `URI.encode_www_form_component` but it follows CGI's spec
4. `Addressable::URI.encode` - is 3rd party dependency (we've already adopted) but is the closest option to `URI.escape`

I applied 1 for places where we process query parameters and 3 for the rest of URLs and file paths. 

Note that there is different behaviour between `URI.escape` and `URI.encode_www_form_component` especially for whitespaces. While `URI.escape` and `Addressable::URI.escape` can work well for file paths including whitespaces,  `URI.encode_www_form_component` is only effective for "query parameters" really.

These are examples of differences among those APIs (except for `CGI.escape`). 
<details> 

```
[3] pry(main)> URI.escape 'a b'
(pry):3: warning: URI.escape is obsolete
=> "a%20b"
[4] pry(main)> URI.encode_www_form_component 'a b'
=> "a+b"
[5] pry(main)> Addressable::URI.encode('a b')
=> "a%20b"
```

```
[2] pry(main)> URI.escape('~/app/fastlane/screenshots/en_US/a 1.jpg')
(pry):2: warning: URI.escape is obsolete
=> "~/app/fastlane/screenshots/en_US/a%201.jpg"
[3] pry(main)> Addressable::URI.encode('~/app/fastlane/screenshots/en_US/a 1.jpg')
=> "~/app/fastlane/screenshots/en_US/a%201.jpg"
[4] pry(main)> URI.encode_www_form_component('~/app/fastlane/screenshots/en_US/a 1.jpg')
=> "%7E%2Fapp%2Ffastlane%2Fscreenshots%2Fen_US%2Fa+1.jpg"
```

```
[10] pry(main)> URI.escape('http://fastlane.tools/search?query=あいうえお')
(pry):10: warning: URI.escape is obsolete
=> "http://fastlane.tools/search?query=%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A"
[11] pry(main)> URI.encode_www_form_component('http://fastlane.tools/search?query=あいうえお')
=> "http%3A%2F%2Ffastlane.tools%2Fsearch%3Fquery%3D%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A"
[12] pry(main)> Addressable::URI.encode('http://fastlane.tools/search?query=あいうえお')
=> "http://fastlane.tools/search?query=%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A"
```

</details>

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

We can test the followings -

* deliver/lib/assets/summary.html.erb - with `deliver` command with HTML preview (See if screenshots are correctly shown and linked)
* frameit/lib/frameit/frame_downloader.rb - with `fastlane frameit download_frames`
* fastlane/lib/fastlane/actions/xcodebuild.rb - with `Fastfile` below
  * This previously used `URI.escape` but changed it to `URI.encode_www_form_component`, which seems wrong. `Addressable::URI.encode` would be better https://github.com/fastlane/fastlane/commit/5e864f8850014f661a557b77b7a199b76cdf4a7d#diff-cbec5511af30c2da21c2488e6f8baff4eabe4745fb5d01755aa506836b4db920R310-R313  

Fastfile
<details>

```ruby
platform :ios do
  desc "Push a new release build to the App Store"
  lane :release do
    app_store_connect_api_key(in_house: false)
    match
    increment_build_number
    
    ENV['XCODE_BUILD_PATH'] = 'build'
    xcarchive(
      sdk: 'iphoneos',
      scheme: 'FastlaneTest'
    )

    xcexport(
      export_path: File.join(ENV['XCODE_BUILD_PATH'], 'export'),
      export_options_plist: {
        method: 'app-store',
        uploadSymbols: true,
        manifest: {
          appURL: 'https://fastlane.tools/search?query=ファストレーン',
          displayImageURL: 'https://fastlane.tools/ファストレーン.jpg',
          fullSizeImageURL: 'https://fastlane.tools/ファストレーン.jpg',
          assetPackManifestURL: 'https://fastlane.tools/ファストレーン.plist',
        }
      }
    )
  end
```
</details>

Result - exportOption.plist (See if the URLs are escaped correctly)
<details>
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>manifest</key>
        <dict>
                <key>appURL</key>
                <string>https://fastlane.tools/search?query=%E3%83%95%E3%82%A1%E3%82%B9%E3%83%88%E3%83%AC%E3%83%BC%E3%83%B3</string>
                <key>assetPackManifestURL</key>
                <string>https://fastlane.tools/%E3%83%95%E3%82%A1%E3%82%B9%E3%83%88%E3%83%AC%E3%83%BC%E3%83%B3.plist</string>
                <key>displayImageURL</key>
                <string>https://fastlane.tools/%E3%83%95%E3%82%A1%E3%82%B9%E3%83%88%E3%83%AC%E3%83%BC%E3%83%B3.jpg</string>
                <key>fullSizeImageURL</key>
                <string>https://fastlane.tools/%E3%83%95%E3%82%A1%E3%82%B9%E3%83%88%E3%83%AC%E3%83%BC%E3%83%B3.jpg</string>
        </dict>
        <key>method</key>
        <string>app-store</string>
        <key>teamID</key>
        <string>2Q7H62SFG3</string>
        <key>uploadSymbols</key>
        <true/>
</dict>
</plist>
```
</details>

We can't really test them and might be good to consider deprecation/removal😞 

* fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb - Google's API this action uses was removed apparently
  * There is no description about `https://play.google.com/apps/publish/delegatePrivateApp?service_account=&continueUrl=` https://developers.google.com/android/work/play/custom-app-api/get-started#retrieve_the_developer_account_id
  * It existed on the same page in Nov 2020 http://web.archive.org/web/20201112040731/developers.google.com/android/work/play/custom-app-api/get-started
* fastlane/lib/fastlane/actions/hipchat.rb - Hipchat service ended
* gym/lib/gym/generators/package_command_generator_xcode7.rb - Who uses/keeps Xcode 7 now? 😂 