### PR TITLE
[precheck] remove all instances of `is_string` in options and use `type`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -302,6 +302,7 @@ Lint/IsStringUsage:
     - 'fastlane/**/*'
     - 'gym/**/*'
     - 'match/**/*'
+    - 'precheck/**/*'
     - 'screengrab/**/*'
     - 'supply/**/*'
 

--- a/precheck/lib/precheck/module.rb
+++ b/precheck/lib/precheck/module.rb
@@ -1,5 +1,6 @@
 require 'fastlane_core/helper'
 require 'fastlane_core/ui/ui'
+require 'fastlane/boolean'
 
 module Precheck
   # Use this to just setup the configuration attribute and set it later somewhere else
@@ -13,6 +14,7 @@ module Precheck
 
   Helper = FastlaneCore::Helper # you gotta love Ruby: Helper.* should use the Helper class contained in FastlaneCore
   UI = FastlaneCore::UI
+  Boolean = Fastlane::Boolean
   ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
 
   ENV['APP_IDENTIFIER'] ||= ENV["PRECHECK_APP_IDENTIFIER"]

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -90,19 +90,19 @@ module Precheck
                                      short_option: "-r",
                                      env_name: "PRECHECK_DEFAULT_RULE_LEVEL",
                                      description: "The default rule level unless otherwise configured",
-                                     is_string: false,
+                                     skip_type_validation: true, # allow String, Symbol
                                      default_value: RULE_LEVELS[:error]),
         FastlaneCore::ConfigItem.new(key: :include_in_app_purchases,
                                      short_option: "-i",
                                      env_name: "PRECHECK_INCLUDE_IN_APP_PURCHASES",
                                      description: "Should check in-app purchases?",
-                                     is_string: false,
+                                     type: Boolean,
                                      optional: true,
                                      default_value: true),
         FastlaneCore::ConfigItem.new(key: :use_live,
                                      env_name: "PRECHECK_USE_LIVE",
                                      description: "Should force check live app?",
-                                     is_string: false,
+                                     type: Boolean,
                                      default_value: false)
       ] + rules
     end

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -90,7 +90,7 @@ module Precheck
                                      short_option: "-r",
                                      env_name: "PRECHECK_DEFAULT_RULE_LEVEL",
                                      description: "The default rule level unless otherwise configured",
-                                     skip_type_validation: true, # allow String, Symbol
+                                     type: Symbol,
                                      default_value: RULE_LEVELS[:error]),
         FastlaneCore::ConfigItem.new(key: :include_in_app_purchases,
                                      short_option: "-i",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `is_string` is slowly being replaced by `type` to make the docs clearer, options safer, and Swift generation more correct.
- This PR does this for only `precheck` tool.

### Description
In this PR,
- Remove `is_string: false` from precheck options
- Updated rubocop.yml for precheck linting

### Testing Steps
- No functionality changed, all existing unit tests should pass.