### PR TITLE
[scan] fix crash if no derived data

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -175,6 +175,8 @@ module Scan
 
     def find_xcresults_in_derived_data
       derived_data_path = Scan.config[:derived_data_path]
+      return [] if derived_data_path.nil? # Swift packages might not have derived data
+
       xcresults_path = File.join(derived_data_path, "Logs", "Test", "*.xcresult")
       return Dir[xcresults_path]
     end


### PR DESCRIPTION
### Motivation and Context
Addresses https://github.com/fastlane/fastlane/issues/19865#issuecomment-1023253618
- `scan` would crash if there is no derived data (which can happen when testing a Swift Package)

### Description
Return an empty array if no derived data when looking for `.xcresult`s
