### PR TITLE
[match] Ignore force_for_new_devices for developer_id provisioning type

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -239,7 +239,7 @@ module Match
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :force_for_new_devices,
                                      env_name: "MATCH_FORCE_FOR_NEW_DEVICES",
-                                     description: "Renew the provisioning profiles if the device count on the developer portal has changed. Ignored for profile type 'appstore'",
+                                     description: "Renew the provisioning profiles if the device count on the developer portal has changed. Ignored for profile types 'appstore' and 'developer_id'",
                                      type: Boolean,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_confirmation,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -243,13 +243,14 @@ module Match
       force = params[:force]
 
       if params[:force_for_new_devices] && !params[:readonly]
-        if prov_type != :appstore && !params[:force]
+        prov_types_without_devices = [:appstore, :developer_id]
+        if !prov_types_without_devices.include?(prov_type) && !params[:force]
           force = device_count_different?(profile: profile, keychain_path: keychain_path, platform: params[:platform].to_sym)
         else
           # App Store provisioning profiles don't contain device identifiers and
           # thus shouldn't be renewed if the device count has changed.
-          UI.important("Warning: `force_for_new_devices` is set but is ignored for App Store provisioning profiles.")
-          UI.important("You can safely stop specifying `force_for_new_devices` when running Match for type 'appstore'.")
+          UI.important("Warning: `force_for_new_devices` is set but is ignored for App Store & Developer ID provisioning profiles.")
+          UI.important("You can safely stop specifying `force_for_new_devices` when running Match for type 'appstore' or 'developer_id'.")
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
We noticed that if you pass `developer_id` provisioning profile type and force update profiles for new devices - the provisioning profile is regenerated, but the `developer_id` provisioning profile is like the `appstore` and doesn't contain devices.
Logs:
```

+-------------------------------------+---------------------------------------------------------+
| app_identifier                      | *                                                       |
| force                               | true                                                    |
| cert_id                             | *                                                       |
| provisioning_name                   | match * macos                                           |
| ignore_profiles_with_different_name | true                                                    |
| api_key                             | ********                                                |
| team_id                             | *                                                       |
| team_name                           | *                                                       |
| fail_on_name_taken                  | false                                                   |
| platform                            | macos                                                   |
| developer_id                        | true                                                    |
| adhoc                               | false                                                   |
| development                         | false                                                   |
| skip_install                        | false                                                   |
| skip_fetch_profiles                 | false                                                   |
| skip_certificate_verification       | false                                                   |
| readonly                            | false                                                   |
+-------------------------------------+---------------------------------------------------------+

[19:14:39]: Creating authorization token for App Store Connect API
[19:14:39]: Fetching profiles...
[19:14:41]: Verifying certificates...
[19:14:42]: Found 1 matching profile(s)
[19:14:42]: Recreating the profile
[19:14:48]: Creating new provisioning profile for '*' with name 'match Direct * macos' for 'macos' platform
[19:14:50]: Downloading provisioning profile...
[19:14:50]: Successfully downloaded provisioning profile...

```

### Description
I've added an exception for `developer_id` provisioning profile type in a manner it was made for `appstore` and updated descriptions & warnings.

### Testing Steps
Run the following code:
```
  sync_code_signing(
      platform: 'macos',
      app_identifier: [
        'com.your.bundle.id',
      ],
      type: 'developer_id',
      readonly: false,
      force_for_new_devices: true,
  )
```