### PR TITLE
[Regression][fastlane_core][deliver] Fix deliver is unable to automatically select the latest build and submit it for review

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -78,11 +78,15 @@ module FastlaneCore
         watched_app_version_alternate = alternate_version(watched_app_version)
         versions = [watched_app_version, watched_app_version_alternate].compact
 
-        UI.important("There is no app version to watch") if versions.empty?
-        if versions.empty? && select_latest
-          UI.message("Watch build version should not be present when there is no app version to watch") unless watched_build_version.nil?
-          UI.important("Search for the latest build")
-          versions = [nil]
+        if versions.empty?
+          if select_latest
+            UI.message("Watched build version should not be present when there is no app version to watch") unless watched_build_version.nil?
+            UI.message("Searching for the latest build")
+            versions = [nil]
+          else
+            error_message = "FastlaneCore::BuildWatcher has no app version to watch"
+            UI.crash!(error_message)
+          end
         end
 
         version_matches = versions.map do |version|

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -78,6 +78,13 @@ module FastlaneCore
         watched_app_version_alternate = alternate_version(watched_app_version)
         versions = [watched_app_version, watched_app_version_alternate].compact
 
+        UI.important("There is no app version to watch") if versions.empty?
+        if versions.empty? && select_latest
+          UI.important("Watch build version should not be present when there is no app version to watch") unless watched_build_version.nil?
+          UI.important("Search for the latest build")
+          versions = [nil]
+        end
+
         version_matches = versions.map do |version|
           match = VersionMatches.new
           match.version = version

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -3,6 +3,9 @@ require 'spaceship/connect_api'
 require_relative 'ui/ui'
 
 module FastlaneCore
+  class BuildWatcherError < StandardError
+  end
+
   class BuildWatcher
     VersionMatches = Struct.new(:version, :builds)
 
@@ -84,8 +87,7 @@ module FastlaneCore
             UI.message("Searching for the latest build")
             versions = [nil]
           else
-            error_message = "FastlaneCore::BuildWatcher has no app version to watch"
-            UI.crash!(error_message)
+            raise BuildWatcherError.new, "There is no app version to watch"
           end
         end
 
@@ -109,8 +111,8 @@ module FastlaneCore
           error_builds = matched_builds.map do |build|
             "#{build.app_version}(#{build.version}) for #{build.platform} - #{build.processing_state}"
           end.join("\n")
-          error_message = "FastlaneCore::BuildWatcher found more than 1 matching build: \n#{error_builds}"
-          UI.crash!(error_message)
+          error_message = "Found more than 1 matching build: \n#{error_builds}"
+          raise BuildWatcherError.new, error_message
         end
 
         version_match = version_matches.reject do |match|

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -80,7 +80,7 @@ module FastlaneCore
 
         UI.important("There is no app version to watch") if versions.empty?
         if versions.empty? && select_latest
-          UI.important("Watch build version should not be present when there is no app version to watch") unless watched_build_version.nil?
+          UI.message("Watch build version should not be present when there is no app version to watch") unless watched_build_version.nil?
           UI.important("Search for the latest build")
           versions = [nil]
         end

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -296,8 +296,10 @@ describe FastlaneCore::BuildWatcher do
         it 'returns a ready to submit build when select_latest is true' do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([ready_build])
 
-          allow(UI).to receive(:important)
-          allow(UI).to receive(:success)
+          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: , platform: #{ready_build.platform}")
+          expect(UI).to receive(:important).with("There is no app version to watch")
+          expect(UI).to receive(:important).with("Search for the latest build")
+          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
           expect(FastlaneCore::BuildWatcher).to receive(:sleep).never
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: true, return_spaceship_testflight_build: false)
@@ -308,8 +310,10 @@ describe FastlaneCore::BuildWatcher do
         it 'does not return a ready to submit build when select_latest is false' do
           expect(Spaceship::ConnectAPI::Build).to_not(receive(:all))
 
-          allow(UI).to receive(:important)
-          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: , platform: #{ready_build.platform}")
+          expect(UI).to receive(:important).with("Read more information on why this build isn't showing up yet - https://github.com/fastlane/fastlane/issues/14997")
+          expect(UI).to receive(:important).with("There is no app version to watch").exactly(3).times
+          expect(UI).to receive(:message).with("Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)").exactly(3).times
 
           # Break loop after 3 times
           allow(FastlaneCore::BuildWatcher).to receive(:loop).and_yield.and_yield.and_yield.and_return(nil)
@@ -327,8 +331,11 @@ describe FastlaneCore::BuildWatcher do
         it 'returns a ready to submit build when select_latest is true' do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([ready_build])
 
-          allow(UI).to receive(:important)
-          allow(UI).to receive(:success)
+          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: #{ready_build.version}, platform: #{ready_build.platform}")
+          expect(UI).to receive(:important).with("There is no app version to watch")
+          expect(UI).to receive(:message).with("Watch build version should not be present when there is no app version to watch")
+          expect(UI).to receive(:important).with("Search for the latest build")
+          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
           expect(FastlaneCore::BuildWatcher).to receive(:sleep).never
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: true, return_spaceship_testflight_build: false)
@@ -339,9 +346,10 @@ describe FastlaneCore::BuildWatcher do
         it 'does not return a ready to submit build when select_latest is false' do
           expect(Spaceship::ConnectAPI::Build).to_not(receive(:all))
 
-          allow(UI).to receive(:important)
-          allow(UI).to receive(:message)
-
+          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: #{ready_build.version}, platform: #{ready_build.platform}")
+          expect(UI).to receive(:important).with("Read more information on why this build isn't showing up yet - https://github.com/fastlane/fastlane/issues/14997")
+          expect(UI).to receive(:important).with("There is no app version to watch").exactly(3).times
+          expect(UI).to receive(:message).with("Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)").exactly(3).times
           # Break loop after 3 times
           allow(FastlaneCore::BuildWatcher).to receive(:loop).and_yield.and_yield.and_yield.and_return(nil)
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -119,7 +119,7 @@ describe FastlaneCore::BuildWatcher do
 
       expect do
         FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false)
-      end.to raise_error("FastlaneCore::BuildWatcher found more than 1 matching build: \n#{error_builds}")
+      end.to raise_error(FastlaneCore::BuildWatcherError, "Found more than 1 matching build: \n#{error_builds}")
     end
 
     it 'sleeps 10 seconds by default' do
@@ -331,7 +331,7 @@ describe FastlaneCore::BuildWatcher do
 
           expect do
             FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
-          end.to raise_error("FastlaneCore::BuildWatcher has no app version to watch")
+          end.to raise_error(FastlaneCore::BuildWatcherError, "There is no app version to watch")
         end
       end
 
@@ -364,7 +364,7 @@ describe FastlaneCore::BuildWatcher do
 
           expect do
             FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
-          end.to raise_error("FastlaneCore::BuildWatcher has no app version to watch")
+          end.to raise_error(FastlaneCore::BuildWatcherError, "There is no app version to watch")
         end
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Deliver is unable to automatically select the latest build and submit it for review. 
Resolves #18680

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Request for the latest build will be made in `matching_build` method when `select_latest` is true even if `app_version` is missing. There will be a crash if `app_version` is missing and `select_latest` is false to not loop indefinitely.
Tested by successfully submitting a build for review without setting `app_version`.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
