### PR TITLE
[pilot][upload_to_testflight] Send pkg to mac testflight when both ipa and pkg are available

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -108,7 +108,7 @@ module Pilot
 
     def wait_for_build_processing_to_be_complete(return_when_build_appears = false)
       platform = fetch_app_platform
-      if config[:ipa]
+      if config[:ipa] && platform != "osx"
         app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
         app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
       elsif config[:pkg]

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -18,6 +18,11 @@ module Pilot
 
       UI.user_error!("No ipa or pkg file given") if config[:ipa].nil? && config[:pkg].nil?
 
+      if config[:ipa] && config[:pkg]
+        UI.important("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
+        UI.important("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
+      end
+
       check_for_changelog_or_whats_new!(options)
 
       UI.success("Ready to upload new build to TestFlight (App: #{fetch_app_id})...")
@@ -25,24 +30,29 @@ module Pilot
       dir = Dir.mktmpdir
 
       platform = fetch_app_platform
-      if options[:ipa]
+      ipa_path = options[:ipa]
+      if ipa_path && platform != 'osx'
+        asset_path = ipa_path
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(app_id: fetch_app_id,
-                                                                      ipa_path: options[:ipa],
+                                                                      ipa_path: ipa_path,
                                                                   package_path: dir,
                                                                       platform: platform)
       else
+        pkg_path = options[:pkg]
+        asset_path = pkg_path
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(app_id: fetch_app_id,
-                                                                        pkg_path: options[:pkg],
+                                                                        pkg_path: pkg_path,
                                                                     package_path: dir,
                                                                         platform: platform)
       end
 
       transporter = transporter_for_selected_team(options)
-      result = transporter.upload(package_path: package_path, asset_path: options[:ipa] || options[:pkg])
+      result = transporter.upload(package_path: package_path, asset_path: asset_path)
 
       unless result
         transporter_errors = transporter.displayable_errors
-        UI.user_error!("Error uploading ipa file: \n #{transporter_errors}")
+        file_type = platform == "osx" ? "pkg" : "ipa"
+        UI.user_error!("Error uploading #{file_type} file: \n #{transporter_errors}")
       end
 
       UI.success("Successfully uploaded the new binary to App Store Connect")

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -665,265 +665,151 @@ describe "Build Manager" do
     end
 
     describe "uploads file" do
+      let(:fake_build_manager) { Pilot::BuildManager.new }
+      let(:fake_app_id) { 123 }
+      let(:fake_dir) { "fake dir" }
+
+      before(:each) do
+        allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
+
+        fake_itunestransporter = double
+        allow(fake_itunestransporter).to receive(:upload).and_return(true)
+        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+
+        # allow Manager.login method this time
+        expect(fake_build_manager).to receive(:login).at_least(:once)
+
+        # check for changelog or whats new!
+        expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
+
+        expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
+        expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
+
+        fake_app = double
+        expect(fake_app).to receive(:id).and_return(fake_app_id)
+        expect(fake_build_manager).to receive(:app).and_return(fake_app)
+
+        fake_build = double
+        expect(fake_build).to receive(:app_version)
+        expect(fake_build).to receive(:version)
+        expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+        expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+        expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+      end
+
       context "ipa for ios platform" do
-        let(:fake_build_manager) { Pilot::BuildManager.new }
-        let(:fake_app_id) { 123 }
-        let(:fake_dir) { "fake dir" }
         let(:fake_app_platform) { "ios" }
         let(:upload_options) do
           {
-            apple_id: fake_app_id,
-            skip_waiting_for_build_processing: true,
             ipa: 'foo'
           }
         end
 
         before(:each) do
           allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
-          allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
 
           fake_ipauploadpackagebuilder = double
           allow(fake_ipauploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, ipa_path: upload_options[:ipa], package_path: fake_dir, platform: fake_app_platform).and_return(true)
           allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
-
-          fake_itunestransporter = double
-          allow(fake_itunestransporter).to receive(:upload).and_return(true)
-          allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
-
-          expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
-          expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
         end
 
-        it "when skip_waiting_for_build_processing and apple_id are not set" do
-          # remove options that make login unnecessary
-          upload_options.delete(:apple_id)
-          upload_options.delete(:skip_waiting_for_build_processing)
-
-          # allow Manager.login method this time
-          expect(fake_build_manager).to receive(:login).at_least(:once)
-
-          # check for changelog or whats new!
-          expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
-
-          # other stuff required to let `upload` work:
-
-          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
-          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
-          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
-
-          fake_app = double
-          expect(fake_app).to receive(:id).and_return(fake_app_id)
-          expect(fake_build_manager).to receive(:app).and_return(fake_app)
-
-          fake_build = double
-          expect(fake_build).to receive(:app_version)
-          expect(fake_build).to receive(:version)
-          expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-          expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
-          expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
-
-          expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
-
-          fake_build_manager.upload(upload_options)
-        end
-      end
-
-      context "pkg for osx platform" do
-        let(:fake_build_manager) { Pilot::BuildManager.new }
-        let(:fake_app_id) { 123 }
-        let(:fake_dir) { "fake dir" }
-        let(:fake_app_platform) { "osx" }
-        let(:upload_options) do
-          {
-            apple_id: fake_app_id,
-            skip_waiting_for_build_processing: true,
-            pkg: 'bar'
-          }
-        end
-
-        before(:each) do
-          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
-          allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
-
-          fake_pkguploadpackagebuilder = double
-          allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
-          allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
-
-          fake_itunestransporter = double
-          allow(fake_itunestransporter).to receive(:upload).and_return(true)
-          allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
-
-          expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
-          expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
-        end
-
-        it "when skip_waiting_for_build_processing and apple_id are not set" do
-          # remove options that make login unnecessary
-          upload_options.delete(:apple_id)
-          upload_options.delete(:skip_waiting_for_build_processing)
-
-          # allow Manager.login method this time
-          expect(fake_build_manager).to receive(:login).at_least(:once)
-
-          # check for changelog or whats new!
-          expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
-
-          # other stuff required to let `upload` work:
-
-          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
-          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
-          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
-
-          fake_app = double
-          expect(fake_app).to receive(:id).and_return(fake_app_id)
-          expect(fake_build_manager).to receive(:app).and_return(fake_app)
-
-          fake_build = double
-          expect(fake_build).to receive(:app_version)
-          expect(fake_build).to receive(:version)
-          expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-          expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
-          expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
-
-          expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
-
-          fake_build_manager.upload(upload_options)
-        end
-      end
-
-      context "pkg for osx platform when both ipa and pkg are available" do
-        let(:fake_build_manager) { Pilot::BuildManager.new }
-        let(:fake_app_id) { 123 }
-        let(:fake_dir) { "fake dir" }
-        let(:fake_app_platform) { "osx" }
-        let(:upload_options) do
-          {
-            apple_id: fake_app_id,
-            skip_waiting_for_build_processing: true,
-            ipa: 'foo',
-            pkg: 'bar'
-          }
-        end
-
-        before(:each) do
-          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
-          allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
-
-          fake_pkguploadpackagebuilder = double
-          allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
-          allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
-
-          fake_itunestransporter = double
-          allow(fake_itunestransporter).to receive(:upload).and_return(true)
-          allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
-
-          expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
-          expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
-
-          expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
-          expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
-        end
-
-        it "when skip_waiting_for_build_processing and apple_id are not set" do
-          # remove options that make login unnecessary
-          upload_options.delete(:apple_id)
-          upload_options.delete(:skip_waiting_for_build_processing)
-
-          # allow Manager.login method this time
-          expect(fake_build_manager).to receive(:login).at_least(:once)
-
-          # check for changelog or whats new!
-          expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
-
-          # other stuff required to let `upload` work:
-
-          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
-          expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_version))
-          expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
-          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
-          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
-
-          fake_app = double
-          expect(fake_app).to receive(:id).and_return(fake_app_id)
-          expect(fake_build_manager).to receive(:app).and_return(fake_app)
-
-          fake_build = double
-          expect(fake_build).to receive(:app_version)
-          expect(fake_build).to receive(:version)
-          expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-          expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
-          expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
-
-          expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
-
-          fake_build_manager.upload(upload_options)
-        end
-      end
-
-      context "ipa for ios platform when both ipa and pkg are available" do
-        let(:fake_build_manager) { Pilot::BuildManager.new }
-        let(:fake_app_id) { 123 }
-        let(:fake_dir) { "fake dir" }
-        let(:fake_app_platform) { "ios" }
-        let(:upload_options) do
-          {
-            apple_id: fake_app_id,
-            skip_waiting_for_build_processing: true,
-            ipa: 'foo',
-            pkg: 'bar'
-          }
-        end
-
-        before(:each) do
-          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
-          allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
-
-          fake_ipauploadpackagebuilder = double
-          allow(fake_ipauploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, ipa_path: upload_options[:ipa], package_path: fake_dir, platform: fake_app_platform).and_return(true)
-          allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
-
-          fake_itunestransporter = double
-          allow(fake_itunestransporter).to receive(:upload).and_return(true)
-          allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
-
-          expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
-          expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
-
-          expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
-          expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
-        end
-
-        it "when skip_waiting_for_build_processing and apple_id are not set" do
-          # remove options that make login unnecessary
-          upload_options.delete(:apple_id)
-          upload_options.delete(:skip_waiting_for_build_processing)
-
-          # allow Manager.login method this time
-          expect(fake_build_manager).to receive(:login).at_least(:once)
-
-          # check for changelog or whats new!
-          expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
-
-          # other stuff required to let `upload` work:
-
+        it "gets file analysed with IpaFileAnalyser" do
           expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
           expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
           expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
           expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_version))
           expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_build))
 
-          fake_app = double
-          expect(fake_app).to receive(:id).and_return(fake_app_id)
-          expect(fake_build_manager).to receive(:app).and_return(fake_app)
+          fake_build_manager.upload(upload_options)
+        end
+      end
 
-          fake_build = double
-          expect(fake_build).to receive(:app_version)
-          expect(fake_build).to receive(:version)
-          expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-          expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
-          expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+      context "pkg for osx platform" do
+        let(:fake_app_platform) { "osx" }
+        let(:upload_options) do
+          {
+            pkg: 'bar'
+          }
+        end
 
-          expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+        before(:each) do
+          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+
+          fake_pkguploadpackagebuilder = double
+          allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+          allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
+        end
+
+        it "gets file analysed with PkgFileAnalyser" do
+          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+          expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_version))
+          expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
+          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
+          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
+
+          fake_build_manager.upload(upload_options)
+        end
+      end
+
+      context "pkg for osx platform when both ipa and pkg are available" do
+        let(:fake_app_platform) { "osx" }
+        let(:upload_options) do
+          {
+            ipa: 'foo',
+            pkg: 'bar'
+          }
+        end
+
+        before(:each) do
+          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+
+          fake_pkguploadpackagebuilder = double
+          allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+          allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
+
+          expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
+          expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
+        end
+
+        it "gets file analysed with PkgFileAnalyser" do
+          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+          expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_version))
+          expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
+          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
+          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
+
+          fake_build_manager.upload(upload_options)
+        end
+      end
+
+      context "ipa for ios platform when both ipa and pkg are available" do
+        let(:fake_app_platform) { "ios" }
+        let(:upload_options) do
+          {
+            ipa: 'foo',
+            pkg: 'bar'
+          }
+        end
+
+        before(:each) do
+          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+
+          fake_ipauploadpackagebuilder = double
+          allow(fake_ipauploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, ipa_path: upload_options[:ipa], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+          allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
+
+          expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
+          expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
+        end
+
+        it "gets file analysed with IpaFileAnalyser" do
+          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
+          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
+          expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_version))
+          expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_build))
 
           fake_build_manager.upload(upload_options)
         end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -664,204 +664,269 @@ describe "Build Manager" do
       end
     end
 
-    describe "uses Manager.login for pkg for osx platform" do
-      let(:fake_build_manager) { Pilot::BuildManager.new }
-      let(:fake_app_id) { 123 }
-      let(:fake_dir) { "fake dir" }
-      let(:fake_app_platform) { "osx" }
-      let(:upload_options) do
-        {
-          apple_id: fake_app_id,
-          skip_waiting_for_build_processing: true,
-          pkg: 'bar'
-        }
+    describe "uploads file" do
+      context "ipa for ios platform" do
+        let(:fake_build_manager) { Pilot::BuildManager.new }
+        let(:fake_app_id) { 123 }
+        let(:fake_dir) { "fake dir" }
+        let(:fake_app_platform) { "ios" }
+        let(:upload_options) do
+          {
+            apple_id: fake_app_id,
+            skip_waiting_for_build_processing: true,
+            ipa: 'foo'
+          }
+        end
+
+        before(:each) do
+          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+          allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
+
+          fake_ipauploadpackagebuilder = double
+          allow(fake_ipauploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, ipa_path: upload_options[:ipa], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+          allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
+
+          fake_itunestransporter = double
+          allow(fake_itunestransporter).to receive(:upload).and_return(true)
+          allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+
+          expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
+          expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
+        end
+
+        it "when skip_waiting_for_build_processing and apple_id are not set" do
+          # remove options that make login unnecessary
+          upload_options.delete(:apple_id)
+          upload_options.delete(:skip_waiting_for_build_processing)
+
+          # allow Manager.login method this time
+          expect(fake_build_manager).to receive(:login).at_least(:once)
+
+          # check for changelog or whats new!
+          expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
+
+          # other stuff required to let `upload` work:
+
+          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
+          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
+
+          fake_app = double
+          expect(fake_app).to receive(:id).and_return(fake_app_id)
+          expect(fake_build_manager).to receive(:app).and_return(fake_app)
+
+          fake_build = double
+          expect(fake_build).to receive(:app_version)
+          expect(fake_build).to receive(:version)
+          expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+          expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+          expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+          expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+
+          fake_build_manager.upload(upload_options)
+        end
       end
 
-      before(:each) do
-        allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
-        allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
+      context "pkg for osx platform" do
+        let(:fake_build_manager) { Pilot::BuildManager.new }
+        let(:fake_app_id) { 123 }
+        let(:fake_dir) { "fake dir" }
+        let(:fake_app_platform) { "osx" }
+        let(:upload_options) do
+          {
+            apple_id: fake_app_id,
+            skip_waiting_for_build_processing: true,
+            pkg: 'bar'
+          }
+        end
 
-        fake_pkguploadpackagebuilder = double
-        allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
-        allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
+        before(:each) do
+          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+          allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
 
-        fake_itunestransporter = double
-        allow(fake_itunestransporter).to receive(:upload).and_return(true)
-        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+          fake_pkguploadpackagebuilder = double
+          allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+          allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
 
-        expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
-        expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
+          fake_itunestransporter = double
+          allow(fake_itunestransporter).to receive(:upload).and_return(true)
+          allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+
+          expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
+          expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
+        end
+
+        it "when skip_waiting_for_build_processing and apple_id are not set" do
+          # remove options that make login unnecessary
+          upload_options.delete(:apple_id)
+          upload_options.delete(:skip_waiting_for_build_processing)
+
+          # allow Manager.login method this time
+          expect(fake_build_manager).to receive(:login).at_least(:once)
+
+          # check for changelog or whats new!
+          expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
+
+          # other stuff required to let `upload` work:
+
+          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
+          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
+
+          fake_app = double
+          expect(fake_app).to receive(:id).and_return(fake_app_id)
+          expect(fake_build_manager).to receive(:app).and_return(fake_app)
+
+          fake_build = double
+          expect(fake_build).to receive(:app_version)
+          expect(fake_build).to receive(:version)
+          expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+          expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+          expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+          expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+
+          fake_build_manager.upload(upload_options)
+        end
       end
 
-      it "when skip_waiting_for_build_processing and apple_id are not set" do
-        # remove options that make login unnecessary
-        upload_options.delete(:apple_id)
-        upload_options.delete(:skip_waiting_for_build_processing)
+      context "pkg for osx platform when both ipa and pkg are available" do
+        let(:fake_build_manager) { Pilot::BuildManager.new }
+        let(:fake_app_id) { 123 }
+        let(:fake_dir) { "fake dir" }
+        let(:fake_app_platform) { "osx" }
+        let(:upload_options) do
+          {
+            apple_id: fake_app_id,
+            skip_waiting_for_build_processing: true,
+            ipa: 'foo',
+            pkg: 'bar'
+          }
+        end
 
-        # allow Manager.login method this time
-        expect(fake_build_manager).to receive(:login).at_least(:once)
+        before(:each) do
+          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+          allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
 
-        # check for changelog or whats new!
-        expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
+          fake_pkguploadpackagebuilder = double
+          allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+          allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
 
-        # other stuff required to let `upload` work:
+          fake_itunestransporter = double
+          allow(fake_itunestransporter).to receive(:upload).and_return(true)
+          allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
 
-        expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
-        expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
-        expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
+          expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
+          expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
 
-        fake_app = double
-        expect(fake_app).to receive(:id).and_return(fake_app_id)
-        expect(fake_build_manager).to receive(:app).and_return(fake_app)
+          expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
+          expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
+        end
 
-        fake_build = double
-        expect(fake_build).to receive(:app_version)
-        expect(fake_build).to receive(:version)
-        expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
-        expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+        it "when skip_waiting_for_build_processing and apple_id are not set" do
+          # remove options that make login unnecessary
+          upload_options.delete(:apple_id)
+          upload_options.delete(:skip_waiting_for_build_processing)
 
-        expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+          # allow Manager.login method this time
+          expect(fake_build_manager).to receive(:login).at_least(:once)
 
-        fake_build_manager.upload(upload_options)
-      end
-    end
+          # check for changelog or whats new!
+          expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
 
-    describe "uses Manager.login for pkg for osx platform when both ipa and pkg are available" do
-      let(:fake_build_manager) { Pilot::BuildManager.new }
-      let(:fake_app_id) { 123 }
-      let(:fake_dir) { "fake dir" }
-      let(:fake_app_platform) { "osx" }
-      let(:upload_options) do
-        {
-          apple_id: fake_app_id,
-          skip_waiting_for_build_processing: true,
-          ipa: 'foo',
-          pkg: 'bar'
-        }
-      end
+          # other stuff required to let `upload` work:
 
-      before(:each) do
-        allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
-        allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
+          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+          expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_version))
+          expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
+          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
+          expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
 
-        fake_pkguploadpackagebuilder = double
-        allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
-        allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
+          fake_app = double
+          expect(fake_app).to receive(:id).and_return(fake_app_id)
+          expect(fake_build_manager).to receive(:app).and_return(fake_app)
 
-        fake_itunestransporter = double
-        allow(fake_itunestransporter).to receive(:upload).and_return(true)
-        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+          fake_build = double
+          expect(fake_build).to receive(:app_version)
+          expect(fake_build).to receive(:version)
+          expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+          expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+          expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
 
-        expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
-        expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
+          expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
 
-        expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
-        expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
-      end
-
-      it "when skip_waiting_for_build_processing and apple_id are not set" do
-        # remove options that make login unnecessary
-        upload_options.delete(:apple_id)
-        upload_options.delete(:skip_waiting_for_build_processing)
-
-        # allow Manager.login method this time
-        expect(fake_build_manager).to receive(:login).at_least(:once)
-
-        # check for changelog or whats new!
-        expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
-
-        # other stuff required to let `upload` work:
-
-        expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
-        expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_version))
-        expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
-        expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
-        expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
-
-        fake_app = double
-        expect(fake_app).to receive(:id).and_return(fake_app_id)
-        expect(fake_build_manager).to receive(:app).and_return(fake_app)
-
-        fake_build = double
-        expect(fake_build).to receive(:app_version)
-        expect(fake_build).to receive(:version)
-        expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
-        expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
-
-        expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
-
-        fake_build_manager.upload(upload_options)
-      end
-    end
-
-    describe "uses Manager.login for ipa for ios platform when both ipa and pkg are available" do
-      let(:fake_build_manager) { Pilot::BuildManager.new }
-      let(:fake_app_id) { 123 }
-      let(:fake_dir) { "fake dir" }
-      let(:fake_app_platform) { "ios" }
-      let(:upload_options) do
-        {
-          apple_id: fake_app_id,
-          skip_waiting_for_build_processing: true,
-          ipa: 'foo',
-          pkg: 'bar'
-        }
+          fake_build_manager.upload(upload_options)
+        end
       end
 
-      before(:each) do
-        allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
-        allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
+      context "ipa for ios platform when both ipa and pkg are available" do
+        let(:fake_build_manager) { Pilot::BuildManager.new }
+        let(:fake_app_id) { 123 }
+        let(:fake_dir) { "fake dir" }
+        let(:fake_app_platform) { "ios" }
+        let(:upload_options) do
+          {
+            apple_id: fake_app_id,
+            skip_waiting_for_build_processing: true,
+            ipa: 'foo',
+            pkg: 'bar'
+          }
+        end
 
-        fake_ipauploadpackagebuilder = double
-        allow(fake_ipauploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, ipa_path: upload_options[:ipa], package_path: fake_dir, platform: fake_app_platform).and_return(true)
-        allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
+        before(:each) do
+          allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+          allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
 
-        fake_itunestransporter = double
-        allow(fake_itunestransporter).to receive(:upload).and_return(true)
-        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+          fake_ipauploadpackagebuilder = double
+          allow(fake_ipauploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, ipa_path: upload_options[:ipa], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+          allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
 
-        expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
-        expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
+          fake_itunestransporter = double
+          allow(fake_itunestransporter).to receive(:upload).and_return(true)
+          allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
 
-        expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
-        expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
-      end
+          expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
+          expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
 
-      it "when skip_waiting_for_build_processing and apple_id are not set" do
-        # remove options that make login unnecessary
-        upload_options.delete(:apple_id)
-        upload_options.delete(:skip_waiting_for_build_processing)
+          expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
+          expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
+        end
 
-        # allow Manager.login method this time
-        expect(fake_build_manager).to receive(:login).at_least(:once)
+        it "when skip_waiting_for_build_processing and apple_id are not set" do
+          # remove options that make login unnecessary
+          upload_options.delete(:apple_id)
+          upload_options.delete(:skip_waiting_for_build_processing)
 
-        # check for changelog or whats new!
-        expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
+          # allow Manager.login method this time
+          expect(fake_build_manager).to receive(:login).at_least(:once)
 
-        # other stuff required to let `upload` work:
+          # check for changelog or whats new!
+          expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
 
-        expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
-        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
-        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
-        expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_version))
-        expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_build))
+          # other stuff required to let `upload` work:
 
-        fake_app = double
-        expect(fake_app).to receive(:id).and_return(fake_app_id)
-        expect(fake_build_manager).to receive(:app).and_return(fake_app)
+          expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
+          expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
+          expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_version))
+          expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_build))
 
-        fake_build = double
-        expect(fake_build).to receive(:app_version)
-        expect(fake_build).to receive(:version)
-        expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
-        expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+          fake_app = double
+          expect(fake_app).to receive(:id).and_return(fake_app_id)
+          expect(fake_build_manager).to receive(:app).and_return(fake_app)
 
-        expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+          fake_build = double
+          expect(fake_build).to receive(:app_version)
+          expect(fake_build).to receive(:version)
+          expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+          expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+          expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
 
-        fake_build_manager.upload(upload_options)
+          expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+
+          fake_build_manager.upload(upload_options)
+        end
       end
     end
   end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -522,7 +522,7 @@ describe "Build Manager" do
   end
 
   describe "#upload" do
-    describe "uses Manager.login (which does spaceship login)" do
+    describe "uses Manager.login (which does spaceship login) for ipa" do
       let(:fake_build_manager) { Pilot::BuildManager.new }
       let(:fake_app_id) { 123 }
       let(:fake_dir) { "fake dir" }
@@ -574,6 +574,207 @@ describe "Build Manager" do
         expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
         expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
         expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
+
+        fake_app = double
+        expect(fake_app).to receive(:id).and_return(fake_app_id)
+        expect(fake_build_manager).to receive(:app).and_return(fake_app)
+
+        fake_build = double
+        expect(fake_build).to receive(:app_version)
+        expect(fake_build).to receive(:version)
+        expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+        expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+        expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+
+        fake_build_manager.upload(upload_options)
+      end
+    end
+
+    describe "uses Manager.login for pkg for osx platform" do
+      let(:fake_build_manager) { Pilot::BuildManager.new }
+      let(:fake_app_id) { 123 }
+      let(:fake_dir) { "fake dir" }
+      let(:fake_app_platform) { "osx" }
+      let(:upload_options) do
+        {
+          apple_id: fake_app_id,
+          skip_waiting_for_build_processing: true,
+          pkg: 'bar'
+        }
+      end
+
+      before(:each) do
+        allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+        allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
+
+        fake_pkguploadpackagebuilder = double
+        allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+        allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
+
+        fake_itunestransporter = double
+        allow(fake_itunestransporter).to receive(:upload).and_return(true)
+        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+
+        expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
+        expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
+      end
+
+      it "when skip_waiting_for_build_processing and apple_id are not set" do
+        # remove options that make login unnecessary
+        upload_options.delete(:apple_id)
+        upload_options.delete(:skip_waiting_for_build_processing)
+
+        # allow Manager.login method this time
+        expect(fake_build_manager).to receive(:login).at_least(:once)
+
+        # check for changelog or whats new!
+        expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
+
+        # other stuff required to let `upload` work:
+
+        expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+        expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
+        expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
+
+        fake_app = double
+        expect(fake_app).to receive(:id).and_return(fake_app_id)
+        expect(fake_build_manager).to receive(:app).and_return(fake_app)
+
+        fake_build = double
+        expect(fake_build).to receive(:app_version)
+        expect(fake_build).to receive(:version)
+        expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+        expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+        expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+
+        fake_build_manager.upload(upload_options)
+      end
+    end
+
+    describe "uses Manager.login for pkg for osx platform when both ipa and pkg are available" do
+      let(:fake_build_manager) { Pilot::BuildManager.new }
+      let(:fake_app_id) { 123 }
+      let(:fake_dir) { "fake dir" }
+      let(:fake_app_platform) { "osx" }
+      let(:upload_options) do
+        {
+          apple_id: fake_app_id,
+          skip_waiting_for_build_processing: true,
+          ipa: 'foo',
+          pkg: 'bar'
+        }
+      end
+
+      before(:each) do
+        allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+        allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
+
+        fake_pkguploadpackagebuilder = double
+        allow(fake_pkguploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, pkg_path: upload_options[:pkg], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+        allow(FastlaneCore::PkgUploadPackageBuilder).to receive(:new).and_return(fake_pkguploadpackagebuilder)
+
+        fake_itunestransporter = double
+        allow(fake_itunestransporter).to receive(:upload).and_return(true)
+        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+
+        expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
+        expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
+
+        expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
+        expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
+      end
+
+      it "when skip_waiting_for_build_processing and apple_id are not set" do
+        # remove options that make login unnecessary
+        upload_options.delete(:apple_id)
+        upload_options.delete(:skip_waiting_for_build_processing)
+
+        # allow Manager.login method this time
+        expect(fake_build_manager).to receive(:login).at_least(:once)
+
+        # check for changelog or whats new!
+        expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
+
+        # other stuff required to let `upload` work:
+
+        expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+        expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_version))
+        expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
+        expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version)
+        expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build)
+
+        fake_app = double
+        expect(fake_app).to receive(:id).and_return(fake_app_id)
+        expect(fake_build_manager).to receive(:app).and_return(fake_app)
+
+        fake_build = double
+        expect(fake_build).to receive(:app_version)
+        expect(fake_build).to receive(:version)
+        expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+        expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+        expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+
+        fake_build_manager.upload(upload_options)
+      end
+    end
+
+    describe "uses Manager.login for ipa for ios platform when both ipa and pkg are available" do
+      let(:fake_build_manager) { Pilot::BuildManager.new }
+      let(:fake_app_id) { 123 }
+      let(:fake_dir) { "fake dir" }
+      let(:fake_app_platform) { "ios" }
+      let(:upload_options) do
+        {
+          apple_id: fake_app_id,
+          skip_waiting_for_build_processing: true,
+          ipa: 'foo',
+          pkg: 'bar'
+        }
+      end
+
+      before(:each) do
+        allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+        allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
+
+        fake_ipauploadpackagebuilder = double
+        allow(fake_ipauploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, ipa_path: upload_options[:ipa], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+        allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
+
+        fake_itunestransporter = double
+        allow(fake_itunestransporter).to receive(:upload).and_return(true)
+        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+
+        expect(UI).to receive(:important).with("WARNING: Both `ipa` and `pkg` options are defined either explicitly or with default_value (build found in directory)")
+        expect(UI).to receive(:important).with("Uploading `ipa` is preferred by default. Set `app_platform` to `osx` to force uploading `pkg`")
+
+        expect(UI).to receive(:success).with("Ready to upload new build to TestFlight (App: #{fake_app_id})...")
+        expect(UI).to receive(:success).with("Successfully uploaded the new binary to App Store Connect")
+      end
+
+      it "when skip_waiting_for_build_processing and apple_id are not set" do
+        # remove options that make login unnecessary
+        upload_options.delete(:apple_id)
+        upload_options.delete(:skip_waiting_for_build_processing)
+
+        # allow Manager.login method this time
+        expect(fake_build_manager).to receive(:login).at_least(:once)
+
+        # check for changelog or whats new!
+        expect(fake_build_manager).to receive(:check_for_changelog_or_whats_new!).with(upload_options)
+
+        # other stuff required to let `upload` work:
+
+        expect(fake_build_manager).to receive(:fetch_app_id).and_return(fake_app_id).exactly(2).times
+        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version)
+        expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build)
+        expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_version))
+        expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_build))
 
         fake_app = double
         expect(fake_app).to receive(:id).and_return(fake_app_id)

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -438,6 +438,78 @@ describe "Build Manager" do
       expect(fake_build_manager).to receive(:fetch_app_platform)
       expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version).and_return("1.2.3")
       expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build).and_return("123")
+      expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_version))
+      expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_build))
+
+      fake_build = double
+      expect(fake_build).to receive(:app_version).and_return("1.2.3")
+      expect(fake_build).to receive(:version).and_return("123")
+      expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+      fake_build_manager.wait_for_build_processing_to_be_complete
+    end
+
+    it "wait given :pkg" do
+      options = { pkg: "some_path.pkg" }
+      fake_build_manager.instance_variable_set(:@config, options)
+
+      expect(fake_build_manager).to receive(:fetch_app_platform)
+      expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_version))
+      expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
+      expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version).and_return("1.2.3")
+      expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build).and_return("123")
+
+      fake_build = double
+      expect(fake_build).to receive(:app_version).and_return("1.2.3")
+      expect(fake_build).to receive(:version).and_return("123")
+      expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+      fake_build_manager.wait_for_build_processing_to_be_complete
+    end
+
+    it "wait given :ipa and :pkg and platform ios" do
+      options = { ipa: "some_path.ipa", pkg: "some_path.pkg" }
+      fake_build_manager.instance_variable_set(:@config, options)
+
+      expect(fake_build_manager).to receive(:fetch_app_platform).and_return("ios")
+      expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_version).and_return("1.2.3")
+      expect(FastlaneCore::IpaFileAnalyser).to receive(:fetch_app_build).and_return("123")
+      expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_version))
+      expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_build))
+
+      fake_build = double
+      expect(fake_build).to receive(:app_version).and_return("1.2.3")
+      expect(fake_build).to receive(:version).and_return("123")
+      expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+      fake_build_manager.wait_for_build_processing_to_be_complete
+    end
+
+    it "wait given :ipa and :pkg and osx platform" do
+      options = { ipa: "some_path.ipa", pkg: "some_path.pkg", app_platform: "osx" }
+      fake_build_manager.instance_variable_set(:@config, options)
+
+      expect(fake_build_manager.config[:app_platform]).to be == "osx"
+      expect(fake_build_manager).to receive(:fetch_app_platform).and_return("osx")
+
+      expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_version))
+      expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
+      expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version).and_return("1.2.3")
+      expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build).and_return("123")
+
+      fake_build = double
+      expect(fake_build).to receive(:app_version).and_return("1.2.3")
+      expect(fake_build).to receive(:version).and_return("123")
+      expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+      fake_build_manager.wait_for_build_processing_to_be_complete
+    end
+
+    it "wait given :app_version and :build_number" do
+      options = { app_version: "1.2.3", build_number: "123" }
+      fake_build_manager.instance_variable_set(:@config, options)
+
+      expect(fake_build_manager).to receive(:fetch_app_platform)
 
       fake_build = double
       expect(fake_build).to receive(:app_version).and_return("1.2.3")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #19760

### Description
When both `ipa` and `pkg` files are available in project directory, `pilot` tries to upload `ipa` file instead of `pkg` when uploading build to Mac Testflight. 
This PR changes `pilot` to upload `pkg` file when `app_platform` is set to `osx`.
Tested with unit tests.

### Testing Steps
Update `Gemfile` and run `bundle install`
```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "lucgrabowski-send-pkg-to-mac-testflight"
```