### PR TITLE
[snapshot] Fix Swift compiler version check for `SnapshotHelper.swift`

### DIFF
--- a/snapshot/example/fastlane/SnapshotHelper.swift
+++ b/snapshot/example/fastlane/SnapshotHelper.swift
@@ -180,8 +180,8 @@ open class Snapshot: NSObject {
                 simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
 
                 let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
-                #if swift(<5.0)
-                    UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                #if swift(<4.2)
+                    try UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
                 #else
                     try image.pngData()?.write(to: path, options: .atomic)
                 #endif

--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -302,4 +302,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.25]
+// SnapshotHelperVersion [1.26]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Closes #18792

### Description
There was a wrong compiler version check for `UIImagePNGRepresentation` deprecation, which led to a compile error in _snapshot_

### Testing Steps
1. Checkout this branch.
2. Go to _snapshot_ and open the Example.xcodeproj
3. Open SnapshotHelper.swift with a Swift version set at 4.0
4. Compile it.
5. :rocket: 