### PR TITLE
[fastlane_core] add pods project schemes environment variable

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -123,9 +123,13 @@ module FastlaneCore
     # Get all available schemes in an array
     def schemes
       @schemes ||= if workspace?
-                     workspace.schemes.reject do |k, v|
-                       v.include?("Pods/Pods.xcodeproj")
-                     end.keys
+                     if FastlaneCore::Env.truthy?("FASTLANE_INCLUDE_PODS_PROJECT_SCHEMES")
+                       workspace.schemes.keys
+                     else
+                       workspace.schemes.reject do |k, v|
+                         v.include?("Pods/Pods.xcodeproj")
+                       end.keys
+                     end
                    else
                      Xcodeproj::Project.schemes(path)
                    end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
At my workplace for one of our projects, we run a test spec from one of our internal cocoapods as a smoke test before running lengthier UI tests that depend on that pod. I was able to use the cocoapods `post_install` block to make the scheme public when installing on CI, but we're still unable to run those tests on fastlane since fastlane filters out pods schemes.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I added an environment variable to optionally disable the filtering out of environment variables.
I tested this out by verifying that the scheme could be found with the environment set to a truthy value, and it could not be found when the environment variable is unset or set to a falsy value.
