### PR TITLE
[fastlane_core] use -assetFile instead of -f for IPA upload with iTMS

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -186,7 +186,7 @@ module Deliver
       end
 
       transporter = transporter_for_selected_team
-      result = transporter.upload(package_path: package_path)
+      result = transporter.upload(package_path: package_path, asset_path: upload_ipa || upload_pkg)
 
       unless result
         transporter_errors = transporter.displayable_errors

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -63,7 +63,7 @@ describe Deliver::Runner do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
           .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'ios')
           .and_return('path')
-        expect(transporter).to receive(:upload).with(package_path: 'path').and_return(true)
+        expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.ipa').and_return(true)
         runner.upload_binary
       end
     end
@@ -77,7 +77,7 @@ describe Deliver::Runner do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
           .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'appletvos')
           .and_return('path')
-        expect(transporter).to receive(:upload).with(package_path: 'path').and_return(true)
+        expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.ipa').and_return(true)
         runner.upload_binary
       end
     end
@@ -93,7 +93,7 @@ describe Deliver::Runner do
         expect_any_instance_of(FastlaneCore::PkgUploadPackageBuilder).to receive(:generate)
           .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: '/tmp', platform: 'osx')
           .and_return('path')
-        expect(transporter).to receive(:upload).with(package_path: 'path').and_return(true)
+        expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.pkg').and_return(true)
         runner.upload_binary
       end
     end

--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -33,7 +33,7 @@ module FastlaneCore
       File.write(File.join(self.package_path, METADATA_FILE_NAME), xml)
       UI.success("Wrote XML data to '#{self.package_path}'") if FastlaneCore::Globals.verbose?
 
-      return self.package_path
+      return ipa_path
     end
 
     def unique_ipa_path(ipa_path)

--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -33,7 +33,7 @@ module FastlaneCore
       File.write(File.join(self.package_path, METADATA_FILE_NAME), xml)
       UI.success("Wrote XML data to '#{self.package_path}'") if FastlaneCore::Globals.verbose?
 
-      return ipa_path
+      return self.package_path
     end
 
     def unique_ipa_path(ipa_path)

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -1,4 +1,5 @@
 require 'shellwords'
+require 'tmpdir'
 require 'fileutils'
 require 'credentials_manager/account_manager'
 
@@ -148,6 +149,14 @@ module FastlaneCore
       end
     end
 
+    def file_upload_option(source)
+      if File.extname(source) == ".itmsp"
+        return "-f #{source.shellescape}"
+      else
+        return "-assetFile #{source.shellescape}"
+      end
+    end
+
     def additional_upload_parameters
       # As Apple recommends in Transporter User Guide we shouldn't specify the -t transport parameter
       # and instead allow Transporter to use automatic transport discovery
@@ -177,7 +186,7 @@ module FastlaneCore
         ("-u #{username.shellescape}" unless use_jwt),
         ("-p #{shell_escaped_password(password)}" unless use_jwt),
         ("-jwt #{jwt}" if use_jwt),
-        "-f \"#{source}\"",
+        file_upload_option(source),
         additional_upload_parameters, # that's here, because the user might overwrite the -t option
         "-k 100000",
         ("-WONoPause true" if Helper.windows?), # Windows only: process instantly returns instead of waiting for key press
@@ -261,7 +270,7 @@ module FastlaneCore
           ("-u #{username.shellescape}" unless use_jwt),
           ("-p @env:ITMS_TRANSPORTER_PASSWORD" unless use_jwt),
           ("-jwt #{jwt}" if use_jwt),
-          "-assetFile #{source.shellescape}",
+          file_upload_option(source),
           additional_upload_parameters, # that's here, because the user might overwrite the -t option
           '-k 100000',
           ("-itc_provider #{provider_short_name}" if jwt.nil? && !provider_short_name.to_s.empty?),
@@ -282,7 +291,7 @@ module FastlaneCore
           ("-u #{username.shellescape}" unless use_jwt),
           ("-p #{password.shellescape}" unless use_jwt),
           ("-jwt #{jwt}" if use_jwt),
-          "-f #{source.shellescape}",
+          file_upload_option(source),
           additional_upload_parameters, # that's here, because the user might overwrite the -t option
           '-k 100000',
           ("-itc_provider #{provider_short_name}" if jwt.nil? && !provider_short_name.to_s.empty?),
@@ -472,12 +481,27 @@ module FastlaneCore
     # @param app_id [Integer] The unique App ID
     # @param dir [String] the path in which the package file is located
     # @param package_path [String] the path to the package file (used instead of app_id and dir)
+    # @param asset_path [String] the path to the ipa/dmg/pkg file (used instead of package_path if running on macOS)
     # @return (Bool) True if everything worked fine
     # @raise [Deliver::TransporterTransferError] when something went wrong
     #   when transferring
-    def upload(app_id = nil, dir = nil, package_path: nil)
-      raise "app_id and dir are required or package_path is required" if (app_id.nil? || dir.nil?) && package_path.nil?
-      actual_dir = package_path || File.join(dir, "#{app_id}.itmsp")
+    def upload(app_id = nil, dir = nil, package_path: nil, asset_path: nil)
+      raise "app_id and dir are required or package_path or asset_path is required" if (app_id.nil? || dir.nil?) && package_path.nil? && asset_path.nil?
+
+      # Transport can upload .ipa, .dmg, and .pkg files directly with -assetFile
+      # However, -assetFile requires -assetDescription if Linux or Windows
+      # This will give the asset directly if macOS and asset_path exists
+      # otherwise it will use the .itmsp package
+      actual_dir = if Helper.is_mac? && asset_path
+                     # The asset gets deleted upon completion so copying to a temp directory
+                     tmp_asset_path = File.join(Dir.tmpdir, File.basename(asset_path))
+                     FileUtils.cp(asset_path, tmp_asset_path)
+                     tmp_asset_path
+                   elsif package_path
+                     package_path
+                   else
+                     File.join(dir, "#{app_id}.itmsp")
+                   end
 
       UI.message("Going to upload updated app to App Store Connect")
       UI.success("This might take a few minutes. Please don't interrupt the script.")
@@ -492,7 +516,7 @@ module FastlaneCore
         result = @transporter_executor.execute(command, ItunesTransporter.hide_transporter_output?)
       rescue TransporterRequiresApplicationSpecificPasswordError => ex
         handle_two_step_failure(ex)
-        return upload(app_id, dir, package_path: package_path)
+        return upload(app_id, dir, package_path: package_path, asset_path: asset_path)
       end
 
       if result

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -261,7 +261,7 @@ module FastlaneCore
           ("-u #{username.shellescape}" unless use_jwt),
           ("-p @env:ITMS_TRANSPORTER_PASSWORD" unless use_jwt),
           ("-jwt #{jwt}" if use_jwt),
-          "-f #{source.shellescape}",
+          "-assetFile #{source.shellescape}",
           additional_upload_parameters, # that's here, because the user might overwrite the -t option
           '-k 100000',
           ("-itc_provider #{provider_short_name}" if jwt.nil? && !provider_short_name.to_s.empty?),

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -187,7 +187,7 @@ describe FastlaneCore do
         ("-u #{email.shellescape}" if jwt.nil?),
         ("-p @env:ITMS_TRANSPORTER_PASSWORD" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
-        "-f /tmp/my.app.id.itmsp",
+        "-assetFile /tmp/my.app.id.itmsp",
         (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -38,7 +38,7 @@ module Pilot
       end
 
       transporter = transporter_for_selected_team(options)
-      result = transporter.upload(package_path: package_path)
+      result = transporter.upload(package_path: package_path, asset_path: options[:ipa] || options[:pkg])
 
       unless result
         transporter_errors = transporter.displayable_errors


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Resolves #19572


### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
When previously calling iTMSTransporter to upload an IPA to Testflight, Fastlane would point to the itmsp folder, which would contain the IPA for uploading and the metadata.xml.  On Nov 2nd, several people started noticing their Testflight uploads start failing with "An error occurred while trying to call the requested method validateAssets. (1272)" and were forced to use manual intervention to submit their IPAs to Testflight.   

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Should no longer see "An error occurred while trying to call the requested method validateAssets. (1272)" when deploying an IPA to Testflight.