### PR TITLE
Revert "[spaceship][deliver][pilot] temporarily fix finding app by filtering bundle id locally"

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -78,17 +78,7 @@ module Spaceship
 
       def self.find(bundle_id, client: nil)
         client ||= Spaceship::ConnectAPI
-
-        # On 2022/2/2, filtering by bundle identifier started to fail for identifiers longer than 25 characters
-        # Temporarily removing this filter and filtering locally until this is fixed
-        #
-        # Also go uncomment the tests in spaceship/spec/connectapi/models/app_spec.rb when this is fixed
-        #
-        # return all(client: client, filter: { bundleId: bundle_id }).find do |app|
-        #   app.bundle_id == bundle_id
-        # end
-
-        return all(client: client).find do |app|
+        return all(client: client, filter: { bundleId: bundle_id }).find do |app|
           app.bundle_id == bundle_id
         end
       end

--- a/spaceship/spec/connect_api/models/app_spec.rb
+++ b/spaceship/spec/connect_api/models/app_spec.rb
@@ -81,17 +81,17 @@ describe Spaceship::ConnectAPI::App do
   end
 
   describe "App object" do
-    #    it 'finds app by bundle id' do
-    #      model = Spaceship::ConnectAPI::App.find("com.joshholtz.FastlaneTest")
-    #      expect(model.bundle_id).to eq("com.joshholtz.FastlaneTest")
-    #    end
-    #
-    #    it 'creates beta group' do
-    #      app = Spaceship::ConnectAPI::App.find("com.joshholtz.FastlaneTest")
-    #
-    #      model = app.create_beta_group(group_name: "Brand New Group", public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
-    #      expect(model.id).to eq("123456789")
-    #    end
+    it 'finds app by bundle id' do
+      model = Spaceship::ConnectAPI::App.find("com.joshholtz.FastlaneTest")
+      expect(model.bundle_id).to eq("com.joshholtz.FastlaneTest")
+    end
+
+    it 'creates beta group' do
+      app = Spaceship::ConnectAPI::App.find("com.joshholtz.FastlaneTest")
+
+      model = app.create_beta_group(group_name: "Brand New Group", public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
+      expect(model.id).to eq("123456789")
+    end
 
     it '#get_review_submissions' do
       ConnectAPIStubbing::Tunes.stub_get_review_submissions


### PR DESCRIPTION
Reverts fastlane/fastlane#19900

Apple has a fix in place and is waiting to be deployed. Will merge then and push out a new version when deployed.