### PR TITLE
[match] update :force_for_new_certificates option description

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -249,7 +249,7 @@ module Match
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :force_for_new_certificates,
                                      env_name:  "MATCH_FORCE_FOR_NEW_CERTIFICATES",
-                                     description: "Renew the provisioning profiles if the device count on the developer portal has changed. Works only for the 'development' provisioning profile type. Requires 'include_all_certificates' option to be 'true'",
+                                     description: "Renew the provisioning profiles if the certificate count on the developer portal has changed. Works only for the 'development' provisioning profile type. Requires 'include_all_certificates' option to be 'true'",
                                      type: Boolean,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :skip_confirmation,


### PR DESCRIPTION
I'm not sure if this is the right documentation now, but it looks like it was a copy and paste error before.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
The description of the parameter matches another one so closely, that it does not seem right.

### Description
Changed the description to better match the parameter name.

### Testing Steps
run

```
fastlane actions match
```