### PR TITLE
[action][adb_devices] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/adb_devices.rb
+++ b/fastlane/lib/fastlane/actions/adb_devices.rb
@@ -27,7 +27,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :adb_path,
                                        env_name: "FL_ADB_PATH",
                                        description: "The path to your `adb` binary (can be left blank if the ANDROID_SDK_ROOT environment variable is set)",
-                                       is_string: true,
                                        optional: true,
                                        default_value: "adb")
         ]

--- a/fastlane/spec/actions_specs/adb_devices_spec.rb
+++ b/fastlane/spec/actions_specs/adb_devices_spec.rb
@@ -17,6 +17,16 @@ describe Fastlane do
 
         expect(result).to match_array([])
       end
+
+      it "calls AdbHelper for loading all the devices" do
+        expect_any_instance_of(Fastlane::Helper::AdbHelper).to receive(:load_all_devices).and_return([1, 2, 3])
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb_devices
+        end").runner.execute(:test)
+
+        expect(result).to match_array([1, 2, 3])
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safter, and Swift generation more correct.
- This PR does this for only `adb_devices` action.

### Description
- Remove is_string from adb_path param

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.
