### PR TITLE
[action][git_commit action] use safer way of calling `sh`

### DIFF
--- a/fastlane/lib/fastlane/actions/git_commit.rb
+++ b/fastlane/lib/fastlane/actions/git_commit.rb
@@ -2,22 +2,20 @@ module Fastlane
   module Actions
     class GitCommitAction < Action
       def self.run(params)
-        paths = params[:path].map(&:shellescape).join(' ')
-
-        skip_git_hooks = params[:skip_git_hooks] ? '--no-verify' : ''
+        paths = params[:path]
+        skip_git_hooks = params[:skip_git_hooks] ? ['--no-verify'] : []
 
         if params[:allow_nothing_to_commit]
           # Here we check if the path passed in parameter contains any modification
           # and we skip the `git commit` command if there is none.
           # That means you can have other files modified that are not in the path parameter
           # and still make use of allow_nothing_to_commit.
-          repo_clean = Actions.sh("git status #{paths} --porcelain").empty?
+          repo_clean = Actions.sh('git', 'status', *paths, '--porcelain').empty?
           UI.success("Nothing to commit, working tree clean ✅.") if repo_clean
           return if repo_clean
         end
 
-        command = "git commit -m #{params[:message].shellescape} #{paths} #{skip_git_hooks}".strip
-        result = Actions.sh(command)
+        result = Actions.sh('git', 'commit', '-m', params[:message], *paths, *skip_git_hooks)
         UI.success("Successfully committed \"#{params[:path]}\" 💾.")
         return result
       end

--- a/fastlane/spec/actions_specs/git_commit_spec.rb
+++ b/fastlane/spec/actions_specs/git_commit_spec.rb
@@ -55,10 +55,10 @@ describe Fastlane do
 
       it "generates the correct git command when configured to allow nothing to commit and there are changes to commit" do
         expect(Fastlane::Actions).to receive(:sh)
-          .with("git status ./fastlane/README.md --porcelain")
+          .with(*%w[git status ./fastlane/README.md --porcelain])
           .and_return("M  ./fastlane/README.md")
         expect(Fastlane::Actions).to receive(:sh)
-          .with("git commit -m message ./fastlane/README.md")
+          .with(*%w[git commit -m message ./fastlane/README.md])
           .and_call_original
 
         result = Fastlane::FastFile.new.parse("lane :test do
@@ -70,7 +70,7 @@ describe Fastlane do
 
       it "does not generate the git command when configured to allow nothing to commit and there are no changes to commit" do
         expect(Fastlane::Actions).to receive(:sh)
-          .with("git status ./fastlane/README.md --porcelain")
+          .with(*%w[git status ./fastlane/README.md --porcelain])
           .and_return("")
         result = Fastlane::FastFile.new.parse("lane :test do
           git_commit(path: './fastlane/README.md', message: 'message', allow_nothing_to_commit: true)


### PR DESCRIPTION
By letting `sh` do all the escaping and argument handling for us

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] ~I've updated the documentation if necessary.~

### Motivation and Context

Even though the current implementation likely already worked for all cases (including spaces in paths etc), it is usually better and safer to let `sh` do the escaping and shell arguments handling for us rather than pass a full string built by us (and have the shell interpret it and split it back in individual arguments)

### Description

Used `sh("git", "command", "args")` instead of `sh("git command args")` as the former is considered more safe against injection and shell param interpretation

PS: There might be a couple more actions that also use `Actions.sh` that way instead of passing arguments as separate parameters; I only updated that action because I happened to using it stumble upon this while taking a look at its source code, but feel free to apply a similar change to other actions using `Actions.sh` as well.

(Optionally, we could consider migrating to the `Git` rubygem to do those git-related tasks in git-related fastlane actions… 🤔 )

### Testing Steps

Run the action with a couple of paths containing spaces and special characters