### PR TITLE
[spaceship] Adding missing method to fetch build IDs for beta group

### DIFF
--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -251,9 +251,7 @@ module Spaceship
           test_flight_request_client.get("betaGroups/#{group_id}/builds")
         end
 
-        def get_build_ids_for_beta_group(group_id: nil)
-          raise "group_id is nil" if group_id.nil?
-
+        def get_build_ids_for_beta_group(group_id:)
           test_flight_request_client.get("betaGroups/#{group_id}/relationships/builds", {})
         end
 

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -251,6 +251,12 @@ module Spaceship
           test_flight_request_client.get("betaGroups/#{group_id}/builds")
         end
 
+        def get_build_ids_for_beta_group(group_id: nil)
+          raise "group_id is nil" if group_id.nil?
+
+          test_flight_request_client.get("betaGroups/#{group_id}/relationships/builds", {})
+        end
+
         #
         # betaTesters
         #

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -421,6 +421,20 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
         end
       end
 
+      context 'get_build_ids_for_beta_group' do
+        let(:path) { "betaGroups" }
+        let(:beta_group_id) { "123" }
+
+        it 'succeeds' do
+          url = "#{path}/#{beta_group_id}/relationships/builds"
+          params = {}
+          req_mock = test_request_params(url, params)
+
+          expect(client).to receive(:request).with(:get).and_yield(req_mock).and_return(req_mock)
+          client.get_build_ids_for_beta_group(group_id: beta_group_id)
+        end
+      end
+
       context 'patch_beta_groups' do
         let(:path) { "betaGroups" }
         let(:beta_group_id) { "123" }


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Implementing the following missing TestFlight/Beta Groups endpoint to fetch build IDs for a beta group: https://developer.apple.com/documentation/appstoreconnectapi/get_all_build_ids_in_a_beta_group