### PR TITLE
[action][update_app_group_identifiers] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_app_group_identifiers.rb
@@ -53,10 +53,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :app_group_identifiers,
                                        env_name: "FL_UPDATE_APP_GROUP_IDENTIFIER_APP_GROUP_IDENTIFIERS",
                                        description: "An Array of unique identifiers for the app groups. Eg. ['group.com.test.testapp']",
-                                       is_string: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("The parameter app_group_identifiers need to be an Array.") unless value.kind_of?(Array)
-                                       end)
+                                       type: Array)
         ]
       end
 

--- a/fastlane/spec/actions_specs/update_app_group_identifiers_spec.rb
+++ b/fastlane/spec/actions_specs/update_app_group_identifiers_spec.rb
@@ -33,17 +33,6 @@ describe Fastlane do
         end.to raise_error("Could not find entitlements file at path 'xyz.#{File.join(test_path, entitlements_path)}'")
       end
 
-      it "throws an error when the identifiers are not in an array" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-          update_app_group_identifiers(
-            entitlements_file: '#{File.join(test_path, entitlements_path)}',
-            app_group_identifiers: '#{new_app_group}'
-          )
-          end").runner.execute(:test)
-        end.to raise_error('The parameter app_group_identifiers need to be an Array.')
-      end
-
       it "throws an error when the entitlements file is not parsable" do
         File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.application-groups</key><array><string>group.com.</array></dict></plist>')
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `update_app_group_identifiers` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.