### PR TITLE
[docs] Adjust markdown docs generator to move files to dedicated directory

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -477,10 +477,11 @@ def clone_docs(debug: false)
   else
     require 'tmpdir'
     git_url = ENV['FASTLANE_DOCS_GIT_URL'] || "https://github.com/fastlane/docs"
+    git_branch = ENV['FASTLANE_DOCS_GIT_BRANCH'] || "master"
 
     Dir.mktmpdir("fl_clone") do |tmp_dir|
       Dir.chdir(tmp_dir) do
-        sh("git clone #{git_url} --depth=1")
+        sh("git clone #{git_url} --branch #{git_branch} --depth=1")
         Dir.chdir("docs") do
           yield
         end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -477,11 +477,10 @@ def clone_docs(debug: false)
   else
     require 'tmpdir'
     git_url = ENV['FASTLANE_DOCS_GIT_URL'] || "https://github.com/fastlane/docs"
-    git_branch = ENV['FASTLANE_DOCS_GIT_BRANCH'] || "master"
 
     Dir.mktmpdir("fl_clone") do |tmp_dir|
       Dir.chdir(tmp_dir) do
-        sh("git clone #{git_url} --branch #{git_branch} --depth=1")
+        sh("git clone #{git_url} --depth=1")
         Dir.chdir("docs") do
           yield
         end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -411,8 +411,8 @@ lane :update_docs do |options|
     plugin_scores_cache_path = File.expand_path("./plugin_scores_cache.yml")
     docs_path = generate_markdown_docs(target_path: ".")
     yml_path = File.expand_path("./mkdocs.yml")
-    actions_md_path = File.expand_path(File.join(docs_path, "docs/actions.md"))
-    action_docs = Dir[File.join(docs_path, "docs", "actions", "*")].collect do |current|
+    actions_md_path = File.expand_path(File.join(docs_path, "docs/generated/actions.md"))
+    action_docs = Dir[File.join(docs_path, "docs", "generated", "actions", "*")].collect do |current|
       File.expand_path(current) # to make sure we commit the change
     end
 

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -134,15 +134,16 @@ module Fastlane
       require 'yaml'
       FileUtils.mkdir_p(target_path)
       docs_dir = File.join(target_path, "docs")
+      generated_actions_dir = File.join("generated", "actions")
 
       # Generate actions.md
       template = File.join(Fastlane::ROOT, "lib/assets/Actions.md.erb")
       result = ERB.new(File.read(template), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
-      File.write(File.join(docs_dir, "actions.md"), result)
+      File.write(File.join(docs_dir, "generated", "actions.md"), result)
 
-      # Generate actions sub pages (e.g. actions/slather.md, actions/scan.md)
+      # Generate actions sub pages (e.g. generated/actions/slather.md, generated/actions/scan.md)
       all_actions_ref_yml = []
-      FileUtils.mkdir_p(File.join(docs_dir, "actions"))
+      FileUtils.mkdir_p(File.join(docs_dir, generated_actions_dir))
       ActionsList.all_actions do |action|
         @action = action # to provide a reference in the .html.erb template
         @action_filename = filename_for_action(action)
@@ -165,7 +166,7 @@ module Fastlane
         template = File.join(Fastlane::ROOT, "lib/assets/ActionDetails.md.erb")
         result = ERB.new(File.read(template), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
 
-        file_name = File.join("actions", "#{action.action_name}.md")
+        file_name = File.join(generated_actions_dir, "#{action.action_name}.md")
         File.write(File.join(docs_dir, file_name), result)
 
         all_actions_ref_yml << { action.action_name => file_name }

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -135,6 +135,7 @@ module Fastlane
       FileUtils.mkdir_p(target_path)
       docs_dir = File.join(target_path, "docs")
       generated_actions_dir = File.join("generated", "actions")
+      FileUtils.mkdir_p(File.join(docs_dir, generated_actions_dir))
 
       # Generate actions.md
       template = File.join(Fastlane::ROOT, "lib/assets/Actions.md.erb")

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -167,10 +167,14 @@ module Fastlane
         template = File.join(Fastlane::ROOT, "lib/assets/ActionDetails.md.erb")
         result = ERB.new(File.read(template), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
 
+        # Actions get placed in "generated/actions" directory
         file_name = File.join(generated_actions_dir, "#{action.action_name}.md")
         File.write(File.join(docs_dir, file_name), result)
 
-        all_actions_ref_yml << { action.action_name => file_name }
+        # The action pages when published get moved to the "actions" directory
+        # The mkdocs.yml file needs to reference the "actions" directory (not the "generated/actions" directory)
+        published_file_name = File.join("actions", "#{action.action_name}.md")
+        all_actions_ref_yml << { action.action_name => published_file_name }
       end
 
       # Modify the mkdocs.yml to list all the actions


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Adjust `markdown_docs_generator` to move files to `docs/generated` directory in docs repository

**This PR should be considered together with:** https://github.com/fastlane/docs/pull/1095

### Description
Adjust `update_docs` lane in `Fastfile` and `generate!` in `markdown_docs_generator` to move auto-generated files to `docs/generated` directory in docs repository

Urls in actions documentation will not change. There is a PR in docs repository to copy files from generated to correct locations

### Testing Steps

Update `Gemfile` and run `bundle install`:
```ruby
gem "fastlane", :git => "https://github.com/lucgrabowski/fastlane.git", :branch => "lucgrabowski-move-autogenerated-files-to-dedicated-directory"
```