### PR TITLE
[action] [update_code_signing_settings] add entitlements file path ca…

### DIFF
--- a/fastlane/lib/fastlane/actions/update_code_signing_settings.rb
+++ b/fastlane/lib/fastlane/actions/update_code_signing_settings.rb
@@ -50,6 +50,10 @@ module Fastlane
               set_build_setting(config, "PROVISIONING_PROFILE_SPECIFIER", params[:profile_name])
               UI.important("Set Provisioning Profile name to: #{params[:profile_name]} for target: #{target.name} for build configuration: #{config.name}")
             end
+            if params[:entitlements_file_path]
+              set_build_setting(config, "CODE_SIGN_ENTITLEMENTS", params[:entitlements_file_path])
+              UI.important("Set Entitlements file path to: #{params[:entitlements_file_path]} for target: #{target.name} for build configuration: #{config.name}")
+            end
             # Since Xcode 8, this is no longer needed, you simply use PROVISIONING_PROFILE_SPECIFIER
             if params[:profile_uuid]
               set_build_setting(config, "PROVISIONING_PROFILE", params[:profile_uuid])
@@ -143,6 +147,10 @@ module Fastlane
                                        env_name: "FL_CODE_SIGN_IDENTITY",
                                        description: "Code signing identity type (iPhone Developer, iPhone Distribution)",
                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :entitlements_file_path,
+                                       env_name: "FL_CODE_SIGN_ENTITLEMENTS_FILE_PATH",
+                                       description: "Path to your entitlements file",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :profile_name,
                                        env_name: "FL_PROVISIONING_PROFILE_SPECIFIER",
                                        description: "Provisioning profile name to use for code signing",
@@ -172,6 +180,15 @@ module Fastlane
           update_code_signing_settings(
             use_automatic_signing: true,
             path: "demo-project/demo/demo.xcodeproj"
+          )',
+          ' # more advanced manual code signing
+          update_code_signing_settings(
+            use_automatic_signing: true,
+            path: "demo-project/demo/demo.xcodeproj",
+            team_id: "QABC123DEV",
+            bundle_identifier: "com.demoapp.QABC123DEV",
+            profile_name: "Demo App Deployment Profile",
+            entitlements_file_path: "Demo App/generated/New.entitlements"
           )'
         ]
       end
@@ -185,7 +202,7 @@ module Fastlane
       end
 
       def self.authors
-        ["mathiasAichinger", "hjanuschka", "p4checo", "portellaa", "aeons", "att55"]
+        ["mathiasAichinger", "hjanuschka", "p4checo", "portellaa", "aeons", "att55", "abcdev"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/spec/actions_specs/update_code_signing_settings_spec.rb
+++ b/fastlane/spec/actions_specs/update_code_signing_settings_spec.rb
@@ -128,6 +128,34 @@ describe Fastlane do
         end
       end
 
+      it "sets code sign entitlements file" do
+        # G3KGXDXQL9
+        allow(UI).to receive(:success)
+        expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
+
+        ["Debug", "Release"].each do |configuration|
+          expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: demo for build configuration: #{configuration}")
+          expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: today for build configuration: #{configuration}")
+          expect(UI).to receive(:important).with("Set Entitlements file path to: Test.entitlements for target: demo for build configuration: #{configuration}")
+          expect(UI).to receive(:important).with("Set Entitlements file path to: Test.entitlements for target: today for build configuration: #{configuration}")
+        end
+
+        result = Fastlane::FastFile.new.parse("lane :test do
+          update_code_signing_settings(use_automatic_signing: false, path: '#{project_path}', team_id: 'G3KGXDXQL9', entitlements_file_path: 'Test.entitlements')
+        end").runner.execute(:test)
+        expect(result).to eq(false)
+
+        project = Xcodeproj::Project.open(project_path)
+        project.targets.each do |target|
+          target.build_configuration_list.get_setting("CODE_SIGN_STYLE").map do |build_config, value|
+            expect(value).to eq("Manual")
+          end
+          target.build_configuration_list.get_setting("CODE_SIGN_ENTITLEMENTS").map do |build_config, value|
+            expect(value).to eq("Test.entitlements")
+          end
+        end
+      end
+
       it "sets profile name" do
         # G3KGXDXQL9
         allow(UI).to receive(:success)

--- a/fastlane/spec/fixtures/xcodeproj/update-code-signing-settings.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/update-code-signing-settings.xcodeproj/project.pbxproj
@@ -425,6 +425,7 @@
 		77C503131DD3175E00AC8FF0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = today/Test.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;
@@ -442,6 +443,7 @@
 		77C503141DD3175E00AC8FF0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+			    CODE_SIGN_ENTITLEMENTS = today/Test.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = G3KGXDXQL9;


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fastlane already has a couple of actions to change/add entries in an apps entitlements file but there is no action that considers that this file is not added to the build settings. Leaving no other option than manually adding this file by opening the project in Xcode and clicking through UI.

We'd like to integrate fastlane into CI/CD of one of our projects where these entitlements files are generated on a per client basis. Hence the need for automation at this point.

### Description
Extended the existing action `update_code_signing_settings` to also handle the build setting `CODE_SIGN_ENTITLEMENTS`.

### Testing Steps
Added test case to existing `update_code_signing_settings_spec.rb` to add the new `CODE_SIGN_ENTITLEMENTS` entry in a Xcode project file where it is missing and to modify a project with an already existing one.

