### PR TITLE
[pem] fix issue OpenSSL empty password

### DIFF
--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -73,7 +73,8 @@ module PEM
 
         if PEM.config[:generate_p12]
           p12_cert_path = File.join(output_path, "#{filename_base}.p12")
-          p12 = OpenSSL::PKCS12.create(PEM.config[:p12_password], certificate_type, pkey, x509_certificate)
+          p12_password = PEM.config[:p12_password] == "" ? nil : PEM.config[:p12_password]
+          p12 = OpenSSL::PKCS12.create(p12_password, certificate_type, pkey, x509_certificate)
           File.write(p12_cert_path, p12.to_der)
           UI.message("p12 certificate: ".green + Pathname.new(p12_cert_path).realpath.to_s)
         end

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -86,7 +86,7 @@ module PEM
                                      env_name: "PEM_P12_PASSWORD",
                                      sensitive: true,
                                      description: "The password that is used for your p12 file",
-                                     default_value: ""),
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :pem_name,
                                      short_option: "-o",
                                      env_name: "PEM_FILE_NAME",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves [this issue](https://github.com/fastlane/fastlane/issues/2808). I'm having similar problems: passing an empty password to `pem` will make the generated `p12` file impossible to import to the Keychain.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
`OpenSSL` seems to have some kind of issue if the `passphrase` used to generate a `PKCS12` file is `""` (empty string). Thus, I'm replacing that with a `nil` value and also marking the parameter as `optional` (not doing so makes the user to introduce it manually).

After the fix in this pull-request, it looks like this:
https://user-images.githubusercontent.com/11335612/136920514-b6730a44-5804-4a08-9655-9264b1923993.mov

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
* Use `pem` lane and enable `generate_p12` option. Don't pass any `p12_password`.
```
# inside custom lane...
pem(
  development: options[:development],
  generate_p12: true,
  force: true,
  app_identifier: app_identifier,
  username: username,
  team_id: team_id,
  team_name: team_name,
  pem_name: app_name
)
```
* Try to import to Keychain (double-click) and introduce an empty `passphrase` when asked.
https://user-images.githubusercontent.com/11335612/136920349-7aba2681-499e-48ce-9d92-8caed2eb7b3b.mov
