### PR TITLE
[action][zip] Fix regression in `zip` by escaping all args

### DIFF
--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -34,7 +34,7 @@ module Fastlane
         def run_zip_command
           # The 'zip' command archives relative to the working directory, chdir to produce expected results relative to `path`
           Dir.chdir(File.expand_path("..", path)) do
-            Actions.sh(zip_command)
+            Actions.sh(*zip_command)
           end
         end
 
@@ -52,8 +52,8 @@ module Fastlane
           # The zip command is executed from the paths **parent** directory, as a result we use just the basename, which is the file or folder within
           basename = File.basename(path)
 
-          command << output_path.shellescape
-          command << basename.shellescape
+          command << output_path
+          command << basename
 
           unless include.empty?
             command << "-i"

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -55,6 +55,11 @@ describe Fastlane::Actions do
         expect_command("ls -la /tmp")
         Fastlane::Actions.sh(["ls -la", "/tmp"])
       end
+
+      it "does not automatically escape array arguments from older fastlane syntax" do
+        expect_command('git log --oneline')
+        Fastlane::Actions.sh(["git", "log --oneline"])
+      end
     end
 
     context "with a postfix block" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

After I carried out some refactoring work in #19149, I mistakenly introduced a regression with argument escaping that was raised in #19203 and partially patched in #19207.

I say partially because prior to my regression, all input (including `:password`) was escaped and also my new inputs (`:include` and `:exclude`) should also have been escaped when invoked as a shell command.

My intention with the original refactoring was to rely on **sh_helper.rb**’s internal implementation that uses `shelljoin` and properly escapes the arguments passed in however I got caught out by some legacy behaviours that operate in a very similar way

#### `Actions.sh` Behaviours

```ruby
Actions.sh("git diff My Project.xcodeproj") 
# $ git diff My Project.xcodeproj
# ❌

Actions.sh("git", "diff", "My Project.xcodeproj")
# $ git diff My\ Project.xcodeproj
# ✅

cmd = ["git", "diff", "My Project.xcodeproj"]
Actions.sh(cmd)
# $ git diff My Project.xcodeproj
# ❌

Actions.sh(*cmd)
# $ git diff My\ Project.xcodeproj
# ✅
```

This regression/fix focuses on the last two examples. It turns out that example three is supporting legacy behaviour that **does not** escape any of the arguments whereas example four will escape each argument just like example two. 

This is because the use of the `*` is Ruby magic to convert the array into a variable argument list just like the one used in the second example.

### Description

The fix itself is simple. It involves adding the `*` and reverting the manual escaping of individual arguments. 

In addition to this though, I have had to update the specs to expect the variable list of arguments instead of arrays. I’ve also reworked the spec that ensures that the arguments are escaped to be more of a sanctify check since the only real way to check without doing a full on integration test is to see if `UI.command` prints the right output. 

Finally, I’ve added an extra test to **sh_helper_spec.rb** just to document the intention of not escaping array arguments.

Moving forward, there is probably some work to be done to clear up confusion here but `Actions.sh` is so frequently used both in fastlane and in plugins that it would be a massive effort to remove the legacy behaviour and clear things up. I’d be happy to try and help in the efforts though but I don’t really have a good plan of my own.

### Testing Steps

The same steps from #19207 apply 
