### PR TITLE
[scan] fix off by one for scan's number_of_retries with xcode 13

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -515,7 +515,7 @@ module Scan
                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :number_of_retries,
                                     env_name: 'SCAN_NUMBER_OF_RETRIES',
-                                    description: "The number of times a test can fail before scan should stop retrying",
+                                    description: "In Xcode 13 and up, individual tests will retry on failure (see '-test-iterations' under `xcodebuild --help`). In Xcode 12 and under, the number of times a test can fail before scan should stop retrying",
                                     type: Integer,
                                     default_value: 0)
 

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -515,7 +515,7 @@ module Scan
                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :number_of_retries,
                                     env_name: 'SCAN_NUMBER_OF_RETRIES',
-                                    description: "In Xcode 13 and up, individual tests will retry on failure (see '-test-iterations' under `xcodebuild --help`). In Xcode 12 and under, the number of times a test can fail before scan should stop retrying",
+                                    description: "The number of times a test can fail",
                                     type: Integer,
                                     default_value: 0)
 

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -72,9 +72,13 @@ module Scan
       end
       options << "-xctestrun '#{config[:xctestrun]}'" if config[:xctestrun]
       options << config[:xcargs] if config[:xcargs]
-      if config[:number_of_retries] >= 1 && FastlaneCore::Helper.xcode_at_least?(13)
+
+      # Number of retries does not equal xcodebuild's -test-iterations number
+      # It needs include 1 iteration by default
+      number_of_retries = config[:number_of_retries] + 1
+      if number_of_retries > 1 && FastlaneCore::Helper.xcode_at_least?(13)
         options << "-retry-tests-on-failure"
-        options << "-test-iterations #{config[:number_of_retries]}"
+        options << "-test-iterations #{number_of_retries}"
       end
 
       # detect_values will ensure that these values are present as Arrays if

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -191,7 +191,7 @@ describe Scan do
                                          "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
                                          "-resultBundlePath '#{result_bundle_path}.xcresult'",
                                          "-retry-tests-on-failure",
-                                         "-test-iterations 1",
+                                         "-test-iterations 2",
                                          :build,
                                          :test
                                        ])


### PR DESCRIPTION
### Motivation and Context
Fixes #19842

### Description
- Adds 1 more test iteration to `:number_of_retries` is using Xcode 13's retries (test iterations)
- Updates `:number_of_retries` description to explain difference in behavior between Xcode 12 and under and Xcode 13 and up
