### PR TITLE
Add default empty array values in ZipAction initialize

### DIFF
--- a/fastlane/lib/fastlane/actions/zip.rb
+++ b/fastlane/lib/fastlane/actions/zip.rb
@@ -10,8 +10,8 @@ module Fastlane
           @verbose = params[:verbose]
           @password = params[:password]
           @symlinks = params[:symlinks]
-          @include = params[:include]
-          @exclude = params[:exclude]
+          @include = params[:include] || []
+          @exclude = params[:exclude] || []
 
           @output_path += ".zip" unless @output_path.end_with?(".zip")
         end

--- a/fastlane/spec/actions_specs/zip_spec.rb
+++ b/fastlane/spec/actions_specs/zip_spec.rb
@@ -1,4 +1,17 @@
 describe Fastlane do
+
+  describe Fastlane::Actions::ZipAction do
+    describe "zip" do
+      it "sets default values for optional include and exclude parameters" do
+        params = { path: "Test.app" }
+        action = Fastlane::Actions::ZipAction::Runner.new(params)
+
+        expect(action.include).to eq([])
+        expect(action.exclude).to eq([])
+      end
+    end
+  end
+
   describe Fastlane::FastFile do
     before do
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
-->
Resolves #19293

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
`include` and `exclude` parameters in `ZipAction` `initialize` method should default to `[]`. It prevents from crash when running `ZipAction.run(params)` without specifying `include` and `exclude` options.

Note that adding default value (`true`) to `verbose` in `initialize` as defined in `available_options` would break unit tests:
`it "generates a valid zip command without verbose output"`
`it "encrypts the contents of the zip archive using a password"`

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Tested with unit tests