### PR TITLE
[action][tryouts] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/tryouts.rb
+++ b/fastlane/lib/fastlane/actions/tryouts.rb
@@ -91,7 +91,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :notes,
                                      env_name: "TRYOUTS_NOTES",
                                      description: "Release notes",
-                                     is_string: true,
                                      optional: true),
           FastlaneCore::ConfigItem.new(key: :notes_path,
                                      env_name: "TRYOUTS_NOTES_PATH",
@@ -103,7 +102,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :notify,
                                      env_name: "TRYOUTS_NOTIFY",
                                      description: "Notify testers? 0 for no",
-                                     is_string: false,
+                                     type: Integer,
                                      default_value: 1),
           FastlaneCore::ConfigItem.new(key: :status,
                                      env_name: "TRYOUTS_STATUS",
@@ -112,7 +111,7 @@ module Fastlane
                                        available_options = ["1", "2"]
                                        UI.user_error!("'#{value}' is not a valid 'status' value. Available options are #{available_options.join(', ')}") unless available_options.include?(value.to_s)
                                      end,
-                                     is_string: false,
+                                     type: Integer,
                                      default_value: 2)
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `tryouts` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.