### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     byebug (11.1.3)
-    claide (1.0.3)
+    claide (1.1.0)
     claide-plugins (0.9.2)
       cork
       nap
@@ -92,7 +92,7 @@ GEM
     crack (0.4.5)
       rexml
     danger (8.2.2)
-      claide (~> 1.0)
+      claide (~> 1.1)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
@@ -338,7 +338,7 @@ GEM
     webrick (1.7.0)
     word_wrap (1.0.0)
     xcode-install (2.6.8)
-      claide (>= 0.9.1, < 1.1.0)
+      claide (>= 0.9.1, <= 1.1.0)
       fastlane (>= 2.1.0, < 3.0.0)
     xcodeproj (1.19.0)
       CFPropertyList (>= 2.3.3, < 4.0)


### PR DESCRIPTION
Seems like CLAide has updated to version 1.1.0.
Might be worth updating it here in the `Gemfile.lock` as well.
See the change in commit for CLAide :
https://github.com/CocoaPods/CLAide/commit/c5a837cd35252ae1e2cd4533b7093dd679edc588#

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Hopefully should resolve this issue
```
/Users/distiller/.rubies/ruby-3.0.2/lib/ruby/3.0.0/rubygems/specification.rb:2245:in `raise_if_conflicts': Unable to activate xcode-install-2.8.0, because claide-1.1.0 conflicts with claide (>= 0.9.1, < 1.1.0) (Gem::ConflictError)
```
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
Seems like in the Gemfile.lock the claide version was being limited in between(>= 0.9.1, < 1.1.0), but since 6 days ago claide was update to 1.1.0 this condition doesn't satisfy and fastlane fails at the step `Fetching claide-1.0.3.gem`

<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
I've not tested these changes, as I'm not proficient in ruby. However, from the logs I figured changing the above might solve the issue. I could be wrong. Could someone who is more experienced please help validate?
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
