### PR TITLE
[action][xcode_server_get_assets] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
+++ b/fastlane/lib/fastlane/actions/xcode_server_get_assets.rb
@@ -243,7 +243,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :integration_number,
                                        env_name: "FL_XCODE_SERVER_GET_ASSETS_INTEGRATION_NUMBER",
                                        description: "Optionally you can override which integration's assets should be downloaded. If not provided, the latest integration is used",
-                                       is_string: false,
+                                       type: Integer,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: "FL_XCODE_SERVER_GET_ASSETS_USERNAME",
@@ -265,13 +265,13 @@ module Fastlane
                                        env_name: "FL_XCODE_SERVER_GET_ASSETS_KEEP_ALL_ASSETS",
                                        description: "Whether to keep all assets or let the script delete everything except for the .xcarchive",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :trust_self_signed_certs,
                                        env_name: "FL_XCODE_SERVER_GET_ASSETS_TRUST_SELF_SIGNED_CERTS",
                                        description: "Whether to trust self-signed certs on your Xcode Server",
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: true)
         ]
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `xcode_server_get_assets` action.

### Description
- Remove `is_string: false` from options

### Testing Steps
- No functionality changed, all existing unit tests should pass.