### PR TITLE
[docs] Fixed the broken `pry` links inside the ToolsAndDebugging.md

### DIFF
--- a/ToolsAndDebugging.md
+++ b/ToolsAndDebugging.md
@@ -2,9 +2,9 @@
 
 For detailed instructions on how to get started with contributing to _fastlane_, first check out [YourFirstPR.md][first-pr] and [Testing.md](Testing.md). This guide will focus on more advanced instructions on how to debug _fastlane_ and _spaceship_ issues and work on patches.
 
-## Debug using [pry](http://pryrepl.org/)
+## Debug using [pry](http://pry.github.io/)
 
-Before you’re able to use [pry](http://pryrepl.org/), make sure to have completed the [YourFirstPR.md][first-pr] setup part, as this will install all required development dependencies.
+Before you’re able to use [pry](http://pry.github.io/), make sure to have completed the [YourFirstPR.md][first-pr] setup part, as this will install all required development dependencies.
 
 To add a breakpoint anywhere in the _fastlane_ codebase, add the following 2 lines wherever you want to jump in
 

--- a/ToolsAndDebugging.md
+++ b/ToolsAndDebugging.md
@@ -4,7 +4,7 @@ For detailed instructions on how to get started with contributing to _fastlane_,
 
 ## Debug using [pry](https://pry.github.io/)
 
-Before you’re able to use [pry](http://pry.github.io/), make sure to have completed the [YourFirstPR.md][first-pr] setup part, as this will install all required development dependencies.
+Before you’re able to use [pry](https://pry.github.io/), make sure to have completed the [YourFirstPR.md][first-pr] setup part, as this will install all required development dependencies.
 
 To add a breakpoint anywhere in the _fastlane_ codebase, add the following 2 lines wherever you want to jump in
 

--- a/ToolsAndDebugging.md
+++ b/ToolsAndDebugging.md
@@ -2,7 +2,7 @@
 
 For detailed instructions on how to get started with contributing to _fastlane_, first check out [YourFirstPR.md][first-pr] and [Testing.md](Testing.md). This guide will focus on more advanced instructions on how to debug _fastlane_ and _spaceship_ issues and work on patches.
 
-## Debug using [pry](http://pry.github.io/)
+## Debug using [pry](https://pry.github.io/)
 
 Before you’re able to use [pry](http://pry.github.io/), make sure to have completed the [YourFirstPR.md][first-pr] setup part, as this will install all required development dependencies.
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- I was reading `ToolsAndDebugging.md` and notice that `pry` links were broken, giving 404

### Description
- Fixed the broken `pry` links inside the ToolsAndDebugging.md

### Testing Steps
- **Broken** ToolsAndDebugging.md: https://github.com/fastlane/fastlane/blob/master/ToolsAndDebugging.md#debug-using-pry
- **Fixed** ToolsAndDebugging.md: https://github.com/fastlane/fastlane/blob/crazymanish-ToolsAndDebugging-update/ToolsAndDebugging.md#debug-using-pry
