### PR TITLE
[action][git_pull] clean-up the verify-blocks for Boolean validation

### DIFF
--- a/fastlane/lib/fastlane/actions/git_pull.rb
+++ b/fastlane/lib/fastlane/actions/git_pull.rb
@@ -23,20 +23,14 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :only_tags,
                                        description: "Simply pull the tags, and not bring new commits to the current branch from the remote",
-                                       is_string: false,
+                                       type: Boolean,
                                        optional: true,
-                                       default_value: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("Please pass a valid value for only_tags. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
-                                       end),
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :rebase,
                                        description: "Rebase on top of the remote branch instead of merge",
-                                       is_string: false,
+                                       type: Boolean,
                                        optional: true,
-                                       default_value: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("Please pass a valid value for rebase. Use one of the following: true, false") unless value.kind_of?(TrueClass) || value.kind_of?(FalseClass)
-                                       end)
+                                       default_value: false)
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- git_pull action verify_blocks was using old fashion style Bool validation

### Description
- Now added, `type: Boolean` which will do Bool validation itself, without adding extra verify_block

### Testing Steps
- No functionality changed really, just a small clean-up.