### PR TITLE
[scan] fix `regular expression` to find failed tests suite-name

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -122,7 +122,7 @@ module Scan
       suites = failing_tests.split(/(?=\n\s+[\w\s]+:\n)/)
 
       suites.each do |suite|
-        suite_name = suite.match(/\s*([\w\s]+):/).captures.first
+        suite_name = suite.match(/\s*([\w\s\S]+):/).captures.first
 
         test_cases = suite.split(":\n").fetch(1, []).split("\n").each
                           .select { |line| line.match?(/^\s+/) }

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -111,7 +111,7 @@ Failing tests:
         @scan.retry_execute(retries: 5, error_output: error_output)
       end
 
-      it "retry a failed test even if scheme name has non-whitespace character", requires_xcodebuild: true do
+      it "retry a failed test when scheme name has non-whitespace character", requires_xcodebuild: true do
         error_output = <<-ERROR_OUTPUT
 Failing tests:
   Fastlane-App-Tests:

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -111,6 +111,20 @@ Failing tests:
         @scan.retry_execute(retries: 5, error_output: error_output)
       end
 
+      it "retry a failed test even if scheme name has non-whitespace character", requires_xcodebuild: true do
+        error_output = <<-ERROR_OUTPUT
+Failing tests:
+  Fastlane-App-Tests:
+          FastlaneAppTests.testCoinToss()
+          ERROR_OUTPUT
+
+        expect(Fastlane::UI).to receive(:important).with("Retrying tests: Fastlane-App-Tests/FastlaneAppTests/testCoinToss").once
+        expect(Fastlane::UI).to receive(:important).with("Number of retries remaining: 4").once
+        expect(@scan).to receive(:execute)
+
+        @scan.retry_execute(retries: 5, error_output: error_output)
+      end
+
       it "fail to parse error output", requires_xcodebuild: true do
         error_output = <<-ERROR_OUTPUT
 Failing tests:

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -111,7 +111,7 @@ Failing tests:
         @scan.retry_execute(retries: 5, error_output: error_output)
       end
 
-      it "retry a failed test when scheme name has non-whitespace character", requires_xcodebuild: true do
+      it "retry a failed test when project scheme name has non-whitespace character", requires_xcodebuild: true do
         error_output = <<-ERROR_OUTPUT
 Failing tests:
   Fastlane-App-Tests:


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Resolves #18659

### Description
- **Earlier,** Regular expression was failing to find tests suite-name when the project scheme was having "non-whitespace" character i.e dash -
- **Now,** Updated the regular expression to find tests suite-name even if a project scheme will have "non-whitespace" character i.e dash -

### Testing Steps
- Added Unit test for "non-whitespace" character scheme which should pass
or
- Unzip demo project [scan-broken-dashtests.zip](https://github.com/fastlane/fastlane/files/6446366/scan-broken-dashtests.zip)
- Update/Install bundle using `bundle install` or `bundle update`
- Run `bundle exec fastlane test`

### Screenshot
<img width="1262" alt="Screenshot 2021-05-08 at 20 19 53" src="https://user-images.githubusercontent.com/5364500/117550033-35ae2c00-b03e-11eb-9864-e90a59fbdb14.png">

