### PR TITLE
[scan] Fixed typo in error message

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -226,7 +226,7 @@ module Scan
         FileUtils.cp(xctestrun_file, output_path)
         UI.message("Successfully copied xctestrun file: #{output_path}")
       else
-        UI.user_error!("Could not find .xctextrun file to copy")
+        UI.user_error!("Could not find .xctestrun file to copy")
       end
     end
 


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Minor typo in a user-facing error message. I came across this error in one of my builds and it threw me off slightly as I didn't expect that filename.
I don't have access to my Mac at this time so I wasn't able to run the tests but I presume that this shouldn't break anything.
