### PR TITLE
[docs] Improve gradle action

### DIFF
--- a/fastlane/lib/fastlane/actions/gradle.rb
+++ b/fastlane/lib/fastlane/actions/gradle.rb
@@ -258,8 +258,21 @@ module Fastlane
             # ...
 
             properties: {
-              "versionCode" => 100,
-              "versionName" => "1.0.0",
+              "exampleNumber" => 100,
+              "exampleString" => "1.0.0",
+              # ...
+            }
+          )
+          ```
+
+          You can use this to change the version code and name of your app:
+          ```ruby
+          gradle(
+            # ...
+
+            properties: {
+              "android.injected.version.code" => 100,
+              "android.injected.version.name" => "1.0.0",
               # ...
             }
           )


### PR DESCRIPTION
By explaining android.injected.version.code and name can be used to change the apps versionCode and versionName.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
A typical use case while using Fastlane is to change the version code / name of your app. While you can do this by passing a gradle propertie and adding code in your build.gradle, its so much easier via the `android.injected.version` notation and doens't require code in build.gradle.
By adding this example to the docs we can help devs to use that.

### Description
The documentation shows an example how you can pass versionName and versionCode as a gradle property while building. To make this work you also need to add code in your build.gradle that checks if the variable is set or not and passes that to androids versionName and versionCode. A much simpler approach is actually to pass the properties `android.injected.version.name` and `android.injected.version.code` as this will modify version code and name without additional code.

There was also this closed issue: https://github.com/fastlane/fastlane/issues/15633 and I've discovered the varaibles first here: https://stackoverflow.com/questions/36213977/is-it-possible-to-set-android-version-code-and-name-via-a-gradle-task/36221899# and then here: https://www.javadoc.io/static/com.android.tools.build/builder-model/2.5.0-alpha-preview-02/constant-values.html

### Testing Steps
I've tested this in a fastlane lane manually and in a ci environment.
