### PR TITLE
[action][latest_testflight_build] make `LatestTestflightBuildNumberAction` not overwrite existing Actions.lane_context

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -9,9 +9,18 @@ module Fastlane
 
     class AppStoreBuildNumberAction < Action
       def self.run(params)
+        build_v, build_nr = get_build_version_and_number(params)
+
+        Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER] = build_nr
+        Actions.lane_context[SharedValues::LATEST_VERSION] = build_v
+
+        return build_nr
+      end
+
+      def self.get_build_version_and_number(params)
         require 'spaceship'
 
-        result = get_build_number(params)
+        result = get_build_info(params)
         build_nr = result.build_nr
 
         # Convert build_nr to int (for legacy use) if no "." in string
@@ -19,13 +28,10 @@ module Fastlane
           build_nr = build_nr.to_i
         end
 
-        Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER] = build_nr
-        Actions.lane_context[SharedValues::LATEST_VERSION] = result.build_v
-
-        return build_nr
+        return result.build_v, build_nr
       end
 
-      def self.get_build_number(params)
+      def self.get_build_info(params)
         # Prompts select team if multiple teams and none specified
         if (api_token = Spaceship::ConnectAPI::Token.from(hash: params[:api_key], filepath: params[:api_key_path]))
           UI.message("Creating authorization token for App Store Connect API")

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -9,16 +9,8 @@ module Fastlane
 
     class LatestTestflightBuildNumberAction < Action
       def self.run(params)
-        current_build_nr = Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER]
-        current_build_v = Actions.lane_context[SharedValues::LATEST_VERSION]
+        build_v, build_nr = AppStoreBuildNumberAction.get_build_version_and_number(params)
 
-        AppStoreBuildNumberAction.run(params)
-
-        build_nr = Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER]
-        build_v = Actions.lane_context[SharedValues::LATEST_VERSION]
-
-        Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER] = current_build_nr
-        Actions.lane_context[SharedValues::LATEST_VERSION] = current_build_v
         Actions.lane_context[SharedValues::LATEST_TESTFLIGHT_BUILD_NUMBER] = build_nr
         Actions.lane_context[SharedValues::LATEST_TESTFLIGHT_VERSION] = build_v
         return build_nr

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -9,9 +9,16 @@ module Fastlane
 
     class LatestTestflightBuildNumberAction < Action
       def self.run(params)
+        current_build_nr = Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER]
+        current_build_v = Actions.lane_context[SharedValues::LATEST_VERSION]
+
         AppStoreBuildNumberAction.run(params)
+
         build_nr = Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER]
         build_v = Actions.lane_context[SharedValues::LATEST_VERSION]
+
+        Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER] = current_build_nr
+        Actions.lane_context[SharedValues::LATEST_VERSION] = current_build_v
         Actions.lane_context[SharedValues::LATEST_TESTFLIGHT_BUILD_NUMBER] = build_nr
         Actions.lane_context[SharedValues::LATEST_TESTFLIGHT_VERSION] = build_v
         return build_nr

--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -25,7 +25,7 @@ describe Fastlane do
       end
 
       it "returns value as string (with build number as version string)" do
-        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_number).and_return(OpenStruct.new({ build_nr: "1.2.3", build_v: "foo" }))
+        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_info).and_return(OpenStruct.new({ build_nr: "1.2.3", build_v: "foo" }))
 
         result = Fastlane::FastFile.new.parse("lane :test do
           app_store_build_number(username: 'name@example.com', app_identifier: 'x.y.z')
@@ -35,7 +35,7 @@ describe Fastlane do
       end
 
       it "returns value as integer (with build number as version number)" do
-        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_number).and_return(OpenStruct.new({ build_nr: "3", build_v: "foo" }))
+        allow(Fastlane::Actions::AppStoreBuildNumberAction).to receive(:get_build_info).and_return(OpenStruct.new({ build_nr: "3", build_v: "foo" }))
 
         result = Fastlane::FastFile.new.parse("lane :test do
           app_store_build_number(username: 'name@example.com', app_identifier: 'x.y.z')
@@ -45,7 +45,7 @@ describe Fastlane do
       end
     end
 
-    describe "#get_build_number" do
+    describe "#get_build_info" do
       let(:fake_api_key_json_path) do
         "./spaceship/spec/connect_api/fixtures/asc_key.json"
       end
@@ -133,7 +133,7 @@ describe Fastlane do
             expect(UI).to receive(:message).with("Fetching the latest build number for live-version")
             expect(UI).to receive(:message).with("Latest upload for live-version #{app_version} is build: #{build_number}")
 
-            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_number(options)
+            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
             expect(result.build_nr).to eq(build_number)
             expect(result.build_v).to eq(app_version)
           end
@@ -147,7 +147,7 @@ describe Fastlane do
 
             options[:api_key] = "api_key"
             options[:api_key_path] = "api_key_path"
-            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_number(options)
+            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
             expect(result.build_nr).to eq(build_number)
             expect(result.build_v).to eq(app_version)
           end
@@ -169,7 +169,7 @@ describe Fastlane do
             expect(UI).to receive(:message).with("Latest upload for live-version #{app_version} is build: #{build_number}")
 
             options[:username] = "username"
-            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_number(options)
+            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
             expect(result.build_nr).to eq(build_number)
             expect(result.build_v).to eq(app_version)
           end
@@ -211,7 +211,7 @@ describe Fastlane do
             expect(Spaceship::ConnectAPI).to receive(:get_builds).with(filter: expected_filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1).and_return([build])
             expect(UI).to receive(:message).with("Latest upload for version #{app_version} on any platform is build: #{build_number}")
 
-            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_number(options)
+            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
             expect(result.build_nr).to eq(build_number)
             expect(result.build_v).to eq(app_version)
           end
@@ -229,7 +229,7 @@ describe Fastlane do
             expect(Spaceship::ConnectAPI).to receive(:get_builds).with(filter: expected_filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1).and_return([build])
             expect(UI).to receive(:message).with("Latest upload for version #{app_version} on #{platform} platform is build: #{build_number}")
 
-            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_number(options)
+            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
             expect(result.build_nr).to eq(build_number)
             expect(result.build_v).to eq(app_version)
           end
@@ -248,7 +248,7 @@ describe Fastlane do
             expect(Spaceship::ConnectAPI).to receive(:get_builds).with(filter: expected_filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1).and_return([build])
             expect(UI).to receive(:message).with("Latest upload for version #{app_version} on any platform is build: #{build_number}")
 
-            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_number(options)
+            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
             expect(result.build_nr).to eq(build_number)
             expect(result.build_v).to eq(app_version)
           end
@@ -266,7 +266,7 @@ describe Fastlane do
             expect(Spaceship::ConnectAPI).to receive(:get_builds).with(filter: expected_filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1).and_return([build])
             expect(UI).to receive(:message).with("Latest upload for version #{app_version} on #{platform} platform is build: #{build_number}")
 
-            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_number(options)
+            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
             expect(result.build_nr).to eq(build_number)
             expect(result.build_v).to eq(app_version)
           end
@@ -290,7 +290,7 @@ describe Fastlane do
             expect(UI).to receive(:important).with("Could not find a build for version #{app_version} on #{platform} platform on App Store Connect")
             expect(UI).to receive(:user_error!).with("Could not find a build on App Store Connect - and 'initial_build_number' option is not set")
 
-            Fastlane::Actions::AppStoreBuildNumberAction.get_build_number(options)
+            Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
           end
         end
 
@@ -312,7 +312,7 @@ describe Fastlane do
             expect(UI).to receive(:important).with("Could not find a build for version #{app_version} on #{platform} platform on App Store Connect")
             expect(UI).to receive(:message).with("Using initial build number of 5678")
 
-            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_number(options)
+            result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
             expect(result.build_nr).to eq(5678)
             expect(result.build_v).to eq(app_version)
           end


### PR DESCRIPTION
Heyo!

The `LatestTestflightBuildNumberAction` had an issue, where it would overwrite existing values for `Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER]` and `Actions.lane_context[SharedValues::LATEST_VERSION]`.

This fixes it :)

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid

There are two offences I'm not sure how to fix, and would appreciate guidance on how to do it:

```
Offenses:

fastlane/lib/fastlane/actions/latest_testflight_build_number.rb:21:9: W: Lint/MissingKeysOnSharedArea: Found setting a value for SharedValues in a function but the const is not declared in SharedValues module
        Actions.lane_context[SharedValues::LATEST_BUILD_NUMBER] = current_build_nr
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
fastlane/lib/fastlane/actions/latest_testflight_build_number.rb:22:9: W: Lint/MissingKeysOnSharedArea: Found setting a value for SharedValues in a function but the const is not declared in SharedValues module
        Actions.lane_context[SharedValues::LATEST_VERSION] = current_build_v
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1233 files inspected, 2 offenses detected
```

- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I have a custom action that is basically a wrapper around `AppStoreBuildNumberAction` that tries to read the value in the action context, to not connect to ASC when it's not needed.

However, if you first call the `AppStoreBuildNumberAction`, and `LatestTestflightBuildNumberAction` later, the values in the context gets clobbered.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
