### PR TITLE
[Fastlane.swift] take into account `.fastlaneDefault` case when retrieving `OptionalConfigValue` as a ruby argument

### DIFF
--- a/fastlane/swift/OptionalConfigValue.swift
+++ b/fastlane/swift/OptionalConfigValue.swift
@@ -16,10 +16,13 @@ public enum OptionalConfigValue<T> {
     case `nil`
 
     func asRubyArgument(name: String, type: RubyCommand.Argument.ArgType? = nil) -> RubyCommand.Argument? {
-        if case let .userDefined(value) = self {
-            return RubyCommand.Argument(name: name, value: value, type: type)
-        }
-        return nil
+      switch self {
+        case .userDefined(let value), .fastlaneDefault(let value):
+          return RubyCommand.Argument(name: name, value: value, type: type)
+          
+        default:
+          return nil
+      }
     }
 }
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When retrieving a `OptionalConfigValue` as a ruby argument, if the case is `.fastlaneDefault` (used for setting the values defined in configuration files such as Scanfile, MakeFile, Gymfile, Deliverfile, etc) the returned value is `nil`, instead of the default value.
Resolves [#19196](https://github.com/fastlane/fastlane/issues/19196)

### Description
Added  `.fastlaneDefault` case to return the appropriate value as a `RubyCommand.Argument` instead of `nil`.

### Testing Steps
Tested the use case described in the open issue. Executed `scan` function in swift. It works on CI and it doesn't ask to select a scheme anymore when not in CI, it takes the correct value specified on the Scanfile.
