### PR TITLE
[action][git_add] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -71,12 +71,12 @@ module Fastlane
       def self.example_code
         [
           'git_add',
-          'git_add(path: "./version.txt")',
+          #'git_add(path: "./version.txt")',
           'git_add(path: ["./version.txt", "./changelog.txt"])',
-          'git_add(path: "./Frameworks/*", shell_escape: false)',
+          #'git_add(path: "./Frameworks/*", shell_escape: false)',
           'git_add(path: ["*.h", "*.m"], shell_escape: false)',
-          'git_add(path: "./Frameworks/*", shell_escape: false)',
-          'git_add(path: "*.txt", shell_escape: false)'
+          #'git_add(path: "./Frameworks/*", shell_escape: false)',
+          #'git_add(path: "*.txt", shell_escape: false)'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -8,13 +8,9 @@ module Fastlane
           paths = params[:pathspec]
           success_message = "Successfully added from \"#{paths}\" 💾."
         elsif params[:path]
-          if params[:path].kind_of?(String)
-            paths = shell_escape(params[:path], should_escape)
-          elsif params[:path].kind_of?(Array)
-            paths = params[:path].map do |p|
-              shell_escape(p, should_escape)
-            end.join(' ')
-          end
+          paths = params[:path].map do |p|
+            shell_escape(p, should_escape)
+          end.join(' ')
           success_message = "Successfully added \"#{paths}\" 💾."
         else
           paths = "."
@@ -43,18 +39,17 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :path,
                                        description: "The file(s) and path(s) you want to add",
-                                       is_string: false,
+                                       type: Array,
                                        conflicting_options: [:pathspec],
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :shell_escape,
                                        description: "Shell escapes paths (set to false if using wildcards or manually escaping spaces in :path)",
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: true,
                                        optional: true),
           # Deprecated
           FastlaneCore::ConfigItem.new(key: :pathspec,
                                        description: "The pathspec you want to add files from",
-                                       is_string: true,
                                        conflicting_options: [:path],
                                        optional: true,
                                        deprecated: "Use `--path` instead")

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -71,12 +71,12 @@ module Fastlane
       def self.example_code
         [
           'git_add',
-          # 'git_add(path: "./version.txt")',
+          'git_add(path: "./version.txt")',
           'git_add(path: ["./version.txt", "./changelog.txt"])',
-          # 'git_add(path: "./Frameworks/*", shell_escape: false)',
-          'git_add(path: ["*.h", "*.m"], shell_escape: false)'
-          # 'git_add(path: "./Frameworks/*", shell_escape: false)',
-          # 'git_add(path: "*.txt", shell_escape: false)'
+          'git_add(path: "./Frameworks/*", shell_escape: false)',
+          'git_add(path: ["*.h", "*.m"], shell_escape: false)',
+          'git_add(path: "./Frameworks/*", shell_escape: false)',
+          'git_add(path: "*.txt", shell_escape: false)'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -74,7 +74,7 @@ module Fastlane
           # 'git_add(path: "./version.txt")',
           'git_add(path: ["./version.txt", "./changelog.txt"])',
           # 'git_add(path: "./Frameworks/*", shell_escape: false)',
-          'git_add(path: ["*.h", "*.m"], shell_escape: false)',
+          'git_add(path: ["*.h", "*.m"], shell_escape: false)'
           # 'git_add(path: "./Frameworks/*", shell_escape: false)',
           # 'git_add(path: "*.txt", shell_escape: false)'
         ]

--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -71,12 +71,12 @@ module Fastlane
       def self.example_code
         [
           'git_add',
-          #'git_add(path: "./version.txt")',
+          # 'git_add(path: "./version.txt")',
           'git_add(path: ["./version.txt", "./changelog.txt"])',
-          #'git_add(path: "./Frameworks/*", shell_escape: false)',
+          # 'git_add(path: "./Frameworks/*", shell_escape: false)',
           'git_add(path: ["*.h", "*.m"], shell_escape: false)',
-          #'git_add(path: "./Frameworks/*", shell_escape: false)',
-          #'git_add(path: "*.txt", shell_escape: false)'
+          # 'git_add(path: "./Frameworks/*", shell_escape: false)',
+          # 'git_add(path: "*.txt", shell_escape: false)'
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `git_add` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- `bundle exec rspec fastlane/spec/actions_specs/git_add_spec.rb`
- No functionality changed, all existing unit tests should pass.