### PR TITLE
[deliver] Resolves issue uploading iPad Pro 5th gen screenshots

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -324,6 +324,7 @@ module Deliver
       is_3rd_gen = [
         "iPad Pro (12.9-inch) (3rd generation)", # Default simulator has this name
         "iPad Pro (12.9-inch) (4th generation)", # Default simulator has this name
+        "iPad Pro (12.9-inch) (5th generation)", # Default simulator has this name
         "IPAD_PRO_3GEN_129", # Screenshots downloaded from App Store Connect has this name
         "ipadPro129" # Legacy: screenshots downloaded from iTunes Connect used to have this name
       ].any? { |key| filename.include?(key) }

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -36,6 +36,13 @@ describe Deliver::AppScreenshot do
       end
     end
 
+    context "when filename contains 'iPad Pro (5th generation)'" do
+      it "returns iPad Pro(12.9-inch) 3rd generation" do
+        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (5th generation){2732x2048}.png", "de-DE")
+        expect(screenshot.screen_size).to eq(ScreenSize::IOS_IPAD_PRO_12_9)
+      end
+    end
+
     context "when filename contains 'IPAD_PRO_3GEN_129'" do
       it "returns iPad Pro(12.9-inch) 3rd generation" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/IPAD_PRO_3GEN_129-AAABBBCCCDDD{2732x2048}.png", "de-DE")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
I experienced the same issue as described in #16262 but for iPad Pro 12.9 (5th Gen.): screenshots of the 5th gen. are uploaded into the slot of the 2nd gen. iPad Pro 12.9 inch.
This can be fixed in the same way as in #16288.

### Description
The problem was in resolve_ipadpro_conflict_if_needed() function which uses simulator name to resolve conflicts (2nd gen/3rd/4th/5th gens have the same screen size). I added new simulator name to the list.

### Testing Steps
Added new unit tests to the app_screenshot_spec.rb, to recognize this corner case.
Run `bundle exec rspec deliver/spec/app_screenshot_spec.rb` to test.

To test in real world, you need to have a project with screenshots made on 2nd and 5th gens iPad Pros 12.9" simulators. There is no need to submit screenshots to the App Store, preview html clearly shows the issues.