### PR TITLE
[Slather] Add github option to slather action

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -9,6 +9,7 @@ module Fastlane
           jenkins: '--jenkins',
           buildkite: '--buildkite',
           teamcity: '--teamcity',
+          github: '--github',
 
           coveralls: '--coveralls',
           simple_output: '--simple-output',
@@ -154,6 +155,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :input_format,
                                        env_name: "FL_SLATHER_INPUT_FORMAT", # The name of the environment variable
                                        description: "The input format that slather should look for",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :github,
+                                       env_name: "FL_SLATHER_GITHUB_ENABLED", # The name of the environment variable
+                                       description: "Tell slather that it is running on Github Actions",
+                                       type: Boolean,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :buildkite,
                                        env_name: "FL_SLATHER_BUILDKITE_ENABLED", # The name of the environment variable


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Hi there.

I found slather has `--github` option, and so I also added the option to SlatherAction.

```
❯ slather coverage --help | grep github
    --github                                 Indicate that the builds are running on Github Actions
```

https://github.com/SlatherOrg/slather/blob/master/lib/slather/command/coverage_command.rb#L11