### PR TITLE
[gym] measure build time in gym and share data to lane_context

### DIFF
--- a/fastlane/lib/fastlane/actions/build_app.rb
+++ b/fastlane/lib/fastlane/actions/build_app.rb
@@ -5,6 +5,7 @@ module Fastlane
       PKG_OUTPUT_PATH ||= :PKG_OUTPUT_PATH
       DSYM_OUTPUT_PATH ||= :DSYM_OUTPUT_PATH
       XCODEBUILD_ARCHIVE ||= :XCODEBUILD_ARCHIVE # originally defined in XcodebuildAction
+      GYM_BUILD_TIME = :GYM_BUILD_TIME
     end
 
     class BuildAppAction < Action
@@ -65,7 +66,8 @@ module Fastlane
           end
         end
 
-        gym_output_path = Gym::Manager.new.work(values)
+        manager = Gym::Manager.new
+        gym_output_path = manager.work(values)
         if gym_output_path.nil?
           UI.important("No output path received from gym")
           return nil
@@ -95,6 +97,10 @@ module Fastlane
           ENV[SharedValues::DSYM_OUTPUT_PATH.to_s] = absolute_dsym_path
         end
 
+        # build time spent for `xcodebuild build/archive`
+        # If you give true to skip_build_archive, this is going to be `nil`.
+        Actions.lane_context[SharedValues::GYM_BUILD_TIME] = manager.build_time
+
         return absolute_output_path
       end
       # rubocop:enable Metrics/PerceivedComplexity
@@ -112,7 +118,8 @@ module Fastlane
           ['IPA_OUTPUT_PATH', 'The path to the newly generated ipa file'],
           ['PKG_OUTPUT_PATH', 'The path to the newly generated pkg file'],
           ['DSYM_OUTPUT_PATH', 'The path to the dSYM files'],
-          ['XCODEBUILD_ARCHIVE', 'The path to the xcodebuild archive']
+          ['XCODEBUILD_ARCHIVE', 'The path to the xcodebuild archive'],
+          ['GYM_BUILD_TIME', 'The build time spent for xcodebuild archive/build']
         ]
       end
 

--- a/gym/lib/gym/manager.rb
+++ b/gym/lib/gym/manager.rb
@@ -4,6 +4,10 @@ require_relative 'runner'
 
 module Gym
   class Manager
+    def initialize
+      @runner = Runner.new
+    end
+
     def work(options)
       Gym.config = options
 
@@ -16,7 +20,11 @@ module Gym
                                          hide_keys: [],
                                              title: "Summary for gym #{Fastlane::VERSION}")
 
-      return Runner.new.run
+      return @runner.run
+    end
+
+    def build_time
+      @runner.build_time
     end
   end
 end

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -12,6 +12,9 @@ require_relative 'error_handler'
 
 module Gym
   class Runner
+    # @return (Float) Elapsed time for `xcodebuild archive` or `build`
+    attr_reader :build_time
+
     # @return (String) The path to the resulting ipa
     def run
       unless Gym.config[:skip_build_archive]
@@ -107,13 +110,14 @@ module Gym
     def build_app
       command = BuildCommandGenerator.generate
       print_command(command, "Generated Build Command") if FastlaneCore::Globals.verbose?
+      start = Time.now
       FastlaneCore::CommandExecutor.execute(command: command,
                                           print_all: true,
                                       print_command: !Gym.config[:silent],
                                               error: proc do |output|
                                                 ErrorHandler.handle_build_error(output)
                                               end)
-
+      @build_time = Time.now - start
       unless Gym.config[:skip_archive]
         mark_archive_as_built_by_gym(BuildCommandGenerator.archive_path)
         UI.success("Successfully stored the archive. You can find it in the Xcode Organizer.") unless Gym.config[:archive_path].nil?


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

In my project, we are measuring build time by wrapping `build_ios_app` with Benchmark.measure`, like below. This is enough to monitor the trend of changes in our app's build time. 

```ruby
tms = Benchmark.measure do 
  build_ios_app
end
UI.message("Build Time: #{tms.real} secs")
```

However, this is not only inaccurate to see how much time "xcodebuild archive" spends but also not looking great on `Fastfile` as it brings "Ruby" code to fastlane's beautiful DSLs.

This PR adds a small tweak to expose the elapsed time for building/archiving app in `gym` to `Actions.lane_context`, which then we can use it for logging.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I considered using `Benchmark` module initially as I used it in our project but realised `require 'benchmark'` in fastlane is not worth doing because `Benchmark` is useful when it comes to measuring "CPU time" that is executing code but `xcodebuild archive` normally takes time for IO for copying files so CPU time isn't suitable to see build time. 

Instead I simply used `Time.now` to get start time and finish time and worked out the elapsed time!

There are various tools to check build time but this PR's one benefits by having no dependency other than fastlane itself. 

https://github.com/MobileNativeFoundation/XCLogParser


### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Add this to Gemfile and run `bundle install`

```ruby
gem 'fastlane', git: 'https://github.com/ainame/fastlane.git', branch: 'measure-build-time'
```

You can test this with something like this lane.

```ruby
lane :test do 
  match
  build_ios_app
  UI.message("Build Time = #{Actions.lane_context[SharedValues::GYM_BUILD_TIME]} secs")
end