### PR TITLE
[snapshot] added 10 second timeout to wait for device to fully boot before overriding status bar (adjust by setting SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT environment variable)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,8 +271,8 @@ workflows:
           ruby_version: '2.7'
           ruby_opt: -W:deprecated
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 12.5.1, Ruby 3.0)'
-          xcode_version: '12.5.1'
+          name: 'Execute tests on macOS (Xcode 13.0.0, Ruby 3.0)'
+          xcode_version: '13.0.0'
           ruby_version: '3.0'
           ruby_opt: -W:deprecated
       - tests_ubuntu:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,6 @@ aliases:
     run:
       name: Set Ruby version
       command: | # see https://circleci.com/docs/2.0/testing-ios/#using-ruby
-        if [ "${_RUBY_VERSION}" = "3.0" ]; then
-          # See https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
-          echo "Ruby 3.0 is not installed in macOS image based on Xcode 12.5.1"
-          ruby-install ruby 3.0
-        fi
         echo "ruby-${_RUBY_VERSION}" > ~/.ruby-version
         echo 'chruby ruby-${_RUBY_VERSION}' >> ~/.bash_profile
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ aliases:
       name: Set Ruby version
       command: | # see https://circleci.com/docs/2.0/testing-ios/#using-ruby
         echo "ruby-${_RUBY_VERSION}" > ~/.ruby-version
-        echo 'chruby ruby-${_RUBY_VERSION}' >> ~/.bash_profile
+        # https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command
         echo 'chruby ruby-${_RUBY_VERSION}' >> $BASH_ENV
 
   - &bundle_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ aliases:
     run:
       name: Set Ruby version
       command: | # see https://circleci.com/docs/2.0/testing-ios/#using-ruby
+        echo "Ruby Version: ${_RUBY_VERSION}"
         echo "ruby-${_RUBY_VERSION}" > ~/.ruby-version
         echo 'chruby ruby-${_RUBY_VERSION}' >> ~/.bash_profile
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ aliases:
     run:
       name: Set Ruby version
       command: | # see https://circleci.com/docs/2.0/testing-ios/#using-ruby
-        echo "Ruby Version: ${_RUBY_VERSION}"
         echo "ruby-${_RUBY_VERSION}" > ~/.ruby-version
         echo 'chruby ruby-${_RUBY_VERSION}' >> ~/.bash_profile
+        echo 'chruby ruby-${_RUBY_VERSION}' >> $BASH_ENV
 
   - &bundle_install
     run:

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -123,7 +123,7 @@ module Snapshot
                                      type: Boolean),
         FastlaneCore::ConfigItem.new(key: :override_status_bar,
                                      env_name: 'SNAPSHOT_OVERRIDE_STATUS_BAR',
-                                     description: "Enabling this option will automatically override the status bar to show 9:41 AM, full battery, and full reception",
+                                     description: "Enabling this option will automatically override the status bar to show 9:41 AM, full battery, and full reception (Adjust 'SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT' environment variable if override status bar is not working. Might be because simulator is not fully booted. Defaults to 10 seconds)",
                                      default_value: false,
                                      is_string: false),
         FastlaneCore::ConfigItem.new(key: :override_status_bar_arguments,

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -119,6 +119,13 @@ module Snapshot
       # Boot the simulator and wait for it to finish booting
       Helper.backticks("xcrun simctl bootstatus #{device_udid} -b &> /dev/null")
 
+      # "Booted" status is not enough for to adjust the status bar
+      # Simulator could stil be booting with Apple logo
+      # Need to wait "some amount of time" until home screen shows
+      boot_sleep = ENV["SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT"].to_i || 10
+      UI.message("Waiting #{boot_sleep} seconds for device to fully boot before overriding status bar... Set 'SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT' environemnt variable to adjust timeout")
+      sleep(boot_sleep) if boot_sleep > 0
+
       UI.message("Overriding Status Bar")
 
       if arguments.nil? || arguments.empty?


### PR DESCRIPTION
### Motivation and Context
Follow up to #19344. Turns out that this mostly works but not fully. The "Booted" status can still show while the simulator is booting (Apple logo showing). This "Booting" status doesn't allow the status bar to be overridden.

### Description
Adds a sleep after trying to boot the simulator to make sure device is fully operational before attempting to set the status bar. Can be adjusted using the `SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT` environemtn variable. Defaults to 10 seconds.

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-snapshot-override-status-bar-sim-boot-timeout"
```
