### PR TITLE
[action][cloc] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/cloc.rb
+++ b/fastlane/lib/fastlane/actions/cloc.rb
@@ -38,28 +38,24 @@ module Fastlane
                                        env_name: "FL_CLOC_BINARY_PATH",
                                        description: "Where the cloc binary lives on your system (full path including 'cloc')",
                                        optional: true,
-                                       is_string: true,
                                        default_value: '/usr/local/bin/cloc'),
           FastlaneCore::ConfigItem.new(key: :exclude_dir,
                                        env_name: "FL_CLOC_EXCLUDE_DIR",
-                                       description: "Comma separated list of directories to exclude", # a short description of this parameter
-                                       optional: true,
-                                       is_string: true),
+                                       description: "Comma separated list of directories to exclude",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :output_directory,
                                        env_name: "FL_CLOC_OUTPUT_DIRECTORY",
                                        description: "Where to put the generated report file",
-                                       is_string: true,
                                        default_value: "build"),
           FastlaneCore::ConfigItem.new(key: :source_directory,
-                                      env_name: "FL_CLOC_SOURCE_DIRECTORY",
-                                      description: "Where to look for the source code (relative to the project root folder)",
-                                      is_string: true,
-                                      default_value: ""),
+                                       env_name: "FL_CLOC_SOURCE_DIRECTORY",
+                                       description: "Where to look for the source code (relative to the project root folder)",
+                                       default_value: ""),
           FastlaneCore::ConfigItem.new(key: :xml,
-                                      env_name: "FL_CLOC_XML",
-                                      description: "Should we generate an XML File (if false, it will generate a plain text file)?",
-                                      is_string: false,
-                                      default_value: true)
+                                       env_name: "FL_CLOC_XML",
+                                       description: "Should we generate an XML File (if false, it will generate a plain text file)?",
+                                       type: Boolean,
+                                       default_value: true)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `cloc` action.

### Description
- Remove `is_string: true` from options
- Added `type: Boolean`
- Fixed formatting `spacing` for couple of options

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.