### PR TITLE
[gradle] add output context with "tasks" options

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -64,7 +64,7 @@ module Fastlane
                                 print_command_output: params[:print_command_output])
 
         # If we didn't build, then we return now, as it makes no sense to search for apk's in a non-`assemble` or non-`build` scenario
-        return result unless gradle_task =~ /\b(assemble)/ || task =~ /\b(bundle)/
+        return result unless gradle_task =~ /\b(assemble)/ || gradle_task =~ /\b(bundle)/
 
         apk_search_path = File.join(project_dir, '**', 'build', 'outputs', 'apk', '**', '*.apk')
         aab_search_path = File.join(project_dir, '**', 'build', 'outputs', 'bundle', '**', '*.aab')

--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -64,7 +64,7 @@ module Fastlane
                                 print_command_output: params[:print_command_output])
 
         # If we didn't build, then we return now, as it makes no sense to search for apk's in a non-`assemble` or non-`build` scenario
-        return result unless task =~ /\b(assemble)/ || task =~ /\b(bundle)/
+        return result unless gradle_task =~ /\b(assemble)/ || task =~ /\b(bundle)/
 
         apk_search_path = File.join(project_dir, '**', 'build', 'outputs', 'apk', '**', '*.apk')
         aab_search_path = File.join(project_dir, '**', 'build', 'outputs', 'bundle', '**', '*.aab')

--- a/fastlane/spec/actions_specs/gradle_spec.rb
+++ b/fastlane/spec/actions_specs/gradle_spec.rb
@@ -181,6 +181,48 @@ describe Fastlane do
           expect(last_action[:name]).to eq(task_name)
         end
       end
+
+      describe "setting of Actions.lane_context" do
+        after(:each) do
+          Fastlane::Actions.lane_context.delete(Fastlane::Actions::SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS)
+          Fastlane::Actions.lane_context.delete(Fastlane::Actions::SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS)
+          Fastlane::Actions.lane_context.delete(Fastlane::Actions::SharedValues::GRADLE_ALL_OUTPUT_JSON_OUTPUT_PATHS)
+          Fastlane::Actions.lane_context.delete(Fastlane::Actions::SharedValues::GRADLE_ALL_MAPPING_TXT_OUTPUT_PATHS)
+        end
+
+        it "sets context when assemble" do
+          result = Fastlane::FastFile.new.parse("lane :build do
+            gradle(tasks: ['assembleRelease', 'assembleReleaseAndroidTest'], gradle_path: './README.md')
+          end").runner.execute(:build)
+
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS]).to eq([])
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS]).to eq([])
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_OUTPUT_JSON_OUTPUT_PATHS]).to eq([])
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_MAPPING_TXT_OUTPUT_PATHS]).to eq([])
+        end
+
+        it "sets context when bundle" do
+          result = Fastlane::FastFile.new.parse("lane :build do
+            gradle(tasks: ['bundleRelease'], gradle_path: './README.md')
+          end").runner.execute(:build)
+
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS]).to eq([])
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS]).to eq([])
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_OUTPUT_JSON_OUTPUT_PATHS]).to eq([])
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_MAPPING_TXT_OUTPUT_PATHS]).to eq([])
+        end
+
+        it "does not set context if not assemble or bundle" do
+          result = Fastlane::FastFile.new.parse("lane :build do
+            gradle(tasks: ['someOtherThing'], gradle_path: './README.md')
+          end").runner.execute(:build)
+
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS]).to eq(nil)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS]).to eq(nil)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_OUTPUT_JSON_OUTPUT_PATHS]).to eq(nil)
+          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_ALL_MAPPING_TXT_OUTPUT_PATHS]).to eq(nil)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Support filling apk/aab/etc output contexts with `tasks` options in `gradle`/`build_android_app` actions

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Before this change, `gradle`/`build_android_app` detects if `task` option contains `assemble` or `bundle` wording and decides to fill output files in context or not.

With `tasks` option (and without `task`) will cause `gradle`/`build_android_app` stop before searching output files because of empty `task` option.

`gradle` action pass tasks to real gradle with calculated `gradle_task` variable which choose `task` option or string-concatenated-with-spaces `tasks` option, so we can detect this variable instead of `task` option directly.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Since original behavior doesn't have spec, we have to test manually.
Simple POC is calling `gradle(tasks: %W(assembleRelease assembleReleaseAndroidTest))` and check if paths of output files in listed in context (e.g. `lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS]`)