### PR TITLE
[action][notarize] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -177,7 +177,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :package,
                                        env_name: 'FL_NOTARIZE_PACKAGE',
                                        description: 'Path to package to notarize, e.g. .app bundle or disk image',
-                                       is_string: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Could not find package at '#{value}'") unless File.exist?(value)
                                        end),
@@ -190,8 +189,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :bundle_id,
                                        env_name: 'FL_NOTARIZE_BUNDLE_ID',
                                        description: 'Bundle identifier to uniquely identify the package',
-                                       optional: true,
-                                       is_string: true),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: 'FL_NOTARIZE_USERNAME',
                                        description: 'Apple ID username',
@@ -221,7 +219,6 @@ module Fastlane
                                        description: 'Path to AppStore Connect API key',
                                        optional: true,
                                        conflicting_options: [:username],
-                                       is_string: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("API Key not found at '#{value}'") unless File.exist?(value)
                                        end)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `notarize` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.