### PR TITLE
[pilot] added missing unit tests for the Pilot::Manager class

### DIFF
--- a/pilot/spec/manager_spec.rb
+++ b/pilot/spec/manager_spec.rb
@@ -178,7 +178,7 @@ describe Pilot do
         before(:each) do
           allow(Spaceship::ConnectAPI::App)
             .to receive(:get)
-            .with({:app_id => fake_app_id})
+            .with({ app_id: fake_app_id })
             .and_return(fake_app)
 
           fake_manager.instance_variable_set(:@app_id, fake_app_id)
@@ -200,7 +200,7 @@ describe Pilot do
 
           allow(Spaceship::ConnectAPI::App)
             .to receive(:get)
-            .with({:app_id => fake_app_id})
+            .with({ app_id: fake_app_id })
             .and_return(fake_app)
 
           expect(fake_manager).to receive(:fetch_app_id)
@@ -222,7 +222,7 @@ describe Pilot do
 
             allow(Spaceship::ConnectAPI::App)
               .to receive(:get)
-              .with({:app_id => fake_app_id})
+              .with({ app_id: fake_app_id })
               .and_return(fake_app)
 
             expect(fake_manager).to receive(:fetch_app_id)
@@ -245,7 +245,7 @@ describe Pilot do
 
             allow(Spaceship::ConnectAPI::App)
               .to receive(:get)
-              .with({:app_id => fake_app_id})
+              .with({ app_id: fake_app_id })
               .and_return(nil)
 
             expect(fake_manager).to receive(:fetch_app_id)

--- a/pilot/spec/manager_spec.rb
+++ b/pilot/spec/manager_spec.rb
@@ -13,8 +13,6 @@ describe Pilot do
     let(:fake_app) { "fake app" }
     let(:fake_app_identifier) { "fake app_identifier" }
     let(:fake_ipa) { "fake ipa" }
-    let(:fake_username) { "fake username" }
-    let(:fake_app_platform) { "ios" }
 
     describe "what happens on 'start'" do
       context "when 'config' variable is already set" do
@@ -309,6 +307,8 @@ describe Pilot do
       end
 
       context "when 'app_id' variable is not set, config does not has apple_id but found the app_identifier" do
+        let(:fake_username) { "fake username" }
+
         before(:each) do
           fake_manager.instance_variable_set(:@config, { apple_id: nil })
 
@@ -413,6 +413,8 @@ describe Pilot do
     end
 
     describe "what happens on fetching the 'app_platform'" do
+      let(:fake_app_platform) { "ios" }
+
       context "when config has 'app_platform' variable" do
         before(:each) do
           expect(UI).to receive(:verbose).with("App Platform (#{fake_app_platform})")
@@ -461,6 +463,26 @@ describe Pilot do
           fetch_app_platform_result = fake_manager.fetch_app_platform
 
           expect(fetch_app_platform_result).to eq(fake_app_platform)
+        end
+      end
+
+      context "when FastlaneCore::IpaFileAnalyser failed to fetch the 'app_platform' variable and its not required to enter manually" do
+        before(:each) do
+          expect(UI).not_to receive(:verbose).with("App Platform (#{fake_app_platform})")
+          fake_manager.instance_variable_set(:@config, { ipa: fake_ipa })
+
+          allow(FastlaneCore::IpaFileAnalyser)
+            .to receive(:fetch_app_platform)
+            .with(fake_ipa)
+            .and_return(nil)
+        end
+
+        it "does not ask user to enter the app's platform manually" do
+          expect(UI).not_to receive(:input).with("Please enter the app's platform (appletvos, ios, osx): ")
+
+          fetch_app_platform_result = fake_manager.fetch_app_platform(required: false)
+
+          expect(fetch_app_platform_result).to eq(nil)
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `Pilot::Manager` class was missing some unit-tests

### Description
In this PR, 
- added missing unit tests for the `Pilot::Manager` class, Now every single line is backed by Unit tests - 💯 
- added unit-tests for [app](https://github.com/fastlane/fastlane/blob/98f669dadc5a426d4b7c68590ea586d85103b429/pilot/lib/pilot/manager.rb#L42)
- added unit-tests for [fetch_app_id](https://github.com/fastlane/fastlane/blob/98f669dadc5a426d4b7c68590ea586d85103b429/pilot/lib/pilot/manager.rb#L58)
- added unit-tests for [fetch_app_identifier](https://github.com/fastlane/fastlane/blob/98f669dadc5a426d4b7c68590ea586d85103b429/pilot/lib/pilot/manager.rb#L74)
- added unit-tests for [fetch_app_platform](https://github.com/fastlane/fastlane/blob/98f669dadc5a426d4b7c68590ea586d85103b429/pilot/lib/pilot/manager.rb#L82)

### Testing Steps
- CI tests should be green. 

### Screenshot
<img width="983" alt="Screenshot 2021-07-29 at 00 28 44" src="https://user-images.githubusercontent.com/5364500/127405181-193e303f-b78f-4501-8533-cdfeeb3371a6.png">
