### PR TITLE
[pilot][upload_to_testflight] Add missing method

### DIFF
--- a/fastlane_core/lib/fastlane_core/pkg_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/pkg_file_analyser.rb
@@ -10,6 +10,11 @@ module FastlaneCore
       return nil
     end
 
+    # Fetches the app platform from the given pkg file.
+    def self.fetch_app_platform(path)
+      return "osx"
+    end
+
     # Fetches the app version from the given pkg file.
     def self.fetch_app_version(path)
       xml = self.fetch_distribution_xml_file(path)

--- a/pilot/spec/manager_spec.rb
+++ b/pilot/spec/manager_spec.rb
@@ -490,11 +490,6 @@ describe Pilot do
           before(:each) do
             expect(UI).to receive(:verbose).with("App Platform (#{fake_app_platform})")
             fake_manager.instance_variable_set(:@config, { pkg: fake_pkg })
-
-            allow(FastlaneCore::PkgFileAnalyser)
-              .to receive(:fetch_app_platform)
-              .with(fake_pkg)
-              .and_return(fake_app_platform)
           end
 
           it "uses the FastlaneCore::PkgFileAnalyser with 'pkg' path to find the 'app_platform' value" do
@@ -535,7 +530,7 @@ describe Pilot do
             expect(UI).to receive(:verbose).with("App Platform (#{fake_app_platform})")
             fake_manager.instance_variable_set(:@config, { pkg: fake_pkg })
 
-            allow_any_instance_of(FastlaneCore::PkgFileAnalyser)
+            allow(FastlaneCore::PkgFileAnalyser)
               .to receive(:fetch_app_platform)
               .with(fake_pkg)
               .and_return(nil)

--- a/pilot/spec/manager_spec.rb
+++ b/pilot/spec/manager_spec.rb
@@ -471,7 +471,7 @@ describe Pilot do
             expect(UI).to receive(:verbose).with("App Platform (#{fake_app_platform})")
             fake_manager.instance_variable_set(:@config, { ipa: fake_ipa })
 
-            allow(FastlaneCore::IpaFileAnalyser)
+            expect(FastlaneCore::IpaFileAnalyser)
               .to receive(:fetch_app_platform)
               .with(fake_ipa)
               .and_return(fake_app_platform)
@@ -490,6 +490,11 @@ describe Pilot do
           before(:each) do
             expect(UI).to receive(:verbose).with("App Platform (#{fake_app_platform})")
             fake_manager.instance_variable_set(:@config, { pkg: fake_pkg })
+
+            expect(FastlaneCore::PkgFileAnalyser)
+              .to receive(:fetch_app_platform)
+              .with(fake_pkg)
+              .and_return(fake_app_platform)
           end
 
           it "uses the FastlaneCore::PkgFileAnalyser with 'pkg' path to find the 'app_platform' value" do

--- a/pilot/spec/manager_spec.rb
+++ b/pilot/spec/manager_spec.rb
@@ -535,8 +535,8 @@ describe Pilot do
             expect(UI).to receive(:verbose).with("App Platform (#{fake_app_platform})")
             fake_manager.instance_variable_set(:@config, { pkg: fake_pkg })
 
-            allow(FastlaneCore::PkgFileAnalyser)
-              .to receive(:fetch_app_platform)
+            allow_any_instance_of(FastlaneCore::PkgFileAnalyser)
+              .to receive(:fetch_app_platform_not_real)
               .with(fake_pkg)
               .and_return(nil)
           end

--- a/pilot/spec/manager_spec.rb
+++ b/pilot/spec/manager_spec.rb
@@ -536,7 +536,7 @@ describe Pilot do
             fake_manager.instance_variable_set(:@config, { pkg: fake_pkg })
 
             allow_any_instance_of(FastlaneCore::PkgFileAnalyser)
-              .to receive(:fetch_app_platform_not_real)
+              .to receive(:fetch_app_platform)
               .with(fake_pkg)
               .and_return(nil)
           end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

While setting up TestFlight for our Mac app I came across this error:

```shell
/opt/homebrew/Cellar/fastlane/2.193.0/libexec/gems/fastlane-2.193.0/pilot/lib/pilot/manager.rb:86:in `fetch_app_platform': \e[0;31;49m[!] undefined method `fetch_app_platform' for FastlaneCore::PkgFileAnalyser:Class (NoMethodError)
Did you mean?  fetch_app_identifier\e[0m
Did you mean?  fetch_app_identifier
```

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This pull request adds the missing method so that folks do not have to specify the `app_platform` and Fastlane can figure it out automatically. I'm not 100% sure of this solution but it seemed like the simplest. I _think_ it is a safe assumption that any `.pkg` will be for a Mac app but would be happy to adjust the solution if I'm making a bad assumption.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
