### PR TITLE
[action][clean_cocoapods_cache] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
+++ b/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
@@ -22,7 +22,6 @@ module Fastlane
                                        env_name: "FL_CLEAN_COCOAPODS_CACHE_DEVELOPMENT",
                                        description: "Pod name to be removed from cache",
                                        optional: true,
-                                       is_string: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("You must specify pod name which should be removed from cache") if value.to_s.empty?
                                        end)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `clean_cocoapods_cache` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.