### PR TITLE
[action][appetize_viewing_url_generator] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/appetize_viewing_url_generator.rb
+++ b/fastlane/lib/fastlane/actions/appetize_viewing_url_generator.rb
@@ -50,7 +50,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :public_key,
                                        env_name: "APPETIZE_PUBLICKEY",
                                        description: "Public key of the app you wish to update",
-                                       is_string: true,
                                        sensitive: true,
                                        default_value: Actions.lane_context[SharedValues::APPETIZE_PUBLIC_KEY],
                                        default_value_dynamic: true,
@@ -63,18 +62,15 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :base_url,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_BASE",
                                        description: "Base URL of Appetize service",
-                                       is_string: true,
                                        default_value: "https://appetize.io/embed",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :device,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_DEVICE",
                                        description: "Device type: iphone4s, iphone5s, iphone6, iphone6plus, ipadair, iphone6s, iphone6splus, ipadair2, nexus5, nexus7 or nexus9",
-                                       is_string: true,
                                        default_value: "iphone5s"),
           FastlaneCore::ConfigItem.new(key: :scale,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_SCALE",
                                        description: "Scale of the simulator",
-                                       is_string: true,
                                        optional: true,
                                        verify_block: proc do |value|
                                          available = ["25", "50", "75", "100"]
@@ -83,7 +79,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :orientation,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_ORIENTATION",
                                        description: "Device orientation",
-                                       is_string: true,
                                        default_value: "portrait",
                                        verify_block: proc do |value|
                                          available = ["portrait", "landscape"]
@@ -92,12 +87,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :language,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_LANGUAGE",
                                        description: "Device language in ISO 639-1 language code, e.g. 'de'",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :color,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_COLOR",
                                        description: "Color of the device",
-                                       is_string: true,
                                        default_value: "black",
                                        verify_block: proc do |value|
                                          available = ["black", "white", "silver", "gray"]
@@ -106,22 +99,18 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :launch_url,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_LAUNCH_URL",
                                        description: "Specify a deep link to open when your app is launched",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :os_version,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_OS_VERSION",
                                        description: "The operating system version on which to run your app, e.g. 10.3, 8.0",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :params,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_PARAMS",
                                        description: "Specify params value to be passed to Appetize",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :proxy,
                                        env_name: "APPETIZE_VIEWING_URL_GENERATOR_PROXY",
                                        description: "Specify a HTTP proxy to be passed to Appetize",
-                                       is_string: true,
                                        optional: true)
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `appetize_viewing_url_generator` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.