### PR TITLE
[match][cert] allow developer_id creation if using apple id

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -154,8 +154,11 @@ module Cert
         when :developer_id_kext
           return Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_KEXT
         when :developer_id_installer
-          raise "Cannot do with ASC API?"
-          # return Spaceship.certificate.developer_id_installer
+          if !Spaceship::ConnectAPI.token.nil?
+            raise "As of 2021-11-09, the App Store Connect API does not allow accessing DEVELOPER_ID_INSTALLER with the API Key. Please file an issue on GitHub if this has changed and needs to be updated"
+          else
+            return Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_INSTALLER
+          end
         else
           UI.user_error("Unaccepted value for :type - #{Cert.config[:type]}")
         end

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -70,6 +70,7 @@ module Match
       UI.error("for the user #{username}")
       UI.error("Make sure to use the same user and team every time you run 'match' for this")
       UI.error("Git repository. This might be caused by revoking the certificate on the Dev Portal")
+      UI.error("If missing certificate is a Developer ID Installer, you may need to auth with Apple ID instead of App Store API Key")
       UI.user_error!("To reset the certificates of your Apple account, you can use the `fastlane match nuke` feature, more information on https://docs.fastlane.tools/actions/match/")
     end
 

--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -41,6 +41,9 @@ module Spaceship
         MAC_APP_DEVELOPMENT = "MAC_APP_DEVELOPMENT"
         DEVELOPER_ID_KEXT = "DEVELOPER_ID_KEXT"
         DEVELOPER_ID_APPLICATION = "DEVELOPER_ID_APPLICATION"
+
+        # As of 2021-11-09, this is only available with Apple ID auth
+        DEVELOPER_ID_INSTALLER = "DEVELOPER_ID_INSTALLER"
       end
 
       def self.type


### PR DESCRIPTION
### Motivation and Context
Disovered (when testing another match PR) that I was having issues running match with a developer id

### Description
- cert
  - opens creation of developer id certificates if authoring with Apple ID. This works because the unofficial API allows this 
- match
  - when used with ASC API, listing all certs won't return developer id certs
  - this changes adds a little line of description in the error that mentions using apple id 

### Testing Steps
Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-fix-developer_id-certs-not-being-listed"
```
