### PR TITLE
[fastlane_core] fix TransportExecutor to specifically look for ipa, dmg, ipa, and zip and not directory for -assetFile and then fall bask to -f

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -150,7 +150,10 @@ module FastlaneCore
     end
 
     def file_upload_option(source)
-      if !File.directory?(source) && [".ipa", ".pkg", ".dmg", ".zip"].include?(File.extname(source).downcase)
+      ext = File.extname(source).downcase
+      is_asset_file_type = !File.directory?(source) && [".ipa", ".pkg", ".dmg", ".zip"].include?(ext)
+
+      if is_asset_file_type
         return "-assetFile #{source.shellescape}"
       else
         return "-f #{source.shellescape}"
@@ -492,7 +495,11 @@ module FastlaneCore
       # However, -assetFile requires -assetDescription if Linux or Windows
       # This will give the asset directly if macOS and asset_path exists
       # otherwise it will use the .itmsp package
-      actual_dir = if Helper.is_mac? && asset_path
+
+      force_itmsp = FastlaneCore::Env.truthy?("ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD")
+      can_use_asset_path = Helper.is_mac? && asset_path
+
+      actual_dir = if can_use_asset_path && !force_itmsp
                      # The asset gets deleted upon completion so copying to a temp directory
                      tmp_asset_path = File.join(Dir.tmpdir, File.basename(asset_path))
                      FileUtils.cp(asset_path, tmp_asset_path)

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -150,10 +150,10 @@ module FastlaneCore
     end
 
     def file_upload_option(source)
-      if File.extname(source) == ".itmsp"
-        return "-f #{source.shellescape}"
-      else
+      if !File.directory?(source) && [".ipa", ".pkg", ".dmg", ".zip"].include?(File.extname(source).downcase)
         return "-assetFile #{source.shellescape}"
+      else
+        return "-f #{source.shellescape}"
       end
     end
 

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -336,6 +336,27 @@ describe FastlaneCore do
               end
             end
           end
+
+          describe "with package_path and asset_path" do
+            describe "upload command generation" do
+              it 'generates a call to xcrun iTMSTransporter with -assetFile' do
+                expect(Dir).to receive(:tmpdir).and_return("/tmp")
+                expect(FileUtils).to receive(:cp)
+
+                transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
+                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp', asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command(jwt: jwt, use_asset_path: true))
+              end
+            end
+
+            describe "upload command generation with ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD=true" do
+              it 'generates a call to xcrun iTMSTransporter with -assetFile' do
+                stub_const('ENV', { 'ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD' => 'true' })
+
+                transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
+                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp', asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command(jwt: jwt, use_asset_path: false))
+              end
+            end
+          end
         end
       end
 


### PR DESCRIPTION
### Motivation and Context
Fixes #19619
Fixes #19613

### Description
New logic was sometimes trying to upoad a directory with `-assetFile` (which didn't work) when it should have been using `-f` instead. Switched logic around to specifically look for not a directory and either `.ipa`, `.dmg`, `.pkg`, or `.zip` before trying to use `-assetFile`.

### Testing Steps
Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-fix-transporter-assetFile-uploading-directory"
```
