### PR TITLE
[action][update_fastlane] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/update_fastlane.rb
+++ b/fastlane/lib/fastlane/actions/update_fastlane.rb
@@ -122,12 +122,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :no_update,
                                        env_name: "FL_NO_UPDATE",
                                        description: "Don't update during this run. This is used internally",
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :nightly,
                                        env_name: "FL_UPDATE_FASTLANE_NIGHTLY",
                                        description: "Opt-in to install and use nightly fastlane builds",
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false,
                                        deprecated: "Nightly builds are no longer being made available")
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `update_fastlane` action.

### Description
- Remove `is_string: true` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.