### PR TITLE
[pilot] added the Pilot::BuildManager::list method unit tests

### DIFF
--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -702,8 +702,8 @@ describe "Build Manager" do
         it "prints the processing and processed both builds" do
           expect(FastlaneCore::PrintTable).to receive(:transform_output).with([["1.0.0", "1234"]]).and_return([])
           expect(FastlaneCore::PrintTable).to receive(:transform_output).with([["1.1.0", "12345", 100]]).and_return([])
-          expect(Terminal::Table).to receive(:new).with({ :headings=>["Version #", "Build #"], :rows=>[], :title=>"\e[32m#{fake_app_name} Processing Builds\e[0m" }).and_return("fake Terminal::Table fake_processing_builds")
-          expect(Terminal::Table).to receive(:new).with({ :headings=>["Version #", "Build #", "Installs"], :rows=>[], :title=>"\e[32m#{fake_app_name} Builds\e[0m" }).and_return("fake Terminal::Table fake_processed_builds")
+          expect(Terminal::Table).to receive(:new).with({ headings: ["Version #", "Build #"], rows: [], title: "\e[32m#{fake_app_name} Processing Builds\e[0m" }).and_return("fake Terminal::Table fake_processing_builds")
+          expect(Terminal::Table).to receive(:new).with({ headings: ["Version #", "Build #", "Installs"], rows: [], title: "\e[32m#{fake_app_name} Builds\e[0m" }).and_return("fake Terminal::Table fake_processed_builds")
           expect(STDOUT).to receive(:puts).with("fake Terminal::Table fake_processing_builds")
           expect(STDOUT).to receive(:puts).with("fake Terminal::Table fake_processed_builds")
 

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -673,8 +673,7 @@ describe "Build Manager" do
         before(:each) do
           fake_build_manager.instance_variable_set(:@config, input_options_without_app_identifier)
           allow(fake_build_manager).to receive(:start).with(input_options_without_app_identifier)
-          allow(Terminal::Table).to receive(:new).and_return("fake Terminal::Table")
-          expect(STDOUT).to receive(:puts).with("fake Terminal::Table").exactly(2).times
+          allow(Terminal::Table).to receive(:new).and_return("")
         end
 
         it "asks the user to enter the app_identifier manually" do
@@ -704,8 +703,6 @@ describe "Build Manager" do
           expect(FastlaneCore::PrintTable).to receive(:transform_output).with([["1.1.0", "12345", 100]]).and_return([])
           expect(Terminal::Table).to receive(:new).with({ headings: ["Version #", "Build #"], rows: [], title: "\e[32m#{fake_app_name} Processing Builds\e[0m" }).and_return("fake Terminal::Table fake_processing_builds")
           expect(Terminal::Table).to receive(:new).with({ headings: ["Version #", "Build #", "Installs"], rows: [], title: "\e[32m#{fake_app_name} Builds\e[0m" }).and_return("fake Terminal::Table fake_processed_builds")
-          expect(STDOUT).to receive(:puts).with("fake Terminal::Table fake_processing_builds")
-          expect(STDOUT).to receive(:puts).with("fake Terminal::Table fake_processed_builds")
 
           fake_build_manager.list(input_options_with_app_identifier)
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `Pilot::BuildManager::list` **method** unit tests were missing
- See method implementation: https://github.com/fastlane/fastlane/blob/0072e332e8fac0a1b37d8bc630bb802710ce5df5/pilot/lib/pilot/build_manager.rb#L184

### Description
- In this PR, added `Pilot::BuildManager::list` method unit tests
- Now, every single line is backed by unit-test of this method, 💯 %

### Testing Steps
- CI jobs should be green

<img width="593" alt="Screenshot 2021-08-02 at 01 16 09" src="https://user-images.githubusercontent.com/5364500/127788250-24907d41-014c-49ad-8faf-4952083c2e94.png">
