### PR TITLE
[spaceship] new team switching endpoint

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -147,6 +147,7 @@ module Spaceship
       available_teams = teams.collect do |team|
         {
           team_id: (team["contentProvider"] || {})["contentProviderId"],
+          public_team_id: (team["contentProvider"] || {})["contentProviderPublicId"],
           team_name: (team["contentProvider"] || {})["name"]
         }
       end
@@ -161,10 +162,19 @@ module Spaceship
       end
 
       response = request(:post) do |req|
-        req.url("ra/v2/session/webSession")
+        req.url("https://appstoreconnect.apple.com/olympus/v1/providerSwitchRequests")
         req.body = {
-          contentProviderId: team_id,
-          dsId: user_detail_data.ds_id # https://github.com/fastlane/fastlane/issues/6711
+          "data": {
+            "type": "providerSwitchRequests",
+            "relationships": {
+              "provider": {
+                "data": {
+                  "type": "providers",
+                  "id": result[:public_team_id]
+                }
+              }
+            }
+          }
         }.to_json
         req.headers['Content-Type'] = 'application/json'
       end

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -113,8 +113,8 @@ describe Spaceship::TunesClient do
       let(:user_details_data) do
         {
           'associatedAccounts' => [
-            { 'contentProvider' => { 'name' => 'Tom', 'contentProviderId' => 1234 } },
-            { 'contentProvider' => { 'name' => 'Harry', 'contentProviderId' => 5678 } }
+            { 'contentProvider' => { 'name' => 'Tom', 'contentProviderId' => 1234, 'contentProviderPublicId' => '1111-2222-3333-4444' } },
+            { 'contentProvider' => { 'name' => 'Harry', 'contentProviderId' => 5678, 'contentProviderPublicId' => '2222-3333-4444-5555' } }
           ],
           'sessionToken' => { 'contentProviderId' => 1234 }
         }

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -25,6 +25,10 @@ class TunesStubbing
         to_return(status: 200, body: itc_read_fixture_file('olympus_session.json'))
       stub_request(:get, "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com").
         to_return(status: 200, body: { authServiceKey: 'e0abc' }.to_json, headers: { 'Content-Type' => 'application/json' })
+      stub_request(:post, "https://appstoreconnect.apple.com/olympus/v1/providerSwitchRequests").
+        with(body: "{\"data\":{\"type\":\"providerSwitchRequests\",\"relationships\":{\"provider\":{\"data\":{\"type\":\"providers\",\"id\":\"2222-3333-4444-5555\"}}}}}",
+              headers: { 'Content-Type' => 'application/json' }).
+        to_return(status: 200, body: "", headers: {})
 
       # Actual login
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").
@@ -35,11 +39,6 @@ class TunesStubbing
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").
         with(body: { "accountName" => "bad-username", "password" => "bad-password", "rememberMe" => true }.to_json).
         to_return(status: 401, body: '{}', headers: { 'Set-Cookie' => 'session=invalid' })
-
-      stub_request(:post, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/v2/session/webSession").
-        with(body: "{\"contentProviderId\":\"5678\",\"dsId\":null}",
-              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type' => 'application/json' }).
-        to_return(status: 200, body: "", headers: {})
 
       # 2FA: Request security code to trusted phone
       [1, 2].each do |id|


### PR DESCRIPTION
### Motivation and Context
Fixes #19124

### Description
- Endpoint `ra/v1/session/webSession` no longer exists for switching teams
- Need to use new `https://appstoreconnect.apple.com/olympus/v1/providerSwitchRequests` endpoint
  - This endpoint doesn't take the team "team id" that was previously being used
  - The id that is now required is referred to as the "public provider id" which is a UUID
  - This can still (for now) be fetched from the `/WebObjects/iTunesConnect.woa/ra/user/detail` but uses `contentProviderPublicId` instead of `contentProviderId`

### Testing Steps

- Update `Gemfile` to 👇 and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-new-team-switching-endpoint"
```
