### PR TITLE
[action][app_store_connect_api_key] Change default token duration

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
+++ b/fastlane/lib/fastlane/actions/app_store_connect_api_key.rb
@@ -80,7 +80,7 @@ module Fastlane
                                        env_name: "APP_STORE_CONNECT_API_KEY_DURATION",
                                        description: "The token session duration",
                                        optional: true,
-                                       default_value: Spaceship::ConnectAPI::Token::MAX_TOKEN_DURATION,
+                                       default_value: Spaceship::ConnectAPI::Token::DEFAULT_TOKEN_DURATION,
                                        type: Integer,
                                        verify_block: proc do |value|
                                          UI.user_error!("The duration can't be more than 1200 (20 minutes) and the value entered was '#{value}'") unless value <= 1200

--- a/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
@@ -134,7 +134,7 @@ describe Fastlane do
           issuer_id: issuer_id,
           key: File.binread(fake_api_key_p8_path),
           is_key_content_base64: false,
-          duration: 1200,
+          duration: 500,
           in_house: false
         }
 

--- a/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
           issuer_id: issuer_id,
           key: File.binread(fake_api_key_p8_path),
           is_key_content_base64: false,
-          duration: 1200,
+          duration: 500,
           in_house: false
         }
 

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -13,6 +13,7 @@ module Spaceship
     class Token
       # maximum expiration supported by AppStore (20 minutes)
       MAX_TOKEN_DURATION = 1200
+      DEFAULT_TOKEN_DURATION = 500
 
       attr_reader :key_id
       attr_reader :issuer_id
@@ -80,7 +81,7 @@ module Spaceship
         @duration = duration
         @in_house = in_house
 
-        @duration ||= MAX_TOKEN_DURATION
+        @duration ||= DEFAULT_TOKEN_DURATION
         @duration = @duration.to_i if @duration
 
         refresh!


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

This change fixes a problem detailed in this discussion: https://github.com/fastlane/fastlane/discussions/18100

To summarize, folks are running into issues uploading their builds to App Store Connect using the API key because their machine's time is not the same as the time on Apple servers. Since the default value for this action is the same as the maximum duration that Apple's API will allow, this causes uploads to fail with cryptic messages that do not clearly point folks to the root cause. 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I've lowered the default value so that folks with times that are not the same as Apple's servers should not run into this issue when using the default settings. This should reduce the number of people that run into this issue but will not eliminate the issue. If we wanted to do that one possible way to do so would be to check the system time against a standard time source to ensure it is within some acceptable range.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Ran tests.