### PR TITLE
[supply] fix #18670 Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true.

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -102,7 +102,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('simctl', '~> 1.6.3') # Used for querying and interacting with iOS simulators
   spec.add_dependency('jwt', '>= 2.1.0', '< 3') # Used for generating authentication tokens for App Store Connect API
   spec.add_dependency('google-apis-playcustomapp_v1', '~> 0.1') # Google API Client to access Custom app Publishing API
-  spec.add_dependency('google-apis-androidpublisher_v3', '~> 0.1') # Google API Client to access Play Publishing API
+  spec.add_dependency('google-apis-androidpublisher_v3', '~> 0.3') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '~> 1.31') # Access Google Cloud Storage for match
   spec.add_dependency('emoji_regex', '>= 0.1', '< 4.0') # Used to scan for Emoji in the changelog
   spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used for S3 storage in fastlane match

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -162,7 +162,13 @@ module Supply
     def commit_current_edit!
       ensure_active_edit!
 
-      call_google_api { client.commit_edit(current_package_name, current_edit.id) }
+      call_google_api do
+        client.commit_edit(
+          current_package_name,
+          current_edit.id,
+          changes_not_sent_for_review: Supply.config[:changes_not_sent_for_review]
+        )
+      end
 
       self.current_edit = nil
       self.current_package_name = nil

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -283,7 +283,7 @@ module Supply
                                      end),
         FastlaneCore::ConfigItem.new(key: :changes_not_sent_for_review,
                                      env_name: "SUPPLY_CHANGES_NOT_SENT_FOR_REVIEW",
-                                     description: "Indicates that the changes in this edit will not be reviewed until they are explicitly sent for review from the Google Play Console UI.",
+                                     description: "Indicates that the changes in this edit will not be reviewed until they are explicitly sent for review from the Google Play Console UI",
                                      type: Boolean,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :in_app_update_priority,

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -281,6 +281,11 @@ module Supply
                                          UI.user_error!("Version code '#{version_code}' is not an integer") if version_code == 0
                                        end
                                      end),
+        FastlaneCore::ConfigItem.new(key: :changes_not_sent_for_review,
+                                     env_name: "SUPPLY_CHANGES_NOT_SENT_FOR_REVIEW",
+                                     description: "Indicates that the changes in this edit will not be reviewed until they are explicitly sent for review from the Google Play Console UI.",
+                                     type: Boolean,
+                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :in_app_update_priority,
                                      env_name: "SUPPLY_IN_APP_UPDATE_PRIORITY",
                                      optional: true,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format: -->
Resolves #18670 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Added 'changes_not_sent_for_review' option to supply to specify whether or not to send changes for review. Have tested and successfully uploaded to an app in Rejected state on Google Play, before this change, that would have resulted in an error. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
See issue for details
