### PR TITLE
[action][commit_github_file] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/commit_github_file.rb
+++ b/fastlane/lib/fastlane/actions/commit_github_file.rb
@@ -107,7 +107,6 @@ module Fastlane
                                        description: "Personal API Token for GitHub - generate one at https://github.com/settings/tokens",
                                        conflicting_options: [:api_bearer],
                                        sensitive: true,
-                                       is_string: true,
                                        code_gen_sensitive: true,
                                        default_value: ENV["GITHUB_API_TOKEN"],
                                        default_value_dynamic: true,
@@ -129,7 +128,6 @@ module Fastlane
                                        env_name: 'FL_COMMIT_GITHUB_FILE_PATH',
                                        description: 'The relative path to your file from project root e.g. assets/my_app.xcarchive',
                                        optional: false,
-                                       is_string: true,
                                        verify_block: proc do |value|
                                          value = File.expand_path(value)
                                          UI.user_error!("File not found at path '#{value}'") unless File.exist?(value)
@@ -142,7 +140,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :secure,
                                        env_name: "FL_COMMIT_GITHUB_FILE_SECURE",
                                        description: "Optionally disable secure requests (ssl_verify_peer)",
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: true,
                                        optional: true)
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `commit_github_file` action.

### Description
- Remove `is_string: true` from options
- Added `type: Boolean`

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.