### PR TITLE
[trainer][regression] fixes fail_build parameter which stopped working

### DIFF
--- a/fastlane/lib/fastlane/actions/trainer.rb
+++ b/fastlane/lib/fastlane/actions/trainer.rb
@@ -9,8 +9,8 @@ module Fastlane
 
         fail_build = params[:fail_build]
         resulting_paths = Trainer::TestParser.auto_convert(params)
-        resulting_paths.each do |path, test_successful|
-          UI.test_failure!("Unit tests failed") if fail_build && !test_successful
+        resulting_paths.each do |path, test_results|
+          UI.test_failure!("Unit tests failed") if fail_build && !test_results[:successful]
         end
 
         return resulting_paths

--- a/fastlane/spec/actions_specs/trainer_spec.rb
+++ b/fastlane/spec/actions_specs/trainer_spec.rb
@@ -1,0 +1,32 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "Trainer Integration" do
+      context ":fail_build" do
+        it "does not raise an error if tests fail and fail_build is false" do
+          expect do
+            Fastlane::FastFile.new.parse("lane :parse_test_result do
+                trainer(
+                  path: '../trainer/spec/fixtures/Test.test_result.xcresult',
+                  output_directory: '/tmp/trainer_results',
+                  fail_build: false
+                )
+              end").runner.execute(:parse_test_result)
+          end.not_to(raise_error)
+        end
+
+        it "raises an error if tests fail and fail_build is true" do
+          failing_xcresult_path = "../trainer/spec/fixtures/Test.test_result.xcresult"
+          expect do
+            Fastlane::FastFile.new.parse("lane :parse_test_result do
+                trainer(
+                  path: '../trainer/spec/fixtures/Test.test_result.xcresult',
+                  output_directory: '/tmp/trainer_results',
+                  fail_build: true
+                )
+              end").runner.execute(:parse_test_result)
+          end.to raise_error(FastlaneCore::Interface::FastlaneTestFailure)
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/trainer_spec.rb
+++ b/fastlane/spec/actions_specs/trainer_spec.rb
@@ -2,7 +2,7 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Trainer Integration" do
       context ":fail_build" do
-        it "does not raise an error if tests fail and fail_build is false" do
+        it "does not raise an error if tests fail and fail_build is false", requires_xcode: true do
           expect do
             Fastlane::FastFile.new.parse("lane :parse_test_result do
                 trainer(
@@ -14,7 +14,7 @@ describe Fastlane do
           end.not_to(raise_error)
         end
 
-        it "raises an error if tests fail and fail_build is true" do
+        it "raises an error if tests fail and fail_build is true", requires_xcode: true do
           failing_xcresult_path = "../trainer/spec/fixtures/Test.test_result.xcresult"
           expect do
             Fastlane::FastFile.new.parse("lane :parse_test_result do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Trainer has been migrated to Fastlane and is now official part of the tool. As part of the migration, the parser code has been updated and now it is returning a different format (as confirmed by @joshdholtz here: https://github.com/fastlane/fastlane/issues/19839#issuecomment-1020770300 )
The problem with this is that the Trainer action has not been updated accordingly, and the fail_build parameter has stopped working (before we were checking for a boolean, now we are checking for a hashmap that is always populated):
The previous parser return value was: `{"path/to/file1.xml" => true, ...}`
The current trainer return value is: `{"path/to/file1.xcresult" => {:to_path => "path/to/file1.xml", :successful => true, number_of_tests: ..}, ...}`
Described in https://github.com/fastlane/fastlane/issues/19839

### Description
Updated the code parsing the response from the test parser.
Added tests to prevent this from regressing.
Fixes https://github.com/fastlane/fastlane/issues/19883

### Testing Steps
To run the suite:
`bundle exec rspec ./fastlane/spec/actions_specs/trainer_spec.rb`

To test this manually:
Run fastlane trainer action. In the fastlane root, run the following command:
```
bundle exec fastlane run trainer path:'./trainer/spec/fixtures/Test.test_result.xcresult' output_directory:'/tmp/trainer_results' fail_build:'true'
```
Desired output. Fastlane exits with code 1
Actual output: Fastlane exits with code 0