### PR TITLE
[action][environment_variable] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/environment_variable.rb
+++ b/fastlane/lib/fastlane/actions/environment_variable.rb
@@ -29,27 +29,19 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(
-            key: :set,
-            env_name: 'FL_ENVIRONMENT_VARIABLE_SET',
-            description: 'Set the environment variables named',
-            optional: true,
-            type: Hash
-          ),
-          FastlaneCore::ConfigItem.new(
-            key: :get,
-            env_name: 'FL_ENVIRONMENT_VARIABLE_GET',
-            description: 'Get the environment variable named',
-            optional: true,
-            is_string: true
-          ),
-          FastlaneCore::ConfigItem.new(
-            key: :remove,
-            env_name: 'FL_ENVIRONMENT_VARIABLE_REMOVE',
-            description: 'Remove the environment variable named',
-            optional: true,
-            is_string: true
-          )
+          FastlaneCore::ConfigItem.new(key: :set,
+                                       env_name: 'FL_ENVIRONMENT_VARIABLE_SET',
+                                       description: 'Set the environment variables named',
+                                       optional: true,
+                                       type: Hash),
+          FastlaneCore::ConfigItem.new(key: :get,
+                                       env_name: 'FL_ENVIRONMENT_VARIABLE_GET',
+                                       description: 'Get the environment variable named',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :remove,
+                                       env_name: 'FL_ENVIRONMENT_VARIABLE_REMOVE',
+                                       description: 'Remove the environment variable named',
+                                       optional: true)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `environment_variable` action.

### Description
- Remove `is_string: true` from options
- Improve formatting

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.