### PR TITLE
[action][lcov] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/lcov.rb
+++ b/fastlane/lib/fastlane/actions/lcov.rb
@@ -22,21 +22,17 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :project_name,
                                        env_name: "FL_LCOV_PROJECT_NAME",
                                        description: "Name of the project"),
-
           FastlaneCore::ConfigItem.new(key: :scheme,
                                        env_name: "FL_LCOV_SCHEME",
                                        description: "Scheme of the project"),
-
           FastlaneCore::ConfigItem.new(key: :arch,
                                        env_name: "FL_LCOV_ARCH",
                                        description: "The build arch where will search .gcda files",
                                        default_value: "i386"),
-
           FastlaneCore::ConfigItem.new(key: :output_dir,
                                        env_name: "FL_LCOV_OUTPUT_DIR",
                                        description: "The output directory that coverage data will be stored. If not passed will use coverage_reports as default value",
                                        optional: true,
-                                       is_string: true,
                                        default_value: "coverage_reports")
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `lcov` action.

### Description
- Remove `is_string: true` from options
- Fixed formatting

### Testing Steps
- No functionality changed, all existing unit tests should pass.