### PR TITLE
[action][update_plist] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/update_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_plist.rb
@@ -50,7 +50,7 @@ module Fastlane
                                        description: "Path to plist file",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :block,
-                                       is_string: false,
+                                       type: :string_callback,
                                        description: 'A block to process plist with custom logic')
 
         ]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `update_plist` action.

### Description
- Remove `is_string: false` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.