### PR TITLE
[pilot] Introducing `timeout feature` for Apple build-processing waiting-time

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -145,9 +145,9 @@ module FastlaneCore
         pending_duration = end_time - current_time
 
         if current_time > end_time
-          UI.crash!("FastlaneCore::BuildWatcher exceeded the '#{timeout_duration.to_i} second(s)' timeout duration, Stopping now!")
+          UI.crash!("FastlaneCore::BuildWatcher exceeded the '#{timeout_duration.to_i}' timeout duration, Stopping now!")
         else
-          UI.message("Will 'force stop' watching build after pending #{pending_duration.to_i} second(s) timeout duration around #{end_time} time!")
+          UI.message("Will 'force stop' watching build after pending #{pending_duration.to_i} timeout duration around #{end_time} time!")
         end
       end
     end

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -24,6 +24,11 @@ module FastlaneCore
         UI.message("Waiting for processing on... app_id: #{app_id}, app_version: #{app_version}, build_version: #{build_version}, platform: #{platform}")
 
         build_watching_start_time = Time.new
+        unless timeout_duration.nil?
+          end_time = build_watching_start_time + timeout_duration
+          UI.message("Will timeout watching build after #{timeout_duration} seconds around #{end_time} time!")
+        end
+
         showed_info = false
         loop do
           matched_build, app_version_queried = matching_build(watched_app_version: app_version, watched_build_version: build_version, app_id: app_id, platform: platform, select_latest: select_latest)
@@ -145,9 +150,9 @@ module FastlaneCore
         pending_duration = end_time - current_time
 
         if current_time > end_time
-          UI.crash!("FastlaneCore::BuildWatcher exceeded the '#{timeout_duration.to_i}' timeout duration, Stopping now!")
+          UI.crash!("FastlaneCore::BuildWatcher exceeded the '#{timeout_duration.to_i}' seconds, Stopping now!")
         else
-          UI.message("Will 'force stop' watching build after pending #{pending_duration.to_i} timeout duration around #{end_time} time!")
+          UI.verbose("Will timeout watching build after pending #{pending_duration.to_i} seconds around #{end_time} time!")
         end
       end
     end

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -147,7 +147,7 @@ module FastlaneCore
         if current_time > end_time
           UI.crash!("FastlaneCore::BuildWatcher exceeded the '#{timeout_duration.to_i} second(s)' timeout duration, Stopping now!")
         else
-          UI.message("Will 'force stop' watching build after pending '#{pending_duration.to_i} second(s)' timeout duration ~ #{end_time} time!")
+          UI.message("Will 'force stop' watching build after pending #{pending_duration.to_i} second(s) timeout duration around #{end_time} time!")
         end
       end
     end

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -26,7 +26,7 @@ module FastlaneCore
         build_watching_start_time = Time.new
         unless timeout_duration.nil?
           end_time = build_watching_start_time + timeout_duration
-          UI.message("Will timeout watching build after #{timeout_duration} seconds around #{end_time} time!")
+          UI.message("Will timeout watching build after #{timeout_duration} seconds around #{end_time}...")
         end
 
         showed_info = false
@@ -152,7 +152,7 @@ module FastlaneCore
         if current_time > end_time
           UI.crash!("FastlaneCore::BuildWatcher exceeded the '#{timeout_duration.to_i}' seconds, Stopping now!")
         else
-          UI.verbose("Will timeout watching build after pending #{pending_duration.to_i} seconds around #{end_time} time!")
+          UI.verbose("Will timeout watching build after pending #{pending_duration.to_i} seconds around #{end_time}...")
         end
       end
     end

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -153,7 +153,7 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
       expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
-      expect(UI).to receive(:message).with(/Will 'force stop' watching build after pending [0-5]{1} second/) # Normally, it will be 4 seconds always, but really depends on speed, dont want to fail on slow CI
+      expect(UI).to receive(:message).with(/Will 'force stop' watching build after pending [0-5]{1} timeout duration around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2}) time!/)
       expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
       expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{ready_build.platform}")
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
@@ -168,7 +168,7 @@ describe FastlaneCore::BuildWatcher do
 
       expect do
         FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false, timeout_duration: -1)
-      end.to raise_error("FastlaneCore::BuildWatcher exceeded the '-1 second(s)' timeout duration, Stopping now!")
+      end.to raise_error("FastlaneCore::BuildWatcher exceeded the '-1' timeout duration, Stopping now!")
     end
 
     describe 'alternate versions' do

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -153,7 +153,8 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
       expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
-      expect(UI).to receive(:message).with(/Will 'force stop' watching build after pending [0-5]{1} timeout duration around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2}) time!/)
+      expect(UI).to receive(:message).with(/Will timeout watching build after [4-5]{1} seconds around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2}) time!/)
+      expect(UI).to receive(:verbose).with(/Will timeout watching build after pending [0-5]{1} seconds around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2}) time!/)
       expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
       expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{ready_build.platform}")
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
@@ -168,7 +169,7 @@ describe FastlaneCore::BuildWatcher do
 
       expect do
         FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false, timeout_duration: -1)
-      end.to raise_error("FastlaneCore::BuildWatcher exceeded the '-1' timeout duration, Stopping now!")
+      end.to raise_error("FastlaneCore::BuildWatcher exceeded the '-1' seconds, Stopping now!")
     end
 
     describe 'alternate versions' do

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -146,6 +146,31 @@ describe FastlaneCore::BuildWatcher do
       found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', poll_interval: 123, return_spaceship_testflight_build: false)
     end
 
+    it 'notifies when a build is still processing with timeout duration' do
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(FastlaneCore::BuildWatcher).to receive(:sleep)
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+
+      expect(UI).to receive(:message).with(/Will 'force stop' watching build after pending [0-5]{1} second/) # Normally, it will be 4 seconds always, but really depends on speed, dont want to fail on slow CI
+      expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
+      expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{ready_build.platform}")
+      expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
+      found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false, timeout_duration: 5)
+
+      expect(found_build).to eq(ready_build)
+    end
+
+    it 'raises error when a build is still processing and timeout duration exceeded' do
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+
+      expect do
+        FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false, timeout_duration: -1)
+      end.to raise_error("FastlaneCore::BuildWatcher exceeded the '-1 second(s)' timeout duration, Stopping now!")
+    end
+
     describe 'alternate versions' do
       describe '1.0 with 1.0.0 alternate' do
         it 'specific version returns one with alternate returns none' do

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -153,8 +153,8 @@ describe FastlaneCore::BuildWatcher do
       expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
       expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
-      expect(UI).to receive(:message).with(/Will timeout watching build after [4-5]{1} seconds around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2}) time!/)
-      expect(UI).to receive(:verbose).with(/Will timeout watching build after pending [0-5]{1} seconds around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2}) time!/)
+      expect(UI).to receive(:message).with(/Will timeout watching build after [4-5]{1} seconds around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2})\.\.\./)
+      expect(UI).to receive(:verbose).with(/Will timeout watching build after pending [0-5]{1} seconds around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2})\.\.\./)
       expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
       expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{ready_build.platform}")
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -105,6 +105,7 @@ module Pilot
         app_version: app_version,
         build_version: app_build,
         poll_interval: config[:wait_processing_interval],
+        timeout_duration: config[:wait_processing_timeout_duration],
         return_when_build_appears: return_when_build_appears,
         return_spaceship_testflight_build: false
       )

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -286,6 +286,14 @@ module Pilot
                                      verify_block: proc do |value|
                                        UI.user_error!("Please enter a valid positive number of seconds") unless value.to_i > 0
                                      end),
+        FastlaneCore::ConfigItem.new(key: :wait_processing_timeout_duration,
+                                     env_name: "PILOT_WAIT_PROCESSING_TIMEOUT_DURATION",
+                                     description: "Timeout duration in seconds to wait for App Store Connect processing. If set, after exceeding timeout duration, this will `force stop` to wait for App Store Connect processing and exit with exception",
+                                     optional: true,
+                                     type: Integer,
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Please enter a valid positive number of seconds") unless value.to_i > 0
+                                     end),
         FastlaneCore::ConfigItem.new(key: :wait_for_uploaded_build,
                                      env_name: "PILOT_WAIT_FOR_UPLOADED_BUILD",
                                      deprecated: "No longer needed with the transition over to the App Store Connect API",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
**Apple build processing does not work very well always**... Randomly CI keeps running for Apple build processing waiting time until CI timeout itself i.e CircleCI has 5 Hours timeout

**Problem:** 
- Running CI for one job 5 hours **randomly** create waiting-queue for other jobs
- Manually we have to stop the CI job after a certain time...i.e 1 hour [This is slightly inconvenience 😇]

### Description
- Introducing `timeout feature` for Apple build-processing waiting-time
- `FastlaneCore::BuildWatcher` will 'force stop' watching build after timeout duration
- Please see attached screenshot for logs

### Testing Steps
- Update Gemfile and run `bundle install` with
```
gem "fastlane", :git => "git@github.com:crazymanish/fastlane.git", :branch => "pilot-timeout"
```
- With the below test lane, run `bundle exec fastlane test`

```ruby
lane :test do
    PILOT_WAIT_PROCESSING_TIMEOUT_DURATION=60 # in your .env file

    gym
    pilot
  end
```

```ruby
lane :test do
    gym
    pilot(wait_processing_timeout_duration: 60)
  end
```

### Screenshot
<img width="1439" alt="Screenshot 2021-05-08 at 17 52 12" src="https://user-images.githubusercontent.com/5364500/117545604-caa52b00-b026-11eb-8eec-81eb745a477e.png">
