### PR TITLE
[fastlane_core] ConfigItem - `auto_convert_value` improvements for Boolean type

### DIFF
--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -180,8 +180,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :warnings, env_name: "FL_APPLEDOC_WARNINGS", description: "Documentation generation warnings", is_string: true, optional: true),
 
           # MISCELLANEOUS
-          FastlaneCore::ConfigItem.new(key: :logformat, env_name: "FL_APPLEDOC_LOGFORMAT", description: "Log format [0-3]", is_string: false, optional: true),
-          FastlaneCore::ConfigItem.new(key: :verbose, env_name: "FL_APPLEDOC_VERBOSE", description: "Log verbosity level [0-6,xcode]", is_string: false, optional: true)
+          FastlaneCore::ConfigItem.new(key: :logformat, env_name: "FL_APPLEDOC_LOGFORMAT", description: "Log format [0-3]", type: Integer, optional: true),
+          FastlaneCore::ConfigItem.new(key: :verbose, env_name: "FL_APPLEDOC_VERBOSE", description: "Log verbosity level [0-6,xcode]", type: Integer, optional: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -180,8 +180,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :warnings, env_name: "FL_APPLEDOC_WARNINGS", description: "Documentation generation warnings", is_string: true, optional: true),
 
           # MISCELLANEOUS
-          FastlaneCore::ConfigItem.new(key: :logformat, env_name: "FL_APPLEDOC_LOGFORMAT", description: "Log format [0-3]", type: Integer, optional: true),
-          FastlaneCore::ConfigItem.new(key: :verbose, env_name: "FL_APPLEDOC_VERBOSE", description: "Log verbosity level [0-6,xcode]", type: Integer, optional: true)
+          FastlaneCore::ConfigItem.new(key: :logformat, env_name: "FL_APPLEDOC_LOGFORMAT", description: "Log format [0-3]", is_string: false, optional: true),
+          FastlaneCore::ConfigItem.new(key: :verbose, env_name: "FL_APPLEDOC_VERBOSE", description: "Log verbosity level [0-6,xcode]", is_string: false, optional: true)
         ]
       end
 

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -276,9 +276,9 @@ module FastlaneCore
       elsif data_type != String
         # Special treatment if the user specified true, false or YES, NO
         # There is no boolean type, so we just do it here
-        if %w(YES yes true TRUE).include?(value)
+        if %w(yes YES true TRUE 1).include?(value)
           return true
-        elsif %w(NO no false FALSE).include?(value)
+        elsif %w(no NO false FALSE 0).include?(value)
           return false
         end
       end

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -276,9 +276,9 @@ module FastlaneCore
       elsif data_type != String
         # Special treatment if the user specified true, false, on, off or YES, NO
         # There is no boolean type, so we just do it here
-        if %w(yes YES true TRUE on ON 1).include?(value)
+        if %w(yes YES true TRUE on ON).include?(value)
           return true
-        elsif %w(no NO false FALSE off OFF 0).include?(value)
+        elsif %w(no NO false FALSE off OFF).include?(value)
           return false
         end
       end

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -274,11 +274,11 @@ module FastlaneCore
         rescue JSON::ParserError
         end
       elsif data_type != String
-        # Special treatment if the user specified true, false or YES, NO
+        # Special treatment if the user specified true, false, on, off or YES, NO
         # There is no boolean type, so we just do it here
-        if %w(yes YES true TRUE 1).include?(value)
+        if %w(yes YES true TRUE on ON 1).include?(value)
           return true
-        elsif %w(no NO false FALSE 0).include?(value)
+        elsif %w(no NO false FALSE off OFF 0).include?(value)
           return false
         end
       end

--- a/fastlane_core/spec/config_item_spec.rb
+++ b/fastlane_core/spec/config_item_spec.rb
@@ -101,5 +101,87 @@ describe FastlaneCore do
         end
       end
     end
+
+    describe "ConfigItem Boolean type auto_convert value" do
+      it "auto convert to 'true' Boolean type if default value is 'yes' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "yes")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(true)
+      end
+
+      it "auto convert to 'true' Boolean type if default value is 'YES' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "YES")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(true)
+      end
+
+      it "auto convert to 'true' Boolean type if default value is 'TRUE' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "TRUE")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(true)
+      end
+
+      it "auto convert to 'true' Boolean type if default value is 'true' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "true")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(true)
+      end
+
+      it "auto convert to 'true' Boolean type if default value is '1' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "1")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(true)
+      end
+
+      it "auto convert to 'false' Boolean type if default value is 'no' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "no")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(false)
+      end
+
+      it "auto convert to 'false' Boolean type if default value is 'NO' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "NO")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(false)
+      end
+
+      it "auto convert to 'false' Boolean type if default value is 'FALSE' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "FALSE")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(false)
+      end
+
+      it "auto convert to 'false' Boolean type if default value is 'false' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "false")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(false)
+      end
+
+      it "auto convert to 'false' Boolean type if default value is '0' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "0")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(false)
+      end
+    end
   end
 end

--- a/fastlane_core/spec/config_item_spec.rb
+++ b/fastlane_core/spec/config_item_spec.rb
@@ -151,14 +151,6 @@ describe FastlaneCore do
         expect(auto_convert_value).to be(true)
       end
 
-      it "auto convert to 'true' Boolean type if default value is '1' string" do
-        result = FastlaneCore::ConfigItem.new(key: :foo,
-                                     type: FastlaneCore::Boolean,
-                                     default_value: "1")
-        auto_convert_value = result.auto_convert_value(result.default_value)
-        expect(auto_convert_value).to be(true)
-      end
-
       it "auto convert to 'false' Boolean type if default value is 'no' string" do
         result = FastlaneCore::ConfigItem.new(key: :foo,
                                      type: FastlaneCore::Boolean,
@@ -203,14 +195,6 @@ describe FastlaneCore do
         result = FastlaneCore::ConfigItem.new(key: :foo,
                                      type: FastlaneCore::Boolean,
                                      default_value: "OFF")
-        auto_convert_value = result.auto_convert_value(result.default_value)
-        expect(auto_convert_value).to be(false)
-      end
-
-      it "auto convert to 'false' Boolean type if default value is '0' string" do
-        result = FastlaneCore::ConfigItem.new(key: :foo,
-                                     type: FastlaneCore::Boolean,
-                                     default_value: "0")
         auto_convert_value = result.auto_convert_value(result.default_value)
         expect(auto_convert_value).to be(false)
       end

--- a/fastlane_core/spec/config_item_spec.rb
+++ b/fastlane_core/spec/config_item_spec.rb
@@ -119,6 +119,14 @@ describe FastlaneCore do
         expect(auto_convert_value).to be(true)
       end
 
+      it "auto convert to 'true' Boolean type if default value is 'true' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "true")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(true)
+      end
+
       it "auto convert to 'true' Boolean type if default value is 'TRUE' string" do
         result = FastlaneCore::ConfigItem.new(key: :foo,
                                      type: FastlaneCore::Boolean,
@@ -127,10 +135,18 @@ describe FastlaneCore do
         expect(auto_convert_value).to be(true)
       end
 
-      it "auto convert to 'true' Boolean type if default value is 'true' string" do
+      it "auto convert to 'true' Boolean type if default value is 'on' string" do
         result = FastlaneCore::ConfigItem.new(key: :foo,
                                      type: FastlaneCore::Boolean,
-                                     default_value: "true")
+                                     default_value: "on")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(true)
+      end
+
+      it "auto convert to 'true' Boolean type if default value is 'ON' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "ON")
         auto_convert_value = result.auto_convert_value(result.default_value)
         expect(auto_convert_value).to be(true)
       end
@@ -159,6 +175,14 @@ describe FastlaneCore do
         expect(auto_convert_value).to be(false)
       end
 
+      it "auto convert to 'false' Boolean type if default value is 'false' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "false")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(false)
+      end
+
       it "auto convert to 'false' Boolean type if default value is 'FALSE' string" do
         result = FastlaneCore::ConfigItem.new(key: :foo,
                                      type: FastlaneCore::Boolean,
@@ -167,10 +191,18 @@ describe FastlaneCore do
         expect(auto_convert_value).to be(false)
       end
 
-      it "auto convert to 'false' Boolean type if default value is 'false' string" do
+      it "auto convert to 'false' Boolean type if default value is 'off' string" do
         result = FastlaneCore::ConfigItem.new(key: :foo,
                                      type: FastlaneCore::Boolean,
-                                     default_value: "false")
+                                     default_value: "off")
+        auto_convert_value = result.auto_convert_value(result.default_value)
+        expect(auto_convert_value).to be(false)
+      end
+
+      it "auto convert to 'false' Boolean type if default value is 'OFF' string" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                     type: FastlaneCore::Boolean,
+                                     default_value: "OFF")
         auto_convert_value = result.auto_convert_value(result.default_value)
         expect(auto_convert_value).to be(false)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Fastlane_Core `ENV.truthy?` check for `["no", "false", "off", "0"]` [see here](https://github.com/fastlane/fastlane/blob/master/fastlane_core/lib/fastlane_core/env.rb#L5) but
- Fastlane_Core ConfigItem auto-convert value was using only `NO no false FALSE`

### Description
- Added a couple of more options to ConfigItem for Boolean type auto-convert i.e `off, OFF` for false and `on, ON` for true. 

### Testing Steps
- No existing functionality changed, also added unit tests, 
