### PR TITLE
[action][ensure_xcode_version] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
@@ -85,7 +85,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_ENSURE_XCODE_VERSION",
                                        description: "Xcode version to verify that is selected",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :strict,
                                        description: "Should the version be verified strictly (all 3 version numbers), or matching only the given version numbers (i.e. `11.3` == `11.3.x`)",
@@ -109,7 +108,7 @@ module Fastlane
 
       def self.example_code
         [
-          'ensure_xcode_version(version: "7.2")'
+          'ensure_xcode_version(version: "12.5")'
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `ensure_xcode_version` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.