### PR TITLE
[snapshot] add iPad mini devices so that they can be included in the HTML report page

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -117,6 +117,10 @@ module Snapshot
         'iPad Air' => 'iPad Air',
         'iPad (5th generation)' => 'iPad (5th generation)',
         'iPad (7th generation)' => 'iPad (7th generation)',
+        'iPad mini 2' => 'iPad mini 2',
+        'iPad mini 3' => 'iPad mini 3',
+        'iPad mini 4' => 'iPad mini 4',
+        'iPad mini (6th generation)' => 'iPad mini (6th generation)',
         'iPad Pro (9.7-inch)' => 'iPad Pro (9.7-inch)',
         'iPad Pro (9.7 inch)' => 'iPad Pro (9.7-inch)', # iOS 10.3.1 simulator
         'iPad Pro (10.5-inch)' => 'iPad Pro (10.5-inch)',


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Adding snapshot support for iPad mini devices