### PR TITLE
[action][badge] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -65,7 +65,7 @@ module Fastlane
                                        env_name: "FL_BADGE_DARK",
                                        description: "Adds a dark flavored badge ontop of your icon",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        verify_block: proc do |value|
                                          UI.user_error!("dark is only a flag and should always be true") unless value == true
                                        end),
@@ -80,20 +80,19 @@ module Fastlane
                                        env_name: "FL_BADGE_NO_BADGE",
                                        description: "Hides the beta badge",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        verify_block: proc do |value|
                                          UI.user_error!("no_badge is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :shield,
                                        env_name: "FL_BADGE_SHIELD",
                                        description: "Add a shield to your app icon from shields.io",
-                                       optional: true,
-                                       is_string: true),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :alpha,
                                        env_name: "FL_BADGE_ALPHA",
                                        description: "Adds and alpha badge instead of the default beta one",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        verify_block: proc do |value|
                                          UI.user_error!("alpha is only a flag and should always be true") unless value == true
                                        end),
@@ -101,7 +100,6 @@ module Fastlane
                                        env_name: "FL_BADGE_PATH",
                                        description: "Sets the root path to look for AppIcons",
                                        optional: true,
-                                       is_string: true,
                                        default_value: '.',
                                        verify_block: proc do |value|
                                          UI.user_error!("path needs to be a valid directory") if Dir[value].empty?
@@ -110,33 +108,31 @@ module Fastlane
                                        env_name: "FL_BADGE_SHIELD_IO_TIMEOUT",
                                        description: "Set custom duration for the timeout of the shields.io request in seconds",
                                        optional: true,
-                                       is_string: false,
+                                       skip_type_validation: true, # allow integers, strings both
                                        verify_block: proc do |value|
                                          UI.user_error!("shield_io_timeout needs to be an integer > 0") if value.to_i < 1
                                        end),
           FastlaneCore::ConfigItem.new(key: :glob,
                                        env_name: "FL_BADGE_GLOB",
                                        description: "Glob pattern for finding image files",
-                                       optional: true,
-                                       is_string: true),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :alpha_channel,
                                        env_name: "FL_BADGE_ALPHA_CHANNEL",
                                        description: "Keeps/adds an alpha channel to the icon (useful for android icons)",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        verify_block: proc do |value|
                                          UI.user_error!("alpha_channel is only a flag and should always be true") unless value == true
                                        end),
           FastlaneCore::ConfigItem.new(key: :shield_gravity,
                                        env_name: "FL_BADGE_SHIELD_GRAVITY",
                                        description: "Position of shield on icon. Default: North - Choices include: NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast",
-                                       optional: true,
-                                       is_string: true),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :shield_no_resize,
                                        env_name: "FL_BADGE_SHIELD_NO_RESIZE",
                                        description: "Shield image will no longer be resized to aspect fill the full icon. Instead it will only be shrunk to not exceed the icon graphic",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        verify_block: proc do |value|
                                          UI.user_error!("shield_no_resize is only a flag and should always be true") unless value == true
                                        end)

--- a/fastlane/lib/fastlane/actions/badge.rb
+++ b/fastlane/lib/fastlane/actions/badge.rb
@@ -108,7 +108,7 @@ module Fastlane
                                        env_name: "FL_BADGE_SHIELD_IO_TIMEOUT",
                                        description: "Set custom duration for the timeout of the shields.io request in seconds",
                                        optional: true,
-                                       skip_type_validation: true, # allow integers, strings both
+                                       type: Integer, # allow integers, strings both
                                        verify_block: proc do |value|
                                          UI.user_error!("shield_io_timeout needs to be an integer > 0") if value.to_i < 1
                                        end),


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `badge` action.

### Description
- Remove `is_string: true` from options
- Added `type: Boolean` 

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.