### PR TITLE
[action][add_git_tag] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -63,7 +63,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :includes_lane,
                                        env_name: "FL_GIT_TAG_INCLUDES_LANE",
                                        description: "Whether the current lane should be included in the tag and message composition, e.g. '<grouping>/<lane>/<prefix><build_number><postfix>'",
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :prefix,
                                        env_name: "FL_GIT_TAG_PREFIX",
@@ -78,7 +78,7 @@ module Fastlane
                                        description: "The build number. Defaults to the result of increment_build_number if you\'re using it",
                                        default_value: Actions.lane_context[Actions::SharedValues::BUILD_NUMBER],
                                        default_value_dynamic: true,
-                                       is_string: false,
+                                       type: Integer,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "FL_GIT_TAG_MESSAGE",
@@ -94,13 +94,13 @@ module Fastlane
                                        env_name: "FL_GIT_TAG_FORCE",
                                        description: "Force adding the tag",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :sign,
                                        env_name: "FL_GIT_TAG_SIGN",
                                        description: "Make a GPG-signed tag, using the default e-mail address's key",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false)
         ]
       end

--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -78,7 +78,7 @@ module Fastlane
                                        description: "The build number. Defaults to the result of increment_build_number if you\'re using it",
                                        default_value: Actions.lane_context[Actions::SharedValues::BUILD_NUMBER],
                                        default_value_dynamic: true,
-                                       skip_type_validation: true, # skipping validation because we allow integer and string both
+                                       skip_type_validation: true, # skipping validation because we both allow integer and string
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "FL_GIT_TAG_MESSAGE",

--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -78,7 +78,7 @@ module Fastlane
                                        description: "The build number. Defaults to the result of increment_build_number if you\'re using it",
                                        default_value: Actions.lane_context[Actions::SharedValues::BUILD_NUMBER],
                                        default_value_dynamic: true,
-                                       type: Integer,
+                                       skip_type_validation: true, # skipping validation because we allow integer and string both
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "FL_GIT_TAG_MESSAGE",

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -154,7 +154,7 @@ describe Fastlane do
           add_git_tag ({
             tag: '#{tag}',
             grouping: 'grouping',
-            build_number: #{build_number},
+            build_number: 'build_number',
             prefix: 'prefix',
           })
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/add_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/add_git_tag_spec.rb
@@ -9,6 +9,55 @@ describe Fastlane do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER] = build_number
       end
 
+      context "when 'includes_lane' option is enabled" do
+        it "appends lane_name in the tag and git message" do
+          lane_name = "fake_lane_name"
+          message = "builds/#{lane_name}/#{build_number} (fastlane)"
+          tag = "builds/#{lane_name}/#{build_number}"
+
+          expect(UI).to receive(:message).with("Adding git tag '#{tag.shellescape}' 🎯.")
+          expect(Fastlane::Actions).to receive(:sh).with("git tag -am #{message.shellescape} #{tag.shellescape}")
+
+          Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+          options = FastlaneCore::Configuration.create(Fastlane::Actions::AddGitTagAction.available_options, {})
+
+          Fastlane::Actions::AddGitTagAction.run(options)
+        end
+
+        it "removes spaces from lane_name before appending it in the tag and git message" do
+          lane_name = "fake lane name with spaces"
+          lane_name_without_spaces = "fakelanenamewithspaces"
+          message = "builds/#{lane_name_without_spaces}/#{build_number} (fastlane)"
+          tag = "builds/#{lane_name_without_spaces}/#{build_number}"
+
+          expect(UI).to receive(:message).with("Adding git tag '#{tag.shellescape}' 🎯.")
+          expect(Fastlane::Actions).to receive(:sh).with("git tag -am #{message.shellescape} #{tag.shellescape}")
+
+          Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+          options = FastlaneCore::Configuration.create(Fastlane::Actions::AddGitTagAction.available_options, {})
+
+          Fastlane::Actions::AddGitTagAction.run(options)
+        end
+      end
+
+      context "when 'includes_lane' option is not enabled" do
+        it "doesn't append lane_name in the tag and git message" do
+          lane_name = "fake_lane_name"
+          message = "builds/#{build_number} (fastlane)"
+          tag = "builds/#{build_number}"
+
+          expect(UI).to receive(:message).with("Adding git tag '#{tag.shellescape}' 🎯.")
+          expect(Fastlane::Actions).to receive(:sh).with("git tag -am #{message.shellescape} #{tag.shellescape}")
+
+          Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = lane_name
+          options = FastlaneCore::Configuration.create(Fastlane::Actions::AddGitTagAction.available_options, {
+            includes_lane: false,
+          })
+
+          Fastlane::Actions::AddGitTagAction.run(options)
+        end
+      end
+
       it "generates a tag based on existing context" do
         result = Fastlane::FastFile.new.parse("lane :test do
           add_git_tag
@@ -105,7 +154,7 @@ describe Fastlane do
           add_git_tag ({
             tag: '#{tag}',
             grouping: 'grouping',
-            build_number: 'build_number',
+            build_number: #{build_number},
             prefix: 'prefix',
           })
         end").runner.execute(:test)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `add_git_tag` action.

### Description
- Remove `is_string` from Boolean params and added `type: Boolean`
- Remove `is_string` from build_number param ~and added `type: Integer`~
- Added missing unit-tests for `includes_lane` param

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.