### PR TITLE
[spaceship] Updated v2 web-session endpoint 

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -161,7 +161,7 @@ module Spaceship
       end
 
       response = request(:post) do |req|
-        req.url("ra/v1/session/webSession")
+        req.url("ra/v2/session/webSession")
         req.body = {
           contentProviderId: team_id,
           dsId: user_detail_data.ds_id # https://github.com/fastlane/fastlane/issues/6711

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -36,7 +36,7 @@ class TunesStubbing
         with(body: { "accountName" => "bad-username", "password" => "bad-password", "rememberMe" => true }.to_json).
         to_return(status: 401, body: '{}', headers: { 'Set-Cookie' => 'session=invalid' })
 
-      stub_request(:post, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/v1/session/webSession").
+      stub_request(:post, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/v2/session/webSession").
         with(body: "{\"contentProviderId\":\"5678\",\"dsId\":null}",
               headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type' => 'application/json' }).
         to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #19124

### Description
- It seems Apple suddenly removed the v1 endpoint! 

### Testing Steps

- Update `Gemfile` to 👇 and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "crazymanish-spaceship-client-fix"
```
- Try to `download_dsyms` or `latest_testflight_build_number`