### PR TITLE
[action][git_commit] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/actions/test_sample_code.rb
+++ b/fastlane/actions/test_sample_code.rb
@@ -65,6 +65,8 @@ module Fastlane
 
             if config_item.data_type == Fastlane::Boolean
               config_item.ensure_boolean_type_passes_validation(value)
+            elsif config_item.data_type == Array
+              config_item.ensure_array_type_passes_validation(value)
             else
               config_item.ensure_generic_type_passes_validation(value)
             end

--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -67,7 +67,7 @@ module Fastlane
 
       def self.example_code
         [
-          # 'git_commit(path: "./version.txt", message: "Version Bump")',
+          'git_commit(path: "./version.txt", message: "Version Bump")',
           'git_commit(path: ["./version.txt", "./changelog.txt"], message: "Version Bump")',
           'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation")',
           'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation", skip_git_hooks: true)'

--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -67,7 +67,7 @@ module Fastlane
 
       def self.example_code
         [
-          'git_commit(path: "./version.txt", message: "Version Bump")',
+          #'git_commit(path: "./version.txt", message: "Version Bump")',
           'git_commit(path: ["./version.txt", "./changelog.txt"], message: "Version Bump")',
           'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation")',
           'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation", skip_git_hooks: true)'

--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -67,7 +67,7 @@ module Fastlane
 
       def self.example_code
         [
-          #'git_commit(path: "./version.txt", message: "Version Bump")',
+          # 'git_commit(path: "./version.txt", message: "Version Bump")',
           'git_commit(path: ["./version.txt", "./changelog.txt"], message: "Version Bump")',
           'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation")',
           'git_commit(path: ["./*.txt", "./*.md"], message: "Update documentation", skip_git_hooks: true)'

--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -2,11 +2,7 @@ module Fastlane
   module Actions
     class GitCommitAction < Action
       def self.run(params)
-        if params[:path].kind_of?(String)
-          paths = params[:path].shellescape
-        else
-          paths = params[:path].map(&:shellescape).join(' ')
-        end
+        paths = params[:path].map(&:shellescape).join(' ')
 
         skip_git_hooks = params[:skip_git_hooks] ? '--no-verify' : ''
 
@@ -38,7 +34,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :path,
                                        description: "The file(s) or directory(ies) you want to commit. You can pass an array of multiple file-paths or fileglobs \"*.txt\" to commit all matching files. The files already staged but not specified and untracked files won't be committed",
-                                       is_string: false),
+                                       type: Array),
           FastlaneCore::ConfigItem.new(key: :message,
                                        description: "The commit message that should be used"),
           FastlaneCore::ConfigItem.new(key: :skip_git_hooks,

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -216,6 +216,17 @@ module FastlaneCore
       end
     end
 
+    def ensure_array_type_passes_validation(value)
+      if @skip_type_validation
+        return
+      end
+
+      # Arrays can be an either be an array or string that gets split by comma in auto_convert_type
+      if !value.kind_of?(Array) && !value.kind_of?(String)
+        UI.user_error!("'#{self.key}' value must be either `true` or `false`! Found #{value.class} instead.")
+      end
+    end
+
     # Make sure, the value is valid (based on the verify block)
     # Raises an exception if the value is invalid
     def valid?(value)
@@ -225,6 +236,8 @@ module FastlaneCore
       # Verify that value is the type that we're expecting, if we are expecting a type
       if data_type == Fastlane::Boolean
         ensure_boolean_type_passes_validation(value)
+      elsif data_type == Array
+        ensure_array_type_passes_validation(value)
       else
         ensure_generic_type_passes_validation(value)
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `git_commit` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- `bundle exec rspec fastlane/spec/actions_specs/git_commit_spec.rb`
- No functionality changed, all existing/new unit tests should pass.