### PR TITLE
[fastlane_core] add env var to skip printing plugins table

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -36,7 +36,8 @@ module Fastlane
       # do not use "include" as it may be some where in the commandline where "env" is required, therefore explicit index->0
       unless ARGV[0] == "env" || CLIToolsDistributor.running_version_command? || CLIToolsDistributor.running_help_command?
         # *after* loading the plugins
-        Fastlane.plugin_manager.load_plugins
+        hide_plugins_table = FastlaneCore::Env.truthy?("FASTLANE_HIDE_PLUGINS_TABLE")
+        Fastlane.plugin_manager.load_plugins(print_table: !hide_plugins_table)
         Fastlane::PluginUpdateManager.start_looking_for_updates
       end
       self.new.run

--- a/fastlane_core/README.md
+++ b/fastlane_core/README.md
@@ -23,6 +23,7 @@ You can hide the inline changelog by setting the `FASTLANE_HIDE_CHANGELOG` envir
 
 - To hide timestamps in each row, set the `FASTLANE_HIDE_TIMESTAMP` environment variable to true.
 - To disable output formatting, set the `FASTLANE_DISABLE_OUTPUT_FORMAT` environment variable to true.
+- To prevent _fastlane_ from printing the plugins table on every lane run, set the `FASTLANE_HIDE_PLUGINS_TABLE` environment variable to true.
 
 ## Interacting with the user
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I find the plugins table printing very annoying 😅 So I added an env var to optionally skip printing it.

### Description

This PR introduces an env var that, when set, won't print the plugins table at the beginning of every lane run. The env var is called `FASTLANE_HIDE_PLUGINS_TABLE`, and I've updated `fastlane_core/README.md` to document it.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem 'fastlane', git: 'https://github.com/fastlane/fastlane.git', branch: 'rogerluan-add-env-var-to-skip-plugins-table'
```

And run `bundle install` to apply the changes. 

You can set an env var by using e.g. `export FASTLANE_HIDE_PLUGINS_TABLE=true` to set it to true, and `unset FASTLANE_HIDE_PLUGINS_TABLE` to unset it.