### PR TITLE
[scan][xcov] set xcresult path in SharedValues and use as default in xcov

### DIFF
--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -4,6 +4,7 @@ module Fastlane
       SCAN_DERIVED_DATA_PATH = :SCAN_DERIVED_DATA_PATH
       SCAN_GENERATED_PLIST_FILE = :SCAN_GENERATED_PLIST_FILE
       SCAN_GENERATED_PLIST_FILES = :SCAN_GENERATED_PLIST_FILES
+      SCAN_GENERATED_XCRESULT_PATH = :SCAN_GENERATED_XCRESULT_PATH
       SCAN_ZIP_BUILD_PRODUCTS_PATH = :SCAN_ZIP_BUILD_PRODUCTS_PATH
     end
 
@@ -29,6 +30,8 @@ module Fastlane
             raise ex
           end
         ensure
+          Actions.lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH] = File.absolute_path(Scan.cache[:result_bundle_path])
+
           unless values[:derived_data_path].to_s.empty?
             plist_files_before = manager.plist_files_before || []
 
@@ -70,6 +73,7 @@ module Fastlane
           ['SCAN_DERIVED_DATA_PATH', 'The path to the derived data'],
           ['SCAN_GENERATED_PLIST_FILE', 'The generated plist file'],
           ['SCAN_GENERATED_PLIST_FILES', 'The generated plist files'],
+          ['SCAN_GENERATED_XCRESULT_PATH', 'The path to the generated .xcresult'],
           ['SCAN_ZIP_BUILD_PRODUCTS_PATH', 'The path to the zipped build products']
         ]
       end

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -30,7 +30,7 @@ module Fastlane
             raise ex
           end
         ensure
-          if (result_bundle_path = Scan.cache[:result_bundle_path])
+          if Scan.cache && (result_bundle_path = Scan.cache[:result_bundle_path])
             Actions.lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH] = File.absolute_path(result_bundle_path)
           else
             Actions.lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH] = nil

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -30,7 +30,11 @@ module Fastlane
             raise ex
           end
         ensure
-          Actions.lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH] = File.absolute_path(Scan.cache[:result_bundle_path])
+          if (result_bundle_path = Scan.cache[:result_bundle_path])
+            Actions.lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH] = File.absolute_path(result_bundle_path)
+          else
+            Actions.lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH] = nil
+          end
 
           unless values[:derived_data_path].to_s.empty?
             plist_files_before = manager.plist_files_before || []

--- a/fastlane/lib/fastlane/actions/xcov.rb
+++ b/fastlane/lib/fastlane/actions/xcov.rb
@@ -5,6 +5,11 @@ module Fastlane
         Actions.verify_gem!('xcov')
         require 'xcov'
 
+        if values[:xccov_file_direct_path].nil? && (path = Actions.lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH])
+          UI.verbose("Pulling xcov 'xccov_file_direct_path' from SharedValues::SCAN_GENERATED_XCRESULT_PATH")
+          values[:xccov_file_direct_path] = path
+        end
+
         Xcov::Manager.new(values).run
       end
 


### PR DESCRIPTION
### Motivation and Context
Fixes #19824

### Description
- Add `SharedValues::SCAN_GENERATED_XCRESULT_PATH` to `scan`/`run_tests`
- Use `SharedValues::SCAN_GENERATED_XCRESULT_PATH` as default value for `xccov_file_direct_path` in `xcov`
