### PR TITLE
[produce] Fix service name typo for Produce

### DIFF
--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -97,7 +97,7 @@ module Produce
         bundle_id.update_capability(ACCESS_WIFI_INFORMATION, enabled: on)
       end
 
-      if options.access_wifi
+      if options.app_attest
         UI.message("\tApp Attest")
         bundle_id.update_capability(APP_ATTEST, enabled: on)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

There was a small typo for a service name in Produce, as mentioned by https://github.com/fastlane/fastlane/pull/18853#issuecomment-902516128

### Testing steps

```bundle exec fastlane produce enable_services --app-attest```

```bundle exec fastlane produce disable_services --app-attest```
