### PR TITLE
[team_id] Fix `SIGH_TEAM_ID` was defined twice

### DIFF
--- a/fastlane/lib/fastlane/actions/team_id.rb
+++ b/fastlane/lib/fastlane/actions/team_id.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         UI.message("Setting Team ID to '#{team}' for all build steps")
 
-        [:CERT_TEAM_ID, :SIGH_TEAM_ID, :PEM_TEAM_ID, :PRODUCE_TEAM_ID, :SIGH_TEAM_ID, :FASTLANE_TEAM_ID].each do |current|
+        [:CERT_TEAM_ID, :PEM_TEAM_ID, :PRODUCE_TEAM_ID, :SIGH_TEAM_ID, :FASTLANE_TEAM_ID].each do |current|
           ENV[current.to_s] = team
         end
       end

--- a/fastlane/spec/actions_specs/team_id_spec.rb
+++ b/fastlane/spec/actions_specs/team_id_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane do
           team_id '#{new_val}'
         end").runner.execute(:test)
 
-        [:CERT_TEAM_ID, :SIGH_TEAM_ID, :PEM_TEAM_ID, :PRODUCE_TEAM_ID, :SIGH_TEAM_ID, :FASTLANE_TEAM_ID].each do |current|
+        [:CERT_TEAM_ID, :PEM_TEAM_ID, :PRODUCE_TEAM_ID, :SIGH_TEAM_ID, :FASTLANE_TEAM_ID].each do |current|
           expect(ENV[current.to_s]).to eq(new_val)
         end
       end


### PR DESCRIPTION

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Setting the value twice is redundant.

### Description
`SIGH_TEAM_ID` was included twice on the same line.

### Testing Steps
