### PR TITLE
[screengrab] version bump lib to 2.1.1

### DIFF
--- a/screengrab/version.properties
+++ b/screengrab/version.properties
@@ -1,3 +1,3 @@
 major=2
 minor=1
-patch=0
+patch=1


### PR DESCRIPTION
### Motivation and Context
Fixes #19480

### Description
Dependency for falcon was already changed to 2.2.0 but version needs to be bumped and also deployed out to maven central
