### PR TITLE
[spaceship] Adding three missing beta testers/groups methods

### DIFF
--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -366,7 +366,7 @@ module Spaceship
           test_flight_request_client.post("builds/#{build_id}/relationships/individualTesters", body)
         end
 
-        def delete_beta_testers_from_build(beta_tester_ids: [], build_id: nil)
+        def delete_beta_testers_from_build(build_id: nil, beta_tester_ids: [])
           body = {
             data: beta_tester_ids.map do |id|
               {

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -191,7 +191,7 @@ module Spaceship
           test_flight_request_client.post("builds/#{build_id}/relationships/betaGroups", body)
         end
 
-        def delete_beta_groups_from_build(beta_group_ids: [], build_id: nil)
+        def delete_beta_groups_from_build(build_id: nil, beta_group_ids: [])
           body = {
             data: beta_group_ids.map do |id|
               {

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -191,6 +191,19 @@ module Spaceship
           test_flight_request_client.post("builds/#{build_id}/relationships/betaGroups", body)
         end
 
+        def delete_beta_groups_from_build(beta_group_ids: [], build_id: nil)
+          body = {
+            data: beta_group_ids.map do |id|
+              {
+                type: "betaGroups",
+                id: id
+              }
+            end
+          }
+
+          test_flight_request_client.delete("builds/#{build_id}/relationships/betaGroups", nil, body)
+        end
+
         def create_beta_group(app_id: nil, group_name: nil, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
           body = {
             data: {
@@ -338,6 +351,32 @@ module Spaceship
           }
 
           test_flight_request_client.post("betaTesters/#{beta_tester_id}/relationships/builds", body)
+        end
+
+        def add_beta_testers_to_build(build_id: nil, beta_tester_ids: [])
+          body = {
+            data: beta_tester_ids.map do |id|
+              {
+                type: "betaTesters",
+                id: id
+              }
+            end
+          }
+
+          test_flight_request_client.post("builds/#{build_id}/relationships/individualTesters", body)
+        end
+
+        def delete_beta_testers_from_build(beta_tester_ids: [], build_id: nil)
+          body = {
+            data: beta_tester_ids.map do |id|
+              {
+                type: "betaTesters",
+                id: id
+              }
+            end
+          }
+
+          test_flight_request_client.delete("builds/#{build_id}/relationships/individualTesters", nil, body)
         end
 
         #

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -397,6 +397,30 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
         end
       end
 
+      context 'delete_beta_groups_from_build' do
+        let(:path) { "builds" }
+        let(:build_id) { "123" }
+        let(:beta_group_ids) { ["123", "456"] }
+        let(:body) do
+          {
+            data: beta_group_ids.map do |id|
+              {
+                type: "betaGroups",
+                id: id
+              }
+            end
+          }
+        end
+
+        it 'succeeds' do
+          url = "#{path}/#{build_id}/relationships/betaGroups"
+          req_mock = test_request_body(url, body)
+
+          expect(client).to receive(:request).with(:delete).and_yield(req_mock).and_return(req_mock)
+          client.delete_beta_groups_from_build(build_id: build_id, beta_group_ids: beta_group_ids)
+        end
+      end
+
       context 'patch_beta_groups' do
         let(:path) { "betaGroups" }
         let(:beta_group_id) { "123" }
@@ -594,6 +618,54 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
           expect(client).to receive(:request).with(:post).and_yield(req_mock).and_return(req_mock)
           client.add_beta_tester_to_builds(beta_tester_id: beta_tester_id, build_ids: build_ids)
+        end
+      end
+
+      context 'add_beta_testers_to_build' do
+        let(:path) { "builds" }
+        let(:build_id) { "123" }
+        let(:beta_tester_ids) { ["123", "456"] }
+        let(:body) do
+          {
+            data: beta_tester_ids.map do |id|
+              {
+                type: "betaTesters",
+                id: id
+              }
+            end
+          }
+        end
+
+        it 'succeeds' do
+          url = "#{path}/#{build_id}/relationships/individualTesters"
+          req_mock = test_request_body(url, body)
+
+          expect(client).to receive(:request).with(:post).and_yield(req_mock).and_return(req_mock)
+          client.add_beta_testers_to_build(build_id: build_id, beta_tester_ids: beta_tester_ids)
+        end
+      end
+
+      context 'delete_beta_testers_from_build' do
+        let(:path) { "builds" }
+        let(:build_id) { "123" }
+        let(:beta_tester_ids) { ["123", "456"] }
+        let(:body) do
+          {
+            data: beta_tester_ids.map do |id|
+              {
+                type: "betaTesters",
+                id: id
+              }
+            end
+          }
+        end
+
+        it 'succeeds' do
+          url = "#{path}/#{build_id}/relationships/individualTesters"
+          req_mock = test_request_body(url, body)
+
+          expect(client).to receive(:request).with(:delete).and_yield(req_mock).and_return(req_mock)
+          client.delete_beta_testers_from_build(build_id: build_id, beta_tester_ids: beta_tester_ids)
         end
       end
     end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Implementing the following missing TestFlight endpoints for beta testers/groups related functionality:

[Add testers to build](https://developer.apple.com/documentation/appstoreconnectapi/assign_individual_testers_to_a_build)
[Remove testers from build](https://developer.apple.com/documentation/appstoreconnectapi/remove_individual_testers_from_a_build)
[Remove groups from build](https://developer.apple.com/documentation/appstoreconnectapi/remove_access_for_beta_groups_to_a_build)