### PR TITLE
[action][get_ipa_info_plist_value] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/get_ipa_info_plist_value.rb
+++ b/fastlane/lib/fastlane/actions/get_ipa_info_plist_value.rb
@@ -40,7 +40,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :ipa,
                                        env_name: "FL_GET_IPA_INFO_PLIST_VALUE_IPA",
                                        description: "Path to IPA",
-                                       is_string: true,
                                        default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
                                        default_value_dynamic: true)
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `get_ipa_info_plist_value` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.