### PR TITLE
[fastlane_core] symbolize keys in options of type Hash

### DIFF
--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -282,7 +282,7 @@ module FastlaneCore
         return value.map { |k, v| "#{k.to_s.shellescape}=#{v.shellescape}" }.join(' ') if value.kind_of?(Hash)
       elsif data_type == Hash && value.kind_of?(String)
         begin
-          parsed = JSON.parse(value)
+          parsed = JSON.parse(value, :symbolize_names => true)
           return parsed if parsed.kind_of?(Hash)
         rescue JSON::ParserError
         end

--- a/fastlane_core/lib/fastlane_core/configuration/config_item.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/config_item.rb
@@ -282,7 +282,7 @@ module FastlaneCore
         return value.map { |k, v| "#{k.to_s.shellescape}=#{v.shellescape}" }.join(' ') if value.kind_of?(Hash)
       elsif data_type == Hash && value.kind_of?(String)
         begin
-          parsed = JSON.parse(value, :symbolize_names => true)
+          parsed = JSON.parse(value)
           return parsed if parsed.kind_of?(Hash)
         rescue JSON::ParserError
         end

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -29,7 +29,7 @@ module Spaceship
       attr_accessor :in_house
 
       def self.from(hash: nil, filepath: nil)
-        api_token ||= self.create(**hash) if hash
+        api_token ||= self.create(**hash.transform_keys(&:to_sym)) if hash
         api_token ||= self.from_json_file(filepath) if filepath
         return api_token
       end

--- a/spaceship/spec/connect_api/token_spec.rb
+++ b/spaceship/spec/connect_api/token_spec.rb
@@ -9,6 +9,11 @@ describe Spaceship::ConnectAPI::Token do
   let(:fake_api_key_base64_json_path) { "./spaceship/spec/connect_api/fixtures/asc_key_base64.json" }
   let(:fake_api_key_in_house_json_path) { "./spaceship/spec/connect_api/fixtures/asc_key_in_house.json" }
 
+  let(:private_key) do
+    json = JSON.parse(File.read(fake_api_key_json_path), { symbolize_names: true })
+    json[:key]
+  end
+
   context '#from_json_file' do
     it 'successfully creates token' do
       token = Spaceship::ConnectAPI::Token.from_json_file(fake_api_key_json_path)
@@ -76,82 +81,117 @@ describe Spaceship::ConnectAPI::Token do
     end
   end
 
+  context '#from' do
+    describe 'hash' do
+      it 'with string keys' do
+        token = Spaceship::ConnectAPI::Token.from(hash: {
+          "key_id" => "key_id",
+          "issuer_id" => "issuer_id",
+          "key" => private_key,
+          "duration" => 200,
+          "in_house" => true
+        })
+
+        expect(token.key_id).to eq('key_id')
+        expect(token.issuer_id).to eq('issuer_id')
+        expect(token.text).not_to(be_nil)
+        expect(token.duration).to eq(200)
+        expect(token.in_house).to eq(true)
+      end
+
+      it 'with symbols keys' do
+        token = Spaceship::ConnectAPI::Token.from(hash: {
+          key_id: "key_id",
+          issuer_id: "issuer_id",
+          key: private_key,
+          duration: 200,
+          in_house: true
+        })
+
+        expect(token.key_id).to eq('key_id')
+        expect(token.issuer_id).to eq('issuer_id')
+        expect(token.text).not_to(be_nil)
+        expect(token.duration).to eq(200)
+        expect(token.in_house).to eq(true)
+      end
+    end
+  end
+
   context '#create' do
-    let(:private_key) do
-      json = JSON.parse(File.read(fake_api_key_json_path), { symbolize_names: true })
-      json[:key]
+    describe 'with arguments' do
+      it "with key" do
+        token = Spaceship::ConnectAPI::Token.create(
+          key_id: "key_id",
+          issuer_id: "issuer_id",
+          key: private_key,
+          duration: 200,
+          in_house: true
+        )
+
+        expect(token.key_id).to eq('key_id')
+        expect(token.issuer_id).to eq('issuer_id')
+        expect(token.text).not_to(be_nil)
+        expect(token.duration).to eq(200)
+        expect(token.in_house).to eq(true)
+      end
+
+      it "with filepath" do
+        expect(File).to receive(:binread).with('/path/to/file').and_return(private_key)
+        token = Spaceship::ConnectAPI::Token.create(
+          key_id: "key_id",
+          issuer_id: "issuer_id",
+          filepath: "/path/to/file",
+          duration: 200,
+          in_house: true
+        )
+
+        expect(token.key_id).to eq('key_id')
+        expect(token.issuer_id).to eq('issuer_id')
+        expect(token.text).not_to(be_nil)
+        expect(token.duration).to eq(200)
+        expect(token.in_house).to eq(true)
+      end
     end
 
-    it "with arguments with key" do
-      token = Spaceship::ConnectAPI::Token.create(
-        key_id: "key_id",
-        issuer_id: "issuer_id",
-        key: private_key,
-        duration: 200,
-        in_house: true
-      )
+    describe 'with environment variables' do
+      it "with key" do
+        stub_const('ENV', {
+          'SPACESHIP_CONNECT_API_KEY_ID' => 'key_id',
+          'SPACESHIP_CONNECT_API_ISSUER_ID' => 'issuer_id',
+          'SPACESHIP_CONNECT_API_KEY_FILEPATH' => nil,
+          'SPACESHIP_CONNECT_API_TOKEN_DURATION' => '200',
+          'SPACESHIP_CONNECT_API_IN_HOUSE' => 'no',
+          'SPACESHIP_CONNECT_API_KEY' => private_key
+        })
 
-      expect(token.key_id).to eq('key_id')
-      expect(token.issuer_id).to eq('issuer_id')
-      expect(token.text).not_to(be_nil)
-      expect(token.duration).to eq(200)
-      expect(token.in_house).to eq(true)
-    end
+        token = Spaceship::ConnectAPI::Token.create
 
-    it "with arguments with filepath" do
-      expect(File).to receive(:binread).with('/path/to/file').and_return(private_key)
-      token = Spaceship::ConnectAPI::Token.create(
-        key_id: "key_id",
-        issuer_id: "issuer_id",
-        filepath: "/path/to/file",
-        duration: 200,
-        in_house: true
-      )
+        expect(token.key_id).to eq('key_id')
+        expect(token.issuer_id).to eq('issuer_id')
+        expect(token.text).not_to(be_nil)
+        expect(token.duration).to eq(200)
+        expect(token.in_house).to eq(false)
+      end
 
-      expect(token.key_id).to eq('key_id')
-      expect(token.issuer_id).to eq('issuer_id')
-      expect(token.text).not_to(be_nil)
-      expect(token.duration).to eq(200)
-      expect(token.in_house).to eq(true)
-    end
+      it "with filepath" do
+        expect(File).to receive(:binread).with('/path/to/file').and_return(private_key)
+        stub_const('ENV', {
+          'SPACESHIP_CONNECT_API_KEY_ID' => 'key_id',
+          'SPACESHIP_CONNECT_API_ISSUER_ID' => 'issuer_id',
+          'SPACESHIP_CONNECT_API_KEY_FILEPATH' => '/path/to/file',
+          'SPACESHIP_CONNECT_API_TOKEN_DURATION' => '200',
+          'SPACESHIP_CONNECT_API_IN_HOUSE' => 'true',
+          'SPACESHIP_CONNECT_API_KEY' => nil
+        })
 
-    it "with environment variables with key" do
-      stub_const('ENV', {
-        'SPACESHIP_CONNECT_API_KEY_ID' => 'key_id',
-        'SPACESHIP_CONNECT_API_ISSUER_ID' => 'issuer_id',
-        'SPACESHIP_CONNECT_API_KEY_FILEPATH' => nil,
-        'SPACESHIP_CONNECT_API_TOKEN_DURATION' => '200',
-        'SPACESHIP_CONNECT_API_IN_HOUSE' => 'no',
-        'SPACESHIP_CONNECT_API_KEY' => private_key
-      })
+        token = Spaceship::ConnectAPI::Token.create
 
-      token = Spaceship::ConnectAPI::Token.create
-
-      expect(token.key_id).to eq('key_id')
-      expect(token.issuer_id).to eq('issuer_id')
-      expect(token.text).not_to(be_nil)
-      expect(token.duration).to eq(200)
-      expect(token.in_house).to eq(false)
-    end
-
-    it "with environment variables with filepath" do
-      expect(File).to receive(:binread).with('/path/to/file').and_return(private_key)
-      stub_const('ENV', {
-        'SPACESHIP_CONNECT_API_KEY_ID' => 'key_id',
-        'SPACESHIP_CONNECT_API_ISSUER_ID' => 'issuer_id',
-        'SPACESHIP_CONNECT_API_KEY_FILEPATH' => '/path/to/file',
-        'SPACESHIP_CONNECT_API_TOKEN_DURATION' => '200',
-        'SPACESHIP_CONNECT_API_IN_HOUSE' => 'true',
-        'SPACESHIP_CONNECT_API_KEY' => nil
-      })
-
-      token = Spaceship::ConnectAPI::Token.create
-
-      expect(token.key_id).to eq('key_id')
-      expect(token.issuer_id).to eq('issuer_id')
-      expect(token.text).not_to(be_nil)
-      expect(token.duration).to eq(200)
-      expect(token.in_house).to eq(true)
+        expect(token.key_id).to eq('key_id')
+        expect(token.issuer_id).to eq('issuer_id')
+        expect(token.text).not_to(be_nil)
+        expect(token.duration).to eq(200)
+        expect(token.in_house).to eq(true)
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
When Hash options are provided via environment, they are parsed as JSON and auto-converted to a hash. However, Ruby treats string and symbol keys differently, and fastlane actions normally expect keys as symbols.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Converts keys to symbols when parsing an option from a JSON string in the environment.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
The `APP_STORE_CONNECT_API_KEY` environment variable is a common example exposing the issue. Any key inside the JSON would be parsed as nil, because accessing e.g. `"key_id"` (parsed) is different than `:key_id` (expected).