### PR TITLE
[fastlane_core][pilot] fix pilot is unable to select latest build when distribute_only is true

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -82,9 +82,13 @@ module FastlaneCore
         versions = [watched_app_version, watched_app_version_alternate].compact
 
         if versions.empty?
-          message = watched_build_version.nil? ? "Searching for the latest build" : "Searching for the latest build with build number: #{watched_build_version}"
-          UI.message(message)
-          versions = [nil]
+          if select_latest
+            message = watched_build_version.nil? ? "Searching for the latest build" : "Searching for the latest build with build number: #{watched_build_version}"
+            UI.message(message)
+            versions = [nil]
+          else
+            raise BuildWatcherError.new, "There is no app version to watch"
+          end
         end
 
         version_matches = versions.map do |version|

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -82,13 +82,9 @@ module FastlaneCore
         versions = [watched_app_version, watched_app_version_alternate].compact
 
         if versions.empty?
-          if select_latest
-            UI.message("Watched build version should not be present when there is no app version to watch") unless watched_build_version.nil?
-            UI.message("Searching for the latest build")
-            versions = [nil]
-          else
-            raise BuildWatcherError.new, "There is no app version to watch"
-          end
+          message = watched_build_version.nil? ? "Searching for the latest build" : "Searching for the latest build with build number: #{watched_build_version}"
+          UI.message(message)
+          versions = [nil]
         end
 
         version_matches = versions.map do |version|

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -324,12 +324,12 @@ describe FastlaneCore::BuildWatcher do
 
         it 'returns a ready to submit build when select_latest is true' do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([ready_build])
+          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: , platform: #{ready_build.platform}")
           expect(UI).to receive(:message).with("Searching for the latest build")
           expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: true, return_spaceship_testflight_build: false)
 
           expect(found_build).to eq(ready_build)
@@ -339,6 +339,7 @@ describe FastlaneCore::BuildWatcher do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([processing_build])
           expect(FastlaneCore::BuildWatcher).to receive(:sleep)
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([ready_build])
+          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: , platform: #{ready_build.platform}")
           expect(UI).to receive(:message).with("Searching for the latest build")
@@ -346,7 +347,6 @@ describe FastlaneCore::BuildWatcher do
           expect(UI).to receive(:message).with("Searching for the latest build")
           expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: true, return_spaceship_testflight_build: false)
 
           expect(found_build).to eq(ready_build)
@@ -354,12 +354,12 @@ describe FastlaneCore::BuildWatcher do
 
         it 'returns a ready to submit build when select_latest is false' do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([ready_build])
+          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: , platform: #{ready_build.platform}")
           expect(UI).to receive(:message).with("Searching for the latest build")
           expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
 
           expect(found_build).to eq(ready_build)
@@ -369,6 +369,7 @@ describe FastlaneCore::BuildWatcher do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([processing_build])
           expect(FastlaneCore::BuildWatcher).to receive(:sleep)
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([ready_build])
+          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: , platform: #{ready_build.platform}")
           expect(UI).to receive(:message).with("Searching for the latest build")
@@ -376,7 +377,6 @@ describe FastlaneCore::BuildWatcher do
           expect(UI).to receive(:message).with("Searching for the latest build")
           expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
 
           expect(found_build).to eq(ready_build)
@@ -390,12 +390,12 @@ describe FastlaneCore::BuildWatcher do
 
         it 'returns a ready to submit build when select_latest is true' do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([ready_build])
+          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: #{ready_build.version}, platform: #{ready_build.platform}")
           expect(UI).to receive(:message).with("Searching for the latest build with build number: #{ready_build.version}")
           expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: true, return_spaceship_testflight_build: false)
 
           expect(found_build).to eq(ready_build)
@@ -405,6 +405,7 @@ describe FastlaneCore::BuildWatcher do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([processing_build])
           expect(FastlaneCore::BuildWatcher).to receive(:sleep)
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([ready_build])
+          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: #{ready_build.version}, platform: #{ready_build.platform}")
           expect(UI).to receive(:message).with("Searching for the latest build with build number: #{ready_build.version}")
@@ -412,7 +413,6 @@ describe FastlaneCore::BuildWatcher do
           expect(UI).to receive(:message).with("Searching for the latest build with build number: #{ready_build.version}")
           expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: true, return_spaceship_testflight_build: false)
 
           expect(found_build).to eq(ready_build)
@@ -420,12 +420,12 @@ describe FastlaneCore::BuildWatcher do
 
         it 'returns a ready to submit build when select_latest is false' do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([ready_build])
+          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: #{ready_build.version}, platform: #{ready_build.platform}")
           expect(UI).to receive(:message).with("Searching for the latest build with build number: #{ready_build.version}")
           expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: false, return_spaceship_testflight_build: false)
 
           expect(found_build).to eq(ready_build)
@@ -435,6 +435,7 @@ describe FastlaneCore::BuildWatcher do
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([processing_build])
           expect(FastlaneCore::BuildWatcher).to receive(:sleep)
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([ready_build])
+          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: #{ready_build.version}, platform: #{ready_build.platform}")
           expect(UI).to receive(:message).with("Searching for the latest build with build number: #{ready_build.version}")
@@ -442,7 +443,6 @@ describe FastlaneCore::BuildWatcher do
           expect(UI).to receive(:message).with("Searching for the latest build with build number: #{ready_build.version}")
           expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
 
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
           found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: false, return_spaceship_testflight_build: false)
 
           expect(found_build).to eq(ready_build)

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -352,34 +352,29 @@ describe FastlaneCore::BuildWatcher do
           expect(found_build).to eq(ready_build)
         end
 
-        it 'returns a ready to submit build when select_latest is false' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([ready_build])
+        it 'raises error when select_latest is false' do
+          expect(Spaceship::ConnectAPI::Build).to_not(receive(:all))
           expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: , platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Searching for the latest build")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
+          expect(UI).to_not(receive(:message).with("Searching for the latest build"))
 
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
+          expect do
+            FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
+          end.to raise_error(FastlaneCore::BuildWatcherError, "There is no app version to watch")
         end
 
-        it 'waits when a build is still processing and returns a ready to submit build when select_latest is false' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([processing_build])
-          expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version).and_return([ready_build])
+        # it 'waits when a build is still processing and returns a ready to submit build when select_latest is false' do
+        it 'raises error when build is still processing select_latest is false' do
+          expect(Spaceship::ConnectAPI::Build).to_not(receive(:all))
           expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: , platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Searching for the latest build")
-          expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{processing_build.platform}")
-          expect(UI).to receive(:message).with("Searching for the latest build")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
+          expect(UI).to_not(receive(:message).with("Searching for the latest build"))
 
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
+          expect do
+            FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
+          end.to raise_error(FastlaneCore::BuildWatcherError, "There is no app version to watch")
         end
       end
 
@@ -418,34 +413,28 @@ describe FastlaneCore::BuildWatcher do
           expect(found_build).to eq(ready_build)
         end
 
-        it 'returns a ready to submit build when select_latest is false' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([ready_build])
+        it 'raises error when select_latest is false' do
+          expect(Spaceship::ConnectAPI::Build).to_not(receive(:all))
           expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: #{ready_build.version}, platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Searching for the latest build with build number: #{ready_build.version}")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
+          expect(UI).to_not(receive(:message).with("Searching for the latest build with build number: #{ready_build.version}"))
 
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: false, return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
+          expect do
+            FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: false, return_spaceship_testflight_build: false)
+          end.to raise_error(FastlaneCore::BuildWatcherError, "There is no app version to watch")
         end
 
-        it 'waits when a build is still processing and returns a ready to submit build when select_latest is false' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([processing_build])
-          expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_no_version_but_with_build_number).and_return([ready_build])
+        it 'raises error when build is still processing and select_latest is false' do
+          expect(Spaceship::ConnectAPI::Build).to_not(receive(:all))
           expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: #{ready_build.version}, platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Searching for the latest build with build number: #{ready_build.version}")
-          expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{processing_build.platform}")
-          expect(UI).to receive(:message).with("Searching for the latest build with build number: #{ready_build.version}")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
+          expect(UI).to_not(receive(:message).with("Searching for the latest build with build number: #{ready_build.version}"))
 
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: false, return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
+          expect do
+            FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: false, return_spaceship_testflight_build: false)
+          end.to raise_error(FastlaneCore::BuildWatcherError, "There is no app version to watch")
         end
       end
     end

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -363,19 +363,6 @@ describe FastlaneCore::BuildWatcher do
             FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
           end.to raise_error(FastlaneCore::BuildWatcherError, "There is no app version to watch")
         end
-
-        # it 'waits when a build is still processing and returns a ready to submit build when select_latest is false' do
-        it 'raises error when build is still processing select_latest is false' do
-          expect(Spaceship::ConnectAPI::Build).to_not(receive(:all))
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
-
-          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: , platform: #{ready_build.platform}")
-          expect(UI).to_not(receive(:message).with("Searching for the latest build"))
-
-          expect do
-            FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, poll_interval: 0, select_latest: false, return_spaceship_testflight_build: false)
-          end.to raise_error(FastlaneCore::BuildWatcherError, "There is no app version to watch")
-        end
       end
 
       describe 'with build number' do
@@ -414,18 +401,6 @@ describe FastlaneCore::BuildWatcher do
         end
 
         it 'raises error when select_latest is false' do
-          expect(Spaceship::ConnectAPI::Build).to_not(receive(:all))
-          expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
-
-          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: , build_version: #{ready_build.version}, platform: #{ready_build.platform}")
-          expect(UI).to_not(receive(:message).with("Searching for the latest build with build number: #{ready_build.version}"))
-
-          expect do
-            FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, build_version: '1', poll_interval: 2, select_latest: false, return_spaceship_testflight_build: false)
-          end.to raise_error(FastlaneCore::BuildWatcherError, "There is no app version to watch")
-        end
-
-        it 'raises error when build is still processing and select_latest is false' do
           expect(Spaceship::ConnectAPI::Build).to_not(receive(:all))
           expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -107,7 +107,7 @@ module Pilot
         poll_interval: config[:wait_processing_interval],
         return_when_build_appears: return_when_build_appears,
         return_spaceship_testflight_build: false,
-        select_latest: app_version.nil? && config[:distribute_only]
+        select_latest: config[:distribute_only]
       )
 
       unless latest_build.app_version == app_version && latest_build.version == app_build

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -106,7 +106,8 @@ module Pilot
         build_version: app_build,
         poll_interval: config[:wait_processing_interval],
         return_when_build_appears: return_when_build_appears,
-        return_spaceship_testflight_build: false
+        return_spaceship_testflight_build: false,
+        select_latest: app_version.nil? && config[:distribute_only]
       )
 
       unless latest_build.app_version == app_version && latest_build.version == app_build


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Pilot is unable to automatically select the build with `distribute_only` option, starting from version `2.181.0`. With changes from `2.183.0`, instead of infinite loop in `BuildWatcher`, there was a crash with error message "There is no app version to watch"
Resolves #18606 


### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Analysis done in comment in issue: https://github.com/fastlane/fastlane/issues/18606#issuecomment-842590188
`BuildWatcher` will send a request for the latest build if `app_version` is not provided even if `select_latest` is `false` (which happens for `pilot`).

Tested with specs. 

Not tested by distributing builds available on Testflight yet.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Update `Gemfile` and run `bundle install`:
```ruby
gem "fastlane", :git => "git@github.com:lucgrabowski/fastlane.git", :branch => "lukaszgrabowski-fix-pilot-unable-to-select-build"
```
