### PR TITLE
[action][rsync] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/rsync.rb
+++ b/fastlane/lib/fastlane/actions/rsync.rb
@@ -32,20 +32,17 @@ module Fastlane
                                        env_name: "FL_RSYNC_EXTRA", # The name of the environment variable
                                        description: "Port", # a short description of this parameter
                                        optional: true,
-                                       default_value: "-av",
-                                       is_string: true),
+                                       default_value: "-av"),
           FastlaneCore::ConfigItem.new(key: :source,
                                        short_option: "-S",
                                        env_name: "FL_RSYNC_SRC", # The name of the environment variable
                                        description: "source file/folder", # a short description of this parameter
-                                       optional: false,
-                                       is_string: true),
+                                       optional: false),
           FastlaneCore::ConfigItem.new(key: :destination,
                                        short_option: "-D",
                                        env_name: "FL_RSYNC_DST", # The name of the environment variable
                                        description: "destination file/folder", # a short description of this parameter
-                                       optional: false,
-                                       is_string: true)
+                                       optional: false)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `rsync` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.