### PR TITLE
[snapshot] wait for simulator to boot before overriding status bar

### DIFF
--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -116,7 +116,8 @@ module Snapshot
       device_udid = TestCommandGenerator.device_udid(device_type)
 
       UI.message("Launch Simulator #{device_type}")
-      Helper.backticks("xcrun instruments -w #{device_udid} &> /dev/null")
+      # Boot the simulator and wait for it to finish booting
+      Helper.backticks("xcrun simctl bootstatus #{device_udid} -b &> /dev/null")
 
       UI.message("Overriding Status Bar")
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
If the simulator is not booted when the status bar is updated it does not do anything and the default status bar is used.

Resolves #19317

### Description
`xcrun instruments` fails with the error "xcrun: error: Failed to locate 'instruments'." This command will boot the simulator if it's not curerntly booted and then wait for it finish booting before terminating.

### Testing Steps
Use `snapshot` while the `override_status_bar` option is `true`.

<details>
<summary>
Some of the tests failed for me, although they do not seem related to this change.
</summary>

```
rspec ./fastlane/spec/actions_specs/app_store_connect_api_key_spec.rb:95 # Fastlane Fastlane::FastFile App Store Connect API Key raise error when no key_filepath or key_content
rspec ./fastlane/spec/actions_specs/import_from_git_spec.rb:162 # Fastlane Fastlane::FastFile import_from_git with caching works with new tags
rspec ./fastlane/spec/actions_specs/import_from_git_spec.rb:200 # Fastlane Fastlane::FastFile import_from_git with caching works with branch
rspec ./match/spec/importer_spec.rb:47 # Match Match::Runner imports a .cert, .p12 and .mobileprovision (iOS provision) into the match repo
rspec ./match/spec/importer_spec.rb:64 # Match Match::Runner imports a .cert, .p12 and .provisionprofile (osx provision) into the match repo
rspec ./match/spec/importer_spec.rb:81 # Match Match::Runner imports a .cert and .p12 without profile into the match repo (backwards compatibility)
rspec ./match/spec/importer_spec.rb:98 # Match Match::Runner imports a .cert and .p12 when the type is set to developer_id
rspec ./pilot/spec/build_manager_spec.rb:661 # Build Manager #transporter_for_selected_team with one team id
rspec ./pilot/spec/build_manager_spec.rb:677 # Build Manager #transporter_for_selected_team with inferred provider id
rspec ./pilot/spec/build_manager_spec.rb:633 # Build Manager #transporter_for_selected_team with itc_provider with nil Spaceship::TunesClient
rspec ./pilot/spec/build_manager_spec.rb:646 # Build Manager #transporter_for_selected_team with itc_provider with nil Spaceship::TunesClient
rspec ./pilot/spec/manager_spec.rb[1:1:2:2:1:1:1] # Pilot Pilot::Manager what happens on 'login' when using web session when username input param is given behaves like performing the spaceship login using username and password by pilot performs the login using username and password
rspec ./pilot/spec/manager_spec.rb[1:1:2:2:2:1:1] # Pilot Pilot::Manager what happens on 'login' when using web session when username input param is not given but found apple_id in AppFile behaves like performing the spaceship login using username and password by pilot performs the login using username and password
rspec ./sigh/spec/runner_spec.rb:142 # Sigh Sigh::Runner#devices_to_use devices for development
rspec ./sigh/spec/runner_spec.rb:152 # Sigh Sigh::Runner#devices_to_use devices for adhoc
```
</details>
