### PR TITLE
[pilot] improve the existing Pilot::BuildManager::Upload method unit tests

### DIFF
--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -480,24 +480,31 @@ describe "Build Manager" do
   describe "#upload" do
     describe "uses Manager.login (which does spaceship login)" do
       let(:fake_build_manager) { Pilot::BuildManager.new }
+      let(:fake_app_id) { 123 }
+      let(:fake_dir) { "fake dir" }
+      let(:fake_app_platform) { "ios" }
       let(:upload_options) do
         {
-          apple_id: 'mock_apple_id',
+          apple_id: fake_app_id,
           skip_waiting_for_build_processing: true,
           ipa: 'foo'
         }
       end
 
       before(:each) do
-        allow(fake_build_manager).to receive(:fetch_app_platform).and_return('ios')
+        allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+        allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
 
         fake_ipauploadpackagebuilder = double
-        allow(fake_ipauploadpackagebuilder).to receive(:generate).and_return(true)
+        allow(fake_ipauploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, ipa_path: upload_options[:ipa], package_path: fake_dir, platform: fake_app_platform).and_return(true)
         allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
 
         fake_itunestransporter = double
         allow(fake_itunestransporter).to receive(:upload).and_return(true)
         allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+
+        expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
+        expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
       end
 
       it "NOT when skip_waiting_for_build_processing and apple_id are set" do
@@ -515,22 +522,27 @@ describe "Build Manager" do
         # allow Manager.login method this time
         expect(fake_build_manager).to receive(:login).at_least(:once)
 
+        # check for changelog or whats new!
+        expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
+
         # other stuff required to let `upload` work:
 
-        expect(fake_build_manager).to receive(:fetch_app_id).and_return(123).exactly(2).times
+        expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
         expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
         expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
 
         fake_app = double
-        expect(fake_app).to receive(:id).and_return(123)
+        expect(fake_app).to receive(:id).and_return(fake_app_id)
         expect(fake_build_manager).to receive(:app).and_return(fake_app)
 
         fake_build = double
         expect(fake_build).to receive(:app_version)
         expect(fake_build).to receive(:version)
+        expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
         expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
 
-        expect(fake_build_manager).to receive(:distribute)
+        expect(fake_build_manager).to receive(:distribute).with(upload_options, build:fake_build)
 
         fake_build_manager.upload(upload_options)
       end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -542,7 +542,7 @@ describe "Build Manager" do
         expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
         expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
 
-        expect(fake_build_manager).to receive(:distribute).with(upload_options, build:fake_build)
+        expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
 
         fake_build_manager.upload(upload_options)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `Pilot::BuildManager::Upload` **method** unit tests was missing in couple of scenarios

### Description
- In this PR, **improve the existing** `Pilot::BuildManager::Upload` method unit tests
- In the upcoming PR, will add new unit tests for missing scenarios. 

### Testing Steps
- CI jobs should be green