### PR TITLE
[action][number_of_commits] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/number_of_commits.rb
+++ b/fastlane/lib/fastlane/actions/number_of_commits.rb
@@ -42,7 +42,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :all,
                                        env_name: "FL_NUMBER_OF_COMMITS_ALL",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        description: "Returns number of all commits instead of current branch")
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `number_of_commits` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.