### PR TITLE
[fastlane_core][configuration] suggestion message improvement when fetching value with non-symbol key

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/configuration.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration.rb
@@ -212,7 +212,7 @@ module FastlaneCore
     # if 'force_ask' is true, the option is not required to be optional to ask
     # rubocop:disable Metrics/PerceivedComplexity
     def fetch(key, ask: true, force_ask: false)
-      UI.crash!("Key '#{key}' must be a symbol. Example :app_id.") unless key.kind_of?(Symbol)
+      UI.crash!("Key '#{key}' must be a symbol. Example :#{key}") unless key.kind_of?(Symbol)
 
       option = verify_options_key!(key)
 

--- a/fastlane_core/spec/configuration_spec.rb
+++ b/fastlane_core/spec/configuration_spec.rb
@@ -671,7 +671,7 @@ describe FastlaneCore do
           it "raises an error if a non symbol was given" do
             expect do
               @config.fetch(123)
-            end.to raise_error("Key '123' must be a symbol. Example :app_id.")
+            end.to raise_error("Key '123' must be a symbol. Example :123")
           end
 
           it "raises an error if this option does not exist" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- When fetching value with non-symbol key Fastlane provides us the suggestion to use symbol key, which was slightly outdated and was using `:app_id` in the example always.

### Description
- Fix the suggestion message, now Fastlane will provide us symbol key suggestion always instead of hardcoded `:app_id`

### Testing Steps
- Updated unit tests
- Nothing changed in functionality 
