### PR TITLE
[action][ensure_no_debug_code] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
+++ b/fastlane/lib/fastlane/actions/ensure_no_debug_code.rb
@@ -84,18 +84,16 @@ module Fastlane
                                        env_name: "FL_ENSURE_NO_DEBUG_CODE_EXTENSIONS",
                                        description: "An array of file extensions that should be searched for",
                                        optional: true,
-                                       is_string: false),
+                                       type: Array),
           FastlaneCore::ConfigItem.new(key: :exclude,
                                        env_name: "FL_ENSURE_NO_DEBUG_CODE_EXCLUDE",
                                        description: "Exclude a certain pattern from the search",
-                                       optional: true,
-                                       is_string: true),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :exclude_dirs,
                                        env_name: "FL_ENSURE_NO_DEBUG_CODE_EXCLUDE_DIRS",
                                        description: "An array of dirs that should not be included in the search",
                                        optional: true,
-                                       type: Array,
-                                       is_string: false)
+                                       type: Array)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `ensure_no_debug_code` action.

### Description
- Remove `is_string: true` from options
- Added `type: Array`

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.