### PR TITLE
[action][download_dsyms] fix: `download_dsyms` with `wait_for_dsym_processing` is not checking the latest data from Connect API

### DIFF
--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -114,39 +114,39 @@ module Fastlane
           end
 
           UI.verbose("Build_version: #{asc_build_number} matches #{build_number}, grabbing dsym_url") if build_number
-
-          build.build_bundles&.each do |build_bundle|
-            download_dsym(build_bundle: build_bundle, build: build, app: app, wait_for_dsym_processing: wait_for_dsym_processing, wait_timeout: wait_timeout, output_directory: output_directory)
-          end
+          download_dsym(build: build, app: app, wait_for_dsym_processing: wait_for_dsym_processing, wait_timeout: wait_timeout, output_directory: output_directory)
         end
       end
 
-      def self.download_dsym(build_bundle: nil, build: nil, app: nil, wait_for_dsym_processing: nil, wait_timeout: nil, output_directory: nil)
+      def self.download_dsym(build: nil, app: nil, wait_for_dsym_processing: nil, wait_timeout: nil, output_directory: nil)
         start = Time.now
-        download_url = nil
+        dsym_urls = []
 
         loop do
-          download_url = build_bundle.dsym_url
+          build_bundles = build.build_bundles.select { |b| b.includes_symbols == true }
+          dsym_urls = build_bundles.map(&:dsym_url).compact
 
-          unless download_url
-            if !wait_for_dsym_processing || (Time.now - start) > wait_timeout
-              # In some cases, AppStoreConnect does not process the dSYMs, thus no error should be thrown.
-              UI.message("Could not find any dSYM for #{build.version} (#{build.app_version})")
-            else
-              UI.message("Waiting for dSYM file to appear...")
-              sleep(30)
-              next
-            end
+          break if build_bundles.count == dsym_urls.count
+
+          if !wait_for_dsym_processing || (Time.now - start) > wait_timeout
+            # In some cases, AppStoreConnect does not process the dSYMs, thus no error should be thrown.
+            UI.message("Could not find any dSYM for #{build.version} (#{build.app_version})")
+            break
+          else
+            UI.message("Waiting for dSYM file to appear...")
+            sleep(30)
+            build = Spaceship::ConnectAPI::Build.get(build_id: build.id)
+            next
           end
-
-          break
         end
 
-        if download_url
-          self.download(download_url, build, app, output_directory)
-          return if build.version
-        else
+        if dsym_urls.count == 0
           UI.message("No dSYM URL for #{build.version} (#{build.app_version})")
+        else
+          dsym_urls.each do |url|
+            self.download(url, build, app, output_directory)
+          end
+          return if build.version
         end
       end
       # rubocop:enable Metrics/PerceivedComplexity

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -136,7 +136,6 @@ module Fastlane
             UI.message("Waiting for dSYM file to appear...")
             sleep(30) unless FastlaneCore::Helper.is_test?
             build = Spaceship::ConnectAPI::Build.get(build_id: build.id)
-            next
           end
         end
 
@@ -146,7 +145,6 @@ module Fastlane
           dsym_urls.each do |url|
             self.download(url, build, app, output_directory)
           end
-          return if build.version
         end
       end
       # rubocop:enable Metrics/PerceivedComplexity

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -134,7 +134,7 @@ module Fastlane
             break
           else
             UI.message("Waiting for dSYM file to appear...")
-            sleep(30)
+            sleep(30) unless FastlaneCore::Helper.is_test?
             build = Spaceship::ConnectAPI::Build.get(build_id: build.id)
             next
           end

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -44,6 +44,7 @@ describe Fastlane do
         allow(build6).to receive(:build_bundles).and_return([build_bundle])
 
         allow(build_bundle).to receive(:dsym_url).and_return(download_url)
+        allow(build_bundle).to receive(:includes_symbols).and_return(true)
 
         allow(empty_build).to receive(:build_bundles).and_return(nil)
 

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -93,7 +93,7 @@ describe Fastlane do
            [build5, '2.0.0', '2', '2020-09-12T14:00:00+01:00'],
            [build6, '2.0.0', '5', '2020-09-12T15:00:00+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
-            expect(build).to receive(:version).and_return(build_number).twice
+            expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
             expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, build, app, nil)
           end
@@ -125,10 +125,7 @@ describe Fastlane do
           expect(Spaceship::ConnectAPI::Build).to receive(:get).with(build_id: build_id).and_return(build1)
 
           build = build1
-          expect(build).to receive(:version).and_return(build_number)
-
           expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, build, app, nil)
-
           expect(Fastlane::Actions::DownloadDsymsAction).not_to(receive(:download))
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -143,7 +140,7 @@ describe Fastlane do
 
           [[build1, '1.07.0', '3', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
-            expect(build).to receive(:version).and_return(build_number).twice
+            expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
             expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, build, app, nil)
           end
@@ -160,7 +157,7 @@ describe Fastlane do
 
           [[build1, '2.0.0', '2', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
-            expect(build).to receive(:version).and_return(build_number).twice
+            expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
             expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, build, app, nil)
           end
@@ -185,7 +182,7 @@ describe Fastlane do
 
           [[build2, '2.0.0', '3', '2020-09-12T11:00:00+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version).twice
-            expect(build).to receive(:version).and_return(build_number).exactly(3).times
+            expect(build).to receive(:version).and_return(build_number).exactly(2).times
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
 
             expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, build, app, nil)
@@ -215,7 +212,7 @@ describe Fastlane do
 
           [[build2, '1.0.0', '42', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
-            expect(build).to receive(:version).and_return(build_number).twice
+            expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
 
             expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, build, app, nil)
@@ -239,7 +236,7 @@ describe Fastlane do
 
           [[build2, '2.0.0', '42', '2020-09-12T14:10:30+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
-            expect(build).to receive(:version).and_return(build_number).twice
+            expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
 
             expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, build, app, nil)
@@ -267,7 +264,7 @@ describe Fastlane do
           [[build5, '2.0.0', '2', '2020-09-12T14:00:00+01:00'],
            [build6, '2.0.0', '5', '2020-09-12T15:00:00+01:00']].each do |build, version, build_number, uploaded_date|
             expect(build).to receive(:app_version).and_return(version)
-            expect(build).to receive(:version).and_return(build_number).twice
+            expect(build).to receive(:version).and_return(build_number)
             expect(build).to receive(:uploaded_date).and_return(uploaded_date)
             expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, build, app, nil)
           end

--- a/fastlane/spec/actions_specs/download_dsyms_spec.rb
+++ b/fastlane/spec/actions_specs/download_dsyms_spec.rb
@@ -17,9 +17,11 @@ describe Fastlane do
       let(:build6) { double('build6') }
 
       let(:build_bundle) { double('build_bundle') }
-      let(:empty_build_bundle) { double('empty_build_bundle') }
+      let(:not_processed_build_bundle) { double('not_processed_build_bundle') }
+      let(:no_symbols_build_bundle) { double('no_symbols_build_bundle') }
 
-      let(:empty_build) { double('empty_build') }
+      let(:not_processed_build) { double('not_processed_build') }
+      let(:no_symbols_build) { double('no_symbols_build') }
 
       let(:download_url) { 'https://example.com/myapp-dsym' }
 
@@ -43,10 +45,17 @@ describe Fastlane do
         allow(build5).to receive(:build_bundles).and_return([build_bundle])
         allow(build6).to receive(:build_bundles).and_return([build_bundle])
 
+        allow(not_processed_build).to receive(:build_bundles).and_return([not_processed_build_bundle])
+        allow(no_symbols_build).to receive(:build_bundles).and_return([no_symbols_build_bundle])
+
         allow(build_bundle).to receive(:dsym_url).and_return(download_url)
         allow(build_bundle).to receive(:includes_symbols).and_return(true)
 
-        allow(empty_build).to receive(:build_bundles).and_return(nil)
+        allow(not_processed_build_bundle).to receive(:dsym_url).and_return(nil)
+        allow(not_processed_build_bundle).to receive(:includes_symbols).and_return(true)
+
+        allow(no_symbols_build_bundle).to receive(:dsym_url).and_return(nil)
+        allow(no_symbols_build_bundle).to receive(:includes_symbols).and_return(false)
 
         allow(Fastlane::Actions::DownloadDsymsAction).to receive(:download)
       end
@@ -93,6 +102,37 @@ describe Fastlane do
 
           Fastlane::FastFile.new.parse("lane :test do
               download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp')
+          end").runner.execute(:test)
+        end
+      end
+
+      context 'with wait_for_dsym_processing' do
+        it 'downloads all dsyms of all builds in all trains' do
+          expect(build_resp).to receive(:to_models).and_return([not_processed_build])
+
+          # Returns not processed build (no dsym url)
+          build = not_processed_build
+          build_id = 1
+          version = '2.0.0'
+          build_number = '5'
+          uploaded_date = '2020-09-12T15:00:00+01:00'
+          expect(build).to receive(:id).and_return(build_id)
+          expect(build).to receive(:app_version).and_return(version)
+          expect(build).to receive(:version).and_return(build_number)
+          expect(build).to receive(:uploaded_date).and_return(uploaded_date)
+
+          # Refetches build info
+          expect(Spaceship::ConnectAPI::Build).to receive(:get).with(build_id: build_id).and_return(build1)
+
+          build = build1
+          expect(build).to receive(:version).and_return(build_number)
+
+          expect(Fastlane::Actions::DownloadDsymsAction).to receive(:download).with(download_url, build, app, nil)
+
+          expect(Fastlane::Actions::DownloadDsymsAction).not_to(receive(:download))
+
+          Fastlane::FastFile.new.parse("lane :test do
+              download_dsyms(username: 'user@fastlane.tools', app_identifier: 'tools.fastlane.myapp', wait_for_dsym_processing: true)
           end").runner.execute(:test)
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
PR #19508 introduced `download_dsyms` to the Appstore Connect API, however when the symbols are still in the processing phase and we call the action with the parameter `wait_for_dsym_processing` set to `true`, the action was not updating the build data in order to get the newly created download URL.

Fix #19569

### Description
A change was made to check if the number of available URLs is the same as build bundles (app or app clips) that include symbols. If these numbers are different and the flag `wait_for_dsym_processing` is true, so it waits 30 seconds and requests new data from the API.
The previous behavior is still there of already processed symbols.

### Testing Steps
To test this you should use a combination of `upload_to_testflight` + `download_dsyms(wait_for_dsym_processing: true)` in order to make it work.
