### PR TITLE
[bundle_install] Add frozen option

### DIFF
--- a/fastlane/lib/fastlane/actions/bundle_install.rb
+++ b/fastlane/lib/fastlane/actions/bundle_install.rb
@@ -24,6 +24,7 @@ module Fastlane
           cmd << "--trust-policy" if params[:trust_policy]
           cmd << "--without #{params[:without]}" if params[:without]
           cmd << "--with #{params[:with]}" if params[:with]
+          cmd << "--frozen" if params[:frozen]
 
           return sh(cmd.join(' '))
         else
@@ -146,7 +147,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :with,
                                        env_name: "FL_BUNDLE_INSTALL_WITH",
                                        description: "Include gems that are part of the specified named group",
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :frozen,
+                                       env_name: "FL_BUNDLE_INSTALL_FROZEN",
+                                       description: "Don't allow the Gemfile.lock to be updated after install",
+                                       type: Boolean,
+                                       default_value: false)
         ]
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Bundler has `--frozen` option.

```
OPTIONS
.....
       --frozen
              Do not allow the Gemfile.lock to be updated after this install. Exits non-zero if there are going to be changes to the Gemfile.lock.
.....
```

I also added the option to bundle_install action. 