### PR TITLE
[regression][pilot] Fix upload using `api_key_path + apple_id` input options

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -400,7 +400,7 @@ module Pilot
         Spaceship::ConnectAPI.token = api_token
       elsif !Spaceship::ConnectAPI.token.nil?
         UI.message("Using existing authorization token for App Store Connect API")
-      }
+      end
 
       return Spaceship::ConnectAPI.token
     end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -366,8 +366,8 @@ module Pilot
     # If there are multiple teams, infer the provider from the selected team name.
     # If there are fewer than two teams, don't infer the provider.
     def transporter_for_selected_team(options)
-      # Ensure that `Spaceship::ConnectAPI.token` is set correctly, if required
-      login
+      # Ensure that user is authenticated
+      start(options)
 
       # Use JWT auth
       api_token = Spaceship::ConnectAPI.token

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -366,8 +366,11 @@ module Pilot
     # If there are multiple teams, infer the provider from the selected team name.
     # If there are fewer than two teams, don't infer the provider.
     def transporter_for_selected_team(options)
+      # Ensure that `Spaceship::ConnectAPI.token` is set correctly, if required
+      login
+
       # Use JWT auth
-      api_token = app_store_connect_api_token(options)
+      api_token = Spaceship::ConnectAPI.token
       unless api_token.nil?
         api_token.refresh! if api_token.expired?
         return FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, api_token.text)
@@ -391,18 +394,6 @@ module Pilot
         UI.verbose("Couldn't infer a provider short name for team with id #{tunes_client.team_id} automatically: #{ex}. Proceeding without provider short name.")
         return generic_transporter
       end
-    end
-
-    # This with return existing authorization token for App Store Connect API or create new token if possible
-    def app_store_connect_api_token(options)
-      if (api_token = Spaceship::ConnectAPI::Token.from(hash: options[:api_key], filepath: options[:api_key_path]))
-        UI.message("Creating authorization token for App Store Connect API")
-        Spaceship::ConnectAPI.token = api_token
-      elsif !Spaceship::ConnectAPI.token.nil?
-        UI.message("Using existing authorization token for App Store Connect API")
-      end
-
-      return Spaceship::ConnectAPI.token
     end
 
     def distribute_build(uploaded_build, options)

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -367,7 +367,7 @@ module Pilot
     # If there are fewer than two teams, don't infer the provider.
     def transporter_for_selected_team(options)
       # Use JWT auth
-      api_token = Spaceship::ConnectAPI.token
+      api_token = app_store_connect_api_token(options)
       unless api_token.nil?
         api_token.refresh! if api_token.expired?
         return FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, api_token.text)
@@ -391,6 +391,18 @@ module Pilot
         UI.verbose("Couldn't infer a provider short name for team with id #{tunes_client.team_id} automatically: #{ex}. Proceeding without provider short name.")
         return generic_transporter
       end
+    end
+
+    # This with return existing authorization token for App Store Connect API or create new token if possible
+    def app_store_connect_api_token(options)
+      if (api_token = Spaceship::ConnectAPI::Token.from(hash: options[:api_key], filepath: options[:api_key_path]))
+        UI.message("Creating authorization token for App Store Connect API")
+        Spaceship::ConnectAPI.token = api_token
+      elsif !Spaceship::ConnectAPI.token.nil?
+        UI.message("Using existing authorization token for App Store Connect API")
+      }
+
+      return Spaceship::ConnectAPI.token
     end
 
     def distribute_build(uploaded_build, options)

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -501,8 +501,8 @@ describe "Build Manager" do
       end
 
       it "NOT when skip_waiting_for_build_processing and apple_id are set" do
-        # should execute Manager.login (which will set `spaceship token` if required)
-        expect(fake_build_manager).to (receive(:login))
+        # should not execute Manager.login (which does spaceship login)
+        expect(fake_build_manager).not_to (receive(:login))
 
         fake_build_manager.upload(upload_options)
       end
@@ -560,10 +560,6 @@ describe "Build Manager" do
           "name" => "456 name"
         }
       }
-    end
-
-    before(:each) do
-      allow(fake_manager).to receive(:login)
     end
 
     it "with API token" do

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -563,9 +563,12 @@ describe "Build Manager" do
     end
 
     describe "with API token" do
+      before(:each) do
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
+      end
+
       it "uses the existing API token if possible" do
         options = {}
-        allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
         expect(UI).to receive(:message).with("Using existing authorization token for App Store Connect API")
 
         transporter = fake_manager.send(:transporter_for_selected_team, options)
@@ -580,7 +583,6 @@ describe "Build Manager" do
         options[:api_key] = "api_key"
         options[:api_key_path] = "api_key_path"
 
-        allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
         expect(Spaceship::ConnectAPI::Token).to receive(:from).with(hash: "api_key", filepath: "api_key_path").and_return(true)
         expect(UI).to receive(:message).with("Creating authorization token for App Store Connect API")
         expect(Spaceship::ConnectAPI).to receive(:token=)

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -562,15 +562,35 @@ describe "Build Manager" do
       }
     end
 
-    it "with API token" do
-      options = {}
-      allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
+    describe "with API token" do
+      it "uses the existing API token if possible" do
+        options = {}
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
+        expect(UI).to receive(:message).with("Using existing authorization token for App Store Connect API")
 
-      transporter = fake_manager.send(:transporter_for_selected_team, options)
-      expect(transporter.instance_variable_get(:@jwt)).not_to(be_nil)
-      expect(transporter.instance_variable_get(:@user)).to be_nil
-      expect(transporter.instance_variable_get(:@password)).to be_nil
-      expect(transporter.instance_variable_get(:@provider_short_name)).to be_nil
+        transporter = fake_manager.send(:transporter_for_selected_team, options)
+        expect(transporter.instance_variable_get(:@jwt)).not_to(be_nil)
+        expect(transporter.instance_variable_get(:@user)).to be_nil
+        expect(transporter.instance_variable_get(:@password)).to be_nil
+        expect(transporter.instance_variable_get(:@provider_short_name)).to be_nil
+      end
+
+      it "creates and sets new API token if required" do
+        options = {}
+        options[:api_key] = "api_key"
+        options[:api_key_path] = "api_key_path"
+
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
+        expect(Spaceship::ConnectAPI::Token).to receive(:from).with(hash: "api_key", filepath: "api_key_path").and_return(true)
+        expect(UI).to receive(:message).with("Creating authorization token for App Store Connect API")
+        expect(Spaceship::ConnectAPI).to receive(:token=)
+
+        transporter = fake_manager.send(:transporter_for_selected_team, options)
+        expect(transporter.instance_variable_get(:@jwt)).not_to(be_nil)
+        expect(transporter.instance_variable_get(:@user)).to be_nil
+        expect(transporter.instance_variable_get(:@password)).to be_nil
+        expect(transporter.instance_variable_get(:@provider_short_name)).to be_nil
+      end
     end
 
     describe "with itc_provider" do

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -502,7 +502,7 @@ describe "Build Manager" do
 
       it "NOT when skip_waiting_for_build_processing and apple_id are set" do
         # should not execute Manager.login (which does spaceship login)
-        expect(fake_build_manager).not_to (receive(:login))
+        expect(fake_build_manager).not_to(receive(:login))
 
         fake_build_manager.upload(upload_options)
       end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -567,9 +567,11 @@ describe "Build Manager" do
         allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
       end
 
-      it "uses the existing API token if possible" do
-        options = {}
+      it "uses the existing API token if found" do
+        expect(Spaceship::ConnectAPI::Token).to receive(:from).with(hash: nil, filepath: nil).and_return(false)
         expect(UI).to receive(:message).with("Using existing authorization token for App Store Connect API")
+
+        options = {}
 
         transporter = fake_manager.send(:transporter_for_selected_team, options)
         expect(transporter.instance_variable_get(:@jwt)).not_to(be_nil)
@@ -578,14 +580,14 @@ describe "Build Manager" do
         expect(transporter.instance_variable_get(:@provider_short_name)).to be_nil
       end
 
-      it "creates and sets new API token if required" do
-        options = {}
-        options[:api_key] = "api_key"
-        options[:api_key_path] = "api_key_path"
-
+      it "creates and sets new API token using the input api_key and api_key_path" do
         expect(Spaceship::ConnectAPI::Token).to receive(:from).with(hash: "api_key", filepath: "api_key_path").and_return(true)
         expect(UI).to receive(:message).with("Creating authorization token for App Store Connect API")
         expect(Spaceship::ConnectAPI).to receive(:token=)
+
+        options = {}
+        options[:api_key] = "api_key"
+        options[:api_key_path] = "api_key_path"
 
         transporter = fake_manager.send(:transporter_for_selected_team, options)
         expect(transporter.instance_variable_get(:@jwt)).not_to(be_nil)

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -501,8 +501,8 @@ describe "Build Manager" do
       end
 
       it "NOT when skip_waiting_for_build_processing and apple_id are set" do
-        # should not execute Manager.login (which does spaceship login)
-        expect(fake_build_manager).not_to(receive(:login))
+        # should execute Manager.login (which will set `spaceship token` if required)
+        expect(fake_build_manager).to (receive(:login))
 
         fake_build_manager.upload(upload_options)
       end
@@ -562,38 +562,19 @@ describe "Build Manager" do
       }
     end
 
-    describe "with API token" do
-      before(:each) do
-        allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
-      end
+    before(:each) do
+      allow(fake_manager).to receive(:login)
+    end
 
-      it "uses the existing API token if found" do
-        expect(UI).to receive(:message).with("Using existing authorization token for App Store Connect API")
+    it "with API token" do
+      options = {}
+      allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
 
-        options = {}
-
-        transporter = fake_manager.send(:transporter_for_selected_team, options)
-        expect(transporter.instance_variable_get(:@jwt)).not_to(be_nil)
-        expect(transporter.instance_variable_get(:@user)).to be_nil
-        expect(transporter.instance_variable_get(:@password)).to be_nil
-        expect(transporter.instance_variable_get(:@provider_short_name)).to be_nil
-      end
-
-      it "creates and sets new API token using the input api_key and api_key_path params" do
-        expect(Spaceship::ConnectAPI::Token).to receive(:from).with(hash: "api_key", filepath: "api_key_path").and_return(true)
-        expect(UI).to receive(:message).with("Creating authorization token for App Store Connect API")
-        expect(Spaceship::ConnectAPI).to receive(:token=)
-
-        options = {}
-        options[:api_key] = "api_key"
-        options[:api_key_path] = "api_key_path"
-
-        transporter = fake_manager.send(:transporter_for_selected_team, options)
-        expect(transporter.instance_variable_get(:@jwt)).not_to(be_nil)
-        expect(transporter.instance_variable_get(:@user)).to be_nil
-        expect(transporter.instance_variable_get(:@password)).to be_nil
-        expect(transporter.instance_variable_get(:@provider_short_name)).to be_nil
-      end
+      transporter = fake_manager.send(:transporter_for_selected_team, options)
+      expect(transporter.instance_variable_get(:@jwt)).not_to(be_nil)
+      expect(transporter.instance_variable_get(:@user)).to be_nil
+      expect(transporter.instance_variable_get(:@password)).to be_nil
+      expect(transporter.instance_variable_get(:@provider_short_name)).to be_nil
     end
 
     describe "with itc_provider" do

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -568,7 +568,6 @@ describe "Build Manager" do
       end
 
       it "uses the existing API token if found" do
-        expect(Spaceship::ConnectAPI::Token).to receive(:from).with(hash: nil, filepath: nil).and_return(false)
         expect(UI).to receive(:message).with("Using existing authorization token for App Store Connect API")
 
         options = {}

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -580,7 +580,7 @@ describe "Build Manager" do
         expect(transporter.instance_variable_get(:@provider_short_name)).to be_nil
       end
 
-      it "creates and sets new API token using the input api_key and api_key_path" do
+      it "creates and sets new API token using the input api_key and api_key_path params" do
         expect(Spaceship::ConnectAPI::Token).to receive(:from).with(hash: "api_key", filepath: "api_key_path").and_return(true)
         expect(UI).to receive(:message).with("Creating authorization token for App Store Connect API")
         expect(Spaceship::ConnectAPI).to receive(:token=)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Resolves #18767
- In the last release v2.184, PR #18186 introduced the regression in pilot upload when using `api_key_path + apple_id` input options

#### More details:
- **Pilot don't login** when `apple_id` input option is given...please [see here](https://github.com/fastlane/fastlane/blob/master/pilot/lib/pilot/build_manager.rb#L16)
- Also, CLI `api_key_path` input param **does not set** `Spaceship::ConnectAPI.token` same as [app_store_connect_api_key](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb#L43) action

Now, the **problem** is: When pilot is trying to upload binary, there is no Token for [ItunesTransporter](https://github.com/fastlane/fastlane/blob/master/pilot/lib/pilot/build_manager.rb#L370), and pilot is not trying to generate a new token using the given `api_key_path` input option which is exactly happening in #18767
and
User doesn't see this problem when apple_id not given because in that case, pilot `always do login` and **sets**  the `Spaceship::ConnectAPI.token` at the starting itself...[see here](https://github.com/fastlane/fastlane/blob/master/pilot/lib/pilot/build_manager.rb#L16)

### Description
- Fix the above regression

### Testing Steps
- Update Gemfile and run `bundle install` with
```
gem "fastlane", :git => "git@github.com:fastlane/fastlane.git", :branch => "crazymanish-pilot-token-creation-fix"
```
- Try pilot's upload using  CLI
```bash
bundle exec fastlane pilot upload --api_key_path /Users/runner/work/_temp/api_key***.json -p 1528xxxxxx`
```
