### PR TITLE
[docs] update AppStoreConnect.md about missing required parameter 

### DIFF
--- a/spaceship/docs/AppStoreConnect.md
+++ b/spaceship/docs/AppStoreConnect.md
@@ -68,7 +68,8 @@ app = Spaceship::ConnectAPI::App.create(name: "App Name",
                                         sku: "123",
                                         primary_locale: "English",
                                         bundle_id: "com.krausefx.app",
-                                        platforms: ["IOS"])
+                                        platforms: ["IOS"],
+                                        company_name: "krause inc")
 ```
 
 To update non version specific details, use the following code


### PR DESCRIPTION
Added mandatory company name parameter

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Documentation gap in the app store connect documentation.  There is a missing required parameter on the create endpoint for Company Name.
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
I added the company name parameter in the documentation example.
<!-- Please describe in detail how you tested your changes. -->
Documentation

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
