### PR TITLE
[action][get_version_number] - search for MARKETING_VERSION in build settings if target has no INFO_PLIST

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -109,8 +109,10 @@ module Fastlane
           options = plist_files.keys
           selected = UI.select("What build configuration would you like to use?", options)
           plist_file = plist_files[selected]
-        else
+        elsif plist_files_count > 0
           plist_file = plist_files.values.first
+        else
+          return nil
         end
 
         # $(SRCROOT) is the path of where the XcodeProject is
@@ -131,6 +133,8 @@ module Fastlane
       end
 
       def self.get_version_number_from_plist!(plist_file)
+        return '$(MARKETING_VERSION)' if plist_file.nil?
+
         plist = Xcodeproj::Plist.read_from_path(plist_file)
         UI.user_error!("Unable to read plist: #{plist_file}") unless plist
 

--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -150,7 +150,7 @@ module Fastlane
       end
 
       def self.details
-        "This action will return the current version number set on your project."
+        "This action will return the current version number set on your project. It first looks in the plist and then for '$(MARKETING_VERSION)' in the build settings."
       end
 
       def self.available_options

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -21,6 +21,13 @@ describe Fastlane do
       end
 
       context "Target Settings" do
+        it "gets the correct version number for AggTarget without INFO_PLIST build option", requires_xcodeproj: true do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            get_version_number(xcodeproj: '#{File.join(xcodeproj_dir, xcodeproj_filename)}', target: 'AggTarget')
+          end").runner.execute(:test)
+          expect(result).to eq("7.6.6")
+        end
+
         it "gets the correct version number for 'TargetVariableParentheses'", requires_xcodeproj: true do
           result = Fastlane::FastFile.new.parse("lane :test do
             get_version_number(xcodeproj: '#{xcodeproj_dir}', target: 'TargetVariableParentheses')

--- a/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/actions/get_version_number/get_version_number.xcodeproj/project.pbxproj
@@ -1756,6 +1756,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = WPBN76YKX2;
+				MARKETING_VERSION = 7.6.6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1765,6 +1766,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = WPBN76YKX2;
+				MARKETING_VERSION = 7.6.6;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I have a project with static lib target, and it has no INFO_PLIST in build settings. And get_version_number fails to get MARKETING_VERSION from build settings

### Description
Despite missing INFO_PLISToption, there still is a MARKETING_VERSION 😅.
So I added an option to skip looking for the value, or used variable in the Info.plist file if there is none. As the default value for looking in the build settings, I use MARKETING_VERSION, which is default from Xcode 11.

### Testing Steps
I've updated specs for get_version_number to cover this case.

Manual steps:
1. Create target w/o INFO_PLIST build setting (static lib, aggregate).
2. Set MARKETING_VERSION build setting.
3. Run get_version_number on that target.