### PR TITLE
[action][update_urban_airship_configuration] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/update_urban_airship_configuration.rb
+++ b/fastlane/lib/fastlane/actions/update_urban_airship_configuration.rb
@@ -58,7 +58,6 @@ module Fastlane
                                        description: "The production app secret"),
           FastlaneCore::ConfigItem.new(key: :detect_provisioning_mode,
                                        env_name: "URBAN_AIRSHIP_DETECT_PROVISIONING_MODE",
-                                       is_string: false,
                                        type: Boolean,
                                        optional: true,
                                        description: "Automatically detect provisioning mode")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `update_urban_airship_configuration` action.

### Description
- Remove `is_string: false` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.