### PR TITLE
[action][sh] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/sh.rb
+++ b/fastlane/lib/fastlane/actions/sh.rb
@@ -24,17 +24,15 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :command,
                                          description: 'Shell command to be executed',
-                                         optional: false,
-                                         is_string: true),
+                                         optional: false),
           FastlaneCore::ConfigItem.new(key: :log,
                                          description: 'Determines whether fastlane should print out the executed command itself and output of the executed command. If command line option --troubleshoot is used, then it overrides this option to true',
                                          optional: true,
-                                         is_string: false,
+                                         type: Boolean,
                                          default_value: true),
           FastlaneCore::ConfigItem.new(key: :error_callback,
                                          description: 'A callback invoked with the command output if there is a non-zero exit status',
                                          optional: true,
-                                         is_string: false,
                                          type: :string_callback,
                                          default_value: nil)
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `sh` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.