### PR TITLE
[action][validate_play_store_json_key] fix the Options formatting

### DIFF
--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -42,53 +42,49 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(
-            key: :json_key,
-            env_name: "SUPPLY_JSON_KEY",
-            short_option: "-j",
-            conflicting_options: [:json_key_data],
-            optional: true, # this shouldn't be optional but is until I find out how json_key OR json_key_data can be required
-            description: "The path to a file containing service account JSON, used to authenticate with Google",
-            code_gen_sensitive: true,
-            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
-            default_value_dynamic: true,
-            verify_block: proc do |value|
-              UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
-              UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
-            end
-          ),
-          FastlaneCore::ConfigItem.new(
-            key: :json_key_data,
-            env_name: "SUPPLY_JSON_KEY_DATA",
-            short_option: "-c",
-            conflicting_options: [:json_key],
-            optional: true,
-            description: "The raw service account JSON data used to authenticate with Google",
-            code_gen_sensitive: true,
-            default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
-            default_value_dynamic: true,
-            verify_block: proc do |value|
-              begin
-                JSON.parse(value)
-              rescue JSON::ParserError
-                UI.user_error!("Could not parse service account json: JSON::ParseError")
-              end
-            end
-          ),
+          FastlaneCore::ConfigItem.new(key: :json_key,
+                                       env_name: "SUPPLY_JSON_KEY",
+                                       short_option: "-j",
+                                       conflicting_options: [:json_key_data],
+                                       optional: true,
+                                       description: "The path to a file containing service account JSON, used to authenticate with Google",
+                                       code_gen_sensitive: true,
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
+                                       default_value_dynamic: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not find service account json file at path '#{File.expand_path(value)}'") unless File.exist?(File.expand_path(value))
+                                         UI.user_error!("'#{value}' doesn't seem to be a JSON file") unless FastlaneCore::Helper.json_file?(File.expand_path(value))
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :json_key_data,
+                                       env_name: "SUPPLY_JSON_KEY_DATA",
+                                       short_option: "-c",
+                                       conflicting_options: [:json_key],
+                                       optional: true,
+                                       description: "The raw service account JSON data used to authenticate with Google",
+                                       code_gen_sensitive: true,
+                                       default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
+                                       default_value_dynamic: true,
+                                       verify_block: proc do |value|
+                                         begin
+                                           JSON.parse(value)
+                                         rescue JSON::ParserError
+                                           UI.user_error!("Could not parse service account json: JSON::ParseError")
+                                         end
+                                       end),
           # stuff
           FastlaneCore::ConfigItem.new(key: :root_url,
-            env_name: "SUPPLY_ROOT_URL",
-            description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/",
-            optional: true,
-            verify_block: proc do |value|
-              UI.user_error!("Could not parse URL '#{value}'") unless value =~ URI.regexp
-            end),
+                                       env_name: "SUPPLY_ROOT_URL",
+                                       description: "Root URL for the Google Play API. The provided URL will be used for API calls in place of https://www.googleapis.com/",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Could not parse URL '#{value}'") unless value =~ URI.regexp
+                                       end),
           FastlaneCore::ConfigItem.new(key: :timeout,
-            env_name: "SUPPLY_TIMEOUT",
-            optional: true,
-            description: "Timeout for read, open, and send (in seconds)",
-            type: Integer,
-            default_value: 300)
+                                       env_name: "SUPPLY_TIMEOUT",
+                                       optional: true,
+                                       description: "Timeout for read, open, and send (in seconds)",
+                                       type: Integer,
+                                       default_value: 300)
         ]
       end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Options formatting was slightly off.

### Description
- fix Options formatting

### Testing Steps
- No functionality changed, all existing unit tests should pass.