### PR TITLE
[deliver] migrate to new app store review process

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -200,11 +200,11 @@ module Deliver
 
       submission = app.get_in_progress_review_submission(platform: platform)
       if submission
-        submission.cancel_submission()
+        submission.cancel_submission
         UI.message("Review submission cancellation has been requested")
 
         # An app version won't get removed from review instantly
-        # Polling until app version has a state of DEVELOPER_REJECT 
+        # Polling until app version has a state of DEVELOPER_REJECT
         loop do
           version = app.get_edit_app_store_version(platform: platform)
           if version.app_store_state == Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::DEVELOPER_REJECTED

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -212,7 +212,7 @@ module Deliver
           end
 
           UI.message("Waiting for cancellation to take effect...")
-          sleep(10)
+          sleep(15)
         end
 
         UI.success("Successfully cancelled previous submission!")

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -197,8 +197,25 @@ module Deliver
     def reject_version_if_possible
       app = Deliver.cache[:app]
       platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
-      if app.reject_version_if_possible!(platform: platform)
-        UI.success("Successfully rejected previous version!")
+
+      submission = app.get_in_progress_review_submission(platform: platform)
+      if submission
+        submission.cancel_submission()
+        UI.message("Review submission cancellation has been requested")
+
+        # An app version won't get removed from review instantly
+        # Polling until app version has a state of DEVELOPER_REJECT 
+        loop do
+          version = app.get_edit_app_store_version(platform: platform)
+          if version.app_store_state == Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::DEVELOPER_REJECTED
+            break
+          end
+
+          UI.message("Waiting for cancellation to take effect...")
+          sleep(10)
+        end
+
+        UI.success("Successfully cancelled previous submission!")
       end
     end
 

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -30,12 +30,16 @@ module Deliver
     private
 
     def create_review_submission(options, app, version, platform)
+      # Can't submit a review if there is already a review in progress
       if app.get_in_progress_review_submission(platform: platform)
         UI.user_error!("Cannot submit for review - A review submission is already in progress")
       end
 
+      # There can only be one open submission per platform per app
+      # There might be a submission already created so we need to check
+      # 1. Create the submission if its not already created
+      # 2. Error if submission already contains some items for review (because we don't know what they are)
       submission = app.get_ready_review_submission(platform: platform, includes: "items")
-
       if submission.nil?
         submission = app.create_review_submission(platform: platform)
       elsif !submission.items.empty?

--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -28,14 +28,12 @@ module Deliver
     end
 
     private
-    
+
     def create_review_submission(options, app, version, platform)
       if app.get_in_progress_review_submission(platform: platform)
         UI.user_error!("Cannot submit for review - A review submission is already in progress")
       end
 
-      # TODO: I don't like this logic here
-      # Maybe error out if there are aleady items in this review?
       submission = app.get_ready_review_submission(platform: platform, includes: "items")
 
       if submission.nil?

--- a/deliver/spec/submit_for_review_spec.rb
+++ b/deliver/spec/submit_for_review_spec.rb
@@ -8,10 +8,16 @@ describe Deliver::SubmitForReview do
     let(:app) { double('app') }
     let(:edit_version) do
       double('edit_version',
+             id: '1',
              version_string: "1.0.0")
     end
     let(:selected_build) { double('selected_build') }
     let(:idfa_declaration) { double('idfa_declaration') }
+
+    let(:empty_submission) do
+      double('empty_submission',
+             id: '1')
+    end
 
     before do
       allow(Deliver).to receive(:cache).and_return({ app: app })
@@ -84,7 +90,12 @@ describe Deliver::SubmitForReview do
         expect(edit_version).to receive(:fetch_idfa_declaration).and_return(nil)
         expect(edit_version).to receive(:uses_idfa).and_return(false)
 
-        expect(edit_version).to receive(:create_app_store_version_submission)
+        expect(app).to receive(:get_in_progress_review_submission).and_return(nil)
+        expect(app).to receive(:get_ready_review_submission).and_return(nil)
+        expect(app).to receive(:create_review_submission).and_return(empty_submission)
+
+        expect(empty_submission).to receive(:add_app_store_version_to_review_items).with(app_store_version_id: edit_version.id)
+        expect(empty_submission).to receive(:submit_for_review)
 
         review_submitter.submit!(options)
       end
@@ -108,7 +119,12 @@ describe Deliver::SubmitForReview do
           expect(edit_version).to receive(:fetch_idfa_declaration).and_return(nil)
           expect(edit_version).to receive(:uses_idfa).and_return(false)
 
-          expect(edit_version).to receive(:create_app_store_version_submission)
+          expect(app).to receive(:get_in_progress_review_submission).and_return(nil)
+          expect(app).to receive(:get_ready_review_submission).and_return(nil)
+          expect(app).to receive(:create_review_submission).and_return(empty_submission)
+
+          expect(empty_submission).to receive(:add_app_store_version_to_review_items).with(app_store_version_id: edit_version.id)
+          expect(empty_submission).to receive(:submit_for_review)
 
           review_submitter.submit!(options)
         end
@@ -135,7 +151,12 @@ describe Deliver::SubmitForReview do
             contentRightsDeclaration: "USES_THIRD_PARTY_CONTENT"
           })
 
-          expect(edit_version).to receive(:create_app_store_version_submission)
+          expect(app).to receive(:get_in_progress_review_submission).and_return(nil)
+          expect(app).to receive(:get_ready_review_submission).and_return(nil)
+          expect(app).to receive(:create_review_submission).and_return(empty_submission)
+
+          expect(empty_submission).to receive(:add_app_store_version_to_review_items).with(app_store_version_id: edit_version.id)
+          expect(empty_submission).to receive(:submit_for_review)
 
           review_submitter.submit!(options)
         end
@@ -159,7 +180,12 @@ describe Deliver::SubmitForReview do
           expect(edit_version).to receive(:update).with(attributes: { usesIdfa: false }).and_return(edit_version)
           expect(edit_version).to receive(:uses_idfa).and_return(false).exactly(2).times
 
-          expect(edit_version).to receive(:create_app_store_version_submission)
+          expect(app).to receive(:get_in_progress_review_submission).and_return(nil)
+          expect(app).to receive(:get_ready_review_submission).and_return(nil)
+          expect(app).to receive(:create_review_submission).and_return(empty_submission)
+
+          expect(empty_submission).to receive(:add_app_store_version_to_review_items).with(app_store_version_id: edit_version.id)
+          expect(empty_submission).to receive(:submit_for_review)
 
           review_submitter.submit!(options)
         end
@@ -182,7 +208,12 @@ describe Deliver::SubmitForReview do
           expect(edit_version).to receive(:uses_idfa).and_return(false).exactly(2).times
           expect(idfa_declaration).to receive(:delete!)
 
-          expect(edit_version).to receive(:create_app_store_version_submission)
+          expect(app).to receive(:get_in_progress_review_submission).and_return(nil)
+          expect(app).to receive(:get_ready_review_submission).and_return(nil)
+          expect(app).to receive(:create_review_submission).and_return(empty_submission)
+
+          expect(empty_submission).to receive(:add_app_store_version_to_review_items).with(app_store_version_id: edit_version.id)
+          expect(empty_submission).to receive(:submit_for_review)
 
           review_submitter.submit!(options)
         end
@@ -216,7 +247,12 @@ describe Deliver::SubmitForReview do
             attributesActionWithPreviousAd: true
           })
 
-          expect(edit_version).to receive(:create_app_store_version_submission)
+          expect(app).to receive(:get_in_progress_review_submission).and_return(nil)
+          expect(app).to receive(:get_ready_review_submission).and_return(nil)
+          expect(app).to receive(:create_review_submission).and_return(empty_submission)
+
+          expect(empty_submission).to receive(:add_app_store_version_to_review_items).with(app_store_version_id: edit_version.id)
+          expect(empty_submission).to receive(:submit_for_review)
 
           review_submitter.submit!(options)
         end
@@ -250,7 +286,12 @@ describe Deliver::SubmitForReview do
             attributesActionWithPreviousAd: true
           })
 
-          expect(edit_version).to receive(:create_app_store_version_submission)
+          expect(app).to receive(:get_in_progress_review_submission).and_return(nil)
+          expect(app).to receive(:get_ready_review_submission).and_return(nil)
+          expect(app).to receive(:create_review_submission).and_return(empty_submission)
+
+          expect(empty_submission).to receive(:add_app_store_version_to_review_items).with(app_store_version_id: edit_version.id)
+          expect(empty_submission).to receive(:submit_for_review)
 
           review_submitter.submit!(options)
         end

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -435,7 +435,8 @@ module Spaceship
         client ||= Spaceship::ConnectAPI
         filter = {
           state: [
-            Spaceship::ConnectAPI::ReviewSubmission::ReviewSubmissionState::WAITING_FOR_REVIEW
+            Spaceship::ConnectAPI::ReviewSubmission::ReviewSubmissionState::WAITING_FOR_REVIEW,
+            Spaceship::ConnectAPI::ReviewSubmission::ReviewSubmissionState::IN_REVIEW
           ].join(","),
           platform: platform
         }


### PR DESCRIPTION
### Motivation and Context
App Store Connect is releasing the new review process to everyone on January 25th (according to the email that was sent out)

✅ This pull request **is** only to migrate the existing options and functionality to the new API
❌ This pull request **is not** meant to fully take advantage of the new app review submission features (including multiple items)

### Description
Using `Spaceship::ConnectAPI` changes from #19751 by @valerio-castelli

- Migrates `reject_if_possible`
- Migrates `submit_for_review`

### Tasks
- [x] Wait for official App Store Connect API to be released
- [x] Update `submit_for_review` changes