### PR TITLE
[fastlane_core] fix non-UTF-8 char issues when analysing ipa

### DIFF
--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -73,7 +73,7 @@ module FastlaneCore
     end
 
     def self.fetch_info_plist_with_unzip(path)
-      entry, error, = Open3.capture3("unzip", "-Z", "-1", path, "*/Payload/*.app/Info.plist")
+      entry, error, = Open3.capture3("unzip", "-Z", "-1", path, "*Payload/*.app/Info.plist")
 
       # unzip can return multiple Info.plist files if is an embedded app bundle (a WatchKit app)
       #   - ContainsWatchApp/Payload/Sample.app/Watch/Sample WatchKit App.app/Info.plist

--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -73,12 +73,9 @@ module FastlaneCore
     end
 
     def self.fetch_info_plist_with_unzip(path)
-      list, error, = Open3.capture3("unzip", "-Z", "-1", path)
+      entry, error, = Open3.capture3("unzip", "-Z", "-1", path, "*.app/Info.plist")
       UI.command_output(error) unless error.empty?
-      return nil if list.empty?
-      entry = list.chomp.split("\n").find do |e|
-        File.fnmatch("**/Payload/*.app/Info.plist", e, File::FNM_PATHNAME)
-      end
+      return nil if entry.empty?
       data, error, = Open3.capture3("unzip", "-p", path, entry)
       UI.command_output(error) unless error.empty?
       return nil if data.empty?

--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -73,10 +73,20 @@ module FastlaneCore
     end
 
     def self.fetch_info_plist_with_unzip(path)
-      entry, error, = Open3.capture3("unzip", "-Z", "-1", path, "*.app/Info.plist")
+      entry, error, = Open3.capture3("unzip", "-Z", "-1", path, "*/Payload/*.app/Info.plist")
+
+      # unzip can return multiple Info.plist files if is an embedded app bundle (a WatchKit app)
+      #   - ContainsWatchApp/Payload/Sample.app/Watch/Sample WatchKit App.app/Info.plist
+      #   - ContainsWatchApp/Payload/Sample.app/Info.plist
+      #
+      # we can determine the main Info.plist by the shortest path
+      entry = entry.lines.map(&:chomp).min_by(&:size)
+
       UI.command_output(error) unless error.empty?
       return nil if entry.empty?
       data, error, = Open3.capture3("unzip", "-p", path, entry)
+      puts("data: #{data}")
+      puts("error: #{error}")
       UI.command_output(error) unless error.empty?
       return nil if data.empty?
       data

--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -83,7 +83,7 @@ module FastlaneCore
       entry = entry.lines.map(&:chomp).min_by(&:size)
 
       UI.command_output(error) unless error.empty?
-      return nil if entry.empty?
+      return nil if entry.nil? || entry.empty?
       data, error, = Open3.capture3("unzip", "-p", path, entry)
       puts("data: #{data}")
       puts("error: #{error}")

--- a/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_file_analyser.rb
@@ -85,8 +85,6 @@ module FastlaneCore
       UI.command_output(error) unless error.empty?
       return nil if entry.nil? || entry.empty?
       data, error, = Open3.capture3("unzip", "-p", path, entry)
-      puts("data: #{data}")
-      puts("error: #{error}")
       UI.command_output(error) unless error.empty?
       return nil if data.empty?
       data

--- a/fastlane_core/spec/ipa_file_analyser_spec.rb
+++ b/fastlane_core/spec/ipa_file_analyser_spec.rb
@@ -2,20 +2,53 @@ describe FastlaneCore do
   describe FastlaneCore::IpaFileAnalyser do
     let(:ipa) { 'iOSAppOnly' }
     let(:path) { File.expand_path("../fixtures/ipas/#{ipa}.ipa", __FILE__) }
-    describe '::fetch_app_identifier' do
-      subject { described_class.fetch_app_identifier(path) }
-      it { is_expected.to eq('com.example.Sample') }
-      context 'when contains embedded app bundle' do
-        let('ipa') { 'ContainsWatchApp' }
+
+    context 'with fetch_info_plist_with_rubyzip' do
+      before(:each) do
+        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_info_plist_with_rubyzip).and_call_original
+      end
+
+      describe '::fetch_app_identifier' do
+        subject { described_class.fetch_app_identifier(path) }
         it { is_expected.to eq('com.example.Sample') }
+        context 'when contains embedded app bundle' do
+          let('ipa') { 'ContainsWatchApp' }
+          it { is_expected.to eq('com.example.Sample') }
+        end
+      end
+
+      describe '::fetch_app_build' do
+        subject { described_class.fetch_app_build(path) }
+        it { is_expected.to eq('1') }
+        context 'when contains embedded app bundle' do
+          let('ipa') { 'ContainsWatchApp' }
+          it { is_expected.to eq('1') }
+        end
       end
     end
-    describe '::fetch_app_build' do
-      subject { described_class.fetch_app_build(path) }
-      it { is_expected.to eq('1') }
-      context 'when contains embedded app bundle' do
-        let('ipa') { 'ContainsWatchApp' }
+
+    context 'with fetch_info_plist_with_unzip' do
+      before(:each) do
+        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_info_plist_with_rubyzip).and_return(nil)
+        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_info_plist_with_unzip).and_call_original
+      end
+
+      describe '::fetch_app_identifier' do
+        subject { described_class.fetch_app_identifier(path) }
+        it { is_expected.to eq('com.example.Sample') }
+        context 'when contains embedded app bundle' do
+          let('ipa') { 'ContainsWatchApp' }
+          it { is_expected.to eq('com.example.Sample') }
+        end
+      end
+
+      describe '::fetch_app_build' do
+        subject { described_class.fetch_app_build(path) }
         it { is_expected.to eq('1') }
+        context 'when contains embedded app bundle' do
+          let('ipa') { 'ContainsWatchApp' }
+          it { is_expected.to eq('1') }
+        end
       end
     end
   end

--- a/fastlane_core/spec/ipa_file_analyser_spec.rb
+++ b/fastlane_core/spec/ipa_file_analyser_spec.rb
@@ -28,26 +28,28 @@ describe FastlaneCore do
     end
 
     context 'with fetch_info_plist_with_unzip' do
-      before(:each) do
-        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_info_plist_with_rubyzip).and_return(nil)
-        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_info_plist_with_unzip).and_call_original
-      end
-
-      describe '::fetch_app_identifier' do
-        subject { described_class.fetch_app_identifier(path) }
-        it { is_expected.to eq('com.example.Sample') }
-        context 'when contains embedded app bundle' do
-          let('ipa') { 'ContainsWatchApp' }
-          it { is_expected.to eq('com.example.Sample') }
+      unless FastlaneCore::Helper.windows?
+        before(:each) do
+          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_info_plist_with_rubyzip).and_return(nil)
+          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_info_plist_with_unzip).and_call_original
         end
-      end
 
-      describe '::fetch_app_build' do
-        subject { described_class.fetch_app_build(path) }
-        it { is_expected.to eq('1') }
-        context 'when contains embedded app bundle' do
-          let('ipa') { 'ContainsWatchApp' }
+        describe '::fetch_app_identifier' do
+          subject { described_class.fetch_app_identifier(path) }
+          it { is_expected.to eq('com.example.Sample') }
+          context 'when contains embedded app bundle' do
+            let('ipa') { 'ContainsWatchApp' }
+            it { is_expected.to eq('com.example.Sample') }
+          end
+        end
+
+        describe '::fetch_app_build' do
+          subject { described_class.fetch_app_build(path) }
           it { is_expected.to eq('1') }
+          context 'when contains embedded app bundle' do
+            let('ipa') { 'ContainsWatchApp' }
+            it { is_expected.to eq('1') }
+          end
         end
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Fixed an issue (#19692) where `ipa_file_analyser.rb` can't handle non-UTF-8 chars inside file names if the IPA file exceeds 4G.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Instead of getting the full file list and then looking for the app's `Info.plist` file, I change the code to look for the `Info.plist` file directly in the zip file.

Tested with my own app (around 6.6G) which has files with `Ö` in the file name.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
