### PR TITLE
[action][crashlytics] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -133,28 +133,27 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :notes,
                                        env_name: "CRASHLYTICS_NOTES",
                                        description: "The release notes as string - uses :notes_path under the hood",
-                                       optional: true,
-                                       is_string: true),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :groups,
                                        env_name: "CRASHLYTICS_GROUPS",
                                        description: "The groups used for distribution, separated by commas",
-                                       optional: true,
-                                       is_string: false),
+                                       skip_type_validation: true, # allows String, Array
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :emails,
                                        env_name: "CRASHLYTICS_EMAILS",
                                        description: "Pass email addresses of testers, separated by commas",
-                                       optional: true,
-                                       is_string: false),
+                                       skip_type_validation: true, # allows String, Array
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :notifications,
                                        env_name: "CRASHLYTICS_NOTIFICATIONS",
                                        description: "Crashlytics notification option (true/false)",
                                        default_value: true,
-                                       is_string: false),
+                                       type: Boolean),
           FastlaneCore::ConfigItem.new(key: :debug,
                                        env_name: "CRASHLYTICS_DEBUG",
                                        description: "Crashlytics debug option (true/false)",
                                        default_value: false,
-                                       is_string: false)
+                                       type: Boolean)
 
         ]
       end

--- a/fastlane/lib/fastlane/actions/crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/crashlytics.rb
@@ -2,9 +2,6 @@ module Fastlane
   module Actions
     class CrashlyticsAction < Action
       def self.run(params)
-        params[:groups] = params[:groups].join(",") if params[:groups].kind_of?(Array)
-        params[:emails] = params[:emails].join(",") if params[:emails].kind_of?(Array)
-
         params.values # to validate all inputs before looking for the ipa/apk
         tempfiles = []
 
@@ -137,12 +134,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :groups,
                                        env_name: "CRASHLYTICS_GROUPS",
                                        description: "The groups used for distribution, separated by commas",
-                                       skip_type_validation: true, # allows String, Array
+                                       type: Array,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :emails,
                                        env_name: "CRASHLYTICS_EMAILS",
                                        description: "Pass email addresses of testers, separated by commas",
-                                       skip_type_validation: true, # allows String, Array
+                                       type: Array,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :notifications,
                                        env_name: "CRASHLYTICS_NOTIFICATIONS",

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -47,9 +47,9 @@ module Fastlane
           command << params[:api_token]
           command << params[:build_secret]
           command << "-ipaPath '#{params[:ipa_path]}'"
-          command << "-emails '#{params[:emails]}'" if params[:emails]
+          command << "-emails '#{params[:emails].join(",").shellescape}'" if params[:emails]
           command << "-notesPath '#{params[:notes_path]}'" if params[:notes_path]
-          command << "-groupAliases '#{params[:groups]}'" if params[:groups]
+          command << "-groupAliases '#{params[:groups].join(",").shellescape}'" if params[:groups]
           command << "-notifications #{(params[:notifications] ? 'YES' : 'NO')}"
           command << "-debug #{(params[:debug] ? 'YES' : 'NO')}"
 
@@ -74,9 +74,9 @@ module Fastlane
           command << "-androidManifest #{File.expand_path(android_manifest_path).shellescape}"
 
           # Optional
-          command << "-betaDistributionEmails #{params[:emails].shellescape}" if params[:emails]
+          command << "-betaDistributionEmails #{params[:emails].join(",").shellescape}" if params[:emails]
           command << "-betaDistributionReleaseNotesFilePath #{File.expand_path(params[:notes_path]).shellescape}" if params[:notes_path]
-          command << "-betaDistributionGroupAliases #{params[:groups].shellescape}" if params[:groups]
+          command << "-betaDistributionGroupAliases #{params[:groups].join(",").shellescape}" if params[:groups]
           command << "-betaDistributionNotifications #{(params[:notifications] ? 'true' : 'false')}"
 
           return command

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -47,9 +47,9 @@ module Fastlane
           command << params[:api_token]
           command << params[:build_secret]
           command << "-ipaPath '#{params[:ipa_path]}'"
-          command << "-emails '#{params[:emails].join(',').shellescape}'" if params[:emails]
+          command << "-emails '#{params[:emails].join(',')}'" if params[:emails]
           command << "-notesPath '#{params[:notes_path]}'" if params[:notes_path]
-          command << "-groupAliases '#{params[:groups].join(',').shellescape}'" if params[:groups]
+          command << "-groupAliases '#{params[:groups].join(',')}'" if params[:groups]
           command << "-notifications #{(params[:notifications] ? 'YES' : 'NO')}"
           command << "-debug #{(params[:debug] ? 'YES' : 'NO')}"
 

--- a/fastlane/lib/fastlane/helper/crashlytics_helper.rb
+++ b/fastlane/lib/fastlane/helper/crashlytics_helper.rb
@@ -47,9 +47,9 @@ module Fastlane
           command << params[:api_token]
           command << params[:build_secret]
           command << "-ipaPath '#{params[:ipa_path]}'"
-          command << "-emails '#{params[:emails].join(",").shellescape}'" if params[:emails]
+          command << "-emails '#{params[:emails].join(',').shellescape}'" if params[:emails]
           command << "-notesPath '#{params[:notes_path]}'" if params[:notes_path]
-          command << "-groupAliases '#{params[:groups].join(",").shellescape}'" if params[:groups]
+          command << "-groupAliases '#{params[:groups].join(',').shellescape}'" if params[:groups]
           command << "-notifications #{(params[:notifications] ? 'YES' : 'NO')}"
           command << "-debug #{(params[:debug] ? 'YES' : 'NO')}"
 
@@ -74,9 +74,9 @@ module Fastlane
           command << "-androidManifest #{File.expand_path(android_manifest_path).shellescape}"
 
           # Optional
-          command << "-betaDistributionEmails #{params[:emails].join(",").shellescape}" if params[:emails]
+          command << "-betaDistributionEmails #{params[:emails].join(',').shellescape}" if params[:emails]
           command << "-betaDistributionReleaseNotesFilePath #{File.expand_path(params[:notes_path]).shellescape}" if params[:notes_path]
-          command << "-betaDistributionGroupAliases #{params[:groups].join(",").shellescape}" if params[:groups]
+          command << "-betaDistributionGroupAliases #{params[:groups].join(',').shellescape}" if params[:groups]
           command << "-betaDistributionNotifications #{(params[:notifications] ? 'true' : 'false')}"
 
           return command


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `crashlytics` action.

### Description
- Remove `is_string: true` from options
- Added `type: Boolean` 

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.