### PR TITLE
[scan] add parallel_testing option to scan

### DIFF
--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -134,9 +134,6 @@ public protocol ScanfileProtocol: class {
     /// Generate the json compilation database with clang naming convention (compile_commands.json)
     var useClangReportName: Bool { get }
 
-    /// Optionally override the per-target setting in the scheme for running tests in parallel. Equivalent to -parallel-testing-enabled
-    var parallelTesting: Bool? { get }
-
     /// Specify the exact number of test runners that will be spawned during parallel testing. Equivalent to -parallel-testing-worker-count
     var concurrentWorkers: Int? { get }
 
@@ -276,7 +273,6 @@ public extension ScanfileProtocol {
     var outputXctestrun: Bool { return false }
     var resultBundle: Bool { return false }
     var useClangReportName: Bool { return false }
-    var parallelTesting: Bool? { return nil }
     var concurrentWorkers: Int? { return nil }
     var maxConcurrentSimulators: Int? { return nil }
     var disableConcurrentTesting: Bool { return false }
@@ -312,4 +308,4 @@ public extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.101]
+// FastlaneRunnerAPIVersion [0.9.102]

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -134,6 +134,9 @@ public protocol ScanfileProtocol: class {
     /// Generate the json compilation database with clang naming convention (compile_commands.json)
     var useClangReportName: Bool { get }
 
+    /// Optionally override the per-target setting in the scheme for running tests in parallel. Equivalent to -parallel-testing-enabled
+    var parallelTesting: Bool? { get }
+
     /// Specify the exact number of test runners that will be spawned during parallel testing. Equivalent to -parallel-testing-worker-count
     var concurrentWorkers: Int? { get }
 
@@ -273,6 +276,7 @@ public extension ScanfileProtocol {
     var outputXctestrun: Bool { return false }
     var resultBundle: Bool { return false }
     var useClangReportName: Bool { return false }
+    var parallelTesting: Bool? { return nil }
     var concurrentWorkers: Int? { return nil }
     var maxConcurrentSimulators: Int? { return nil }
     var disableConcurrentTesting: Bool { return false }

--- a/fastlane/swift/ScanfileProtocol.swift
+++ b/fastlane/swift/ScanfileProtocol.swift
@@ -308,4 +308,4 @@ public extension ScanfileProtocol {
 
 // Please don't remove the lines below
 // They are used to detect outdated files
-// FastlaneRunnerAPIVersion [0.9.102]
+// FastlaneRunnerAPIVersion [0.9.101]

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -328,6 +328,11 @@ module Scan
                                      default_value: false),
 
         # concurrency
+        FastlaneCore::ConfigItem.new(key: :parallel_testing,
+                                     type: Boolean,
+                                     env_name: "SCAN_PARALLEL_TESTING",
+                                     description: "Optionally override the per-target setting in the scheme for running tests in parallel. Equivalent to -parallel-testing-enabled",
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :concurrent_workers,
                                      type: Integer,
                                      env_name: "SCAN_CONCURRENT_WORKERS",

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -55,6 +55,7 @@ module Scan
       end
       options << "-resultBundlePath '#{result_bundle_path(true)}'" if config[:result_bundle]
       if FastlaneCore::Helper.xcode_at_least?(10)
+        options << "-parallel-testing-enabled #{config[:parallel_testing] ? 'YES' : 'NO'}" unless config[:parallel_testing].nil?
         options << "-parallel-testing-worker-count #{config[:concurrent_workers]}" if config[:concurrent_workers]
         options << "-maximum-concurrent-test-simulator-destinations #{config[:max_concurrent_simulators]}" if config[:max_concurrent_simulators]
         options << "-disable-concurrent-testing" if config[:disable_concurrent_testing]

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -355,6 +355,40 @@ describe Scan do
         end
       end
 
+      describe "Test Parallel Testing" do
+        # don't want to override settings defined in xcode unless explicitly asked to
+        it "doesn't add option if not passed explicitly", requires_xcodebuild: true do
+          log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+          options = { project: "./scan/examples/standard/app.xcodeproj" }
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+          result = @test_command_generator.generate
+          expect(result).not_to include("-parallel-testing-enabled YES") if FastlaneCore::Helper.xcode_at_least?(10)
+          expect(result).not_to include("-parallel-testing-enabled NO") if FastlaneCore::Helper.xcode_at_least?(10)
+        end
+
+        it "specify YES when set to true", requires_xcodebuild: true do
+          log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+          options = { project: "./scan/examples/standard/app.xcodeproj", parallel_testing: true }
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+          result = @test_command_generator.generate
+          expect(result).to include("-parallel-testing-enabled YES") if FastlaneCore::Helper.xcode_at_least?(10)
+        end
+
+        it "specify NO when set to false", requires_xcodebuild: true do
+          log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+          options = { project: "./scan/examples/standard/app.xcodeproj", parallel_testing: false }
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+          result = @test_command_generator.generate
+          expect(result).to include("-parallel-testing-enabled NO") if FastlaneCore::Helper.xcode_at_least?(10)
+        end
+      end
+
       describe "Test Concurrent Workers" do
         before do
           options = { project: "./scan/examples/standard/app.xcodeproj", concurrent_workers: 4 }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #19856 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Added code for `-parallel-testing-enabled` to fastlane.
- Added `parallel_testing` option to `scan/lib/scan/options.rb`
- Consumed that option in `scan/lib/scan/test_command_generator.rb`
- Added tests for true/false/not set to `scan/spec/test_command_generator_spec.rb`
- Updated `fastlane/swift/ScanfileProtocol.swift` to support the new option
