### PR TITLE
[update_project_provisioning] Fail when profile cannot be verified

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -37,7 +37,9 @@ module Fastlane
 
         p7.verify([cert], store)
         failed_to_verify = (p7.data.nil? || p7.data == "") && !(p7.error_string || "").empty?
-        UI.crash!("Profile could not be verified: #{p7.error_string}") if failed_to_verify
+        if failed_to_verify
+          UI.crash!("Profile could not be verified with error: '#{p7.error_string}'. Try regenerating provisioning profile.")
+        end
         data = Plist.parse_xml(p7.data)
 
         target_filter = params[:target_filter] || params[:build_configuration_filter]

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -36,10 +36,7 @@ module Fastlane
         store.add_cert(cert)
 
         p7.verify([cert], store)
-        failed_to_verify = (p7.data.nil? || p7.data == "") && !(p7.error_string || "").empty?
-        if failed_to_verify
-          UI.crash!("Profile could not be verified with error: '#{p7.error_string}'. Try regenerating provisioning profile.")
-        end
+        check_verify!(p7)
         data = Plist.parse_xml(p7.data)
 
         target_filter = params[:target_filter] || params[:build_configuration_filter]
@@ -84,6 +81,13 @@ module Fastlane
 
         # complete
         UI.success("Successfully updated project settings in '#{folder}'")
+      end
+
+      def self.check_verify!(p7)
+        failed_to_verify = (p7.data.nil? || p7.data == "") && !(p7.error_string || "").empty?
+        if failed_to_verify
+          UI.crash!("Profile could not be verified with error: '#{p7.error_string}'. Try regenerating provisioning profile.")
+        end
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -34,7 +34,10 @@ module Fastlane
         UI.user_error!("Could not find valid certificate at '#{params[:certificate]}'") unless File.size(params[:certificate]) > 0
         cert = OpenSSL::X509::Certificate.new(File.read(params[:certificate]))
         store.add_cert(cert)
+
         p7.verify([cert], store)
+        failed_to_verify = (p7.data.nil? || p7.data == "") && !(p7.error_string || "").empty?
+        UI.crash!("Profile could not be verified: #{p7.error_string}") if failed_to_verify
         data = Plist.parse_xml(p7.data)
 
         target_filter = params[:target_filter] || params[:build_configuration_filter]

--- a/fastlane/spec/actions_specs/update_project_provisioning_spec.rb
+++ b/fastlane/spec/actions_specs/update_project_provisioning_spec.rb
@@ -99,6 +99,46 @@ describe Fastlane do
           end
         end
       end
+
+      describe "check_verify" do
+        let(:p7) { double('p7') }
+
+        context 'pass' do
+          it 'has data and nil error_string' do
+            allow(p7).to receive(:data).and_return("data")
+            allow(p7).to receive(:error_string).and_return(nil)
+
+            Fastlane::Actions::UpdateProjectProvisioningAction.check_verify!(p7)
+          end
+
+          it 'has data and empty error_string' do
+            allow(p7).to receive(:data).and_return("data")
+            allow(p7).to receive(:error_string).and_return("")
+
+            Fastlane::Actions::UpdateProjectProvisioningAction.check_verify!(p7)
+          end
+        end
+
+        context 'fail' do
+          it 'has no data' do
+            allow(p7).to receive(:data).and_return(nil)
+            allow(p7).to receive(:error_string).and_return("Some error")
+
+            expect do
+              Fastlane::Actions::UpdateProjectProvisioningAction.check_verify!(p7)
+            end.to raise_error(FastlaneCore::Interface::FastlaneCrash)
+          end
+
+          it 'has empty data' do
+            allow(p7).to receive(:data).and_return("")
+            allow(p7).to receive(:error_string).and_return("Some error")
+
+            expect do
+              Fastlane::Actions::UpdateProjectProvisioningAction.check_verify!(p7)
+            end.to raise_error(FastlaneCore::Interface::FastlaneCrash)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Improving error message. Relates to https://github.com/fastlane/fastlane/discussions/20167 and https://github.com/fastlane/fastlane/issues/20164

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Fail `update_project_provisioning` when provisioning profile cannot be verified. 
Add a meaningfull error message.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
