### PR TITLE
[action][pod_lib_lint] add "configuration" option

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_lib_lint.rb
+++ b/fastlane/lib/fastlane/actions/pod_lib_lint.rb
@@ -27,6 +27,7 @@ module Fastlane
         command << "--skip-import-validation" if params[:skip_import_validation]
         command << "--skip-tests" if params[:skip_tests]
         command << "--analyze" if params[:analyze]
+        command << "--configuration=#{params[:configuration]}" if params[:configuration]
 
         result = Actions.sh(command.join(' '))
         UI.success("Pod lib lint Successfully ⬆️ ")
@@ -150,7 +151,12 @@ module Fastlane
                                        description: "Validate with the Xcode Static Analysis tool (available since cocoapods >= 1.6.1)",
                                        type: Boolean,
                                        default_value: false,
-                                       env_name: "FL_POD_LIB_LINT_ANALYZE")
+                                       env_name: "FL_POD_LIB_LINT_ANALYZE"),
+          FastlaneCore::ConfigItem.new(key: :configuration,
+                                       description: "Build using the given configuration (if not provided, configuration defaults to Release)",
+                                       type: String,
+                                       optional: true,
+                                       env_name: "FL_POD_LIB_LINT_CONFIGURATION")
         ]
       end
 

--- a/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
+++ b/fastlane/spec/actions_specs/pod_lib_lint_spec.rb
@@ -156,6 +156,14 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec pod lib lint --analyze")
       end
+
+      it "generates the correct pod lib lint command with configuration parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_lib_lint(configuration: 'Debug')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec pod lib lint --configuration=Debug")
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Implements #19581

### Description
Added "configuration" option to the pod_lib_lint action. This maps to the "--configuration" option that is available in CocoaPods since v1.10.

### Testing Steps
Apart from added unit tests, I've tested the setup locally with a pod I maintain and the lane like:

```
  lane :test_fastlane_change do
    pod_lib_lint(
      podspec: "POD_NAME.podspec",
      allow_warnings: true,
      skip_tests: true,
      platforms: "macos",
      no_subspecs: true,
      configuration: 'Debug'
    )
  end
  ```
