### PR TITLE
[match] Don't force update macos development certs if macos device count unchanged

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -343,7 +343,7 @@ module Match
             [
               Spaceship::ConnectAPI::Device::DeviceClass::APPLE_TV
             ]
-          when :mac, :catalyst
+          when :macos, :catalyst
             [
               Spaceship::ConnectAPI::Device::DeviceClass::MAC
             ]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
We noticed that if you pass `development` provisioning profile type and force update profiles for new devices - the provisioning profile is regenerated every time even if the device count is unchanged.
Logs:
```
+-------------------------------------+--------------------------------------------------------------+
|                                      Summary for sigh 2.192.0                                      |
+-------------------------------------+--------------------------------------------------------------+
| app_identifier                      | *                                                            |
| force                               | true                                                         |
| cert_id                             | *                                                            |
| provisioning_name                   | match * macos                                                |
| ignore_profiles_with_different_name | true                                                         |
| api_key                             | ********                                                     |
| team_id                             | *                                                            |
| team_name                           | *                                                            |
| fail_on_name_taken                  | false                                                        |
| platform                            | macos                                                        |
| development                         | true                                                         |
| adhoc                               | false                                                        |
| developer_id                        | false                                                        |
| skip_install                        | false                                                        |
| skip_fetch_profiles                 | false                                                        |
| skip_certificate_verification       | false                                                        |
| readonly                            | false                                                        |
+-------------------------------------+--------------------------------------------------------------+

[19:15:38]: Creating authorization token for App Store Connect API
[19:15:38]: Fetching profiles...
[19:15:42]: Verifying certificates...
[19:15:42]: Found 1 matching profile(s)
[19:15:42]: Recreating the profile
[19:15:49]: Creating new provisioning profile for '*' with name 'match Development * macos' for 'macos' platform
[19:15:53]: Downloading provisioning profile...
[19:15:53]: Successfully downloaded provisioning profile...
[19:15:54]: Installing provisioning profile...
```

### Description
Fixed typo in a platform switch 😅.

### Testing Steps
Run the following code:
```
  sync_code_signing(
      platform: 'macos',
      app_identifier: [
        'com.your.bundle.id',
      ],
      type: 'development',
      readonly: false,
      force_for_new_devices: true,
  )
```