### PR TITLE
[action][notarize] support using notarytool instead of altool if using Xcode 13 and up

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -253,7 +253,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :use_notarytool,
                                        env_name: 'FL_NOTARIZE_USE_NOTARYTOOL',
                                        description: 'Whether to `xcrun notarytool` or `xcrun altool`',
-                                       default_value: Helper.xcode_at_least?("13.0"), # Notary tool added in Xcode 13
+                                       default_value: Helper.mac? && Helper.xcode_at_least?("13.0"), # Notary tool added in Xcode 13
                                        default_value_dynamic: true,
                                        type: Boolean),
           FastlaneCore::ConfigItem.new(key: :try_early_stapling,

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -195,7 +195,7 @@ module Fastlane
 
       def self.staple(package_path, verbose)
         Actions.sh(
-          "xcrun stapler staple \"#{package_path}\"",
+          "xcrun stapler staple #{package_path.shellescape}",
           log: verbose
         )
       end

--- a/fastlane/spec/actions_specs/notarize_spec.rb
+++ b/fastlane/spec/actions_specs/notarize_spec.rb
@@ -1,0 +1,64 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "notarize" do
+      let(:success_submit_response) do
+        {
+         'status': 'Accepted',
+         'id': '1111-2222-3333-4444'
+        }.to_json
+      end
+      let(:invalid_submit_response) do
+        {
+         'status': 'Invalid',
+         'statusSummary': 'Archive contains critical validation errors',
+         'id': '1111-2222-3333-4444'
+        }.to_json
+      end
+
+      context "with notary tool" do
+        let(:package) { Tempfile.new('app.ipa.zip') }
+        let(:bundle_id) { 'com.some.app' }
+
+        context "with Apple ID" do
+          let(:username) { 'myusername@example.com' }
+          let(:asc_provider) { '123456789' }
+          let(:app_specific_password) { 'secretpass' }
+
+          it "successful" do
+            stub_const('ENV', { "FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD" => app_specific_password })
+
+            expect(Fastlane::Actions).to receive(:sh).with("xcrun notarytool submit #{package.path} --output-format json --wait --apple-id #{username} --password #{app_specific_password} --team-id #{asc_provider}", { error_callback: anything, log: false }).and_return(success_submit_response)
+
+            expect(Fastlane::Actions).to receive(:sh).with("xcrun stapler staple #{package.path}", { log: false })
+
+            result = Fastlane::FastFile.new.parse("lane :test do
+              notarize(
+                package: '#{package.path}',
+                bundle_id: '#{bundle_id}',
+                username: '#{username}',
+                asc_provider: '#{asc_provider}',
+              )
+            end").runner.execute(:test)
+          end
+
+          it "invalid" do
+            stub_const('ENV', { "FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD" => app_specific_password })
+
+            expect(Fastlane::Actions).to receive(:sh).with("xcrun notarytool submit #{package.path} --output-format json --wait --apple-id #{username} --password #{app_specific_password} --team-id #{asc_provider}", { error_callback: anything, log: false }).and_return(invalid_submit_response)
+
+            expect do
+              result = Fastlane::FastFile.new.parse("lane :test do
+                notarize(
+                  package: '#{package.path}',
+                  bundle_id: '#{bundle_id}',
+                  username: '#{username}',
+                  asc_provider: '#{asc_provider}',
+                )
+              end").runner.execute(:test)
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not notarize package with message 'Archive contains critical validation errors'")
+          end
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/notarize_spec.rb
+++ b/fastlane/spec/actions_specs/notarize_spec.rb
@@ -33,6 +33,7 @@ describe Fastlane do
 
             result = Fastlane::FastFile.new.parse("lane :test do
               notarize(
+                use_notarytool: true,
                 package: '#{package.path}',
                 bundle_id: '#{bundle_id}',
                 username: '#{username}',
@@ -49,6 +50,7 @@ describe Fastlane do
             expect do
               result = Fastlane::FastFile.new.parse("lane :test do
                 notarize(
+                  use_notarytool: true,
                   package: '#{package.path}',
                   bundle_id: '#{bundle_id}',
                   username: '#{username}',

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -21,6 +21,8 @@ module Spaceship
       attr_reader :duration
       attr_reader :expiration
 
+      attr_reader :key_raw
+
       # Temporary attribute not needed to create the JWT text
       # There is no way to determine if the team associated with this
       # key is for App Store or Enterprise so this is the temporary workaround


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`altool` is being deprecated for notarizing in Xcode 13 and being replaced with `notarytool`. This PR aims at using `notarytool` if Xcode 13 is being used which simplifies a lot of logic compared to `altool`.

### Description
- Added new option called `use_notarytool`
  - It has a dynamic default that defaults to `true` if Xcode 13 or higher is being used
  - Allows user to override if need be
- Uses same logic for altool if less than Xcode 13
- Uses `xcrun notarytool submit --wait` if using Xcode 13
  - Supports Apple ID auth
  - Supports API Key auth

### Testing Steps
Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-notarize-with-notarytool"
```
