### PR TITLE
[snapshot] Allow iPods to run alongside iPhone and iPad

### DIFF
--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -69,7 +69,7 @@ module Snapshot
         # Check each device to see if it is an iOS device
         all_ios = devices.map do |device|
           device = device.downcase
-          device.include?('iphone') || device.include?('ipad')
+          device.include?('iphone') || device.include?('ipad') || device.include?('ipod')
         end
         # Return true if all devices are iOS devices
         return true unless all_ios.include?(false)

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -37,7 +37,7 @@ describe Snapshot do
         @test_command_generator = Snapshot::TestCommandGenerator.new
       end
       it "returns true with only iOS devices" do
-        devices = ["iPhone 8", "iPad Air 2", "iPhone X", "iPhone 8 plus"]
+        devices = ["iPhone 8", "iPad Air 2", "iPhone X", "iPhone 8 plus", "iPod touch (7th generation)"]
         result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
         expect(result).to be(true)
       end
@@ -48,14 +48,26 @@ describe Snapshot do
         expect(result).to be(true)
       end
 
-      it "returns false with mixed device OS" do
-        devices = ["Apple TV 1080p", "iPad Air 2", "iPhone 8"]
+      it "returns false with mixed device OS of Apple TV and iPhone" do
+        devices = ["Apple TV 1080p", "iPhone 8"]
+        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+        expect(result).to be(false)
+      end
+
+      it "returns false with mixed device OS of Apple TV and iPad" do
+        devices = ["Apple TV 1080p", "iPad Air 2"]
+        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+        expect(result).to be(false)
+      end
+
+      it "returns false with mixed device OS of Apple TV and iPod" do
+        devices = ["Apple TV 1080p", "iPod touch (7th generation)"]
         result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
         expect(result).to be(false)
       end
 
       it "returns true with custom named iOS devices" do
-        devices = ["11.0 - iPhone X", "11.0 - iPad Air 2"]
+        devices = ["11.0 - iPhone X", "11.0 - iPad Air 2", "13.0 - iPod touch"]
         result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
         expect(result).to be(true)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #18842
Allows iPod touch device to run snapshot in parallel with iPhone and iPad devices

### Description
This allows the device to start with ipod as well as iphone and iPad as they are all I(Pad)OS devices. I added unit tests for having iPods in conjunction with other device types

### Testing Steps
Ran the full test suite for fastlane as well as ran my screenshots using the changed fastlane using iPod touch 7th Gen and iPhone 12 simulators
