### PR TITLE
Fix crash in match when passing a frozen value as app_identifiers

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -82,9 +82,9 @@ module Match
         app_identifiers = params[:app_identifier].to_s.split(/\s*,\s*/).uniq
       end
 
-      # sometimes we get an array with arrays, this is a bug. To unblock people using match, I suggest we flatten!
+      # sometimes we get an array with arrays, this is a bug. To unblock people using match, I suggest we flatten
       # then in the future address the root cause of https://github.com/fastlane/fastlane/issues/11324
-      app_identifiers.flatten!
+      app_identifiers = app_identifiers.flatten
 
       # Verify the App ID (as we don't want 'match' to fail at a later point)
       if spaceship


### PR DESCRIPTION
### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] ~I've updated the documentation if necessary.~

### Motivation and Context

When calling `match` with a frozen array (`our_app_ids.freeze`) for the `app_identifiers` parameter, we got a crash because `match` is trying to mutate that input value in-place. See https://github.com/wordpress-mobile/WordPress-iOS/pull/18214/commits/cd585aeb31f245992fad7a61679fd4a16962072b for some more details.

This PR replaces the mutation in-place with a new assignment instead, to avoid modifying the original value that the call site passed to `match`.

### Description

This crash was due to [this patching PR](https://github.com/fastlane/fastlane/pull/11333) (made back in 2017 by @taquitos to quick-fix another issue), which calls `app_identifiers.flatten!`, mutating that parameter in place.

 - My quick fix simply consists of changing this to `app_identifiers = app_identifiers.flatten`, to avoid modifying the original in-place and thus allow frozen values to be passed at call site.
 - But tbh I'm not sure this fix is still required nowadays in 2022, as I [expect `FastlaneCore::ConfigItem#auto_convert_value` to already take care of this nowadays](https://github.com/fastlane/fastlane/blob/668d976ec61d74509f3123ea1b7fe1836a1052e4/fastlane_core/lib/fastlane_core/configuration/config_item.rb#L269-L273), right?
 - Though I'm not sure if that `auto_convert_value` appeared after the patch from 2017 (meaning that that `auto_convert_value` of comma-separated strings to Array did not exist back then and was added later, rendering this `.split(/\s*,\s*/).uniq` in `match` now obsolete) or was already present back then (meaning that the bug in match that we tried to patch was due to something else and more complicated)… 🤔 
 - Also worth mentioning the following related past PRs/Issues where we seem to have done some back and forth on this:
    - https://github.com/fastlane/fastlane/issues/11243
    - https://github.com/fastlane/fastlane/pull/11407
    - https://github.com/fastlane/fastlane/pull/11423
    - https://github.com/fastlane/fastlane/pull/11424 (reverting 11407)

### Testing Steps

I thought about writing a spec for this but couldn't think of a reliable way of how to test just this part of the `Match::Runner` without stubbing basically everything, only to test that line in isolation.

Another option could have been to extract lines L79-L87 into a dedicated private method, and write a test for it. But:
 - I'm not sure how the fastlane team regards "testing private methods" (quite a controversial topic)
 - I preferred to gather feedback on the fix implementation (i.e. will this patch do for now, or do we consider we can get rid of all the L79-L87 logic and consider that `ConfigItem#auto_convert_value` should already cover all this nowadays) first

_(\cc @mokagio FYI, as the discoverer of that bug in our tooling)_