### PR TITLE
[regression][zip] fix the `shellescape` for the folder path

### DIFF
--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -52,8 +52,8 @@ module Fastlane
           # The zip command is executed from the paths **parent** directory, as a result we use just the basename, which is the file or folder within
           basename = File.basename(path)
 
-          command << output_path
-          command << basename
+          command << output_path.shellescape
+          command << basename.shellescape
 
           unless include.empty?
             command << "-i"
@@ -68,6 +68,7 @@ module Fastlane
           command
         end
       end
+
       def self.run(params)
         Runner.new(params).run
       end

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -67,12 +67,12 @@ describe Fastlane do
       end
 
       it "archives a directory with shell escaped path" do
-        escaped_expected_input_path = "escaped()_input_folder_path".shellescape
-        escaped_expected_output_path = "output()_path".shellescape
+        expected_input_path = "escaped()_input_folder_path".shellescape
+        expected_output_path = "output()_path".shellescape
 
         allow(File).to receive(:exist?).and_return(true)
         allow(File).to receive(:expand_path).and_return("..")
-        expect(Fastlane::Actions).to receive(:sh).with(["zip", "-r", "#{File.expand_path(escaped_expected_output_path)}.zip", escaped_expected_input_path])
+        expect(Fastlane::Actions).to receive(:sh).with(["zip", "-r", "#{File.expand_path(expected_output_path)}.zip", expected_input_path])
 
         Fastlane::FastFile.new.parse("lane :test do
           zip(path: 'fake/escaped()_input_folder_path', output_path: 'output()_path')

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -66,6 +66,14 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      it "archives a directory with shell escaped path" do
+        expect(Fastlane::Actions).to receive(:sh).with(["zip", "-r", "#{File.expand_path('output\\(\\)_path')}.zip", "zip"])
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          zip(path: '#{@fixtures_path}', output_path: 'output()_path')
+        end").runner.execute(:test)
+      end
+
       it "supports excluding specific files or directories" do
         expect(Fastlane::Actions).to receive(:sh).with(["zip", "-r", "#{File.expand_path(@fixtures_path)}.zip", "zip", "-x", "zip/.git/*", "zip/README.md"])
 

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -67,10 +67,12 @@ describe Fastlane do
       end
 
       it "archives a directory with shell escaped path" do
-        expect(Fastlane::Actions).to receive(:sh).with(["zip", "-r", "#{File.expand_path('output\\(\\)_path')}.zip", "zip"])
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:expand_path).and_return("..")
+        expect(Fastlane::Actions).to receive(:sh).with(["zip", "-r", "#{File.expand_path('output\\(\\)_path')}.zip", "escaped\\(\\)_input_folder_path"])
 
-        result = Fastlane::FastFile.new.parse("lane :test do
-          zip(path: '#{@fixtures_path}', output_path: 'output()_path')
+        Fastlane::FastFile.new.parse("lane :test do
+          zip(path: 'fake/escaped()_input_folder_path', output_path: 'output()_path')
         end").runner.execute(:test)
       end
 

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -67,9 +67,12 @@ describe Fastlane do
       end
 
       it "archives a directory with shell escaped path" do
+        escaped_expected_input_path = "escaped()_input_folder_path".shellescape
+        escaped_expected_output_path = "output()_path".shellescape
+
         allow(File).to receive(:exist?).and_return(true)
         allow(File).to receive(:expand_path).and_return("..")
-        expect(Fastlane::Actions).to receive(:sh).with(["zip", "-r", "#{File.expand_path('output\\(\\)_path')}.zip", "escaped\\(\\)_input_folder_path"])
+        expect(Fastlane::Actions).to receive(:sh).with(["zip", "-r", "#{File.expand_path(escaped_expected_output_path)}.zip", escaped_expected_input_path])
 
         Fastlane::FastFile.new.parse("lane :test do
           zip(path: 'fake/escaped()_input_folder_path', output_path: 'output()_path')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Resolves #19203
- Regression PR: https://github.com/fastlane/fastlane/pull/19149

### Description
- In this PR, fix the `shellescape` for the folder path

### Testing Steps
- Update `Gemfile` to 👇 and run `bundle install`, `bundle update fastlane`, or `bundle update`
```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "crazymanish-zip-regression-fix"
```
- Try to `zip` action using below lane `bundle exec fastlane test_zip_fix`

```ruby
lane :test_zip_fix do
    versioned_bundle_name = "Some-App (1134.2123518)"
    zip(path: "./Build", output_path: "./Build/#{versioned_bundle_name}.xcarchive.zip")
end

