### PR TITLE
[action][swiftlint] Added support for `--fix mode` option

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -11,13 +11,12 @@ module Fastlane
           UI.user_error!("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
         end
 
+        # See 'Breaking' section release notes here: https://github.com/realm/SwiftLint/releases/tag/0.43.0
         if params[:mode] == :autocorrect && version >= Gem::Version.new('0.43.0')
           UI.deprecated("Your version of swiftlint (#{version}) has deprecated autocorrect mode, please start using fix mode in input param")
           UI.important("For now, switching swiftlint mode `from :autocorrect to :fix` for you 😇")
           params[:mode] = :fix
-        end
-
-        if params[:mode] == :fix && version < Gem::Version.new('0.43.0')
+        elsif params[:mode] == :fix && version < Gem::Version.new('0.43.0')
           UI.important("Your version of swiftlint (#{version}) does not support fix mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
           UI.important("For now, switching swiftlint mode `from :fix to :autocorrect` for you 😇")
           params[:mode] = :autocorrect
@@ -68,7 +67,7 @@ module Fastlane
       end
 
       def self.supported_no_cache_option(params)
-        if params[:mode] == :autocorrect || params[:mode] == :fix || params[:mode] == :lint
+        if [:autocorrect, :fix, :lint].include?(params[:mode])
           return " --no-cache"
         else
           return ""

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -103,7 +103,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :mode,
                                        env_name: "FL_SWIFTLINT_MODE",
                                        description: "SwiftLint mode: :lint, :fix, :autocorrect or :analyze",
-                                       is_string: false,
+                                       type: Symbol,
                                        default_value: :lint,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :path,

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -17,6 +17,12 @@ module Fastlane
           params[:mode] = :fix
         end
 
+        if params[:mode] == :fix && version < Gem::Version.new('0.43.0')
+          UI.deprecated("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
+          UI.important("For now, switching swiftlint mode `from :fix to :autocorrect` for you 😇")
+          params[:mode] = :autocorrect
+        end
+
         mode_format = params[:mode] == :fix ? "--" : ""
         command = (params[:executable] || "swiftlint").dup
         command << " #{mode_format}#{params[:mode]}"

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -18,7 +18,7 @@ module Fastlane
         end
 
         if params[:mode] == :fix && version < Gem::Version.new('0.43.0')
-          UI.deprecated("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
+          UI.important("Your version of swiftlint (#{version}) does not support fix mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
           UI.important("For now, switching swiftlint mode `from :fix to :autocorrect` for you 😇")
           params[:mode] = :autocorrect
         end

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -11,8 +11,15 @@ module Fastlane
           UI.user_error!("Your version of swiftlint (#{version}) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
         end
 
+        if params[:mode] == :autocorrect && version >= Gem::Version.new('0.43.0')
+          UI.deprecated("Your version of swiftlint (#{version}) has deprecated autocorrect mode, please start using fix mode in input param")
+          UI.important("For now, switching swiftlint mode `from :autocorrect to :fix` for you 😇")
+          params[:mode] = :fix
+        end
+
+        mode_format = params[:mode] == :fix ? "--" : ""
         command = (params[:executable] || "swiftlint").dup
-        command << " #{params[:mode]}"
+        command << " #{mode_format}#{params[:mode]}"
         command << optional_flags(params)
 
         if params[:files]
@@ -55,7 +62,7 @@ module Fastlane
       end
 
       def self.supported_no_cache_option(params)
-        if params[:mode] == :autocorrect || params[:mode] == :lint
+        if params[:mode] == :autocorrect || params[:mode] == :fix || params[:mode] == :lint
           return " --no-cache"
         else
           return ""
@@ -89,7 +96,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :mode,
                                        env_name: "FL_SWIFTLINT_MODE",
-                                       description: "SwiftLint mode: :lint, :autocorrect or :analyze",
+                                       description: "SwiftLint mode: :lint, :fix, :autocorrect or :analyze",
                                        is_string: false,
                                        default_value: :lint,
                                        optional: true),

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -205,6 +205,16 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint")
         end
 
+        it "supports fix mode option" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :fix
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint --fix")
+        end
+
         it "supports autocorrect mode option" do
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
@@ -213,6 +223,20 @@ describe Fastlane do
           end").runner.execute(:test)
 
           expect(result).to eq("swiftlint autocorrect")
+        end
+
+        it "switches autocorrect mode to fix mode option if swiftlint does not support it" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.43.0'))
+          expect(FastlaneCore::UI).to receive(:deprecated).with("Your version of swiftlint (0.43.0) has deprecated autocorrect mode, please start using fix mode in input param")
+          expect(FastlaneCore::UI).to receive(:important).with("For now, switching swiftlint mode `from :autocorrect to :fix` for you 😇")
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :autocorrect
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint --fix")
         end
       end
 
@@ -376,6 +400,17 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint --no-cache")
         end
 
+        it "adds no-cache option if mode is :fix" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :fix,
+              no_cache: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint --fix --no-cache")
+        end
+
         it "omits format option if mode is :analyze" do
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
@@ -409,6 +444,17 @@ describe Fastlane do
           end").runner.execute(:test)
 
           expect(result).to eq("swiftlint lint")
+        end
+
+        it "doesn't add no-cache option if mode is :fix" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :fix,
+              no_cache: false
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint --fix")
         end
       end
 

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -206,6 +206,7 @@ describe Fastlane do
         end
 
         it "supports fix mode option" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.43.0'))
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
               mode: :fix
@@ -237,6 +238,20 @@ describe Fastlane do
           end").runner.execute(:test)
 
           expect(result).to eq("swiftlint --fix")
+        end
+
+        it "switches fix mode to autocorrect mode option if swiftlint does not support it" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.42.0'))
+          expect(FastlaneCore::UI).to receive(:deprecated).with("Your version of swiftlint (0.42.0) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
+          expect(FastlaneCore::UI).to receive(:important).with("For now, switching swiftlint mode `from :fix to :autocorrect` for you 😇")
+
+          result = Fastlane::FastFile.new.parse("lane :test do
+            swiftlint(
+              mode: :fix
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint autocorrect")
         end
       end
 
@@ -401,6 +416,8 @@ describe Fastlane do
         end
 
         it "adds no-cache option if mode is :fix" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.43.0'))
+
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
               mode: :fix,
@@ -447,6 +464,8 @@ describe Fastlane do
         end
 
         it "doesn't add no-cache option if mode is :fix" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.43.0'))
+
           result = Fastlane::FastFile.new.parse("lane :test do
             swiftlint(
               mode: :fix,

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -242,7 +242,7 @@ describe Fastlane do
 
         it "switches fix mode to autocorrect mode option if swiftlint does not support it" do
           allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.42.0'))
-          expect(FastlaneCore::UI).to receive(:deprecated).with("Your version of swiftlint (0.42.0) does not support autocorrect mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
+          expect(FastlaneCore::UI).to receive(:important).with("Your version of swiftlint (0.42.0) does not support fix mode.\nUpdate swiftlint using `brew update && brew upgrade swiftlint`")
           expect(FastlaneCore::UI).to receive(:important).with("For now, switching swiftlint mode `from :fix to :autocorrect` for you 😇")
 
           result = Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Resolves #18604
- Recently, Swiftlint has removed the `autocorrect` mode and introduced `--fix` mode (Please see attached screenshot)

### Description (In this PR)
- Added support for `--fix` mode
- Also, based on the Swiftlint version, autocorrect mode will automatically switch to fix mode & vice-versa.
- Added unit tests.

### Testing Steps
- Download demo Xcode project with Swiftlint lane in Zip [MyApp.zip](https://github.com/fastlane/fastlane/files/6488226/MyApp.zip)
- Run `bundle exec fastlane test` 
or
- Update Gemfile and run `bundle install` with
```
gem "fastlane", :git => "git@github.com:crazymanish/fastlane.git", :branch => "swiftlint-fix-mode-support"
```
- Try below lanes
```ruby
lane :test_swiftlint_in_autocorrect_mode do
    swiftlint(mode: :autocorrect)
end

lane :test_swiftlint_in_fix_mode do
    swiftlint(mode: :fix)    
end
```

### Screenshot
<img width="1092" alt="Screenshot 2021-05-15 at 21 30 15" src="https://user-images.githubusercontent.com/5364500/118378442-37df3000-b5d4-11eb-9dc4-3f757fcf411c.png">

.
.
<img width="1034" alt="Screenshot 2021-05-15 at 19 59 09" src="https://user-images.githubusercontent.com/5364500/118378449-3f063e00-b5d4-11eb-9db1-e7e9b6b74cb0.png">
