### PR TITLE
[spaceship] Handle breaking changes from psych

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ PATH
       multipart-post (~> 2.0.0)
       naturally (~> 2.2)
       plist (>= 3.1.0, < 4.0.0)
+      psych (~> 3)
       rubyzip (>= 2.0.0, < 3.0.0)
       security (= 0.1.3)
       simctl (~> 1.6.3)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -106,6 +106,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('google-cloud-storage', '~> 1.31') # Access Google Cloud Storage for match
   spec.add_dependency('emoji_regex', '>= 0.1', '< 4.0') # Used to scan for Emoji in the changelog
   spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used for S3 storage in fastlane match
+  spec.add_dependency('psych', '~> 3') # lock to older version since breaking changes interfere with http-cookie
 
   # Development only
   spec.add_development_dependency('rake')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #18768

Psych ([see comment here](https://github.com/ruby/psych/issues/503#issuecomment-851304708)) introduced breaking changes for 4.0.0

### Description
Our constraints allow using psych 4.0.0 (transitive dependency from http-cookie) which will break cookie-based authentication. Use cases are: creating a cookie via spaceauth or downloading dsysm via fastlane_session (because the AppStoreConnectApi doesn't offer it right now)

I tried first creating a PR for [http-cookie](https://github.com/sparklemotion/http-cookie/pull/33) but have no response right now. We could wait until they answer.. or just quick fix it now.

### Testing Steps
I build fastlane locally with my changes and executed fastlane spaceauth -u ... and it worked again ;)
