### PR TITLE
[match] fix `nuke` exception when nuking with the empty files storage

### DIFF
--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -247,9 +247,8 @@ module Match
         UI.success("Successfully deleted certificate")
       end
 
-      if self.files.count > 0
-        files_to_delete = delete_files!
-      end
+      files_to_delete = delete_files! if self.files.count > 0
+      files_to_delete ||= []
 
       self.encryption.encrypt_files if self.encryption
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Closes: https://github.com/fastlane/fastlane/issues/18863
- Nuke is failing with exception when nuking with the empty files storage
- In this [line#256](https://github.com/fastlane/fastlane/blob/master/match/lib/match/nuke.rb#L256) because **files_to_delete** was nil in this [line#251](https://github.com/fastlane/fastlane/blob/master/match/lib/match/nuke.rb#L251)

### Description
- Now, initializing `files_to_delete` with [] if needed.
Please note: I notice there is no spec file for this `nuke.rb` 🤯  I will be adding all the unit-tests for all the FastlaneTools once I will finish Fastlane actions' is_string deprecation goal! 

### Testing Steps
- I don't know exactly... 🤷‍♂️
- maybe create a new certificate manually? and don't store that in git-repo and run nuke 😜🤨
