### PR TITLE
[fastlane team] Improved the README file avatars resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,31 +37,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <tr>
 <td id='iulian-onofrei'>
 <a href='https://github.com/revolter'>
-<img src='https://github.com/revolter.png?size=140'>
+<img src='https://github.com/revolter.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/Revolt666'>Iulian Onofrei</a></h4>
 </td>
 <td id='jimmy-dee'>
 <a href='https://github.com/jdee'>
-<img src='https://github.com/jdee.png?size=140'>
+<img src='https://github.com/jdee.png' width='140px;'>
 </a>
 <h4 align='center'>Jimmy Dee</h4>
 </td>
 <td id='kohki-miki'>
 <a href='https://github.com/giginet'>
-<img src='https://github.com/giginet.png?size=140'>
+<img src='https://github.com/giginet.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/giginet'>Kohki Miki</a></h4>
 </td>
 <td id='josh-holtz'>
 <a href='https://github.com/joshdholtz'>
-<img src='https://github.com/joshdholtz.png?size=140'>
+<img src='https://github.com/joshdholtz.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/joshdholtz'>Josh Holtz</a></h4>
 </td>
 <td id='aaron-brager'>
 <a href='https://github.com/getaaron'>
-<img src='https://github.com/getaaron.png?size=140'>
+<img src='https://github.com/getaaron.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/getaaron'>Aaron Brager</a></h4>
 </td>
@@ -69,31 +69,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <tr>
 <td id='stefan-natchev'>
 <a href='https://github.com/snatchev'>
-<img src='https://github.com/snatchev.png?size=140'>
+<img src='https://github.com/snatchev.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/snatchev'>Stefan Natchev</a></h4>
 </td>
 <td id='manu-wallner'>
 <a href='https://github.com/milch'>
-<img src='https://github.com/milch.png?size=140'>
+<img src='https://github.com/milch.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/acrooow'>Manu Wallner</a></h4>
 </td>
 <td id='jorge-revuelta-h'>
 <a href='https://github.com/minuscorp'>
-<img src='https://github.com/minuscorp.png?size=140'>
+<img src='https://github.com/minuscorp.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/minuscorp'>Jorge Revuelta H</a></h4>
 </td>
 <td id='satoshi-namai'>
 <a href='https://github.com/ainame'>
-<img src='https://github.com/ainame.png?size=140'>
+<img src='https://github.com/ainame.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/ainame'>Satoshi Namai</a></h4>
 </td>
 <td id='jan-piotrowski'>
 <a href='https://github.com/janpio'>
-<img src='https://github.com/janpio.png?size=140'>
+<img src='https://github.com/janpio.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/Sujan'>Jan Piotrowski</a></h4>
 </td>
@@ -101,31 +101,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <tr>
 <td id='felix-krause'>
 <a href='https://github.com/KrauseFx'>
-<img src='https://github.com/KrauseFx.png?size=140'>
+<img src='https://github.com/KrauseFx.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/KrauseFx'>Felix Krause</a></h4>
 </td>
 <td id='fumiya-nakamura'>
 <a href='https://github.com/nafu'>
-<img src='https://github.com/nafu.png?size=140'>
+<img src='https://github.com/nafu.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/nafu003'>Fumiya Nakamura</a></h4>
 </td>
 <td id='andrew-mcburney'>
 <a href='https://github.com/armcburney'>
-<img src='https://github.com/armcburney.png?size=140'>
+<img src='https://github.com/armcburney.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/armcburney'>Andrew McBurney</a></h4>
 </td>
 <td id='luka-mirosevic'>
 <a href='https://github.com/lmirosevic'>
-<img src='https://github.com/lmirosevic.png?size=140'>
+<img src='https://github.com/lmirosevic.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lmirosevic'>Luka Mirosevic</a></h4>
 </td>
 <td id='olivier-halligon'>
 <a href='https://github.com/AliSoftware'>
-<img src='https://github.com/AliSoftware.png?size=140'>
+<img src='https://github.com/AliSoftware.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/aligatr'>Olivier Halligon</a></h4>
 </td>
@@ -133,31 +133,31 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <tr>
 <td id='danielle-tomlinson'>
 <a href='https://github.com/endocrimes'>
-<img src='https://github.com/endocrimes.png?size=140'>
+<img src='https://github.com/endocrimes.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/endocrimes'>Danielle Tomlinson</a></h4>
 </td>
 <td id='max-ott'>
 <a href='https://github.com/max-ott'>
-<img src='https://github.com/max-ott.png?size=140'>
+<img src='https://github.com/max-ott.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/ott_max'>Max Ott</a></h4>
 </td>
 <td id='matthew-ellis'>
 <a href='https://github.com/matthewellis'>
-<img src='https://github.com/matthewellis.png?size=140'>
+<img src='https://github.com/matthewellis.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/mellis1995'>Matthew Ellis</a></h4>
 </td>
 <td id='joshua-liebowitz'>
 <a href='https://github.com/taquitos'>
-<img src='https://github.com/taquitos.png?size=140'>
+<img src='https://github.com/taquitos.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/taquitos'>Joshua Liebowitz</a></h4>
 </td>
 <td id='daniel-jankowski'>
 <a href='https://github.com/mollyIV'>
-<img src='https://github.com/mollyIV.png?size=140'>
+<img src='https://github.com/mollyIV.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/mollyIV'>Daniel Jankowski</a></h4>
 </td>
@@ -165,25 +165,25 @@ If the above doesn't help, please [submit an issue](https://github.com/fastlane/
 <tr>
 <td id='roger-oba'>
 <a href='https://github.com/rogerluan'>
-<img src='https://github.com/rogerluan.png?size=140'>
+<img src='https://github.com/rogerluan.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/rogerluan_'>Roger Oba</a></h4>
 </td>
 <td id='maksym-grebenets'>
 <a href='https://github.com/mgrebenets'>
-<img src='https://github.com/mgrebenets.png?size=140'>
+<img src='https://github.com/mgrebenets.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/mgrebenets'>Maksym Grebenets</a></h4>
 </td>
 <td id='helmut-januschka'>
 <a href='https://github.com/hjanuschka'>
-<img src='https://github.com/hjanuschka.png?size=140'>
+<img src='https://github.com/hjanuschka.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/hjanuschka'>Helmut Januschka</a></h4>
 </td>
 <td id='jérôme-lacoste'>
 <a href='https://github.com/lacostej'>
-<img src='https://github.com/lacostej.png?size=140'>
+<img src='https://github.com/lacostej.png' width='140px;'>
 </a>
 <h4 align='center'><a href='https://twitter.com/lacostej'>Jérôme Lacoste</a></h4>
 </td>

--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ task(:generate_team_table) do
     content << "<tr>" if counter % number_of_rows == 0
     content << "<td id='#{github_user_id}'>"
     content << "<a href='#{github_profile_url}'>"
-    content << "<img src='#{github_profile_url}.png?size=140'>"
+    content << "<img src='#{github_profile_url}.png' width='140px;'>"
     content << "</a>"
     if user_content['twitter']
       content << "<h4 align='center'><a href='https://twitter.com/#{user_content['twitter']}'>#{github_user_name}</a></h4>"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Just notice, README file avatars were `low resolution`

### Description
- Make it better now by using a higher resolution image 😊

### Testing Steps
- **Earlier** low-resolution avatars: https://github.com/fastlane/fastlane#fastlane-team
- **Now** high-resolution avatars: https://github.com/crazymanish/fastlane/tree/read-me-avatars

#### Screenshot
<img width="1816" alt="Screenshot 2021-05-27 at 23 22 19" src="https://user-images.githubusercontent.com/5364500/119898823-9b594e00-bf42-11eb-80ec-8955ffb98649.png">

