### PR TITLE
[action][spm] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -48,7 +48,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :enable_code_coverage,
                                        env_name: "FL_SPM_ENABLE_CODE_COVERAGE",
                                        description: "Enables code coverage for the generated Xcode project when using the 'generate-xcodeproj' and the 'test' command",
-                                       is_string: false,
+                                       type: Boolean,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :build_path,
                                        env_name: "FL_SPM_BUILD_PATH",
@@ -74,7 +74,7 @@ module Fastlane
                                        env_name: "FL_SPM_DISABLE_SANDBOX",
                                        description: "Disable using the sandbox when executing subprocesses",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :xcpretty_output,
                                        env_name: "FL_SPM_XCPRETTY_OUTPUT",
@@ -92,7 +92,7 @@ module Fastlane
                                        short_option: "-v",
                                        env_name: "FL_SPM_VERBOSE",
                                        description: "Increase verbosity of informational output",
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false)
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `spm` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.