### PR TITLE
[supplly] fix update_listing_for_language to work in Ruby 3.0

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -279,7 +279,7 @@ module Supply
     def update_listing_for_language(language: nil, title: nil, short_description: nil, full_description: nil, video: nil)
       ensure_active_edit!
 
-      listing = AndroidPublisher::Listing.new({
+      listing = AndroidPublisher::Listing.new(**{
         language: language,
         title: title,
         full_description: full_description,


### PR DESCRIPTION
### Motivation and Context
Fixes #18698

### Description
Need to add double splat (**) when passing a Hash into `AndroidPublisher::Listing`
