### PR TITLE
[action][installr] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/installr.rb
+++ b/fastlane/lib/fastlane/actions/installr.rb
@@ -66,35 +66,32 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :api_token,
-                                     env_name: "INSTALLR_API_TOKEN",
-                                     sensitive: true,
-                                     description: "API Token for Installr Access",
-                                     verify_block: proc do |value|
-                                       UI.user_error!("No API token for Installr given, pass using `api_token: 'token'`") unless value && !value.empty?
-                                     end),
+                                       env_name: "INSTALLR_API_TOKEN",
+                                       sensitive: true,
+                                       description: "API Token for Installr Access",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No API token for Installr given, pass using `api_token: 'token'`") unless value && !value.empty?
+                                       end),
           FastlaneCore::ConfigItem.new(key: :ipa,
-                                     env_name: "INSTALLR_IPA_PATH",
-                                     description: "Path to your IPA file. Optional if you use the _gym_ or _xcodebuild_ action",
-                                     default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
-                                     default_value_dynamic: true,
-                                     verify_block: proc do |value|
-                                       UI.user_error!("Couldn't find build file at path '#{value}'") unless File.exist?(value)
-                                     end),
+                                       env_name: "INSTALLR_IPA_PATH",
+                                       description: "Path to your IPA file. Optional if you use the _gym_ or _xcodebuild_ action",
+                                       default_value: Actions.lane_context[SharedValues::IPA_OUTPUT_PATH],
+                                       default_value_dynamic: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find build file at path '#{value}'") unless File.exist?(value)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :notes,
-                                     env_name: "INSTALLR_NOTES",
-                                     description: "Release notes",
-                                     is_string: true,
-                                     optional: true),
+                                       env_name: "INSTALLR_NOTES",
+                                       description: "Release notes",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :notify,
-                                     env_name: "INSTALLR_NOTIFY",
-                                     description: "Groups to notify (e.g. 'dev,qa')",
-                                     is_string: true,
-                                     optional: true),
+                                       env_name: "INSTALLR_NOTIFY",
+                                       description: "Groups to notify (e.g. 'dev,qa')",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :add,
-                                     env_name: "INSTALLR_ADD",
-                                     description: "Groups to add (e.g. 'exec,ops')",
-                                     is_string: true,
-                                     optional: true)
+                                       env_name: "INSTALLR_ADD",
+                                       description: "Groups to add (e.g. 'exec,ops')",
+                                       optional: true)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `installr` action.

### Description
- Remove `is_string: true` from options
- Fixed the options formatting

### Testing Steps
- No functionality changed, all existing unit tests should pass.