### PR TITLE
[action][set_build_number_repository] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/set_build_number_repository.rb
+++ b/fastlane/lib/fastlane/actions/set_build_number_repository.rb
@@ -41,7 +41,7 @@ module Fastlane
                                        env_name: "USE_HG_REVISION_NUMBER",
                                        description: "Use hg revision number instead of hash (ignored for non-hg repos)",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
                                        env_name: "XCODEPROJ_PATH",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `set_build_number_repository` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.