### PR TITLE
[match] Fix typo in Match::Storage::S3Storage#s3_object_path

### DIFF
--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -168,10 +168,10 @@ module Match
       private
 
       def s3_object_path(file_name)
-        santized = sanitize_file_name(file_name)
-        return santized if santized.start_with?(s3_object_prefix)
+        sanitized = sanitize_file_name(file_name)
+        return sanitized if sanitized.start_with?(s3_object_prefix)
 
-        s3_object_prefix + santized
+        s3_object_prefix + sanitized
       end
 
       def strip_s3_object_prefix(object_path)


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Less typos in the source code? 😅 

### Description

Fixes a small typo in a local variable.

### Testing Steps

None.
