### PR TITLE
[docs] modernize markdown syntax of auto-generated README documentation

### DIFF
--- a/fastlane/lib/fastlane/documentation/docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/docs_generator.rb
@@ -4,21 +4,18 @@ module Fastlane
       output_path ||= File.join(FastlaneCore::FastlaneFolder.path || '.', 'README.md')
 
       output = ["fastlane documentation"]
-      output << "================"
+      output << "----"
+      output << ""
 
       output << "# Installation"
       output << ""
       output << "Make sure you have the latest version of the Xcode command line tools installed:"
       output << ""
-      output << "```"
+      output << "```sh"
       output << "xcode-select --install"
       output << "```"
       output << ""
-      output << "Install _fastlane_ using"
-      output << "```"
-      output << "[sudo] gem install fastlane -NV"
-      output << "```"
-      output << "or alternatively using `brew install fastlane`"
+      output << "For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)"
       output << ""
       output << "# Available Actions"
 
@@ -32,7 +29,10 @@ module Fastlane
           next
         end
 
-        output << "## #{formatted_platform(platform)}" if platform
+        if platform
+          output << ""
+          output << "## #{formatted_platform(platform)}"
+        end
 
         lanes.each do |lane_name, lane|
           next if lane.is_private
@@ -45,8 +45,10 @@ module Fastlane
       end
 
       output << "This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run."
-      output << "More information about fastlane can be found on [fastlane.tools](https://fastlane.tools)."
-      output << "The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools)."
+      output << ""
+      output << "More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools)."
+      output << ""
+      output << "The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools)."
       output << ""
 
       begin
@@ -78,10 +80,13 @@ module Fastlane
       full_name = [platform, lane].reject(&:nil?).join(' ')
 
       output = []
+      output << ""
       output << "### #{full_name}"
+      output << ""
+      output << "```sh"
+      output << "[bundle exec] fastlane #{full_name}"
       output << "```"
-      output << "fastlane #{full_name}"
-      output << "```"
+      output << ""
       output << description
       output
     end

--- a/fastlane/spec/docs_generator_spec.rb
+++ b/fastlane/spec/docs_generator_spec.rb
@@ -9,6 +9,7 @@ describe Fastlane do
 
       output = File.read(output_path)
 
+      expect(output).to include('installation instructions')
       expect(output).to include('# Available Actions')
       expect(output).to include('### test')
       expect(output).to include('# iOS')
@@ -27,6 +28,7 @@ describe Fastlane do
 
       output = File.read(output_path)
 
+      expect(output).to include('installation instructions')
       expect(output).to include('# Available Actions')
       expect(output).to include('## Android')
       expect(output).to include('### android lane')

--- a/fastlane/spec/docs_generator_spec.rb
+++ b/fastlane/spec/docs_generator_spec.rb
@@ -9,7 +9,6 @@ describe Fastlane do
 
       output = File.read(output_path)
 
-      expect(output).to include('gem install fastlane')
       expect(output).to include('# Available Actions')
       expect(output).to include('### test')
       expect(output).to include('# iOS')
@@ -28,7 +27,6 @@ describe Fastlane do
 
       output = File.read(output_path)
 
-      expect(output).to include('gem install fastlane')
       expect(output).to include('# Available Actions')
       expect(output).to include('## Android')
       expect(output).to include('### android lane')

--- a/fastlane/spec/private_public_fastfile_spec.rb
+++ b/fastlane/spec/private_public_fastfile_spec.rb
@@ -37,7 +37,7 @@ describe Fastlane do
         Fastlane::DocsGenerator.run(ff, output_path)
         output = File.read(output_path)
 
-        expect(output).to include('gem install fastlane')
+        expect(output).to include('installation instructions')
         expect(output).to include('such smooth')
         expect(output).to_not(include('private'))
       end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR modifies the behavior of the `README.md` generator (the one that generates documentation for your lanes, under `fastlane/README.md` directory).

Since this doc generator was written (probably haha) the markdown syntax has evolved a bit, and the generated docs don't follow markdown best practices (of leaving line breaks around headers and code snippets, for instance), causing some markdown parsers (like [MacDown](https://macdown.uranusjr.com)) to not parse them properly.

### Description

I've modernized the markdown syntax, and made minor changes to the messages. I also removed manual (duplicated) fastlane installation instructions, pointing users to our latest documentation at https://docs.fastlane.tools/#installing-fastlane (which strongly suggests using `bundler`).

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-modernize-docs-generation"
```

And run `bundle install` to apply the changes. 