### PR TITLE
[regression] [frameit] fix missing iPad Pro (2nd generation) frames

### DIFF
--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -75,6 +75,7 @@ IPAD_MINI_VERSION = "2019"
 IPAD_RENAMING_SCHEME = {
   'iPad Pro 11' => 'iPad Pro (11-inch)',
   'iPad Pro 13' => "iPad Pro (12.9-inch) (#{IPAD_PRO_12_9_VERSION})",
+  'iPad Pro' => 'iPad Pro', # don't rename the iPad Pro 1st or 2nd gen from the 'legacy' folder
   'iPad Air' => "iPad Air (#{IPAD_AIR_VERSION})",
   'iPad Mini' => "iPad Mini (#{IPAD_MINI_VERSION})",
   'iPad' => 'iPad 10.2' # must be the last one so that only 'iPad' without any version will be renamed to 10.2


### PR DESCRIPTION
they were added to the frames_generator in #18439, but accidentally renamed to e.g. "iPad 10.2 Pro Space Gray"

Related: https://github.com/fastlane/frameit-frames/pull/24

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. [N/A]

### Motivation and Context

Resolves fastlane/fastlane#19238

When using frameit to generate screenshots for submission to the App Store, the minimum required device types are:

* iPhone 6.5" Display
* iPhone 5.5" Display
* iPad Pro (3rd Gen) 12.9" Display
* iPad Pro (2nd Gen) 12.9" Display

The last device is not included in Facebook's device frames anymore, which requires frameit to maintain its frames manually in the "legacy" folder. This was done by #18439, but it left the rename rules intact, accidentally renaming the frames to e.g. "iPad 10.2 Pro Space Gray". The accompanying commit to frameit-frames used the incorrect file names, breaking frameit for iPad Pro 2nd gen.

This causes frameit not to be able to find the frames for iPad Pro 2nd gen, and subsequently causes deliver to fail to submit all required screenshots. This **prevents automated deployments**, as app developers now have to manually generate the iPad Pro 2nd gen screenshots (or copy them from 3rd gen, which is what we have been doing) and upload them to App Store Connect.

### Description

Don't incorrectly rename the iPad Pro (2nd generation) frames from the "legacy" folder.
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps

To test:

1. Create an "iPad Pro (12.9-inch) (2nd generation)" simulator device (one is not available by default on recent versions of Xcode)
2. Add "iPad Pro (12.9-inch) (2nd generation)" to the devices option in your Snapfile.
3. Run snapshot.
4. Run frameit. Notice that errors occur because it can't find the frames for iPad Pro 2nd gen.
5. Run deliver. Notice that the fourth screenshots tab in App Store Connect is empty, and you can't submit your app for review.
6. Download the frames from this branch into ~/.fastlane/frameit
7. Repeat the process and notice that everything works as expected.

