### PR TITLE
[action][get_push_certificate] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/get_push_certificate.rb
+++ b/fastlane/lib/fastlane/actions/get_push_certificate.rb
@@ -55,7 +55,7 @@ module Fastlane
         @options << FastlaneCore::ConfigItem.new(key: :new_profile,
                                      description: "Block that is called if there is a new profile",
                                      optional: true,
-                                     is_string: false)
+                                     type: :string_callback)
         @options
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `get_push_certificate` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing/new unit tests should pass.