### PR TITLE
[scan] Add `Success rate` row to results

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -156,7 +156,8 @@ module Scan
         title: "Test Results",
         rows: [
           ["Number of tests", result[:tests]],
-          ["Number of failures", failures_str]
+          ["Number of failures", failures_str],
+          ["Success rate", result[:failures].fdiv(result[:tests]).round(2).to_s + " %"]
         ]
       }))
       puts("")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change adds `Success rate` row to results so user gains better idea how many (percentage) tests are passing/failing.

### Description
Add new row when puts results.
