### PR TITLE
[scan] add support for SPM packages with new :package_path option

### DIFF
--- a/scan/examples/package/.gitignore
+++ b/scan/examples/package/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/scan/examples/package/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/scan/examples/package/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/scan/examples/package/Package.swift
+++ b/scan/examples/package/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "package",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "package",
+            targets: ["package"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "package",
+            dependencies: []),
+        .testTarget(
+            name: "packageTests",
+            dependencies: ["package"]),
+    ]
+)

--- a/scan/examples/package/README.md
+++ b/scan/examples/package/README.md
@@ -1,0 +1,3 @@
+# package
+
+A description of this package.

--- a/scan/examples/package/Sources/package/package.swift
+++ b/scan/examples/package/Sources/package/package.swift
@@ -1,0 +1,3 @@
+struct package {
+    var text = "Hello, World!"
+}

--- a/scan/examples/package/Tests/packageTests/packageTests.swift
+++ b/scan/examples/package/Tests/packageTests/packageTests.swift
@@ -1,0 +1,11 @@
+    import XCTest
+    @testable import package
+
+    final class packageTests: XCTestCase {
+        func testExample() {
+            // This is an example of a functional test case.
+            // Use XCTAssert and related functions to verify your tests produce the correct
+            // results.
+            XCTAssertEqual(package().text, "Hello, World!")
+        }
+    }

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -16,31 +16,35 @@ module Scan
       prevalidate
 
       # Detect the project
-      FastlaneCore::Project.detect_projects(config)
-      Scan.project = FastlaneCore::Project.new(config)
+      if Scan.config[:package_path]
 
-      # Go into the project's folder, as there might be a Snapfile there
-      imported_path = File.expand_path(Scan.scanfile_name)
-      Dir.chdir(File.expand_path("..", Scan.project.path)) do
-        config.load_configuration_file(Scan.scanfile_name) unless File.expand_path(Scan.scanfile_name) == imported_path
-      end
-
-      Scan.project.select_scheme
-
-      devices = Scan.config[:devices] || Array(Scan.config[:device]) # important to use Array(nil) for when the value is nil
-      if devices.count > 0
-        detect_simulator(devices, '', '', '', nil)
       else
-        if Scan.project.ios?
-          # An iPhone 5s is a reasonably small and useful default for tests
-          detect_simulator(devices, 'iOS', 'IPHONEOS_DEPLOYMENT_TARGET', 'iPhone 5s', nil)
-        elsif Scan.project.tvos?
-          detect_simulator(devices, 'tvOS', 'TVOS_DEPLOYMENT_TARGET', 'Apple TV 1080p', 'TV')
-        end
-      end
-      detect_destination
+        FastlaneCore::Project.detect_projects(config)
+        Scan.project = FastlaneCore::Project.new(config)
 
-      default_derived_data
+        # Go into the project's folder, as there might be a Snapfile there
+        imported_path = File.expand_path(Scan.scanfile_name)
+        Dir.chdir(File.expand_path("..", Scan.project.path)) do
+          config.load_configuration_file(Scan.scanfile_name) unless File.expand_path(Scan.scanfile_name) == imported_path
+        end
+
+        Scan.project.select_scheme
+
+        devices = Scan.config[:devices] || Array(Scan.config[:device]) # important to use Array(nil) for when the value is nil
+        if devices.count > 0
+          detect_simulator(devices, '', '', '', nil)
+        else
+          if Scan.project.ios?
+            # An iPhone 5s is a reasonably small and useful default for tests
+            detect_simulator(devices, 'iOS', 'IPHONEOS_DEPLOYMENT_TARGET', 'iPhone 5s', nil)
+          elsif Scan.project.tvos?
+            detect_simulator(devices, 'tvOS', 'TVOS_DEPLOYMENT_TARGET', 'Apple TV 1080p', 'TV')
+          end
+        end
+        detect_destination
+
+        default_derived_data
+      end
 
       coerce_to_array_of_strings(:only_testing)
       coerce_to_array_of_strings(:skip_testing)

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -44,7 +44,6 @@ module Scan
       detect_destination
 
       default_derived_data
-      
 
       coerce_to_array_of_strings(:only_testing)
       coerce_to_array_of_strings(:skip_testing)
@@ -222,14 +221,18 @@ module Scan
         Scan.config[:destination] = ["platform=macOS,variant=Mac Catalyst"]
       elsif Scan.devices && Scan.devices.count > 0
         Scan.config[:destination] = Scan.devices.map { |d| "platform=#{d.os_type} Simulator,id=#{d.udid}" }
-      elsif Scan.project.mac_app?
+      elsif Scan.project && Scan.project.mac_app?
         Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]
       end
     end
 
     # get deployment target version
     def self.get_deployment_target_version(deployment_target_key)
-      Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
+      version = Scan.config[:deployment_target_version]
+      version ||= Scan.project.build_settings(key: deployment_target_key) if Scan.project
+      version ||= 0
+
+      return version
     end
   end
 end

--- a/scan/lib/scan/module.rb
+++ b/scan/lib/scan/module.rb
@@ -23,6 +23,7 @@ module Scan
     end
 
     def building_mac_catalyst_for_mac?
+      return false unless Scan.project
       Scan.project.supports_mac_catalyst? && Scan.config[:catalyst_platform] == "macos"
     end
   end

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -24,7 +24,6 @@ module Scan
                                        v = File.expand_path(value.to_s)
                                        UI.user_error!("Workspace file not found at path '#{v}'") unless File.exist?(v)
                                        UI.user_error!("Workspace file invalid") unless File.directory?(v)
-                                       UI.user_error!("Workspace file is not a workspace, must end with .xcworkspace") unless v.include?(".xcworkspace")
                                      end),
         FastlaneCore::ConfigItem.new(key: :project,
                                      short_option: "-p",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -31,11 +31,23 @@ module Scan
                                      optional: true,
                                      env_name: "SCAN_PROJECT",
                                      description: "Path to the project file",
+                                     conflicting_options: [:package_path],
                                      verify_block: proc do |value|
                                        v = File.expand_path(value.to_s)
                                        UI.user_error!("Project file not found at path '#{v}'") unless File.exist?(v)
                                        UI.user_error!("Project file invalid") unless File.directory?(v)
                                        UI.user_error!("Project file is not a project file, must end with .xcodeproj") unless v.include?(".xcodeproj")
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :package_path,
+                                     short_option: "-P",
+                                     optional: true,
+                                     env_name: "SCAN_PACKAGE_PATH",
+                                     description: "Path to the Swift Package",
+                                     conflicting_options: [:project],
+                                     verify_block: proc do |value|
+                                       v = File.expand_path(value.to_s)
+                                       UI.user_error!("Package path not found at path '#{v}'") unless File.exist?(v)
+                                       UI.user_error!("Package path invalid") unless File.directory?(v)
                                      end),
         FastlaneCore::ConfigItem.new(key: :scheme,
                                      short_option: "-s",

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -18,7 +18,7 @@ module Scan
       prefixes = ["set -o pipefail &&"]
 
       package_path = Scan.config[:package_path]
-      prefixes << "cd #{package_path} &&" if package_path && package_path != ""
+      prefixes << "cd #{package_path} &&" if package_path.to_s != ""
 
       prefixes
     end
@@ -27,7 +27,7 @@ module Scan
     # This will also include the scheme (if given)
     # @return [Array] The array with all the components to join
     def project_path_array
-      if Scan.config[:package_path]
+      unless Scan.config[:package_path].nil?
         params = []
         params << "-scheme #{Scan.config[:scheme]}" if Scan.config[:scheme]
         return params
@@ -185,15 +185,15 @@ module Scan
       ext = FastlaneCore::Helper.xcode_version.to_i >= 11 ? '.xcresult' : '.test_result'
       path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + attempt + ext
 
+      Scan.cache[:result_bundle_path] = path
+
       # The result bundle path will be in the package pack directory if specified
       delete_path = path
-      delete_path = File.join(Scan.config[:package_path], path) if Scan.config[:package_path] && Scan.config[:package_path] != ""
-
+      delete_path = File.join(Scan.config[:package_path], path) if Scan.config[:package_path].to_s != ""
       if File.directory?(delete_path)
         FileUtils.remove_dir(delete_path)
       end
-      Scan.cache[:result_bundle_path] = path
-
+      
       return path
     end
   end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -29,7 +29,8 @@ module Scan
     def project_path_array
       unless Scan.config[:package_path].nil?
         params = []
-        params << "-scheme #{Scan.config[:scheme]}" if Scan.config[:scheme]
+        params << "-scheme #{Scan.config[:scheme].shellescape}" if Scan.config[:scheme]
+        params << "-workspace #{Scan.config[:workspace].shellescape}" if Scan.config[:workspace]
         return params
       end
 

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -147,10 +147,13 @@ module Scan
 
     # Store the raw file
     def xcodebuild_log_path
-      parts = [
-        Scan.config[:app_name] || (Scan.project && Scan.project.app_name),
-        Scan.config[:scheme]
-      ].compact
+      parts = []
+      if Scan.config[:app_name]
+        parts << Scan.config[:app_name]
+      elsif Scan.project
+        parts << Scan.project.app_name
+      end
+      parts << Scan.config[:scheme] if Scan.config[:scheme]
 
       file_name = "#{parts.join('-')}.log"
       containing = File.expand_path(Scan.config[:buildlog_path])
@@ -187,13 +190,11 @@ module Scan
 
       Scan.cache[:result_bundle_path] = path
 
-      # The result bundle path will be in the package pack directory if specified
+      # The result bundle path will be in the package path directory if specified
       delete_path = path
       delete_path = File.join(Scan.config[:package_path], path) if Scan.config[:package_path].to_s != ""
-      if File.directory?(delete_path)
-        FileUtils.remove_dir(delete_path)
-      end
-      
+      FileUtils.remove_dir(delete_path) if File.directory?(delete_path)
+
       return path
     end
   end

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -15,13 +15,24 @@ module Scan
     end
 
     def prefix
-      ["set -o pipefail &&"]
+      prefixes = ["set -o pipefail &&"]
+
+      package_path = Scan.config[:package_path]
+      prefixes << "cd #{package_path} &&" if package_path && package_path != ""
+
+      prefixes
     end
 
     # Path to the project or workspace as parameter
     # This will also include the scheme (if given)
     # @return [Array] The array with all the components to join
     def project_path_array
+      if Scan.config[:package_path]
+        params = []
+        params << "-scheme #{Scan.config[:scheme]}" if Scan.config[:scheme]
+        return params
+      end
+
       proj = Scan.project.xcodebuild_parameters
       return proj if proj.count > 0
       UI.user_error!("No project/workspace found")
@@ -33,7 +44,7 @@ module Scan
       options = []
       options += project_path_array unless config[:xctestrun]
       options << "-sdk '#{config[:sdk]}'" if config[:sdk]
-      options << destination # generated in `detect_values`
+      options << destination if destination # generated in `detect_values`
       options << "-toolchain '#{config[:toolchain]}'" if config[:toolchain]
       if config[:derived_data_path] && !options.include?("-derivedDataPath #{config[:derived_data_path].shellescape}")
         options << "-derivedDataPath #{config[:derived_data_path].shellescape}"
@@ -136,7 +147,12 @@ module Scan
 
     # Store the raw file
     def xcodebuild_log_path
-      file_name = "#{Scan.config[:app_name] || Scan.project.app_name}-#{Scan.config[:scheme]}.log"
+      parts = [
+        Scan.config[:app_name] || (Scan.project && Scan.project.app_name),
+        Scan.config[:scheme]
+      ].compact
+
+      file_name = "#{parts.join('-')}.log"
       containing = File.expand_path(Scan.config[:buildlog_path])
       FileUtils.mkdir_p(containing)
 
@@ -168,8 +184,13 @@ module Scan
       attempt = retry_count > 0 ? "-#{retry_count}" : ""
       ext = FastlaneCore::Helper.xcode_version.to_i >= 11 ? '.xcresult' : '.test_result'
       path = File.join(Scan.config[:output_directory], Scan.config[:scheme]) + attempt + ext
-      if File.directory?(path)
-        FileUtils.remove_dir(path)
+
+      # The result bundle path will be in the package pack directory if specified
+      delete_path = path
+      delete_path = File.join(Scan.config[:package_path], path) if Scan.config[:package_path] && Scan.config[:package_path] != ""
+
+      if File.directory?(delete_path)
+        FileUtils.remove_dir(delete_path)
       end
       Scan.cache[:result_bundle_path] = path
 

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -2,7 +2,7 @@ describe Scan do
   describe Scan::DetectValues do
     describe 'Xcode project' do
       describe 'detects FastlaneCore::Project' do
-        it 'with no :project or :package_path given' do
+        it 'with no :project or :package_path given', requires_xcodebuild: true do
           # Mocks input from detect_projects
           project = FastlaneCore::Project.new({
             project: "./scan/examples/standard/app.xcodeproj"
@@ -15,7 +15,7 @@ describe Scan do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
         end
 
-        it 'with :project given' do
+        it 'with :project given', requires_xcodebuild: true do
           expect(FastlaneCore::Project).to receive(:detect_projects)
           expect(FastlaneCore::Project).to receive(:new).and_call_original
 
@@ -27,7 +27,7 @@ describe Scan do
 
     describe 'SPM package' do
       describe 'does not attempt to detect FastlaneCore::Project' do
-        it 'with :package_path given' do
+        it 'with :package_path given', requires_xcodebuild: true do
           expect(FastlaneCore::Project).to_not(receive(:detect_projects))
 
           options = { package_path: "./scan/examples/package/" }

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -1,5 +1,41 @@
 describe Scan do
   describe Scan::DetectValues do
+    describe 'Xcode project' do
+      describe 'detects FastlaneCore::Project' do
+        it 'with no :project or :package_path given' do
+          # Mocks input from detect_projects
+          project = FastlaneCore::Project.new({
+            project: "./scan/examples/standard/app.xcodeproj"
+          })
+
+          expect(FastlaneCore::Project).to receive(:detect_projects)
+          expect(FastlaneCore::Project).to receive(:new).and_return(project)
+
+          options = {}
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        end
+
+        it 'with :project given' do
+          expect(FastlaneCore::Project).to receive(:detect_projects)
+          expect(FastlaneCore::Project).to receive(:new).and_call_original
+
+          options = { project: "./scan/examples/standard/app.xcodeproj" }
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        end
+      end
+    end
+
+    describe 'SPM package' do
+      describe 'does not attempt to detect FastlaneCore::Project' do
+        it 'with :package_path given' do
+          expect(FastlaneCore::Project).to_not(receive(:detect_projects))
+
+          options = { package_path: "./scan/examples/package/" }
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        end
+      end
+    end
+
     describe 'Xcode config handling' do
       before do
         options = { project: "./scan/examples/standard/app.xcodeproj" }

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -249,15 +249,15 @@ describe Scan do
 
             result = @test_command_generator.generate
             expect(result).to start_with([
-                                          "set -o pipefail &&",
-                                          "cd ./scan/examples/package/ &&",
-                                          "env NSUnbufferedIO=YES xcodebuild",
-                                          "-scheme package",
-                                          "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                          "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
-                                          :build,
-                                          :test
-                                        ])
+                                           "set -o pipefail &&",
+                                           "cd ./scan/examples/package/ &&",
+                                           "env NSUnbufferedIO=YES xcodebuild",
+                                           "-scheme package",
+                                           "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                           "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
+                                           :build,
+                                           :test
+                                         ])
           end
 
           it "#project_path_array", requires_xcodebuild: true do
@@ -277,16 +277,16 @@ describe Scan do
 
             result = @test_command_generator.generate
             expect(result).to start_with([
-                                          "set -o pipefail &&",
-                                          "cd ./scan/examples/package/ &&",
-                                          "env NSUnbufferedIO=YES xcodebuild",
-                                          "-scheme package",
-                                          "-workspace .",
-                                          "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
-                                          "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
-                                          :build,
-                                          :test
-                                        ])
+                                           "set -o pipefail &&",
+                                           "cd ./scan/examples/package/ &&",
+                                           "env NSUnbufferedIO=YES xcodebuild",
+                                           "-scheme package",
+                                           "-workspace .",
+                                           "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                           "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
+                                           :build,
+                                           :test
+                                         ])
           end
 
           it "#project_path_array", requires_xcodebuild: true do


### PR DESCRIPTION
### Motivation and Context
Fixes #17734

### Description

Adds support for testing SPM packages with `scan`

- New `:package_path` option
  - Conflicts with `:project`

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-scan-spm-packages"
```
