### PR TITLE
Fix get_app_preview_sets

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
@@ -58,9 +58,9 @@ module Spaceship
       # API
       #
 
-      def self.all(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+      def self.all(client: nil, app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
-        resp = client.get_app_preview_sets(filter: filter, includes: includes, limit: limit, sort: sort)
+        resp = client.get_app_preview_sets(app_store_version_localization_id: app_store_version_localization_id, filter: filter, includes: includes, limit: limit, sort: sort)
         return resp.to_models
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
@@ -70,7 +70,7 @@ module Spaceship
         client ||= Spaceship::ConnectAPI
         filter ||= {}
         filter["appStoreVersionLocalization"] = id
-        return Spaceship::ConnectAPI::AppPreviewSet.all(client: client, filter: filter, includes: includes, limit: limit, sort: sort)
+        return Spaceship::ConnectAPI::AppPreviewSet.all(client: client, app_store_version_localization_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
       end
 
       def create_app_preview_set(client: nil, attributes: nil)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -354,9 +354,9 @@ module Spaceship
         # appPreviewSets
         #
 
-        def get_app_preview_sets(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_app_preview_sets(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appPreviewSets", params)
+          tunes_request_client.get("appStoreVersionLocalizations/#{app_store_version_localization_id}/appPreviewSets", params)
         end
 
         def get_app_preview_set(app_preview_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)


### PR DESCRIPTION
🔑
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently in Spaceship I get errors when calling the get_app_preview_sets function of AppStoreVersionLocalization. The error message says that this resource does not allow get_collection requests.

### Description
When using Spaceship to retrieve App Preview Sets the get_app_preview_sets request URL is incorrect. The correct request URL is: "appStoreVersionLocalizations/#{app_store_version_localization_id}/appPreviewSets". To fix this I've simply copied the style used when retrieving screenshot sets which follows the same format.

### Testing Steps
```
require 'spaceship'

app_name = '<app_name>'
key_id = '<key_id>'
issuer_id = '<issuer_id>'
token_path = '<path to your API key>'
language_with_app_previews = 'language code i.e. en-US'

token = Spaceship::ConnectAPI::Token.create(
  key_id: key_id,
  issuer_id: issuer_id,
  filepath:  File.absolute_path(token_path)
)

Spaceship::ConnectAPI.token = token

app = Spaceship::ConnectAPI::App.find(app_name)

version = app.get_edit_app_store_version(includes: 'appStoreVersionLocalizations')
localizations = version.app_store_version_localizations
lang_locale = localizations.select{ |locale| locale.locale == language_with_app_previews }.first

preview_sets = lang_locale.get_app_preview_sets # This step will fail prior to this PR
puts "Preview Sets: #{preview_sets}"
```
