### PR TITLE
[spaceship] retries developer portal requests that receive 502 Bad Gateway up to 5 times (usually works after 1 retry)

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -208,7 +208,13 @@ module Spaceship
       # Overridden from Spaceship::Client
       def handle_error(response)
         body = response.body.empty? ? {} : response.body
-        body = JSON.parse(body) if body.kind_of?(String)
+
+        # Setting body nil if invalid JSON which can happen if 502
+        begin
+          body = JSON.parse(body) if body.kind_of?(String)
+        rescue
+          nil
+        end
 
         case response.status.to_i
         when 401
@@ -220,6 +226,14 @@ module Spaceship
             raise ProgramLicenseAgreementUpdated, format_errors(response)
           else
             raise AccessForbiddenError, format_errors(response)
+          end
+        when 502
+          # Issue - https://github.com/fastlane/fastlane/issues/19264
+          # This 502 with "Could not process this request" body sometimes
+          # work and sometimes doesn't
+          # Usually retrying once or twice will solve the issue
+          if body && body.include?("Could not process this request")
+            raise BadGatewayError, "Could not process this request"
           end
         end
       end


### PR DESCRIPTION
### Motivation and Context
Fixes #19264

### Description
The developer portal has recently started returning HTTP response of 502 Bad Gateway with a body of "Could not process this request"

It turns out this the requests will work most times but not all the time. This fix will retry requests up to 5 times if:
- Using `Spaceship::ConnectAPI` with Apple ID against developer portal
- HTTP status code of 502
- Body contains "Could not process this request"

### Testing Steps
Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-retry-developer-portal-asc-apple-id-requests-bad-gateway"
```
