### PR TITLE
[scan] Return results when running scan

### DIFF
--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -13,14 +13,13 @@ module Fastlane
         require 'scan'
         manager = Scan::Manager.new
 
-        results = nil
-
         begin
           results = manager.work(values)
 
           zip_build_products_path = Scan.cache[:zip_build_products_path]
           Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = zip_build_products_path if zip_build_products_path
 
+          return results
         rescue FastlaneCore::Interface::FastlaneBuildFailure => ex
           # Specifically catching FastlaneBuildFailure to prevent build/compile errors from being
           # silenced when :fail_build is set to false
@@ -47,8 +46,6 @@ module Fastlane
             Actions.lane_context[SharedValues::SCAN_GENERATED_PLIST_FILE] = all_test_summaries.last
           end
         end
-
-        return results
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -13,13 +13,14 @@ module Fastlane
         require 'scan'
         manager = Scan::Manager.new
 
+        results = nil
+
         begin
-          manager.work(values)
+          results = manager.work(values)
 
           zip_build_products_path = Scan.cache[:zip_build_products_path]
           Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = zip_build_products_path if zip_build_products_path
 
-          return true
         rescue FastlaneCore::Interface::FastlaneBuildFailure => ex
           # Specifically catching FastlaneBuildFailure to prevent build/compile errors from being
           # silenced when :fail_build is set to false
@@ -46,6 +47,8 @@ module Fastlane
             Actions.lane_context[SharedValues::SCAN_GENERATED_PLIST_FILE] = all_test_summaries.last
           end
         end
+
+        return results
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -56,6 +56,14 @@ module Fastlane
         "More information: https://docs.fastlane.tools/actions/scan/"
       end
 
+      def self.return_value
+        'Outputs has of results with :number_of_tests, :number_of_failures, :number_of_retries, :number_of_tests_excluding_retries, :number_of_failures_excluding_retries'
+      end
+
+      def self.return_type
+        :hash
+      end
+
       def self.author
         "KrauseFx"
       end

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -303,6 +303,7 @@ module Scan
       end
 
       open_report
+      results
     end
 
     def open_report


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
I wanted an easy way of getting the results from scan with `fail_build: false`. With this update, it's easy to view the results of scan simply by storing the value when you call it. I started a discussion [here](https://github.com/fastlane/fastlane/discussions/19859) as well but figured I'd just make a PR when I realized how straightforward it'd be.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I just added `results` to the end of `handle_results`, which will mean it gets returned from `run`.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Run scan in a new project and store the value. Print it to see the results.