### PR TITLE
[action][say] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/say.rb
+++ b/fastlane/lib/fastlane/actions/say.rb
@@ -3,7 +3,7 @@ module Fastlane
     class SayAction < Action
       def self.run(params)
         text = params[:text]
-        text = text.join(' ') if text.kind_of?(Array)
+        text = text.join(' ')
         text = text.tr("'", '"')
 
         if params[:mute]
@@ -23,12 +23,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :text,
                                        description: 'Text to be spoken out loud (as string or array of strings)',
                                        optional: false,
-                                       is_string: false),
+                                       type: Array),
           FastlaneCore::ConfigItem.new(key: :mute,
                                        env_name: "SAY_MUTE",
                                        description: 'If say should be muted with text printed out',
                                        optional: false,
-                                       is_string: false,
                                        type: Boolean,
                                        default_value: false)
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `say` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.