### PR TITLE
Start of fixing snapshot for mac

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -22,6 +22,8 @@ module FastlaneCore
           output = stdout.read
         end
 
+        @devices << Device.new(name: "Mac", os_type: "macOS", os_version: nil, udid: nil, state: "Booted", is_simulator: false)
+
         runtime_info = ''
         Open3.popen3('xcrun simctl list runtimes') do |stdin, stdout, stderr, wait_thr|
           # This regex outputs the version info in the format "<platform> <version><exact version>"


### PR DESCRIPTION
### Motivation and Context
Fixes #18709 

### Description
- [x] fix SnapshotHelper.swift to take screenshot
- [ ] fix SnapshotHelper.swift to take screenshot without window frame
- [ ] fix the snapshot image collector to look in the Mac library caches under bundle id for the snapshots taken
- [ ] maybe update docs
