### PR TITLE
[action][reset_simulator_contents] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -44,14 +44,12 @@ module Fastlane
                                        short_option: "-i",
                                        env_name: "FASTLANE_RESET_SIMULATOR_VERSIONS",
                                        description: "Which OS versions of Simulators you want to reset content and settings, this does not remove/recreate the simulators",
-                                       is_string: false,
                                        optional: true,
                                        type: Array),
           FastlaneCore::ConfigItem.new(key: :os_versions,
                                        short_option: "-v",
                                        env_name: "FASTLANE_RESET_SIMULATOR_OS_VERSIONS",
                                        description: "Which OS versions of Simulators you want to reset content and settings, this does not remove/recreate the simulators",
-                                       is_string: false,
                                        optional: true,
                                        type: Array)
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `reset_simulator_contents` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.