### PR TITLE
[docs] Improve explanation of `company_name` in `create_app_online`

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/create_app_online.md
+++ b/fastlane/lib/fastlane/actions/docs/create_app_online.md
@@ -68,7 +68,7 @@ Options for create:
   -y, --sku STRING     SKU Number (e.g. '1234') (PRODUCE_SKU)
   -j, --platform STRING The platform to use (optional) (PRODUCE_PLATFORM)
   -m, --language STRING Primary Language (e.g. 'English', 'German') (PRODUCE_LANGUAGE)
-  -c, --company_name STRING The name of your company. Only required if it's the first app you create (PRODUCE_COMPANY_NAME)
+  -c, --company_name STRING The name of your company. It's used to set company name on App Store Connect team's app pages. Only required if it's the first app you create (PRODUCE_COMPANY_NAME)
   -i, --skip_itc [VALUE] Skip the creation of the app on App Store Connect (PRODUCE_SKIP_ITC)
   -d, --skip_devcenter [VALUE] Skip the creation of the app on the Apple Developer Portal (PRODUCE_SKIP_DEVCENTER)
   -s, --itc_users ARRAY Array of App Store Connect users. If provided, you can limit access to this newly created app for users with the App Manager, Developer, Marketer or Sales roles (ITC_USERS)

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -77,7 +77,7 @@ module Produce
         FastlaneCore::ConfigItem.new(key: :company_name,
                                      short_option: "-c",
                                      env_name: "PRODUCE_COMPANY_NAME",
-                                     description: "The name of your company. Only required if it's the first app you create",
+                                     description: "The name of your company. It's used to set company name on App Store Connect team's app pages. Only required if it's the first app you create",
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :skip_itc,
                                      short_option: "-i",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Explain in more detail the meaning of `company_name` parameter in `create_app_online` docs
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
`company_name` parameter is required when creating first app on App Store Connect team and as it can be set only once without contacting Apple support its description could be more detailed.
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
