### PR TITLE
[Fastlane.Swift] Fix complexity limits introduced in Swift 5.4

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -325,7 +325,8 @@ module Fastlane
       if args.empty?
         implm += "let args: [RubyCommand.Argument] = []\n"
       else
-        implm += "let args = [#{args.group_by { |h| h[:name] }.keys.join(",\n")}]\n"
+        implm += "let array: [RubyCommand.Argument?] = [#{args.group_by { |h| h[:name] }.keys.join(",\n")}]\n"
+        implm += "let args: [RubyCommand.Argument] = array\n"
         implm += ".filter { $0?.value != nil }\n"
         implm += ".compactMap { $0 }\n"
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Swift 5.4 introduced new complexity limits so it prevented FastlaneRunner to build with the new Xcode 12.5. Fixes #18740.

### Description
This PR breaks the `filter` + `compactMap` in two expressions to prevent compiler errors.

### Testing Steps
1. Checkout and install this branch.
2. Open `FastlaneSwiftRunner` project and build it.
3. 🚀 
