### PR TITLE
[trainer] Fix reports failure with skipped tests

### DIFF
--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -136,7 +136,7 @@ module Trainer
 
     # @return [Bool] were all tests successful? Is false if at least one test failed
     def tests_successful?
-      self.data.collect { |a| a[:number_of_failures] }.all?(&:zero?)
+      self.data.collect { |a| a[:number_of_failures_excluding_retries] }.all?(&:zero?)
     end
 
     private


### PR DESCRIPTION
Trainer would fail if there are any skipped tests in case of retries.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Noticed that when using `trainer` with retried tests, it would fail the action even when the end result with retries is success. Using `number_of_failures_excluding_retries` to fix the issue.

I think the issue is the same as this. Resolves #19687

### Description
Changed the check for `tests_successful` for `trainer` test_parser` to use number of failures excluding retries

### Testing Steps
Use trainer on an xcresult file that includes retries but with an overall successful result with `fail_build` set to `tree` and expect trainer to succeed.
