### PR TITLE
[regression][create-keychain] allow `timeout: 0` to specify "no time-out"

### DIFF
--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -126,8 +126,8 @@ module Fastlane
                                        type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :timeout,
-                                       description: 'timeout interval in seconds',
-                                       type: Integer,
+                                       description: 'timeout interval in seconds. Set `false` if you want to specify "no time-out"',
+                                       skip_type_validation: true, # allow integers & Bool->`false` for "no timeout"
                                        default_value: 300),
           FastlaneCore::ConfigItem.new(key: :lock_when_sleeps,
                                        description: 'Lock keychain when the system sleeps',

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -47,7 +47,10 @@ module Fastlane
         commands << Fastlane::Actions.sh("security unlock-keychain -p #{escaped_password} #{keychain_path}", log: false) if params[:unlock]
 
         command = "security set-keychain-settings"
-        command << " -t #{params[:timeout]}" if params[:timeout]
+
+        # https://ss64.com/osx/security-keychain-settings.html
+        # omitting 'timeout' option to specify "no timeout" if required
+        command << " -t #{params[:timeout]}" if params[:timeout] > 0
         command << " -l" if params[:lock_when_sleeps]
         command << " -u" if params[:lock_after_timeout]
         command << " #{keychain_path}"

--- a/fastlane/lib/fastlane/actions/create_keychain.rb
+++ b/fastlane/lib/fastlane/actions/create_keychain.rb
@@ -126,8 +126,8 @@ module Fastlane
                                        type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :timeout,
-                                       description: 'timeout interval in seconds. Set `false` if you want to specify "no time-out"',
-                                       skip_type_validation: true, # allow integers & Bool->`false` for "no timeout"
+                                       description: 'timeout interval in seconds. Set `0` if you want to specify "no time-out"',
+                                       type: Integer,
                                        default_value: 300),
           FastlaneCore::ConfigItem.new(key: :lock_when_sleeps,
                                        description: 'Lock keychain when the system sleeps',

--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -92,6 +92,27 @@ describe Fastlane do
           expect(result[1]).to include('~/Library/Keychains/test.keychain')
         end
 
+        it "works with `timeout: false` to specify 'no time-out'" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: 'testpassword',
+              timeout: false,
+              lock_when_sleeps: true,
+              lock_after_timeout: true,
+            })
+          end").runner.execute(:test)
+
+          expect(result.size).to eq(3)
+          expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+
+          expect(result[1]).to start_with('security set-keychain-settings')
+          expect(result[1]).not_to include('-t')
+          expect(result[1]).to include('-l')
+          expect(result[1]).to include('-u')
+          expect(result[1]).to include('~/Library/Keychains/test.keychain')
+        end
+
         it "works with default_keychain" do
           result = Fastlane::FastFile.new.parse("lane :test do
             create_keychain ({

--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -150,7 +150,7 @@ describe Fastlane do
           expect(result[1]).to eq('security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain')
 
           expect(result[2]).to start_with('security set-keychain-settings')
-          expect(result[2]).not_to include('-t 0')
+          expect(result[2]).to_not(include('-t'))
           expect(result[2]).to_not(include('-l'))
           expect(result[2]).to_not(include('-u'))
           expect(result[2]).to include('~/Library/Keychains/test.keychain')

--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -92,27 +92,6 @@ describe Fastlane do
           expect(result[1]).to include('~/Library/Keychains/test.keychain')
         end
 
-        it "works with `timeout: false` to specify 'no time-out'" do
-          result = Fastlane::FastFile.new.parse("lane :test do
-            create_keychain ({
-              name: 'test.keychain',
-              password: 'testpassword',
-              timeout: false,
-              lock_when_sleeps: true,
-              lock_after_timeout: true,
-            })
-          end").runner.execute(:test)
-
-          expect(result.size).to eq(3)
-          expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
-
-          expect(result[1]).to start_with('security set-keychain-settings')
-          expect(result[1]).not_to include('-t')
-          expect(result[1]).to include('-l')
-          expect(result[1]).to include('-u')
-          expect(result[1]).to include('~/Library/Keychains/test.keychain')
-        end
-
         it "works with default_keychain" do
           result = Fastlane::FastFile.new.parse("lane :test do
             create_keychain ({

--- a/fastlane/spec/actions_specs/create_keychain_spec.rb
+++ b/fastlane/spec/actions_specs/create_keychain_spec.rb
@@ -134,6 +134,28 @@ describe Fastlane do
           expect(result[2]).to include('~/Library/Keychains/test.keychain')
         end
 
+        it "works with 'timeout: 0' to specify 'no timeout', skips -t param" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            create_keychain ({
+              name: 'test.keychain',
+              password: 'testpassword',
+              unlock: true,
+              timeout: 0
+            })
+          end").runner.execute(:test)
+
+          expect(result.size).to eq(4)
+          expect(result[0]).to eq('security create-keychain -p testpassword ~/Library/Keychains/test.keychain')
+
+          expect(result[1]).to eq('security unlock-keychain -p testpassword ~/Library/Keychains/test.keychain')
+
+          expect(result[2]).to start_with('security set-keychain-settings')
+          expect(result[2]).not_to include('-t 0')
+          expect(result[2]).to_not(include('-l'))
+          expect(result[2]).to_not(include('-u'))
+          expect(result[2]).to include('~/Library/Keychains/test.keychain')
+        end
+
         it "works with all params" do
           result = Fastlane::FastFile.new.parse("lane :test do
             create_keychain ({


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Resolves: https://github.com/fastlane/fastlane/issues/18892 https://github.com/fastlane/fastlane/issues/18936
- Regression PR: https://github.com/fastlane/fastlane/pull/18857
- Regression PR broke the `create_keychain` action to allow `timeout: false` to specify "no time-out"

### Description
- In this PR, now we will allow `timeout: 0` to specify "no time-out" 
- Added the unit test to ensure that this will not break in the future

### Testing Steps
- `bundle exec rspec fastlane/spec/actions_specs/create_keychain_spec.rb`