### PR TITLE
[action][unlock_keychain] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/unlock_keychain.rb
+++ b/fastlane/lib/fastlane/actions/unlock_keychain.rb
@@ -81,7 +81,7 @@ module Fastlane
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :add_to_search_list,
                                        env_name: "FL_UNLOCK_KEYCHAIN_ADD_TO_SEARCH_LIST",
-                                       description: "Add to keychain search list",
+                                       description: "Add to keychain search list, valid values are true, false, :add, and :replace",
                                        skip_type_validation: true, # allow Boolean, Symbol
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :set_default,

--- a/fastlane/lib/fastlane/actions/unlock_keychain.rb
+++ b/fastlane/lib/fastlane/actions/unlock_keychain.rb
@@ -82,12 +82,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :add_to_search_list,
                                        env_name: "FL_UNLOCK_KEYCHAIN_ADD_TO_SEARCH_LIST",
                                        description: "Add to keychain search list",
-                                       is_string: false,
+                                       skip_type_validation: true, # allow Boolean, Symbol
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :set_default,
                                        env_name: "FL_UNLOCK_KEYCHAIN_SET_DEFAULT",
                                        description: "Set as default keychain",
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false)
 
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `unlock_keychain` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.