### PR TITLE
[snapshot] fix tests if xcbeautify is installed

### DIFF
--- a/snapshot/spec/test_command_generator_spec.rb
+++ b/snapshot/spec/test_command_generator_spec.rb
@@ -116,7 +116,7 @@ describe Snapshot do
 
       describe 'copy_simulator_logs' do
         before (:each) do
-          @config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {
+          @config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, {
             output_directory: '/tmp/scan_results',
             output_simulator_logs: true,
             devices: ['iPhone 6 (10.1)', 'iPhone 6s'],
@@ -186,7 +186,7 @@ describe Snapshot do
         let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
 
         def configure(options)
-          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
         end
 
         context 'default options' do
@@ -418,7 +418,7 @@ describe Snapshot do
         let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleMacOS", namespace_log_files: true } }
 
         it "uses default parameters on macOS", requires_xcode: true do
-          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options.merge(devices: ["Mac"]))
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options.merge(devices: ["Mac"]))
           expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
           command = Snapshot::TestCommandGenerator.generate(
             devices: ["Mac"],
@@ -448,7 +448,7 @@ describe Snapshot do
       describe "Unique logs" do
         let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
         let(:simulator_launcher) do
-          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
           launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
           launcher_config.devices = ["iPhone 6"]
           return simulator_launcher = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config)
@@ -480,7 +480,7 @@ describe Snapshot do
       describe "Unique logs disabled" do
         let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
         let(:simulator_launcher) do
-          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+          Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
           launcher_config = Snapshot::SimulatorLauncherConfiguration.new(snapshot_config: Snapshot.config)
           launcher_config.devices = ["iPhone 6"]
           return simulator_launcher = Snapshot::SimulatorLauncher.new(launcher_configuration: launcher_config)

--- a/snapshot/spec/test_command_generator_xcode_8_spec.rb
+++ b/snapshot/spec/test_command_generator_xcode_8_spec.rb
@@ -47,7 +47,7 @@ describe Snapshot do
 
     describe 'copy_simulator_logs' do
       before (:each) do
-        @config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, {
+        @config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, {
           output_directory: '/tmp/scan_results',
           output_simulator_logs: true,
           devices: ['iPhone 6 (10.1)', 'iPhone 6s'],
@@ -117,7 +117,7 @@ describe Snapshot do
       let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
 
       def configure(options)
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
       end
 
       context 'default options' do
@@ -246,7 +246,7 @@ describe Snapshot do
       let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleMacOS", namespace_log_files: true } }
 
       it "uses default parameters on macOS", requires_xcode: true do
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options.merge(devices: ["Mac"]))
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options.merge(devices: ["Mac"]))
         expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
         command = Snapshot::TestCommandGeneratorXcode8.generate(device_type: "Mac", language: "en", locale: nil)
         expect(command).to eq(
@@ -272,7 +272,7 @@ describe Snapshot do
       let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests", namespace_log_files: true } }
 
       it 'uses correct name and language', requires_xcode: true do
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
         log_path = Snapshot::TestCommandGeneratorXcode8.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: nil)
         expect(log_path).to eq(
           File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt.log").to_s
@@ -280,7 +280,7 @@ describe Snapshot do
       end
 
       it 'uses includes locale if specified', requires_xcode: true do
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
         log_path = Snapshot::TestCommandGeneratorXcode8.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: "pt_BR")
         expect(log_path).to eq(
           File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests-iPhone 6-pt-pt_BR.log").to_s
@@ -288,7 +288,7 @@ describe Snapshot do
       end
 
       it 'can work without parameters', requires_xcode: true do
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
         log_path = Snapshot::TestCommandGeneratorXcode8.xcodebuild_log_path
         expect(log_path).to eq(
           File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s
@@ -300,7 +300,7 @@ describe Snapshot do
       let(:options) { { project: "./snapshot/example/Example.xcodeproj", scheme: "ExampleUITests" } }
 
       it 'uses correct file name', requires_xcode: true do
-        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.plain_options, options)
         log_path = Snapshot::TestCommandGeneratorXcode8.xcodebuild_log_path(device_type: "iPhone 6", language: "pt", locale: nil)
         expect(log_path).to eq(
           File.expand_path("#{FastlaneCore::Helper.buildlog_path}/snapshot/Example-ExampleUITests.log").to_s


### PR DESCRIPTION
### Motivation and Context
`snapshot` tests woudl fail (locall) if `xcbeautify` was installed

### Description
- Switch tests to use `plain_options` instead of `available_options`
  - `available_options` is cached and won't change default value when `xcbeautify` installation is being mocked
