### PR TITLE
[spaceship] Add visible_apps relationship to invite users with app permissions and fetch user's app permissions

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/user.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user.rb
@@ -57,10 +57,10 @@ module Spaceship
         return all(client: client, filter: { email: email }, includes: includes)
       end
 
-      def fetch_visible_apps(client: nil)
+      def fetch_visible_apps(client: nil, limit: nil)
         client ||= Spaceship::ConnectAPI
-        resp = client.get_user_visible_apps(user_id: id).all_pages
-        return resp.flat_map(&:to_models)
+        resp = client.get_user_visible_apps(user_id: id, limit: limit)
+        return resp.to_models
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/user.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user.rb
@@ -57,7 +57,7 @@ module Spaceship
         return all(client: client, filter: { email: email }, includes: includes)
       end
 
-      def fetch_visible_apps(client: nil, limit: nil)
+      def get_visible_apps(client: nil, limit: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.get_user_visible_apps(user_id: id, limit: limit)
         return resp.to_models

--- a/spaceship/lib/spaceship/connect_api/models/user.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user.rb
@@ -16,6 +16,8 @@ module Spaceship
       attr_accessor :email_vetting_required
       attr_accessor :notifications
 
+      attr_accessor :visible_apps
+
       attr_mapping({
         "username" => "username",
         "firstName" => "first_name",
@@ -27,8 +29,14 @@ module Spaceship
         "allAppsVisible" => "all_apps_visible",
         "provisioningAllowed" => "provisioning_allowed",
         "emailVettingRequired" => "email_vetting_required",
-        "notifications" => "notifications"
+        "notifications" => "notifications",
+
+        "visibleApps" => "visible_apps"
       })
+
+      ESSENTIAL_INCLUDES = [
+        "visibleApps"
+      ].join(",")
 
       def self.type
         return "users"

--- a/spaceship/lib/spaceship/connect_api/models/user.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user.rb
@@ -56,6 +56,12 @@ module Spaceship
         client ||= Spaceship::ConnectAPI
         return all(client: client, filter: { email: email }, includes: includes)
       end
+
+      def fetch_visible_apps(client: nil)
+        client ||= Spaceship::ConnectAPI
+        resp = client.get_user_visible_apps(user_id: id).all_pages
+        return resp.flat_map(&:to_models)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/user.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user.rb
@@ -46,13 +46,13 @@ module Spaceship
       # API
       #
 
-      def self.all(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+      def self.all(client: nil, filter: {}, includes: ESSENTIAL_INCLUDES, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
         resps = client.get_users(filter: filter, includes: includes).all_pages
         return resps.flat_map(&:to_models)
       end
 
-      def self.find(client: nil, email: nil, includes: nil)
+      def self.find(client: nil, email: nil, includes: ESSENTIAL_INCLUDES)
         client ||= Spaceship::ConnectAPI
         return all(client: client, filter: { email: email }, includes: includes)
       end

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -86,10 +86,10 @@ module Spaceship
       end
 
       # Get visible apps for invited user
-      def fetch_visible_apps(client: nil)
+      def fetch_visible_apps(client: nil, limit: nil)
         client ||= Spaceship::ConnectAPI
-        resp = client.get_user_invitation_visible_apps(user_invitation_id: id).all_pages
-        return resp.flat_map(&:to_models)
+        resp = client.get_user_invitation_visible_apps(user_invitation_id: id, limit: limit)
+        return resp.to_models
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -50,13 +50,13 @@ module Spaceship
       # Managing invitations
       #
 
-      def self.all(client: nil, filter: {}, includes: nil, sort: nil)
+      def self.all(client: nil, filter: {}, includes: ESSENTIAL_INCLUDES, sort: nil)
         client ||= Spaceship::ConnectAPI
         resps = client.get_user_invitations(filter: filter, includes: includes, sort: sort).all_pages
         return resps.flat_map(&:to_models)
       end
 
-      def self.find(client: nil, email: nil, includes: nil)
+      def self.find(client: nil, email: nil, includes: ESSENTIAL_INCLUDES)
         client ||= Spaceship::ConnectAPI
         return all(client: client, filter: { email: email }, includes: includes)
       end

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -89,7 +89,7 @@ module Spaceship
       def fetch_visible_apps(client: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.get_user_invitation_visible_apps(user_invitation_id: id)
-        return resp.to_models.first
+        return resp.to_models
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -61,7 +61,7 @@ module Spaceship
         return all(client: client, filter: { email: email }, includes: includes)
       end
 
-      def self.create(client: nil, email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil)
+      def self.create(client: nil, email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil, visible_apps: [])
         client ||= Spaceship::ConnectAPI
         resp = client.post_user_invitation(
           email: email,
@@ -69,7 +69,8 @@ module Spaceship
           last_name: last_name,
           roles: roles,
           provisioning_allowed: provisioning_allowed,
-          all_apps_visible: all_apps_visible
+          all_apps_visible: all_apps_visible,
+          visible_apps: visible_apps
         )
         return resp.to_models.first
       end

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -79,6 +79,13 @@ module Spaceship
         client ||= Spaceship::ConnectAPI
         client.delete_user_invitation(user_invitation_id: id)
       end
+
+      # Get visible apps for invited user
+      def fetch_visible_apps(client: nil)
+        client ||= Spaceship::ConnectAPI
+        resp = client.get_user_invitation_visible_apps(user_invitation_id: id)
+        return resp.to_models.first
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -86,7 +86,7 @@ module Spaceship
       end
 
       # Get visible apps for invited user
-      def fetch_visible_apps(client: nil, limit: nil)
+      def get_visible_apps(client: nil, limit: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.get_user_invitation_visible_apps(user_invitation_id: id, limit: limit)
         return resp.to_models

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -11,15 +11,23 @@ module Spaceship
       attr_accessor :all_apps_visible
       attr_accessor :provisioning_allowed
 
+      attr_accessor :visible_apps
+
       attr_mapping({
         "firstName" => "first_name",
         "lastName" => "last_name",
         "email" => "email",
         "roles" => "roles",
         "allAppsVisible" => "all_apps_visible",
-        "provisioningAllowed" => "provisioning_allowed"
+        "provisioningAllowed" => "provisioning_allowed",
+
+        "visibleApps" => "visible_apps"
       })
 
+      ESSENTIAL_INCLUDES = [
+        "visibleApps"
+      ].join(",")
+      
       module UserRole
         ADMIN = "ADMIN"
         FINANCE = "FINANCE"

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -88,8 +88,8 @@ module Spaceship
       # Get visible apps for invited user
       def fetch_visible_apps(client: nil)
         client ||= Spaceship::ConnectAPI
-        resp = client.get_user_invitation_visible_apps(user_invitation_id: id)
-        return resp.to_models
+        resp = client.get_user_invitation_visible_apps(user_invitation_id: id).all_pages
+        return resp.flat_map(&:to_models)
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -27,7 +27,7 @@ module Spaceship
       ESSENTIAL_INCLUDES = [
         "visibleApps"
       ].join(",")
-      
+
       module UserRole
         ADMIN = "ADMIN"
         FINANCE = "FINANCE"

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -61,6 +61,11 @@ module Spaceship
         return all(client: client, filter: { email: email }, includes: includes)
       end
 
+      # Create and post user invitation
+      # App Store Connect allows for the following combinations of `all_apps_visible` and `visible_app_ids`:
+      # - if `all_apps_visible` is `nil`, you don't have to provide values for `visible_app_ids`
+      # - if `all_apps_visible` is true, you must provide values for `visible_app_ids`.
+      # - if `all_apps_visible` is false, you must not provide values for `visible_app_ids`.
       def self.create(client: nil, email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil, visible_app_ids: [])
         client ||= Spaceship::ConnectAPI
         resp = client.post_user_invitation(

--- a/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user_invitation.rb
@@ -61,7 +61,7 @@ module Spaceship
         return all(client: client, filter: { email: email }, includes: includes)
       end
 
-      def self.create(client: nil, email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil, visible_apps: [])
+      def self.create(client: nil, email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil, visible_app_ids: [])
         client ||= Spaceship::ConnectAPI
         resp = client.post_user_invitation(
           email: email,
@@ -70,7 +70,7 @@ module Spaceship
           roles: roles,
           provisioning_allowed: provisioning_allowed,
           all_apps_visible: all_apps_visible,
-          visible_apps: visible_apps
+          visible_app_ids: visible_app_ids
         )
         return resp.to_models.first
       end

--- a/spaceship/lib/spaceship/connect_api/users/users.rb
+++ b/spaceship/lib/spaceship/connect_api/users/users.rb
@@ -43,8 +43,8 @@ module Spaceship
         end
 
         # Get app permissions for user
-        def get_user_visible_apps(user_id: id)
-          params = users_request_client.build_params(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_user_visible_apps(user_id: id, limit: nil)
+          params = users_request_client.build_params(filter: {}, includes: nil, limit: limit, sort: nil)
           users_request_client.get("users/#{user_id}/visibleApps", params)
         end
 
@@ -92,8 +92,8 @@ module Spaceship
         end
 
         # Get all app permissions for invited user
-        def get_user_invitation_visible_apps(user_invitation_id: id)
-          params = users_request_client.build_params(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_user_invitation_visible_apps(user_invitation_id: id, limit: nil)
+          params = users_request_client.build_params(filter: {}, includes: nil, limit: limit, sort: nil)
           users_request_client.get("userInvitations/#{user_invitation_id}/visibleApps", params)
         end
       end

--- a/spaceship/lib/spaceship/connect_api/users/users.rb
+++ b/spaceship/lib/spaceship/connect_api/users/users.rb
@@ -75,6 +75,11 @@ module Spaceship
         def delete_user_invitation(user_invitation_id: nil)
           users_request_client.delete("userInvitations/#{user_invitation_id}")
         end
+
+        # Get all visible apps for invited user
+        def get_user_invitation_visible_apps(user_invitation_id: id)
+          users_request_client.get("userInvitations/#{user_invitation_id}/visibleApps")
+        end
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/users/users.rb
+++ b/spaceship/lib/spaceship/connect_api/users/users.rb
@@ -42,6 +42,11 @@ module Spaceship
           users_request_client.post("users/#{user_id}/relationships/visibleApps", body)
         end
 
+        # Get app permissions for user
+        def get_user_visible_apps(user_id: id)
+          users_request_client.get("users/#{user_id}/visibleApps")
+        end
+
         #
         # invitations (invited users)
         #
@@ -85,7 +90,7 @@ module Spaceship
           users_request_client.delete("userInvitations/#{user_invitation_id}")
         end
 
-        # Get all visible apps for invited user
+        # Get all app permissions for invited user
         def get_user_invitation_visible_apps(user_invitation_id: id)
           users_request_client.get("userInvitations/#{user_invitation_id}/visibleApps")
         end

--- a/spaceship/lib/spaceship/connect_api/users/users.rb
+++ b/spaceship/lib/spaceship/connect_api/users/users.rb
@@ -63,8 +63,17 @@ module Spaceship
                 lastName: last_name,
                 roles: roles,
                 provisioningAllowed: provisioning_allowed,
-                allAppsVisible: all_apps_visible,
-                visible_apps: visible_apps
+                allAppsVisible: all_apps_visible
+              },
+              relationships: {
+                visibleApps: {
+                  data: visible_apps.map do |id|
+                    {
+                      id: id,
+                      type: "apps"
+                    }
+                  end
+                }
               }
             }
           }

--- a/spaceship/lib/spaceship/connect_api/users/users.rb
+++ b/spaceship/lib/spaceship/connect_api/users/users.rb
@@ -46,14 +46,14 @@ module Spaceship
         # invitations (invited users)
         #
 
-        # Get all invited users (not yet accepted)
+        # Get all invited users
         def get_user_invitations(filter: {}, includes: nil, limit: nil, sort: nil)
           params = users_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
           users_request_client.get("userInvitations", params)
         end
 
         # Invite new users to App Store Connect
-        def post_user_invitation(email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil)
+        def post_user_invitation(email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil, visible_apps: [])
           body = {
             data: {
               type: "userInvitations",
@@ -63,7 +63,8 @@ module Spaceship
                 lastName: last_name,
                 roles: roles,
                 provisioningAllowed: provisioning_allowed,
-                allAppsVisible: all_apps_visible
+                allAppsVisible: all_apps_visible,
+                visible_apps: visible_apps
               }
             }
           }

--- a/spaceship/lib/spaceship/connect_api/users/users.rb
+++ b/spaceship/lib/spaceship/connect_api/users/users.rb
@@ -53,7 +53,7 @@ module Spaceship
         end
 
         # Invite new users to App Store Connect
-        def post_user_invitation(email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil, visible_apps: [])
+        def post_user_invitation(email: nil, first_name: nil, last_name: nil, roles: [], provisioning_allowed: nil, all_apps_visible: nil, visible_app_ids: [])
           body = {
             data: {
               type: "userInvitations",
@@ -67,7 +67,7 @@ module Spaceship
               },
               relationships: {
                 visibleApps: {
-                  data: visible_apps.map do |id|
+                  data: visible_app_ids.map do |id|
                     {
                       id: id,
                       type: "apps"

--- a/spaceship/lib/spaceship/connect_api/users/users.rb
+++ b/spaceship/lib/spaceship/connect_api/users/users.rb
@@ -44,7 +44,8 @@ module Spaceship
 
         # Get app permissions for user
         def get_user_visible_apps(user_id: id)
-          users_request_client.get("users/#{user_id}/visibleApps")
+          params = users_request_client.build_params(filter: {}, includes: nil, limit: nil, sort: nil)
+          users_request_client.get("users/#{user_id}/visibleApps", params)
         end
 
         #
@@ -92,7 +93,8 @@ module Spaceship
 
         # Get all app permissions for invited user
         def get_user_invitation_visible_apps(user_invitation_id: id)
-          users_request_client.get("userInvitations/#{user_invitation_id}/visibleApps")
+          params = users_request_client.build_params(filter: {}, includes: nil, limit: nil, sort: nil)
+          users_request_client.get("userInvitations/#{user_invitation_id}/visibleApps", params)
         end
       end
     end

--- a/spaceship/spec/connect_api/users/user_client_spec.rb
+++ b/spaceship/spec/connect_api/users/user_client_spec.rb
@@ -56,6 +56,32 @@ describe Spaceship::ConnectAPI::Users::Client do
           client.get_users
         end
       end
+
+      context 'get_user_visible_apps' do
+        let(:user_id) { "42" }
+        let(:path) { "users/#{user_id}/visibleApps" }
+
+        it 'succeeds' do
+          params = {}
+          req_mock = test_request_params(path, params)
+          expect(client).to receive(:request).with(:get).and_yield(req_mock).and_return(req_mock)
+          client.get_user_visible_apps(user_id: user_id)
+        end
+      end
+    end
+
+    describe "user_invitations" do
+      context 'get_user_invitation_visible_apps' do
+        let(:invitation_id) { "42" }
+        let(:path) { "userInvitations/#{invitation_id}/visibleApps" }
+
+        it 'succeeds' do
+          params = {}
+          req_mock = test_request_params(path, params)
+          expect(client).to receive(:request).with(:get).and_yield(req_mock).and_return(req_mock)
+          client.get_user_invitation_visible_apps(user_invitation_id: invitation_id)
+        end
+      end
     end
   end
 end

--- a/spaceship/spec/connect_api/users/user_client_spec.rb
+++ b/spaceship/spec/connect_api/users/user_client_spec.rb
@@ -71,6 +71,55 @@ describe Spaceship::ConnectAPI::Users::Client do
     end
 
     describe "user_invitations" do
+      context 'post_user_invitation' do
+        let(:path) { "userInvitations" }
+        let(:attributes) { 
+          {
+            email: "test@example.com",
+            firstName: "Firstname",
+            lastName: "Lastname",
+            roles: [],
+            provisioningAllowed: true,
+            allAppsVisible: false
+          } 
+        }
+        let(:visible_app_ids) { ["123", "456"] }
+        let(:body) do
+          {
+            data: {
+              type: "userInvitations",
+              attributes: attributes,
+              relationships: {
+                visibleApps: {
+                  data: visible_app_ids.map do |id|
+                    {
+                      id: id,
+                      type: "apps"
+                    }
+                  end
+                }
+              }
+            }
+          }
+        end
+
+        it 'succeeds' do
+          url = path
+          req_mock = test_request_body(url, body)
+
+          expect(client).to receive(:request).with(:post).and_yield(req_mock).and_return(req_mock)
+          client.post_user_invitation(
+            email: "test@example.com",
+            first_name: "Firstname",
+            last_name: "Lastname",
+            roles: [],
+            provisioning_allowed: true,
+            all_apps_visible: false,
+            visible_app_ids: ["123", "456"]
+          )
+        end
+      end
+
       context 'get_user_invitation_visible_apps' do
         let(:invitation_id) { "42" }
         let(:path) { "userInvitations/#{invitation_id}/visibleApps" }

--- a/spaceship/spec/connect_api/users/user_client_spec.rb
+++ b/spaceship/spec/connect_api/users/user_client_spec.rb
@@ -73,7 +73,7 @@ describe Spaceship::ConnectAPI::Users::Client do
     describe "user_invitations" do
       context 'post_user_invitation' do
         let(:path) { "userInvitations" }
-        let(:attributes) { 
+        let(:attributes) {
           {
             email: "test@example.com",
             firstName: "Firstname",
@@ -81,7 +81,7 @@ describe Spaceship::ConnectAPI::Users::Client do
             roles: [],
             provisioningAllowed: true,
             allAppsVisible: false
-          } 
+          }
         }
         let(:visible_app_ids) { ["123", "456"] }
         let(:body) do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
`User` and `UserInvitation` models should have a relationship to `visible_apps` to manage app permissions.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Changes:
It's possible to assign app permissions when inviting user with `post_user_invitation`.
It's possible to fetch app permissions (`visible_apps`) for both `User` and `UserInvitation`

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Testing in `irb`:

```ruby
require 'spaceship'
Spaceship::ConnectAPI.login

users = Spaceship::ConnectAPI::User.all(includes: Spaceship::ConnectAPI::User::ESSENTIAL_INCLUDES)
# or
users = Spaceship::ConnectAPI::User.all(includes: "visibleApps")
# or
users = Spaceship::ConnectAPI::User.all

user = Spaceship::ConnectAPI::User.find(email:"USER_EMAIL").first
user.get_visible_apps 
user.get_visible_apps(limit: 1)

user = Spaceship::ConnectAPI::User.find(email:"USER_EMAIL", includes: "visibleApps")


invitations = Spaceship::ConnectAPI::UserInvitation.all(includes: Spaceship::ConnectAPI::UserInvitation::ESSENTIAL_INCLUDES)
# or
invitations = Spaceship::ConnectAPI::UserInvitation.all(includes: "visibleApps")
# or 
invitations = Spaceship::ConnectAPI::UserInvitation.all

Spaceship::ConnectAPI::UserInvitation.create(email: "YOUR_EMAIL", first_name: "YOUR_FIRST_NAME", last_name: "YOUR_LAST_NAME", roles: ["DEVELOPER"], provisioning_allowed: true, all_apps_visible: false, visible_app_ids: ["APP_ID"])
user_invitation = Spaceship::ConnectAPI::UserInvitation.find("YOUR_EMAIL")
user_invitation.get_visible_apps
user_invitation.get_visible_apps(limit: 1)
user_invitation.first.delete!

# Testing of invalid combinations of `all_apps_visible` and `visible_app_ids`:

Spaceship::ConnectAPI::UserInvitation.create(email: "YOUR_EMAIL", first_name: "YOUR_FIRST_NAME", last_name: "YOUR_LAST_NAME", roles: ["DEVELOPER"], provisioning_allowed: true, all_apps_visible: true, visible_app_ids: ["APP_ID"])
# It will fail with "The provided entity includes a relationship with an invalid value - If you set allAppsVisible to true, you must not provide values for the visibleApps relationship. - /data/relationships/visibleApps"

Spaceship::ConnectAPI::UserInvitation.create(email: "YOUR_EMAIL", first_name: "YOUR_FIRST_NAME", last_name: "YOUR_LAST_NAME", roles: ["DEVELOPER"], provisioning_allowed: true, all_apps_visible: false)
# It will fail with "The provided visible app information is invalid. - If you set allAppsVisible to false, you must provide at least one value for the visibleApps relationship. - /data/attributes/allAppsVisible
```