### PR TITLE
[fastlane_core] skip overriding String.clear method when disabling colorization.

### DIFF
--- a/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
+++ b/fastlane_core/lib/fastlane_core/ui/disable_colors.rb
@@ -10,6 +10,7 @@ class String
     end
   end
   Colored::EXTRAS.keys.each do |extra|
+    next if extra == 'clear'
     define_method(extra) do
       self # do nothing with the string, but return it
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Setting `FASTLANE_DISABLE_COLORS=1` may lead to errors in other libraries due to override of method `String.clear`, [which not overridden](https://github.com/defunkt/colored/blob/829bde0f8832406be1cacc5c99c49d976e05ccfc/lib/colored.rb#L54) in `colored` gem.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
