### PR TITLE
[spaceship] parse response body as json if not already

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -208,20 +208,25 @@ module Spaceship
       # Overridden from Spaceship::Client
       def handle_error(response)
         body = response.body
-        body = JSON.parse(body) if body.kind_of?(String)
 
-        case response.status.to_i
-        when 401
-          raise UnauthorizedAccessError, format_errors(response) if response && (body || {})['errors']
-        when 403
-          error = (body['errors'] || []).first || {}
-          error_code = error['code']
-          if error_code == "FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED"
-            raise ProgramLicenseAgreementUpdated, format_errors(response) if response && (body || {})['errors']
-          else
-            raise AccessForbiddenError, format_errors(response) if response && (body || {})['errors']
+        unless body.empty?
+          body = JSON.parse(body) if body.kind_of?(String)
+
+          case response.status.to_i
+          when 401
+            raise UnauthorizedAccessError, format_errors(response) if response && (body || {})['errors']
+          when 403
+            error = (body['errors'] || []).first || {}
+            error_code = error['code']
+            if error_code == "FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED"
+              raise ProgramLicenseAgreementUpdated, format_errors(response) if response && (body || {})['errors']
+            else
+              raise AccessForbiddenError, format_errors(response) if response && (body || {})['errors']
+            end
           end
         end
+
+        return false
       end
 
       def format_errors(response)

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -157,6 +157,14 @@ describe Spaceship::ConnectAPI::APIClient do
           client.send(:handle_error, mock_response)
         end.to raise_error(Spaceship::UnauthorizedAccessError, /Unknown error/)
       end
+
+      it 'raises UnauthorizedAccessError when body is string' do
+        allow(mock_response).to receive(:body).and_return('{"errors":[{"title": "Some title", "detail": "some detail"}]}')
+
+        expect do
+          client.send(:handle_error, mock_response)
+        end.to raise_error(Spaceship::UnauthorizedAccessError, /Some title - some detail/)
+      end
     end
 
     describe "status of 403" do
@@ -179,13 +187,19 @@ describe Spaceship::ConnectAPI::APIClient do
       end
 
       it 'raises AccessForbiddenError with no errors in body' do
-        allow(mock_response).to receive(:body).and_return({
-
-        })
+        allow(mock_response).to receive(:body).and_return({})
 
         expect do
           client.send(:handle_error, mock_response)
         end.to raise_error(Spaceship::AccessForbiddenError, /Unknown error/)
+      end
+
+      it 'raises AccessForbiddenError when body is string' do
+        allow(mock_response).to receive(:body).and_return('{"errors":[{"title": "Some title", "detail": "some detail"}]}')
+
+        expect do
+          client.send(:handle_error, mock_response)
+        end.to raise_error(Spaceship::AccessForbiddenError, /Some title - some detail/)
       end
 
       it 'raises AccessForbiddenError with errors in body' do

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -125,4 +125,83 @@ describe Spaceship::ConnectAPI::APIClient do
       end.to raise_error(Spaceship::AccessForbiddenError)
     end
   end
+
+  describe "#handle_error" do
+    let(:mock_token) { double('token') }
+    let(:client) { Spaceship::ConnectAPI::APIClient.new(token: mock_token) }
+    let(:mock_response) { double('response') }
+
+    describe "status of 200" do
+      before(:each) do
+        allow(mock_response).to receive(:status).and_return(200)
+      end
+
+      it 'does not raise' do
+        allow(mock_response).to receive(:body).and_return({})
+
+        expect do
+          client.send(:handle_error, mock_response)
+        end.to_not(raise_error)
+      end
+    end
+
+    describe "status of 401" do
+      before(:each) do
+        allow(mock_response).to receive(:status).and_return(401)
+      end
+
+      it 'raises UnauthorizedAccessError with no errors in body' do
+        allow(mock_response).to receive(:body).and_return({})
+
+        expect do
+          client.send(:handle_error, mock_response)
+        end.to raise_error(Spaceship::UnauthorizedAccessError, /Unknown error/)
+      end
+    end
+
+    describe "status of 403" do
+      before(:each) do
+        allow(mock_response).to receive(:status).and_return(403)
+      end
+
+      it 'raises ProgramLicenseAgreementUpdated with no errors in body FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED' do
+        allow(mock_response).to receive(:body).and_return({
+          "errors" => [
+            {
+              "code" => "FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED"
+            }
+          ]
+        })
+
+        expect do
+          client.send(:handle_error, mock_response)
+        end.to raise_error(Spaceship::ProgramLicenseAgreementUpdated)
+      end
+
+      it 'raises AccessForbiddenError with no errors in body' do
+        allow(mock_response).to receive(:body).and_return({
+
+        })
+
+        expect do
+          client.send(:handle_error, mock_response)
+        end.to raise_error(Spaceship::AccessForbiddenError, /Unknown error/)
+      end
+
+      it 'raises AccessForbiddenError with errors in body' do
+        allow(mock_response).to receive(:body).and_return({
+          "errors" => [
+            {
+              "title" => "Some title",
+              "detail" => "some detail"
+            }
+          ]
+        })
+
+        expect do
+          client.send(:handle_error, mock_response)
+        end.to raise_error(Spaceship::AccessForbiddenError, /Some title - some detail/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`spaceship` failed to parse an api-responses such as expired membership when running `fastlane match`. This MR checks if the respone body is an object of type `String` and parses the body as a JSON object if that is the case (better handling for #18431 and similar failures).

### Description
updates `handle_error` and `format_errors` in `Spaceshipt::ConnectAPIT::APIClient` and checks wether `response.body` is empty or not. uses an empty object if String is empty. Then parses result as JSON if the result is tyoe of string

### Testing Steps
`rspec` and `rubocop` went through as-well as `bundle exec fastlane test`
