### PR TITLE
[Fastlane.Swift] Use ArgumentProcessor port to start fastlane socket_server

### DIFF
--- a/fastlane/swift/MainProcess.swift
+++ b/fastlane/swift/MainProcess.swift
@@ -49,7 +49,7 @@ class MainProcess {
             let path = main.run(bash: "which fastlane").stdout
             let pids = main.run("lsof", "-t", "-i", ":\(argumentProcessor.port)").stdout.split(separator: "\n")
             pids.forEach { main.run("kill", "-9", $0) }
-            rubySocketCommand = main.runAsync(path, "socket_server", "-c", "1200", "-p", argumentProcessor.port)
+            rubySocketCommand = main.runAsync(path, "socket_server", "-c", argumentProcessor.timeout, "-p", argumentProcessor.port)
             lastPrintDate = Date()
             rubySocketCommand.stderror.onStringOutput { print($0) }
             rubySocketCommand.stdout.onStringOutput { stdout in

--- a/fastlane/swift/MainProcess.swift
+++ b/fastlane/swift/MainProcess.swift
@@ -47,9 +47,9 @@ class MainProcess {
             let PATH = run("/bin/bash", "-c", "-l", "eval $(/usr/libexec/path_helper -s) ; echo $PATH").stdout
             main.env["PATH"] = PATH
             let path = main.run(bash: "which fastlane").stdout
-            let pids = main.run("lsof", "-t", "-i", ":2000").stdout.split(separator: "\n")
+            let pids = main.run("lsof", "-t", "-i", ":\(argumentProcessor.port)").stdout.split(separator: "\n")
             pids.forEach { main.run("kill", "-9", $0) }
-            rubySocketCommand = main.runAsync(path, "socket_server", "-c", "1200")
+            rubySocketCommand = main.runAsync(path, "socket_server", "-c", "1200", "-p", argumentProcessor.port)
             lastPrintDate = Date()
             rubySocketCommand.stderror.onStringOutput { print($0) }
             rubySocketCommand.stdout.onStringOutput { stdout in


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When running [Fastlane.Swift](https://docs.fastlane.tools/getting-started/ios/fastlane-swift/) in the context of a Swift Package the fastlane `socket_server` will always be started on port `2000` even if the `swiftServerPort` argument is present specifying a different port.

For example when running a Swift Package with the following `Fastfile.swift`:

<details>

<summary>Package.swift</summary>

```swift
// swift-tools-version: 5.5

import PackageDescription

let package = Package(
    name: "FastlaneSwiftPackage",
    products: [
        .executable(
            name: "FastlaneSwiftPackage",
            targets: [
                "FastlaneSwiftPackage"
            ]
        )
    ],
    dependencies: [
        .package(
            url: "https://github.com/fastlane/fastlane",
            .exact("2.179.0")
        )
    ],
    targets: [
        .executableTarget(
            name: "FastlaneSwiftPackage",
            dependencies: [
                .product(
                    name: "Fastlane",
                    package: "fastlane"
                )
            ]
        )
    ]
)
```

</details>

```swift
import Foundation
import Fastlane

@main
class Fastfile: LaneFile {
    
    static func main() {
        Main().run(with: Fastfile())
    }
    
    func testLane() {
        echo(message: "It works!")
    }
    
}
```

Running the executable of the Swift Package while specifying a custom `swiftServerPort` (Example: 2001) will result in an `input stream error occurred` error.

```bash
$ swift run FastlaneSwiftPackage lane testLane swiftServerPort 2001 logmode verbose

[1649928851.489028]: [Fastlane.RunnerArgument(name: "lane", value: "testLane")]
[1649928851.505865]: input stream error occurred
[1649928851.506022]: sending: { "commandType": "control", "command": {"command":"done"} }
[1649928851.506174]: sending: { "commandType": "control", "command": {"command":"done"} }
[1649928851.506207]: connection closed!
```

Running the same command without specifying a custom `swiftServerPort` results in a successful execution.

```bash
$ swift run FastlaneSwiftPackage lane testLane logmode verbose

[1649928936.7901359]: [Fastlane.RunnerArgument(name: "lane", value: "testLane")]
[1649928936.802382]: connected!
[1649928936.802453]: Running lane: testLane
[1649928936.802713]: sending: { "commandType": "action", "command": {"commandID" : "","methodName" : "echo","args" : [{"name":"message","value":"It works!"}]} }
[11:35:36]: It works!

[1649928936.804315]: ready for next
[1649928936.8043299]: response is: {"payload":{"status":"ready_for_next","return_object":"","closure_argument_value":""}}
[1649928936.804336]: command executed
[1649928936.804397]: Done running lane: testLane 🚀
[1649928936.8044372]: sending: { "commandType": "control", "command": {"command":"done"} }
[1649928936.804626]: sending: { "commandType": "control", "command": {"command":"done"} }
[1649928936.804687]: connection closed!
```

The reason for this behaviour can be found in the `MainProcess.swift` file where the fastlane `socket_server` is started without the port argument `-p` and therefore the `socket_server` will always be started on port `2000` (as this is the default value) even if a `swiftServerPort` argument is present.

https://github.com/fastlane/fastlane/blob/baeb59551d615fdb258a6b80ebea29345c7c66e0/fastlane/swift/MainProcess.swift#L52

### Description

This PR adds the port argument `-p` when launching the fastlane `socket_server` using the port of the `ArgumentProcessor`.

```swift
rubySocketCommand = main.runAsync(path, "socket_server", "-c", "1200", "-p", argumentProcessor.port)
```

Additionally, the hard coded port `2000` has been also replaced with the port of the `ArgumentProcessor` when trying to kill any previous process running on that port.

```swift
let pids = main.run("lsof", "-t", "-i", ":\(argumentProcessor.port)").stdout.split(separator: "\n")
pids.forEach { main.run("kill", "-9", $0) }
```