### PR TITLE
[Regression][Ruby 3.0][app_store_connect_api_key] Fix spaceship connect-api token creation

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -40,7 +40,7 @@ module Fastlane
 
         # Creates Spaceship API Key session
         # User does not need to pass the token into any actions because of this
-        Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(key) if options[:set_spaceship_token]
+        Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(**key) if options[:set_spaceship_token]
 
         return key
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Resolves #18754
- In the last release v2.184, PR #18186 introduced the regression 

### Description
- Fix above regression

### Testing Steps
- Update Gemfile and run `bundle install` with
```
gem "fastlane", :git => "git@github.com:crazymanish/fastlane.git", :branch => "app_store_connect_api_key-regression-fix"
```
- Try below lane using `bundle exec fastlane test_regression`
```ruby
lane :test_regression do
    app_store_connect_api_key
end
