### PR TITLE
[fastlane_core] build watcher fails when build_beta_detail is nil - fix

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -156,7 +156,11 @@ module FastlaneCore
         #
         # If set, this method will only return true if all three statuses are complete
         if wait_for_build_beta_detail_processing
-          is_processed &&= build.build_beta_detail.processed?
+          if build.build_beta_detail.nil?
+            is_processed = false
+          else
+            is_processed &&= build.build_beta_detail.processed?
+          end
         end
 
         return is_processed

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -156,8 +156,7 @@ module FastlaneCore
         #
         # If set, this method will only return true if all three statuses are complete
         if wait_for_build_beta_detail_processing
-          is_processed &&= (build&.build_beta_detail.processed? || false)
-          end
+          is_processed &&= (build.build_beta_detail&.processed? || false)
         end
 
         return is_processed

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -156,10 +156,7 @@ module FastlaneCore
         #
         # If set, this method will only return true if all three statuses are complete
         if wait_for_build_beta_detail_processing
-          if build.build_beta_detail.nil?
-            is_processed = false
-          else
-            is_processed &&= build.build_beta_detail.processed?
+          is_processed &&= (build&.build_beta_detail.processed? || false)
           end
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #19330 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
It seems that `build_beta_detail` in `build` that we get from server can be `nil`, even though it's in build's `ESSENTIAL_INCLUDES`.
Treat build as not processed if `wait_for_build_beta_detail_processing=true` and `build.build_beta_detail.nil?`

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I don't have a mac app that I could use for tests

Update Gemfile and run bundle install
```ruby
gem "fastlane", :git => "https://github.com/lucgrabowski/fastlane.git", :branch => "lucgrabowski-build-watcher-fails-when-beta-build-detail-is-nil-fix"
```