### PR TITLE
[action][update_icloud_container_identifiers] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/update_icloud_container_identifiers.rb
+++ b/fastlane/lib/fastlane/actions/update_icloud_container_identifiers.rb
@@ -61,10 +61,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :icloud_container_identifiers,
                                        env_name: "FL_UPDATE_ICLOUD_CONTAINER_IDENTIFIERS_IDENTIFIERS",
                                        description: "An Array of unique identifiers for the iCloud containers. Eg. ['iCloud.com.test.testapp']",
-                                       is_string: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("The parameter icloud_container_identifiers needs to be an Array.") unless value.kind_of?(Array)
-                                       end)
+                                       type: Array)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `update_icloud_container_identifiers` action.

### Description
- Remove `is_string: false` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.