### PR TITLE
[action][import_from_git] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/import_from_git.rb
+++ b/fastlane/lib/fastlane/actions/import_from_git.rb
@@ -24,7 +24,7 @@ module Fastlane
           # `conflicting_options`, `verify_block`) are completely ignored.
           FastlaneCore::ConfigItem.new(key: :url,
                                        description: "The URL of the repository to import the Fastfile from",
-                                       default_value: nil),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :branch,
                                        description: "The branch or tag to check-out on the repository",
                                        default_value: 'HEAD',
@@ -39,12 +39,10 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "The version to checkout on the repository. Optimistic match operator or multiple conditions can be used to select the latest version within constraints",
-                                       default_value: nil,
                                        type: Array,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :cache_path,
                                        description: "The path to a directory where the repository should be cloned into. Defaults to `nil`, which causes the repository to be cloned on every call, to a temporary directory",
-                                       default_value: nil,
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/actions/import_from_git.rb
+++ b/fastlane/lib/fastlane/actions/import_from_git.rb
@@ -40,7 +40,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        description: "The version to checkout on the repository. Optimistic match operator or multiple conditions can be used to select the latest version within constraints",
                                        default_value: nil,
-                                       is_string: false,
+                                       type: Array,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :cache_path,
                                        description: "The path to a directory where the repository should be cloned into. Defaults to `nil`, which causes the repository to be cloned on every call, to a temporary directory",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `import_from_git` action.

### Description
- Remove `is_string: true` from options and removed `default_value: nil`
- Added `type: Array` 

### Testing Steps
- No functionality changed, all existing unit tests should pass.