### PR TITLE
[fastlane][docs] update doc generator for plugins for updated mkdocs version

### DIFF
--- a/fastlane/assets/render_plugin.md.erb
+++ b/fastlane/assets/render_plugin.md.erb
@@ -12,11 +12,24 @@
 <details>
 <summary class="plugin-actions">Provided actions</summary>
 
- Name | Category | Description
-------|----------|------------
+<table>
+  <theader>
+    <tr>
+      <th>Name</th>
+      <th>Category</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
 <%- @plugin.data[:actions].each do |action| -%>
-  **<%= action.name %>** | <%= action.category || "-" %> | <%= action.description || action.details || "-" %>
+    <tr>
+      <td><strong><%= action.name %></strong></td>
+      <td><%= action.category || "-" %></td>
+      <td><%= action.description || action.details || "-" %></td>
+    </tr>
 <%- end -%>
+</tbody>
+</table>
 
 </details>
 <% end %>
@@ -24,12 +37,25 @@
 <details>
 <summary class="score-details">Score details</summary>
 
- Metric | Points | Description
---------|--------|-------------
+<table>
+  <theader>
+    <tr>
+      <th>Metric</th>
+      <th>Points</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
 <%- @plugin.ratings.each do |current_rating| -%>
-<%= current_rating.key %> | <b><%= current_rating.value %></b> | <%= current_rating.description %>
+    <tr>
+      <td><%= current_rating.key %></td>
+      <td><%= current_rating.value %></td>
+      <td><%= current_rating.description %></td>
+    </tr>
 <%- end -%>
- 
+</tbody>
+</table>
+
 </details>
 
 <p>

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -175,7 +175,7 @@ module Fastlane
       mkdocs_yml_path = File.join(target_path, "mkdocs.yml")
       raise "Could not find mkdocs.yml in #{target_path}, make sure to point to the fastlane/docs repo" unless File.exist?(mkdocs_yml_path)
       mkdocs_yml = YAML.load_file(mkdocs_yml_path)
-      hidden_actions_array = mkdocs_yml["pages"].find { |p| !p["_Actions"].nil? }
+      hidden_actions_array = mkdocs_yml["nav"].find { |p| !p["_Actions"].nil? }
       hidden_actions_array["_Actions"] = all_actions_ref_yml
       File.write(mkdocs_yml_path, mkdocs_yml.to_yaml)
 


### PR DESCRIPTION
### Motivation and Context

https://docs.fastlane.tools was recently updated to the newest version of `mkdocs`. This newest version does not render markdown tables in the `<details>` tag like the previous version did so the tables were displayed in raw markdown text.

### Description

This PR, instead of creating tables in markdown, generates tables in HTML.
