### PR TITLE
[action][setup_jenkins] Fix type for `add_keychain_to_search_list` option

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_jenkins.rb
+++ b/fastlane/lib/fastlane/actions/setup_jenkins.rb
@@ -129,8 +129,8 @@ module Fastlane
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :add_keychain_to_search_list,
                                        env_name: "FL_SETUP_JENKINS_ADD_KEYCHAIN_TO_SEARCH_LIST",
-                                       description: "Add to keychain search list",
-                                       type: Symbol,
+                                       description: "Add to keychain search list, valid values are true, false, :add, and :replace",
+                                       skip_type_validation: true, # allow Boolean, Symbol
                                        default_value: :replace),
           FastlaneCore::ConfigItem.new(key: :set_default_keychain,
                                        env_name: "FL_SETUP_JENKINS_SET_DEFAULT_KEYCHAIN",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- UnlockKeychainAction supports Boolean and Symbol both, see: https://github.com/fastlane/fastlane/pull/19000#discussion_r659056613
- SetupJenkinsAction internally use **UnlockKeychainAction** for`add_keychain_to_search_list` option

### Description
- In this PR, fix type for `add_keychain_to_search_list` option to avoid any regression 😉  

### Testing Steps
- Unit tests should be all green
