### PR TITLE
[trainer] Return Test Plan Configuration in JUnit output

### DIFF
--- a/trainer/lib/assets/junit.xml.erb
+++ b/trainer/lib/assets/junit.xml.erb
@@ -7,6 +7,11 @@
 <testsuites tests="<%= number_of_tests %>" failures="<%= number_of_failures %>">
   <% @results.each do |testsuite| %>
     <testsuite name=<%= (testsuite[:target_name].nil? ? testsuite[:test_name] : testsuite[:target_name]).encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests_excluding_retries] %>" failures="<%= testsuite[:number_of_failures_excluding_retries] %>" <% if testsuite[:number_of_skipped] %>skipped="<%= testsuite[:number_of_skipped] %>" <% end %>time="<%= testsuite[:duration] %>">
+      <% unless testsuite[:configuration_name].nil? %>
+        <properties>
+          <property name="Configuration" value="<%= testsuite[:configuration_name] %>"/>
+        </properties>
+      <% end %>
       <% testsuite[:tests].each do |test| %>
         <testcase classname=<%= test[:test_group].encode(:xml => :attr) %> name=<%= test[:name].encode(:xml => :attr) %> time="<%= test[:duration] %>">
           <% (test[:failures] || []).each do |failure| %>
@@ -15,7 +20,7 @@
           <% end %>
           <% if test[:skipped] %>
             <skipped/>
-          <% end%>
+          <% end %>
         </testcase>
       <% end %>
     </testsuite>

--- a/trainer/lib/trainer/junit_generator.rb
+++ b/trainer/lib/trainer/junit_generator.rb
@@ -19,7 +19,7 @@ module Trainer
 
       xml = xml.gsub('system_', 'system-').delete("\e") # Jenkins can not parse 'ESC' symbol
 
-      # We have to manuall clear empty lines
+      # We have to manually clear empty lines
       # They may contain white spaces
       clean_xml = []
       xml.each_line do |row|

--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -230,6 +230,14 @@ module Trainer
       all_summaries = summaries.map(&:summaries).flatten
       testable_summaries = all_summaries.map(&:testable_summaries).flatten
 
+      summary_to_name = {}
+
+      all_summaries.each do |summary|
+        summary.testable_summaries.each do |testable_summary|
+          summary_to_name[testable_summary] = summary.name
+        end
+      end
+
       # Maps ActionTestableSummary to rows for junit generator
       rows = testable_summaries.map do |testable_summary|
         all_tests = testable_summary.all_tests.flatten
@@ -317,6 +325,7 @@ module Trainer
           project_path: testable_summary.project_relative_path,
           target_name: testable_summary.target_name,
           test_name: testable_summary.name,
+          configuration_name: summary_to_name[testable_summary],
           duration: all_tests.map(&:duration).inject(:+),
           tests: test_rows
         }

--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -230,13 +230,7 @@ module Trainer
       all_summaries = summaries.map(&:summaries).flatten
       testable_summaries = all_summaries.map(&:testable_summaries).flatten
 
-      summary_to_name = {}
-
-      all_summaries.each do |summary|
-        summary.testable_summaries.each do |testable_summary|
-          summary_to_name[testable_summary] = summary.name
-        end
-      end
+      summaries_to_names = test_summaries_to_configuration_names(all_summaries)
 
       # Maps ActionTestableSummary to rows for junit generator
       rows = testable_summaries.map do |testable_summary|
@@ -325,7 +319,7 @@ module Trainer
           project_path: testable_summary.project_relative_path,
           target_name: testable_summary.target_name,
           test_name: testable_summary.name,
-          configuration_name: summary_to_name[testable_summary],
+          configuration_name: summaries_to_names[testable_summary],
           duration: all_tests.map(&:duration).inject(:+),
           tests: test_rows
         }
@@ -344,6 +338,16 @@ module Trainer
       end
 
       self.data = rows
+    end
+
+    def test_summaries_to_configuration_names(test_summaries)
+      summary_to_name = {}
+      test_summaries.each do |summary|
+        summary.testable_summaries.each do |testable_summary|
+          summary_to_name[testable_summary] = summary.name
+        end
+      end
+      summary_to_name
     end
 
     # Convert the Hashes and Arrays in something more useful

--- a/trainer/spec/fixtures/XCResult.junit
+++ b/trainer/spec/fixtures/XCResult.junit
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="7" failures="2">
+    <testsuite name="TestUITests" tests="1" failures="0" skipped="0" time="16.05245804786682">
+        <properties>
+          <property name="Configuration" value="Test Scheme Action"/>
+        </properties>
+        <testcase classname="TestUITests" name="testExample()" time="16.05245804786682">
+        </testcase>
+    </testsuite>
+    <testsuite name="TestThisDude" tests="6" failures="2" skipped="0" time="0.5279300212860107">
+        <properties>
+          <property name="Configuration" value="Test Scheme Action"/>
+        </properties>
+        <testcase classname="TestTests" name="testExample()" time="0.0005381107330322266">
+        </testcase>
+        <testcase classname="TestTests" name="testFailureJosh1()" time="0.006072044372558594">
+            <failure message="XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestTests/TestTests.swift#CharacterRangeLen=0&amp;EndingLineNumber=36&amp;StartingLineNumber=36)">
+            </failure>
+        </testcase>
+        <testcase classname="TestTests" name="testPerformanceExample()" time="0.2661939859390259">
+        </testcase>
+        <testcase classname="TestThisDude" name="testExample()" time="0.0004099607467651367">
+        </testcase>
+        <testcase classname="TestThisDude" name="testFailureJosh2()" time="0.001544952392578125">
+            <failure message="XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestThisDude/TestThisDude.swift#CharacterRangeLen=0&amp;EndingLineNumber=35&amp;StartingLineNumber=35)">
+            </failure>
+        </testcase>
+        <testcase classname="TestThisDude" name="testPerformanceExample()" time="0.2531709671020508">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/trainer/spec/junit_generator_spec.rb
+++ b/trainer/spec/junit_generator_spec.rb
@@ -24,7 +24,7 @@ describe Trainer do
       expect(tp.to_junit).to eq(junit)
     end
 
-    it "works with an xcresult" do
+    it "works with an xcresult", requires_xcode: true do
       tp = Trainer::TestParser.new("./trainer/spec/fixtures/Test.test_result.xcresult")
       junit = File.read("./trainer/spec/fixtures/XCResult.junit")
       expect(tp.to_junit).to eq(junit)

--- a/trainer/spec/junit_generator_spec.rb
+++ b/trainer/spec/junit_generator_spec.rb
@@ -23,5 +23,11 @@ describe Trainer do
       junit = File.read("./trainer/spec/fixtures/Valid2-x.junit")
       expect(tp.to_junit).to eq(junit)
     end
+
+    it "works with an xcresult" do
+      tp = Trainer::TestParser.new("./trainer/spec/fixtures/Test.test_result.xcresult")
+      junit = File.read("./trainer/spec/fixtures/XCResult.junit")
+      expect(tp.to_junit).to eq(junit)
+    end
   end
 end

--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -96,6 +96,7 @@ describe Trainer do
                                   project_path: "Test.xcodeproj",
                                   target_name: "TestUITests",
                                   test_name: "TestUITests",
+                                  configuration_name: "Test Scheme Action",
                                   duration: 16.05245804786682,
                                   tests: [
                                     {
@@ -118,6 +119,7 @@ describe Trainer do
                                   project_path: "Test.xcodeproj",
                                   target_name: "TestThisDude",
                                   test_name: "TestThisDude",
+                                  configuration_name: "Test Scheme Action",
                                   duration: 0.5279300212860107,
                                   tests: [
                                     {


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

We've started looking at using `Test Plan` configurations so that we can run our whole UI test suite against different dynamic font sizes. However, there is an issue when using `fastlane` + `trainer` to generate `JUnit`: There's no way to determine which Test Plan configuration the failure originated from - you just get duplicated `<testsuite>`s. We'd like to be able to raise the configuration that failed, and the information simply isn't there right now. For reference, this is how it appears within Xcode when you open the xcresult:

<img width="215" alt="Screenshot 2022-02-25 at 16 22 56" src="https://user-images.githubusercontent.com/465802/155750365-c84b0dfc-0116-4f3e-be67-964a8b2103cd.png">

And how it appears in the `JUnit` file after this change:

<img width="603" alt="Screenshot 2022-02-25 at 17 06 37" src="https://user-images.githubusercontent.com/465802/155757068-44dc8caf-17c4-4d73-a9b2-038ead039c64.png">

### Description

The `Test Plan` configuration name is already available to us (via `ActionTestableSummary`), it's just not being used anywhere yet. This PR makes a couple of changes:

- Retrieve the name from the `ActionTestableSummary`, and set it on the returned test results `row` as `configuration_name`.
- Looking at the `JUnit` spec, there's obviously nothing particularly specific to this case, so I settled on using a `property` on the `testsuite`, as defined in the spec called `Configuration`.

### Testing Steps
The new field is now available on the `xcresult` based tests in `test_parser_spec`, so I have updated those, and I've added a new test within `junit_generator_spec` that verifies the output (also some extra coverage as currently there are no tests for `xcresult` -> `junit`).