### PR TITLE
[clean_cocoapods_cache] Add allow-root option

### DIFF
--- a/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
+++ b/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
@@ -24,7 +24,12 @@ module Fastlane
                                        optional: true,
                                        verify_block: proc do |value|
                                          UI.user_error!("You must specify pod name which should be removed from cache") if value.to_s.empty?
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :allow_root,
+                                       env_name: "FL_CLEAN_COCOAPODS_CACHE_ALLOW_ROOT",
+                                       description: "Allows CocoaPods to run as root",
+                                       type: Boolean,
+                                       default_value: false)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
+++ b/fastlane/lib/fastlane/actions/clean_cocoapods_cache.rb
@@ -7,6 +7,7 @@ module Fastlane
         cmd = ['pod cache clean']
 
         cmd << params[:name].to_s if params[:name]
+        cmd << '--allow-root' if params[:allow_root]
         cmd << '--all'
 
         Actions.sh(cmd.join(' '))


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Cocoapods has `--allow-root` option.

```
❯ pod cache clean
Options:
...
    --allow-root   Allows CocoaPods to run as root
...
```

I also added the option to clean_cocoapods_cache action. 