### PR TITLE
[action][chatwork] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/chatwork.rb
+++ b/fastlane/lib/fastlane/actions/chatwork.rb
@@ -41,6 +41,7 @@ module Fastlane
                                        env_name: "CHATWORK_API_TOKEN",
                                        description: "ChatWork API Token",
                                        sensitive: true,
+                                       code_gen_sensitive: true,
                                        verify_block: proc do |value|
                                          unless value.to_s.length > 0
                                            UI.error("Please add 'ENV[\"CHATWORK_API_TOKEN\"] = \"your token\"' to your Fastfile's `before_all` section.")
@@ -53,13 +54,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :roomid,
                                        env_name: "FL_CHATWORK_ROOMID",
                                        description: "The room ID",
-                                       is_string: false),
+                                       type: Integer),
           FastlaneCore::ConfigItem.new(key: :success,
                                        env_name: "FL_CHATWORK_SUCCESS",
                                        description: "Was this build successful? (true/false)",
                                        optional: true,
                                        default_value: true,
-                                       is_string: false)
+                                       type: Boolean)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `chatwork` action.

### Description
- Remove `is_string: true` from options
- Added `type: Boolean` `type: Integer`

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.