### PR TITLE
[docs] Update docs templates to allow for parsing markdown in foldable details

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
@@ -247,7 +247,7 @@ new CleanStatusBar()
 
 # Advanced _screengrab_
 
-<details>
+<details markdown="1">
 <summary>Launch Arguments</summary>
 
 You can provide additional arguments to your test cases on launch. These strings will be available in your tests through `InstrumentationRegistry.getArguments()`.
@@ -277,7 +277,7 @@ if (extras != null) {
 ```
 </details>
 
-<details>
+<details markdown="1">
 <summary>Detecting screengrab at runtime</summary>
 
 For some apps, it is helpful to know when _screengrab_ is running so that you can display specific data for your screenshots. For iOS fastlane users, this is much like "FASTLANE_SNAPSHOT". In order to do this, you'll need to have at least two product flavors of your app.

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -104,7 +104,7 @@ deliver(
 
 ## More options
 
-<details>
+<details markdown="1">
 <summary>View all available options and their valid values</summary>
 
 ## Available options
@@ -497,7 +497,7 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 
 ## Reference
 
-<details>
+<details markdown="1">
 <summary>View all available categories, etc.</summary>
 
 ### Available Categories


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Changing docs templates for actions to allow for parsing markdown in foldable details.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
There are 2 templates that are used by bot to regenerate docs.
Without this change bot will override changes in docs as written in https://github.com/fastlane/docs/pull/1075#issuecomment-886803348

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
