### PR TITLE
[action][retrieve_devices] New Action | Retrieve and log all devices for an Apple Certificate

### DIFF
--- a/fastlane/actions/retrieve_devices.rb
+++ b/fastlane/actions/retrieve_devices.rb
@@ -1,0 +1,104 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      DEVICES_FOR_APPLE_CERTIFICATE = :DEVICES_FOR_APPLE_CERTIFICATE
+    end
+
+    class RetrieveDevicesAction < Action
+      def self.run(params)
+        require 'spaceship'
+        if (api_token = Spaceship::ConnectAPI::Token.from(hash: params[:api_key], filepath: params[:api_key_path]))
+          UI.message("Creating authorization token for App Store Connect API")
+          Spaceship::ConnectAPI.token = api_token
+        elsif !Spaceship::ConnectAPI.token.nil?
+          UI.message("Using existing authorization token for App Store Connect API")
+        else
+          UI.message("Login to App Store Connect (#{params[:username]})")
+          credentials = CredentialsManager::AccountManager.new(user: params[:username])
+          Spaceship::ConnectAPI.login(credentials.user, credentials.password, use_portal: true, use_tunes: false)
+          UI.message("Login successful")
+        end
+
+        UI.message("Fetching list of currently registered devices...")
+        existing_devices = Spaceship::ConnectAPI::Device.all.map { |ed| { name: ed.name, udid: ed.udid }}
+
+        UI.success("Successfully retrieved the following devices")
+
+        existing_devices.each do |ed|
+          UI.message("UDID: #{ed[:udid]} | NAME: #{ed[:name]}")
+        end
+
+        Actions.lane_context[SharedValues::FL_CHANGELOG] = existing_devices
+        # sh "shellcommand ./path"
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "A short description with <= 80 characters of what this action does"
+      end
+
+      def self.details
+        [
+          "This action will retrieve a list of names and UDIDs of each device registered with your Apple Certificate.",
+          "This list is exactly the same as the list used to compare against what is/isn't registered in the `register_device/s` action.",
+        ].join("\n")
+      end
+
+      def self.available_options
+        # Define all options your action supports.
+        user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)
+        user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
+
+        puts "FOUND"
+        puts Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APP_STORE_CONNECT_API_KEY]
+
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                       env_names: ["FL_RETRIEVE_DEVICES_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
+                                       description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
+                                       optional: true,
+                                       conflicting_options: [:api_key],
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :api_key,
+                                       env_names: ["FL_RETRIEVE_DEVICES_API_KEY", "APP_STORE_CONNECT_API_KEY"],
+                                       description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#use-return-value-and-pass-in-as-an-option)",
+                                       type: Hash,
+                                       default_value: Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APP_STORE_CONNECT_API_KEY],
+                                       default_value_dynamic: true,
+                                       optional: true,
+                                       sensitive: true,
+                                       conflicting_options: [:api_key_path]),
+          FastlaneCore::ConfigItem.new(key: :username,
+                                       env_name: "DELIVER_USER",
+                                       description: "Optional: Your Apple ID",
+                                       optional: true,
+                                       default_value: user,
+                                       default_value_dynamic: true)
+        ]
+      end
+
+      def self.output
+        [
+          ['DEVICES_FOR_APPLE_CERTIFICATE', 'A hash with the Name and UDID of each device registered with Apple']
+        ]
+      end
+
+      def self.return_value
+      end
+
+      def self.authors
+        ["builtbyproxy"]
+      end
+
+      def self.is_supported?(platform)
+         [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end

--- a/fastlane/actions/retrieve_devices.rb
+++ b/fastlane/actions/retrieve_devices.rb
@@ -20,7 +20,7 @@ module Fastlane
         end
 
         UI.message("Fetching list of currently registered devices...")
-        existing_devices = Spaceship::ConnectAPI::Device.all.map { |ed| { name: ed.name, udid: ed.udid }}
+        existing_devices = Spaceship::ConnectAPI::Device.all.map { |ed| { name: ed.name, udid: ed.udid } }
 
         UI.success("Successfully retrieved the following devices")
 
@@ -28,7 +28,7 @@ module Fastlane
           UI.message("UDID: #{ed[:udid]} | NAME: #{ed[:name]}")
         end
 
-        Actions.lane_context[SharedValues::FL_CHANGELOG] = existing_devices
+        Actions.lane_context[SharedValues::DEVICES_FOR_APPLE_CERTIFICATE] = existing_devices
         # sh "shellcommand ./path"
       end
 
@@ -37,25 +37,18 @@ module Fastlane
       #####################################################
 
       def self.description
-        "A short description with <= 80 characters of what this action does"
-      end
-
-      def self.details
         [
           "This action will retrieve a list of names and UDIDs of each device registered with your Apple Certificate.",
-          "This list is exactly the same as the list used to compare against what is/isn't registered in the `register_device/s` action.",
+          "This list is exactly the same as the list used to compare against what is/isn't registered in the `register_device/s` action."
         ].join("\n")
       end
 
+      def self.details; end
+
       def self.available_options
-        # Define all options your action supports.
         user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)
         user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
-        puts "FOUND"
-        puts Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::APP_STORE_CONNECT_API_KEY]
-
-        # Below a few examples
         [
           FastlaneCore::ConfigItem.new(key: :api_key_path,
                                        env_names: ["FL_RETRIEVE_DEVICES_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
@@ -97,7 +90,11 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-         [:ios, :mac].include?(platform)
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.category
+        :misc
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/retrieve_devices.rb
+++ b/fastlane/lib/fastlane/actions/retrieve_devices.rb
@@ -37,13 +37,15 @@ module Fastlane
       #####################################################
 
       def self.description
+        "This action will retrieve a list of each device registered with Apple"
+      end
+
+      def self.details
         [
           "This action will retrieve a list of names and UDIDs of each device registered with your Apple Certificate.",
           "This list is exactly the same as the list used to compare against what is/isn't registered in the `register_device/s` action."
         ].join("\n")
       end
-
-      def self.details; end
 
       def self.available_options
         user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid | **~I can't get this to pass. If I run `new_action` it will generate it in a directory other than `lib/fastlane/actions`, but then rubocop will fail. It's also not liking my naming of the file?~** (seems to build in the PR)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When we register a device, we do so using the [register_devices action](https://docs.fastlane.tools/actions/register_devices/). However, often at times it feels like these devices are being registered to a box. At times we have the liberty of checking our [developer account](https://developer.apple.com/). However, with so much happening in the CLI, it's odd to jump out and into a UI. 

There's a bigger option here to parse the result to `register_devices` but I would like some general input before moving closer to that goal. 

This is very much just a check right now, hence why we only map the `name` and `udid` to our `existing_devices` sharedValue.

### Description
This action takes what exists in the [register_devices action](https://docs.fastlane.tools/actions/register_devices/) and moves it to a QOL action called `retrieve_devices`. The intention is to allow us to quickly loop through what we are changing, ensure the changes exist, and move on. 

This isn't a crazy change, its simply intended to give more visibility over an already cloudy process.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Run `fastlane action retrieve_devices` and `fastlane run retrieve_devices` and ensure the output is to your satisfaction for both the project AND the documented use case. Thank you
