### PR TITLE
[gym] correctly inherit OTHER_SWIFT_FLAGS when using option 'analyze_build_time'

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -43,7 +43,7 @@ module Gym
           options << "-scmProvider system"
         end
         options << config[:xcargs] if config[:xcargs]
-        options << "OTHER_SWIFT_FLAGS=\"-Xfrontend -debug-time-function-bodies\"" if config[:analyze_build_time]
+        options << "OTHER_SWIFT_FLAGS=\"\\\$(value) -Xfrontend -debug-time-function-bodies\"" if config[:analyze_build_time]
 
         options
       end

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -328,7 +328,7 @@ describe Gym do
                                "-project ./gym/examples/standard/Example.xcodeproj",
                                "-destination 'generic/platform=iOS'",
                                "-archivePath #{Gym::BuildCommandGenerator.archive_path.shellescape}",
-                               "OTHER_SWIFT_FLAGS=\"-Xfrontend -debug-time-function-bodies\"",
+                               "OTHER_SWIFT_FLAGS=\"\\$(value) -Xfrontend -debug-time-function-bodies\"",
                                :archive,
                                "| tee #{@log_path.shellescape}",
                                "| xcpretty"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass (well, sort of. Tests unrelated to my change were failing, but the test for the code I changed was passing when run in isolation)
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
We had an issue with the Apollo SDK when using CocoaPods. Turns out the root cause of that bug was the OTHER_SWIFT_FLAGS not being successfully inherited here. See details of that bug here: https://github.com/apollographql/apollo-ios/issues/2047 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Added an additional escape character to the $ on "$(inherited)" OTHER_SWIFT_FLAGS so that it successfully gets passed to xcodebuild rather than being evaluated too early.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I tested `gym` on an example project with a custom OTHER_SWIFT_FLAGS setting and ensured that the actual `CompileSwiftSources` command in the build log had the custom flag in addition to the build time analysis ones.

```
-D MY_SWIFT_FLAG -Xfrontend -debug-time-function-bodies
```

