### PR TITLE
[action][testfairy] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -192,7 +192,6 @@ module Fastlane
                                        env_name: "FL_TESTFAIRY_UPLOAD_URL", # The name of the environment variable
                                        description: "API URL for TestFairy", # a short description of this parameter
                                        default_value: "https://upload.testfairy.com",
-                                       is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :testers_groups,
                                        optional: true,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `testfairy` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.