### PR TITLE
Fix and ammend gemspec metadata

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -58,7 +58,6 @@ Gem::Specification.new do |spec|
     "changelog_uri" => "https://github.com/fastlane/fastlane/releases",
     "documentation_uri" => "https://docs.fastlane.tools/",
     "homepage_uri" => spec.homepage,
-    "mailing_list_uri" => "https://github.com/fastlane/fastlane/discussions",
     "source_code_uri" => "https://github.com/fastlane/fastlane"
   }
 

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -54,7 +54,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://fastlane.tools"
   spec.license       = "MIT"
   spec.metadata      = {
-    "docs_url" => "https://docs.fastlane.tools"
+    "bug_tracker_uri" => "https://github.com/fastlane/fastlane/issues",
+    "changelog_uri" => "https://github.com/fastlane/fastlane/releases",
+    "documentation_uri" => "https://docs.fastlane.tools/",
+    "homepage_uri" => spec.homepage,
+    "mailing_list_uri" => "https://github.com/fastlane/fastlane/discussions",
+    "source_code_uri" => "https://github.com/fastlane/fastlane"
   }
 
   spec.required_ruby_version = '>= 2.5'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Was browsing rubygems.org and wanted to see the official docs but got linked to rubydoc.info instead.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

The `docs_url` key is called `documentation_uri`. Right now, because of the wrong key [rubygems.org](https://rubygems.org/gems/fastlane) links to [rubydoc.info](https://www.rubydoc.info/gems/fastlane/2.195.0) instead of the URL previously set in `docs_url`.

The other keys were set to show what could be done to also show up on RubyGems.org. While there is no "mailing list", I think GitHub discussions are the closest thing.

Happy to add, change, remove any attributes that are unwanted. See the [`metadata` docs](https://guides.rubygems.org/specification-reference/#metadata) for the possible keys.

