### PR TITLE
[supply][Ruby 3] fix Ruby 3 keyword args issues

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -279,13 +279,13 @@ module Supply
     def update_listing_for_language(language: nil, title: nil, short_description: nil, full_description: nil, video: nil)
       ensure_active_edit!
 
-      listing = AndroidPublisher::Listing.new(**{
+      listing = AndroidPublisher::Listing.new(
         language: language,
         title: title,
         full_description: full_description,
         short_description: short_description,
         video: video
-      })
+      )
 
       call_google_api do
         client.update_edit_listing(

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -233,10 +233,10 @@ module Supply
         end
       end
 
-      AndroidPublisher::LocalizedText.new({
+      AndroidPublisher::LocalizedText.new(
         language: language,
         text: changelog_text
-      })
+      )
     end
 
     def upload_changelogs(release_notes, release, track)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
https://github.com/fastlane/fastlane/issues/18698

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Due to the lack of unit tests, we missed some Ruby 3 keyword args issues. I fixed another issue in `supply/lib/supply/uploader.rb`. 
I checked with `git grep "Google::Apis"` and `git grep "AndroidPublisher::"` but the rest looks okay.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
