### PR TITLE
[match] Don't add key if cert already present

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -191,12 +191,12 @@ module Match
             UI.verbose("Certificate '#{File.basename(cert_path)}' is already installed on this machine")
           else
             Utils.import(cert_path, params[:keychain_name], password: params[:keychain_password])
-          end
 
-          # Import the private key
-          # there seems to be no good way to check if it's already installed - so just install it
-          # Key will only be added to the partition list if it isn't already installed
-          Utils.import(keys.last, params[:keychain_name], password: params[:keychain_password])
+            # Import the private key
+            # there seems to be no good way to check if it's already installed - so just install it
+            # Key will only be added to the partition list if it isn't already installed
+            Utils.import(keys.last, params[:keychain_name], password: params[:keychain_password])
+          end
         else
           UI.message("Skipping installation of certificate as it would not work on this operating system.")
         end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves: https://github.com/fastlane/fastlane/issues/19268

### Description
Avoid adding a private key to the keychain if the cert is already present while doing `fetch_certificate`. The issue is with `security import` which adds a random private key if this key is already present.
