### PR TITLE
Add native xcode 13 retries

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -51,7 +51,9 @@ module Scan
         end
       end
 
-      execute(retries: Scan.config[:number_of_retries])
+      # Set retries to 0 if Xcode 13 because TestCommandGenerator will set '-retry-tests-on-failure -test-iterations'
+      retries = Helper.xcode_at_least?(13) ? 0 : Scan.config[:number_of_retries]
+      execute(retries: retries)
     end
 
     def execute(retries: 0)

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -72,11 +72,9 @@ module Scan
       end
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]
-      if config[:number_of_retries] >= 1
-        if FastlaneCore::Helper.xcode_at_least?(13)
-          options << "-retry-tests-on-failure"
-          options << "-test-iterations #{config[:number_of_retries]}"
-        end
+      if config[:number_of_retries] >= 1 && FastlaneCore::Helper.xcode_at_least?(13)
+        options << "-retry-tests-on-failure"
+        options << "-test-iterations #{config[:number_of_retries]}"
       end
 
       # detect_values will ensure that these values are present as Arrays if

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -72,6 +72,12 @@ module Scan
       end
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]
+      if config[:number_of_retries] >= 1
+        if FastlaneCore::Helper.xcode_at_least?(13)
+          options << "-retry-tests-on-failure"
+          options << "-test-iterations #{config[:number_of_retries]}"
+        end
+      end
 
       # detect_values will ensure that these values are present as Arrays if
       # they are present at all


### PR DESCRIPTION
### Motivation and Context
#19612

### Description
Use `-retry-tests-on-failure -test-iterations <number>` if `number_of_retries` >= 1 and using Xcode 13