### PR TITLE
[fastlane][plugins] Updated the ruby version in plugins' template

### DIFF
--- a/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
+++ b/fastlane/lib/fastlane/plugins/template/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-       - image: circleci/ruby:2.4.2
+       - image: circleci/ruby:2.5
 
     working_directory: ~/repo
 

--- a/fastlane/lib/fastlane/plugins/template/.github/workflows/test.yml
+++ b/fastlane/lib/fastlane/plugins/template/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.4
+        ruby-version: 2.5
     - name: Install dependencies
       run: bundle check || bundle install --jobs=4 --retry=3 --path vendor/bundle
     - name: Run tests


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Recently, after ruby3.0 support, Fastlane already dropped the Ruby2.4 support

### Description
- In this PR, Updated the ruby version in the plugins' template files for CircleCI and GitHub both

### Testing Steps
- 
