### PR TITLE
[Fastlane.Swift] Swift fastlane upgrader #18933

### DIFF
--- a/fastlane/lib/fastlane/swift_runner_upgrader.rb
+++ b/fastlane/lib/fastlane/swift_runner_upgrader.rb
@@ -216,10 +216,10 @@ module Fastlane
       # Check if upgrade is needed
       # If fastlane build settings exists already, we don't need any more changes to the Xcode project
       self.fastlane_runner_target.build_configurations.each { |config|
-        return false if dry_run && config.build_settings["CODE_SIGN_IDENTITY"].nil?
-        return false if dry_run && config.build_settings["MACOSX_DEPLOYMENT_TARGET"].nil?
+        return true if dry_run && config.build_settings["CODE_SIGN_IDENTITY"].nil?
+        return true if dry_run && config.build_settings["MACOSX_DEPLOYMENT_TARGET"].nil?
       }
-      return true if dry_run
+      return false if dry_run
 
       # Proceed to upgrade
       self.fastlane_runner_target.build_configurations.each { |config|
@@ -236,11 +236,10 @@ module Fastlane
       phase_copy_sign = self.fastlane_runner_target.copy_files_build_phases.select { |phase_copy| phase_copy.name == "FastlaneRunnerCopySigned" }.first
 
       old_phase_copy_sign = self.fastlane_runner_target.shell_script_build_phases.select { |phase_copy| phase_copy.shell_script == "cd \"${SRCROOT}\"\ncd ../..\ncp \"${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}\" .\n" }.first
-      unless phase_copy_sign
-        return false if dry_run
-      end
 
-      return true if dry_run
+      return true if dry_run && phase_copy_sign.nil?
+
+      return false if dry_run
 
       # Proceed to upgrade
       old_phase_copy_sign.remove_from_project unless old_phase_copy_sign.nil?


### PR DESCRIPTION
+ fix upgrades checks to avoid false not up-to-date messages.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
After fixing #18933, some [users report that an interactive message is always shown on execution](https://github.com/fastlane/fastlane/issues/18933#issuecomment-1028770132). 
I've verified that indeed the message appears, but it shouldn't.
This PR fixes that problem. After an upgrade, there must be no more messages asking to upgrade the project.
 
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #18933
-->

### Description
<!-- Describe your changes in detail. -->
Fix upgrade checks.
After an upgrade, there must be no messages asking to upgrade the project.

<!-- Please describe in detail how you tested your changes. -->
I've a [simple fastlane test project](https://github.com/kikeenrique/fastlane-swift-basic).
There I run **`bundle exec fastlane custom --verbose`** and that runs the code to fix/test.

I've checked different statuses of FastlaneSwiftRunner.xcodeproj: not including checked flags or not including FastlaneRunnerCopySigned build phase. It consists merely on run a first upgrade with the above mentioned command, and then discard flags or build phase related diffs and re run the command.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->

- [clone fastlane test project](https://github.com/kikeenrique/fastlane-swift-basic)

- Run `bundle exec fastlane custom --verbose`. Check that message "Should we try to upgrade just your FastlaneSwiftRunner project? (y/n)" appears.
- Re run `bundle exec fastlane custom --verbose`. Check that message does not appear again.

<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
