### PR TITLE
[action] gradle: Update for GRADLE_OUTPUT_JSON_OUTPUT_PATH and GRADLE…

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -68,7 +68,7 @@ module Fastlane
 
         apk_search_path = File.join(project_dir, '**', 'build', 'outputs', 'apk', '**', '*.apk')
         aab_search_path = File.join(project_dir, '**', 'build', 'outputs', 'bundle', '**', '*.aab')
-        output_json_search_path = File.join(project_dir, '**', 'build', 'outputs', 'apk', '**', 'output.json')
+        output_json_search_path = File.join(project_dir, '**', 'build', 'outputs', 'apk', '**', 'output-metadata.json')
         mapping_txt_search_path = File.join(project_dir, '**', 'build', 'outputs', 'mapping', '**', 'mapping.txt')
 
         # Our apk/aab is now built, but there might actually be multiple ones that were built if a flavor was not specified in a multi-flavor project (e.g. `assembleRelease`)

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -68,7 +68,7 @@ module Fastlane
 
         apk_search_path = File.join(project_dir, '**', 'build', 'outputs', 'apk', '**', '*.apk')
         aab_search_path = File.join(project_dir, '**', 'build', 'outputs', 'bundle', '**', '*.aab')
-        output_json_search_path = File.join(project_dir, '**', 'build', 'outputs', 'apk', '**', 'output-metadata.json')
+        output_json_search_path = File.join(project_dir, '**', 'build', 'outputs', 'apk', '**', 'output*.json') # output.json in Android Stuido 3 and output-metadata.json in Android Studio 4
         mapping_txt_search_path = File.join(project_dir, '**', 'build', 'outputs', 'mapping', '**', 'mapping.txt')
 
         # Our apk/aab is now built, but there might actually be multiple ones that were built if a flavor was not specified in a multi-flavor project (e.g. `assembleRelease`)


### PR DESCRIPTION
…_ALL_OUTPUT_JSON_OUTPUT_PATHS in Android studio 4+

The output.json file has been rename to output-metadata.json in Android studio 4+

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I need to read meta data from this file, but this one has renamed

### Description
The old shared value (GRADLE_OUTPUT_JSON_OUTPUT_PATH || GRADLE_ALL_OUTPUT_JSON_OUTPUT_PATHS) is outdated, need to update with new file name

### Testing Steps
