### PR TITLE
[supply] support :access_token in supply params

### DIFF
--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -81,6 +81,12 @@ module Fastlane
                                            UI.user_error!("Could not parse service account json: JSON::ParseError")
                                          end
                                        end),
+          FastlaneCore::ConfigItem.new(key: :access_token,
+                                       env_name: "SUPPLY_ACCESS_TOKEN",
+                                       conflicting_options: [:issuer, :key, :json_key_data, :json_key],
+                                       optional: true, # alternative for :json_key
+                                       description: "The access token, used to authenticate with Google",
+                                       code_gen_sensitive: true),
           FastlaneCore::ConfigItem.new(key: :developer_account_id,
                                        short_option: "-k",
                                        env_name: "SUPPLY_DEVELOPER_ACCOUNT_ID",

--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -71,6 +71,12 @@ module Fastlane
                                            UI.user_error!("Could not parse service account json: JSON::ParseError")
                                          end
                                        end),
+          FastlaneCore::ConfigItem.new(key: :access_token,
+                                       env_name: "SUPPLY_ACCESS_TOKEN",
+                                       conflicting_options: [:issuer, :key, :json_key_data, :json_key],
+                                       optional: true, # alternative for :json_key
+                                       description: "The access token, used to authenticate with Google",
+                                       code_gen_sensitive: true),
           # stuff
           FastlaneCore::ConfigItem.new(key: :root_url,
                                        env_name: "SUPPLY_ROOT_URL",

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -49,16 +49,16 @@ module Supply
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
       auth_client = nil
-      
+
       if params[:access_token]
-        signet = Signet::OAuth2::Client.new access_token: params[:access_token] # Client#needs_access_token? will return false
-        auth_client = Google::Auth::Credentials.new signet
+        signet = Signet::OAuth2::Client.new(access_token: params[:access_token]) # Client#needs_access_token? will return false
+        auth_client = Google::Auth::Credentials.new(signet)
       else
         auth_client = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
         UI.verbose("Fetching a new access token from Google...")
         auth_client.fetch_access_token!
       end
-        
+
       if FastlaneCore::Env.truthy?("DEBUG")
         Google::Apis.logger.level = Logger::DEBUG
       end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -21,7 +21,7 @@ module Supply
 
     # Supply authentication file
     def self.service_account_authentication(params: nil)
-      unless params[:json_key] || params[:json_key_data]
+      unless params[:json_key] || params[:json_key_data] || params[:access_token]
         if UI.interactive?
           UI.important("To not be asked about this value, you can specify it using 'json_key'")
           json_key_path = UI.input("The service account json file used to authenticate with Google: ")
@@ -38,6 +38,8 @@ module Supply
         service_account_json = File.open(File.expand_path(params[:json_key]))
       elsif params[:json_key_data]
         service_account_json = StringIO.new(params[:json_key_data])
+      elsif params[:access_token]
+        service_account_json = nil
       end
 
       service_account_json
@@ -46,12 +48,17 @@ module Supply
     # Initializes the service and its auth_client using the specified information
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
-      auth_client = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
-
-      UI.verbose("Fetching a new access token from Google...")
-
-      auth_client.fetch_access_token!
-
+      auth_client = nil
+      
+      if params[:access_token]
+        signet = Signet::OAuth2::Client.new access_token: params[:access_token] # Client#needs_access_token? will return false
+        auth_client = Google::Auth::Credentials.new signet
+      else
+        auth_client = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
+        UI.verbose("Fetching a new access token from Google...")
+        auth_client.fetch_access_token!
+      end
+        
       if FastlaneCore::Env.truthy?("DEBUG")
         Google::Apis.logger.level = Logger::DEBUG
       end

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -92,7 +92,7 @@ module Supply
         FastlaneCore::ConfigItem.new(key: :json_key,
                                      env_name: "SUPPLY_JSON_KEY",
                                      short_option: "-j",
-                                     conflicting_options: [:issuer, :key, :json_key_data],
+                                     conflicting_options: [:issuer, :key, :json_key_data, :access_token],
                                      optional: true, # this shouldn't be optional but is until --key and --issuer are completely removed
                                      description: "The path to a file containing service account JSON, used to authenticate with Google",
                                      code_gen_sensitive: true,
@@ -118,6 +118,12 @@ module Supply
                                          UI.user_error!("Could not parse service account json  JSON::ParseError")
                                        end
                                      end),
+        FastlaneCore::ConfigItem.new(key: :access_token,
+                                     env_name: "SUPPLY_ACCESS_TOKEN",
+                                     conflicting_options: [:issuer, :key, :json_key_data, :json_key],
+                                     optional: true, # alternative for :json_key
+                                     description: "The access token, used to authenticate with Google",
+                                     code_gen_sensitive: true),
         FastlaneCore::ConfigItem.new(key: :apk,
                                      env_name: "SUPPLY_APK",
                                      description: "Path to the APK file to upload",


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Resolves https://github.com/fastlane/fastlane/discussions/20022 hopefully (~still testing~ help needed!)

### Description
https://docs.fastlane.tools/getting-started/android/setup/ mentions only Service Account JSON Key authentication.

There are better (!) ways of authenticating to Google nowadays than using a JSON Key. See [Workload Identity Federation docs](https://cloud.google.com/iam/docs/workload-identity-federation). Unfortunately, `googleauth` library in Ruby [is not yet updated](https://github.com/googleapis/google-auth-library-ruby/issues/354#issuecomment-1059140943) (even though Python, NodeJS, Golang all are since February 2021).

This new way prevents the need to encode ANY long-lived credentials. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
This can easily be setup using GitHub Actions using:
```yaml
jobs:
  build:
    permissions:
      id-token: write
      actions: write
      contents: read
    steps:
      - id: 'auth'
        name: 'Authenticate to Google Cloud'
        uses: 'google-github-actions/auth@v0'
        with:
          workload_identity_provider: 'projects/yourproject-numeric-id/locations/global/workloadIdentityPools/default/providers/github'
          service_account: 'github-deploy@yourproject.iam.gserviceaccount.com'
          access_token_scopes: https://www.googleapis.com/auth/androidpublisher
          token_format: access_token # output: steps.auth.outputs.access_token

      - name: Deploy to beta
        run: fastlane android beta
        env:
          SUPPLY_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }} # from Google Auth

```