### PR TITLE
[fastlane_core] fix parsing of passwords with trailing spaces due to wrong whitespace handling in Fastlane::Shell::password method

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -145,7 +145,10 @@ module FastlaneCore
     def password(message)
       verify_interactive!(message)
 
-      ask("#{format_string}#{message.to_s.yellow}") { |q| q.echo = "*" }
+      ask("#{format_string}#{message.to_s.yellow}") do |q|
+        q.whitespace = :chomp
+        q.echo = "*"
+      end
     end
 
     private


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:-->
Resolves #18683

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
The default highline whitespace handling is `:strip` that simply removes all trailing whitespaces (see the [related docs](https://github.com/JEG2/highline/blob/5e4503f659090b8bde69d7d35823540acc6362b9/lib/highline/question.rb#L421)). I changed it to `:chomp`.

I assume that trailing tabs and spaces should be permitted for passwords.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
The following passwords would fail previously:
- "password_with_a_space_in_the_end  "
- "password_with_multiple_spaces_in_the_end       "
- "password_with_multiple_spaces_and_tabs_in_the_end    \t   \t"

In order to test it you can create a keychain with the following command and use one of the passwords from above:
```
$ security create-keychain ~/Library/Keychains/test.keychain-db
```
Next, you should use one of the actions that will try to use that keychain:
1. E.g. by specifying `MATCH_KEYCHAIN_NAME=test` and running match.
2. Or e.g. with `bundle exec fastlane run get_certificates keychain_path:~/Library/Keychains/test.keychain-db`