### PR TITLE
[spaceship] Add missing method to individually assign beta tester to builds

### DIFF
--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -337,7 +337,7 @@ module Spaceship
             end
           }
 
-          test_flight_request_client.post("betaTesters/#{beta_tester_id}/relationships/builds", nil, body)
+          test_flight_request_client.post("betaTesters/#{beta_tester_id}/relationships/builds", body)
         end
 
         #

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -327,6 +327,19 @@ module Spaceship
           test_flight_request_client.delete("apps/#{app_id}/relationships/betaTesters", nil, body)
         end
 
+        def add_beta_tester_to_builds(beta_tester_id: nil, build_ids: [])
+          body = {
+            data: build_ids.map do |id|
+              {
+                type: "builds",
+                id: id
+              }
+            end
+          }
+
+          test_flight_request_client.post("betaTesters/#{beta_tester_id}/relationships/builds", nil, body)
+        end
+
         #
         # betaTesterMetrics
         #

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -572,6 +572,30 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           client.delete_beta_testers_from_app(beta_tester_ids: beta_tester_ids, app_id: app_id)
         end
       end
+
+      context 'add_beta_tester_to_builds' do
+        let(:beta_tester_id) { "123" }
+        let(:build_ids) { ["1234", "5678"] }
+        let(:path) { "betaTesters/#{beta_tester_id}/relationships/builds" }
+        let(:body) do
+          {
+            data: build_ids.map do |id|
+              {
+                type: "builds",
+                id: id
+              }
+            end
+          }
+        end
+
+        it 'succeeds' do
+          url = path
+          req_mock = test_request_body(url, body)
+
+          expect(client).to receive(:request).with(:post).and_yield(req_mock).and_return(req_mock)
+          client.add_beta_tester_to_builds(beta_tester_id: beta_tester_id, build_ids: build_ids)
+        end
+      end
     end
 
     describe "builds" do


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Implementing the endpoint that allows you to individually assign a beta tester to builds. [[ASC API docs](https://developer.apple.com/documentation/appstoreconnectapi/individually_assign_a_beta_tester_to_builds)]