### PR TITLE
[action][jazzy] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/jazzy.rb
+++ b/fastlane/lib/fastlane/actions/jazzy.rb
@@ -19,20 +19,14 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(
-            key: :config,
-            env_name: 'FL_JAZZY_CONFIG',
-            description: 'Path to jazzy config file',
-            is_string: true,
-            optional: true
-          ),
-          FastlaneCore::ConfigItem.new(
-            key: :module_version,
-            env_name: 'FL_JAZZY_MODULE_VERSION',
-            description: 'Version string to use as part of the the default docs title and inside the docset',
-            is_string: true,
-            optional: true
-          )
+          FastlaneCore::ConfigItem.new(key: :config,
+                                       env_name: 'FL_JAZZY_CONFIG',
+                                       description: 'Path to jazzy config file',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :module_version,
+                                       env_name: 'FL_JAZZY_MODULE_VERSION',
+                                       description: 'Version string to use as part of the the default docs title and inside the docset',
+                                       optional: true)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `jazzy` action.

### Description
- Remove `is_string: true` from options
- Fixed formatting

### Testing Steps
- No functionality changed, all existing unit tests should pass.