### PR TITLE
[scan] Fix typo in xcpretty_reporter_options_generator.rb

### DIFF
--- a/scan/lib/scan/xcpretty_reporter_options_generator.rb
+++ b/scan/lib/scan/xcpretty_reporter_options_generator.rb
@@ -13,7 +13,7 @@ module Scan
                Scan.config[:xcpretty_args])
     end
 
-    # Intialize with values from Scan.config matching these param names
+    # Initialize with values from Scan.config matching these param names
     def initialize(open_report, output_types, output_files, output_directory, use_clang_report_name, xcpretty_args)
       @open_report = open_report
       @output_types = output_types


### PR DESCRIPTION

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Intialize -> Initialize
