### PR TITLE
[action][update_url_schemes] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/update_url_schemes.rb
+++ b/fastlane/lib/fastlane/actions/update_url_schemes.rb
@@ -51,33 +51,22 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(
-            key: :path,
-            env_name: 'FL_UPDATE_URL_SCHEMES_PATH',
-            description: 'The Plist file\'s path',
-            is_string: true,
-            optional: false,
-            verify_block: proc do |path|
-              UI.user_error!("Could not find plist at path '#{path}'") unless File.exist?(path)
-            end
-          ),
-
-          FastlaneCore::ConfigItem.new(
-            key: :url_schemes,
-            env_name: "FL_UPDATE_URL_SCHEMES_SCHEMES",
-            description: 'The new URL schemes',
-            is_string: false,
-            optional: true,
-            verify_block: proc do |url_schemes|
-              string = "The URL schemes must be an array of strings, got '#{url_schemes}'."
-              verify_schemes!(url_schemes, string)
-            end
-          ),
-
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: 'FL_UPDATE_URL_SCHEMES_PATH',
+                                       description: 'The Plist file\'s path',
+                                       optional: false,
+                                       verify_block: proc do |path|
+                                         UI.user_error!("Could not find plist at path '#{path}'") unless File.exist?(path)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :url_schemes,
+                                       env_name: "FL_UPDATE_URL_SCHEMES_SCHEMES",
+                                       description: 'The new URL schemes',
+                                       type: Array,
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :update_url_schemes,
-            description: "Block that is called to update schemes with current schemes passed in as parameter",
-            optional: true,
-            is_string: false)
+                                       description: "Block that is called to update schemes with current schemes passed in as parameter",
+                                       optional: true,
+                                       type: :string_callback)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `update_url_schemes` action.

### Description
- Remove `is_string: true/false` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.