### PR TITLE
[action][upload_app_privacy_details_to_app_store] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_app_privacy_details_to_app_store.rb
+++ b/fastlane/lib/fastlane/actions/upload_app_privacy_details_to_app_store.rb
@@ -205,7 +205,7 @@ module Fastlane
                                        env_name: "FASTLANE_ITC_TEAM_ID",
                                        description: "The ID of your App Store Connect team if you're in multiple teams",
                                        optional: true,
-                                       is_string: false, # as we also allow integers, which we convert to strings anyway
+                                       skip_type_validation: true, # as we also allow integers, which we convert to strings anyway
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:itc_team_id),
                                        default_value_dynamic: true),
@@ -221,7 +221,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :json_path,
                                        env_name: "UPLOAD_APP_PRIVACY_DETAILS_TO_APP_STORE_JSON_PATH",
                                        description: "Path to the app usage data JSON",
-                                       is_string: true,
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("Could not find JSON file at path '#{File.expand_path(value)}'") unless File.exist?(value)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `upload_app_privacy_details_to_app_store` action.

### Description
- Remove `is_string: true/false` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.