### PR TITLE
[scan] Fix: test retries succeeding when they shouldn't

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -126,7 +126,7 @@ module Scan
 
         test_cases = suite.split(":\n").fetch(1, []).split("\n").each
                           .select { |line| line.match?(/^\s+/) }
-                          .map { |line| line.strip.gsub(".", "/").gsub("()", "") }
+                          .map { |line| line.strip.gsub(/[\s\.]/, "/").gsub(/[(\-\[)\](\(\))]/, "") }
                           .map { |line| suite_name + "/" + line }
 
         retryable_tests += test_cases

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -126,7 +126,7 @@ module Scan
 
         test_cases = suite.split(":\n").fetch(1, []).split("\n").each
                           .select { |line| line.match?(/^\s+/) }
-                          .map { |line| line.strip.gsub(/[\s\.]/, "/").gsub(/[(\-\[)\](\(\))]/, "") }
+                          .map { |line| line.strip.gsub(/[\s\.]/, "/").gsub(/[\-\[\]\(\)]/, "") }
                           .map { |line| suite_name + "/" + line }
 
         retryable_tests += test_cases

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -102,9 +102,10 @@ describe Scan do
 Failing tests:
   FastlaneAppTests:
           FastlaneAppTests.testCoinToss()
+          -[FastlaneAppTestsOC testCoinTossOC]
           ERROR_OUTPUT
 
-        expect(Fastlane::UI).to receive(:important).with("Retrying tests: FastlaneAppTests/FastlaneAppTests/testCoinToss").once
+        expect(Fastlane::UI).to receive(:important).with("Retrying tests: FastlaneAppTests/FastlaneAppTests/testCoinToss, FastlaneAppTests/FastlaneAppTestsOC/testCoinTossOC").once
         expect(Fastlane::UI).to receive(:important).with("Number of retries remaining: 4").once
         expect(@scan).to receive(:execute)
 
@@ -116,9 +117,10 @@ Failing tests:
 Failing tests:
   Fastlane-App-Tests:
           FastlaneAppTests.testCoinToss()
+          -[FastlaneAppTestsOC testCoinTossOC]
           ERROR_OUTPUT
 
-        expect(Fastlane::UI).to receive(:important).with("Retrying tests: Fastlane-App-Tests/FastlaneAppTests/testCoinToss").once
+        expect(Fastlane::UI).to receive(:important).with("Retrying tests: Fastlane-App-Tests/FastlaneAppTests/testCoinToss, Fastlane-App-Tests/FastlaneAppTestsOC/testCoinTossOC").once
         expect(Fastlane::UI).to receive(:important).with("Number of retries remaining: 4").once
         expect(@scan).to receive(:execute)
 
@@ -130,6 +132,7 @@ Failing tests:
 Failing tests:
 FastlaneAppTests:
 FastlaneAppTests.testCoinToss()
+-[FastlaneAppTestsOC testCoinTossOC]
           ERROR_OUTPUT
 
         expect do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
The action `Scan` has a parameter called `number_of_retries` that allows tests to be re-run if some of them fail. However, currently the parsing code provides the wrong name of failed tests to `xcodebuild`'s `-only-testing` option if these tests are Objective-C codes (it works well with Swift codes).
For example, such a failed test could be printed in the log as: 
```
Failing tests:
MyFastlaneTests:
    -[MyObjectiveCTestClass testCoinToss]
```
Which results in the command line as 
`xcodebuild -only-testing:MyFastlaneTests/-[MyObjectiveCTestClass testCoinToss]`. 
Whereas the correct output should be: 
`xcodebuild -only-testing:MyFastlaneTests/MyObjectiveCTestClass/testCoinToss`.

This PR fixes such an issue by adding more parsing logic to the function responsible for generating retry tests.
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #18587

### Description
<!-- Describe your changes in detail. -->
We change the parsing code in the method `retryable_tests`, which adds the detection of `-[` and `]` when erasing them and the detection of whitespace when replacing them for `/`.
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the Fastlane team. -->
Added an objective c version sample method in the file `scan/spec/runner_spec.rb` in the test named `retry a fail test` and the next two tests.
