### PR TITLE
[gym] improved provisioning export with odd names in specs

### DIFF
--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -105,40 +105,48 @@ describe Gym::CodeSigningMapping do
       expect(result).to eq({ "identifier.1": "value.1" })
     end
 
-    describe "handle conflicts" do
-      it "Both primary and secondary are available, and both match the export method, it should prefer the primary mapping" do
-        result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-pStoreValue2" },
-                                       secondary_mapping: { "identifier.1" => "Ap-pStoreValue1" },
-                                           export_method: "app-store")
+    context "Both primary and secondary are available" do
+      context "Both match the export method" do
+        it "should prefer the primary mapping" do
+          result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-pStoreValue2" },
+                                         secondary_mapping: { "identifier.1" => "Ap-pStoreValue1" },
+                                             export_method: "app-store")
 
-        expect(result).to eq({ "identifier.1": "Ap-pStoreValue2" })
+          expect(result).to eq({ "identifier.1": "Ap-pStoreValue2" })
+        end
       end
 
-      it "Both primary and secondary are available, and the secondary is the only one that matches the export type" do
-        result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-p StoreValue1" },
-                                       secondary_mapping: { "identifier.1" => "Ad-HocValue" },
-                                           export_method: "app-store")
+      context "The primary is the only one that matches the export type" do
+        it "should prefer the primary mapping" do
+          result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-p StoreValue1" },
+                                         secondary_mapping: { "identifier.1" => "Ad-HocValue" },
+                                             export_method: "app-store")
 
-        expect(result).to eq({ "identifier.1": "Ap-p StoreValue1" })
+          expect(result).to eq({ "identifier.1": "Ap-p StoreValue1" })
+        end
       end
 
-      it "Both primary and secondary are available, and the seocndary is the only one that matches the export type" do
-        result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-p StoreValue1" },
-                                       secondary_mapping: { "identifier.1" => "Ad-HocValue" },
-                                           export_method: "ad-hoc")
+      context "The secondary is the only one that matches the export type" do
+        it "should prefer the secondary mapping" do
+          result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-p StoreValue1" },
+                                         secondary_mapping: { "identifier.1" => "Ad-HocValue" },
+                                             export_method: "ad-hoc")
 
-        expect(result).to eq({ "identifier.1": "Ad-HocValue" })
+          expect(result).to eq({ "identifier.1": "Ad-HocValue" })
+        end
       end
 
-      it "both primary and secondary are available, and neither of them match the export type, it should choose the secondary_mapping" do
-        result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "AppStore" },
-                                       secondary_mapping: { "identifier.1" => "Adhoc" },
-                                           export_method: "development")
+      context "Neither of them match the export type" do
+        it "should choose the secondary_mapping" do
+          result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "AppStore" },
+                                         secondary_mapping: { "identifier.1" => "Adhoc" },
+                                             export_method: "development")
 
-        expect(result).to eq({ "identifier.1": "Adhoc" })
+          expect(result).to eq({ "identifier.1": "Adhoc" })
+        end
       end
 
-      context "when both primary and secondary are available and same value" do
+      context "Both have the same value" do
         let(:result) do
           csm.merge_profile_mapping(primary_mapping: { primary_key => "AppStore" },
                                     secondary_mapping: { secondary_key => "AppStore" },

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -182,26 +182,26 @@ describe Gym::CodeSigningMapping do
         end
       end
     end
+  end
 
-    describe "#test_target?" do
-      let(:csm) { Gym::CodeSigningMapping.new(project: nil) }
-      context "when build_setting include TEST_TARGET_NAME" do
-        it "is test target" do
-          build_settings = { "TEST_TARGET_NAME" => "Sample" }
-          expect(csm.test_target?(build_settings)).to be(true)
-        end
+  describe "#test_target?" do
+    let(:csm) { Gym::CodeSigningMapping.new(project: nil) }
+    context "when build_setting include TEST_TARGET_NAME" do
+      it "is test target" do
+        build_settings = { "TEST_TARGET_NAME" => "Sample" }
+        expect(csm.test_target?(build_settings)).to be(true)
       end
-      context "when build_setting include TEST_HOST" do
-        it "is test target" do
-          build_settings = { "TEST_HOST" => "Sample" }
-          expect(csm.test_target?(build_settings)).to be(true)
-        end
+    end
+    context "when build_setting include TEST_HOST" do
+      it "is test target" do
+        build_settings = { "TEST_HOST" => "Sample" }
+        expect(csm.test_target?(build_settings)).to be(true)
       end
-      context "when build_setting include neither TEST_HOST nor TEST_TARGET_NAME" do
-        it "is not test target" do
-          build_settings = {}
-          expect(csm.test_target?(build_settings)).to be(false)
-        end
+    end
+    context "when build_setting include neither TEST_HOST nor TEST_TARGET_NAME" do
+      it "is not test target" do
+        build_settings = {}
+        expect(csm.test_target?(build_settings)).to be(false)
       end
     end
   end


### PR DESCRIPTION

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Gym provisioning profile resolution for exporting the ipa when detecting profiles from project is not clear in the documentation.

### Description
Gym detects by default the provisioning profiles. The documentation states that it is possible to define the export provisioning profiles. However, the actual resolution is consistent with the specs of `CodeSigningMapping`. This MR only clarifies the spec for the mapping.
