### PR TITLE
[action][ensure_git_branch] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_git_branch.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_branch.rb
@@ -35,7 +35,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :branch,
                                        env_name: "FL_ENSURE_GIT_BRANCH_NAME",
                                        description: "The branch that should be checked for. String that can be either the full name of the branch or a regex e.g. `^feature\/.*$` to match",
-                                       is_string: true,
                                        default_value: 'master')
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `ensure_git_branch` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.