### PR TITLE
[spaceship] add ability to invite a single TestFlight user

### DIFF
--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -290,6 +290,28 @@ module Spaceship
           test_flight_request_client.post("bulkBetaTesterAssignments", body)
         end
 
+        # attributes - {email: "", firstName: "", lastName: ""}
+        def post_beta_tester_assignment(beta_group_ids: [], attributes: {})
+          body = {
+            data: {
+              attributes: attributes,
+              relationships: {
+                betaGroups: {
+                  data: beta_group_ids.map do |id|
+                    {
+                      type: "betaGroups",
+                      id: id
+                    }
+                  end
+                }
+              },
+              type: "betaTesters"
+            }
+          }
+
+          test_flight_request_client.post("betaTesters", body)
+        end
+
         def add_beta_tester_to_group(beta_group_id: nil, beta_tester_ids: nil)
           beta_tester_ids || []
           body = {

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -502,6 +502,38 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
         end
       end
 
+      context 'post_beta_tester_assignment' do
+        let(:path) { "betaTesters" }
+        let(:beta_group_ids) { ["123", "456"] }
+        let(:attributes) { { email: "email1", firstName: "first1", lastName: "last1" } }
+        let(:body) do
+          {
+            data: {
+              attributes: attributes,
+              relationships: {
+                betaGroups: {
+                  data: beta_group_ids.map do |id|
+                    {
+                      type: "betaGroups",
+                      id: id
+                    }
+                  end
+                }
+              },
+              type: "betaTesters"
+            }
+          }
+        end
+
+        it 'succeeds' do
+          url = path
+          req_mock = test_request_body(url, body)
+
+          expect(client).to receive(:request).with(:post).and_yield(req_mock).and_return(req_mock)
+          client.post_beta_tester_assignment(beta_group_ids: beta_group_ids, attributes: attributes)
+        end
+      end
+
       context "add_beta_tester_to_group" do
         let(:beta_group_id) { "123" }
         let(:beta_tester_ids) { ["1234", "5678"] }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
While trying to get https://github.com/fastlane/boarding working, I noticed that the  `Spaceship::ConnectAPI.post_bulk_beta_tester_assignments` doesn't seem to be available when using an API key (https://github.com/fastlane/fastlane/issues/18004).
 
However, the App Store Connect API docs [specify](https://developer.apple.com/documentation/appstoreconnectapi/create_a_beta_tester) another endpoint that can be used to invite new TestFlight users (although not in batch).