### PR TITLE
Add support for iPhone 13 device family with updated colors

### DIFF
--- a/frameit/lib/frameit/device_types.rb
+++ b/frameit/lib/frameit/device_types.rb
@@ -47,6 +47,9 @@ module Frameit
     PURPLE ||= "Purple"
     GRAPHITE ||= "Graphite"
     PACIFIC_BLUE ||= "Pacific Blue"
+    MIDNIGHT ||= "Midnight"
+    STARLIGHT ||= "Starlight"
+    SIERRA ||= "Sierra"
 
     def self.all_colors
       Color.constants.map { |c| Color.const_get(c).upcase.gsub(' ', '_') }
@@ -124,6 +127,10 @@ module Frameit
     IPHONE_12_PRO ||= Frameit::Device.new("iphone-12-pro", "Apple iPhone 12 Pro", 10, [[1170, 2532], [2532, 1170]], 460, Color::SPACE_GRAY, Platform::IOS)
     IPHONE_12_PRO_MAX ||= Frameit::Device.new("iphone12-pro-max", "Apple iPhone 12 Pro Max", 10, [[1284, 2778], [2778, 1284]], 458, Color::GRAPHITE, Platform::IOS)
     IPHONE_12_MINI ||= Frameit::Device.new("iphone-12-mini", "Apple iPhone 12 Mini", 10, [[1125, 2436], [2436, 1125]], 476, Color::BLACK, Platform::IOS)
+    IPHONE_13 ||= Frameit::Device.new("iphone-13", "Apple iPhone 13", 11, [[1170, 2532], [2532, 1170]], 460, Color::MIDNIGHT, Platform::IOS)
+    IPHONE_13_PRO ||= Frameit::Device.new("iphone-13-pro", "Apple iPhone 13 Pro", 11, [[1170, 2532], [2532, 1170]], 460, Color::GRAPHITE, Platform::IOS)
+    IPHONE_13_PRO_MAX ||= Frameit::Device.new("iphone13-pro-max", "Apple iPhone 13 Pro Max", 11, [[1284, 2778], [2778, 1284]], 458, Color::GRAPHITE, Platform::IOS)
+    IPHONE_13_MINI ||= Frameit::Device.new("iphone-13-mini", "Apple iPhone 13 Mini", 11, [[1080, 2340], [2340, 1080]], 476, Color::MIDNIGHT, Platform::IOS)
     IPAD_10_2 ||= Frameit::Device.new("ipad-10-2", "Apple iPad 10.2", 1, [[1620, 2160], [2160, 1620]], 264, Color::SPACE_GRAY, Platform::IOS)
     IPAD_AIR_2 ||= Frameit::Device.new("ipad-air-2", "Apple iPad Air 2", 1, [[1536, 2048], [2048, 1536]], 264, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
     IPAD_AIR_2019 ||= Frameit::Device.new("ipad-air-2019", "Apple iPad Air (2019)", 2, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS)

--- a/frameit/spec/device_spec.rb
+++ b/frameit/spec/device_spec.rb
@@ -33,9 +33,9 @@ describe Frameit::Device do
         expect_screen_size_from_file("Apple iPhone XS-Landscape{2436x1125}.jpg", Platform::IOS).to eq(Devices::IPHONE_XS)
       end
 
-      it "should detect iPhone 12 Mini in portrait and landscape based on priority" do
-        expect_screen_size_from_file("screenshot-Portrait{1125x2436}.jpg", Platform::IOS).to eq(Devices::IPHONE_12_MINI)
-        expect_screen_size_from_file("screenshot-Landscape{2436x1125}.jpg", Platform::IOS).to eq(Devices::IPHONE_12_MINI)
+      it "should detect iPhone 13 in portrait and landscape based on priority" do
+        expect_screen_size_from_file("screenshot-Portrait{1170x2532}.jpg", Platform::IOS).to eq(Devices::IPHONE_13)
+        expect_screen_size_from_file("screenshot-Landscape{2532x1170}.jpg", Platform::IOS).to eq(Devices::IPHONE_13)
       end
 
       it "should detect iPhone X instead of iPhone XS because of the file name containing device name" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Add support for the iPhone 13 family of devices (13, 13 Pro, 13 Pro Max, 13 Mini) to frameit

### Description
Add support for the iPhone 13 family of devices (13, 13 Pro, 13 Pro Max, 13 Mini) to frameit

- Added 3 new colors in `frameit/devices_type.rb` (Midnight, Starlight, Sierra)

- Added 4 new devices in `frameit/devices_type.rb` (iPhone 13, iPhone 13 Pro, iPhone 13 Pro Max, iPhone 13 Mini)

Related: https://github.com/fastlane/frameit-frames/pull/27

The above added the actual frame images.
### Testing Steps
To test this branch, modify your Gemfile as:

gem "fastlane", :git => "https://github.com/casperson/fastlane.git", :branch => "frameit-add-iphone13-devices"
And run `bundle install` to apply the changes.