### PR TITLE
[action][appetize] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -109,7 +109,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :api_host,
                                        env_name: "APPETIZE_API_HOST",
                                        description: "Appetize API host",
-                                       is_string: true,
                                        default_value: 'api.appetize.io',
                                        verify_block: proc do |value|
                                          UI.user_error!("API host should not contain the scheme e.g. `https`") if value.start_with?('https')
@@ -118,29 +117,24 @@ module Fastlane
                                        env_name: "APPETIZE_API_TOKEN",
                                        sensitive: true,
                                        description: "Appetize.io API Token",
-                                       is_string: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("No API Token for Appetize.io given, pass using `api_token: 'token'`") unless value.to_s.length > 0
                                        end),
           FastlaneCore::ConfigItem.new(key: :url,
                                        env_name: "APPETIZE_URL",
                                        description: "URL from which the ipa file can be fetched. Alternative to :path",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        env_name: "APPETIZE_PLATFORM",
                                        description: "Platform. Either `ios` or `android`",
-                                       is_string: true,
                                        default_value: 'ios'),
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "APPETIZE_FILE_PATH",
                                        description: "Path to zipped build on the local filesystem. Either this or `url` must be specified",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :public_key,
                                        env_name: "APPETIZE_PUBLICKEY",
                                        description: "If not provided, a new app will be created. If provided, the existing build will be overwritten",
-                                       is_string: true,
                                        optional: true,
                                        verify_block: proc do |value|
                                          if value.start_with?("private_")
@@ -150,7 +144,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :note,
                                        env_name: "APPETIZE_NOTE",
                                        description: "Notes you wish to add to the uploaded app",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :timeout,
                                        env_name: "APPETIZE_TIMEOUT",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `appetize` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.