### PR TITLE
[action][adb] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/adb.rb
+++ b/fastlane/lib/fastlane/actions/adb.rb
@@ -27,18 +27,15 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :serial,
                                        env_name: "FL_ANDROID_SERIAL",
                                        description: "Android serial of the device to use for this command",
-                                       is_string: true,
                                        default_value: ""),
           FastlaneCore::ConfigItem.new(key: :command,
                                        env_name: "FL_ADB_COMMAND",
                                        description: "All commands you want to pass to the adb command, e.g. `kill-server`",
-                                       optional: true,
-                                       is_string: true),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :adb_path,
                                        env_name: "FL_ADB_PATH",
                                        optional: true,
                                        description: "The path to your `adb` binary (can be left blank if the ANDROID_SDK_ROOT, ANDROID_HOME or ANDROID_SDK environment variable is set)",
-                                       is_string: true,
                                        default_value: "adb")
         ]
       end

--- a/fastlane/spec/actions_specs/adb_spec.rb
+++ b/fastlane/spec/actions_specs/adb_spec.rb
@@ -1,6 +1,21 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "adb" do
+      it "calls AdbHelper to trigger command" do
+        expect_any_instance_of(Fastlane::Helper::AdbHelper)
+          .to receive(:trigger)
+          .with(command: "fake command", serial: "fake serial")
+          .and_return("some stub adb response")
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          adb(command: 'fake command', serial: 'fake serial')
+        end").runner.execute(:test)
+
+        expect(result).to eq("some stub adb response")
+      end
+    end
+
+    describe "adb on non windows" do
       before(:each) do
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safter, and Swift generation more correct.
- This PR does this for only `adb` action.

### Description
- Remove is_string from adb_path param

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.