### PR TITLE
Fix spelling for consistency

### DIFF
--- a/match/lib/match/encryption/openssl.rb
+++ b/match/lib/match/encryption/openssl.rb
@@ -135,7 +135,7 @@ module Match
         UI.crash!("Error encrypting '#{path}'")
       end
 
-      # The encryption parameters in this implementations reflect the old behaviour which depended on the users' local OpenSSL version
+      # The encryption parameters in this implementations reflect the old behavior which depended on the users' local OpenSSL version
       # 1.0.x OpenSSL and earlier versions use MD5, 1.1.0c and newer uses SHA256, we try both before giving an error
       def decrypt_specific_file(path: nil, password: nil, hash_algorithm: "MD5")
         stored_data = Base64.decode64(File.read(path))


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description

Changed`behaviour` to `behavior`  for consistency.

- the search results of `behaviour` (only 1 file)
https://github.com/fastlane/fastlane/search?q=behaviour

- the search results of `behavior` (26 files)
https://github.com/fastlane/fastlane/search?q=behavior