### PR TITLE
[pilot][upload_to_testflight] add Mac support

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -13,6 +13,8 @@ module Fastlane
         unless distribute_only
           values[:ipa] ||= Actions.lane_context[SharedValues::IPA_OUTPUT_PATH]
           values[:ipa] = File.expand_path(values[:ipa]) if values[:ipa]
+          values[:pkg] ||= Actions.lane_context[SharedValues::PKG_OUTPUT_PATH]
+          values[:pkg] = File.expand_path(values[:pkg]) if values[:pkg]
         end
 
         # Only set :api_key from SharedValues if :api_key_path isn't set (conflicting options)
@@ -117,7 +119,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios].include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -119,7 +119,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include?(platform)
+        [:ios, :mac, :tvos].include?(platform)
       end
     end
   end

--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -73,7 +73,8 @@ module Pilot
 
     def fetch_app_identifier
       result = config[:app_identifier]
-      result ||= FastlaneCore::IpaFileAnalyser.fetch_app_identifier(config[:ipa])
+      result ||= FastlaneCore::IpaFileAnalyser.fetch_app_identifier(config[:ipa]) if config[:ipa]
+      result ||= FastlaneCore::PkgFileAnalyser.fetch_app_identifier(config[:pkg]) if config[:pkg]
       result ||= UI.input("Please enter the app's bundle identifier: ")
       UI.verbose("App identifier (#{result})")
       return result
@@ -82,6 +83,7 @@ module Pilot
     def fetch_app_platform(required: true)
       result = config[:app_platform]
       result ||= FastlaneCore::IpaFileAnalyser.fetch_app_platform(config[:ipa]) if config[:ipa]
+      result ||= FastlaneCore::PkgFileAnalyser.fetch_app_platform(config[:pkg]) if config[:pkg]
       if required
         result ||= UI.input("Please enter the app's platform (appletvos, ios, osx): ")
         UI.user_error!("App Platform must be ios, appletvos, or osx") unless ['ios', 'appletvos', 'osx'].include?(result)

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -48,7 +48,6 @@ module Pilot
                                      env_name: "PILOT_PLATFORM",
                                      description: "The platform to use (optional)",
                                      optional: true,
-                                     default_value: 'ios',
                                      verify_block: proc do |value|
                                        UI.user_error!("The platform can only be ios, appletvos, or osx") unless ['ios', 'appletvos', 'osx'].include?(value)
                                      end),
@@ -82,6 +81,26 @@ module Pilot
                                        value = File.expand_path(value)
                                        UI.user_error!("Could not find ipa file at path '#{value}'") unless File.exist?(value)
                                        UI.user_error!("'#{value}' doesn't seem to be an ipa file") unless value.end_with?(".ipa")
+                                     end,
+                                     conflicting_options: [:pkg],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'ipa' and '#{value.key}' options in one run.")
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :pkg,
+                                     short_option: "-P",
+                                     optional: true,
+                                     env_name: "PILOT_PKG",
+                                     description: "Path to your pkg file",
+                                     code_gen_sensitive: true,
+                                     default_value: Dir["*.pkg"].sort_by { |x| File.mtime(x) }.last,
+                                     default_value_dynamic: true,
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Could not find pkg file at path '#{File.expand_path(value)}'") unless File.exist?(value)
+                                       UI.user_error!("'#{value}' doesn't seem to be a pkg file") unless value.end_with?(".pkg")
+                                     end,
+                                     conflicting_options: [:ipa],
+                                     conflict_block: proc do |value|
+                                       UI.user_error!("You can't use 'pkg' and '#{value.key}' options in one run.")
                                      end),
 
         # app review info

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -86,6 +86,10 @@ module Spaceship
         return build_beta_detail.nil? == false && build_beta_detail.ready_for_internal_testing?
       end
 
+      def ready_for_external_testing?
+        return build_beta_detail.nil? == false && build_beta_detail.ready_for_external_testing?
+      end
+
       def ready_for_beta_submission?
         raise "No build_beta_detail included" unless build_beta_detail
         return build_beta_detail.ready_for_beta_submission?

--- a/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build_beta_detail.rb
@@ -53,6 +53,10 @@ module Spaceship
         return internal_build_state == InternalState::READY_FOR_BETA_TESTING
       end
 
+      def processed?
+        return internal_build_state != InternalState::PROCESSING && external_build_state != ExternalState::PROCESSING
+      end
+
       def ready_for_beta_submission?
         return external_build_state == ExternalState::READY_FOR_BETA_SUBMISSION
       end


### PR DESCRIPTION
### Motivation and Context
Apple opened up TestFlight to Mac apps on August 24, 2021

### Description
- Pilot
  - Added new option for `pkg`
  - Removed `ios` as default option on `app_platform` option
- BuildWatcher
  - Turns out that builds have multiple processing states (1 on builds and 2 on buildBetaDetails)
  - The processings are independent of each other but **should** finish at the same time
  - Previously we only wait for the build processing but Mac builds are slower on the buildBetaDetails processing currently
  - Added an option (that pilot uses) to wait for all 3 processing status
- Spaceship
  - Added new helpder function on buildBetaDetails called `processing?` that will return true when internal and external states are done processing

### Testing Steps
Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-pilot-for-mac"
```
