### PR TITLE
[action] allow using a `.xcode-version` file with `xcversion` action

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
@@ -75,7 +75,7 @@ module Fastlane
         [
           "If building your app requires a specific version of Xcode, you can invoke this command before using gym.",
           "For example, to ensure that a beta version of Xcode is not accidentally selected to build, which would make uploading to TestFlight fail.",
-          "You can either manually provide a specific version using `version: ` or you make use of the `.xcode-version` file.",
+          "You can either manually provide a specific version using `version:` or you make use of the `.xcode-version` file.",
           "Using the `strict` parameter, you can either verify the full set of version numbers strictly (i.e. `11.3.1`) or only a subset of them (i.e. `11.3` or `11`)."
         ].join("\n")
       end

--- a/fastlane/lib/fastlane/actions/xcversion.rb
+++ b/fastlane/lib/fastlane/actions/xcversion.rb
@@ -36,8 +36,10 @@ module Fastlane
       end
 
       def self.details
-        "Finds and selects a version of an installed Xcode that best matches the provided [`Gem::Version` requirement specifier](http://www.rubydoc.info/github/rubygems/rubygems/Gem/Version)"
-        "You can either manually provide a specific version using `version:` or you make use of the `.xcode-version` file.",
+        [
+          "Finds and selects a version of an installed Xcode that best matches the provided [`Gem::Version` requirement specifier](http://www.rubydoc.info/github/rubygems/rubygems/Gem/Version)",
+          "You can either manually provide a specific version using `version:` or you make use of the `.xcode-version` file."
+        ].join("\n")
       end
 
       def self.authors

--- a/fastlane/lib/fastlane/actions/xcversion.rb
+++ b/fastlane/lib/fastlane/actions/xcversion.rb
@@ -6,22 +6,6 @@ module Fastlane
 
         version = params[:version]
 
-        if version.to_s.length == 0
-          # The user didn't provide an Xcode version, let's see
-          # if the current project has a `.xcode-version` file
-          #
-          # The code below can be improved to also consider
-          # the directory of the Xcode project
-          xcode_version_paths = Dir.glob(".xcode-version")
-
-          if xcode_version_paths.first
-            UI.verbose("Loading required version from #{xcode_version_paths.first}")
-            version = File.read(xcode_version_paths.first).strip
-          else
-            UI.user_error!("No version: provided when calling the `xcversion` action")
-          end
-        end
-
         xcode = Helper::XcversionHelper.find_xcode(version)
         UI.user_error!("Cannot find an installed Xcode satisfying '#{version}'") if xcode.nil?
 
@@ -29,6 +13,16 @@ module Fastlane
         UI.message("Setting Xcode version to #{xcode.path} for all build steps")
 
         ENV["DEVELOPER_DIR"] = File.join(xcode.path, "/Contents/Developer")
+      end
+
+      def self.read_xcode_version_file
+        xcode_version_paths = Dir.glob(".xcode-version")
+
+        if xcode_version_paths.first
+          return File.read(xcode_version_paths.first).strip
+        end
+
+        return nil
       end
 
       def self.description
@@ -51,7 +45,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_XCODE_VERSION",
                                        description: "The version of Xcode to select specified as a Gem::Version requirement string (e.g. '~> 7.1.0')",
-                                       optional: true,
+                                       default_value: self.read_xcode_version_file,
+                                       default_value_dynamic: true,
                                        verify_block: Helper::XcversionHelper::Verify.method(:requirement))
         ]
       end

--- a/fastlane/spec/actions_specs/xcversion_spec.rb
+++ b/fastlane/spec/actions_specs/xcversion_spec.rb
@@ -5,16 +5,6 @@ describe Fastlane do
         ENV.delete("DEVELOPER_DIR")
       end
 
-      context "when no params are passed" do
-        it "raises an error" do
-          expect do
-            Fastlane::FastFile.new.parse("lane :test do
-              xcversion
-            end").runner.execute(:test)
-          end.to raise_error("Version must be specified")
-        end
-      end
-
       context "when a version requirement is specified" do
         let(:v7_2) do
           double("XcodeInstall::Xcode", version: "7.2", path: "/Test/Xcode7.2")
@@ -74,6 +64,55 @@ describe Fastlane do
                 end").runner.execute(:test)
               end.to raise_error("Cannot find an installed Xcode satisfying '= 7.1'")
             end
+          end
+        end
+      end
+
+      context "when a version is not specified" do
+        context "load a .xcode-version file if it exists" do
+
+          let(:v13_0) do
+            double("XcodeInstall::Xcode", version: "13.0", path: "/Test/Xcode13.0")
+          end
+
+          let(:xcode_version_path) { ".xcode-version" }
+          before do
+            require "xcode/install"
+            installer = double("XcodeInstall::Installer")
+            allow(installer).to receive(:installed_versions).and_return([v13_0])
+            allow(XcodeInstall::Installer).to receive(:new).and_return(installer)
+            expect(Dir).to receive(:glob).with(".xcode-version").and_return([xcode_version_path])
+          end
+
+          it "succeeds if the numbers match" do
+            expect(UI).to receive(:message).with(/Setting Xcode version/)
+            expect(File).to receive(:read).with(xcode_version_path).and_return("13.0")
+
+            result = Fastlane::FastFile.new.parse("lane :test do
+              xcversion
+            end").runner.execute(:test)
+
+            expect(ENV["DEVELOPER_DIR"]).to eq(File.join(v13_0.path, "Contents/Developer"))
+          end
+
+          it "fails if the numbers don't match" do
+            expect(File).to receive(:read).with(xcode_version_path).and_return("14.0")
+
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                xcversion
+              end").runner.execute(:test)
+            end.to raise_error("Cannot find an installed Xcode satisfying '14.0'")
+          end
+        end
+
+        context "no .xcode-version file exists" do
+          it "raises an error" do
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                xcversion
+              end").runner.execute(:test)
+            end.to raise_error("No version: provided when calling the `xcversion` action")
           end
         end
       end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I felt the necessity to unify the implementation to a single `.xcode-version` file, making it consistent with [`xcode-install`](https://github.com/xcpretty/xcode-install/blob/master/XCODE_VERSION.md) itself, and [ensure_xcode_version action](https://docs.fastlane.tools/actions/ensure_xcode_version/).

### Description

This PR allows us to use a `.xcode-version` and omit the `:version` parameter when invoking `xcversion` action. It finds and reads the contents of a `.xcode-version` file just like the [ensure_xcode_version action](https://docs.fastlane.tools/actions/ensure_xcode_version/) does:

https://github.com/fastlane/fastlane/blob/dac31640214dc976da675e863d0efbd4a99cb526/fastlane/lib/fastlane/actions/ensure_xcode_version.rb#L9-L23

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "rogerluan-use-xcode-version-file-with-xcversion"
```

And run `bundle install` to apply the changes. 