### PR TITLE
[fastlane_core] Fix the `ensure_array_type_passes_validation` error message

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -223,7 +223,7 @@ module FastlaneCore
 
       # Arrays can be an either be an array or string that gets split by comma in auto_convert_type
       if !value.kind_of?(Array) && !value.kind_of?(String)
-        UI.user_error!("'#{self.key}' value must be either `true` or `false`! Found #{value.class} instead.")
+        UI.user_error!("'#{self.key}' value must be either `Array` or `comma-separated String`! Found #{value.class} instead.")
       end
     end
 

--- a/fastlane_core/spec/config_item_spec.rb
+++ b/fastlane_core/spec/config_item_spec.rb
@@ -199,5 +199,44 @@ describe FastlaneCore do
         expect(auto_convert_value).to be(false)
       end
     end
+
+    describe "ConfigItem Array type input validation" do
+      it "doesn't raise an error if value is Array type" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                              default_value: ["foo1", "foo2"])
+        expect(UI).not_to receive(:user_error)
+        result.ensure_array_type_passes_validation(result.default_value)
+      end
+
+      it "doesn't raise an error if value is String type" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                              default_value: "foo1")
+        expect(UI).not_to receive(:user_error)
+        result.ensure_array_type_passes_validation(result.default_value)
+      end
+
+      it "doesn't raise an error if value is comma-separated String type" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                              default_value: "foo1,foo2")
+        expect(UI).not_to receive(:user_error)
+        result.ensure_array_type_passes_validation(result.default_value)
+      end
+
+      it "does raise an error if value is Boolean type" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                              default_value: true)
+        expect do
+          result.ensure_array_type_passes_validation(result.default_value)
+        end.to raise_error("'foo' value must be either `Array` or `comma-separated String`! Found TrueClass instead.")
+      end
+
+      it "does raise an error if value is Hash type" do
+        result = FastlaneCore::ConfigItem.new(key: :foo,
+                                              default_value: {})
+        expect do
+          result.ensure_array_type_passes_validation(result.default_value)
+        end.to raise_error("'foo' value must be either `Array` or `comma-separated String`! Found Hash instead.")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `ensure_array_type_passes_validation` error message is slightly misleading...
- https://github.com/fastlane/fastlane/pull/18883#discussion_r652081385

### Description
- Fix the `ensure_array_type_passes_validation` error message
- Added unit tests

### Testing Steps
- No functionality changed, all existing/new unit tests should pass. 
