### PR TITLE
[action][update_keychain_access_groups] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/update_keychain_access_groups.rb
+++ b/fastlane/lib/fastlane/actions/update_keychain_access_groups.rb
@@ -56,10 +56,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :identifiers,
                                        env_name: "FL_UPDATE_KEYCHAIN_ACCESS_GROUPS_IDENTIFIERS",
                                        description: "An Array of unique identifiers for the keychain access groups. Eg. ['your.keychain.access.groups.identifiers']",
-                                       is_string: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("The parameter identifiers need to be an Array.") unless value.kind_of?(Array)
-                                       end)
+                                       type: Array)
         ]
       end
 

--- a/fastlane/spec/actions_specs/update_keychain_access_groups_spec.rb
+++ b/fastlane/spec/actions_specs/update_keychain_access_groups_spec.rb
@@ -32,17 +32,6 @@ describe Fastlane do
         end.to raise_error("Could not find entitlements file at path 'abc.#{File.join(test_path, entitlements_path)}'")
       end
 
-      it "throws an error when the identifiers are not in an array" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            update_keychain_access_groups(
-            entitlements_file: '#{File.join(test_path, entitlements_path)}',
-            identifiers: '#{new_keychain_access_groups}'
-          )
-          end").runner.execute(:test)
-        end.to raise_error('The parameter identifiers need to be an Array.')
-      end
-
       it "throws an error when the entitlements file is not parsable" do
         File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>keychain-access-groups</key><array><string>keychain.access.gorups.</array></dict></plist>')
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `update_keychain_access_groups` action.

### Description
- Remove `is_string: false` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.