### PR TITLE
[action][upload_symbols_to_sentry] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_sentry.rb
@@ -79,7 +79,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :api_host,
                                        env_name: "SENTRY_HOST",
                                        description: "API host url for Sentry",
-                                       is_string: true,
                                        default_value: "https://app.getsentry.com/api/0",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :api_key,
@@ -109,20 +108,14 @@ module Fastlane
                                        description: "Path to your symbols file. For iOS and Mac provide path to app.dSYM.zip",
                                        default_value: Actions.lane_context[SharedValues::DSYM_OUTPUT_PATH],
                                        default_value_dynamic: true,
-                                       optional: true,
-                                       verify_block: proc do |value|
-                                         # validation is done in the action
-                                       end),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :dsym_paths,
                                        env_name: "SENTRY_DSYM_PATHS",
                                        description: "Path to an array of your symbols file. For iOS and Mac provide path to app.dSYM.zip",
                                        default_value: Actions.lane_context[SharedValues::DSYM_PATHS],
                                        default_value_dynamic: true,
-                                       is_string: false,
-                                       optional: true,
-                                       verify_block: proc do |value|
-                                         # validation is done in the action
-                                       end)
+                                       type: Array,
+                                       optional: true)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `upload_symbols_to_sentry` action.

### Description
- Remove `is_string: true/false` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.