### PR TITLE
[spaceship] refresh token and retry on authorization errors

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -157,8 +157,6 @@ module Spaceship
       end
 
       def with_asc_retry(tries = 5, &_block)
-        tries = 1 if Object.const_defined?("SpecHelper")
-
         response = yield
 
         status = response.status if response

--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -170,9 +170,16 @@ module Spaceship
 
         return response
       rescue UnauthorizedAccessError => error
-        # Catch unathorized access and re-raising
-        # There is no need to try again
-        raise error
+        tries -= 1
+        puts(error) if Spaceship::Globals.verbose?
+        if tries.zero?
+          raise error
+        else
+          msg = "Token has expired or has been revoked! Trying to refresh..."
+          puts(msg) if Spaceship::Globals.verbose?
+          @token.refresh!
+          retry
+        end
       rescue TimeoutRetryError => error
         tries -= 1
         puts(error) if Spaceship::Globals.verbose?

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -102,6 +102,8 @@ describe Spaceship::ConnectAPI::APIClient do
       body = JSON.generate({ "errors": [] })
       stub_client_request(client.hostname, 401, body)
 
+      expect(mock_token).to receive(:refresh!).exactly(4).times
+
       expect do
         client.get('')
       end.to raise_error(Spaceship::UnauthorizedAccessError)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Apple seems to be revoking tokens before their expiration dates. Several
users reporting problems on issue [#19072][1] were likely affected by
it. Sometimes changing the token duration will work around the problem,
as the tokens are likely being revoked later in the future and allowing
the wait to complete.

This can be seen in practice by adding a `@token.refresh!` couple of extra log
messages to [api_client.rb][2] right at the point where we get an
`UnauthorizedAccessError`:

```
INFO  [2021-10-19 18:38:31.74]: Successfully uploaded the new binary to App Store Connect
INFO  [2021-10-19 18:38:31.74]: If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option
INFO  [2021-10-19 18:38:31.74]: Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.
DEBUG [2021-10-19 18:38:31.82]: App Platform (ios)
INFO  [2021-10-19 18:38:31.92]: Waiting for processing on... app_id: 1370986669, app_version: 2.23.2, build_version: 262025, platform: IOS
WARN  [2021-10-19 18:38:32.26]: Read more information on why this build isn't showing up yet - https://github.com/fastlane/fastlane/issues/14997
INFO  [2021-10-19 18:38:32.26]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
INFO  [2021-10-19 18:39:02.70]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)

token expired?: false  - expiration: 2021-10-19 18:45:04 -0400
Token has expired, has been revoked, or is invalid! Trying to refresh

INFO  [2021-10-19 18:39:33.26]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
INFO  [2021-10-19 18:40:03.69]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
INFO  [2021-10-19 18:40:34.33]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
INFO  [2021-10-19 18:41:04.76]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
INFO  [2021-10-19 18:41:35.21]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
INFO  [2021-10-19 18:42:05.67]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)

token expired?: false  - expiration: 2021-10-19 18:47:52 -0400
Token has expired, has been revoked, or is invalid! Trying to refresh

INFO  [2021-10-19 18:42:36.34]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
INFO  [2021-10-19 18:43:06.80]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
INFO  [2021-10-19 18:43:37.23]: Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)
```

The logs above show that, even though the current token is not expired, the
appconnect API responds with a 401 and the process would otherwise fail.


### Description

This refreshes the token and adds retries to `UnauthorizedAccessError`
before ultimately raising the error if it still continues to fail.

[1]: https://github.com/fastlane/fastlane/issues/19072
[2]: https://github.com/fastlane/fastlane/blob/62af236780a9eace9d0487d0767f50d1a17a1c6c/spaceship/lib/spaceship/connect_api/api_client.rb#L172-L175