### PR TITLE
[action][version_get_podspec] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/version_get_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_get_podspec.rb
@@ -28,7 +28,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: "FL_VERSION_PODSPEC_PATH",
                                        description: "You must specify the path to the podspec file",
-                                       is_string: true,
                                        code_gen_sensitive: true,
                                        default_value: Dir["*.podspec"].last,
                                        default_value_dynamic: true,
@@ -38,7 +37,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :require_variable_prefix,
                                        env_name: "FL_VERSION_BUMP_PODSPEC_VERSION_REQUIRE_VARIABLE_PREFIX",
                                        description: "true by default, this is used for non CocoaPods version bumps only",
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: true)
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `version_get_podspec` action.

### Description
- Remove `is_string: true/false` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.