### PR TITLE
[supply] Prefer all default tracks when downloading metadata from Play store

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -266,14 +266,9 @@ module Supply
       filtered_tracks = tracks.select { |t| !t.releases.nil? && t.releases.any? { |r| r.name == version } }
 
       if filtered_tracks.length > 1
-        # Production track takes precedence if version is present in multiple tracks
+        # Prefer tracks in production, beta, alpha, internal order
         # E.g.: A release might've been promoted from Alpha/Beta track. This means the release will be present in two or more tracks
-        if filtered_tracks.any? { |t| t.track == Supply::Tracks::DEFAULT }
-          filtered_tracks = filtered_tracks.select { |t| t.track == Supply::Tracks::DEFAULT }
-        else
-          # E.g.: A release might be in both Alpha & Beta (not sure if this is possible, just catching if it ever happens), giving Beta precedence.
-          filtered_tracks = filtered_tracks.select { |t| t.track == Supply::Tracks::BETA }
-        end
+        filtered_tracks = filtered_tracks.sort_by { |t| Supply::Tracks::DEFAULTS.index(t.track) || Float::INFINITY }
       end
 
       filtered_track = filtered_tracks.first


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves #19926

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes version selection in a situation where the version is not available in production or beta tracks of Google Play store.

Previously the code preferred the production track version, and if that wasn't available it chose the beta track. This logic failed when neither of these tracks were used, i.e. a version published on the internal track was promoted to the alpha track.

This PR changes the track selection logic by sorting the matching release versions by track. The sort order is production, beta, alpha, internal and everything else after that.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

1. Publish a version to internal track on Play Store.
2. Promote the internal track version to alpha track
3. Download release metadata with download_from_play_store
