### PR TITLE
[fastlane][plugin_manager] Printing comma separated plugin actions

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -326,7 +326,7 @@ module Fastlane
           no_action_found = true
           [current[0].red, current[1][:version_number], "No actions found".red]
         else
-          [current[0], current[1][:version_number], current[1][:actions].join(",\n")]
+          [current[0], current[1][:version_number], current[1][:actions].join(", ")]
         end
       end
 

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -326,7 +326,7 @@ module Fastlane
           no_action_found = true
           [current[0].red, current[1][:version_number], "No actions found".red]
         else
-          [current[0], current[1][:version_number], current[1][:actions].join("\n")]
+          [current[0], current[1][:version_number], current[1][:actions].join(",\n")]
         end
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- When user uses a plugin with multiple actions, Fastlane was printing action-names without comma-separated which is very confusing. [especially when 2 action names can fit into one single line]

### Description
- Now, Fastlane will print plugin action-names with comma-separated.
- This will bring consistency also because Fastlane print all available lanes using comma-separated too [see here](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/runner.rb#L29)

### Testing Steps
- Add a plugin dependency that has multiple actions i.e `fastlane-plugin-slack_bot` and run any lane
- Please see the attached screenshot (Old vs New)

### Screenshot
<img width="759" alt="Screenshot 2021-05-22 at 17 49 54" src="https://user-images.githubusercontent.com/5364500/119232702-76ba3c00-bb26-11eb-8517-a2a90e341fde.png">

