### PR TITLE
[action][add_extra_platforms] Added spec file and missing unit-tests

### DIFF
--- a/fastlane/spec/actions_specs/add_extra_platforms_spec.rb
+++ b/fastlane/spec/actions_specs/add_extra_platforms_spec.rb
@@ -1,0 +1,19 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "add_extra_platforms" do
+      before(:each) do
+        allow(Fastlane::SupportedPlatforms).to receive(:all).and_return([:ios, :macos, :android])
+      end
+
+      it "updates the extra supported platforms" do
+        expect(UI).to receive(:verbose).with("Before injecting extra platforms: [:ios, :macos, :android]")
+        expect(Fastlane::SupportedPlatforms).to receive(:extra=).with([:windows, :neogeo])
+        expect(UI).to receive(:verbose).with("After injecting extra platforms ([:windows, :neogeo])...: [:ios, :macos, :android]")
+
+        Fastlane::FastFile.new.parse("lane :test do
+          add_extra_platforms(platforms: [:windows, :neogeo])
+        end").runner.execute(:test)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- There was no spec file for `add_extra_platforms` action

### Description
- In this PR, Added spec file and missing unit-tests

### Testing Steps
- bundle exec rspec fastlane/spec/actions_specs/add_extra_platforms_spec.rb
