### PR TITLE
process the key hash as parameterized arguments.

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -40,7 +40,7 @@ module Fastlane
 
         # Creates Spaceship API Key session
         # User does not need to pass the token into any actions because of this
-        Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(key) if options[:set_spaceship_token]
+        Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(**key) if options[:set_spaceship_token]
 
         return key
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
Fixes an `InvalidArugmentError` raised when trying to creating an app store connect api token.

### Description
Use the double splat operator to treat the hash as parameterized arguments.

### Testing Steps
Set the `:set_spaceship_option` to `true` when calling the `AppStoreConnectApiKeyAction`.
