### PR TITLE
[spaceship] Adding missing `beta_testers` attribute to BetaGroup

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/beta_group.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_group.rb
@@ -13,6 +13,8 @@ module Spaceship
       attr_accessor :public_link_limit
       attr_accessor :public_link
 
+      attr_accessor :beta_testers
+
       attr_mapping({
         "name" => "name",
         "createdDate" => "created_date",
@@ -21,7 +23,8 @@ module Spaceship
         "publicLinkId" => "public_link_id",
         "publicLinkLimitEnabled" => "public_link_limit_enabled",
         "publicLinkLimit" => "public_link_limit",
-        "publicLink" => "public_link"
+        "publicLink" => "public_link",
+        "betaTesters" => "beta_testers"
       })
 
       def self.type

--- a/spaceship/lib/spaceship/connect_api/models/beta_group.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_group.rb
@@ -12,7 +12,6 @@ module Spaceship
       attr_accessor :public_link_limit_enabled
       attr_accessor :public_link_limit
       attr_accessor :public_link
-
       attr_accessor :beta_testers
 
       attr_mapping({


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adding a `beta_testers` attribute to the BetaGroup model so that data can be included in calls.

