### PR TITLE
[spaceship] migrate YAML.safe_load to support psych v4.0

### DIFF
--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -39,12 +39,7 @@ module Spaceship
       # Example:
       # name: DES5c148586daa451e55afb017aa62418f91
       # value: HSARMTKNSRVTWFlaF/ek8asaa9lymMA0dN8JQ6pY7B3F5kdqTxJvMT19EVEFX8EQudB/uNwBHOHzaa30KYTU/eCP/UF7vGTgxs6PAnlVWKscWssOVHfP2IKWUPaa4Dn+I6ilA7eAFQsiaaVT
-      cookies = YAML.safe_load(
-        itc_cookie_content,
-        [HTTP::Cookie, Time], # classes allowlist
-        [],                   # symbols allowlist
-        true                  # allow YAML aliases
-      )
+      cookies = load_cookies(itc_cookie_content)
 
       # We remove all the un-needed cookies
       cookies.select! do |cookie|
@@ -70,6 +65,24 @@ module Spaceship
       end
 
       return self
+    end
+
+    def load_cookies(content)
+      # When Ruby 2.5 support is dropped, we can safely get rid of the latter branch.
+      if YAML.name == 'Psych' && Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1')
+        YAML.safe_load(
+          content,
+          permitted_classes: [HTTP::Cookie, Time],
+          aliases: true
+        )
+      else
+        YAML.safe_load(
+          content,
+          [HTTP::Cookie, Time], # classes allowlist
+          [],                   # symbols allowlist
+          true                  # allow YAML aliases
+        )
+      end
     end
 
     def session_string


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Closes https://github.com/fastlane/fastlane/issues/18768
https://github.com/fastlane/fastlane/issues/17931#issuecomment-855254278

`psych` v4.0.0 was released lately and it has a breaking change that breaks fastlane in two ways. One is to break `http-cookie` gem, another is by removing legacy positional parameters used in `spaceauth_runner.rb`.

JFYI: `psych` is a backend implementation of YAML used by default in Ruby. `psych` gem is categorised as "default" gem which means it's bundled in Ruby but you can update it to whatever version you want optionally. Ruby 3.0.1 bundles `psych` v3.3.0 but on the master branch of `ruby/ruby` it now points to v4.0.1, which means that it is very likely fastlane users using the next Ruby version (Ruby 3.1.0) are going to see errors due to `psych` v4.0.1.

* Ruby 3.0.1 https://github.com/ruby/ruby/blob/0fb782ee38ea37fd5fe8b1f775f8ad866a82a3f0/ext/psych/lib/psych/versions.rb#L5
* Ruby head  https://github.com/ruby/ruby/blob/8c87efaa8a45166ed977294330c32a4b186b8e7b/ext/psych/lib/psych/versions.rb#L5

Thanks to this ticket https://github.com/fastlane/fastlane/issues/18768, `http-cookie` is now fixed. This PR migrates `spaceauth_runner.rb` using the legacy positional parameters on `YAML.safe_load` which are removed in `psych` v4.0.0.


### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

It is a bit tricky that we need to maintain legacy positional parameters to keep Ruby 2.5 support. Otherwise, it is very straightforward.

v4.0.1 (bundled in Ruby head) https://github.com/ruby/psych/blob/v4.0.1/lib/psych.rb#L323
It's cleaned up. It no longer contains positional arguments for options.

```ruby
  def self.safe_load yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false<br class="Apple-interchange-newline">
```

v3.3.0 (bundled in Ruby 3.0.1) https://github.com/ruby/psych/blob/v3.3.0/lib/psych.rb#L329
There are positional parameters named as `legacy` to keep compatibility. 
```ruby
  def self.safe_load yaml, legacy_permitted_classes = NOT_GIVEN, legacy_permitted_symbols = NOT_GIVEN, legacy_aliases = NOT_GIVEN, legacy_filename = NOT_GIVEN, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false<br class="Apple-interchange-newline">
```

v3.0.2 (bundled in Ruby 2.5.0) https://github.com/ruby/psych/blob/v3.0.2/lib/psych.rb#L313
There is not keyword arguments for options yet.

```ruby
  def self.safe_load yaml, whitelist_classes = [], whitelist_symbols = [], aliases = false, filename = nil, symbolize_names: false<br class="Apple-interchange-newline">
```

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I believe unit tests cover this change but you can give `spaceauth` a try to see if serialised cookie object is restored from yaml file.
