### PR TITLE
[supply] treat no release note as warning instead of error

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -286,10 +286,10 @@ module Supply
 
       filtered_release = filtered_track.releases.first { |r| !r.name.nil? && r.name == version }
 
-      # Since we can release on Alpha/Beta without release notes.
+      # Since we can release on Internal/Alpha/Beta without release notes.
       if filtered_release.release_notes.nil?
-        UI.user_error!("Version '#{version}' for '#{current_package_name}' does not seem to have any release notes. Nothing to download.")
-        return nil
+        UI.message("Version '#{version}' for '#{current_package_name}' does not seem to have any release notes. Nothing to download.")
+        return []
       end
 
       return filtered_release.release_notes.map do |row|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

When download metadata of a Internal Test in Google Play using `bundle exec fastlane supply init`, it raises error when downloading changelogs that has no release notes. However it is allowed if you configure the project through webpage of [Google Play Console](https://play.google.com/console/u/0/developers/).

Here's a testcase:

![](https://i.imgur.com/1HNzvPF.png)

In this case:

1. It is a published internal test
2. It has no release note

It work totally fine for testers, however for certain reason fastlane treat no release note as an error. An interesting comment says
```
# Since we can release on Alpha/Beta without release notes.
```
in [here](https://github.com/fastlane/fastlane/blob/master/supply/lib/supply/client.rb#L289). However since I am new to develop android apps, I'm not sure if it is due to in the past internal tests aren't allow to published without a release note or not.

For your interest, since the process to download changelog is the last process of download whole metadata, it works fine evens it complain with errors and abort itself. However in my use case, I use fastlane in CI and it interrupts the CI process since CI thinks an error has raised. It is confirmed that one can bypass this issue by tricks such as `bundle exec fastlane supply init || true`, however I think it will be better to consider it as an warning instead of an error.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I simple replace `UI.user_error!` to `UI.message` to avoid raising errors and handle the return results to not affect the program behaviour.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Fastlane Version:

```
$ bundle exec fastlane -v
fastlane installation at path:
/home/k45vs/fastlane-test/vendor/bundle/ruby/2.5.0/gems/fastlane-2.195.0/bin/fastlane
-----------------------------
[✔] 🚀
fastlane 2.195.0
```

<details>
<summary>Before: (package name is altered)</summary>

```
$ rm -rf metadata/ && bundle exec fastlane supply init --json_key=ci.json --package_name=com.hidden.message --track=internal

[20:37:53]: 🕗  Downloading metadata, images, screenshots...
[20:37:54]: 📝  Downloading metadata (en-US)
[20:37:54]: Writing to metadata/en-US/title.txt...
[20:37:54]: Writing to metadata/en-US/short_description.txt...
[20:37:54]: Writing to metadata/en-US/full_description.txt...
[20:37:54]: Writing to metadata/en-US/video.txt...
[20:37:54]: 🖼️  Downloading images (en-US)
[20:37:54]: Downloading `featureGraphic` for en-US...
[20:37:55]: 	Downloaded - metadata/en-US/images/featureGraphic.png
[20:37:55]: Downloading `icon` for en-US...
[20:37:55]: 	Downloaded - metadata/en-US/images/icon.png
[20:37:55]: Downloading `tvBanner` for en-US...
[20:37:56]: Downloading `phoneScreenshots` for en-US...
[20:37:57]: 	Downloaded - metadata/en-US/images/phoneScreenshots/1_en-US.png
[20:37:57]: 	Downloaded - metadata/en-US/images/phoneScreenshots/2_en-US.jpeg
[20:37:58]: 	Downloaded - metadata/en-US/images/phoneScreenshots/3_en-US.png
[20:37:58]: 	Downloaded - metadata/en-US/images/phoneScreenshots/4_en-US.png
[20:37:58]: 	Downloaded - metadata/en-US/images/phoneScreenshots/5_en-US.png
[20:37:59]: 	Downloaded - metadata/en-US/images/phoneScreenshots/6_en-US.png
[20:38:00]: 	Downloaded - metadata/en-US/images/phoneScreenshots/7_en-US.png
[20:38:00]: 	Downloaded - metadata/en-US/images/phoneScreenshots/8_en-US.png
[20:38:00]: Downloading `sevenInchScreenshots` for en-US...
[20:38:01]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/1_en-US.png
[20:38:01]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/2_en-US.jpeg
[20:38:02]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/3_en-US.png
[20:38:02]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/4_en-US.png
[20:38:03]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/5_en-US.png
[20:38:04]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/6_en-US.png
[20:38:05]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/7_en-US.png
[20:38:05]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/8_en-US.png
[20:38:05]: Downloading `tenInchScreenshots` for en-US...
[20:38:06]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/1_en-US.png
[20:38:07]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/2_en-US.jpeg
[20:38:07]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/3_en-US.png
[20:38:08]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/4_en-US.png
[20:38:09]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/5_en-US.png
[20:38:10]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/6_en-US.png
[20:38:10]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/7_en-US.png
[20:38:11]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/8_en-US.png
[20:38:11]: Downloading `tvScreenshots` for en-US...
[20:38:11]: Downloading `wearScreenshots` for en-US...
[20:38:12]: 📝  Downloading metadata (zh-CN)
[20:38:12]: Writing to metadata/zh-CN/title.txt...
[20:38:12]: Writing to metadata/zh-CN/short_description.txt...
[20:38:12]: Writing to metadata/zh-CN/full_description.txt...
[20:38:12]: Writing to metadata/zh-CN/video.txt...
[20:38:12]: 🖼️  Downloading images (zh-CN)
[20:38:12]: Downloading `featureGraphic` for zh-CN...
[20:38:12]: Downloading `icon` for zh-CN...
[20:38:12]: Downloading `tvBanner` for zh-CN...
[20:38:13]: Downloading `phoneScreenshots` for zh-CN...
[20:38:14]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/1_zh-CN.png
[20:38:14]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/2_zh-CN.jpeg
[20:38:14]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/3_zh-CN.png
[20:38:15]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/4_zh-CN.png
[20:38:15]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/5_zh-CN.png
[20:38:16]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/6_zh-CN.png
[20:38:16]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/7_zh-CN.png
[20:38:17]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/8_zh-CN.png
[20:38:17]: Downloading `sevenInchScreenshots` for zh-CN...
[20:38:18]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/1_zh-CN.png
[20:38:18]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/2_zh-CN.jpeg
[20:38:19]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/3_zh-CN.png
[20:38:19]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/4_zh-CN.png
[20:38:20]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/5_zh-CN.png
[20:38:21]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/6_zh-CN.png
[20:38:22]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/7_zh-CN.png
[20:38:22]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/8_zh-CN.png
[20:38:22]: Downloading `tenInchScreenshots` for zh-CN...
[20:38:23]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/1_zh-CN.png
[20:38:24]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/2_zh-CN.jpeg
[20:38:25]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/3_zh-CN.png
[20:38:25]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/4_zh-CN.png
[20:38:26]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/5_zh-CN.png
[20:38:27]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/6_zh-CN.png
[20:38:27]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/7_zh-CN.png
[20:38:28]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/8_zh-CN.png
[20:38:28]: Downloading `tvScreenshots` for zh-CN...
[20:38:28]: Downloading `wearScreenshots` for zh-CN...
[20:38:29]: 📝  Downloading metadata (zh-TW)
[20:38:29]: Writing to metadata/zh-TW/title.txt...
[20:38:29]: Writing to metadata/zh-TW/short_description.txt...
[20:38:29]: Writing to metadata/zh-TW/full_description.txt...
[20:38:29]: Writing to metadata/zh-TW/video.txt...
[20:38:29]: 🖼️  Downloading images (zh-TW)
[20:38:29]: Downloading `featureGraphic` for zh-TW...
[20:38:29]: Downloading `icon` for zh-TW...
[20:38:29]: Downloading `tvBanner` for zh-TW...
[20:38:30]: Downloading `phoneScreenshots` for zh-TW...
[20:38:31]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/1_zh-TW.png
[20:38:31]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/2_zh-TW.jpeg
[20:38:31]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/3_zh-TW.png
[20:38:32]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/4_zh-TW.png
[20:38:32]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/5_zh-TW.png
[20:38:33]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/6_zh-TW.png
[20:38:33]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/7_zh-TW.png
[20:38:34]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/8_zh-TW.png
[20:38:34]: Downloading `sevenInchScreenshots` for zh-TW...
[20:38:35]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/1_zh-TW.png
[20:38:35]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/2_zh-TW.jpeg
[20:38:36]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/3_zh-TW.png
[20:38:36]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/4_zh-TW.png
[20:38:37]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/5_zh-TW.png
[20:38:38]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/6_zh-TW.png
[20:38:39]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/7_zh-TW.png
[20:38:40]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/8_zh-TW.png
[20:38:40]: Downloading `tenInchScreenshots` for zh-TW...
[20:38:41]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/1_zh-TW.png
[20:38:41]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/2_zh-TW.jpeg
[20:38:42]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/3_zh-TW.png
[20:38:42]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/4_zh-TW.png
[20:38:43]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/5_zh-TW.png
[20:38:44]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/6_zh-TW.png
[20:38:45]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/7_zh-TW.png
[20:38:45]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/8_zh-TW.png
[20:38:45]: Downloading `tvScreenshots` for zh-TW...
[20:38:46]: Downloading `wearScreenshots` for zh-TW...
[20:38:46]: 📝  Downloading metadata (ja-JP)
[20:38:46]: Writing to metadata/ja-JP/title.txt...
[20:38:46]: Writing to metadata/ja-JP/short_description.txt...
[20:38:46]: Writing to metadata/ja-JP/full_description.txt...
[20:38:46]: Writing to metadata/ja-JP/video.txt...
[20:38:46]: 🖼️  Downloading images (ja-JP)
[20:38:46]: Downloading `featureGraphic` for ja-JP...
[20:38:46]: Downloading `icon` for ja-JP...
[20:38:47]: Downloading `tvBanner` for ja-JP...
[20:38:47]: Downloading `phoneScreenshots` for ja-JP...
[20:38:48]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/1_ja-JP.png
[20:38:48]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/2_ja-JP.jpeg
[20:38:49]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/3_ja-JP.png
[20:38:49]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/4_ja-JP.png
[20:38:50]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/5_ja-JP.png
[20:38:50]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/6_ja-JP.png
[20:38:51]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/7_ja-JP.png
[20:38:51]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/8_ja-JP.png
[20:38:51]: Downloading `sevenInchScreenshots` for ja-JP...
[20:38:52]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/1_ja-JP.png
[20:38:52]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/2_ja-JP.jpeg
[20:38:53]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/3_ja-JP.png
[20:38:54]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/4_ja-JP.png
[20:38:55]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/5_ja-JP.png
[20:38:56]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/6_ja-JP.png
[20:38:56]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/7_ja-JP.png
[20:38:57]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/8_ja-JP.png
[20:38:57]: Downloading `tenInchScreenshots` for ja-JP...
[20:38:58]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/1_ja-JP.png
[20:38:58]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/2_ja-JP.jpeg
[20:38:59]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/3_ja-JP.png
[20:38:59]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/4_ja-JP.png
[20:39:00]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/5_ja-JP.png
[20:39:01]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/6_ja-JP.png
[20:39:02]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/7_ja-JP.png
[20:39:02]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/8_ja-JP.png
[20:39:02]: Downloading `tvScreenshots` for ja-JP...
[20:39:03]: Downloading `wearScreenshots` for ja-JP...
[20:39:03]: 📝  Downloading metadata (ko-KR)
[20:39:03]: Writing to metadata/ko-KR/title.txt...
[20:39:03]: Writing to metadata/ko-KR/short_description.txt...
[20:39:03]: Writing to metadata/ko-KR/full_description.txt...
[20:39:03]: Writing to metadata/ko-KR/video.txt...
[20:39:03]: 🖼️  Downloading images (ko-KR)
[20:39:03]: Downloading `featureGraphic` for ko-KR...
[20:39:04]: Downloading `icon` for ko-KR...
[20:39:04]: Downloading `tvBanner` for ko-KR...
[20:39:04]: Downloading `phoneScreenshots` for ko-KR...
[20:39:05]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/1_ko-KR.png
[20:39:06]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/2_ko-KR.jpeg
[20:39:06]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/3_ko-KR.png
[20:39:06]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/4_ko-KR.png
[20:39:07]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/5_ko-KR.png
[20:39:07]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/6_ko-KR.png
[20:39:07]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/7_ko-KR.png
[20:39:08]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/8_ko-KR.png
[20:39:08]: Downloading `sevenInchScreenshots` for ko-KR...
[20:39:09]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/1_ko-KR.png
[20:39:09]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/2_ko-KR.jpeg
[20:39:10]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/3_ko-KR.png
[20:39:10]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/4_ko-KR.png
[20:39:11]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/5_ko-KR.png
[20:39:12]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/6_ko-KR.png
[20:39:13]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/7_ko-KR.png
[20:39:13]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/8_ko-KR.png
[20:39:13]: Downloading `tenInchScreenshots` for ko-KR...
[20:39:14]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/1_ko-KR.png
[20:39:15]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/2_ko-KR.jpeg
[20:39:15]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/3_ko-KR.png
[20:39:16]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/4_ko-KR.png
[20:39:17]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/5_ko-KR.png
[20:39:18]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/6_ko-KR.png
[20:39:19]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/7_ko-KR.png
[20:39:19]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/8_ko-KR.png
[20:39:19]: Downloading `tvScreenshots` for ko-KR...
[20:39:20]: Downloading `wearScreenshots` for ko-KR...
[20:39:21]: Found '46019811 (1.0.2)' in 'internal' track.
[31m
[!] Version '46019811 (1.0.2)' for 'com.hidden.message' does not seem to have any release notes. Nothing to download.[0m

$ echo $?
1
```

</details>


<details>
<summary>After:  (package name is altered)</summary>

```
$ rm -rf metadata/ && bundle exec fastlane supply init --json_key=ci.json --package_name=com.hidden.message --track=internal
[20:41:09]: 🕗  Downloading metadata, images, screenshots...
[20:41:11]: 📝  Downloading metadata (en-US)
[20:41:11]: Writing to metadata/en-US/title.txt...
[20:41:11]: Writing to metadata/en-US/short_description.txt...
[20:41:11]: Writing to metadata/en-US/full_description.txt...
[20:41:11]: Writing to metadata/en-US/video.txt...
[20:41:11]: 🖼️  Downloading images (en-US)
[20:41:11]: Downloading `featureGraphic` for en-US...
[20:41:11]: 	Downloaded - metadata/en-US/images/featureGraphic.png
[20:41:11]: Downloading `icon` for en-US...
[20:41:12]: 	Downloaded - metadata/en-US/images/icon.png
[20:41:12]: Downloading `tvBanner` for en-US...
[20:41:12]: Downloading `phoneScreenshots` for en-US...
[20:41:13]: 	Downloaded - metadata/en-US/images/phoneScreenshots/1_en-US.png
[20:41:14]: 	Downloaded - metadata/en-US/images/phoneScreenshots/2_en-US.jpeg
[20:41:14]: 	Downloaded - metadata/en-US/images/phoneScreenshots/3_en-US.png
[20:41:14]: 	Downloaded - metadata/en-US/images/phoneScreenshots/4_en-US.png
[20:41:15]: 	Downloaded - metadata/en-US/images/phoneScreenshots/5_en-US.png
[20:41:16]: 	Downloaded - metadata/en-US/images/phoneScreenshots/6_en-US.png
[20:41:16]: 	Downloaded - metadata/en-US/images/phoneScreenshots/7_en-US.png
[20:41:16]: 	Downloaded - metadata/en-US/images/phoneScreenshots/8_en-US.png
[20:41:16]: Downloading `sevenInchScreenshots` for en-US...
[20:41:18]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/1_en-US.png
[20:41:18]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/2_en-US.jpeg
[20:41:19]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/3_en-US.png
[20:41:19]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/4_en-US.png
[20:41:21]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/5_en-US.png
[20:41:22]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/6_en-US.png
[20:41:23]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/7_en-US.png
[20:41:23]: 	Downloaded - metadata/en-US/images/sevenInchScreenshots/8_en-US.png
[20:41:23]: Downloading `tenInchScreenshots` for en-US...
[20:41:24]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/1_en-US.png
[20:41:25]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/2_en-US.jpeg
[20:41:25]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/3_en-US.png
[20:41:26]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/4_en-US.png
[20:41:27]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/5_en-US.png
[20:41:28]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/6_en-US.png
[20:41:28]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/7_en-US.png
[20:41:29]: 	Downloaded - metadata/en-US/images/tenInchScreenshots/8_en-US.png
[20:41:29]: Downloading `tvScreenshots` for en-US...
[20:41:29]: Downloading `wearScreenshots` for en-US...
[20:41:30]: 📝  Downloading metadata (zh-CN)
[20:41:30]: Writing to metadata/zh-CN/title.txt...
[20:41:30]: Writing to metadata/zh-CN/short_description.txt...
[20:41:30]: Writing to metadata/zh-CN/full_description.txt...
[20:41:30]: Writing to metadata/zh-CN/video.txt...
[20:41:30]: 🖼️  Downloading images (zh-CN)
[20:41:30]: Downloading `featureGraphic` for zh-CN...
[20:41:30]: Downloading `icon` for zh-CN...
[20:41:30]: Downloading `tvBanner` for zh-CN...
[20:41:31]: Downloading `phoneScreenshots` for zh-CN...
[20:41:32]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/1_zh-CN.png
[20:41:32]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/2_zh-CN.jpeg
[20:41:32]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/3_zh-CN.png
[20:41:33]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/4_zh-CN.png
[20:41:33]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/5_zh-CN.png
[20:41:34]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/6_zh-CN.png
[20:41:34]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/7_zh-CN.png
[20:41:34]: 	Downloaded - metadata/zh-CN/images/phoneScreenshots/8_zh-CN.png
[20:41:34]: Downloading `sevenInchScreenshots` for zh-CN...
[20:41:35]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/1_zh-CN.png
[20:41:36]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/2_zh-CN.jpeg
[20:41:36]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/3_zh-CN.png
[20:41:37]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/4_zh-CN.png
[20:41:38]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/5_zh-CN.png
[20:41:39]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/6_zh-CN.png
[20:41:39]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/7_zh-CN.png
[20:41:40]: 	Downloaded - metadata/zh-CN/images/sevenInchScreenshots/8_zh-CN.png
[20:41:40]: Downloading `tenInchScreenshots` for zh-CN...
[20:41:41]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/1_zh-CN.png
[20:41:41]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/2_zh-CN.jpeg
[20:41:42]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/3_zh-CN.png
[20:41:42]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/4_zh-CN.png
[20:41:43]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/5_zh-CN.png
[20:41:45]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/6_zh-CN.png
[20:41:46]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/7_zh-CN.png
[20:41:46]: 	Downloaded - metadata/zh-CN/images/tenInchScreenshots/8_zh-CN.png
[20:41:46]: Downloading `tvScreenshots` for zh-CN...
[20:41:46]: Downloading `wearScreenshots` for zh-CN...
[20:41:47]: 📝  Downloading metadata (zh-TW)
[20:41:47]: Writing to metadata/zh-TW/title.txt...
[20:41:47]: Writing to metadata/zh-TW/short_description.txt...
[20:41:47]: Writing to metadata/zh-TW/full_description.txt...
[20:41:47]: Writing to metadata/zh-TW/video.txt...
[20:41:47]: 🖼️  Downloading images (zh-TW)
[20:41:47]: Downloading `featureGraphic` for zh-TW...
[20:41:47]: Downloading `icon` for zh-TW...
[20:41:48]: Downloading `tvBanner` for zh-TW...
[20:41:48]: Downloading `phoneScreenshots` for zh-TW...
[20:41:49]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/1_zh-TW.png
[20:41:49]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/2_zh-TW.jpeg
[20:41:50]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/3_zh-TW.png
[20:41:50]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/4_zh-TW.png
[20:41:51]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/5_zh-TW.png
[20:41:52]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/6_zh-TW.png
[20:41:52]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/7_zh-TW.png
[20:41:53]: 	Downloaded - metadata/zh-TW/images/phoneScreenshots/8_zh-TW.png
[20:41:53]: Downloading `sevenInchScreenshots` for zh-TW...
[20:41:54]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/1_zh-TW.png
[20:41:55]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/2_zh-TW.jpeg
[20:41:56]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/3_zh-TW.png
[20:41:56]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/4_zh-TW.png
[20:41:58]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/5_zh-TW.png
[20:41:59]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/6_zh-TW.png
[20:42:00]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/7_zh-TW.png
[20:42:01]: 	Downloaded - metadata/zh-TW/images/sevenInchScreenshots/8_zh-TW.png
[20:42:01]: Downloading `tenInchScreenshots` for zh-TW...
[20:42:02]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/1_zh-TW.png
[20:42:02]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/2_zh-TW.jpeg
[20:42:03]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/3_zh-TW.png
[20:42:04]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/4_zh-TW.png
[20:42:05]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/5_zh-TW.png
[20:42:06]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/6_zh-TW.png
[20:42:07]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/7_zh-TW.png
[20:42:07]: 	Downloaded - metadata/zh-TW/images/tenInchScreenshots/8_zh-TW.png
[20:42:07]: Downloading `tvScreenshots` for zh-TW...
[20:42:08]: Downloading `wearScreenshots` for zh-TW...
[20:42:08]: 📝  Downloading metadata (ja-JP)
[20:42:08]: Writing to metadata/ja-JP/title.txt...
[20:42:08]: Writing to metadata/ja-JP/short_description.txt...
[20:42:08]: Writing to metadata/ja-JP/full_description.txt...
[20:42:08]: Writing to metadata/ja-JP/video.txt...
[20:42:08]: 🖼️  Downloading images (ja-JP)
[20:42:08]: Downloading `featureGraphic` for ja-JP...
[20:42:08]: Downloading `icon` for ja-JP...
[20:42:09]: Downloading `tvBanner` for ja-JP...
[20:42:09]: Downloading `phoneScreenshots` for ja-JP...
[20:42:10]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/1_ja-JP.png
[20:42:10]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/2_ja-JP.jpeg
[20:42:11]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/3_ja-JP.png
[20:42:11]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/4_ja-JP.png
[20:42:11]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/5_ja-JP.png
[20:42:12]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/6_ja-JP.png
[20:42:12]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/7_ja-JP.png
[20:42:13]: 	Downloaded - metadata/ja-JP/images/phoneScreenshots/8_ja-JP.png
[20:42:13]: Downloading `sevenInchScreenshots` for ja-JP...
[20:42:14]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/1_ja-JP.png
[20:42:14]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/2_ja-JP.jpeg
[20:42:15]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/3_ja-JP.png
[20:42:15]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/4_ja-JP.png
[20:42:16]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/5_ja-JP.png
[20:42:17]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/6_ja-JP.png
[20:42:18]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/7_ja-JP.png
[20:42:18]: 	Downloaded - metadata/ja-JP/images/sevenInchScreenshots/8_ja-JP.png
[20:42:18]: Downloading `tenInchScreenshots` for ja-JP...
[20:42:19]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/1_ja-JP.png
[20:42:20]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/2_ja-JP.jpeg
[20:42:20]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/3_ja-JP.png
[20:42:21]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/4_ja-JP.png
[20:42:21]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/5_ja-JP.png
[20:42:22]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/6_ja-JP.png
[20:42:23]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/7_ja-JP.png
[20:42:24]: 	Downloaded - metadata/ja-JP/images/tenInchScreenshots/8_ja-JP.png
[20:42:24]: Downloading `tvScreenshots` for ja-JP...
[20:42:24]: Downloading `wearScreenshots` for ja-JP...
[20:42:24]: 📝  Downloading metadata (ko-KR)
[20:42:24]: Writing to metadata/ko-KR/title.txt...
[20:42:24]: Writing to metadata/ko-KR/short_description.txt...
[20:42:24]: Writing to metadata/ko-KR/full_description.txt...
[20:42:24]: Writing to metadata/ko-KR/video.txt...
[20:42:24]: 🖼️  Downloading images (ko-KR)
[20:42:24]: Downloading `featureGraphic` for ko-KR...
[20:42:25]: Downloading `icon` for ko-KR...
[20:42:25]: Downloading `tvBanner` for ko-KR...
[20:42:25]: Downloading `phoneScreenshots` for ko-KR...
[20:42:26]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/1_ko-KR.png
[20:42:27]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/2_ko-KR.jpeg
[20:42:27]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/3_ko-KR.png
[20:42:27]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/4_ko-KR.png
[20:42:28]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/5_ko-KR.png
[20:42:28]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/6_ko-KR.png
[20:42:29]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/7_ko-KR.png
[20:42:29]: 	Downloaded - metadata/ko-KR/images/phoneScreenshots/8_ko-KR.png
[20:42:29]: Downloading `sevenInchScreenshots` for ko-KR...
[20:42:30]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/1_ko-KR.png
[20:42:31]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/2_ko-KR.jpeg
[20:42:31]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/3_ko-KR.png
[20:42:32]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/4_ko-KR.png
[20:42:33]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/5_ko-KR.png
[20:42:34]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/6_ko-KR.png
[20:42:34]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/7_ko-KR.png
[20:42:35]: 	Downloaded - metadata/ko-KR/images/sevenInchScreenshots/8_ko-KR.png
[20:42:35]: Downloading `tenInchScreenshots` for ko-KR...
[20:42:36]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/1_ko-KR.png
[20:42:36]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/2_ko-KR.jpeg
[20:42:37]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/3_ko-KR.png
[20:42:37]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/4_ko-KR.png
[20:42:38]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/5_ko-KR.png
[20:42:39]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/6_ko-KR.png
[20:42:39]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/7_ko-KR.png
[20:42:40]: 	Downloaded - metadata/ko-KR/images/tenInchScreenshots/8_ko-KR.png
[20:42:40]: Downloading `tvScreenshots` for ko-KR...
[20:42:40]: Downloading `wearScreenshots` for ko-KR...
[20:42:42]: Found '46019811 (1.0.2)' in 'internal' track.
[20:42:42]: Version '46019811 (1.0.2)' for 'com.hidden.message' does not seem to have any release notes. Nothing to download.
[20:42:42]: [32m✅  Successfully stored metadata in 'metadata'[0m

$ echo $?
0
```

</details>