### PR TITLE
[action][ensure_git_status_clean] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -65,18 +65,17 @@ module Fastlane
                                        description: "The flag whether to show uncommitted changes if the repo is dirty",
                                        optional: true,
                                        default_value: false,
-                                       is_string: false),
+                                       type: Boolean),
           FastlaneCore::ConfigItem.new(key: :show_diff,
                                        env_name: "FL_ENSURE_GIT_STATUS_CLEAN_SHOW_DIFF",
                                        description: "The flag whether to show the git diff if the repo is dirty",
                                        optional: true,
                                        default_value: false,
-                                       is_string: false),
+                                       type: Boolean),
           FastlaneCore::ConfigItem.new(key: :ignored,
                                        env_name: "FL_ENSURE_GIT_STATUS_CLEAN_IGNORED_FILE",
                                        description: "The flag whether to ignore file the git status if the repo is dirty",
-                                       optional: true,
-                                       is_string: true)
+                                       optional: true)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `ensure_git_status_clean` action.

### Description
- Remove `is_string: true` from options
- Added `type: Boolean`

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.