### PR TITLE
[spaceship] spaceauth - add new functionality to check if a user's session is still valid

### DIFF
--- a/spaceship/docs/Authentication.md
+++ b/spaceship/docs/Authentication.md
@@ -26,4 +26,6 @@ Note that Apple does not always allow in all situations. For example for individ
 
 If you _always_ want your security sent via SMS to a specific trusted phone number you can set the `SPACESHIP_2FA_SMS_DEFAULT_PHONE_NUMBER` environment variable to that phone number. The phone number should be specified in the same format as it is displayed in your [Apple ID console](https://appleid.apple.com/) under `TRUSTED PHONE NUMBERS`, e.g. `+49 123 4567890`, `+1-555-123-4567` or similar. Do not leave off the country code or add or remove any numbers, otherwise fastlane will not be able to match the masked value from Apple's API and select the correct number.
 
+## Checking if a session is valid
 
+The `--check_session` flag can be passed if you wish to check if the locally stored session for a user is still valid. This is useful for local testing and CI workflows.

--- a/spaceship/lib/spaceship/commands_generator.rb
+++ b/spaceship/lib/spaceship/commands_generator.rb
@@ -41,7 +41,7 @@ module Spaceship
         c.syntax = 'fastlane spaceship spaceauth'
         c.description = 'Authentication helper for spaceship/fastlane to work with Apple 2-Step/2FA'
         c.option('--copy_to_clipboard', 'Whether the session string should be copied to clipboard. For more info see https://docs.fastlane.tools/best-practices/continuous-integration/#storing-a-manually-verified-session-using-spaceauth`')
-
+        c.option('--check_session', 'Check to see if there is a valid session (either in the cache or via FASTLANE_SESSION). Sets the exit code to 0 if the session is valid or 1 if not.') { Spaceship::Globals.check_session = true }
         c.action do |args, options|
           Spaceship::SpaceauthRunner.new(username: options.user, copy_to_clipboard: options.copy_to_clipboard).run
         end

--- a/spaceship/lib/spaceship/globals.rb
+++ b/spaceship/lib/spaceship/globals.rb
@@ -1,5 +1,9 @@
 module Spaceship
   class Globals
+    class << self
+      attr_writer(:check_session)
+    end
+
     # if spaceship is run with a FastlaneCore available respect the global state there
     # otherwise fallback to $verbose
     def self.verbose?
@@ -7,6 +11,11 @@ module Spaceship
         return FastlaneCore::Globals.verbose? # rubocop:disable Require/MissingRequireStatement
       end
       return $verbose
+    end
+
+    # if spaceship is run with the --check_session flag this value will be set to true
+    def self.check_session
+      return @check_session
     end
   end
 end

--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -16,7 +16,7 @@ module Spaceship
 
     def run
       begin
-        puts("Logging into to App Store Connect (#{@username})...")
+        puts("Logging into to App Store Connect (#{@username})...") unless Spaceship::Globals.check_session
         Spaceship::Tunes.login(@username)
         puts("Successfully logged in to App Store Connect".green)
         puts("")

--- a/spaceship/spec/spaceauth_spec.rb
+++ b/spaceship/spec/spaceauth_spec.rb
@@ -37,6 +37,46 @@ describe Spaceship::SpaceauthRunner do
     end
   end
 
+  describe 'check_session option' do
+    before :each do
+      Spaceship::Globals.check_session = true
+    end
+
+    after :each do
+      Spaceship::Globals.check_session = false
+    end
+
+    it 'when using the default user, it should return a message saying the session is logged in with an exit code of 0' do
+      expect do
+        expect do
+          Spaceship::SpaceauthRunner.new.run
+        end.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(0)
+        end
+      end.to output(/Valid session found \(.*\). Exiting./).to_stdout
+    end
+
+    it 'when passed a known user, it should return a message saying the session is logged in with an exit code of 0' do
+      expect do
+        expect do
+          Spaceship::SpaceauthRunner.new(username: 'spaceship@krausefx.com').run
+        end.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(0)
+        end
+      end.to output(/Valid session found \(.*\). Exiting./).to_stdout
+    end
+
+    it 'when passed an unknown user, it should return a message saying no valid session found with an exit code of 1' do
+      expect do
+        expect do
+          Spaceship::SpaceauthRunner.new(username: 'unknown-user').run
+        end.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(1)
+        end
+      end.to output(/No valid session found \(.*\). Exiting./).to_stdout
+    end
+  end
+
   describe '#session_string' do
     it 'should return the session when called after run' do
       expect(Spaceship::SpaceauthRunner.new.run.session_string).to match(%r{.*domain: idmsa.apple.com.*path: \"\/appleauth\/auth\/\".*})


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

For CI testing it would be useful to quickly/succinctly tell if a `spaceship` session for a specific user is still valid. This would allow a CI build to immediately fail a task that requires authentication if the session is expired/missing.

### Description

This PR adds a new parameter, `--check_session`, to expose existing code in the `spaceauth` command. Using the new parameter allows users to check if a session is still valid. If the session is valid the command will exit with a status code of 0, if the session is invalid it will exit with a status code of 1.

Example Usage:

```
fastlane spaceauth --check_session
[✔] 🚀 
Username: some-valid-user
Valid session found (some-valid-user). Exiting.
```

```
fastlane spaceauth --check_session -u some-expired-user
[✔] 🚀 
No valid session found (some-expired-user). Exiting.
```

### Testing Steps

Testing via the CLI should be pretty straightforward, recommend testing with and without a user set in the `Appfile` and testing with real and fake usernames.

```
fastlane spaceauth --check_session
fastlane spaceauth --check_session -u real-username
fastlane spaceauth --check_session -u fake-username
```

There are also 3 new tests that can be run locally:

```
bundle exec rspec spaceship/spec/spaceauth_spec.rb

Spaceship::SpaceauthRunner
  uses all required cookies for fastlane session
  copy_to_clipboard option
    when true, it should copy the session to clipboard
    when false, it should not copy the session to clipboard
  check_session option
    when using the default user, it should return a message saying the session is logged in with an exit code of 0
    when passed a known user, it should return a message saying the session is logged in with an exit code of 0
    when passed an unknown user, it should return a message saying no valid session found with an exit code of 1
  #session_string
    should return the session when called after run
    should throw when called before run

Finished in 0.83703 seconds (files took 3.54 seconds to load)
8 examples, 0 failures
```