### PR TITLE
[scan] prevent error from raising and prevent xcresult processing when multiple devices with xcpretty

### DIFF
--- a/scan/lib/scan/error_handler.rb
+++ b/scan/lib/scan/error_handler.rb
@@ -28,9 +28,10 @@ module Scan
           print("For more information visit this stackoverflow answer:")
           print("https://stackoverflow.com/a/17031697/445598")
         when /Testing failed on/
-          # This is important because xcbeautify will print:
+          # This is important because xcbeautify and raw output will print:
           # Testing failed on 'iPhone 13 Pro Max'
           # when multiple devices are use.
+          # xcpretty hides this output so its not an issue with xcpretty.
           # We need to catch "Testing failed on" before "Test failed"
           # so that an error isn't raised.
           # Raising an error prevents trainer from processing the xcresult

--- a/scan/lib/scan/error_handler.rb
+++ b/scan/lib/scan/error_handler.rb
@@ -27,6 +27,14 @@ module Scan
           print("If you are using zshell or another shell, make sure to edit the correct bash file.")
           print("For more information visit this stackoverflow answer:")
           print("https://stackoverflow.com/a/17031697/445598")
+        when /Testing failed on/
+          # This is important because xcbeautify will print:
+          # Testing failed on 'iPhone 13 Pro Max'
+          # when multiple devices are use.
+          # We need to catch "Testing failed on" before "Test failed"
+          # so that an error isn't raised.
+          # Raising an error prevents trainer from processing the xcresult
+          return
         when /Testing failed/
           UI.build_failure!("Error building the application. #{details}")
         when /Executed/, /Failing tests:/


### PR DESCRIPTION
### Motivation and Context
Fixes #19827

### Description
- Catches "Testing failed on" before "Testing failed" returns an error
  - `xcbeautify` will _only_ print "Testing failed on" when using multiple devices
  - This will raise an error which will prevent processing by `trainer` on the `xcresult` file
