### PR TITLE
[Fastlane.Swift] Add new Swift 5.5 reserved keywords

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -31,7 +31,7 @@ module Fastlane
 
       # rubocop:disable Layout/LineLength
       # class instance?
-      @reserved_words = %w[associativity async await break case catch class continue convenience default deinit didSet do else enum extension fallthrough false final for func guard if in infix init inout internal lazy let mutating nil operator override precedence private public repeat required return self static struct subscript super switch throws true try var weak where while willSet].to_set
+      @reserved_words = %w[actor associativity async await break case catch class continue convenience default deinit didSet do else enum extension fallthrough false final for func guard if in infix init inout internal lazy let mutating nil operator override precedence private public repeat required return self static struct subscript super switch throws true try var weak where while willSet].to_set
       # rubocop:enable Layout/LineLength
     end
 

--- a/fastlane/lib/fastlane/swift_fastlane_function.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_function.rb
@@ -31,7 +31,7 @@ module Fastlane
 
       # rubocop:disable Layout/LineLength
       # class instance?
-      @reserved_words = %w[associativity break case catch class continue convenience default deinit didSet do else enum extension fallthrough false final for func guard if in infix init inout internal lazy let mutating nil operator override precedence private public repeat required return self static struct subscript super switch throws true try var weak where while willSet].to_set
+      @reserved_words = %w[associativity async await break case catch class continue convenience default deinit didSet do else enum extension fallthrough false final for func guard if in infix init inout internal lazy let mutating nil operator override precedence private public repeat required return self static struct subscript super switch throws true try var weak where while willSet].to_set
       # rubocop:enable Layout/LineLength
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Update the reserved keywords to match the new Swift 5.5 release.

### Description
Added `actor`, `async` and `await` to the reserved keywords set.

### Testing Steps
None
