### PR TITLE
[snapshot] enable Snapshot to take Apple Watch 44mm screenshots (#1709)

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_ios_screenshots.md
@@ -2,7 +2,7 @@
   <img src="/img/actions/snapshot.png" width="250">
 </p>
 
-###### Automate taking localized screenshots of your iOS and tvOS apps on every device
+###### Automate taking localized screenshots of your iOS, tvOS, and watchOS apps on every device
 
 <hr />
 <h4 align="center">
@@ -10,7 +10,7 @@
 </h4>
 <hr />
 
-_snapshot_ generates localized iOS and tvOS screenshots for different device types and languages for the App Store and can be uploaded using ([_deliver_](https://docs.fastlane.tools/actions/deliver/)).
+_snapshot_ generates localized iOS, tvOS, and watchOS screenshots for different device types and languages for the App Store and can be uploaded using ([_deliver_](https://docs.fastlane.tools/actions/deliver/)).
 
 You have to manually create 20 (languages) x 6 (devices) x 5 (screenshots) = **600 screenshots**.
 

--- a/snapshot/lib/assets/SnapfileTemplate
+++ b/snapshot/lib/assets/SnapfileTemplate
@@ -8,7 +8,8 @@
 #   "iPhone X",
 #   "iPad Pro (12.9-inch)",
 #   "iPad Pro (9.7-inch)",
-#   "Apple TV 1080p"
+#   "Apple TV 1080p",
+#   "Apple Watch Series 6 - 44mm"
 # ])
 
 # languages([

--- a/snapshot/lib/assets/SnapfileTemplate.swift
+++ b/snapshot/lib/assets/SnapfileTemplate.swift
@@ -8,7 +8,8 @@ class Snapshotfile: SnapshotfileProtocol {
     //    "iPhone 5",
     //    "iPad Pro (12.9-inch)",
     //    "iPad Pro (9.7-inch)",
-    //    "Apple TV 1080p"
+    //    "Apple TV 1080p",
+    //    "Apple Watch Series 6 - 44mm"
     //    ]
     //}
 

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -306,4 +306,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.26]
+// SnapshotHelperVersion [1.27]

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -193,16 +193,20 @@ open class Snapshot: NSObject {
     }
 
     class func fixLandscapeOrientation(image: UIImage) -> UIImage {
-        if #available(iOS 10.0, *) {
-            let format = UIGraphicsImageRendererFormat()
-            format.scale = image.scale
-            let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-            return renderer.image { context in
-                image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
-            }
-        } else {
+        #if os(watchOS)
             return image
-        }
+        #else
+            if #available(iOS 10.0, *) {
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = image.scale
+                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+                return renderer.image { context in
+                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+                }
+            } else {
+                return image
+            }
+        #endif
     }
 
     class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {

--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -128,7 +128,9 @@ module Snapshot
         'Apple TV 4K (at 1080p)' => 'Apple TV 4K (at 1080p)',
         'Apple TV 4K' => 'Apple TV 4K',
         'Apple TV' => 'Apple TV',
-        'Mac' => 'Mac'
+        'Mac' => 'Mac',
+        'Apple Watch Series 5 - 44mm' => 'Apple Watch Series 5 - 44mm',
+        'Apple Watch Series 6 - 44mm' => 'Apple Watch Series 6 - 44mm'
       }
     end
 

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -45,7 +45,14 @@ module Snapshot
         # on Mac we will always run on host machine, so should specify only platform
         return ["-destination 'platform=macOS'"] if devices.first.to_s =~ /^Mac/
 
-        os = devices.first.to_s =~ /^Apple TV/ ? "tvOS" : "iOS"
+        case devices.first.to_s
+        when /^Apple TV/
+          os = 'tvOS'
+        when /^Apple Watch/
+          os = 'watchOS'
+        else
+          os = 'iOS'
+        end
 
         os_version = Snapshot.config[:ios_version] || Snapshot::LatestOsVersion.version(os)
 
@@ -78,8 +85,15 @@ module Snapshot
           device = device.downcase
           device.include?('apple tv')
         end
-        # Return true if all devices are iOS devices
+        # Return true if all devices are tvOS devices
         return true unless all_tvos.include?(false)
+
+        all_watchos = devices.map do |device|
+          device = device.downcase
+          device.include?('apple watch')
+        end
+        # Return true if all devices are watchOS devices
+        return true unless all_watchos.include?(false)
 
         # There should only be more than 1 device type if
         # it is iOS or tvOS, therefore, if there is more than 1

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -12,10 +12,11 @@ describe Snapshot do
     let(:iphone4s_9_0) { FastlaneCore::DeviceManager::Device.new(name: "iPhone 4s", os_version: '9.0', udid: "4444", state: "Don't Care", is_simulator: true) }
     let(:ipad_air_9_1) { FastlaneCore::DeviceManager::Device.new(name: "iPad Air", os_version: '9.1', udid: "12345", state: "Don't Care", is_simulator: true) }
     let(:appleTV) { FastlaneCore::DeviceManager::Device.new(name: "Apple TV 1080p", os_version: os_version, udid: "22222", state: "Don't Care", is_simulator: true) }
+    let(:appleWatch6_44mm_7_4) { FastlaneCore::DeviceManager::Device.new(name: "Apple Watch Series 6 - 44mm", os_version: '7.4', udid: "5555544", state: "Don't Care", is_simulator: true) }
 
     before do
       allow(Snapshot::LatestOsVersion).to receive(:version).and_return(os_version)
-      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV, iphone6_9_3_2, iphone6_10_1, iphone6s_10_1, iphone4s_9_0, ipad_air_9_1])
+      allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV, iphone6_9_3_2, iphone6_10_1, iphone6s_10_1, iphone4s_9_0, ipad_air_9_1, appleWatch6_44mm_7_4])
       fake_out_xcode_project_loading
     end
 
@@ -48,8 +49,20 @@ describe Snapshot do
         expect(result).to be(true)
       end
 
+      it "returns true with only Apple Watch devices" do
+        devices = ["Apple Watch Series 6 - 44mm"]
+        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+        expect(result).to be(true)
+      end
+
       it "returns false with mixed device OS of Apple TV and iPhone" do
         devices = ["Apple TV 1080p", "iPhone 8"]
+        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+        expect(result).to be(false)
+      end
+
+      it "returns false with mixed device OS of Apple Watch and iPhone" do
+        devices = ["Apple Watch Series 6 - 44mm", "iPhone 8"]
         result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
         expect(result).to be(false)
       end
@@ -250,6 +263,35 @@ describe Snapshot do
               "-project ./snapshot/example/Example.xcodeproj",
               "-derivedDataPath /tmp/path/to/snapshot_derived",
               "-destination 'platform=tvOS Simulator,name=#{name},OS=#{os}'",
+              "FASTLANE_SNAPSHOT=YES",
+              "FASTLANE_LANGUAGE=en",
+              :build,
+              :test,
+              "| tee /path/to/logs",
+              "| xcpretty "
+            ]
+          )
+        end
+
+        it "uses the default parameters on watchOS too", requires_xcode: true do
+          configure(options.merge(devices: ["Apple Watch Series 6 - 44mm"]))
+          expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
+          command = Snapshot::TestCommandGenerator.generate(
+            devices: ["Apple Watch Series 6 - 44mm"],
+            language: "en",
+            locale: nil,
+            log_path: '/path/to/logs'
+          )
+          name = command.join('').match(/name=(.+?),/)[1]
+          os = command.join('').match(/OS=(\d+.\d+)/)[1]
+          expect(command).to eq(
+            [
+              "set -o pipefail &&",
+              "xcodebuild",
+              "-scheme ExampleUITests",
+              "-project ./snapshot/example/Example.xcodeproj",
+              "-derivedDataPath /tmp/path/to/snapshot_derived",
+              "-destination 'platform=watchOS Simulator,name=#{name},OS=#{os}'",
               "FASTLANE_SNAPSHOT=YES",
               "FASTLANE_LANGUAGE=en",
               :build,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
  - 🚨 I have two failing RSpec tests, on the clean `master` branch - see notes below
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

🔑 This PR adds Apple Watch support to _Snapshot_, as requested in some discussion threads ([1](https://github.com/fastlane/fastlane/discussions/17004), [2](https://github.com/fastlane/fastlane/discussions/18370)) and [one old issue](https://github.com/fastlane/fastlane/issues/1709) which was closed because `UIAutomation` was not supported on Apple Watch at the time.

### Description
* changes `test_command_generator.rb` to identify watchOS destination devices
  * new test in ``test_command_generator_spec.rb`
* changes `test_command_generator.rb` to identify when watchOS is the only type of device in the list of devices, or when it's mixed with other device types
  * new test in ``test_command_generator_spec.rb`
* changes `report_generator.rb` include `Apple Watch Series 5 - 44mm` and `Apple Watch Series 6 - 44mm` in the device mappings
  * no evidence of RSpec tests for `report_generator.rb` 😢 
* change `fixLandscapeOrientation` function in `SnapshotHelper.swift` to ignore `UIKit`-specific code when building for Apple Watch

### Notes
* I've had two failing RSpec tests when running on my local machine
  * these fail on the `master` branch with _no_ local changes
  * the failures are for a part of Fastlane that I haven't touched - so I'm confident that I haven't caused a regression
  * [details in this discussion](https://github.com/fastlane/fastlane/discussions/18885)
* This PR only adds support for 44mm Apple Watch, because AppStoreConnect only allows screenshots for that size display
* `SnapshotHelperVersion` not updated - I don't think this is my decision to make 😕 

### Testing Steps

Tested with this `Snapfile`:

```
devices([
  'Apple Watch Series 6 - 44mm'
])
ios_version('7.4')
erase_simulator(false)
test_target_name('watchOS')
scheme('watchOS')
number_of_retries(0)
concurrent_simulators(false)

languages([
  "en-GB",
])
```

*Note:* `test_target_name` and `scheme` parameters are for my "watchOS app" target, not my "watchOS screenshot tests" target. I honestly don't know why this is necessary - maybe just a problem with the setup of my test Xcode project?
