### PR TITLE
[spaceship] Add x-csrf-itc header to requests

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -41,6 +41,7 @@ module Spaceship
     attr_accessor :logger
 
     attr_accessor :csrf_tokens
+    attr_accessor :additional_headers
 
     attr_accessor :provider
 
@@ -717,8 +718,13 @@ module Spaceship
       @csrf_tokens || {}
     end
 
+    def additional_headers
+      @additional_headers || {}
+    end
+
     def request(method, url_or_path = nil, params = nil, headers = {}, auto_paginate = false, &block)
       headers.merge!(csrf_tokens)
+      headers.merge!(additional_headers)
       headers['User-Agent'] = USER_AGENT
 
       # Before encoding the parameters, log them

--- a/spaceship/lib/spaceship/connect_api/testflight/client.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/client.rb
@@ -11,6 +11,9 @@ module Spaceship
 
           super(cookie: cookie, current_team_id: current_team_id, token: token, another_client: another_client)
 
+          # Used by most iris requests starting in July 2021
+          @additional_headers = { 'x-csrf-itc': '[asc-ui]' } if another_client
+
           self.extend(Spaceship::ConnectAPI::TestFlight::API)
           self.test_flight_request_client = self
         end

--- a/spaceship/lib/spaceship/connect_api/tunes/client.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/client.rb
@@ -11,6 +11,9 @@ module Spaceship
 
           super(cookie: cookie, current_team_id: current_team_id, token: token, another_client: another_client)
 
+          # Used by most iris requests starting in July 2021
+          @additional_headers = { 'x-csrf-itc': '[asc-ui]' } if another_client
+
           self.extend(Spaceship::ConnectAPI::Tunes::API)
           self.tunes_request_client = self
         end

--- a/spaceship/lib/spaceship/connect_api/users/client.rb
+++ b/spaceship/lib/spaceship/connect_api/users/client.rb
@@ -11,6 +11,9 @@ module Spaceship
 
           super(cookie: cookie, current_team_id: current_team_id, token: token, another_client: another_client)
 
+          # Used by most iris requests starting in July 2021
+          @additional_headers = { 'x-csrf-itc': '[asc-ui]' } if another_client
+
           self.extend(Spaceship::ConnectAPI::Users::API)
           self.users_request_client = self
         end

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -271,6 +271,7 @@ module Spaceship
         req.url("ra/apps/#{app_id}/details")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
 
       handle_itc_response(r.body)
@@ -319,6 +320,7 @@ module Spaceship
         req.url('ra/apps/create/v2')
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r, 'data')
@@ -334,6 +336,7 @@ module Spaceship
           }
         }.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r, 'data')
@@ -371,6 +374,7 @@ module Spaceship
           }
         }.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r, 'data')
@@ -465,6 +469,7 @@ module Spaceship
           req.url("ra/apps/#{app_id}/platforms/ios/versions/#{version_id}")
           req.body = data.to_json
           req.headers['Content-Type'] = 'application/json'
+          req.headers['x-csrf-itc'] = 'itc'
         end
 
         handle_itc_response(r.body, flaky_api_call: true)
@@ -494,6 +499,7 @@ module Spaceship
         req.url("ra/users/itc/delete")
         req.body = payload.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
     end
 
@@ -528,6 +534,7 @@ module Spaceship
         req.url("ra/users/itc/create")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -559,6 +566,7 @@ module Spaceship
         req.url("ra/users/itc/#{member.user_id}/roles")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -583,6 +591,7 @@ module Spaceship
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
         req.headers['X-Requested-By'] = 'appstoreconnect.apple.com'
+        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r)
@@ -623,6 +632,7 @@ module Spaceship
         req.url("ra/apps/#{app_id}/pricing/intervals")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -749,6 +759,7 @@ module Spaceship
         req.url("ra/apps/#{app_id}/pricing/intervals")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
       data = parse_response(r, 'data')
@@ -1008,6 +1019,7 @@ module Spaceship
         req.url("ra/apps/#{app_id}/testingTypes/#{testing_type}/trains/")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
 
       handle_itc_response(r.body)
@@ -1018,6 +1030,7 @@ module Spaceship
         req.url("ra/apps/#{app_id}/platforms/#{platform}/trains/#{train}/builds/#{build_number}/reject")
         req.body = {}.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1067,6 +1080,7 @@ module Spaceship
         req.url(url)
         req.body = build_info.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1137,6 +1151,7 @@ module Spaceship
 
         req.body = review_info.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1147,6 +1162,7 @@ module Spaceship
       r = request(:get) do |req|
         req.url(url)
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
 
@@ -1164,6 +1180,7 @@ module Spaceship
       r = request(:get) do |req|
         req.url("ra/apps/#{app_id}/versions/#{version}/submit/summary")
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
 
       handle_itc_response(r.body)
@@ -1178,6 +1195,7 @@ module Spaceship
         req.url("ra/apps/#{app_id}/versions/#{version}/submit/complete")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
 
       handle_itc_response(r.body)
@@ -1211,6 +1229,7 @@ module Spaceship
       r = request(:post) do |req|
         req.url("ra/apps/#{app_id}/versions/#{version}/releaseToStore")
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
         req.body = app_id.to_s
       end
 
@@ -1229,6 +1248,7 @@ module Spaceship
       r = request(:post) do |req|
         req.url("ra/apps/#{app_id}/versions/#{version}/phasedRelease/state/COMPLETE")
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
         req.body = app_id.to_s
       end
 
@@ -1296,6 +1316,7 @@ module Spaceship
           req.url("ra/apps/#{app_id}/iaps/family/#{family_id}/")
           req.body = data.to_json
           req.headers['Content-Type'] = 'application/json'
+          req.headers['x-csrf-itc'] = 'itc'
         end
         handle_itc_response(r.body)
       end
@@ -1308,6 +1329,7 @@ module Spaceship
           req.url("ra/apps/#{app_id}/iaps/#{purchase_id}")
           req.body = data.to_json
           req.headers['Content-Type'] = 'application/json'
+          req.headers['x-csrf-itc'] = 'itc'
         end
         handle_itc_response(r.body)
       end
@@ -1321,6 +1343,7 @@ module Spaceship
           pricing_data["subscriptions"] = pricing_intervals
           req.body = pricing_data.to_json
           req.headers['Content-Type'] = 'application/json'
+          req.headers['x-csrf-itc'] = 'itc'
         end
         handle_itc_response(r.body)
       end
@@ -1344,6 +1367,7 @@ module Spaceship
         req.url("ra/apps/#{app_id}/iaps/family/")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1418,6 +1442,7 @@ module Spaceship
         req.url("ra/apps/#{app_id}/iaps")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1465,6 +1490,7 @@ module Spaceship
           }
         }.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       response_object = parse_response(r, 'data')
       errors = response_object['sectionErrorKeys']
@@ -1484,6 +1510,7 @@ module Spaceship
           }
         end.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       true
     end
@@ -1520,6 +1547,7 @@ module Spaceship
         req.url(url)
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
       parse_response(r, 'data')
     end
@@ -1540,6 +1568,7 @@ module Spaceship
       r = request(:post) do |req|
         req.url("ra/apps/#{app_id}/versions/#{version}/reject")
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
         req.body = app_id.to_s
       end
 
@@ -1634,6 +1663,7 @@ module Spaceship
         req.url(url)
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
+        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r, 'data')

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -24,6 +24,9 @@ module Spaceship
       super
 
       @du_client = DUClient.new
+
+      # Used by most WebObjects requests starting in July 2021
+      @additional_headers = { 'x-csrf-itc': 'itc' }
     end
 
     class << self
@@ -271,7 +274,6 @@ module Spaceship
         req.url("ra/apps/#{app_id}/details")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
 
       handle_itc_response(r.body)
@@ -320,7 +322,6 @@ module Spaceship
         req.url('ra/apps/create/v2')
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r, 'data')
@@ -336,7 +337,6 @@ module Spaceship
           }
         }.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r, 'data')
@@ -374,7 +374,6 @@ module Spaceship
           }
         }.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r, 'data')
@@ -469,7 +468,6 @@ module Spaceship
           req.url("ra/apps/#{app_id}/platforms/ios/versions/#{version_id}")
           req.body = data.to_json
           req.headers['Content-Type'] = 'application/json'
-          req.headers['x-csrf-itc'] = 'itc'
         end
 
         handle_itc_response(r.body, flaky_api_call: true)
@@ -499,7 +497,6 @@ module Spaceship
         req.url("ra/users/itc/delete")
         req.body = payload.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
     end
 
@@ -534,7 +531,6 @@ module Spaceship
         req.url("ra/users/itc/create")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -566,7 +562,6 @@ module Spaceship
         req.url("ra/users/itc/#{member.user_id}/roles")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -591,7 +586,6 @@ module Spaceship
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
         req.headers['X-Requested-By'] = 'appstoreconnect.apple.com'
-        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r)
@@ -632,7 +626,6 @@ module Spaceship
         req.url("ra/apps/#{app_id}/pricing/intervals")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -759,7 +752,6 @@ module Spaceship
         req.url("ra/apps/#{app_id}/pricing/intervals")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
       data = parse_response(r, 'data')
@@ -1019,7 +1011,6 @@ module Spaceship
         req.url("ra/apps/#{app_id}/testingTypes/#{testing_type}/trains/")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
 
       handle_itc_response(r.body)
@@ -1030,7 +1021,6 @@ module Spaceship
         req.url("ra/apps/#{app_id}/platforms/#{platform}/trains/#{train}/builds/#{build_number}/reject")
         req.body = {}.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1080,7 +1070,6 @@ module Spaceship
         req.url(url)
         req.body = build_info.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1151,7 +1140,6 @@ module Spaceship
 
         req.body = review_info.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1162,7 +1150,6 @@ module Spaceship
       r = request(:get) do |req|
         req.url(url)
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
 
@@ -1180,7 +1167,6 @@ module Spaceship
       r = request(:get) do |req|
         req.url("ra/apps/#{app_id}/versions/#{version}/submit/summary")
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
 
       handle_itc_response(r.body)
@@ -1195,7 +1181,6 @@ module Spaceship
         req.url("ra/apps/#{app_id}/versions/#{version}/submit/complete")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
 
       handle_itc_response(r.body)
@@ -1229,7 +1214,6 @@ module Spaceship
       r = request(:post) do |req|
         req.url("ra/apps/#{app_id}/versions/#{version}/releaseToStore")
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
         req.body = app_id.to_s
       end
 
@@ -1248,7 +1232,6 @@ module Spaceship
       r = request(:post) do |req|
         req.url("ra/apps/#{app_id}/versions/#{version}/phasedRelease/state/COMPLETE")
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
         req.body = app_id.to_s
       end
 
@@ -1316,7 +1299,6 @@ module Spaceship
           req.url("ra/apps/#{app_id}/iaps/family/#{family_id}/")
           req.body = data.to_json
           req.headers['Content-Type'] = 'application/json'
-          req.headers['x-csrf-itc'] = 'itc'
         end
         handle_itc_response(r.body)
       end
@@ -1329,7 +1311,6 @@ module Spaceship
           req.url("ra/apps/#{app_id}/iaps/#{purchase_id}")
           req.body = data.to_json
           req.headers['Content-Type'] = 'application/json'
-          req.headers['x-csrf-itc'] = 'itc'
         end
         handle_itc_response(r.body)
       end
@@ -1343,7 +1324,6 @@ module Spaceship
           pricing_data["subscriptions"] = pricing_intervals
           req.body = pricing_data.to_json
           req.headers['Content-Type'] = 'application/json'
-          req.headers['x-csrf-itc'] = 'itc'
         end
         handle_itc_response(r.body)
       end
@@ -1367,7 +1347,6 @@ module Spaceship
         req.url("ra/apps/#{app_id}/iaps/family/")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1442,7 +1421,6 @@ module Spaceship
         req.url("ra/apps/#{app_id}/iaps")
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       handle_itc_response(r.body)
     end
@@ -1490,7 +1468,6 @@ module Spaceship
           }
         }.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       response_object = parse_response(r, 'data')
       errors = response_object['sectionErrorKeys']
@@ -1510,7 +1487,6 @@ module Spaceship
           }
         end.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       true
     end
@@ -1547,7 +1523,6 @@ module Spaceship
         req.url(url)
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
       parse_response(r, 'data')
     end
@@ -1568,7 +1543,6 @@ module Spaceship
       r = request(:post) do |req|
         req.url("ra/apps/#{app_id}/versions/#{version}/reject")
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
         req.body = app_id.to_s
       end
 
@@ -1663,7 +1637,6 @@ module Spaceship
         req.url(url)
         req.body = data.to_json
         req.headers['Content-Type'] = 'application/json'
-        req.headers['x-csrf-itc'] = 'itc'
       end
 
       data = parse_response(r, 'data')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Fixes issues #19124 #19140

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Adds a CSRF header to all requests in the tunes client. I discovered that this header was necessary by encountering the issue from #19140 (even on 2.188.0), doing a similar request via the App Store Connect UI, then diffing the requests, and binary searching through the headers to find the one that was missing for the request to succeed.

I verified that requests to create families, create iaps, update families, and update iaps fail without the header but succeed with it.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
