### PR TITLE
[resign] fix incorrectly typoed variable name

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -824,7 +824,7 @@ function resign {
                 fi
 
                 OLD_ICLOUD_ENV=$(echo "$ENTITLEMENTS_VALUE" | sed -e 's,<string>\(.*\)</string>,\1,g')
-                if [[ "$CERTIFICATE" =~ "Distribution:" ]]; then
+                if [[ "$certificate_name" =~ "Distribution:" ]]; then
                     NEW_ICLOUD_ENV="Production"
                 else
                     NEW_ICLOUD_ENV="Development"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
As @kapfab found in https://github.com/fastlane/fastlane/pull/18713#issuecomment-843998584, a previous variable name was incorrectly set when fixing a merge conflict. This resolves that.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Changing the variable from `$CERTIFICATE` to the local `$certificate_name` to ensure the correct environment is used when processing iCloud Environment keys

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
