### PR TITLE
[action][deploygate] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -157,13 +157,12 @@ module Fastlane
                                        description: "Release note for distribution page"),
           FastlaneCore::ConfigItem.new(key: :disable_notify,
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false,
                                        env_name: "DEPLOYGATE_DISABLE_NOTIFY",
                                        description: "Disables Push notification emails"),
           FastlaneCore::ConfigItem.new(key: :distribution_name,
                                        optional: true,
-                                       is_string: true,
                                        env_name: "DEPLOYGATE_DISTRIBUTION_NAME",
                                        description: "Target Distribution Name")
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `deploygate` action.

### Description
- Remove `is_string: true` from options
- Added `type: Boolean` 

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.