### PR TITLE
[action][modify_services] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/modify_services.rb
+++ b/fastlane/lib/fastlane/actions/modify_services.rb
@@ -106,7 +106,6 @@ module Fastlane
                                        display_in_shell: false,
                                        env_name: "PRODUCE_ENABLE_SERVICES",
                                        description: "Array with Spaceship App Services (e.g. #{allowed_services_description})",
-                                       is_string: false,
                                        type: Hash,
                                        default_value: {},
                                        verify_block: proc do |value|


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `modify_services` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.