### PR TITLE
[scan][regression] Fixed scan for `build_for_testing` option

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -257,6 +257,10 @@ module Scan
     end
 
     def handle_results(tests_exit_status)
+      copy_simulator_logs
+      zip_build_products
+      copy_xctestrun
+
       return nil if Scan.config[:build_for_testing]
 
       results = trainer_test_results
@@ -293,10 +297,6 @@ module Scan
         ]
       }))
       puts("")
-
-      copy_simulator_logs
-      zip_build_products
-      copy_xctestrun
 
       if number_of_failures > 0
         open_report


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
- Resolves #19865
- Scan got broken for `build_for_testing` option in this [PR](https://github.com/fastlane/fastlane/pull/19629) 
- Please see attached image for more details

### Description
- In this PR, Moved `copy_simulator_logs, zip_build_products, copy_xctestrun` before early exit so `build_for_testing: true` option can copy those results properly.

### Testing Steps

- Update `Gemfile` to 👇 and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "crazymanish-scan-build-for-testing-regression-fix"
```
- Try to run `scan` with `build_for_testing: true` option
```ruby
lane :test do
      scan(
        build_for_testing: true,               
        should_zip_build_products: true 
      )
  end
```

#### Screenshot
<img width="800" alt="Schermafbeelding 2022-01-28 om 8 28 53 PM" src="https://user-images.githubusercontent.com/5364500/151611031-047b6941-aa99-48bb-9bc1-85dffcf5d53b.png">

