### PR TITLE
[deliver] Add Watch Series 7 screen size

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -63,6 +63,8 @@ module Deliver
       IOS_APPLE_WATCH = "iOS-Apple-Watch"
       # Apple Watch Series 4
       IOS_APPLE_WATCH_SERIES4 = "iOS-Apple-Watch-Series4"
+      # Apple Watch Series 7
+      IOS_APPLE_WATCH_SERIES7 = "iOS-Apple-Watch-Series7"
 
       # Apple TV
       APPLE_TV = "Apple-TV"
@@ -117,6 +119,7 @@ module Deliver
         ScreenSize::MAC => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_DESKTOP,
         ScreenSize::IOS_APPLE_WATCH => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_3,
         ScreenSize::IOS_APPLE_WATCH_SERIES4 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_4,
+        ScreenSize::IOS_APPLE_WATCH_SERIES7 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_7,
         ScreenSize::APPLE_TV => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_APPLE_TV
       }
       return matching[self.screen_size]
@@ -151,6 +154,7 @@ module Deliver
         ScreenSize::MAC => "Mac",
         ScreenSize::IOS_APPLE_WATCH => "Watch",
         ScreenSize::IOS_APPLE_WATCH_SERIES4 => "Watch Series4",
+        ScreenSize::IOS_APPLE_WATCH_SERIES7 => "Watch Series7",
         ScreenSize::APPLE_TV => "Apple TV"
       }
       return matching[self.screen_size]
@@ -312,6 +316,9 @@ module Deliver
         ],
         ScreenSize::IOS_APPLE_WATCH_SERIES4 => [
           [368, 448]
+        ],
+        ScreenSize::IOS_APPLE_WATCH_SERIES7 => [
+          [396, 484]
         ],
         ScreenSize::APPLE_TV => [
           [1920, 1080],

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -143,6 +143,7 @@ describe Deliver::AppScreenshot do
       it "should calculate all supported Apple Watch resolutions" do
         expect_screen_size_from_file("AppleWatch-Series3{312x390}.jpg").to eq(ScreenSize::IOS_APPLE_WATCH)
         expect_screen_size_from_file("AppleWatch-Series4{368x448}.jpg").to eq(ScreenSize::IOS_APPLE_WATCH_SERIES4)
+        expect_screen_size_from_file("AppleWatch-Series7{368x484}.jpg").to eq(ScreenSize::IOS_APPLE_WATCH_SERIES7)
       end
     end
 
@@ -338,6 +339,10 @@ describe Deliver::AppScreenshot do
 
     it "should return watchSeries4 for Apple Watch Series 4" do
       expect(app_screenshot_with(ScreenSize::IOS_APPLE_WATCH_SERIES4).device_type).to eq("APP_WATCH_SERIES_4")
+    end
+
+    it "should return watchSeries7 for Apple Watch Series 7" do
+      expect(app_screenshot_with(ScreenSize::IOS_APPLE_WATCH_SERIES7).device_type).to eq("APP_WATCH_SERIES_7")
     end
 
     it "should return appleTV for Apple TV" do

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -143,7 +143,7 @@ describe Deliver::AppScreenshot do
       it "should calculate all supported Apple Watch resolutions" do
         expect_screen_size_from_file("AppleWatch-Series3{312x390}.jpg").to eq(ScreenSize::IOS_APPLE_WATCH)
         expect_screen_size_from_file("AppleWatch-Series4{368x448}.jpg").to eq(ScreenSize::IOS_APPLE_WATCH_SERIES4)
-        expect_screen_size_from_file("AppleWatch-Series7{368x484}.jpg").to eq(ScreenSize::IOS_APPLE_WATCH_SERIES7)
+        expect_screen_size_from_file("AppleWatch-Series7{396x484}.jpg").to eq(ScreenSize::IOS_APPLE_WATCH_SERIES7)
       end
     end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
@@ -38,6 +38,7 @@ module Spaceship
 
         APP_WATCH_SERIES_3 = "APP_WATCH_SERIES_3"
         APP_WATCH_SERIES_4 = "APP_WATCH_SERIES_4"
+        APP_WATCH_SERIES_7 = "APP_WATCH_SERIES_7"
 
         APP_APPLE_TV = "APP_APPLE_TV"
 
@@ -85,6 +86,7 @@ module Spaceship
 
           APP_WATCH_SERIES_3,
           APP_WATCH_SERIES_4,
+          APP_WATCH_SERIES_7,
 
           APP_DESKTOP
         ]


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Uploading an Apple Watch Series 7 screenshot fails with invalid size. The size is detailed in https://help.apple.com/app-store-connect/#/devd274dd925, however.