### PR TITLE
[spaceship] update AppStoreConnect SandboxTester doc

### DIFF
--- a/spaceship/docs/AppStoreConnect.md
+++ b/spaceship/docs/AppStoreConnect.md
@@ -311,22 +311,27 @@ Right now, _spaceship_ can't modify or create internal testers.
 
 ```ruby
 # Load all sandbox testers
-testers = Spaceship::Tunes::SandboxTester.all
+testers = Spaceship::ConnectAPI::SandboxTester.all
+
+# Delete sandbox testers
+testers.each do |tester|
+  if UI.confirm("Delete #{tester.email}?")
+    tester.delete!
+  end
+end
 
 # Create a sandbox tester
-testers = Spaceship::Tunes::SandboxTester.create!(
-  email: 'sandbox@test.com', # required
-  password: 'Passwordtest1', # required. Must contain >=8 characters, >=1 uppercase, >=1 lowercase, >=1 numeric.
-  country: 'US', # optional, defaults to 'US'
-  first_name: 'Steve', # optional, defaults to 'Test'
-  last_name: 'Brule', # optional, defaults to 'Test'
+testers = Spaceship::ConnectAPI::SandboxTester.create(
+  first_name: "Test", # required
+  last_name: "Three", # required
+  email: "sandbox@test.com", # required
+  password: "Passwordtest1", # required. Must contain >=8 characters, >=1 uppercase, >=1 lowercase, >=1 numeric.
+  confirm_password: "Passwordtest1", # required
+  secret_question: "Question", # required. Must contain >=6 characters
+  secret_answer: "Answer", # required. Must contain >=6 characters
+  birth_date: "1980-03-01", # required
+  app_store_territory: "USA" # required
 )
-
-# Delete sandbox testers by email
-Spaceship::Tunes::SandboxTester.delete!(['sandbox@test.com', 'sandbox2@test.com'])
-
-# Delete all sandbox testers
-Spaceship::Tunes::SandboxTester.delete_all!
 ```
 
 ### App ratings & reviews


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

This doc about creating sandbox tester is using old API.

It seems some people still using old API([ref](https://github.com/fastlane/fastlane/issues/18369#issuecomment-797073099)), this change will solve this problem.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

- changed Spaceship::Tune to Spaceship::ConnectAPI
  - [ref](https://github.com/fastlane/fastlane/pull/16742)
