### PR TITLE
[run_tests] Add examples for simulator descriptions including OS version in `device` parameter documentation

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -60,7 +60,7 @@ module Scan
                                      optional: true,
                                      is_string: true,
                                      env_name: "SCAN_DEVICE",
-                                     description: "The name of the simulator type you want to run tests on (e.g. 'iPhone 6')",
+                                     description: "The name of the simulator type you want to run tests on (e.g. 'iPhone 6' or 'iPhone SE (2nd generation) (14.5)')",
                                      conflicting_options: [:devices],
                                      conflict_block: proc do |value|
                                        UI.user_error!("You can't use 'device' and 'devices' options in one run")
@@ -70,7 +70,7 @@ module Scan
                                      is_string: false,
                                      env_name: "SCAN_DEVICES",
                                      type: Array,
-                                     description: "Array of devices to run the tests on (e.g. ['iPhone 6', 'iPad Air'])",
+                                     description: "Array of devices to run the tests on (e.g. ['iPhone 6', 'iPad Air', 'iPhone SE (2nd generation) (14.5)'])",
                                      conflicting_options: [:device],
                                      conflict_block: proc do |value|
                                        UI.user_error!("You can't use 'device' and 'devices' options in one run")


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I found that the documentation for `run_tests` did not accurately reflect the option for specifying a device OS version.
This should help make that functionality more apparent.

### Description
This documentation-only change reflects the behaviour in https://github.com/fastlane/fastlane/blob/f0b9bbe0c391f034d997ae2ce48bac567c29fa7e/scan/lib/scan/detect_values.rb#L116 and also tests such as https://github.com/fastlane/fastlane/blob/f0b9bbe0c391f034d997ae2ce48bac567c29fa7e/scan/spec/test_command_generator_spec.rb#L671

### Testing Steps
Since no logic was changed only documentation generation needs to be tested.
