### PR TITLE
[match] Adds identifiers supplied to match to the git commit message

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -29,6 +29,16 @@ module Match
 
       update_optional_values_depending_on_storage_type(params)
 
+      if params[:app_identifier].kind_of?(Array)
+        app_identifiers = params[:app_identifier]
+      else
+        app_identifiers = params[:app_identifier].to_s.split(/\s*,\s*/).uniq
+      end
+
+      # sometimes we get an array with arrays, this is a bug. To unblock people using match, I suggest we flatten!
+      # then in the future address the root cause of https://github.com/fastlane/fastlane/issues/11324
+      app_identifiers.flatten!
+
       # Choose the right storage and encryption implementations
       self.storage = Storage.for_mode(params[:storage_mode], {
         git_url: params[:git_url],
@@ -57,7 +67,8 @@ module Match
         team_id: params[:team_id],
         team_name: params[:team_name],
         api_key_path: params[:api_key_path],
-        api_key: params[:api_key]
+        api_key: params[:api_key],
+        identifiers: app_identifiers
       })
       storage.download
 
@@ -74,16 +85,6 @@ module Match
           UI.user_error!("You defined the profile type 'enterprise', but your Apple account doesn't support In-House profiles")
         end
       end
-
-      if params[:app_identifier].kind_of?(Array)
-        app_identifiers = params[:app_identifier]
-      else
-        app_identifiers = params[:app_identifier].to_s.split(/\s*,\s*/).uniq
-      end
-
-      # sometimes we get an array with arrays, this is a bug. To unblock people using match, I suggest we flatten!
-      # then in the future address the root cause of https://github.com/fastlane/fastlane/issues/11324
-      app_identifiers.flatten!
 
       # Verify the App ID (as we don't want 'match' to fail at a later point)
       if spaceship

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -20,6 +20,7 @@ module Match
       attr_accessor :git_basic_authorization
       attr_accessor :git_bearer_authorization
       attr_accessor :git_private_key
+      attr_accessor :identifiers
 
       def self.configure(params)
         return self.new(
@@ -34,7 +35,8 @@ module Match
           clone_branch_directly: params[:clone_branch_directly],
           git_basic_authorization: params[:git_basic_authorization],
           git_bearer_authorization: params[:git_bearer_authorization],
-          git_private_key: params[:git_private_key]
+          git_private_key: params[:git_private_key],
+          identifiers: params[:identifiers]
         )
       end
 
@@ -49,7 +51,8 @@ module Match
                      clone_branch_directly: false,
                      git_basic_authorization: nil,
                      git_bearer_authorization: nil,
-                     git_private_key: nil)
+                     git_private_key: nil,
+                     identifiers: [])
         self.git_url = git_url
         self.shallow_clone = shallow_clone
         self.skip_docs = skip_docs
@@ -60,6 +63,7 @@ module Match
         self.git_basic_authorization = git_basic_authorization
         self.git_bearer_authorization = git_bearer_authorization
         self.git_private_key = git_private_key
+        self.identifiers = identifiers
 
         self.type = type if type
         self.platform = platform if platform
@@ -147,7 +151,9 @@ module Match
           "Updated",
           self.type,
           "and platform",
-          self.platform
+          self.platform,
+          "for identifier(s)",
+          self.identifiers.join(', ')
         ].join(" ")
       end
 

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -67,7 +67,8 @@ describe Match do
             team_id: nil,
             team_name: nil,
             api_key_path: nil,
-            api_key: nil
+            api_key: nil,
+            identifiers: [values[:app_identifier]]
           ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
@@ -152,7 +153,8 @@ describe Match do
             team_id: nil,
             team_name: nil,
             api_key_path: nil,
-            api_key: nil
+            api_key: nil,
+            identifiers: [values[:app_identifier]]
           ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
@@ -236,7 +238,8 @@ describe Match do
             team_id: nil,
             team_name: nil,
             api_key_path: nil,
-            api_key: nil
+            api_key: nil,
+            identifiers: [values[:app_identifier]]
           ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)
@@ -306,7 +309,8 @@ describe Match do
             team_id: nil,
             team_name: nil,
             api_key_path: nil,
-            api_key: nil
+            api_key: nil,
+            identifiers: [values[:app_identifier]]
           ).and_return(fake_storage)
 
           expect(fake_storage).to receive(:download).and_return(nil)

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -1,13 +1,18 @@
 describe Match do
   describe Match::Storage::GitStorage do
     describe "#generate_commit_message" do
-      it "works" do
-        storage = Match::Storage::GitStorage.new(
-          type: "appstore",
-          platform: "ios"
-        )
-        result = storage.generate_commit_message
-        expect(result).to eq("[fastlane] Updated appstore and platform ios")
+      [["tools.fastlane.com"], ["tools.fastlane.com", "tools.fastlane.com.extension"]].each do |identifiers|
+        context "With identifiers #{identifiers}" do
+          it "works" do
+            storage = Match::Storage::GitStorage.new(
+              type: "appstore",
+              platform: "ios",
+              identifiers: identifiers
+            )
+            result = storage.generate_commit_message
+            expect(result).to eq("[fastlane] Updated appstore and platform ios for identifier(s) #{identifiers.join(', ')}")
+          end
+        end
       end
     end
 
@@ -120,7 +125,8 @@ describe Match do
           platform: "ios",
           git_url: git_url,
           shallow_clone: false,
-          skip_docs: true
+          skip_docs: true,
+          identifiers: ["tools.fastlane.com"]
         )
 
         expected_commands = [
@@ -130,7 +136,7 @@ describe Match do
           "git reset --hard",
           "git add #{random_file}",
           "git add match_version.txt",
-          "git commit -m " + '[fastlane] Updated appstore and platform ios'.shellescape,
+          "git commit -m " + '[fastlane] Updated appstore and platform ios for identifier(s) tools.fastlane.com'.shellescape,
           "git push origin #{git_branch}"
         ]
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
We have multiple teams developing multiple apps. We all use `fastlane` to automate our deployment, it's so great to have a reliable automated process. Recently we had to renew our iOS Distribution certificate which resulted in all teams renewing their respective Distribution provisioning profiles. This was super easy using `fastlane match` however the git repo we use for storage does not have a readable commit log. I wanted to include the identifiers supplied to `match` from the CLI or Matchfile in the commit message to give us better visibility at a glance of our log.

### Description
First I moved the `app_identifiers` block of code in the runner above the storage selection. I want to pass this into the storage object. 
I fixed up the `runner_spec` according to expect these extra params.
Next I added the `identifiers` to the `git_storage` and used them in the `generate_commit_message` func.
I updated the `git_storage_spec` with context block testing for single and multiple identifiers.
Ensuring it works with multiple identifers was important to us as we have an app with linked extensions.
After the changes were made I ran the test suite and rubocop analysis.

### Testing Steps
I ran:
```
bundle exec rspec
bundle exec rubocop -a
```