### PR TITLE
[pem] Add macOS platform support

### DIFF
--- a/fastlane/lib/fastlane/actions/get_push_certificate.rb
+++ b/fastlane/lib/fastlane/actions/get_push_certificate.rb
@@ -60,7 +60,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac].include?(platform)
       end
 
       def self.example_code

--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -20,11 +20,11 @@ module PEM
           remaining_days = (existing_certificate.expires - Time.now) / 60 / 60 / 24
 
           display_platform = ''
-          if PEM.config[:website_push]
-            display_platform = " #{PEM.config[:platform]} platform"
+          unless PEM.config[:website_push]
+            display_platform = "#{PEM.config[:platform]} "
           end
 
-          UI.message("Existing push notification profile for '#{existing_certificate.owner_name}'#{display_platform} is valid for #{remaining_days.round} more days.")
+          UI.message("Existing #{display_platform}push notification profile for '#{existing_certificate.owner_name}' is valid for #{remaining_days.round} more days.")
           if remaining_days > PEM.config[:active_days_limit]
             if PEM.config[:force]
               UI.success("You already have an existing push certificate, but a new one will be created since the --force option has been set.")

--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -19,12 +19,12 @@ module PEM
         if existing_certificate
           remaining_days = (existing_certificate.expires - Time.now) / 60 / 60 / 24
 
-          platfrom_string = ''
-          if PEM.config[:platform] && !PEM.config[:website_push]
-            platfrom_string = " #{PEM.config[:platform]} platform"
+          display_platform = ''
+          if PEM.config[:website_push]
+            display_platform = " #{PEM.config[:platform]} platform"
           end
 
-          UI.message("Existing push notification profile for '#{existing_certificate.owner_name}'#{platfrom_string} is valid for #{remaining_days.round} more days.")
+          UI.message("Existing push notification profile for '#{existing_certificate.owner_name}'#{display_platform} is valid for #{remaining_days.round} more days.")
           if remaining_days > PEM.config[:active_days_limit]
             if PEM.config[:force]
               UI.success("You already have an existing push certificate, but a new one will be created since the --force option has been set.")

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -6,26 +6,19 @@ require_relative 'module'
 
 module PEM
   class Options
-    def self.default_platform
-      case Fastlane::Helper::LaneHelper.current_platform.to_s
-      when "mac"
-        "macos"
-      else
-        "ios"
-      end
-    end
-
     def self.available_options
       user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)
       user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
       [
         FastlaneCore::ConfigItem.new(key: :platform,
-                                     env_name: "PEM_PLATFORM",
                                      description: "Set certificate's platform. Used for creation of production & development certificates. Supported platforms: ios, macos",
-                                     default_value: default_platform,
-                                     default_value_dynamic: true,
-                                     optional: true),
+                                     short_option: "-m",
+                                     env_name: "PEM_PLATFORM",
+                                     default_value: "ios",
+                                     verify_block: proc do |value|
+                                       UI.user_error!("The platform can only be ios or macos") unless ['ios', 'macos'].include?(value)
+                                     end),
         FastlaneCore::ConfigItem.new(key: :development,
                                      env_name: "PEM_DEVELOPMENT",
                                      description: "Renew the development push certificate instead of the production one",

--- a/pem/lib/pem/options.rb
+++ b/pem/lib/pem/options.rb
@@ -1,15 +1,31 @@
 require 'fastlane_core/configuration/config_item'
 require 'credentials_manager/appfile_config'
+require 'fastlane/helper/lane_helper'
 
 require_relative 'module'
 
 module PEM
   class Options
+    def self.default_platform
+      case Fastlane::Helper::LaneHelper.current_platform.to_s
+      when "mac"
+        "macos"
+      else
+        "ios"
+      end
+    end
+
     def self.available_options
       user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)
       user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
 
       [
+        FastlaneCore::ConfigItem.new(key: :platform,
+                                     env_name: "PEM_PLATFORM",
+                                     description: "Set certificate's platform. Used for creation of production & development certificates. Supported platforms: ios, macos",
+                                     default_value: default_platform,
+                                     default_value_dynamic: true,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :development,
                                      env_name: "PEM_DEVELOPMENT",
                                      description: "Renew the development push certificate instead of the production one",

--- a/pem/spec/manager_spec.rb
+++ b/pem/spec/manager_spec.rb
@@ -12,28 +12,44 @@ describe PEM do
     end
 
     it "Successful run" do
+      pem_stub_spaceship_cert(platform: 'ios')
+
       options = { app_identifier: "com.krausefx.app", generate_p12: false }
       PEM.config = FastlaneCore::Configuration.create(PEM::Options.available_options, options)
       PEM::Manager.start
 
-      expect(File.exist?("production_com.krausefx.app.pem")).to eq(true)
-      expect(File.exist?("production_com.krausefx.app.pkey")).to eq(true)
+      expect(File.exist?("production_com.krausefx.app_ios.pem")).to eq(true)
+      expect(File.exist?("production_com.krausefx.app_ios.pkey")).to eq(true)
     end
 
-    it "Successful run with output_path" do
+    it "Successful run with output_path for ios platform" do
+      pem_stub_spaceship_cert(platform: 'ios')
+
       options = { app_identifier: "com.krausefx.app", generate_p12: false, output_path: "tmp/" }
       PEM.config = FastlaneCore::Configuration.create(PEM::Options.available_options, options)
       PEM::Manager.start
 
-      expect(File.exist?("tmp/production_com.krausefx.app.pem")).to eq(true)
-      expect(File.exist?("tmp/production_com.krausefx.app.pkey")).to eq(true)
-      expect(File.exist?("tmp/production_com.krausefx.app.p12")).to eq(false)
+      expect(File.exist?("tmp/production_com.krausefx.app_ios.pem")).to eq(true)
+      expect(File.exist?("tmp/production_com.krausefx.app_ios.pkey")).to eq(true)
+      expect(File.exist?("tmp/production_com.krausefx.app_ios.p12")).to eq(false)
+    end
+
+    it "Successful run with output_path for macos platform" do
+      pem_stub_spaceship_cert(platform: 'macos')
+
+      options = { app_identifier: "com.krausefx.app", generate_p12: false, output_path: "tmp/", platform: 'macos' }
+      PEM.config = FastlaneCore::Configuration.create(PEM::Options.available_options, options)
+      PEM::Manager.start
+
+      expect(File.exist?("tmp/production_com.krausefx.app_macos.pem")).to eq(true)
+      expect(File.exist?("tmp/production_com.krausefx.app_macos.pkey")).to eq(true)
+      expect(File.exist?("tmp/production_com.krausefx.app_macos.p12")).to eq(false)
     end
 
     after :all do
       FileUtils.rm_r("tmp")
-      File.delete("production_com.krausefx.app.pem")
-      File.delete("production_com.krausefx.app.pkey")
+      File.delete("production_com.krausefx.app_ios.pem")
+      File.delete("production_com.krausefx.app_ios.pkey")
 
       ENV.delete("DELIVER_USER")
       ENV.delete("DELIVER_PASSWORD")

--- a/pem/spec/spec_helper.rb
+++ b/pem/spec/spec_helper.rb
@@ -6,12 +6,23 @@ def pem_stub_spaceship
 
   csr = "csr"
   pkey = "pkey"
+
+  expect(Spaceship.certificate).to receive(:create_certificate_signing_request).and_return([csr, pkey])
+  expect(pkey).to receive(:to_pem).twice.and_return("to_pem")
+end
+
+def pem_stub_spaceship_cert(platform: 'ios')
+  csr = "csr"
   cert = "cert"
   x509 = "x509"
 
-  expect(Spaceship.certificate).to receive(:create_certificate_signing_request).and_return([csr, pkey])
-  expect(Spaceship.certificate.production_push).to receive(:create!).with(csr: csr, bundle_id: "com.krausefx.app").and_return(cert)
+  case platform
+  when 'macos'
+    expect(Spaceship.certificate.mac_production_push).to receive(:create!).with(csr: csr, bundle_id: "com.krausefx.app").and_return(cert)
+  else
+    expect(Spaceship.certificate.production_push).to receive(:create!).with(csr: csr, bundle_id: "com.krausefx.app").and_return(cert)
+  end
+
   expect(cert).to receive(:download).and_return(x509)
-  expect(pkey).to receive(:to_pem).twice.and_return("to_pem")
   expect(x509).to receive(:to_pem).and_return("to_pem")
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I need to create push certificates for the macOS platform. And `Spaceship::Portal::Certificate` supports macOS push certificates, so a couple of strings do the thing.

### Description
* Add `platform` parameter to the `pem` action.
* Add platform name to the default base filename.

### Testing Steps
```ruby
pem(app_identifier: "com.krausefx.app", generate_p12: false)
pem(platform: 'macos', app_identifier: "com.krausefx.app", generate_p12: false)
```