### PR TITLE
[deliver][spaceship] migrate AgeRatingDeclaration from AppStoreVersion to AppInfo for App Store Connect API 1.3 update

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -342,7 +342,7 @@ module Deliver
 
       set_review_information(version, options)
       set_review_attachment_file(version, options)
-      set_app_rating(version, options)
+      set_app_rating(app_info, options)
     end
 
     # rubocop:enable Metrics/PerceivedComplexity
@@ -642,7 +642,7 @@ module Deliver
       end
     end
 
-    def set_app_rating(version, options)
+    def set_app_rating(app_info, options)
       return unless options[:app_rating_config_path]
 
       require 'json'
@@ -675,9 +675,23 @@ module Deliver
         has_mapped_values = true
         UI.deprecated("Age rating '#{k}' from iTunesConnect has been deprecated. Please replace with '#{v}'")
       end
-      UI.deprecated("You can find more info at https://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values
 
-      age_rating_declaration = version.fetch_age_rating_declaration
+      # Handle App Store Connect deprecation/migrations of keys/values if possible
+      attributes, deprecation_messages, errors = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecations_if_possible!(attributes)
+      deprecation_messages.each do |message|
+        UI.deprecated(message)
+      end
+
+      unless errors.empty?
+        errors.each do |error|
+          UI.error(error)
+          UI.user_error!("There are Age Rating deprecation errors that cannot be solved automatically... Please apply any fixes and try again")
+        end
+      end
+
+      UI.deprecated("You can find more info at https://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values || !deprecation_messages.empty?
+
+      age_rating_declaration = app_info.fetch_age_rating_declaration
       age_rating_declaration.update(attributes: attributes)
     end
   end

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -685,8 +685,8 @@ module Deliver
       unless errors.empty?
         errors.each do |error|
           UI.error(error)
-          UI.user_error!("There are Age Rating deprecation errors that cannot be solved automatically... Please apply any fixes and try again")
         end
+        UI.user_error!("There are Age Rating deprecation errors that cannot be solved automatically... Please apply any fixes and try again")
       end
 
       UI.deprecated("You can find more info at https://docs.fastlane.tools/actions/deliver/#reference") if has_mapped_values || !deprecation_messages.empty?

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -677,7 +677,7 @@ module Deliver
       end
 
       # Handle App Store Connect deprecation/migrations of keys/values if possible
-      attributes, deprecation_messages, errors = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecations_if_possible!(attributes)
+      attributes, deprecation_messages, errors = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecation_if_possible(attributes)
       deprecation_messages.each do |message|
         UI.deprecated(message)
       end

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -601,24 +601,44 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 
 **Keys**
 
-- `violenceCartoonOrFantasy`
-- `violenceRealistic`
-- `violenceRealisticProlongedGraphicOrSadistic`
-- `profanityOrCrudeHumor`
-- `matureOrSuggestiveThemes`
-- `horrorOrFearThemes`
-- `medicalOrTreatmentInformation`
-- `alcoholTobaccoOrDrugUseOrReferences`
-- `gamblingSimulated`
-- `sexualContentOrNudity`
-- `sexualContentGraphicAndNudity`
+- 'alcoholTobaccoOrDrugUseOrReferences'
+- 'contests'
+- 'gambling'
+- 'gamblingSimulated'
+- 'medicalOrTreatmentInformation'
+- 'profanityOrCrudeHumor'
+
+- 'sexualContentGraphicAndNudity'
+- 'sexualContentOrNudity'
+- 'horrorOrFearThemes'
+- 'matureOrSuggestiveThemes'
+- 'unrestrictedWebAccess'
+- 'violenceCartoonOrFantasy'
+- 'violenceRealisticProlongedGraphicOrSadistic'
+- 'violenceRealistic'
+- 'kidsAgeBand'
 
 #### Boolean
 
 **Keys**
 
+- `gambling`
+- 'seventeenPlus'
 - `unrestrictedWebAccess`
-- `gamblingAndContests`
+
+#### Kids Age
+
+**Values**
+
+- `FIVE_AND_UNDER`
+- `SIX_TO_EIGHT`
+- `NINE_TO_ELEVEN`
+- `null`
+
+**Keys**
+
+- `kidsAgeBand`
+
 </details>
 
 <br />

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -6,6 +6,8 @@ module Spaceship
 
       # Rating
       attr_accessor :alcohol_tobacco_or_drug_use_or_references
+      attr_accessor :contests
+      attr_accessor :gambling
       attr_accessor :gambling_simulated
       attr_accessor :medical_or_treatment_information
       attr_accessor :profanity_or_crude_humor
@@ -16,12 +18,15 @@ module Spaceship
       attr_accessor :violence_realistic_prolonged_graphic_or_sadistic
       attr_accessor :violence_realistic
 
-      # boolean
-      attr_accessor :gambling_and_contests
+      # Boolean
+      attr_accessor :seventeen_plus
       attr_accessor :unrestricted_web_access
 
       # KidsAge
       attr_accessor :kids_age_band
+
+      # Deprecated as of App Store Connect API 1.3
+      attr_accessor :gambling_and_contests
 
       module Rating
         NONE = "NONE"
@@ -37,10 +42,12 @@ module Spaceship
 
       attr_mapping({
         "alcoholTobaccoOrDrugUseOrReferences" => "alcohol_tobacco_or_drug_use_or_references",
-        "gamblingAndContests" => "gambling_and_contests",
+        "contests" => "contests",
+        "gambling" => "gambling",
         "gamblingSimulated" => "gambling_simulated",
         "medicalOrTreatmentInformation" => "medical_or_treatment_information",
         "profanityOrCrudeHumor" => "profanity_or_crude_humor",
+        "seventeenPlus" => "seventeen_plus",
         "sexualContentGraphicAndNudity" => "sexual_content_graphic_and_nudity",
         "sexualContentOrNudity" => "sexual_content_or_nudity",
         "horrorOrFearThemes" => "horror_or_fear_themes",
@@ -49,7 +56,10 @@ module Spaceship
         "violenceCartoonOrFantasy" => "violence_cartoon_or_fantasy",
         "violenceRealisticProlongedGraphicOrSadistic" => "violence_realistic_prolonged_graphic_or_sadistic",
         "violenceRealistic" => "violence_realistic",
-        "kidsAgeBand" => "kids_age_band"
+        "kidsAgeBand" => "kids_age_band",
+
+        # Deprecated as of App Store Connect API 1.3
+        "gamblingAndContests" => "gambling_and_contests",
       })
 
       def self.type
@@ -82,6 +92,31 @@ module Spaceship
         0 => false,
         1 => true
       }
+
+      def self.map_deprecations_if_possible!(hash)
+        messages = []
+        errors = []
+
+        # Deprecated as of App Store Connect API 1.3
+        # If 'gamblingAndContests' found, set value for 'contests' and 'gambling'
+        if hash.key?('gamblingAndContests')
+          value = hash.delete('gamblingAndContests')
+
+          # gambling can be mapped without any issues because both 'gamblingAndContests' and 'gambling' are booleans
+          hash['gambling'] = value
+
+          # contests can only be mapped from false to 'NONE' (need to skip and error if true)
+          if value == true
+            errors << "'gamblingAndContests' could not be mapped to 'contests' - 'contests' requires a value of 'NONE', 'INFREQUENT_OR_MILD', or 'FREQUENT_OR_INTENSE'"
+          else
+            hash['contests'] = 'NONE'
+          end
+
+          messages << "Age Rating 'gamblingAndContests' has been deprecated and split into 'gambling' and 'contests'"
+        end
+
+        return hash, messages, errors
+      end
 
       def self.map_key_from_itc(key)
         key = key.gsub("MZGenre.", "")

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -93,30 +93,24 @@ module Spaceship
         1 => true
       }
 
-      def self.map_deprecations_if_possible!(hash)
+      def self.map_deprecation_if_possible(attributes)
+        attributes = attributes.dup
         messages = []
         errors = []
 
-        # Deprecated as of App Store Connect API 1.3
-        # If 'gamblingAndContests' found, set value for 'contests' and 'gambling'
-        if hash.key?('gamblingAndContests')
-          value = hash.delete('gamblingAndContests')
+        value = attributes.delete('gamblingAndContests')
+        return attributes, messages, errors if value.nil?
 
-          # gambling can be mapped without any issues because both 'gamblingAndContests' and 'gambling' are booleans
-          hash['gambling'] = value
+        messages << "Age Rating 'gamblingAndContests' has been deprecated and split into 'gambling' and 'contests'"
 
-          # contests can only be mapped from false to 'NONE' (need to error if true)
-          if value == true
-            errors << "'gamblingAndContests' could not be mapped to 'contests' - 'contests' requires a value of 'NONE', 'INFREQUENT_OR_MILD', or 'FREQUENT_OR_INTENSE'"
-            hash['contests'] = value # setting to unchanged value
-          else
-            hash['contests'] = 'NONE'
-          end
-
-          messages << "Age Rating 'gamblingAndContests' has been deprecated and split into 'gambling' and 'contests'"
+        attributes['gambling'] = value
+        if value == true
+          errors << "'gamblingAndContests' could not be mapped to 'contests' - 'contests' requires a value of 'NONE', 'INFREQUENT_OR_MILD', or 'FREQUENT_OR_INTENSE'"
+        else
+          attributes['contests'] = 'NONE'
         end
 
-        return hash, messages, errors
+        return attributes, messages, errors
       end
 
       def self.map_key_from_itc(key)

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -105,9 +105,10 @@ module Spaceship
           # gambling can be mapped without any issues because both 'gamblingAndContests' and 'gambling' are booleans
           hash['gambling'] = value
 
-          # contests can only be mapped from false to 'NONE' (need to skip and error if true)
+          # contests can only be mapped from false to 'NONE' (need to error if true)
           if value == true
             errors << "'gamblingAndContests' could not be mapped to 'contests' - 'contests' requires a value of 'NONE', 'INFREQUENT_OR_MILD', or 'FREQUENT_OR_INTENSE'"
+            hash['contests'] = value # setting to unchanged value
           else
             hash['contests'] = 'NONE'
           end

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -106,6 +106,7 @@ module Spaceship
         attributes['gambling'] = value
         if value == true
           errors << "'gamblingAndContests' could not be mapped to 'contests' - 'contests' requires a value of 'NONE', 'INFREQUENT_OR_MILD', or 'FREQUENT_OR_INTENSE'"
+          attributes['contests'] = value
         else
           attributes['contests'] = 'NONE'
         end

--- a/spaceship/lib/spaceship/connect_api/models/app_info.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_info.rb
@@ -82,6 +82,16 @@ module Spaceship
       end
 
       #
+      # Age Rating Declaration
+      #
+
+      def fetch_age_rating_declaration(client: nil)
+        client ||= Spaceship::ConnectAPI
+        resp = client.get_age_rating_declaration(app_info_id: id)
+        return resp.to_models.first
+      end
+
+      #
       # App Info Localizations
       #
 

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -110,10 +110,9 @@ module Spaceship
       # Age Rating Declaration
       #
 
+      # @deprecated
       def fetch_age_rating_declaration(client: nil)
-        client ||= Spaceship::ConnectAPI
-        resp = client.get_age_rating_declaration(app_store_version_id: id)
-        return resp.to_models.first
+        raise 'AppStoreVersion no longer as AgeRatingDelcaration as of App Store Connect API 1.3 - Use AppInfo instead'
       end
 
       #

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -18,7 +18,7 @@ module Spaceship
         #
 
         def get_age_rating_declaration(app_info_id: nil, app_store_version_id: nil)
-          raise "Keyword 'app_store_version_id' is deprecated and 'app_info_id' is required" if app_store_version_id || app_info_if.nil?
+          raise "Keyword 'app_store_version_id' is deprecated and 'app_info_id' is required" if app_store_version_id || app_info_id.nil?
 
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
           tunes_request_client.get("appInfos/#{app_info_id}/ageRatingDeclaration", params)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -17,9 +17,13 @@ module Spaceship
         # ageRatingDeclarations
         #
 
-        def get_age_rating_declaration(app_store_version_id: nil)
-          params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("appStoreVersions/#{app_store_version_id}/ageRatingDeclaration", params)
+        def get_age_rating_declaration(app_info_id: nil, app_store_version_id: nil)
+          raise "Keyword 'app_store_version_id' is deprecated and 'app_info_id' is required" if app_store_version_id
+
+          if app_info_id
+            params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
+            tunes_request_client.get("appInfos/#{app_info_id}/ageRatingDeclaration", params)
+          end
         end
 
         def patch_age_rating_declaration(age_rating_declaration_id: nil, attributes: nil)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -18,12 +18,10 @@ module Spaceship
         #
 
         def get_age_rating_declaration(app_info_id: nil, app_store_version_id: nil)
-          raise "Keyword 'app_store_version_id' is deprecated and 'app_info_id' is required" if app_store_version_id
+          raise "Keyword 'app_store_version_id' is deprecated and 'app_info_id' is required" if app_store_version_id || app_info_if.nil?
 
-          if app_info_id
-            params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-            tunes_request_client.get("appInfos/#{app_info_id}/ageRatingDeclaration", params)
-          end
+          params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
+          tunes_request_client.get("appInfos/#{app_info_id}/ageRatingDeclaration", params)
         end
 
         def patch_age_rating_declaration(age_rating_declaration_id: nil, attributes: nil)

--- a/spaceship/spec/connect_api/models/age_rating_declaration_spec.rb
+++ b/spaceship/spec/connect_api/models/age_rating_declaration_spec.rb
@@ -1,0 +1,84 @@
+describe Spaceship::ConnectAPI::AgeRatingDeclaration do
+  let(:from_itc) do
+    {
+      "MZGenre.CARTOON_FANTASY_VIOLENCE" => 0,
+      "REALISTIC_VIOLENCE" => 1,
+      "HORROR" => 2,
+      "UNRESTRICTED_WEB_ACCESS" => 1,
+      "profanityOrCrudeHumor" => "NONE"
+    }
+  end
+
+  let(:asc_1_2_false_gambling) do
+    {
+      "gamblingAndContests" => false
+    }
+  end
+
+  let(:asc_1_2_true_gambling) do
+    {
+      "gamblingAndContests" => true
+    }
+  end
+
+  describe "Helpers" do
+    describe "#map_deprecations_if_possible!" do
+      it "successful migration of gamblingAndContests" do
+        hash, messages, errors = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecations_if_possible!(asc_1_2_false_gambling)
+
+        expect(hash).to eq({
+          "gambling" => false,
+          "contests" => "NONE"
+        })
+        expect(messages).to eq([
+                                 "Age Rating 'gamblingAndContests' has been deprecated and split into 'gambling' and 'contests'"
+                               ])
+        expect(errors).to eq([])
+      end
+
+      it "unsuccessful migration of gamblingAndContests" do
+        hash, messages, errors = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecations_if_possible!(asc_1_2_true_gambling)
+
+        expect(hash).to eq({
+          "gambling" => true,
+          "contests" => true
+        })
+        expect(messages).to eq([
+                                 "Age Rating 'gamblingAndContests' has been deprecated and split into 'gambling' and 'contests'"
+                               ])
+        expect(errors).to eq([
+                               "'gamblingAndContests' could not be mapped to 'contests' - 'contests' requires a value of 'NONE', 'INFREQUENT_OR_MILD', or 'FREQUENT_OR_INTENSE'"
+                             ])
+      end
+    end
+
+    it "#map_key_from_itc" do
+      keys = from_itc.keys.map do |key|
+        Spaceship::ConnectAPI::AgeRatingDeclaration.map_key_from_itc(key)
+      end
+
+      expect(keys).to eq([
+                           "violenceCartoonOrFantasy",
+                           "violenceRealistic",
+                           "horrorOrFearThemes",
+                           "unrestrictedWebAccess",
+                           "profanityOrCrudeHumor"
+                         ])
+    end
+
+    it "#map_value_from_itc" do
+      values = from_itc.map do |key, value|
+        key = Spaceship::ConnectAPI::AgeRatingDeclaration.map_key_from_itc(key)
+        Spaceship::ConnectAPI::AgeRatingDeclaration.map_value_from_itc(key, value)
+      end
+
+      expect(values).to eq([
+                             "NONE",
+                             "INFREQUENT_OR_MILD",
+                             "FREQUENT_OR_INTENSE",
+                             true,
+                             "NONE"
+                           ])
+    end
+  end
+end

--- a/spaceship/spec/connect_api/models/age_rating_declaration_spec.rb
+++ b/spaceship/spec/connect_api/models/age_rating_declaration_spec.rb
@@ -22,9 +22,9 @@ describe Spaceship::ConnectAPI::AgeRatingDeclaration do
   end
 
   describe "Helpers" do
-    describe "#map_deprecations_if_possible!" do
+    describe "#map_deprecation_if_possible" do
       it "successful migration of gamblingAndContests" do
-        hash, messages, errors = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecations_if_possible!(asc_1_2_false_gambling)
+        hash, messages, errors = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecation_if_possible(asc_1_2_false_gambling)
 
         expect(hash).to eq({
           "gambling" => false,
@@ -37,7 +37,7 @@ describe Spaceship::ConnectAPI::AgeRatingDeclaration do
       end
 
       it "unsuccessful migration of gamblingAndContests" do
-        hash, messages, errors = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecations_if_possible!(asc_1_2_true_gambling)
+        hash, messages, errors = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecation_if_possible(asc_1_2_true_gambling)
 
         expect(hash).to eq({
           "gambling" => true,


### PR DESCRIPTION
### Motivation and Context
App Store Connect API released version 1.3 today
- `AgeRatingDelcaration` deprecated on `AppStoreVersion`
- `AgeRatingDeclaration` added as relationship on `AppInfo`
- `gamblingAndContests` split into
  - `gambling` (boolean value)
  - `contests` (string value)
- Added new `seventeenPlus` rating (boolean value)

### Description
- Moved API and helper methods from `AppStoreVersion` to `AppInfo`
- Added a new deprecation method on `AgeRatingDelcaration` to map values to new format if possible
  - Returns the changed Hash
  - Returns deprecation messages to be printed out
  - Returns error messages to be raised
