### PR TITLE
[Fastlane.Swift] Treat `Bool` as optional to avoid config issues

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -195,7 +195,7 @@ module Fastlane
         else
           if type == "((String) -> Void)?"
             "#{param}: #{type} = nil"
-          elsif optional && type.end_with?('?') && !type.start_with?('Any')
+          elsif optional && type.end_with?('?') && !type.start_with?('Any') || type.start_with?('Bool')
             "#{param}: OptionalConfigValue<#{type}> = .fastlaneDefault(#{default_value})"
           else
             "#{param}: #{type} = #{default_value}"
@@ -286,7 +286,7 @@ module Fastlane
         sanitized_name = sanitize_reserved_word(word: sanitized_name)
         type_string = type_override == :string_callback ? ".stringClosure" : "nil"
 
-        if !(type_override == :string_callback || !(is_optional && default_value.nil? && !type.start_with?('Any')) || type.start_with?('Bool'))
+        if !(type_override == :string_callback || !(is_optional && default_value.nil? && !type.start_with?('Any') || type.start_with?('Bool')))
           { name: "#{sanitized_name.gsub('`', '')}Arg", arg: "let #{sanitized_name.gsub('`', '')}Arg = #{sanitized_name}.asRubyArgument(name: \"#{name}\", type: #{type_string})" }
         else
           { name: "#{sanitized_name.gsub('`', '')}Arg", arg: "let #{sanitized_name.gsub('`', '')}Arg = RubyCommand.Argument(name: \"#{name}\", value: #{sanitized_name}, type: #{type_string})" }

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -286,7 +286,7 @@ module Fastlane
         sanitized_name = sanitize_reserved_word(word: sanitized_name)
         type_string = type_override == :string_callback ? ".stringClosure" : "nil"
 
-        if !(type_override == :string_callback || !(is_optional && default_value.nil? && !type.start_with?('Any')))
+        if !(type_override == :string_callback || !(is_optional && default_value.nil? && !type.start_with?('Any')) || type.start_with?('Bool'))
           { name: "#{sanitized_name.gsub('`', '')}Arg", arg: "let #{sanitized_name.gsub('`', '')}Arg = #{sanitized_name}.asRubyArgument(name: \"#{name}\", type: #{type_string})" }
         else
           { name: "#{sanitized_name.gsub('`', '')}Arg", arg: "let #{sanitized_name.gsub('`', '')}Arg = RubyCommand.Argument(name: \"#{name}\", value: #{sanitized_name}, type: #{type_string})" }
@@ -434,7 +434,7 @@ module Fastlane
 
         if type == "((String) -> Void)?"
           "#{param}: #{type} = nil"
-        elsif optional && type.end_with?('?') && !type.start_with?('Any')
+        elsif (optional && type.end_with?('?') && !type.start_with?('Any')) || type.start_with?('Bool')
           "#{param}: OptionalConfigValue<#{type}> = .fastlaneDefault(#{self.class_name.downcase}.#{static_var_for_parameter_name})"
         else
           "#{param}: #{type} = #{self.class_name.downcase}.#{static_var_for_parameter_name}"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes #17343. This PR aims to treat all `Bool` types as `OptionalConfigValue`s, so the Ruby's default one is used in order to avoid config issues

### Description
Adds `Bool` type to the list of candidates to be a `OptionalConfigValue`.

### Testing Steps
1. Checkout and install this branch
2. Build the interface with `bundle exec fastlane generate_swift_api`
3. Check the source in `Fastlane.swift` and check that all `Bool` arguments are now `OptionalConfigValue<Bool>`
