### PR TITLE
[action][app_store_build_number] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -135,7 +135,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",
                                        description: "sets the build number to given value if no build is in current train",
-                                       is_string: false),
+                                       skip_type_validation: true), # as we also allow integers, which we convert to strings anyway
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        short_option: "-a",
                                        env_name: "FASTLANE_APP_IDENTIFIER",
@@ -155,7 +155,7 @@ module Fastlane
                                        env_name: "APPSTORE_BUILD_NUMBER_LIVE_TEAM_ID",
                                        description: "The ID of your App Store Connect team if you're in multiple teams",
                                        optional: true,
-                                       is_string: false, # as we also allow integers, which we convert to strings anyway
+                                       skip_type_validation: true, # as we also allow integers, which we convert to strings anyway
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:itc_team_id),
                                        default_value_dynamic: true,
@@ -167,7 +167,7 @@ module Fastlane
                                        env_name: "APPSTORE_BUILD_NUMBER_LIVE",
                                        description: "Query the live version (ready-for-sale)",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "LATEST_VERSION",
@@ -178,7 +178,6 @@ module Fastlane
                                        env_name: "APPSTORE_PLATFORM",
                                        description: "The platform to use (optional)",
                                        optional: true,
-                                       is_string: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
                                          UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -276,9 +276,9 @@ describe Fastlane do
           before(:each) do
             expected_filter = { :app => app_id, "preReleaseVersion.platform" => platform, "preReleaseVersion.version" => app_version }
             allow(Spaceship::ConnectAPI)
-            .to receive(:get_builds)
-            .with(filter: expected_filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1)
-            .and_return([nil])
+              .to receive(:get_builds)
+              .with(filter: expected_filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1)
+              .and_return([nil])
 
             options[:version] = app_version
             options[:platform] = platform
@@ -298,9 +298,9 @@ describe Fastlane do
           before(:each) do
             expected_filter = { :app => app_id, "preReleaseVersion.platform" => platform, "preReleaseVersion.version" => app_version }
             allow(Spaceship::ConnectAPI)
-            .to receive(:get_builds)
-            .with(filter: expected_filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1)
-            .and_return([nil])
+              .to receive(:get_builds)
+              .with(filter: expected_filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1)
+              .and_return([nil])
 
             options[:version] = app_version
             options[:platform] = platform

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -272,7 +272,7 @@ describe Fastlane do
           end
         end
 
-        context "when could not found the build and 'initial_build_number' is NOT given in input options" do
+        context "when could not find the build and 'initial_build_number' is NOT given in input options" do
           before(:each) do
             expected_filter = { :app => app_id, "preReleaseVersion.platform" => platform, "preReleaseVersion.version" => app_version }
             allow(Spaceship::ConnectAPI)
@@ -294,7 +294,7 @@ describe Fastlane do
           end
         end
 
-        context "when could not found the build but 'initial_build_number' is given in input options" do
+        context "when could not find the build but 'initial_build_number' is given in input options" do
           before(:each) do
             expected_filter = { :app => app_id, "preReleaseVersion.platform" => platform, "preReleaseVersion.version" => app_version }
             allow(Spaceship::ConnectAPI)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `app_store_build_number` action.

### Description
- Remove `is_string` from Boolean params and added `type: Boolean`
- Added missing unit-tests

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.