### PR TITLE
[action][latest_testflight_build_number] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -57,7 +57,7 @@ module Fastlane
                                        env_name: "CURRENT_BUILD_NUMBER_LIVE",
                                        description: "Query the live version (ready-for-sale)",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :app_identifier,
                                        short_option: "-a",
@@ -82,7 +82,6 @@ module Fastlane
                                        env_name: "APPSTORE_PLATFORM",
                                        description: "The platform to use (optional)",
                                        optional: true,
-                                       is_string: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
                                          UI.user_error!("The platform can only be ios, osx, or appletvos") unless %('osx', ios', 'appletvos').include?(value)
@@ -91,13 +90,13 @@ module Fastlane
                                        env_name: "INITIAL_BUILD_NUMBER",
                                        description: "sets the build number to given value if no build is in current train",
                                        default_value: 1,
-                                       is_string: false),
+                                       skip_type_validation: true), # allow Integer, String
           FastlaneCore::ConfigItem.new(key: :team_id,
                                        short_option: "-k",
                                        env_name: "LATEST_TESTFLIGHT_BUILD_NUMBER_TEAM_ID",
                                        description: "The ID of your App Store Connect team if you're in multiple teams",
                                        optional: true,
-                                       is_string: false, # as we also allow integers, which we convert to strings anyway
+                                       skip_type_validation: true, # allow Integer, String
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:itc_team_id),
                                        default_value_dynamic: true),


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `latest_testflight_build_number` action.

### Description
- Remove `is_string: true` from options
- Added `type: Boolean`

### Testing Steps
- No functionality changed, all existing unit tests should pass.