### PR TITLE
[snapshot] fix the broken CI to support newly added example `snapfile`

### DIFF
--- a/snapshot/example/fastlane/Snapfile
+++ b/snapshot/example/fastlane/Snapfile
@@ -3,8 +3,8 @@
 # A list of devices you want to take the screenshots from
 devices(
   [
-    "iPhone SE (2nd generation)",
-    "iPhone 12 Pro Max"
+    "iPhone 6s",
+    "iPad Air"
   ]
 )
 

--- a/snapshot/example/fastlane/Snapfile
+++ b/snapshot/example/fastlane/Snapfile
@@ -1,17 +1,24 @@
 # Uncomment the lines below you want to change by removing the # in the beginning
 
 # A list of devices you want to take the screenshots from
-devices([
-   "iPhone SE (2nd generation)", 
-   "iPhone 12 Pro Max"
-])
+devices(
+  [
+    "iPhone SE (2nd generation)",
+    "iPhone 12 Pro Max"
+  ]
+)
 
- languages([
-  "en-US",
-  "de-DE",
-  "it-IT",
-#   ["pt", "pt_BR"] # Portuguese with Brazilian locale
- ])
+languages(
+  [
+    "en-US",
+    "de-DE",
+    "it-IT",
+    [
+      "pt",
+      "pt_BR" # Portuguese with Brazilian locale
+    ]
+  ]
+)
 
 # The name of the scheme which contains the UI Tests
 scheme("ExampleUITests")

--- a/snapshot/spec/detect_values_spec.rb
+++ b/snapshot/spec/detect_values_spec.rb
@@ -1,6 +1,10 @@
 describe Snapshot do
   describe Snapshot::DetectValues do
     describe "value coercion" do
+      before(:each) do
+        allow(Snapshot).to receive(:snapfile_name).and_return("some fake snapfile")
+      end
+
       it "coerces only_testing to be an array", requires_xcodebuild: true do
         options = {
             project: "./snapshot/example/Example.xcodeproj",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- PR https://github.com/fastlane/fastlane/pull/18797 got merged into master without running tests on CI `first contribution PR` :) 
- CI is failing on the master branch because of the linting issue and unit-tests are also failing because of newly added snapfile
- Failing **linting** [CI job](https://app.circleci.com/pipelines/github/fastlane/fastlane/3030/workflows/6134f38c-53bf-48d1-bb36-4fb04191e2a5/jobs/69655)
- Failing **unit-test** [CI job](https://app.circleci.com/pipelines/github/fastlane/fastlane/3030/workflows/6134f38c-53bf-48d1-bb36-4fb04191e2a5/jobs/69661)

### Description
- In this PR, fixed the linting issue in the snapfile
- Fixed the unit tests also
- Also, changed the devices "iPhone 6s" in the snapfile for Xcode8 spec `test_command_generator_xcode_8_spec.rb` 😇

### Testing Steps
- `bundle exec rubocop -D snapshot/example/fastlane/Snapfile`
- `bundle exec rspec snapshot/spec`