### PR TITLE
[snapshot] fix compile error on macCatalyst

### DIFF
--- a/snapshot/lib/assets/SnapshotHelper.swift
+++ b/snapshot/lib/assets/SnapshotHelper.swift
@@ -165,7 +165,7 @@ open class Snapshot: NSObject {
             }
 
             let screenshot = XCUIScreen.main.screenshot()
-            #if os(iOS)
+            #if os(iOS) && !targetEnvironment(macCatalyst)
             let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
             #else
             let image = screenshot.image
@@ -306,4 +306,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.27]
+// SnapshotHelperVersion [1.28]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Resolves #19915

### Description
Added `&& !targetEnvironment(macCatalyst)`when checking for the device orientation due to a syntax error when compiling for macCatalyst. Mac does not have a device orientation.

Tested by:
- copying the SnapshotHelper to my project https://github.com/philipparndt/mqtt-analyzer and executing UI Tests.

## Test errors
I get some unrelated test errors when executing `bundle exec rspec`. I get the same errors with and without my patch.

```
Failures:

  1) Fastlane Fastlane::FastFile update_fastlane when no update needed
     Failure/Error: expect(UI).to receive(:success).with("Nothing to update ✅")
     
       (FastlaneCore::UI (class)).success("Nothing to update ✅")
           expected: 1 time with arguments: ("Nothing to update ✅")
           received: 0 times
     # ./fastlane/spec/actions_specs/update_fastlane_spec.rb:18:in `block (4 levels) in <top (required)>'
     # /Library/Ruby/Gems/2.6.0/gems/webmock-3.12.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

  2) Fastlane Fastlane::FastFile update_fastlane when update with RubyGems
     Failure/Error: expect(FastlaneCore::FastlaneFolder).to receive(:swift?).and_return(true)
     
       (FastlaneCore::FastlaneFolder (class)).swift?(*(any args))
           expected: 1 time with any arguments
           received: 0 times with any arguments
     # ./fastlane/spec/actions_specs/update_fastlane_spec.rb:32:in `block (4 levels) in <top (required)>'
     # /Library/Ruby/Gems/2.6.0/gems/webmock-3.12.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

  3) Fastlane Fastlane::FastFile update_fastlane when update with Homebrew
     Failure/Error: expect(Fastlane::Helper).to receive(:homebrew?).and_return(true).twice
     
       (FastlaneCore::Helper).homebrew?(*(any args))
           expected: 2 times with any arguments
           received: 0 times with any arguments
     # ./fastlane/spec/actions_specs/update_fastlane_spec.rb:69:in `block (4 levels) in <top (required)>'
     # /Library/Ruby/Gems/2.6.0/gems/webmock-3.12.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'

Finished in 8 minutes 5 seconds (files took 6.18 seconds to load)
7012 examples, 3 failures

Failed examples:

rspec ./fastlane/spec/actions_specs/update_fastlane_spec.rb:13 # Fastlane Fastlane::FastFile update_fastlane when no update needed
rspec ./fastlane/spec/actions_specs/update_fastlane_spec.rb:28 # Fastlane Fastlane::FastFile update_fastlane when update with RubyGems
rspec ./fastlane/spec/actions_specs/update_fastlane_spec.rb:68 # Fastlane Fastlane::FastFile update_fastlane when update with Homebrew
```



