### PR TITLE
[trainer] Fix missing test failures and improve junit format

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ PATH
       multipart-post (~> 2.0.0)
       naturally (~> 2.2)
       optparse (~> 0.1.1)
+      parallel (>= 1.17.0)
       plist (>= 3.1.0, < 4.0.0)
       rubyzip (>= 2.0.0, < 3.0.0)
       security (= 0.1.3)
@@ -391,4 +392,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   2.2.27
+   2.3.8

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -113,6 +113,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('google-cloud-storage', '~> 1.31') # Access Google Cloud Storage for match
   spec.add_dependency('emoji_regex', '>= 0.1', '< 4.0') # Used to scan for Emoji in the changelog
   spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used for S3 storage in fastlane match
+  spec.add_dependency('parallel', '>= 1.17.0') # Used for trainer
 
   # Development only
   spec.add_development_dependency('rake')

--- a/trainer/lib/assets/junit.xml.erb
+++ b/trainer/lib/assets/junit.xml.erb
@@ -15,7 +15,7 @@
       <% testsuite[:tests].each do |test| %>
         <testcase classname=<%= test[:test_group].encode(:xml => :attr) %> name=<%= test[:name].encode(:xml => :attr) %> time="<%= test[:duration] %>">
           <% (test[:failures] || []).each do |failure| %>
-            <failure message=<%= failure[:failure_message].encode(:xml => :attr) %>>
+            <failure message=<%= failure[:message].encode(:xml => :attr) %>><%= failure[:file_name] %>:<%= failure[:line_number] %>
             </failure>
           <% end %>
           <% if test[:skipped] %>

--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -209,7 +209,7 @@ module Trainer
         testable_summary.all_tests.find_all { |a| a.test_status == 'Failure' }
       end.flatten
 
-       # Find a list of all ids for ActionTestSummary
+      # Find a list of all ids for ActionTestSummary
       summary_ids = failed_tests.map do |test|
         test.summary_ref.id
       end
@@ -226,7 +226,6 @@ module Trainer
     end
 
     def summaries_to_data(testable_summaries, summaries_to_names, failures, output_remove_retry_attempts: false, xcpretty_naming:)
-
       # Maps ActionTestableSummary to rows for junit generator
       rows = testable_summaries.map do |testable_summary|
         all_tests = testable_summary.all_tests.flatten
@@ -351,13 +350,13 @@ module Trainer
       testable_summaries = self.raw_json['TestableSummaries'].collect do |summary_data|
         Trainer::TestResult::ActionTestableSummary.new(summary_data)
       end
-      
+
       self.data = testable_summaries.map do |testable_summary|
         summary_row = {
           project_path: testable_summary.project_path,
           target_name: testable_summary.target_name,
           test_name: testable_summary.test_name,
-          duration: testable_summary.tests.map { |current_test| current_test.duration }.inject(:+),
+          duration: testable_summary.tests.map(&:duration).inject(:+),
           tests: testable_summary.all_tests.map do |current_test|
             test_group, test_name = test_group_and_name(testable_summary, current_test, xcpretty_naming)
             current_row = {

--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -1,10 +1,11 @@
 require 'plist'
-
+require 'parallel'
 require 'fastlane_core/print_table'
 
 require_relative 'junit_generator'
 require_relative 'xcresult'
 require_relative 'module'
+require_relative 'test_result'
 
 module Trainer
   class TestParser
@@ -102,15 +103,9 @@ module Trainer
       UI.user_error!("File not found at path '#{path}'") unless File.exist?(path)
 
       if File.directory?(path) && path.end_with?(".xcresult")
-        parse_xcresult(path, output_remove_retry_attempts: config[:output_remove_retry_attempts])
+        parse_xcresult(path, output_remove_retry_attempts: config[:output_remove_retry_attempts], xcpretty_naming: config[:xcpretty_naming])
       else
-        self.file_content = File.read(path)
-        self.raw_json = Plist.parse_xml(self.file_content)
-
-        return if self.raw_json["FormatVersion"].to_s.length.zero? # maybe that's a useless plist file
-
-        ensure_file_valid!
-        parse_content(config[:xcpretty_naming])
+        parse_test_result(path, config[:xcpretty_naming])
       end
 
       self.number_of_tests = 0
@@ -147,46 +142,15 @@ module Trainer
       UI.user_error!("Format version '#{format_version}' is not supported, must be #{supported_versions.join(', ')}") unless supported_versions.include?(format_version)
     end
 
-    # Converts the raw plist test structure into something that's easier to enumerate
-    def unfold_tests(data)
-      # `data` looks like this
-      # => [{"Subtests"=>
-      #  [{"Subtests"=>
-      #     [{"Subtests"=>
-      #        [{"Duration"=>0.4,
-      #          "TestIdentifier"=>"Unit/testExample()",
-      #          "TestName"=>"testExample()",
-      #          "TestObjectClass"=>"IDESchemeActionTestSummary",
-      #          "TestStatus"=>"Success",
-      #          "TestSummaryGUID"=>"4A24BFED-03E6-4FBE-BC5E-2D80023C06B4"},
-      #         {"FailureSummaries"=>
-      #           [{"FileName"=>"/Users/krausefx/Developer/themoji/Unit/Unit.swift",
-      #             "LineNumber"=>34,
-      #             "Message"=>"XCTAssertTrue failed - ",
-      #             "PerformanceFailure"=>false}],
-      #          "TestIdentifier"=>"Unit/testExample2()",
-
-      tests = []
-      data.each do |current_hash|
-        if current_hash["Subtests"]
-          tests += unfold_tests(current_hash["Subtests"])
-        end
-        if current_hash["TestStatus"]
-          tests << current_hash
-        end
-      end
-      return tests
-    end
-
     # Returns the test group and test name from the passed summary and test
     # Pass xcpretty_naming = true to get the test naming aligned with xcpretty
     def test_group_and_name(testable_summary, test, xcpretty_naming)
       if xcpretty_naming
-        group = testable_summary["TargetName"] + "." + test["TestIdentifier"].split("/")[0..-2].join(".")
-        name = test["TestName"][0..-3]
+        group = testable_summary.target_name + "." + test.identifier.split("/")[0..-2].join(".")
+        name = test.name[0..-3]
       else
-        group = test["TestIdentifier"].split("/")[0..-2].join(".")
-        name = test["TestName"]
+        group = test.identifier.split("/")[0..-2].join(".")
+        name = test.name
       end
       return group, name
     end
@@ -197,40 +161,71 @@ module Trainer
       return output
     end
 
-    def parse_xcresult(path, output_remove_retry_attempts: false)
+    def parse_test_result(path, xcpretty_naming)
+      self.file_content = File.read(path)
+      self.raw_json = Plist.parse_xml(self.file_content)
+
+      return if self.raw_json["FormatVersion"].to_s.length.zero? # maybe that's a useless plist file
+
+      ensure_file_valid!
+      parse_content(xcpretty_naming)
+    end
+
+    def xcresulttool_get_json(path, id = nil)
+      cmd = "xcrun xcresulttool get --format json --path #{path}"
+      cmd << " --id #{id}" unless id.nil?
+      raw = execute_cmd(cmd)
+      JSON.parse(raw)
+    end
+
+    def parse_xcresult(path, output_remove_retry_attempts: false, xcpretty_naming:)
       require 'shellwords'
       path = Shellwords.escape(path)
 
       # Executes xcresulttool to get JSON format of the result bundle object
-      result_bundle_object_raw = execute_cmd("xcrun xcresulttool get --format json --path #{path}")
-      result_bundle_object = JSON.parse(result_bundle_object_raw)
+      result_bundle_object = xcresulttool_get_json(path)
 
       # Parses JSON into ActionsInvocationRecord to find a list of all ids for ActionTestPlanRunSummaries
       actions_invocation_record = Trainer::XCResult::ActionsInvocationRecord.new(result_bundle_object)
       test_refs = actions_invocation_record.actions.map do |action|
         action.action_result.tests_ref
       end.compact
-      ids = test_refs.map(&:id)
+      test_ids = test_refs.map(&:id)
 
       # Maps ids into ActionTestPlanRunSummaries by executing xcresulttool to get JSON
       # containing specific information for each test summary,
-      summaries = ids.map do |id|
-        raw = execute_cmd("xcrun xcresulttool get --format json --path #{path} --id #{id}")
-        json = JSON.parse(raw)
+      summaries = Parallel.map(test_ids) do |id|
+        json = xcresulttool_get_json(path, id)
         Trainer::XCResult::ActionTestPlanRunSummaries.new(json)
       end
 
-      # Converts the ActionTestPlanRunSummaries to data for junit generator
-      failures = actions_invocation_record.issues.test_failure_summaries || []
-      summaries_to_data(summaries, failures, output_remove_retry_attempts: output_remove_retry_attempts)
-    end
-
-    def summaries_to_data(summaries, failures, output_remove_retry_attempts: false)
       # Gets flat list of all ActionTestableSummary
       all_summaries = summaries.map(&:summaries).flatten
       testable_summaries = all_summaries.map(&:testable_summaries).flatten
-
       summaries_to_names = test_summaries_to_configuration_names(all_summaries)
+
+      # Gets flat list of all ActionTestMetadata that failed
+      failed_tests = testable_summaries.map do |testable_summary|
+        testable_summary.all_tests.find_all { |a| a.test_status == 'Failure' }
+      end.flatten
+
+       # Find a list of all ids for ActionTestSummary
+      summary_ids = failed_tests.map do |test|
+        test.summary_ref.id
+      end
+
+      # Maps summary references into array of ActionTestSummary by executing xcresulttool to get JSON
+      # containing more information for each test failure,
+      failures = Parallel.map(summary_ids) do |id|
+        json = xcresulttool_get_json(path, id)
+        Trainer::XCResult::ActionTestSummary.new(json)
+      end
+
+      # Converts the ActionTestPlanRunSummaries to data for junit generator
+      summaries_to_data(testable_summaries, summaries_to_names, failures, output_remove_retry_attempts: output_remove_retry_attempts, xcpretty_naming: xcpretty_naming)
+    end
+
+    def summaries_to_data(testable_summaries, summaries_to_names, failures, output_remove_retry_attempts: false, xcpretty_naming:)
 
       # Maps ActionTestableSummary to rows for junit generator
       rows = testable_summaries.map do |testable_summary|
@@ -243,12 +238,13 @@ module Trainer
 
         test_rows = all_tests.map do |test|
           identifier = "#{test.parent.name}.#{test.name}"
+          test_group, test_name = test_group_and_name(testable_summary, test, xcpretty_naming)
           test_row = {
             identifier: identifier,
-            name: test.name,
+            name: test_name,
             duration: test.duration,
             status: test.test_status,
-            test_group: test.parent.name,
+            test_group: test_group,
 
             # These don't map to anything but keeping empty strings
             guid: ""
@@ -271,10 +267,10 @@ module Trainer
           failure = test.find_failure(failures)
           if failure
             test_row[:failures] = [{
-              file_name: "",
-              line_number: 0,
-              message: "",
-              performance_failure: {},
+              file_name: failure.file_name,
+              line_number: failure.line_number,
+              message: failure.message,
+              performance_failure: failure.performance_failure,
               failure_message: failure.failure_message
             }]
 
@@ -352,33 +348,35 @@ module Trainer
 
     # Convert the Hashes and Arrays in something more useful
     def parse_content(xcpretty_naming)
-      self.data = self.raw_json["TestableSummaries"].collect do |testable_summary|
+      testable_summaries = self.raw_json['TestableSummaries'].collect do |summary_data|
+        Trainer::TestResult::ActionTestableSummary.new(summary_data)
+      end
+      
+      self.data = testable_summaries.map do |testable_summary|
         summary_row = {
-          project_path: testable_summary["ProjectPath"],
-          target_name: testable_summary["TargetName"],
-          test_name: testable_summary["TestName"],
-          duration: testable_summary["Tests"].map { |current_test| current_test["Duration"] }.inject(:+),
-          tests: unfold_tests(testable_summary["Tests"]).collect do |current_test|
+          project_path: testable_summary.project_path,
+          target_name: testable_summary.target_name,
+          test_name: testable_summary.test_name,
+          duration: testable_summary.tests.map { |current_test| current_test.duration }.inject(:+),
+          tests: testable_summary.all_tests.map do |current_test|
             test_group, test_name = test_group_and_name(testable_summary, current_test, xcpretty_naming)
             current_row = {
-              identifier: current_test["TestIdentifier"],
+              identifier: current_test.identifier,
                  test_group: test_group,
                  name: test_name,
-              object_class: current_test["TestObjectClass"],
-              status: current_test["TestStatus"],
-              guid: current_test["TestSummaryGUID"],
-              duration: current_test["Duration"]
+              object_class: current_test.object_class,
+              status: current_test.status,
+              guid: current_test.summary_guid,
+              duration: current_test.duration
             }
-            if current_test["FailureSummaries"]
-              current_row[:failures] = current_test["FailureSummaries"].collect do |current_failure|
-                {
-                  file_name: current_failure['FileName'],
-                  line_number: current_failure['LineNumber'],
-                  message: current_failure['Message'],
-                  performance_failure: current_failure['PerformanceFailure'],
-                  failure_message: "#{current_failure['Message']} (#{current_failure['FileName']}:#{current_failure['LineNumber']})"
-                }
-              end
+            current_row[:failures] = current_test.failure_summaries.map do |current_failure|
+              {
+                file_name: current_failure.file_name,
+                line_number: current_failure.line_number,
+                message: current_failure.message,
+                performance_failure: current_failure.performance_failure,
+                failure_message: current_failure.failure_message
+              }
             end
             current_row
           end

--- a/trainer/lib/trainer/test_result.rb
+++ b/trainer/lib/trainer/test_result.rb
@@ -1,0 +1,139 @@
+module Trainer
+    module TestResult
+ 
+      class AbstractObject
+        attr_accessor :object_class
+        def initialize(data)
+          self.object_class = data['TestObjectClass']
+        end
+      end
+ 
+      # - ActionTestableSummary
+      #   * Kind: object
+      #   * Properties:
+      #     + project_path: String
+      #     + target_name: String
+      #     + test_name: String
+      #     + tests: [Test]
+      class ActionTestableSummary < AbstractObject
+        attr_accessor :project_path
+        attr_accessor :target_name
+        attr_accessor :test_name
+        attr_accessor :tests
+        def initialize(data)
+          self.project_path = data['ProjectPath']
+          self.target_name = data['TargetName']
+          self.test_name = data['TestName']
+          self.tests = data['Tests'].collect do |test_data|
+            ActionTestSummaryIdentifiableObject.create(test_data)
+          end
+          super
+        end
+ 
+        def all_tests
+          tests.map(&:all_subtests).flatten
+        end
+      end
+ 
+      # - ActionTestSummaryIdentifiableObject
+      #   * Kind: object
+      #   * Properties:
+      #     + identifier: String
+      #     + name: String
+      #     + duration: Double
+      class ActionTestSummaryIdentifiableObject < AbstractObject
+        attr_accessor :identifier
+        attr_accessor :name
+        attr_accessor :duration
+        def initialize(data)
+          self.identifier = data['TestIdentifier']
+          self.name = data['TestName']
+          self.duration = data['Duration']
+          super
+        end
+ 
+        def all_subtests
+          raise 'Not overridden'
+        end
+ 
+        def self.create(data)
+          type = data['TestObjectClass']
+          if type == 'IDESchemeActionTestSummaryGroup'
+            ActionTestSummaryGroup.new(data)
+          elsif type == 'IDESchemeActionTestSummary'
+            ActionTestSummary.new(data)
+          else
+            raise "Unsupported type: #{type}"
+          end
+        end
+      end
+ 
+      # - ActionTestSummaryGroup
+      #   * Kind: object
+      #   * Properties:
+      #     + subtests: [Test]
+      class ActionTestSummaryGroup < ActionTestSummaryIdentifiableObject
+        attr_accessor :subtests
+        def initialize(data)
+          self.subtests = (data['Subtests'] || []).collect do |subtests_data|
+            ActionTestSummaryIdentifiableObject.create(subtests_data)
+          end
+          super
+        end
+ 
+        def all_subtests
+          subtests.map(&:all_subtests).flatten
+        end
+      end
+ 
+      # - ActionTestSummary
+      #   * Kind: object
+      #   * Properties:
+      #     + status: String
+      #     + summary_guid: String
+      #     + activity_summaries: [ActivitySummaries]?
+      #     + failure_summaries: [FailureSummary]?
+      class ActionTestSummary < ActionTestSummaryIdentifiableObject
+        attr_accessor :status
+        attr_accessor :summary_guid
+        attr_accessor :failure_summaries
+        def initialize(data)
+          self.status = data['TestStatus']
+          self.summary_guid = data['TestSummaryGUID']
+          self.failure_summaries = (data['FailureSummaries'] || []).collect do |summary_data|
+            ActionTestFailureSummary.new(summary_data)
+          end
+          super
+        end
+ 
+        def all_subtests
+          [self]
+        end
+      end
+ 
+      # - ActionTestFailureSummary
+      #   * Kind: object
+      #   * Properties:
+      #     + file_name: String
+      #     + line_number: Int
+      #     + message: String
+      #     + performance_failure: Bool
+      class ActionTestFailureSummary < AbstractObject
+        attr_accessor :file_name
+        attr_accessor :line_number
+        attr_accessor :message
+        attr_accessor :performance_failure
+        def initialize(data)
+          self.file_name = data['FileName']
+          self.line_number = data['LineNumber']
+          self.message = data['Message']
+          self.performance_failure = data['PerformanceFailure']
+          super
+        end
+ 
+        def failure_message
+          "#{message} (#{file_name}:#{line_number})"
+        end
+      end
+    end
+  end

--- a/trainer/lib/trainer/test_result.rb
+++ b/trainer/lib/trainer/test_result.rb
@@ -1,139 +1,138 @@
 module Trainer
-    module TestResult
- 
-      class AbstractObject
-        attr_accessor :object_class
-        def initialize(data)
-          self.object_class = data['TestObjectClass']
-        end
+  module TestResult
+    class AbstractObject
+      attr_accessor :object_class
+      def initialize(data)
+        self.object_class = data['TestObjectClass']
       end
- 
-      # - ActionTestableSummary
-      #   * Kind: object
-      #   * Properties:
-      #     + project_path: String
-      #     + target_name: String
-      #     + test_name: String
-      #     + tests: [Test]
-      class ActionTestableSummary < AbstractObject
-        attr_accessor :project_path
-        attr_accessor :target_name
-        attr_accessor :test_name
-        attr_accessor :tests
-        def initialize(data)
-          self.project_path = data['ProjectPath']
-          self.target_name = data['TargetName']
-          self.test_name = data['TestName']
-          self.tests = data['Tests'].collect do |test_data|
-            ActionTestSummaryIdentifiableObject.create(test_data)
-          end
-          super
+    end
+
+    # - ActionTestableSummary
+    #   * Kind: object
+    #   * Properties:
+    #     + project_path: String
+    #     + target_name: String
+    #     + test_name: String
+    #     + tests: [Test]
+    class ActionTestableSummary < AbstractObject
+      attr_accessor :project_path
+      attr_accessor :target_name
+      attr_accessor :test_name
+      attr_accessor :tests
+      def initialize(data)
+        self.project_path = data['ProjectPath']
+        self.target_name = data['TargetName']
+        self.test_name = data['TestName']
+        self.tests = data['Tests'].collect do |test_data|
+          ActionTestSummaryIdentifiableObject.create(test_data)
         end
- 
-        def all_tests
-          tests.map(&:all_subtests).flatten
-        end
+        super
       end
- 
-      # - ActionTestSummaryIdentifiableObject
-      #   * Kind: object
-      #   * Properties:
-      #     + identifier: String
-      #     + name: String
-      #     + duration: Double
-      class ActionTestSummaryIdentifiableObject < AbstractObject
-        attr_accessor :identifier
-        attr_accessor :name
-        attr_accessor :duration
-        def initialize(data)
-          self.identifier = data['TestIdentifier']
-          self.name = data['TestName']
-          self.duration = data['Duration']
-          super
-        end
- 
-        def all_subtests
-          raise 'Not overridden'
-        end
- 
-        def self.create(data)
-          type = data['TestObjectClass']
-          if type == 'IDESchemeActionTestSummaryGroup'
-            ActionTestSummaryGroup.new(data)
-          elsif type == 'IDESchemeActionTestSummary'
-            ActionTestSummary.new(data)
-          else
-            raise "Unsupported type: #{type}"
-          end
-        end
+
+      def all_tests
+        tests.map(&:all_subtests).flatten
       end
- 
-      # - ActionTestSummaryGroup
-      #   * Kind: object
-      #   * Properties:
-      #     + subtests: [Test]
-      class ActionTestSummaryGroup < ActionTestSummaryIdentifiableObject
-        attr_accessor :subtests
-        def initialize(data)
-          self.subtests = (data['Subtests'] || []).collect do |subtests_data|
-            ActionTestSummaryIdentifiableObject.create(subtests_data)
-          end
-          super
-        end
- 
-        def all_subtests
-          subtests.map(&:all_subtests).flatten
-        end
+    end
+
+    # - ActionTestSummaryIdentifiableObject
+    #   * Kind: object
+    #   * Properties:
+    #     + identifier: String
+    #     + name: String
+    #     + duration: Double
+    class ActionTestSummaryIdentifiableObject < AbstractObject
+      attr_accessor :identifier
+      attr_accessor :name
+      attr_accessor :duration
+      def initialize(data)
+        self.identifier = data['TestIdentifier']
+        self.name = data['TestName']
+        self.duration = data['Duration']
+        super
       end
- 
-      # - ActionTestSummary
-      #   * Kind: object
-      #   * Properties:
-      #     + status: String
-      #     + summary_guid: String
-      #     + activity_summaries: [ActivitySummaries]?
-      #     + failure_summaries: [FailureSummary]?
-      class ActionTestSummary < ActionTestSummaryIdentifiableObject
-        attr_accessor :status
-        attr_accessor :summary_guid
-        attr_accessor :failure_summaries
-        def initialize(data)
-          self.status = data['TestStatus']
-          self.summary_guid = data['TestSummaryGUID']
-          self.failure_summaries = (data['FailureSummaries'] || []).collect do |summary_data|
-            ActionTestFailureSummary.new(summary_data)
-          end
-          super
-        end
- 
-        def all_subtests
-          [self]
-        end
+
+      def all_subtests
+        raise 'Not overridden'
       end
- 
-      # - ActionTestFailureSummary
-      #   * Kind: object
-      #   * Properties:
-      #     + file_name: String
-      #     + line_number: Int
-      #     + message: String
-      #     + performance_failure: Bool
-      class ActionTestFailureSummary < AbstractObject
-        attr_accessor :file_name
-        attr_accessor :line_number
-        attr_accessor :message
-        attr_accessor :performance_failure
-        def initialize(data)
-          self.file_name = data['FileName']
-          self.line_number = data['LineNumber']
-          self.message = data['Message']
-          self.performance_failure = data['PerformanceFailure']
-          super
-        end
- 
-        def failure_message
-          "#{message} (#{file_name}:#{line_number})"
+
+      def self.create(data)
+        type = data['TestObjectClass']
+        if type == 'IDESchemeActionTestSummaryGroup'
+          ActionTestSummaryGroup.new(data)
+        elsif type == 'IDESchemeActionTestSummary'
+          ActionTestSummary.new(data)
+        else
+          raise "Unsupported type: #{type}"
         end
       end
     end
+
+    # - ActionTestSummaryGroup
+    #   * Kind: object
+    #   * Properties:
+    #     + subtests: [Test]
+    class ActionTestSummaryGroup < ActionTestSummaryIdentifiableObject
+      attr_accessor :subtests
+      def initialize(data)
+        self.subtests = (data['Subtests'] || []).collect do |subtests_data|
+          ActionTestSummaryIdentifiableObject.create(subtests_data)
+        end
+        super
+      end
+
+      def all_subtests
+        subtests.map(&:all_subtests).flatten
+      end
+    end
+
+    # - ActionTestSummary
+    #   * Kind: object
+    #   * Properties:
+    #     + status: String
+    #     + summary_guid: String
+    #     + activity_summaries: [ActivitySummaries]?
+    #     + failure_summaries: [FailureSummary]?
+    class ActionTestSummary < ActionTestSummaryIdentifiableObject
+      attr_accessor :status
+      attr_accessor :summary_guid
+      attr_accessor :failure_summaries
+      def initialize(data)
+        self.status = data['TestStatus']
+        self.summary_guid = data['TestSummaryGUID']
+        self.failure_summaries = (data['FailureSummaries'] || []).collect do |summary_data|
+          ActionTestFailureSummary.new(summary_data)
+        end
+        super
+      end
+
+      def all_subtests
+        [self]
+      end
+    end
+
+    # - ActionTestFailureSummary
+    #   * Kind: object
+    #   * Properties:
+    #     + file_name: String
+    #     + line_number: Int
+    #     + message: String
+    #     + performance_failure: Bool
+    class ActionTestFailureSummary < AbstractObject
+      attr_accessor :file_name
+      attr_accessor :line_number
+      attr_accessor :message
+      attr_accessor :performance_failure
+      def initialize(data)
+        self.file_name = data['FileName']
+        self.line_number = data['LineNumber']
+        self.message = data['Message']
+        self.performance_failure = data['PerformanceFailure']
+        super
+      end
+
+      def failure_message
+        "#{message} (#{file_name}:#{line_number})"
+      end
+    end
   end
+end

--- a/trainer/spec/fixtures/Valid1-x.junit
+++ b/trainer/spec/fixtures/Valid1-x.junit
@@ -4,7 +4,7 @@
         <testcase classname="Unit.Unit" name="testExample" time="0.1">
         </testcase>
         <testcase classname="Unit.Unit" name="testExample2" time="0.1">
-            <failure message="XCTAssertTrue failed -  (/Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift:19)">
+            <failure message="XCTAssertTrue failed - ">/Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift:19
             </failure>
         </testcase>
         <testcase classname="Unit.Unit" name="testPerformanceExample" time="0.2">

--- a/trainer/spec/fixtures/Valid1.junit
+++ b/trainer/spec/fixtures/Valid1.junit
@@ -4,7 +4,7 @@
         <testcase classname="Unit" name="testExample()" time="0.1">
         </testcase>
         <testcase classname="Unit" name="testExample2()" time="0.1">
-            <failure message="XCTAssertTrue failed -  (/Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift:19)">
+            <failure message="XCTAssertTrue failed - ">/Users/liamnichols/Code/Local/Trainer/Unit/Unit.swift:19
             </failure>
         </testcase>
         <testcase classname="Unit" name="testPerformanceExample()" time="0.2">

--- a/trainer/spec/fixtures/XCResult.junit
+++ b/trainer/spec/fixtures/XCResult.junit
@@ -14,7 +14,7 @@
         <testcase classname="TestTests" name="testExample()" time="0.0005381107330322266">
         </testcase>
         <testcase classname="TestTests" name="testFailureJosh1()" time="0.006072044372558594">
-            <failure message="XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestTests/TestTests.swift#CharacterRangeLen=0&amp;EndingLineNumber=36&amp;StartingLineNumber=36)">
+            <failure message="XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestTests/TestTests.swift:37)">
             </failure>
         </testcase>
         <testcase classname="TestTests" name="testPerformanceExample()" time="0.2661939859390259">
@@ -22,7 +22,7 @@
         <testcase classname="TestThisDude" name="testExample()" time="0.0004099607467651367">
         </testcase>
         <testcase classname="TestThisDude" name="testFailureJosh2()" time="0.001544952392578125">
-            <failure message="XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestThisDude/TestThisDude.swift#CharacterRangeLen=0&amp;EndingLineNumber=35&amp;StartingLineNumber=35)">
+            <failure message="XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestThisDude/TestThisDude.swift:36)">
             </failure>
         </testcase>
         <testcase classname="TestThisDude" name="testPerformanceExample()" time="0.2531709671020508">

--- a/trainer/spec/fixtures/XCResult.junit
+++ b/trainer/spec/fixtures/XCResult.junit
@@ -14,7 +14,7 @@
         <testcase classname="TestTests" name="testExample()" time="0.0005381107330322266">
         </testcase>
         <testcase classname="TestTests" name="testFailureJosh1()" time="0.006072044372558594">
-            <failure message="XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestTests/TestTests.swift:37)">
+            <failure message="XCTAssertTrue failed">/Users/josh/Projects/fastlane/test-ios/TestTests/TestTests.swift:37
             </failure>
         </testcase>
         <testcase classname="TestTests" name="testPerformanceExample()" time="0.2661939859390259">
@@ -22,7 +22,7 @@
         <testcase classname="TestThisDude" name="testExample()" time="0.0004099607467651367">
         </testcase>
         <testcase classname="TestThisDude" name="testFailureJosh2()" time="0.001544952392578125">
-            <failure message="XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestThisDude/TestThisDude.swift:36)">
+            <failure message="XCTAssertTrue failed">/Users/josh/Projects/fastlane/test-ios/TestThisDude/TestThisDude.swift:36
             </failure>
         </testcase>
         <testcase classname="TestThisDude" name="testPerformanceExample()" time="0.2531709671020508">

--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -50,7 +50,8 @@ describe Trainer do
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Success",
                                       guid: "6840EEB8-3D7A-4B2D-9A45-6955DC11D32B",
-                                      duration: 0.1
+                                      duration: 0.1,
+                                      failures: []
                                     },
                                     {
                                       identifier: "Unit/testExample2()",
@@ -77,7 +78,8 @@ describe Trainer do
                                       object_class: "IDESchemeActionTestSummary",
                                       status: "Success",
                                       guid: "72D0B210-939D-4751-966F-986B6CB2660C",
-                                      duration: 0.2
+                                      duration: 0.2,
+                                      failures: []
                                     }
                                   ],
                                   number_of_tests: 3,
@@ -139,11 +141,11 @@ describe Trainer do
                                       guid: "",
                                       failures: [
                                         {
-                                          file_name: "",
-                                          line_number: 0,
-                                          message: "",
-                                          performance_failure: {},
-                                          failure_message: "XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestTests/TestTests.swift#CharacterRangeLen=0&EndingLineNumber=36&StartingLineNumber=36)"
+                                          file_name: "/Users/josh/Projects/fastlane/test-ios/TestTests/TestTests.swift",
+                                          line_number: 37,
+                                          message: "XCTAssertTrue failed",
+                                          performance_failure: nil,
+                                          failure_message: "XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestTests/TestTests.swift:37)"
                                           }
                                       ]
                                     },
@@ -172,11 +174,11 @@ describe Trainer do
                                       guid: "",
                                       failures: [
                                         {
-                                          file_name: "",
-                                          line_number: 0,
-                                          message: "",
-                                          performance_failure: {},
-                                          failure_message: "XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestThisDude/TestThisDude.swift#CharacterRangeLen=0&EndingLineNumber=35&StartingLineNumber=35)"
+                                          file_name: "/Users/josh/Projects/fastlane/test-ios/TestThisDude/TestThisDude.swift",
+                                          line_number: 36,
+                                          message: "XCTAssertTrue failed",
+                                          performance_failure: nil,
+                                          failure_message: "XCTAssertTrue failed (/Users/josh/Projects/fastlane/test-ios/TestThisDude/TestThisDude.swift:36)"
                                         }
                                       ]
                                     },


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Bringing changes from https://github.com/fastlane-community/trainer/pull/40 by @robnadin and improving the `junit` format.

This is from the original PR:

------------
* Fix xcpretty_naming for xcresult
* Add test result object hierarchy
* Refactored group and name parsing function

These fixes came about due to the way the test result format has changed between Xcode 10 and 11, and how the logic to parse xcresult bundles in Trainer was not finding any of our failing tests.

In our use case, we were finding that test failures were not being parsed correctly because we were grouping our tests from a collection of other test suites like so:

```
class AllTests: XCTestCase {
    
    override class var testCaseClasses: [XCTestCase.Type] {
        return [
            TestsA.self,
            TestsB.self,
            TestsC.self,
        ]
    }
    
    override class var defaultTestSuite: XCTestSuite {
        let testSuite = XCTestSuite(forTestCaseClass: self)
        let testCases = testCaseClasses.flatMap { testCaseClass in
            testCaseClass.testInvocations.map { testCaseClass.init(invocation: $0) }
        }
        testCases.forEach(testSuite.addTest)
        return testSuite
    }
}

...

class TestsA: XCTestCase {
    
    func testFoo() {
        XCTAssertTrue(false)
    }
}

```
This results in find_failure incorrectly comparing AllTests/testFoo to TestsA/testFoo and returning false due to the identifier and sanitized_test_case_name values not matching in the test metadata.

Instead we should call xcresulttool get --format json and pass it the id we get from the summary reference in the metadata to get an accurate representation of the test failure summary. The benefit of this approach is that we also get explicit file name and line number information that we are able to format in exactly the same way as Trainer has been doing with the older test_result bundles in Xcode 10 and earlier.

----------
### Description

In addition to the changes from the PR described above, I updated the junit template because the current template produces a file name within the failure message which, isn't using the correct convention of how a file path and line number should be defined in junit format and therefore breaks our reporting on GitHub CI to report on the correct line number. 

### Testing Steps
Run trainer against an `xcresult` file with failures and expect the correct file and line numbers reported. These numbers should match what is seen in Xcode if you open the `xcresult` in Xcode directly as shown below for the test file.

<img width="515" alt="Screen Shot 2022-03-23 at 12 42 47 AM" src="https://user-images.githubusercontent.com/12048108/159625546-be5c780d-f825-4b1e-909f-2a88812ff08f.png">

