### PR TITLE
[action][clean_build_artifacts] clean up options default_value

### DIFF
--- a/fastlane/lib/fastlane/actions/clean_build_artifacts.rb
+++ b/fastlane/lib/fastlane/actions/clean_build_artifacts.rb
@@ -33,7 +33,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :exclude_pattern,
                                        env_name: "FL_CLEAN_BUILD_ARTIFACTS_EXCLUDE_PATTERN",
                                        description: "Exclude all files from clearing that match the given Regex pattern: e.g. '.*\.mobileprovision'",
-                                       default_value: nil,
                                        optional: true)
         ]
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Fastlane is smart enough to have **default_value as** `nil` for an optional param/option (No need to mention explicitly)

### Description
- clean up options default_value

### Testing Steps
- n/a
