### PR TITLE
Added case-sensitive .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage/
 rspec_logs.json
 test_output/
 .DS_STORE
+.DS_Store
 .keys
 *.swp
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I am using a case-sensitive file-system for development and therefore macOS is creating `.DS_Store` files, which should not be included in git.

### Description

Created an APFS container with case-sensitive file system. Ran `git status` to see many `.DS_Store` files. Changed `.gitignore` to include the right casing, ran `git status` again and the changes are ignored.

Currently only `.DS_STORE` files are ignored, which are not sufficient on a case-sensitive system.

### Testing Steps

See the description above.