### PR TITLE
[gym] add suppress_xcode_warnings flag

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -72,6 +72,9 @@ module Gym
       def pipe
         pipe = []
         pipe << "| tee #{xcodebuild_log_path.shellescape}"
+        if Gym.config[:suppress_xcode_warnings]
+          pipe << "| sed -e '/warning:/,/\^/d'"
+        end
         unless Gym.config[:disable_xcpretty]
           formatter = Gym.config[:xcpretty_formatter]
           pipe << "| xcpretty"

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -224,6 +224,11 @@ module Gym
                                      verify_block: proc do |value|
                                        UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
+        FastlaneCore::ConfigItem.new(key: :suppress_xcode_warnings,
+                                     env_name: "SUPPRESS_XCODE_WARNINGS",
+                                     description: "Suppress only warnings from the output of xcodebuild to stdout. Output warnings is still saved in buildlog_path",
+                                     optional: true,
+                                     type: Boolean),
         FastlaneCore::ConfigItem.new(key: :suppress_xcode_output,
                                      short_option: "-r",
                                      env_name: "SUPPRESS_OUTPUT",

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -65,6 +65,30 @@ describe Gym do
                            ])
     end
 
+    it "suppressing xcode warnings", requires_xcodebuild: true do
+      log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
+
+      xcargs = { DEBUG: "1", BUNDLE_NAME: "Example App" }
+      options = { project: "./gym/examples/standard/Example.xcodeproj", sdk: "9.0", xcargs: xcargs, scheme: 'Example', suppress_xcode_warnings: true }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      result = Gym::BuildCommandGenerator.generate
+      expect(result).to eq([
+                             "set -o pipefail &&",
+                             "xcodebuild",
+                             "-scheme Example",
+                             "-project ./gym/examples/standard/Example.xcodeproj",
+                             "-sdk '9.0'",
+                             "-destination 'generic/platform=iOS'",
+                             "-archivePath #{Gym::BuildCommandGenerator.archive_path.shellescape}",
+                             "DEBUG=1 BUNDLE_NAME=Example\\ App",
+                             :archive,
+                             "| tee #{log_path.shellescape}",
+                             "| sed -e '/warning:/,/\^/d'",
+                             "| xcpretty"
+                           ])
+    end
+
     it "enables unicode", requires_xcodebuild: true do
       log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I had a problem with the large cicd log output and I have to cut off warnings in the log. I know that `gym` has a `suppress_xcode_output` flag, but it turns off all xcode output which has a useful information. 
I think most of big project has a problem with the large warnings list, which you don't need to see in cicd logs.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
I've added `suppress_xcode_warnings` which is adds `sed` filtering for warnings.
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
2 screenshots with and without suppress_xcode_warnings flag
applyied for project [standard.zip](https://github.com/fastlane/fastlane/files/7403048/standard.zip)
![image](https://user-images.githubusercontent.com/26646435/138558266-350e5d90-4eca-42bf-8b8c-bb91bb9e89c9.png)

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
