### PR TITLE
[fastlane] optimize bash and zsh completion scripts

### DIFF
--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -18,7 +18,7 @@ _fastlane_complete() {
   fi
 
   # parse 'beta' out of 'lane :beta do', etc
-  completions="$(sed -En 's/^[ 	]*lane +:([^ ]+).*$/\1/p' "$file")"
+  completions="$(sed -En 's/^[ 	]*lane +:([^ 	]+).*$/\1/p' "$file")"
   completions="$completions update_fastlane"
 
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )

--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -18,7 +18,7 @@ _fastlane_complete() {
   fi
 
   # parse 'beta' out of 'lane :beta do', etc
-  completions="$(sed -En 's/^\s*lane\s+:(\S+).*$/\1/p' "$file")"
+  completions="$(sed -En 's/^[ 	]*lane +:([^ ]+).*$/\1/p' "$file")"
   completions="$completions update_fastlane"
 
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )

--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -4,6 +4,7 @@ _fastlane_complete() {
   COMPREPLY=()
   local word="${COMP_WORDS[COMP_CWORD]}"
   local completions=""
+  local file
 
   # look for Fastfile either in this directory or fastlane/ then grab the lane names
   if [[ -e "Fastfile" ]]; then
@@ -12,10 +13,12 @@ _fastlane_complete() {
     file="fastlane/Fastfile"
   elif [[ -e ".fastlane/Fastfile" ]]; then
     file=".fastlane/Fastfile"
+  else
+    return 1
   fi
 
   # parse 'beta' out of 'lane :beta do', etc
-  completions=$(grep "^\s*lane \:" $file | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}')
+  completions="$(sed -En 's/^\s*lane\s+:(\S+).*$/\1/p' "$file")"
   completions="$completions update_fastlane"
 
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )

--- a/fastlane/lib/assets/completions/completion.zsh
+++ b/fastlane/lib/assets/completions/completion.zsh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 
 _fastlane_complete() {
-  local word completions
+  local word completions file
   word="$1"
 
   # look for Fastfile either in this directory or fastlane/ then grab the lane names
@@ -11,10 +11,12 @@ _fastlane_complete() {
     file="fastlane/Fastfile"
   elif [[ -e ".fastlane/Fastfile" ]] then
     file=".fastlane/Fastfile"
+  else
+    return 1
   fi
 
   # parse 'beta' out of 'lane :beta do', etc
-  completions=`cat $file | grep "^\s*lane \:" | awk -F ':' '{print $2}' | awk -F ' ' '{print $1}'`
+  completions="$(sed -En 's/^\s*lane\s+:(\S+).*$/\1/p' "$file")"
   completions="$completions
 update_fastlane"
 

--- a/fastlane/lib/assets/completions/completion.zsh
+++ b/fastlane/lib/assets/completions/completion.zsh
@@ -16,7 +16,7 @@ _fastlane_complete() {
   fi
 
   # parse 'beta' out of 'lane :beta do', etc
-  completions="$(sed -En 's/^\s*lane\s+:(\S+).*$/\1/p' "$file")"
+  completions="$(sed -En 's/^[ 	]*lane +:([^ ]+).*$/\1/p' "$file")"
   completions="$completions
 update_fastlane"
 

--- a/fastlane/lib/assets/completions/completion.zsh
+++ b/fastlane/lib/assets/completions/completion.zsh
@@ -16,10 +16,9 @@ _fastlane_complete() {
   fi
 
   # parse 'beta' out of 'lane :beta do', etc
-  completions="$(sed -En 's/^[ 	]*lane +:([^ ]+).*$/\1/p' "$file")"
-  completions="$completions
-update_fastlane"
+  completions="$(sed -En 's/^[ 	]*lane +:([^ 	]+).*$/\1/p' "$file")"
+  completions="$completions update_fastlane"
 
-  reply=( "${(ps:\n:)completions}" )
+  reply=( "${=completions}" )
 }
 


### PR DESCRIPTION
### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

I had issues with `bundle exec rspec`, probably due to a broken installation since it's the first time I've had to use it.

### Motivation and Context

The `_fastlane_complete` function for bash and zsh can be improved:

- It makes 3 calls to get lane names, which can be grouped into a single `sed` call.
- It leaks the `file` variable.
- It continues execution even if no `Fastfile` file has been found.

### Description

Changes:

- Group the 3 calls to `grep` and `awk` into a single `sed` call with [-E for extended regex (POSIX-compatible argument)](https://www.gnu.org/software/sed/manual/sed.html#index-_002dE).
- Makes `$file` variable local.
- Exit the function when no Fastfile file was found.

### Testing Steps

1. Add `compctl -K _fastlane_complete fastlane` to `completion.zsh` file.
2. Add `complete -F _fastlane_complete fastlane` to `completion.bash` file.
3. cd into `fastlane` repository root directory.
4. `source path/to/completion.{bash,zsh}` file depending on shell.
5. Try to complete `fastlane` command.

The same options should appear with and without these changes, while only making a single `sed` call.

### Others

Explanation of `sed` call:

- `-E`: enables extended regexp
- `-n`: disables output unless specifically enabled with `/p`.
- `s/^\s*lane\s+:(\S+).*$/\1/p`: matches whole lines that have a `lane :<lane_name> ...` format and prints only `<lane_name>` ([explanation of RegExp strings](https://www.gnu.org/software/sed/manual/sed.html#ERE-syntax)).
