### PR TITLE
[action][dsym_zip] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/dsym_zip.rb
+++ b/fastlane/lib/fastlane/actions/dsym_zip.rb
@@ -61,7 +61,7 @@ module Fastlane
                                        description: 'Whether or not all dSYM files are to be included. Optional, default is false in which only your app dSYM is included',
                                        default_value: false,
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        env_name: 'DSYM_ZIP_ALL')
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `dsym_zip` action.

### Description
- Remove `is_string: true` from options
- Added `type: Boolean` 

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.