### PR TITLE
[supply] Fix rollout update

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -147,7 +147,7 @@ module Supply
     end
 
     def verify_config!
-      unless metadata_path || Supply.config[:apk] || Supply.config[:apk_paths] || Supply.config[:aab] || Supply.config[:aab_paths] || (Supply.config[:track] && Supply.config[:track_promote_to])
+      unless metadata_path || Supply.config[:apk] || Supply.config[:apk_paths] || Supply.config[:aab] || Supply.config[:aab_paths] || (Supply.config[:track] && Supply.config[:track_promote_to]) || (Supply.config[:track] && Supply.config[:rollout])
         UI.user_error!("No local metadata, apks, aab, or track to promote were found, make sure to run `fastlane supply init` to setup supply")
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Fixes #18442

We expect this config would update the existing release rollout:

```
supply(
    track: production_release_track,
    rollout: percentage,
    package_name: google_play_app_id,
    json_key: json_key
  )
```

But rollout update fails with

```
No local metadata, apks, aab, or track to promote were found, make sure to run `fastlane supply init` to setup supply
```

### Solution

It's [seen that](https://github.com/fastlane/fastlane/blob/master/supply/lib/supply/uploader.rb#L31) to update rollout the only `track` & `rollout` should be defined, other combinations would cause diff behaviour, but the `verify_config` check blocks this to happen.

