### PR TITLE
[action][unlock_keychain] Fix randomly failing unit tests for Ubuntu

### DIFF
--- a/fastlane/spec/actions_specs/unlock_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/unlock_keychain_spec.rb
@@ -3,10 +3,6 @@ describe Fastlane do
     describe "Unlock keychain Integration" do
       let(:keychain_path) { Tempfile.new('foo').path }
 
-      before(:each) do
-        allow(FastlaneCore::Helper).to receive(:keychain_path).with(keychain_path).and_return(keychain_path)
-      end
-
       it "works with path and password and existing keychain" do
         result = Fastlane::FastFile.new.parse("lane :test do
           unlock_keychain ({

--- a/fastlane/spec/actions_specs/unlock_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/unlock_keychain_spec.rb
@@ -1,9 +1,13 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Unlock keychain Integration" do
-      it "works with path and password and existing keychain" do
-        keychain_path = Tempfile.new('foo').path
+      let(:keychain_path) { Tempfile.new('foo').path }
 
+      before(:each) do
+        allow(FastlaneCore::Helper).to receive(:keychain_path).with(keychain_path).and_return(keychain_path)
+      end
+
+      it "works with path and password and existing keychain" do
         result = Fastlane::FastFile.new.parse("lane :test do
           unlock_keychain ({
             path: '#{keychain_path}',
@@ -19,8 +23,6 @@ describe Fastlane do
       end
 
       it "doesn't add keychain to search list" do
-        keychain_path = Tempfile.new('foo').path
-
         result = Fastlane::FastFile.new.parse("lane :test do
           unlock_keychain ({
             path: '#{keychain_path}',
@@ -35,8 +37,6 @@ describe Fastlane do
       end
 
       it "replace keychain in search list" do
-        keychain_path = Tempfile.new('foo').path
-
         result = Fastlane::FastFile.new.parse("lane :test do
           unlock_keychain ({
             path: '#{keychain_path}',
@@ -52,8 +52,6 @@ describe Fastlane do
       end
 
       it "set default keychain" do
-        keychain_path = Tempfile.new('foo').path
-
         result = Fastlane::FastFile.new.parse("lane :test do
           unlock_keychain ({
             path: '#{keychain_path}',


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `unlock_keychain` spec was failing randomly on CI only for Ubuntu
- Failing CI job: https://app.circleci.com/pipelines/github/fastlane/fastlane/2973/workflows/d0d44212-5f02-4d39-8bcc-d1875b9d50de/jobs/69125
or
https://app.circleci.com/pipelines/github/fastlane/fastlane/2972/workflows/768e3b5c-0aa6-4910-9e98-36770f013f74/jobs/69120

### Description
- Now using mock for the `FastlaneCore::Helper` keychain_path 

### Testing Steps
- CI should pass now for all the jobs! 
- Run spec in local using: `bundle exec rspec fastlane/spec/actions_specs/unlock_keychain_spec.rb`
