### PR TITLE
[xcbeautify][snapshot] snapshot allow xcbeautify

### DIFF
--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -381,6 +381,7 @@ describe Gym do
 
         pipe = Gym::BuildCommandGenerator.pipe
         expect(pipe.join(" ")).not_to include("| xcpretty")
+        expect(pipe.join(" ")).not_to include("| xcbeautify")
       end
 
       it "uses no pipe with xcodebuild_formatter of empty string", requires_xcodebuild: true do
@@ -392,6 +393,7 @@ describe Gym do
 
         pipe = Gym::BuildCommandGenerator.pipe
         expect(pipe.join(" ")).not_to include("| xcpretty")
+        expect(pipe.join(" ")).not_to include("| xcbeautify")
       end
 
       describe "with xcodebuild_formatter" do

--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -1,5 +1,6 @@
 require 'fastlane_core/configuration/config_item'
 require 'fastlane_core/device_manager'
+require 'fastlane/helper/xcodebuild_formatter_helper'
 require 'credentials_manager/appfile_config'
 require_relative 'module'
 
@@ -11,9 +12,13 @@ module Snapshot
     end
 
     def self.available_options
+      @options ||= plain_options
+    end
+
+    def self.plain_options
       output_directory = (File.directory?("fastlane") ? "fastlane/screenshots" : "screenshots")
 
-      @options ||= [
+      [
         FastlaneCore::ConfigItem.new(key: :workspace,
                                      short_option: "-w",
                                      env_name: "SNAPSHOT_WORKSPACE",
@@ -194,12 +199,6 @@ module Snapshot
                                      description: "The configuration to use when building the app. Defaults to 'Release'",
                                      default_value_dynamic: true,
                                      optional: true),
-        FastlaneCore::ConfigItem.new(key: :xcpretty_args,
-                                     short_option: "-x",
-                                     env_name: "SNAPSHOT_XCPRETTY_ARGS",
-                                     description: "Additional xcpretty arguments",
-                                     is_string: true,
-                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :sdk,
                                      short_option: "-k",
                                      env_name: "SNAPSHOT_SDK",
@@ -289,11 +288,28 @@ module Snapshot
                                      verify_block: proc do |value|
                                        verify_type('skip_testing', [Array, String], value)
                                      end),
+
+        FastlaneCore::ConfigItem.new(key: :xcodebuild_formatter,
+                                     env_names: ["SNAPSHOT_XCODEBUILD_FORMATTER", "FASTLANE_XCODEBUILD_FORMATTER"],
+                                     description: "xcodebuild formatter to use (ex: 'xcbeautify', 'xcbeautify --quieter', 'xcpretty', 'xcpretty -test')",
+                                     type: String,
+                                     default_value: Fastlane::Helper::XcodebuildFormatterHelper.xcbeautify_installed? ? 'xcbeautify' : 'xcpretty',
+                                     default_value_dynamic: true),
+
+        # xcpretty
+        FastlaneCore::ConfigItem.new(key: :xcpretty_args,
+                                     short_option: "-x",
+                                     env_name: "SNAPSHOT_XCPRETTY_ARGS",
+                                     deprecated: "Use `xcodebuild_formatter: ''` instead",
+                                     description: "Additional xcpretty arguments",
+                                     is_string: true,
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :disable_xcpretty,
                                      env_name: "SNAPSHOT_DISABLE_XCPRETTY",
                                      description: "Disable xcpretty formatting of build",
                                      type: Boolean,
                                      optional: true),
+
         FastlaneCore::ConfigItem.new(key: :suppress_xcode_output,
                                      env_name: "SNAPSHOT_SUPPRESS_XCODE_OUTPUT",
                                      description: "Suppress the output of xcodebuild to stdout. Output is still saved in buildlog_path",

--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -20,190 +20,420 @@ describe Snapshot do
       fake_out_xcode_project_loading
     end
 
-    describe '#destination' do
-      it "returns the highest version available for device if no match for the specified/latest os_version" do
-        allow(Snapshot).to receive(:config).and_return({ ios_version: os_version })
-        devices = ["iPhone 4s", "iPhone 6", "iPhone 6s"]
-        result = Snapshot::TestCommandGenerator.destination(devices)
-        expect(result).to eq([[
-          "-destination 'platform=iOS Simulator,name=iPhone 4s,OS=9.0'",
-          "-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3'",
-          "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3'"
-        ].join(' ')])
-      end
-    end
-
-    describe '#verify_devices_share_os' do
+    context "with xcpretty" do
       before(:each) do
-        @test_command_generator = Snapshot::TestCommandGenerator.new
-      end
-      it "returns true with only iOS devices" do
-        devices = ["iPhone 8", "iPad Air 2", "iPhone X", "iPhone 8 plus", "iPod touch (7th generation)"]
-        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
-        expect(result).to be(true)
+        allow(Fastlane::Helper::XcodebuildFormatterHelper).to receive(:xcbeautify_installed?).and_return(false)
       end
 
-      it "returns true with only Apple TV devices" do
-        devices = ["Apple TV 1080p", "Apple TV 4K", "Apple TV 4K (at 1080p)"]
-        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
-        expect(result).to be(true)
+      describe '#destination' do
+        it "returns the highest version available for device if no match for the specified/latest os_version" do
+          allow(Snapshot).to receive(:config).and_return({ ios_version: os_version })
+          devices = ["iPhone 4s", "iPhone 6", "iPhone 6s"]
+          result = Snapshot::TestCommandGenerator.destination(devices)
+          expect(result).to eq([[
+            "-destination 'platform=iOS Simulator,name=iPhone 4s,OS=9.0'",
+            "-destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3'",
+            "-destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3'"
+          ].join(' ')])
+        end
       end
 
-      it "returns true with only Apple Watch devices" do
-        devices = ["Apple Watch Series 6 - 44mm"]
-        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
-        expect(result).to be(true)
+      describe '#verify_devices_share_os' do
+        before(:each) do
+          @test_command_generator = Snapshot::TestCommandGenerator.new
+        end
+        it "returns true with only iOS devices" do
+          devices = ["iPhone 8", "iPad Air 2", "iPhone X", "iPhone 8 plus", "iPod touch (7th generation)"]
+          result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+          expect(result).to be(true)
+        end
+
+        it "returns true with only Apple TV devices" do
+          devices = ["Apple TV 1080p", "Apple TV 4K", "Apple TV 4K (at 1080p)"]
+          result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+          expect(result).to be(true)
+        end
+
+        it "returns true with only Apple Watch devices" do
+          devices = ["Apple Watch Series 6 - 44mm"]
+          result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+          expect(result).to be(true)
+        end
+
+        it "returns false with mixed device OS of Apple TV and iPhone" do
+          devices = ["Apple TV 1080p", "iPhone 8"]
+          result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+          expect(result).to be(false)
+        end
+
+        it "returns false with mixed device OS of Apple Watch and iPhone" do
+          devices = ["Apple Watch Series 6 - 44mm", "iPhone 8"]
+          result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+          expect(result).to be(false)
+        end
+
+        it "returns false with mixed device OS of Apple TV and iPad" do
+          devices = ["Apple TV 1080p", "iPad Air 2"]
+          result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+          expect(result).to be(false)
+        end
+
+        it "returns false with mixed device OS of Apple TV and iPod" do
+          devices = ["Apple TV 1080p", "iPod touch (7th generation)"]
+          result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+          expect(result).to be(false)
+        end
+
+        it "returns true with custom named iOS devices" do
+          devices = ["11.0 - iPhone X", "11.0 - iPad Air 2", "13.0 - iPod touch"]
+          result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+          expect(result).to be(true)
+        end
+
+        it "returns true with custom named Apple TV devices" do
+          devices = ["11.0 - Apple TV 1080p", "11.0 - Apple TV 4K", "11.0 - Apple TV 4K (at 1080p)"]
+          result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
+          expect(result).to be(true)
+        end
       end
 
-      it "returns false with mixed device OS of Apple TV and iPhone" do
-        devices = ["Apple TV 1080p", "iPhone 8"]
-        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
-        expect(result).to be(false)
+      describe '#find_device' do
+        it 'finds a device that has a matching name and OS version' do
+          found = Snapshot::TestCommandGenerator.find_device('iPhone 6', '9.0')
+          expect(found).to eq(iphone6_9_0)
+        end
+
+        it 'does not find a device that has a different name' do
+          found = Snapshot::TestCommandGenerator.find_device('iPhone 5', '9.0')
+          expect(found).to be(nil)
+        end
+
+        it 'finds a device with the same name, but a different OS version, picking the highest available OS version' do
+          found = Snapshot::TestCommandGenerator.find_device('iPhone 6', '10.0')
+          expect(found).to be(iphone6_9_3)
+        end
       end
 
-      it "returns false with mixed device OS of Apple Watch and iPhone" do
-        devices = ["Apple Watch Series 6 - 44mm", "iPhone 8"]
-        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
-        expect(result).to be(false)
+      describe 'copy_simulator_logs' do
+        before (:each) do
+          @config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {
+            output_directory: '/tmp/scan_results',
+            output_simulator_logs: true,
+            devices: ['iPhone 6 (10.1)', 'iPhone 6s'],
+            project: './snapshot/example/Example.xcodeproj',
+            scheme: 'ExampleUITests',
+            namespace_log_files: true
+          })
+        end
+
+        it 'copies all device log archives to the output directory on macOS 10.12 (Sierra)', requires_xcode: true do
+          Snapshot.config = @config
+          launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
+
+          allow(FastlaneCore::CommandExecutor).
+            to receive(:execute).
+            with(command: "sw_vers -productVersion", print_all: false, print_command: false).
+            and_return('10.12.1')
+
+          expect(FastlaneCore::CommandExecutor).
+            to receive(:execute).
+            with(command: %r{xcrun simctl spawn 33333 log collect --start '\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d' --output /tmp/scan_results/de-DE/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive 2>/dev/null}, print_all: false, print_command: true)
+
+          expect(FastlaneCore::CommandExecutor).
+            to receive(:execute).
+            with(command: %r{xcrun simctl spawn 98765 log collect --start '\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d' --output /tmp/scan_results/en-US/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive 2>/dev/null}, print_all: false, print_command: true)
+
+          Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6 (10.1)"], "de-DE", nil, 0)
+          Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6s (10.1)"], "en-US", nil, 0)
+        end
+
+        it 'copies all iOS 9 device log files to the output directory on macOS 10.12 (Sierra)', requires_xcode: true do
+          Snapshot.config = @config
+          launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
+
+          allow(File).to receive(:exist?).with(/.*system\.log/).and_return(true)
+          allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return('10.12')
+
+          expect(FileUtils).to receive(:rm_f).with(%r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
+          expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
+
+          expect(FileUtils).to receive(:rm_f).with(%r{#{Snapshot.config[:output_directory]}/en-US/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
+          expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/en-US/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
+
+          Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6s"], "de-DE", nil, 0)
+          Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6"], "en-US", nil, 0)
+        end
+
+        it 'copies all device log files to the output directory on macOS 10.11 (El Capitan)', requires_xcode: true do
+          Snapshot.config = @config
+          launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
+
+          allow(File).to receive(:exist?).with(/.*system\.log/).and_return(true)
+          allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return('10.11.6')
+
+          expect(FileUtils).to receive(:rm_f).with(%r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
+          expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
+
+          expect(FileUtils).to receive(:rm_f).with(%r{#{Snapshot.config[:output_directory]}/en-US/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
+          expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/en-US/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
+
+          Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6s"], "de-DE", nil, 0)
+          Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPad Air"], "en-US", nil, 0)
+        end
       end
 
-      it "returns false with mixed device OS of Apple TV and iPad" do
-        devices = ["Apple TV 1080p", "iPad Air 2"]
-        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
-        expect(result).to be(false)
+      describe "Valid iOS Configuration" do
+        let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
+
+        def configure(options)
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        end
+
+        context 'default options' do
+          it "uses the default parameters", requires_xcode: true do
+            configure(options)
+            expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
+            command = Snapshot::TestCommandGenerator.generate(
+              devices: ["iPhone 6"],
+              language: "en",
+              locale: nil,
+              log_path: '/path/to/logs'
+            )
+            name = command.join('').match(/name=(.+?),/)[1]
+            ios = command.join('').match(/OS=(\d+.\d+)/)[1]
+            expect(command).to eq(
+              [
+                "set -o pipefail &&",
+                "xcodebuild",
+                "-scheme ExampleUITests",
+                "-project ./snapshot/example/Example.xcodeproj",
+                "-derivedDataPath /tmp/path/to/snapshot_derived",
+                "-destination 'platform=iOS Simulator,name=#{name},OS=#{ios}'",
+                "FASTLANE_SNAPSHOT=YES",
+                "FASTLANE_LANGUAGE=en",
+                :build,
+                :test,
+                "| tee /path/to/logs",
+                "| xcpretty "
+              ]
+            )
+          end
+
+          it "allows to supply custom xcargs", requires_xcode: true do
+            configure(options.merge(xcargs: "-only-testing:TestBundle/TestSuite/Screenshots"))
+            expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
+            command = Snapshot::TestCommandGenerator.generate(
+              devices: ["iPhone 6"],
+              language: "en",
+              locale: nil,
+              log_path: '/path/to/logs'
+            )
+            name = command.join('').match(/name=(.+?),/)[1]
+            ios = command.join('').match(/OS=(\d+.\d+)/)[1]
+            expect(command).to eq(
+              [
+                "set -o pipefail &&",
+                "xcodebuild",
+                "-scheme ExampleUITests",
+                "-project ./snapshot/example/Example.xcodeproj",
+                "-derivedDataPath /tmp/path/to/snapshot_derived",
+                "-only-testing:TestBundle/TestSuite/Screenshots",
+                "-destination 'platform=iOS Simulator,name=#{name},OS=#{ios}'",
+                "FASTLANE_SNAPSHOT=YES",
+                "FASTLANE_LANGUAGE=en",
+                :build,
+                :test,
+                "| tee /path/to/logs",
+                "| xcpretty "
+              ]
+            )
+          end
+
+          it "uses the default parameters on tvOS too", requires_xcode: true do
+            configure(options.merge(devices: ["Apple TV 1080p"]))
+            expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
+            command = Snapshot::TestCommandGenerator.generate(
+              devices: ["Apple TV 1080p"],
+              language: "en",
+              locale: nil,
+              log_path: '/path/to/logs'
+            )
+            name = command.join('').match(/name=(.+?),/)[1]
+            os = command.join('').match(/OS=(\d+.\d+)/)[1]
+            expect(command).to eq(
+              [
+                "set -o pipefail &&",
+                "xcodebuild",
+                "-scheme ExampleUITests",
+                "-project ./snapshot/example/Example.xcodeproj",
+                "-derivedDataPath /tmp/path/to/snapshot_derived",
+                "-destination 'platform=tvOS Simulator,name=#{name},OS=#{os}'",
+                "FASTLANE_SNAPSHOT=YES",
+                "FASTLANE_LANGUAGE=en",
+                :build,
+                :test,
+                "| tee /path/to/logs",
+                "| xcpretty "
+              ]
+            )
+          end
+
+          it "uses the default parameters on watchOS too", requires_xcode: true do
+            configure(options.merge(devices: ["Apple Watch Series 6 - 44mm"]))
+            expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
+            command = Snapshot::TestCommandGenerator.generate(
+              devices: ["Apple Watch Series 6 - 44mm"],
+              language: "en",
+              locale: nil,
+              log_path: '/path/to/logs'
+            )
+            name = command.join('').match(/name=(.+?),/)[1]
+            os = command.join('').match(/OS=(\d+.\d+)/)[1]
+            expect(command).to eq(
+              [
+                "set -o pipefail &&",
+                "xcodebuild",
+                "-scheme ExampleUITests",
+                "-project ./snapshot/example/Example.xcodeproj",
+                "-derivedDataPath /tmp/path/to/snapshot_derived",
+                "-destination 'platform=watchOS Simulator,name=#{name},OS=#{os}'",
+                "FASTLANE_SNAPSHOT=YES",
+                "FASTLANE_LANGUAGE=en",
+                :build,
+                :test,
+                "| tee /path/to/logs",
+                "| xcpretty "
+              ]
+            )
+          end
+        end
+
+        context 'fixed derivedDataPath' do
+          let(:temp) { Dir.mktmpdir }
+
+          before do
+            configure(options.merge(derived_data_path: temp))
+          end
+
+          it 'uses the fixed derivedDataPath if given', requires_xcode: true do
+            expect(Dir).not_to(receive(:mktmpdir))
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to include("-derivedDataPath #{temp}")
+          end
+        end
+
+        context 'test-without-building' do
+          let(:temp) { Dir.mktmpdir }
+
+          before do
+            configure(options.merge(derived_data_path: temp, test_without_building: true))
+          end
+
+          it 'uses the "test-without-building" command and not the default "build test"', requires_xcode: true do
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to include("test-without-building")
+            expect(command.join('')).not_to(include("build test"))
+          end
+        end
+
+        context 'test-plan' do
+          it 'adds the testplan to the xcodebuild command', requires_xcode: true do
+            configure(options.merge(testplan: 'simple'))
+
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to include("-testPlan 'simple'") if FastlaneCore::Helper.xcode_at_least?(11)
+          end
+        end
+
+        context "only-testing" do
+          it "only tests the test bundle/suite/cases specified in only_testing when the input is an array", requires_xcode: true do
+            configure(options.merge(only_testing: %w(TestBundleA/TestSuiteB TestBundleC)))
+
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to include("-only-testing:TestBundleA/TestSuiteB")
+            expect(command.join('')).to include("-only-testing:TestBundleC")
+          end
+
+          it "only tests the test bundle/suite/cases specified in only_testing when the input is a string", requires_xcode: true do
+            configure(options.merge(only_testing: 'TestBundleA/TestSuiteB'))
+
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to include("-only-testing:TestBundleA/TestSuiteB")
+            expect(command.join('')).not_to(include("-only-testing:TestBundleC"))
+          end
+        end
+
+        context "skip-testing" do
+          it "does not test the test bundle/suite/cases specified in skip_testing when the input is an array", requires_xcode: true do
+            configure(options.merge(skip_testing: %w(TestBundleA/TestSuiteB TestBundleC)))
+
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to include("-skip-testing:TestBundleA/TestSuiteB")
+            expect(command.join('')).to include("-skip-testing:TestBundleC")
+          end
+
+          it "does not test the test bundle/suite/cases specified in skip_testing when the input is a string", requires_xcode: true do
+            configure(options.merge(skip_testing: 'TestBundleA/TestSuiteB'))
+
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to include("-skip-testing:TestBundleA/TestSuiteB")
+            expect(command.join('')).not_to(include("-skip-testing:TestBundleC"))
+          end
+        end
+
+        context "disable_xcpretty" do
+          it "does not include xcpretty in the pipe command when true", requires_xcode: true do
+            configure(options.merge(disable_xcpretty: true))
+
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to_not(include("| xcpretty "))
+          end
+
+          it "includes xcpretty in the pipe command when false", requires_xcode: true do
+            configure(options.merge(disable_xcpretty: false))
+
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to include("| xcpretty ")
+          end
+        end
+
+        context "suppress_xcode_output" do
+          it "includes /dev/null in the pipe command when true", requires_xcode: true do
+            configure(options.merge(suppress_xcode_output: true))
+
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to include("> /dev/null")
+          end
+
+          it "does not include /dev/null in the pipe command when false", requires_xcode: true do
+            configure(options.merge(suppress_xcode_output: false))
+
+            command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
+            expect(command.join('')).to_not(include("> /dev/null"))
+          end
+        end
       end
 
-      it "returns false with mixed device OS of Apple TV and iPod" do
-        devices = ["Apple TV 1080p", "iPod touch (7th generation)"]
-        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
-        expect(result).to be(false)
-      end
+      describe "Valid macOS Configuration" do
+        let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleMacOS", namespace_log_files: true } }
 
-      it "returns true with custom named iOS devices" do
-        devices = ["11.0 - iPhone X", "11.0 - iPad Air 2", "13.0 - iPod touch"]
-        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
-        expect(result).to be(true)
-      end
-
-      it "returns true with custom named Apple TV devices" do
-        devices = ["11.0 - Apple TV 1080p", "11.0 - Apple TV 4K", "11.0 - Apple TV 4K (at 1080p)"]
-        result = Snapshot::TestCommandGenerator.verify_devices_share_os(devices)
-        expect(result).to be(true)
-      end
-    end
-
-    describe '#find_device' do
-      it 'finds a device that has a matching name and OS version' do
-        found = Snapshot::TestCommandGenerator.find_device('iPhone 6', '9.0')
-        expect(found).to eq(iphone6_9_0)
-      end
-
-      it 'does not find a device that has a different name' do
-        found = Snapshot::TestCommandGenerator.find_device('iPhone 5', '9.0')
-        expect(found).to be(nil)
-      end
-
-      it 'finds a device with the same name, but a different OS version, picking the highest available OS version' do
-        found = Snapshot::TestCommandGenerator.find_device('iPhone 6', '10.0')
-        expect(found).to be(iphone6_9_3)
-      end
-    end
-
-    describe 'copy_simulator_logs' do
-      before (:each) do
-        @config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {
-          output_directory: '/tmp/scan_results',
-          output_simulator_logs: true,
-          devices: ['iPhone 6 (10.1)', 'iPhone 6s'],
-          project: './snapshot/example/Example.xcodeproj',
-          scheme: 'ExampleUITests',
-          namespace_log_files: true
-        })
-      end
-
-      it 'copies all device log archives to the output directory on macOS 10.12 (Sierra)', requires_xcode: true do
-        Snapshot.config = @config
-        launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
-
-        allow(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(command: "sw_vers -productVersion", print_all: false, print_command: false).
-          and_return('10.12.1')
-
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(command: %r{xcrun simctl spawn 33333 log collect --start '\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d' --output /tmp/scan_results/de-DE/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive 2>/dev/null}, print_all: false, print_command: true)
-
-        expect(FastlaneCore::CommandExecutor).
-          to receive(:execute).
-          with(command: %r{xcrun simctl spawn 98765 log collect --start '\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d' --output /tmp/scan_results/en-US/system_logs-cfcd208495d565ef66e7dff9f98764da.logarchive 2>/dev/null}, print_all: false, print_command: true)
-
-        Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6 (10.1)"], "de-DE", nil, 0)
-        Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6s (10.1)"], "en-US", nil, 0)
-      end
-
-      it 'copies all iOS 9 device log files to the output directory on macOS 10.12 (Sierra)', requires_xcode: true do
-        Snapshot.config = @config
-        launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
-
-        allow(File).to receive(:exist?).with(/.*system\.log/).and_return(true)
-        allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return('10.12')
-
-        expect(FileUtils).to receive(:rm_f).with(%r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
-        expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
-
-        expect(FileUtils).to receive(:rm_f).with(%r{#{Snapshot.config[:output_directory]}/en-US/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
-        expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/en-US/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
-
-        Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6s"], "de-DE", nil, 0)
-        Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6"], "en-US", nil, 0)
-      end
-
-      it 'copies all device log files to the output directory on macOS 10.11 (El Capitan)', requires_xcode: true do
-        Snapshot.config = @config
-        launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
-
-        allow(File).to receive(:exist?).with(/.*system\.log/).and_return(true)
-        allow(FastlaneCore::CommandExecutor).to receive(:execute).with(command: "sw_vers -productVersion", print_all: false, print_command: false).and_return('10.11.6')
-
-        expect(FileUtils).to receive(:rm_f).with(%r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
-        expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/de-DE/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
-
-        expect(FileUtils).to receive(:rm_f).with(%r{#{Snapshot.config[:output_directory]}/en-US/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
-        expect(FileUtils).to receive(:cp).with(/.*/, %r{#{Snapshot.config[:output_directory]}/en-US/system-cfcd208495d565ef66e7dff9f98764da\.log}).and_return(true)
-
-        Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPhone 6s"], "de-DE", nil, 0)
-        Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config).copy_simulator_logs(["iPad Air"], "en-US", nil, 0)
-      end
-    end
-
-    describe "Valid iOS Configuration" do
-      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
-
-      def configure(options)
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
-      end
-
-      context 'default options' do
-        it "uses the default parameters", requires_xcode: true do
-          configure(options)
+        it "uses default parameters on macOS", requires_xcode: true do
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options.merge(devices: ["Mac"]))
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
           command = Snapshot::TestCommandGenerator.generate(
-            devices: ["iPhone 6"],
+            devices: ["Mac"],
             language: "en",
             locale: nil,
             log_path: '/path/to/logs'
           )
-          name = command.join('').match(/name=(.+?),/)[1]
-          ios = command.join('').match(/OS=(\d+.\d+)/)[1]
           expect(command).to eq(
             [
               "set -o pipefail &&",
               "xcodebuild",
-              "-scheme ExampleUITests",
+              "-scheme ExampleMacOS",
               "-project ./snapshot/example/Example.xcodeproj",
               "-derivedDataPath /tmp/path/to/snapshot_derived",
-              "-destination 'platform=iOS Simulator,name=#{name},OS=#{ios}'",
+              "-destination 'platform=macOS'",
               "FASTLANE_SNAPSHOT=YES",
               "FASTLANE_LANGUAGE=en",
               :build,
@@ -213,279 +443,139 @@ describe Snapshot do
             ]
           )
         end
+      end
 
-        it "allows to supply custom xcargs", requires_xcode: true do
-          configure(options.merge(xcargs: "-only-testing:TestBundle/TestSuite/Screenshots"))
-          expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
-          command = Snapshot::TestCommandGenerator.generate(
-            devices: ["iPhone 6"],
-            language: "en",
-            locale: nil,
-            log_path: '/path/to/logs'
-          )
-          name = command.join('').match(/name=(.+?),/)[1]
-          ios = command.join('').match(/OS=(\d+.\d+)/)[1]
-          expect(command).to eq(
-            [
-              "set -o pipefail &&",
-              "xcodebuild",
-              "-scheme ExampleUITests",
-              "-project ./snapshot/example/Example.xcodeproj",
-              "-derivedDataPath /tmp/path/to/snapshot_derived",
-              "-only-testing:TestBundle/TestSuite/Screenshots",
-              "-destination 'platform=iOS Simulator,name=#{name},OS=#{ios}'",
-              "FASTLANE_SNAPSHOT=YES",
-              "FASTLANE_LANGUAGE=en",
-              :build,
-              :test,
-              "| tee /path/to/logs",
-              "| xcpretty "
-            ]
+      describe "Unique logs" do
+        let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
+        let(:simulator_launcher) do
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+          launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
+          launcher_config.devices = ["iPhone 6"]
+          return simulator_launcher = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config)
+        end
+
+        it 'uses correct name and language', requires_xcode: true do
+          log_path = simulator_launcher.xcodebuild_log_path(language: "pt", locale: nil)
+          expect(log_path).to eq(
+            File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt.log").to_s
           )
         end
 
-        it "uses the default parameters on tvOS too", requires_xcode: true do
-          configure(options.merge(devices: ["Apple TV 1080p"]))
-          expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
-          command = Snapshot::TestCommandGenerator.generate(
-            devices: ["Apple TV 1080p"],
-            language: "en",
-            locale: nil,
-            log_path: '/path/to/logs'
-          )
-          name = command.join('').match(/name=(.+?),/)[1]
-          os = command.join('').match(/OS=(\d+.\d+)/)[1]
-          expect(command).to eq(
-            [
-              "set -o pipefail &&",
-              "xcodebuild",
-              "-scheme ExampleUITests",
-              "-project ./snapshot/example/Example.xcodeproj",
-              "-derivedDataPath /tmp/path/to/snapshot_derived",
-              "-destination 'platform=tvOS Simulator,name=#{name},OS=#{os}'",
-              "FASTLANE_SNAPSHOT=YES",
-              "FASTLANE_LANGUAGE=en",
-              :build,
-              :test,
-              "| tee /path/to/logs",
-              "| xcpretty "
-            ]
+        it 'uses includes locale if specified', requires_xcode: true do
+          log_path = simulator_launcher.xcodebuild_log_path(language: "pt", locale: "pt_BR")
+          expect(log_path).to eq(
+            File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt-pt_BR.log").to_s
           )
         end
 
-        it "uses the default parameters on watchOS too", requires_xcode: true do
-          configure(options.merge(devices: ["Apple Watch Series 6 - 44mm"]))
-          expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
-          command = Snapshot::TestCommandGenerator.generate(
-            devices: ["Apple Watch Series 6 - 44mm"],
-            language: "en",
-            locale: nil,
-            log_path: '/path/to/logs'
-          )
-          name = command.join('').match(/name=(.+?),/)[1]
-          os = command.join('').match(/OS=(\d+.\d+)/)[1]
-          expect(command).to eq(
-            [
-              "set -o pipefail &&",
-              "xcodebuild",
-              "-scheme ExampleUITests",
-              "-project ./snapshot/example/Example.xcodeproj",
-              "-derivedDataPath /tmp/path/to/snapshot_derived",
-              "-destination 'platform=watchOS Simulator,name=#{name},OS=#{os}'",
-              "FASTLANE_SNAPSHOT=YES",
-              "FASTLANE_LANGUAGE=en",
-              :build,
-              :test,
-              "| tee /path/to/logs",
-              "| xcpretty "
-            ]
+        it 'can work without parameters', requires_xcode: true do
+          simulator_launcher.launcher_config.devices = []
+          log_path = simulator_launcher.xcodebuild_log_path
+          expect(log_path).to eq(
+            File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s
           )
         end
       end
 
-      context 'fixed derivedDataPath' do
-        let(:temp) { Dir.mktmpdir }
-
-        before do
-          configure(options.merge(derived_data_path: temp))
+      describe "Unique logs disabled" do
+        let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
+        let(:simulator_launcher) do
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+          launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
+          launcher_config.devices = ["iPhone 6"]
+          return simulator_launcher = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config)
         end
 
-        it 'uses the fixed derivedDataPath if given', requires_xcode: true do
-          expect(Dir).not_to(receive(:mktmpdir))
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("-derivedDataPath #{temp}")
-        end
-      end
-
-      context 'test-without-building' do
-        let(:temp) { Dir.mktmpdir }
-
-        before do
-          configure(options.merge(derived_data_path: temp, test_without_building: true))
-        end
-
-        it 'uses the "test-without-building" command and not the default "build test"', requires_xcode: true do
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("test-without-building")
-          expect(command.join('')).not_to(include("build test"))
-        end
-      end
-
-      context 'test-plan' do
-        it 'adds the testplan to the xcodebuild command', requires_xcode: true do
-          configure(options.merge(testplan: 'simple'))
-
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("-testPlan 'simple'") if FastlaneCore::Helper.xcode_at_least?(11)
-        end
-      end
-
-      context "only-testing" do
-        it "only tests the test bundle/suite/cases specified in only_testing when the input is an array", requires_xcode: true do
-          configure(options.merge(only_testing: %w(TestBundleA/TestSuiteB TestBundleC)))
-
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("-only-testing:TestBundleA/TestSuiteB")
-          expect(command.join('')).to include("-only-testing:TestBundleC")
-        end
-
-        it "only tests the test bundle/suite/cases specified in only_testing when the input is a string", requires_xcode: true do
-          configure(options.merge(only_testing: 'TestBundleA/TestSuiteB'))
-
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("-only-testing:TestBundleA/TestSuiteB")
-          expect(command.join('')).not_to(include("-only-testing:TestBundleC"))
-        end
-      end
-
-      context "skip-testing" do
-        it "does not test the test bundle/suite/cases specified in skip_testing when the input is an array", requires_xcode: true do
-          configure(options.merge(skip_testing: %w(TestBundleA/TestSuiteB TestBundleC)))
-
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("-skip-testing:TestBundleA/TestSuiteB")
-          expect(command.join('')).to include("-skip-testing:TestBundleC")
-        end
-
-        it "does not test the test bundle/suite/cases specified in skip_testing when the input is a string", requires_xcode: true do
-          configure(options.merge(skip_testing: 'TestBundleA/TestSuiteB'))
-
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("-skip-testing:TestBundleA/TestSuiteB")
-          expect(command.join('')).not_to(include("-skip-testing:TestBundleC"))
-        end
-      end
-
-      context "disable_xcpretty" do
-        it "does not include xcpretty in the pipe command when true", requires_xcode: true do
-          configure(options.merge(disable_xcpretty: true))
-
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to_not(include("| xcpretty "))
-        end
-
-        it "includes xcpretty in the pipe command when false", requires_xcode: true do
-          configure(options.merge(disable_xcpretty: false))
-
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("| xcpretty ")
-        end
-      end
-
-      context "suppress_xcode_output" do
-        it "includes /dev/null in the pipe command when true", requires_xcode: true do
-          configure(options.merge(suppress_xcode_output: true))
-
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to include("> /dev/null")
-        end
-
-        it "does not include /dev/null in the pipe command when false", requires_xcode: true do
-          configure(options.merge(suppress_xcode_output: false))
-
-          command = Snapshot::TestCommandGenerator.generate(devices: ["iPhone 6"], language: "en", locale: nil)
-          expect(command.join('')).to_not(include("> /dev/null"))
+        it 'uses correct file name', requires_xcode: true do
+          log_path = simulator_launcher.xcodebuild_log_path(language: "pt", locale: nil)
+          expect(log_path).to eq(
+            File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s
+          )
         end
       end
     end
 
-    describe "Valid macOS Configuration" do
-      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleMacOS", namespace_log_files: true } }
+    describe "#pipe" do
+      it "uses no pipe with disable_xcpretty", requires_xcodebuild: true do
+        options = { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", disable_xcpretty: true }
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
 
-      it "uses default parameters on macOS", requires_xcode: true do
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options.merge(devices: ["Mac"]))
-        expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
-        command = Snapshot::TestCommandGenerator.generate(
-          devices: ["Mac"],
-          language: "en",
-          locale: nil,
-          log_path: '/path/to/logs'
-        )
-        expect(command).to eq(
-          [
-            "set -o pipefail &&",
-            "xcodebuild",
-            "-scheme ExampleMacOS",
-            "-project ./snapshot/example/Example.xcodeproj",
-            "-derivedDataPath /tmp/path/to/snapshot_derived",
-            "-destination 'platform=macOS'",
-            "FASTLANE_SNAPSHOT=YES",
-            "FASTLANE_LANGUAGE=en",
-            :build,
-            :test,
-            "| tee /path/to/logs",
-            "| xcpretty "
-          ]
-        )
-      end
-    end
-
-    describe "Unique logs" do
-      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
-      let(:simulator_launcher) do
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
-        launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
-        launcher_config.devices = ["iPhone 6"]
-        return simulator_launcher = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config)
+        pipe = Snapshot::TestCommandGenerator.pipe.join(" ")
+        expect(pipe).not_to include("| xcpretty")
+        expect(pipe).not_to include("| xcbeautify")
       end
 
-      it 'uses correct name and language', requires_xcode: true do
-        log_path = simulator_launcher.xcodebuild_log_path(language: "pt", locale: nil)
-        expect(log_path).to eq(
-          File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt.log").to_s
-        )
+      it "uses no pipe with xcodebuild_formatter with empty string", requires_xcodebuild: true do
+        options = { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", xcodebuild_formatter: '' }
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
+
+        pipe = Snapshot::TestCommandGenerator.pipe.join(" ")
+        expect(pipe).not_to include("| xcpretty")
+        expect(pipe).not_to include("| xcbeautify")
       end
 
-      it 'uses includes locale if specified', requires_xcode: true do
-        log_path = simulator_launcher.xcodebuild_log_path(language: "pt", locale: "pt_BR")
-        expect(log_path).to eq(
-          File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt-pt_BR.log").to_s
-        )
+      describe "with xcodebuild_formatter" do
+        describe "with no xcpretty options" do
+          it "default when xcbeautify not installed", requires_xcodebuild: true do
+            allow(Fastlane::Helper::XcodebuildFormatterHelper).to receive(:xcbeautify_installed?).and_return(false)
+
+            options = { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" }
+            Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
+
+            pipe = Snapshot::TestCommandGenerator.pipe.join(" ")
+            expect(pipe).to include("| xcpretty")
+          end
+
+          it "default when xcbeautify installed", requires_xcodebuild: true do
+            allow(Fastlane::Helper::XcodebuildFormatterHelper).to receive(:xcbeautify_installed?).and_return(true)
+
+            options = { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" }
+            Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
+
+            pipe = Snapshot::TestCommandGenerator.pipe.join(" ")
+            expect(pipe).to include("| xcbeautify")
+          end
+
+          it "xcpretty override when xcbeautify installed", requires_xcodebuild: true do
+            allow(Fastlane::Helper::XcodebuildFormatterHelper).to receive(:xcbeautify_installed?).and_return(true)
+
+            options = { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", xcodebuild_formatter: 'xcpretty' }
+            Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
+
+            pipe = Snapshot::TestCommandGenerator.pipe.join(" ")
+            expect(pipe).to include("| xcpretty")
+          end
+
+          it "customer formatter", requires_xcodebuild: true do
+            allow(Fastlane::Helper::XcodebuildFormatterHelper).to receive(:xcbeautify_installed?).and_return(true)
+
+            options = { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", xcodebuild_formatter: "/path/to/xcbeautify" }
+            Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
+
+            pipe = Snapshot::TestCommandGenerator.pipe.join(" ")
+            expect(pipe).to include("| /path/to/xcbeautify")
+          end
+        end
+
+        it "with xcpretty options when xcbeautify installed", requires_xcodebuild: true do
+          allow(Fastlane::Helper::XcodebuildFormatterHelper).to receive(:xcbeautify_installed?).and_return(true)
+
+          options = { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", xcpretty_args: "--rspec" }
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
+
+          pipe = Snapshot::TestCommandGenerator.pipe.join(" ")
+          expect(pipe).to include("| xcpretty")
+        end
       end
 
-      it 'can work without parameters', requires_xcode: true do
-        simulator_launcher.launcher_config.devices = []
-        log_path = simulator_launcher.xcodebuild_log_path
-        expect(log_path).to eq(
-          File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s
-        )
-      end
-    end
+      describe "#legacy_xcpretty_options" do
+        it "with xcpretty_args", requires_xcodebuild: true do
+          options = { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", xcpretty_args: "--rspec" }
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
 
-    describe "Unique logs disabled" do
-      let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
-      let(:simulator_launcher) do
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
-        launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
-        launcher_config.devices = ["iPhone 6"]
-        return simulator_launcher = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config)
-      end
-
-      it 'uses correct file name', requires_xcode: true do
-        log_path = simulator_launcher.xcodebuild_log_path(language: "pt", locale: nil)
-        expect(log_path).to eq(
-          File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s
-        )
+          options = Snapshot::TestCommandGenerator.legacy_xcpretty_options
+          expect(options).to eq(['xcpretty_args'])
+        end
       end
     end
   end

--- a/snapshot/spec/test_command_generator_xcode_8_spec.rb
+++ b/snapshot/spec/test_command_generator_xcode_8_spec.rb
@@ -15,6 +15,8 @@ describe Snapshot do
       allow(Snapshot::LatestOsVersion).to receive(:version).and_return(os_version)
       allow(FastlaneCore::DeviceManager).to receive(:simulators).and_return([iphone6_9_0, iphone6_9_3, iphone6_9_2, appleTV, iphone6_9_3_2, iphone6_10_1, iphone6s_10_1, iphone4s_9_0, ipad_air_9_1])
       fake_out_xcode_project_loading
+
+      allow(Fastlane::Helper::XcodebuildFormatterHelper).to receive(:xcbeautify_installed?).and_return(false)
     end
 
     describe '#destination' do


### PR DESCRIPTION
Similar to #19774 

## Motivation
Open up `snapshot`'s options to use `xcbeautify`

## Description
- New `xcodebuild_formatter` option
- Defaults to `xcbeautify` if:
  - `xcbeautify` is installed
  -  No options are set that looks like the user is intending to use `xcpretty`

```rb
# Will use xcbeautify if its installed otherwise will use xcpretty
snapshot
```

```rb
# Will use xcbeautify
snapshot(
  xcodebuild_formatter: "xcbeautify"
)
```

```rb
# Will use xcpretty with scan's legacy xcpretty command building logic
snapshot(
  xcodebuild_formatter: "xcpretty"
)
```

```rb
# Will use xcpretty (even if xcbeautify is installed) because output_style is meant for xcpretty
snapshot(
  xcpretty_test_format: true
)
```

### Options
- Depreciated
  - `disable_xcpretty`
- Added
  - `xcodebuild_formatter`

### Logic

`pipe` previously contained logic for `xcpretty` formatting. It has now been split up to use `xcodebuild_formatter`. It will use the previous `xcpretty` logic if `xcodebuild_formatter` is set to `xcpretty` or if any options `xcpretty` were set that look like the user has been intending to use `xcpretty`

The new "is user trying to use xcpretty logic" is contained in the `legacy_xcpretty_options` method.