### PR TITLE
[Fastlane.Swift] Fix `OptionalConfigValue` for `Any`-based types.

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -195,7 +195,7 @@ module Fastlane
         else
           if type == "((String) -> Void)?"
             "#{param}: #{type} = nil"
-          elsif optional && type.end_with?('?')
+          elsif optional && type.end_with?('?') && !type.start_with?('Any')
             "#{param}: OptionalConfigValue<#{type}> = .fastlaneDefault(#{default_value})"
           else
             "#{param}: #{type} = #{default_value}"
@@ -280,12 +280,13 @@ module Fastlane
         return "[]" # return empty list for argument
       end
 
-      argument_object_strings = @param_names.zip(param_type_overrides, param_default_values, param_optionality_values).map do |name, type_override, default_value, is_optional|
+      argument_object_strings = @param_names.zip(param_type_overrides, param_default_values, param_optionality_values, param_is_strings).map do |name, type_override, default_value, is_optional, is_string|
+        type = get_type(param: name, default_value: default_value, optional: is_optional, param_type_override: type_override, is_string: is_string)
         sanitized_name = camel_case_lower(string: name)
         sanitized_name = sanitize_reserved_word(word: sanitized_name)
         type_string = type_override == :string_callback ? ".stringClosure" : "nil"
 
-        if !(type_override == :string_callback || !(is_optional && default_value.nil?))
+        if !(type_override == :string_callback || !(is_optional && default_value.nil? && !type.start_with?('Any')))
           { name: "#{sanitized_name.gsub('`', '')}Arg", arg: "let #{sanitized_name.gsub('`', '')}Arg = #{sanitized_name}.asRubyArgument(name: \"#{name}\", type: #{type_string})" }
         else
           { name: "#{sanitized_name.gsub('`', '')}Arg", arg: "let #{sanitized_name.gsub('`', '')}Arg = RubyCommand.Argument(name: \"#{name}\", value: #{sanitized_name}, type: #{type_string})" }
@@ -325,7 +326,7 @@ module Fastlane
         implm += "let args: [RubyCommand.Argument] = []\n"
       else
         implm += "let args = [#{args.group_by { |h| h[:name] }.keys.join(",\n")}]\n"
-        implm += ".compactMap { $0 }\n"
+        implm += ".compactMap { $0?.nilify(when: { $0.value == nil }) }\n"
       end
       implm += "let command = RubyCommand(commandID: \"\", methodName: \"#{@function_name}\", className: nil, args: args)\n"
 
@@ -431,7 +432,7 @@ module Fastlane
 
         if type == "((String) -> Void)?"
           "#{param}: #{type} = nil"
-        elsif optional && type.end_with?('?')
+        elsif optional && type.end_with?('?') && !type.start_with?('Any')
           "#{param}: OptionalConfigValue<#{type}> = .fastlaneDefault(#{self.class_name.downcase}.#{static_var_for_parameter_name})"
         else
           "#{param}: #{type} = #{self.class_name.downcase}.#{static_var_for_parameter_name}"

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -326,7 +326,8 @@ module Fastlane
         implm += "let args: [RubyCommand.Argument] = []\n"
       else
         implm += "let args = [#{args.group_by { |h| h[:name] }.keys.join(",\n")}]\n"
-        implm += ".compactMap { $0?.nilify(when: { $0.value == nil }) }\n"
+        implm += ".filter { $0?.value != nil }\n"
+        implm += ".compactMap { $0 }\n"
       end
       implm += "let command = RubyCommand(commandID: \"\", methodName: \"#{@function_name}\", className: nil, args: args)\n"
 

--- a/fastlane/swift/OptionalConfigValue.swift
+++ b/fastlane/swift/OptionalConfigValue.swift
@@ -71,6 +71,8 @@ extension OptionalConfigValue: ExpressibleByStringLiteral where T == String? {
     }
 }
 
+extension OptionalConfigValue: ExpressibleByStringInterpolation where T == String? {}
+
 extension OptionalConfigValue: ExpressibleByNilLiteral {
     public init(nilLiteral _: ()) {
         self = .nil

--- a/fastlane/swift/OptionalConfigValue.swift
+++ b/fastlane/swift/OptionalConfigValue.swift
@@ -23,14 +23,6 @@ public enum OptionalConfigValue<T> {
     }
 }
 
-extension Optional: ExpressibleByIntegerLiteral where Wrapped: ExpressibleByIntegerLiteral {
-    public typealias IntegerLiteralType = Wrapped.IntegerLiteralType
-
-    public init(integerLiteral value: Wrapped.IntegerLiteralType) {
-        self = .some(.init(integerLiteral: value))
-    }
-}
-
 extension Optional: ExpressibleByUnicodeScalarLiteral where Wrapped: ExpressibleByUnicodeScalarLiteral {
     public typealias UnicodeScalarLiteralType = Wrapped.UnicodeScalarLiteralType
 

--- a/fastlane/swift/OptionalConfigValue.swift
+++ b/fastlane/swift/OptionalConfigValue.swift
@@ -23,30 +23,6 @@ public enum OptionalConfigValue<T> {
     }
 }
 
-extension Optional: ExpressibleByUnicodeScalarLiteral where Wrapped: ExpressibleByUnicodeScalarLiteral {
-    public typealias UnicodeScalarLiteralType = Wrapped.UnicodeScalarLiteralType
-
-    public init(unicodeScalarLiteral value: Wrapped.UnicodeScalarLiteralType) {
-        self = .some(.init(unicodeScalarLiteral: value))
-    }
-}
-
-extension Optional: ExpressibleByExtendedGraphemeClusterLiteral where Wrapped: ExpressibleByStringLiteral {
-    public typealias ExtendedGraphemeClusterLiteralType = Wrapped.ExtendedGraphemeClusterLiteralType
-
-    public init(extendedGraphemeClusterLiteral value: Wrapped.ExtendedGraphemeClusterLiteralType) {
-        self = .some(.init(extendedGraphemeClusterLiteral: value))
-    }
-}
-
-extension Optional: ExpressibleByStringLiteral where Wrapped: ExpressibleByStringLiteral {
-    public typealias StringLiteralType = Wrapped.StringLiteralType
-
-    public init(stringLiteral value: Wrapped.StringLiteralType) {
-        self = .some(.init(stringLiteral: value))
-    }
-}
-
 extension OptionalConfigValue: ExpressibleByUnicodeScalarLiteral where T == String? {
     public typealias UnicodeScalarLiteralType = String
 

--- a/fastlane/swift/RubyCommand.swift
+++ b/fastlane/swift/RubyCommand.swift
@@ -70,6 +70,14 @@ struct RubyCommand: RubyCommandable {
                 return ""
             }
         }
+
+        func nilify(when condition: (Self) -> Bool) -> Self? {
+            if condition(self) {
+                return nil
+            } else {
+                return self
+            }
+        }
     }
 
     let commandID: String

--- a/fastlane/swift/RubyCommand.swift
+++ b/fastlane/swift/RubyCommand.swift
@@ -70,14 +70,6 @@ struct RubyCommand: RubyCommandable {
                 return ""
             }
         }
-
-        func nilify(when condition: (Self) -> Bool) -> Self? {
-            if condition(self) {
-                return nil
-            } else {
-                return self
-            }
-        }
     }
 
     let commandID: String


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`OptionalConfigValue` does not provide an `ExpressibleBy` interface for `Any?` parameters, so they have to be filtered out afterwards.
Fixes #18654

### Description
`OptionalConfigItem` does not apply to `Any` types to avoid a breaking compatibility against past releases. This PR resolves the issue.

### Testing Steps
1. Install the following branch:
```ruby
gem 'fastlane', :branch => 'https://github.com/minuscorp/fastlane/fix-configvalue-with-any-type'
```
2. Use an action with an `Any` value:
```swift
incrementBuildNumber(buildNumber: <#T##Any?#>)
```
3. Check that the value is being passed when it is not `nil`.
4. 🚀 
