### PR TITLE
[fastlane] add --force to fastlane release to ensure homebrew PR gets created

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -323,7 +323,7 @@ end
 
 lane :release_brew do
   version = local_version
-  sh("cd .. && brew bump-formula-pr fastlane --url=https://github.com/fastlane/fastlane/archive/#{version}.tar.gz")
+  sh("cd .. && brew bump-formula-pr fastlane --force --url=https://github.com/fastlane/fastlane/archive/#{version}.tar.gz")
 end
 
 lane :release_github do


### PR DESCRIPTION
### Motivation and Context
Sometimes there is an existing fastlane PR on homebrew core which causes the bump PR to not be created

### Description
Add `--force` to to make sure homebrew bump PR always happens
