### PR TITLE
[action][build_and_upload_to_appetize] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
+++ b/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
@@ -64,10 +64,9 @@ module Fastlane
                                        env_name: "APPETIZE_API_TOKEN",
                                        description: "Appetize.io API Token",
                                        sensitive: true,
-                                       is_string: true),
+                                       code_gen_sensitive: true),
           FastlaneCore::ConfigItem.new(key: :public_key,
                                        description: "If not provided, a new app will be created. If provided, the existing build will be overwritten",
-                                       is_string: true,
                                        optional: true,
                                        verify_block: proc do |value|
                                          if value.start_with?("private_")
@@ -76,7 +75,6 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :note,
                                        description: "Notes you wish to add to the uploaded app",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :timeout,
                                        description: "The number of seconds to wait until automatically ending the session due to user inactivity. Must be 30, 60, 90, 120, 180, 300, 600, 1800, 3600 or 7200. Default is 120",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `build_and_upload_to_appetize` action.

### Description
- Remove `is_string: true` from options
- Added `code_gen_sensitive: true` for API token

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.