### PR TITLE
[deliver][snapshot][fastlane_core] fix typos

### DIFF
--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -80,7 +80,7 @@ module Deliver
         screenshots_per_display_type = screenshots_for_language.reject { |screenshot| screenshot.device_type.nil? }.group_by(&:device_type)
 
         screenshots_per_display_type.each do |display_type, screenshots|
-          # create AppScreenshotSet for given display_type if it doesn't exsit
+          # create AppScreenshotSet for given display_type if it doesn't exist
           app_screenshot_set = (app_screenshot_set_per_locale_and_display_type[language] || {})[display_type]
           app_screenshot_set ||= localization.create_app_screenshot_set(attributes: { screenshotDisplayType: display_type })
 

--- a/deliver/spec/sync_screenshots_spec.rb
+++ b/deliver/spec/sync_screenshots_spec.rb
@@ -40,7 +40,7 @@ describe Deliver::SyncScreenshots do
         )
       end
 
-      it 'should enqueue upload jobs for the screenshots that not exsit on App Store Connect' do
+      it 'should enqueue upload jobs for the screenshots that not exist on App Store Connect' do
         delete_worker = mock_queue_worker([])
         upload_worker = mock_queue_worker([Deliver::SyncScreenshots::UploadScreenshotJob.new(app_screenshot_set_55, screenshots[0].path),
                                            Deliver::SyncScreenshots::UploadScreenshotJob.new(app_screenshot_set_55, screenshots[1].path),
@@ -75,7 +75,7 @@ describe Deliver::SyncScreenshots do
         )
       end
 
-      it 'should enqueue upload jobs for the screenshots that not exsit on App Store Connect' do
+      it 'should enqueue upload jobs for the screenshots that not exist on App Store Connect' do
         delete_worker = mock_queue_worker([])
         upload_worker = mock_queue_worker([Deliver::SyncScreenshots::UploadScreenshotJob.new(app_screenshot_set_55, screenshots[1].path),
                                            Deliver::SyncScreenshots::UploadScreenshotJob.new(app_screenshot_set_65, screenshots[3].path)])
@@ -106,7 +106,7 @@ describe Deliver::SyncScreenshots do
         )
       end
 
-      it 'should enqueue delete jobs for the screenshots that not exsit on local' do
+      it 'should enqueue delete jobs for the screenshots that not exist on local' do
         delete_worker = mock_queue_worker([Deliver::SyncScreenshots::DeleteScreenshotJob.new(app_screenshots[0], en_US.locale),
                                            Deliver::SyncScreenshots::DeleteScreenshotJob.new(app_screenshots[1], en_US.locale)])
         upload_worker = mock_queue_worker([])

--- a/deliver/spec/sync_screenshots_spec.rb
+++ b/deliver/spec/sync_screenshots_spec.rb
@@ -40,7 +40,7 @@ describe Deliver::SyncScreenshots do
         )
       end
 
-      it 'should enqueue upload jobs for the screenshots that not exist on App Store Connect' do
+      it 'should enqueue upload jobs for the screenshots that do not exist on App Store Connect' do
         delete_worker = mock_queue_worker([])
         upload_worker = mock_queue_worker([Deliver::SyncScreenshots::UploadScreenshotJob.new(app_screenshot_set_55, screenshots[0].path),
                                            Deliver::SyncScreenshots::UploadScreenshotJob.new(app_screenshot_set_55, screenshots[1].path),
@@ -75,7 +75,7 @@ describe Deliver::SyncScreenshots do
         )
       end
 
-      it 'should enqueue upload jobs for the screenshots that not exist on App Store Connect' do
+      it 'should enqueue upload jobs for the screenshots that do not exist on App Store Connect' do
         delete_worker = mock_queue_worker([])
         upload_worker = mock_queue_worker([Deliver::SyncScreenshots::UploadScreenshotJob.new(app_screenshot_set_55, screenshots[1].path),
                                            Deliver::SyncScreenshots::UploadScreenshotJob.new(app_screenshot_set_65, screenshots[3].path)])
@@ -106,7 +106,7 @@ describe Deliver::SyncScreenshots do
         )
       end
 
-      it 'should enqueue delete jobs for the screenshots that not exist on local' do
+      it 'should enqueue delete jobs for the screenshots that do not exist on local' do
         delete_worker = mock_queue_worker([Deliver::SyncScreenshots::DeleteScreenshotJob.new(app_screenshots[0], en_US.locale),
                                            Deliver::SyncScreenshots::DeleteScreenshotJob.new(app_screenshots[1], en_US.locale)])
         upload_worker = mock_queue_worker([])

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -18,7 +18,7 @@ describe FastlaneCore do
     end
 
     describe '#colors_disabled?' do
-      it "should return false if no environemnt variables set" do
+      it "should return false if no environment variables set" do
         stub_const('ENV', {})
         expect(FastlaneCore::Helper.colors_disabled?).to be(false)
       end

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -123,7 +123,7 @@ module Snapshot
       # Simulator could stil be booting with Apple logo
       # Need to wait "some amount of time" until home screen shows
       boot_sleep = ENV["SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT"].to_i || 10
-      UI.message("Waiting #{boot_sleep} seconds for device to fully boot before overriding status bar... Set 'SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT' environemnt variable to adjust timeout")
+      UI.message("Waiting #{boot_sleep} seconds for device to fully boot before overriding status bar... Set 'SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT' environment variable to adjust timeout")
       sleep(boot_sleep) if boot_sleep > 0
 
       UI.message("Overriding Status Bar")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change fixes some typos in test names and a message.

### Description
Fix misspellings of "environment" and "exist" and change "that not exist" to "that do not exist".

I ran `bundle exec fastlane test`, `bundle exec rspec`, and `bundle exec rubocop -a`.