### PR TITLE
Implement Amazon Appstore support

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -78,7 +78,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('plist', '>= 3.1.0', '< 4.0.0') # Needed for set_build_number_repository and get_info_plist_value actions
   spec.add_dependency('CFPropertyList', '>= 2.3', '< 4.0.0') # Needed to be able to read binary plist format
   spec.add_dependency('addressable', '>= 2.8', '< 3.0.0') # Support for URI templates
-  spec.add_dependency('multipart-post', '~> 2.0.0') # Needed for uploading builds to appetize
+  spec.add_dependency('multipart-post', '~> 2.0.0') # Needed for uploading builds to appetize, Amazon
   spec.add_dependency('word_wrap', '~> 1.0.0') # to add line breaks for tables with long strings
 
   spec.add_dependency('optparse', '~> 0.1.1') # Used to parse options with Commander

--- a/fastlane/lib/fastlane/action_sets/amazon/actions/upload_to_amazon_appstore.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/actions/upload_to_amazon_appstore.rb
@@ -2,17 +2,51 @@ module Fastlane
   module Actions
     module SharedValues
     end
-  
+
     class UploadToAmazonAppstoreAction < Action
       require_relative '../helper.rb'
+      require_relative '../client.rb'
 
       def self.run(params)
-
-        # Do logic here
-        ActionSets::Amazon.do_something
+        app_id = params[:app_id]
+        replace_apk_id = params[:replace_apk_id]
 
         client = ActionSets::Amazon::Client.new
-        client.do_stuff
+        client.authenticate_if_needed
+
+        # Establish current or new edit
+        edit = instance.get_active_edit(app_id: params[:app_id])
+        if edit.nil?
+          edit = instance.create_edit(app_id: app_id)
+        elsif edit.status != 'IN_PROGRESS'
+          UI.error! "Active edit must be 'IN_PROGRESS'; instead, it is '#{edit.status}'."
+        end
+        edit_id = edit.id
+
+        # Get a list of APKs and find our specific APK, or use the first one
+        apks = instance.get_apks(edit_id: edit_id, app_id: app_id)
+        if apks.empty?
+          UI.error! 'Did not find any APKs to replace.'
+        elsif apks.length > 1 && !replace_apk_id
+          apk_ids = apks.map(&:id)
+          UI.user_error! "Found >1 replaceable APKs; pass one of #{apk_ids.join(',')} into apk_id="
+        end
+        apk_id = apks[0].id
+        if replace_apk_id
+          apk = apks.find { |a| a.id == replace_apk_id }
+          UI.user_error! "Unable to find APK with id match #{replace_apk_id}" unless apk
+          apk_id = apk.id
+        end
+
+        # Cache the ETag for this APK, and then use the ETag to replace the APK
+        apk_metadata = instance.get_apk(apk_id, edit_id: edit_id, app_id: app_id)
+        instance.replace_apk(
+          apk_metadata.id,
+          apk_filepath: params[:apk],
+          edit_id: edit_id,
+          app_id: app_id
+        )
+        UI.message "Successfully created new version and replaced APK #{apk_id}."
       end
 
       #####################################################
@@ -29,17 +63,25 @@ module Fastlane
 
       def self.available_options
         [
-          # FastlaneCore::ConfigItem.new(key: :apk,
-          #                               env_name: "AMAZON_APK",
-          #                               description: "Path to the APK file to upload",
-          #                               code_gen_sensitive: true,
-          #                               default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
-          #                               default_value_dynamic: true,
-          #                               optional: true,
-          #                               verify_block: proc do |value|
-          #                                 UI.user_error!("Could not find apk file at path '#{value}'") unless File.exist?(value)
-          #                                 UI.user_error!("apk file is not an apk") unless value.end_with?('.apk')
-          #                               end),
+          FastlaneCore::ConfigItem.new(key: :apk,
+                                        env_name: "AMAZON_APK",
+                                        description: "Path to the APK file to upload",
+                                        code_gen_sensitive: true,
+                                        default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
+                                        default_value_dynamic: true,
+                                        optional: true,
+                                        verify_block: proc do |value|
+                                          UI.user_error!("Could not find apk file at path '#{value}'") unless File.exist?(value)
+                                          UI.user_error!("apk file is not an apk") unless value.end_with?('.apk')
+                                        end),
+          FastlaneCore::ConfigItem.new(key: :app_id,
+                                        env_name: "AMAZON_APP_ID",
+                                        description: "The Amazon Appstore ID for your app",
+                                        optional: false),
+          FastlaneCore::ConfigItem.new(key: :replace_apk_id,
+                                        env_name: "AMAZON_REPLACE_APK_ID",
+                                        description: "The ID of the APK you wish to replace, if applicable",
+                                        optional: true),
         ]
       end
 
@@ -53,7 +95,8 @@ module Fastlane
       def self.example_code
         [
           'upload_to_amazon_appstore(
-            apk: "path"
+            apk: "path",
+            app_id: "amzn1.devportal.mobileapp.ABC123"
           )'
         ]
       end
@@ -68,4 +111,3 @@ module Fastlane
     end
   end
 end
-  

--- a/fastlane/lib/fastlane/action_sets/amazon/actions/upload_to_amazon_appstore.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/actions/upload_to_amazon_appstore.rb
@@ -19,22 +19,22 @@ module Fastlane
         if edit.nil?
           edit = instance.create_edit(app_id: app_id)
         elsif edit.status != 'IN_PROGRESS'
-          UI.error! "Active edit must be 'IN_PROGRESS'; instead, it is '#{edit.status}'."
+          UI.error!("Active edit must be 'IN_PROGRESS'; instead, it is '#{edit.status}'.")
         end
         edit_id = edit.id
 
         # Get a list of APKs and find our specific APK, or use the first one
         apks = instance.get_apks(edit_id: edit_id, app_id: app_id)
         if apks.empty?
-          UI.error! 'Did not find any APKs to replace.'
+          UI.error!('Did not find any APKs to replace.')
         elsif apks.length > 1 && !replace_apk_id
           apk_ids = apks.map(&:id)
-          UI.user_error! "Found >1 replaceable APKs; pass one of #{apk_ids.join(',')} into apk_id="
+          UI.user_error!("Found >1 replaceable APKs; pass one of #{apk_ids.join(',')} into apk_id=")
         end
         apk_id = apks[0].id
         if replace_apk_id
           apk = apks.find { |a| a.id == replace_apk_id }
-          UI.user_error! "Unable to find APK with id match #{replace_apk_id}" unless apk
+          UI.user_error!("Unable to find APK with id match #{replace_apk_id}") unless apk
           apk_id = apk.id
         end
 
@@ -46,7 +46,7 @@ module Fastlane
           edit_id: edit_id,
           app_id: app_id
         )
-        UI.message "Successfully created new version and replaced APK #{apk_id}."
+        UI.message("Successfully created new version and replaced APK #{apk_id}.")
       end
 
       #####################################################
@@ -81,7 +81,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :replace_apk_id,
                                         env_name: "AMAZON_REPLACE_APK_ID",
                                         description: "The ID of the APK you wish to replace, if applicable",
-                                        optional: true),
+                                        optional: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/action_sets/amazon/actions/upload_to_amazon_appstore.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/actions/upload_to_amazon_appstore.rb
@@ -1,0 +1,71 @@
+module Fastlane
+  module Actions
+    module SharedValues
+    end
+  
+    class UploadToAmazonAppstoreAction < Action
+      require_relative '../helper.rb'
+
+      def self.run(params)
+
+        # Do logic here
+        ActionSets::Amazon.do_something
+
+        client = ActionSets::Amazon::Client.new
+        client.do_stuff
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload to Amazon Appstore"
+      end
+
+      def self.details
+        "Upload to Amazon Appstore"
+      end
+
+      def self.available_options
+        [
+          # FastlaneCore::ConfigItem.new(key: :apk,
+          #                               env_name: "AMAZON_APK",
+          #                               description: "Path to the APK file to upload",
+          #                               code_gen_sensitive: true,
+          #                               default_value: Dir["*.apk"].last || Dir[File.join("app", "build", "outputs", "apk", "app-Release.apk")].last,
+          #                               default_value_dynamic: true,
+          #                               optional: true,
+          #                               verify_block: proc do |value|
+          #                                 UI.user_error!("Could not find apk file at path '#{value}'") unless File.exist?(value)
+          #                                 UI.user_error!("apk file is not an apk") unless value.end_with?('.apk')
+          #                               end),
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.category
+        :production
+      end
+
+      def self.example_code
+        [
+          'upload_to_amazon_appstore(
+            apk: "path"
+          )'
+        ]
+      end
+
+      def self.authors
+        ["kreeger", "joshdholtz"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end
+  

--- a/fastlane/lib/fastlane/action_sets/amazon/client.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/client.rb
@@ -1,0 +1,760 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'net/http/post/multipart'
+require 'marcel'
+require 'uri'
+require 'json'
+
+require_relative './request'
+require_relative './types/apk_metadata'
+require_relative './types/client_credentials'
+require_relative './types/details'
+require_relative './types/edit'
+require_relative './types/listing'
+
+module Fastlane::ActionSets::Amazon
+  # Communicates with the API directly.
+  class Client
+    # @return [Time] The time when the credentials were last fetched
+    attr_reader :last_authenticated
+    attr_accessor :client_id, :client_secret, :etag_cache
+
+    # @param [String] client_id The Amazon Appstore API client ID; defaults to
+    #   `$AMAZON_APP_SUBMISSION_API_CLIENT_ID`
+    # @param [String] client_secret The Amazon Appstore API client secret; defaults to
+    #   `$AMAZON_APP_SUBMISSION_API_CLIENT_SECRET`
+    # @param [ClientCredentials] client_credentials Any saved credentials to use (like from a
+    #   preexisting session)
+    def initialize(client_id: nil, client_secret: nil, client_credentials: nil)
+      @base_url = URI('https://developer.amazon.com/api/appstore/')
+      @client_id = client_id || ENV['AMAZON_APP_SUBMISSION_API_CLIENT_ID']
+      @client_secret = client_secret || ENV['AMAZON_APP_SUBMISSION_API_CLIENT_SECRET']
+      if client_credentials
+        @client_credentials = client_credentials
+        @last_authenticated = Time.now
+      end
+      @etag_cache = {}
+    end
+
+    # Authentication functions
+
+    # Gets a new access token from the Amazon API only if it is needed.
+    #
+    # @return [ClientCredentials]
+    def authenticate_if_needed
+      return @client_credentials unless needs_authentication?
+      authenticate!
+    end
+
+    # Determines if our credentials are invalid or out of date.
+    #
+    # @return [Boolean]
+    def needs_authentication?
+      if @client_credentials.nil? || @last_authenticated.nil?
+        return true
+      elsif (@last_authenticated + @client_credentials.expires_in) < Time.now
+        return true
+      else
+        return false
+      end
+    end
+
+    # Authenticates regardless of previous session status.
+    #
+    # @return [ClientCredentials]
+    def authenticate!
+      if @client_id.nil? || @client_secret.nil?
+        raise "Need #client_id and #client_secret to be defined"
+      end
+
+      uri = URI('https://api.amazon.com/auth/o2/token')
+      body = {
+        'client_id' => @client_id,
+        'client_secret' => @client_secret,
+        'grant_type' => 'client_credentials',
+        'scope' => 'appstore::apps:readwrite'
+      }
+
+      headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+      response, _ = make_request(uri, verb: :post, body: body, headers: headers)
+      @client_credentials = ClientCredentials.new(response)
+      @last_authenticated = Time.now
+      return @client_credentials
+    end
+
+    # Edits
+
+    # Returns information about the active edit for the app. Note: returns an
+    # empty response if no open edit exists.
+    #
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Edit]
+    def get_active_edit(app_id:)
+      edit, etag = do_get("v1/applications/#{app_id}/edits")
+      @etag_cache[edit['id']] = etag
+      return edit.empty? ? nil : Edit.new(edit)
+    end
+
+    # Creates a new edit (upcoming release) for an existing app. The Edit is
+    # populated with values from the live version of the app. Note: An app can
+    # have only one edit open at once. This operation fails if an edit already
+    # exists for the given app.
+    #
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Edit]
+    def create_edit(app_id:)
+      edit, etag = do_post("v1/applications/#{app_id}/edits")
+      @etag_cache[edit['id']] = etag
+      return Edit.new(edit)
+    end
+
+    # Returns information about the specified edit.
+    #
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Edit]
+    def get_edit(edit_id, app_id:)
+      edit, etag = do_get("v1/applications/#{app_id}/edits/#{edit_id}")
+      @etag_cache[edit_id] = etag
+      return Edit.new(edit)
+    end
+
+    # Deletes the specified edit.
+    #
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    def delete_edit(edit_id, app_id:)
+      path = "v1/applications/#{app_id}/edits/#{edit_id}"
+      do_delete(path, etag: @etag_cache[edit_id])
+      @etag_cache.delete(edit_id)
+      return nil
+    end
+
+    # Checks that the changes in the edit are valid. Returns the edit if all
+    # validations succeed. Returns a 403 with list of validation errors
+    # otherwise.
+    #
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Edit]
+    def validate_edit(edit_id, app_id:)
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/validate"
+      edit, _ = do_post(path, etag: @etag_cache[edit_id])
+      return Edit.new(edit)
+    end
+
+    # Marks the edit as submitted, making the changes in the edit live if all
+    # validations succeed. Returns a 403 with the list of validation failures
+    # otherwise.
+    #
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Edit]
+    def commit_edit(edit_id, app_id:)
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/commit"
+      edit, _ = do_post(path, etag: @etag_cache[edit_id])
+      return Edit.new(edit)
+    end
+
+    # Listings
+
+    # Gets information related to all localized listings.
+    #
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Hash<String, Listing>]
+    def get_listings(edit_id:, app_id:)
+      listings, _ = do_get("v1/applications/#{app_id}/edits/#{edit_id}/listings")
+      return listings['listings'].each_with_object({}) do |(key, value), obj|
+        obj[key] = Listing.new(value)
+      end
+    end
+
+    # Gets information about the localized listing for a given language.
+    #
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Listing]
+    def get_listing(language, edit_id:, app_id:)
+      etag_key = [edit_id, language].join('-')
+      listing, etag = do_get("v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}")
+      @etag_cache[etag_key] = etag
+      return Listing.new(listing)
+    end
+
+    # Modifies information related to a localized listing.
+    #
+    # @param [Listing] listing The listing to modify
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Listing]
+    def update_listing(listing, edit_id:, app_id:)
+      language = listing.language
+      etag_key = [edit_id, language].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}"
+      listing_json, etag = do_put(path, listing.to_json, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return Listing.new(listing_json)
+    end
+
+    # Removes the localized listing for the given language. Note: Cannot remove
+    # the listing for the default language.
+    #
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    def delete_listing(language, edit_id:, app_id:)
+      etag_key = [edit_id, language].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}"
+      do_delete(path, etag: @etag_cache[etag_key])
+      @etag_cache.delete(etag_key)
+      return nil
+    end
+
+    # Details
+
+    # Get app details such as contact information and default language for the
+    # given edit.
+    #
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Details]
+    def get_details(edit_id:, app_id:)
+      details, etag = do_get("v1/applications/#{app_id}/edits/#{edit_id}/details")
+      etag_key = [edit_id, 'details'].join('-')
+      @etag_cache[etag_key] = etag
+      return Details.new(details)
+    end
+
+    # Update app details for the given edit. Note: Default language cannot be
+    # changed.
+    #
+    # @param [Details] details The details object to update
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Details]
+    def update_details(details, edit_id:, app_id:)
+      etag_key = [edit_id, 'details'].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/details"
+      details_json, etag = do_put(path, details.to_json, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return Details.new(details_json)
+    end
+
+    # APKs
+
+    # List all APKs for the given app.
+    #
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Array<APKMetadata>]
+    def get_apks(edit_id:, app_id:)
+      apks, _ = do_get("v1/applications/#{app_id}/edits/#{edit_id}/apks")
+      return apks.map { |json| APKMetadata.new(json) }
+    end
+
+    # Gets a specified APK for the given app.
+    #
+    # @param [String] apk_id The identifier of the APK
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [APKMetadata]
+    def get_apk(apk_id, edit_id:, app_id:)
+      apk, etag = do_get("v1/applications/#{app_id}/edits/#{edit_id}/apks/#{apk_id}")
+      @etag_cache[apk_id] = etag
+      return APKMetadata.new(apk)
+    end
+
+    # Deletes a specified APK for the given app.
+    #
+    # @param [String] apk_id The identifier of the APK
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    def delete_apk(apk_id, edit_id:, app_id:)
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/apks/#{apk_id}"
+      do_delete(path, etag: @etag_cache[apk_id])
+      @etag_cache.delete(apk_id)
+      return nil
+    end
+
+    # Replaces a specified APK for the given app. Preserves the targeting
+    # information for that APK.
+    #
+    # @param [String] apk_id The identifier of the APK
+    # @param [String] apk_filepath The path to the APK file to upload
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [APKMetadata]
+    def replace_apk(apk_id, apk_filepath:, edit_id:, app_id:)
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/apks/#{apk_id}/replace"
+      body, headers = upload_body_and_headers(apk_filepath)
+      apk_metadata, etag = do_put(path, body, headers: headers, etag: @etag_cache[apk_id])
+      @etag_cache[apk_id] = etag
+      return APKMetadata.new(apk_metadata)
+    end
+
+    # Upload a new APK for the given app (and attaches it).
+    #
+    # @param [String] apk_filepath The path to the APK file to upload
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [APKMetadata]
+    def upload_apk(apk_filepath, edit_id:, app_id:)
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/apks/upload"
+      body, headers = upload_body_and_headers(apk_filepath)
+      apk_metadata, _ = do_post(path, body: body, headers: headers)
+      return APKMetadata.new(apk_metadata)
+    end
+
+    # Upload a new APK for the given app. Used for uploading large APKs.
+    #
+    # @param [String] apk_filepath The path to the APK file to upload
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [String] The file identifier of the APK asset (to be used when
+    #   attaching this to an APK later with `#attach_apk`)
+    def upload_large_apk(apk_filepath, edit_id:, app_id:)
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/apks/large/upload"
+      mime_type = 'application/vnd.android.package-archive'
+      filename = File.basename(apk_filepath)
+      body = {
+        'file' => UploadIO.new(File.expand_path(apk_filepath), mime_type, filename)
+      }
+      headers = { 'fileName' => filename }
+      upload_metadata, _ = do_post(path, body: body, headers: headers)
+      return upload_metadata['fileId']
+    end
+
+    # Attaches an uploaded APK to this edit.
+    #
+    # @param [String] file_id The file identifier of the APK asset to attach
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [APKMetadata]
+    def attach_apk(file_id, edit_id:, app_id:)
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/apks/attach"
+      body = { 'fileId' => file_id }
+      apk, _ = do_post(path, body: body)
+      return APKMetadata.new(apk)
+    end
+
+    # Images
+
+    # List all images for the given language and image type.
+    #
+    # Permissible values for `image_type` include: `small-icons`, `large-icons`,
+    # `screenshots`, `promo-images`, `firetv-screenshots`, `firetv-icons`,
+    # `firetv-backgrounds`, `firetv-featured-backgrounds`,
+    # and `firetv-featured-logos`.
+    #
+    # @param [String] image_type The imageType, as specified in the permissible values
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Array<String>] An array of image asset identifiers
+    def get_images(image_type, language:, edit_id:, app_id:)
+      images, etag = do_get("v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}/#{image_type}")
+      etag_key = [edit_id, language].join('-')
+      @etag_cache[etag_key] = etag
+      return images['images'].map { |json| json['id'] }
+    end
+
+    # Uploads an image and adds it to the list of images for the given language
+    # and image type. If the image type only supports a single image (such as
+    # icons), the uploaded image replaces the existing image.
+    #
+    # Permissible values for `image_type` include: `small-icons`, `large-icons`,
+    # `screenshots`, `promo-images`, `firetv-screenshots`, `firetv-icons`,
+    # `firetv-backgrounds`, `firetv-featured-backgrounds`,
+    # and `firetv-featured-logos`.
+    #
+    # @param [String] filepath The path to the image file to upload
+    # @param [String] image_type The imageType, as specified in the permissible values
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [String] The asset identifier of the image
+    def upload_image(filepath, image_type:, language:, edit_id:, app_id:)
+      etag_key = [edit_id, language].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}/#{image_type}/upload"
+      body, headers = upload_body_and_headers(filepath)
+      image_metadata, etag = do_post(path, body: body, headers: headers, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return image_metadata['image']['id']
+    end
+
+    # Delete a specified image for the given listing.
+    #
+    # Permissible values for `image_type` include: `small-icons`, `large-icons`,
+    # `screenshots`, `promo-images`, `firetv-screenshots`, `firetv-icons`,
+    # `firetv-backgrounds`, `firetv-featured-backgrounds`,
+    # and `firetv-featured-logos`.
+    #
+    # @param [String] asset_id The asset ID of the image
+    # @param [String] image_type The imageType, as specified in the permissible values
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    def delete_image(asset_id, image_type:, language:, edit_id:, app_id:)
+      etag_key = [edit_id, language].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}/#{image_type}/#{asset_id}"
+      _, etag = do_delete(path, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return nil
+    end
+
+    # Deletes all images for the given language and image type.
+    #
+    # Permissible values for `image_type` include: `small-icons`, `large-icons`,
+    # `screenshots`, `promo-images`, `firetv-screenshots`, `firetv-icons`,
+    # `firetv-backgrounds`, `firetv-featured-backgrounds`,
+    # and `firetv-featured-logos`.
+    #
+    # @param [String] image_type The imageType, as specified in the permissible values
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    def delete_all_images(image_type, language:, edit_id:, app_id:)
+      etag_key = [edit_id, language].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}/#{image_type}"
+      _, etag = do_delete(path, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return nil
+    end
+
+    # Videos
+
+    # List all videos for the given language and video type.
+    #
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Array<String>] An array of video asset identifiers
+    def get_videos(language:, edit_id:, app_id:)
+      videos, etag = do_get("v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}/videos")
+      etag_key = [edit_id, language].join('-')
+      @etag_cache[etag_key] = etag
+      return videos['videos'].map { |json| json['id'] }
+    end
+
+    # Uploads a video and adds it to the list of videos for the given language
+    # and video type. If the video type only supports a single video, it will
+    # be replaced instead.
+    #
+    # @param [String] filepath The path to the video file to upload
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [String] The asset identifier of the video
+    def upload_video(filepath, language:, edit_id:, app_id:)
+      etag_key = [edit_id, language].join('-')
+      # NOTE: The Amazon Appstore API documentation denotes this is "…/videos",
+      #       but it's really "…/videos/upload"
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}/videos/upload"
+      body, headers = upload_body_and_headers(filepath)
+      video_metadata, etag = do_post(path, body: body, headers: headers, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return video_metadata['video']['id']
+    end
+
+    # Delete a specified video for the given listing.
+    #
+    # @param [String] asset_id The asset ID of the video
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    def delete_video(asset_id, language:, edit_id:, app_id:)
+      etag_key = [edit_id, language].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}/videos/#{asset_id}"
+      _, etag = do_delete(path, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return nil
+    end
+
+    # Delete the videos associated with the specified language.
+    #
+    # @param [String] language The language (such as en-US)
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    def delete_all_videos(language:, edit_id:, app_id:)
+      etag_key = [edit_id, language].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/listings/#{language}/videos"
+      _, etag = do_delete(path, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return nil
+    end
+
+
+    # Availability
+
+    # Returns availiability information for the specified edit.
+    #
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Availability]
+    def get_availability(edit_id:, app_id:)
+      etag_key = [edit_id, 'availability'].join('-')
+      availability, etag = do_get("v1/applications/#{app_id}/edits/#{edit_id}/availability")
+      @etag_cache[etag_key] = etag
+      return Availability.new(availability)
+    end
+
+    # Updates availiability information for the specified edit.
+    #
+    # @param [Availability] availability The availability metadata to update
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Availability]
+    def update_availability(availability, edit_id:, app_id:)
+      etag_key = [edit_id, 'availability'].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/availability"
+      availability_json, etag = do_put(path, availability.to_json, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return Availability.new(availability_json)
+    end
+
+    # Targeting
+
+    # Gets details about the device targeting for a given APK.
+    #
+    # @param [String] apk_id The identifier of the APK
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Targeting]
+    def get_targeting(apk_id:, edit_id:, app_id:)
+      etag_key = [apk_id, 'targeting'].join('-')
+      targeting, etag = do_get("v1/applications/#{app_id}/edits/#{edit_id}/apks/#{apk_id}/targeting")
+      @etag_cache[etag_key] = etag
+      return Targeting.new(targeting)
+    end
+
+    # Modifies device targeting information for the given APK.
+    #
+    # @param [Targeting] targeting The targeting metadata to update
+    # @param [String] apk_id The identifier of the APK
+    # @param [String] edit_id The identifier of the edit
+    # @param [String] app_id The package name or app identifier for the app
+    #
+    # @return [Targeting]
+    def update_targeting(targeting, apk_id:, edit_id:, app_id:)
+      etag_key = [apk_id, 'targeting'].join('-')
+      path = "v1/applications/#{app_id}/edits/#{edit_id}/apks/#{apk_id}/targeting"
+      targeting_json, etag = do_put(path, targeting.to_json, etag: @etag_cache[etag_key])
+      @etag_cache[etag_key] = etag
+      return Targeting.new(targeting_json)
+    end
+
+    private
+
+    def do_get(path, body: nil, headers: {})
+      raise "Requires authentication" if needs_authentication?
+      make_request(path, verb: :get, body: body, headers: headers)
+    end
+
+    def do_post(path, body: nil, headers: {}, etag: nil)
+      raise "Requires authentication" if needs_authentication?
+      make_request(path, verb: :post, body: body, headers: headers, etag: etag)
+    end
+
+    def do_put(path, body, headers: {}, etag: nil)
+      raise "Requires authentication" if needs_authentication?
+      make_request(path, verb: :put, body: body, headers: headers, etag: etag)
+    end
+
+    def do_delete(path, body: nil, headers: {}, etag: nil)
+      raise "Requires authentication" if needs_authentication?
+      make_request(path, verb: :delete, body: body, headers: headers, etag: etag)
+    end
+
+    def make_request(path_or_uri, verb:, body:, headers:, etag: nil)
+      uri = path_or_uri
+      if path_or_uri.is_a?(String)
+        uri = URI::join(@base_url, path_or_uri)
+      end
+
+      if @client_credentials&.access_token
+        headers['Authorization'] = "Bearer #{@client_credentials.access_token}"
+      end
+      headers['If-Match'] = etag if etag
+      request = Request.new(uri, verb: verb, body: body, headers: headers)
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true if uri.instance_of? URI::HTTPS
+      req = request.as_net_http_request
+      response = http.request(req)
+
+      case response
+      when Net::HTTPSuccess then
+        return (response.body ? JSON.parse(response.body) : nil), response['ETag']
+      else
+        raise "Unexpected HTTP #{response.code} response: #{response.body}"
+      end
+    end
+
+    def upload_body_and_headers(filepath)
+      filename = File.basename(filepath)
+      mime_type = Marcel::MimeType.for(Pathname.new(filepath))
+      body = UploadIO.new(File.expand_path(filepath), mime_type)
+      headers = { 'Content-Type' => mime_type, 'fileName' => filename }
+      if body.respond_to?(:length)
+        headers['Content-Length'] = body.length.to_s
+      elsif body.respond_to?(:stat)
+        headers['Content-Length'] = body.stat.size.to_s
+      end
+      return body, headers
+    end
+  end
+
+  # Request
+
+  # Encapsulates logic for formulating network requests. Agnostic towards
+  # reading files and handling etags; just raw verbs, uris, bodies, and headers.
+  class Request
+    class << self
+      def default_headers
+        {
+          'User-Agent' => 'fastlane-amazon',
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/json',
+        }
+      end
+    end
+
+    # @return [URI]
+    attr_accessor :uri
+    # @return [Symbol]
+    attr_accessor :verb
+    # @return [Object]
+    attr_accessor :body
+    # @return [Hash<String, String>]
+    attr_accessor :headers
+
+    # @param [URI] uri <description>
+    # @param [Symbol] verb <description>
+    # @param [Object, nil] body <description>
+    # @param [Hash<String, String>] headers <description>
+    def initialize(uri, verb: :get, body: nil, headers: {})
+      @uri = uri
+      @verb = verb
+      @body = body
+      @headers = Request.default_headers.merge(headers)
+    end
+
+    # @return [Net::HTTP::Get, Net::HTTP::Delete, Net::HTTP::Post, Net::HTTP::Post::Multipart, Net::HTTP::Put, Net::HTTP::Put::Multipart]
+    def as_net_http_request
+      case verb
+      when :get
+        as_get
+      when :delete
+        as_delete
+      when :post
+        as_post
+      when :put
+        as_put
+      else
+        raise "Unknown HTTP verb #{verb}; supports :get, :post, :put, :delete"
+      end
+    end
+
+    private
+
+    # @return [Net::HTTP::Get]
+    def as_get
+      the_uri = body ? uri + URI.encode_www_form(body) : uri
+      Net::HTTP::Get.new(the_uri.request_uri, headers.merge({
+        'Content-Type' => 'application/x-www-form-urlencoded'
+      }))
+    end
+
+    # @return [Net::HTTP::Delete]
+    def as_delete
+      the_uri = body ? uri + URI.encode_www_form(body) : uri
+      Net::HTTP::Delete.new(the_uri.request_uri, headers.merge({
+        'Content-Type' => 'application/x-www-form-urlencoded'
+      }))
+    end
+
+    # @return [Net::HTTP::Post, Net::HTTP::Post::Multipart]
+    def as_post
+      if is_multipart
+        Net::HTTP::Post::Multipart.new(uri.request_uri, body, headers)
+      else
+        request = Net::HTTP::Post.new(uri.request_uri, headers)
+        if is_upload
+          request.body_stream = body
+        else
+          request.body = encoded_body
+        end
+        request
+      end
+    end
+
+    # @return [Net::HTTP::Put, Net::HTTP::Put::Multipart]
+    def as_put
+      if is_multipart
+        Net::HTTP::Put::Multipart.new(uri.request_uri, body, headers)
+      else
+        request = Net::HTTP::Put.new(uri.request_uri, headers)
+        if is_upload
+          request.body_stream = body
+        else
+          request.body = encoded_body
+        end
+        request
+      end
+    end
+
+    # @return [String, nil]
+    def encoded_body
+      return nil if body.nil?
+
+      case headers['Content-Type']
+      when 'application/x-www-form-urlencoded'
+        URI.encode_www_form(body)
+      when 'application/json'
+        body.to_json
+      else
+        nil
+      end
+    end
+
+    # @return [Boolean]
+    def is_multipart
+      is_upload && (body.is_a?(Hash) || body.is_a?(Array))
+    end
+
+    # @return [Boolean]
+    def is_upload
+      # We don't care about XML, so if we have a body and it's neither JSON nor
+      #   URL-encoded, assume we're uploading files
+      headers['Content-Type'] != 'application/json' &&
+        headers['Content-Type'] != 'application/x-www-form-urlencoded' &&
+        !body.nil?
+    end
+  end
+end

--- a/fastlane/lib/fastlane/action_sets/amazon/client.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/client.rb
@@ -2,7 +2,6 @@
 
 require 'net/http'
 require 'net/http/post/multipart'
-require 'marcel'
 require 'uri'
 require 'json'
 
@@ -618,7 +617,7 @@ module Fastlane::ActionSets::Amazon
 
     def upload_body_and_headers(filepath)
       filename = File.basename(filepath)
-      mime_type = Marcel::MimeType.for(Pathname.new(filepath))
+      mime_type = mime_type_for_file(filepath)
       body = UploadIO.new(File.expand_path(filepath), mime_type)
       headers = { 'Content-Type' => mime_type, 'fileName' => filename }
       if body.respond_to?(:length)
@@ -627,6 +626,10 @@ module Fastlane::ActionSets::Amazon
         headers['Content-Length'] = body.stat.size.to_s
       end
       return body, headers
+    end
+
+    def mime_type_for_file(path)
+      Helper.backticks("file --mime-encoding #{path.shellescape}", print: false)
     end
   end
 

--- a/fastlane/lib/fastlane/action_sets/amazon/client.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/client.rb
@@ -5,7 +5,6 @@ require 'net/http/post/multipart'
 require 'uri'
 require 'json'
 
-require_relative './request'
 require_relative './types/apk_metadata'
 require_relative './types/client_credentials'
 require_relative './types/details'

--- a/fastlane/lib/fastlane/action_sets/amazon/helper.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/helper.rb
@@ -9,14 +9,3 @@ module Fastlane
     end
   end
 end
-
-module Fastlane::ActionSets::Amazon
-  class Client
-    def initialize
-    end
-
-    def do_stuff
-      puts "do stuff"
-    end
-  end
-end

--- a/fastlane/lib/fastlane/action_sets/amazon/helper.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/helper.rb
@@ -1,11 +1,9 @@
 module Fastlane
   module ActionSets
     module Amazon
-
       def do_something
-        puts "do something"
+        puts("do something")
       end
-
     end
   end
 end

--- a/fastlane/lib/fastlane/action_sets/amazon/helper.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/helper.rb
@@ -1,0 +1,22 @@
+module Fastlane
+  module ActionSets
+    module Amazon
+
+      def do_something
+        puts "do something"
+      end
+
+    end
+  end
+end
+
+module Fastlane::ActionSets::Amazon
+  class Client
+    def initialize
+    end
+
+    def do_stuff
+      puts "do stuff"
+    end
+  end
+end

--- a/fastlane/lib/fastlane/action_sets/amazon/types/apk_metadata.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/types/apk_metadata.rb
@@ -1,0 +1,28 @@
+module Fastlane::ActionSets::Amazon
+  # Describes metadata for an APK.
+  class APKMetadata
+    # @return [String] The unique identifier of the APK
+    attr_reader :id
+    # @return [String] The internal name of the APK (not shown to customers)
+    attr_reader :name
+    # @return [String] The version code assigned to the APK (by Amazon)
+    attr_reader :version_code
+
+    # @param [Hash] json
+    def initialize(json)
+      @id = json['id']
+      @name = json['name']
+      @version_code = json['versionCode']
+    end
+
+    # @param [APKMetadata] other
+    # @return [Boolean]
+    def ==(other)
+      id == other.id && name == other.name && version_code == other.version_code
+    end
+
+    def to_s
+      "<Fastlane::ActionSets::Amazon::APKMetadata:#{object_id} id=>\"#{id}\" name=>\"#{name}\" version_code=>\"#{version_code}\">"
+    end
+  end
+end

--- a/fastlane/lib/fastlane/action_sets/amazon/types/availability.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/types/availability.rb
@@ -1,0 +1,55 @@
+module Fastlane::ActionSets::Amazon
+  # Describes availability for an `Edit`.
+  class Availability
+    class DatePair
+      # @return [Time] The timestamp
+      attr_accessor :date_time
+      # @return [String] The timezone ID to go along with `#date_time`
+      attr_accessor :zone_id
+
+      # @param [Hash] json
+      def initialize(json)
+        @date_time = json['dateTime']
+        @zone_id = json['zoneId']
+      end
+
+      # @return [Hash]
+      def to_json
+        { 'dateTime' => date_time, 'zoneId' => zone_id }
+      end
+
+      # @param [DatePair] other
+      # @return [Boolean]
+      def ==(other)
+        date_time == other.date_time && zone_id == other.zone_id
+      end
+
+      def to_s
+        "<Fastlane::ActionSets::Amazon::Availability::DatePair:#{object_id} date_time=>#{date_time} zone_id=>\"#{zone_id}\">"
+      end
+    end
+
+    # @return [DatePair] The date/time when the edit should go live
+    attr_accessor :publishing_date
+
+    # @param [Hash] json
+    def initialize(json)
+      @publishing_date = DatePair.new(json['publishingDate'])
+    end
+
+    # @return [Hash]
+    def to_json
+      { 'publishingDate' => publishing_date.to_json }
+    end
+
+    # @param [Availability] other
+    # @return [Boolean]
+    def ==(other)
+      publishing_date == other.publishing_date
+    end
+
+    def to_s
+      "<Fastlane::ActionSets::Amazon::Availability:#{object_id} publishing_date=>#{publishing_date}>"
+    end
+  end
+end

--- a/fastlane/lib/fastlane/action_sets/amazon/types/client_credentials.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/types/client_credentials.rb
@@ -1,0 +1,34 @@
+module Fastlane::ActionSets::Amazon
+  # Describes a token and its metadata; used for authenticating with an Amazon API.
+  class ClientCredentials
+    # @return [String] The actual access token itself
+    attr_reader :access_token
+    # @return [String] The scope of the token; for our purposes, this is "appstore::apps:readwrite"
+    attr_reader :scope
+    # @return [String] The type of credential; this is always "bearer"
+    attr_reader :token_type
+    # @return [Number] The number of seconds until these credentials expire
+    attr_reader :expires_in
+
+    # @param [Hash] json
+    def initialize(json)
+      @access_token = json['access_token']
+      @scope = json['scope']
+      @token_type = json['token_type']
+      @expires_in = json['expires_in']
+    end
+
+    # @param [ClientCredentials] other
+    # @return [Boolean]
+    def ==(other)
+      access_token == other.access_token &&
+        scope == other.scope &&
+        token_type == other.token_type &&
+        expires_in == other.expires_in
+    end
+
+    def to_s
+      "<Fastlane::ActionSets::Amazon::ClientCredentials:#{object_id} access_token=>\"#{access_token}\">"
+    end
+  end
+end

--- a/fastlane/lib/fastlane/action_sets/amazon/types/details.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/types/details.rb
@@ -1,0 +1,44 @@
+module Fastlane::ActionSets::Amazon
+  # Describes additional metadata that goes along with an `Edit`.
+  class Details
+    # @return [String] The default language code for the Edit
+    attr_accessor :default_language
+    # @return [String] The fully-qualified web address where support can be reached
+    attr_accessor :contact_website
+    # @return [String] The email address where an app support contact person can be reached
+    attr_accessor :contact_email
+    # @return [String] The phone number where an app support contact person can be reached
+    attr_accessor :contact_phone
+
+    # @param [Hash] json
+    def initialize(json)
+      @default_language = json['defaultLanguage']
+      @contact_website = json['contactWebsite']
+      @contact_email = json['contactEmail']
+      @contact_phone = json['contactPhone']
+    end
+
+    # @return [Hash]
+    def to_json
+      {
+        'defaultLanguage' => @default_language,
+        'contactWebsite' => @contact_website,
+        'contactEmail' => @contact_email,
+        'contactPhone' => @contact_phone,
+      }
+    end
+
+    # @param [Details] other
+    # @return [Boolean]
+    def ==(other)
+      default_language == other.default_language &&
+        contact_website == other.contact_website &&
+        contact_email == other.contact_email &&
+        contact_phone == other.contact_phone
+    end
+
+    def to_s
+      "<Fastlane::ActionSets::Amazon::Details:#{object_id} default_language=>\"#{default_language}\" contact_email=>\"#{contact_email}\">"
+    end
+  end
+end

--- a/fastlane/lib/fastlane/action_sets/amazon/types/edit.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/types/edit.rb
@@ -1,0 +1,26 @@
+module Fastlane::ActionSets::Amazon
+  # Describes a version of an app update; the basis for all modifications
+  # against the Amazon App Submission API.
+  class Edit
+    # @return [String] The unique identifier of the edit
+    attr_reader :id
+    # @return [String] The status of the edit; `LIVE`, `IN_PROGRESS`, etc.
+    attr_reader :status
+
+    # @param [Hash] json
+    def initialize(json)
+      @id = json['id']
+      @status = json['status']
+    end
+
+    # @param [Edit] other
+    # @return [Boolean]
+    def ==(other)
+      id == other.id && status == other.status
+    end
+
+    def to_s
+      "<Fastlane::ActionSets::Amazon::Edit:#{object_id} id=>\"#{id}\" status=>\"#{status}\">"
+    end
+  end
+end

--- a/fastlane/lib/fastlane/action_sets/amazon/types/listing.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/types/listing.rb
@@ -1,0 +1,59 @@
+module Fastlane::ActionSets::Amazon
+  # Describes a localized presence of an app `Edit` in the Amazon Appstore.
+  class Listing
+    # @return [String] The language code of the listing (like en-US)
+    attr_accessor :language
+    # @return [String] The localized title of the listing
+    attr_accessor :title
+    # @return [String] The localized long description text for the listing
+    attr_accessor :full_description
+    # @return [String] The localized brief description text for the listing
+    attr_accessor :short_description
+    # @return [String] The localized release notes for the listing
+    attr_accessor :recent_changes
+    # @return [Array<String>] Localized functionality highlights for the listing
+    attr_accessor :feature_bullets
+    # @return [Array<String>] Any localized keywords for the listing
+    attr_accessor :keywords
+
+    # @param [Hash] json
+    def initialize(json)
+      @language = json['language']
+      @title = json['title']
+      @full_description = json['fullDescription']
+      @short_description = json['shortDescription']
+      @recent_changes = json['recentChanges']
+      @feature_bullets = json['featureBullets']
+      @keywords = json['keywords']
+    end
+
+    # @return [Hash]
+    def to_json
+      {
+        'language' => language,
+        'title' => title,
+        'fullDescription' => full_description,
+        'shortDescription' => short_description,
+        'recentChanges' => recent_changes,
+        'featureBullets' => feature_bullets,
+        'keywords' => keywords,
+      }
+    end
+
+    # @param [Listing] other
+    # @return [Boolean]
+    def ==(other)
+      language == other.language &&
+        title == other.title &&
+        full_description == other.full_description &&
+        short_description == other.short_description &&
+        recent_changes == other.recent_changes &&
+        feature_bullets == other.feature_bullets &&
+        keywords == other.keywords
+    end
+
+    def to_s
+      "<Fastlane::ActionSets::Amazon::Listing:#{object_id} language=>\"#{language}\" title=>\"#{title}\">"
+    end
+  end
+end

--- a/fastlane/lib/fastlane/action_sets/amazon/types/targeting.rb
+++ b/fastlane/lib/fastlane/action_sets/amazon/types/targeting.rb
@@ -1,0 +1,106 @@
+module Fastlane::ActionSets::Amazon
+  # Describes availability for an `Edit`.
+  class Targeting
+    class Device
+      class Reason
+        # @return [String] The description of the reason as to why this isn't
+        #   supported
+        attr_accessor :reason
+        # @return [Array<String>] Any further reasons why this isn't supported
+        attr_accessor :details
+
+        # @param [Hash] json
+        def initialize(json)
+          @reason = json['reason']
+          @details = json['details']
+        end
+
+        # @return [Hash]
+        def to_json
+          { 'reason' => reason, 'details' => details }
+        end
+
+        # @param [Reason] other
+        # @return [Boolean]
+        def ==(other)
+          reason == other.reason && details == other.details
+        end
+
+        def to_s
+          "<Fastlane::ActionSets::Amazon::Targeting::Device::Reason:#{object_id} reason=>\"#{reason}\">"
+        end
+      end
+
+      # @return [String] The unique identifier for the device class
+      attr_accessor :id
+      # @return [String] The name of the device class
+      attr_accessor :name
+      # @return [String] The targeting status of this device class; `DISABLED`
+      #   or `TARGETING` usually
+      attr_accessor :status
+      # @return [Reason] If disabled, the reason this was disabled
+      attr_accessor :reason
+
+      # @param [Hash] json
+      def initialize(json)
+        @id = json['id']
+        @name = json['name']
+        @status = json['status']
+        @reason = json['reason'].empty? ? nil : Reason.new(json['reason'])
+      end
+
+      # @return [Hash]
+      def to_json
+        {
+          'id' => id,
+          'name' => name,
+          'status' => status,
+          'reason' => reason ? reason.to_json : {}
+        }
+      end
+
+      # @param [Device] other
+      # @return [Boolean]
+      def ==(other)
+        id == other.id &&
+          name == other.name &&
+          status == other.status &&
+          reason == other.reason
+      end
+
+      def to_s
+        "<Fastlane::ActionSets::Amazon::Targeting::Device:#{object_id} id=>\"#{id}\" name=>\"#{name}\" status=>\"#{status}\">"
+      end
+    end
+
+    # @return [Array<Device>]
+    attr_accessor :amazon_devices
+    # @return [Array<Device>]
+    attr_accessor :non_amazon_devices
+
+    # @param [Hash] json
+    def initialize(json)
+      @amazon_devices = json['amazonDevices'].map { |j| Device.new(j) }
+      @non_amazon_devices = json['nonAmazonDevices'].map { |j| Device.new(j) }
+    end
+
+    # @return [Hash]
+    def to_json
+      {
+        'amazonDevices' => amazon_devices.map(&:to_json),
+        'nonAmazonDevices' => non_amazon_devices.map(&:to_json),
+      }
+    end
+
+    # @param [Availability] other
+    # @return [Boolean]
+    def ==(other)
+      amazon_devices == other.amazon_devices &&
+        non_amazon_devices == other.non_amazon_devices
+    end
+
+    def to_s
+      "<Fastlane::ActionSets::Amazon::Targeting:#{object_id} amazon_devices=>#{amazon_devices} non_amazon_devices=>#{non_amazon_devices}>"
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -112,6 +112,11 @@ module Fastlane
       Dir[File.expand_path('*.rb', File.dirname(__FILE__))].each do |file|
         require file
       end
+
+      Dir[File.expand_path('../action_sets/*/actions/*.rb', File.dirname(__FILE__))].each do |file|
+        puts "🔥 Requiring file: #{file}"
+        require file
+      end
     end
 
     # Import all the helpers

--- a/fastlane/lib/fastlane/actions/actions_helper.rb
+++ b/fastlane/lib/fastlane/actions/actions_helper.rb
@@ -114,7 +114,7 @@ module Fastlane
       end
 
       Dir[File.expand_path('../action_sets/*/actions/*.rb', File.dirname(__FILE__))].each do |file|
-        puts "🔥 Requiring file: #{file}"
+        puts("🔥 Requiring file: #{file}")
         require file
       end
     end

--- a/fastlane/spec/action_sets_specs/amazon/client_spec.rb
+++ b/fastlane/spec/action_sets_specs/amazon/client_spec.rb
@@ -87,7 +87,7 @@ describe Fastlane do
 
         before(:each) do
           seed_environment
-          creds =  Fastlane::ActionSets::Amazon::ClientCredentials.new({
+          creds = Fastlane::ActionSets::Amazon::ClientCredentials.new({
             'access_token' => ENV['AMAZON_APP_SUBMISSION_API_JWT'] || 'jwt.jwt.jwt',
             'scope' => 'appstore::apps:readwrite',
             'token_type' => 'bearer',
@@ -248,10 +248,10 @@ describe Fastlane do
 
         describe 'APK functionality' do
           let(:apk_filepath) { File.join(__dir__, '..', '..', 'fixtures', 'mock-app.apk') }
-          let(:apk_id) { 'M8FYZDFK0GJG0 '}
+          let(:apk_id) { 'M8FYZDFK0GJG0 ' }
           let(:json_data) do
             {
-              'versionCode' => 21040401,
+              'versionCode' => 21_040_401,
               'id' => apk_id,
               'name' => 'APK1'
             }
@@ -263,8 +263,8 @@ describe Fastlane do
 
             result = @instance.get_apks(edit_id: edit_id, app_id: app_id)
             expect(result).to eq([
-              Fastlane::ActionSets::Amazon::APKMetadata.new(json_data)
-            ])
+                                   Fastlane::ActionSets::Amazon::APKMetadata.new(json_data)
+                                 ])
           end
 
           it 'gets a single apk' do
@@ -338,9 +338,9 @@ describe Fastlane do
 
             images = @instance.get_images('screenshots', language: language, edit_id: edit_id, app_id: app_id)
             expect(images).to eq([
-              'amzn1.dex.asset.f98f7b86f7674a7e9ed9192273fc9b56',
-              'amzn1.dex.asset.991a8f7d43254282842896da7bd68f5e'
-            ])
+                                   'amzn1.dex.asset.f98f7b86f7674a7e9ed9192273fc9b56',
+                                   'amzn1.dex.asset.991a8f7d43254282842896da7bd68f5e'
+                                 ])
           end
 
           it 'uploads an image' do
@@ -381,7 +381,7 @@ describe Fastlane do
           let(:language) { 'en-US' }
           let(:json_data) do
             [
-              { id: 'amzn1.dex.asset.f98f7b86f7674a7e9ed9192273fc9b56' },
+              { id: 'amzn1.dex.asset.f98f7b86f7674a7e9ed9192273fc9b56' }
             ]
           end
 
@@ -457,7 +457,7 @@ describe Fastlane do
         end
 
         describe 'targeting functionality' do
-          let(:apk_id) { 'M8FYZDFK0GJG0 '}
+          let(:apk_id) { 'M8FYZDFK0GJG0 ' }
           let(:json_data) do
             {
               'amazonDevices' => [

--- a/fastlane/spec/action_sets_specs/amazon/client_spec.rb
+++ b/fastlane/spec/action_sets_specs/amazon/client_spec.rb
@@ -1,0 +1,499 @@
+require 'date'
+
+describe Fastlane do
+  describe ActionSets do
+    describe Amazon::Client do
+      let(:app_id) { 'amzn1.devportal.mobileapp.abc' }
+
+      def seed_environment
+        ENV['AMAZON_APP_SUBMISSION_API_CLIENT_ID'] ||= 'some-client-id'
+        ENV['AMAZON_APP_SUBMISSION_API_CLIENT_SECRET'] ||= 'some-client-secret'
+      end
+
+      describe '.new' do
+        it 'can be initialized with defaults' do
+          seed_environment
+
+          instance = Fastlane::ActionSets::Amazon::Client.new
+          expect(instance.client_id).to eq(ENV['AMAZON_APP_SUBMISSION_API_CLIENT_ID'])
+          expect(instance.client_secret).to eq(ENV['AMAZON_APP_SUBMISSION_API_CLIENT_SECRET'])
+        end
+
+        it 'can be configured directly' do
+          instance = Fastlane::ActionSets::Amazon::Client.new(client_id: 'other-id', client_secret: 'other-secret')
+          expect(instance.client_id).to eq('other-id')
+          expect(instance.client_secret).to eq('other-secret')
+
+          instance.client_id = 'new-id'
+          instance.client_secret = 'new-secret'
+          expect(instance.client_id).to eq('new-id')
+          expect(instance.client_secret).to eq('new-secret')
+        end
+      end
+
+      describe 'authentication functionality' do
+        before(:each) do
+          seed_environment
+          @instance = Fastlane::ActionSets::Amazon::Client.new
+          stub_request(:post, 'https://api.amazon.com/auth/o2/token').
+            to_return(status: 200, body: {
+              access_token: 'abc123',
+              expires_in: 3600,
+              scope: 'appstore::apps:readwrite',
+              token_type: 'bearer'
+            })
+        end
+
+        describe '#authenticate_if_needed' do
+          it 'kicks off a call to the Amazon API to authenticate' do
+            expect(@instance.needs_authentication?).to be true
+            @instance.authenticate_if_needed
+            expect(@instance.needs_authentication?).to be false
+          end
+
+          it 'does not make duplicate calls' do
+            @instance.authenticate_if_needed
+            previous_auth_timestamp = @instance.last_authenticated
+            @instance.authenticate_if_needed
+            expect(@instance.last_authenticated).to eq(previous_auth_timestamp)
+          end
+        end
+
+        describe '#authenticate!' do
+          it 'kicks off a call to the Amazon API to authenticate' do
+            expect(@instance.needs_authentication?).to be true
+            response = @instance.authenticate!
+            expect(response).to eq(Fastlane::ActionSets::Amazon::ClientCredentials.new({
+              'access_token' => 'abc123',
+              'scope' => 'appstore::apps:readwrite',
+              'token_type' => 'bearer',
+              'expires_in' => 3600
+            }))
+            expect(@instance.needs_authentication?).to be false
+          end
+
+          it 'authenticates even if needs_authentication is false' do
+            @instance.authenticate!
+            previous_auth_timestamp = @instance.last_authenticated
+            @instance.authenticate!
+            expect(@instance.last_authenticated).to be > previous_auth_timestamp
+          end
+        end
+      end
+
+      context 'with client credentials' do
+        let(:base_url) { 'https://developer.amazon.com/api/appstore/v1/applications' }
+        let(:edit_id) { 'amzn1.devportal.apprelease.9fd9ded7f16e4b1ea89dc794b6e04328' }
+
+        before(:each) do
+          seed_environment
+          creds =  Fastlane::ActionSets::Amazon::ClientCredentials.new({
+            'access_token' => ENV['AMAZON_APP_SUBMISSION_API_JWT'] || 'jwt.jwt.jwt',
+            'scope' => 'appstore::apps:readwrite',
+            'token_type' => 'bearer',
+            'expires_in' => 3600
+          })
+          @instance = Fastlane::ActionSets::Amazon::Client.new(client_credentials: creds)
+        end
+
+        describe 'edits functionality' do
+          it 'fetches latest active edit' do
+            stub_request(:get, "#{base_url}/edits").
+              to_return(status: 200, body: {})
+
+            result = @instance.get_active_edit(app_id: app_id)
+            expect(result).to be nil
+          end
+
+          it 'creates an edit' do
+            stub_request(:post, "#{base_url}/edits").
+              to_return(status: 200, body: { id: app_id, status: 'IN_PROGRESS' })
+
+            result = @instance.create_edit(app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::Edit.new({
+              'id' => 'amzn1.devportal.apprelease.abc',
+              'status' => 'IN_PROGRESS'
+            }))
+          end
+
+          it 'gets an edit' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}").
+              to_return(status: 200, body: { id: app_id, status: 'IN_PROGRESS' })
+
+            result = @instance.get_edit(edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::Edit.new({
+              'id' => 'amzn1.devportal.apprelease.9fd9ded7f16e4b1ea89dc794b6e04328',
+              'status' => 'IN_PROGRESS'
+            }))
+          end
+
+          it 'deletes an edit' do
+            stub_request(:delete, "#{base_url}/edits/#{edit_id}").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 204)
+
+            @instance.etag_cache[edit_id] = 'etag-value'
+            result = @instance.delete_edit(edit_id, app_id: app_id)
+            expect(result).to be nil
+          end
+
+          it 'validates an edit' do
+            stub_request(:post, "#{base_url}/edits/#{edit_id}/validate").
+              to_return(status: 200, body: { id: edit_id })
+
+            result = @instance.validate_edit(edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::Edit.new({
+              'id' => edit_id
+            }))
+          end
+
+          it 'commits changes to an edit' do
+            stub_request(:post, "#{base_url}/edits/#{edit_id}/commit").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 200, body: { id: edit_id })
+
+            @instance.etag_cache[edit_id] = 'etag-value'
+            result = @instance.commit_edit(edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::Edit.new({
+              'id' => edit_id
+            }))
+          end
+        end
+
+        describe 'listing functionality' do
+          let(:json_data) do
+            {
+              'language' => 'en-GB',
+              'title' => "O'Reilly",
+              'fullDescription' => 'Placeholder full description',
+              'shortDescription' => 'Placeholder short description',
+              'recentChanges' => 'Release notes coming soon',
+              'featureBullets' => [],
+              'keywords' => []
+            }
+          end
+
+          it 'fetches all listings' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/listings").
+              to_return(status: 200, body: {
+                listings: { 'en-GB' => json_data }
+              })
+
+            listings = @instance.get_listings(edit_id: edit_id, app_id: app_id)
+            expect(listings['en-GB'].language).to eq('en-GB')
+          end
+
+          it 'gets a single listing' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/listings/en-GB").
+              to_return(status: 200, body: json_data)
+
+            listing = @instance.get_listing('en-GB', edit_id: edit_id, app_id: app_id)
+            expect(listing.language).to eq('en-GB')
+          end
+
+          it 'updates a listing' do
+            stub_request(:put, "#{base_url}/edits/#{edit_id}/listings/en-GB").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 200, body: json_data)
+
+            etag_key = [edit_id, 'en-GB'].join('-')
+            @instance.etag_cache[etag_key] = 'etag-value'
+            listing = Fastlane::ActionSets::Amazon::Listing.new(json_data)
+            result = @instance.update_listing(listing, edit_id: edit_id, app_id: app_id)
+            expect(result.short_description).to eq('Placeholder short description')
+          end
+
+          it 'deletes a listing' do
+            stub_request(:delete, "#{base_url}/edits/#{edit_id}/listings/en-GB").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 204)
+
+            etag_key = [edit_id, 'en-GB'].join('-')
+            @instance.etag_cache[etag_key] = 'etag-value'
+            result = @instance.delete_listing('en-GB', edit_id: edit_id, app_id: app_id)
+            expect(result).to be nil
+          end
+        end
+
+        describe 'details functionality' do
+          let(:json_data) do
+            {
+              'defaultLanguage' => 'en-US',
+              'contactWebsite' => 'https://www.oreilly.com/online-learning/support/',
+              'contactEmail' => 'support@oreilly.com',
+              'contactPhone' => '1-800-889-8969'
+            }
+          end
+
+          it 'gets details' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/details").
+              to_return(status: 200, body: json_data)
+
+            result = @instance.get_details(edit_id: edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::Details.new(json_data))
+          end
+
+          it 'updates details' do
+            stub_request(:put, "#{base_url}/edits/#{edit_id}/details").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 200, body: json_data)
+
+            etag_key = [edit_id, 'details'].join('-')
+            @instance.etag_cache[etag_key] = 'etag-value'
+            details = Fastlane::ActionSets::Amazon::Details.new(json_data)
+            result = @instance.update_details(details, edit_id: edit_id, app_id: app_id)
+            expect(result.contact_email).to eq('apps@oreilly.com')
+          end
+        end
+
+        describe 'APK functionality' do
+          let(:apk_filepath) { File.join(__dir__, '..', '..', 'fixtures', 'mock-app.apk') }
+          let(:apk_id) { 'M8FYZDFK0GJG0 '}
+          let(:json_data) do
+            {
+              'versionCode' => 21040401,
+              'id' => apk_id,
+              'name' => 'APK1'
+            }
+          end
+
+          it 'gets apks' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/apks").
+              to_return(status: 200, body: [json_data])
+
+            result = @instance.get_apks(edit_id: edit_id, app_id: app_id)
+            expect(result).to eq([
+              Fastlane::ActionSets::Amazon::APKMetadata.new(json_data)
+            ])
+          end
+
+          it 'gets a single apk' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/apks/#{apk_id}").
+              to_return(status: 200, body: json_data)
+
+            result = @instance.get_apk(apk_id, edit_id: edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::APKMetadata.new(json_data))
+          end
+
+          it 'deletes an apk' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/apks/#{apk_id}").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 204)
+
+            @instance.etag_cache[apk_id] = 'etag-value'
+            result = @instance.delete_apk(apk_id, edit_id: edit_id, app_id: app_id)
+            expect(result).to be nil
+          end
+
+          it 'replaces an apk' do
+            stub_request(:put, "#{base_url}/edits/#{edit_id}/apks/#{apk_id}/replace").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 200, body: json_data)
+
+            @instance.etag_cache[apk_id] = 'etag-value'
+            result = @instance.replace_apk(apk_id, apk_filepath: apk_filepath, edit_id: edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::APKMetadata.new(json_data))
+          end
+
+          it 'uploads a large apk' do
+            stub_request(:post, "#{base_url}/edits/#{edit_id}/apks/large/upload").
+              to_return(status: 200, body: { id: 'amzn1.devportal.fileupload.abc' })
+
+            result = @instance.upload_large_apk(apk_filepath, edit_id: edit_id, app_id: app_id)
+            expect(result).to eq('amzn1.devportal.fileupload.abc')
+          end
+
+          it 'attaches an uploaded apk' do
+            file_id = 'amzn1.devportal.fileupload.abc'
+
+            stub_request(:post, "#{base_url}/edits/#{edit_id}/apks/attach").
+              to_return(status: 200, body: json_data)
+
+            result = @instance.attach_apk(file_id, edit_id: edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::APKMetadata.new(json_data))
+          end
+
+          it 'uploads and attaches an apk' do
+            stub_request(:post, "#{base_url}/edits/#{edit_id}/apks/upload").
+              to_return(status: 200, body: json_data)
+
+            result = @instance.upload_apk(apk_filepath, edit_id: edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::APKMetadata.new(json_data))
+          end
+        end
+
+        describe 'images functionality' do
+          let(:filepath) { File.join(__dir__, '..', '..', 'fixtures', 'mock-image.png') }
+          let(:language) { 'en-US' }
+          let(:json_data) do
+            [
+              { id: 'amzn1.dex.asset.f98f7b86f7674a7e9ed9192273fc9b56' },
+              { id: 'amzn1.dex.asset.991a8f7d43254282842896da7bd68f5e' }
+            ]
+          end
+
+          it 'gets all images' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/listings/#{language}/screenshots").
+              to_return(status: 200, body: json_data)
+
+            images = @instance.get_images('screenshots', language: language, edit_id: edit_id, app_id: app_id)
+            expect(images).to eq([
+              'amzn1.dex.asset.f98f7b86f7674a7e9ed9192273fc9b56',
+              'amzn1.dex.asset.991a8f7d43254282842896da7bd68f5e'
+            ])
+          end
+
+          it 'uploads an image' do
+            stub_request(:post, "#{base_url}/edits/#{edit_id}/listings/#{language}/screenshots/upload").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 200, body: { id: 'amzn1.dex.asset.abc123' })
+
+            @instance.etag_cache[[edit_id, language].join('-')] = 'etag-value'
+            result = @instance.upload_image(filepath, image_type: 'screenshots', language: language, edit_id: edit_id, app_id: app_id)
+            expect(result).to eq('amzn1.dex.asset.abc123')
+          end
+
+          it 'deletes an image' do
+            asset_id = 'amzn1.dex.asset.abc123'
+
+            stub_request(:delete, "#{base_url}/edits/#{edit_id}/listings/#{language}/screenshots/#{asset_id}").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 204)
+
+            @instance.etag_cache[[edit_id, language].join('-')] = 'etag-value'
+            result = @instance.delete_image(asset_id, image_type: 'screenshots', language: language, edit_id: edit_id, app_id: app_id)
+            expect(result).to be nil
+          end
+
+          it 'deletes all images' do
+            stub_request(:delete, "#{base_url}/edits/#{edit_id}/listings/#{language}/screenshots").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 204)
+
+            @instance.etag_cache[[edit_id, language].join('-')] = 'etag-value'
+            result = @instance.delete_all_images('screenshots', language: language, edit_id: edit_id, app_id: app_id)
+            expect(result).to be nil
+          end
+        end
+
+        describe 'videos functionality' do
+          let(:filepath) { File.join(__dir__, '..', '..', 'fixtures', 'mock-video.mp4') }
+          let(:language) { 'en-US' }
+          let(:json_data) do
+            [
+              { id: 'amzn1.dex.asset.f98f7b86f7674a7e9ed9192273fc9b56' },
+            ]
+          end
+
+          it 'gets all videos' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/listings/#{language}/videos").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 200, body: json_data)
+
+            images = @instance.get_videos(language: language, edit_id: edit_id, app_id: app_id)
+            expect(images).to eq(['amzn1.dex.asset.f98f7b86f7674a7e9ed9192273fc9b56'])
+          end
+
+          it 'uploads a video' do
+            stub_request(:post, "#{base_url}/edits/#{edit_id}/listings/#{language}/videos").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 200, body: { id: 'amz1.dex.asset.video1' })
+
+            @instance.etag_cache[[edit_id, language].join('-')] = 'etag-value'
+            result = @instance.upload_video(filepath, language: language, edit_id: edit_id, app_id: app_id)
+            expect(result).to eq('amz1.dex.asset.video1')
+          end
+
+          it 'deletes a video' do
+            asset_id = 'amz1.dex.asset.video1'
+            stub_request(:delete, "#{base_url}/edits/#{edit_id}/listings/#{language}/videos/#{asset_id}").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 204)
+
+            @instance.etag_cache[[edit_id, language].join('-')] = 'etag-value'
+            result = @instance.delete_video(asset_id, language: language, edit_id: edit_id, app_id: app_id)
+            expect(result).to be nil
+          end
+
+          it 'deletes all videos' do
+            stub_request(:delete, "#{base_url}/edits/#{edit_id}/listings/#{language}/videos").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 204)
+
+            @instance.etag_cache[[edit_id, language].join('-')] = 'etag-value'
+            result = @instance.delete_all_videos(language: language, edit_id: edit_id, app_id: app_id)
+            expect(result).to be nil
+          end
+        end
+
+        describe 'availability functionality' do
+          let(:json_data) do
+            {
+              publishingDate: {
+                dateTime: '2022-02-27T15:19:37',
+                zoneId: 'US/Central'
+              }
+            }
+          end
+          it 'gets availability' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/availability").
+              to_return(status: 200, body: json_data)
+
+            result = @instance.get_availability(edit_id: edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::Availability.new(json_data))
+          end
+
+          it 'updates availability' do
+            stub_request(:put, "#{base_url}/edits/#{edit_id}/availability").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 200, body: json_data)
+
+            etag_key = [edit_id, 'availability'].join('-')
+            @instance.etag_cache[etag_key] = 'etag-value'
+            availability = Fastlane::ActionSets::Amazon::Availability.new(json_data)
+            result = @instance.update_availability(availability, edit_id: edit_id, app_id: app_id)
+            expect(result.publishing_date.zone_id).to eq('US/Central')
+          end
+        end
+
+        describe 'targeting functionality' do
+          let(:apk_id) { 'M8FYZDFK0GJG0 '}
+          let(:json_data) do
+            {
+              'amazonDevices' => [
+                {
+                  "id" => "amzn1.appstore.device.177APHJPEZKTD",
+                  "name" => "Fire TV Stick 4K",
+                  "reason" => {},
+                  "status" => "TARGETING"
+                }
+              ],
+              'nonAmazonDevices' => []
+            }
+          end
+
+          it 'gets targeting' do
+            stub_request(:get, "#{base_url}/edits/#{edit_id}/apks/#{apk_id}/targeting").
+              to_return(status: 200, body: json_data)
+
+            result = @instance.get_targeting(apk_id: apk_id, edit_id: edit_id, app_id: app_id)
+            expect(result).to eq(Fastlane::ActionSets::Amazon::Targeting.new(json_data))
+          end
+
+          it 'updates targeting' do
+            stub_request(:put, "#{base_url}/edits/#{edit_id}/apks/#{apk_id}/targeting").
+              with(headers: { 'If-Match' => 'etag-value' }).
+              to_return(status: 200, body: json_data)
+
+            etag_key = [apk_id, 'targeting'].join('-')
+            @instance.etag_cache[etag_key] = 'etag-value'
+            targeting = Fastlane::ActionSets::Amazon::Targeting.new(json_data)
+            result = @instance.update_targeting(targeting, apk_id: apk_id, edit_id: edit_id, app_id: app_id)
+            expect(result.amazon_devices.count).to eq(1)
+            expect(result.non_amazon_devices.count).to eq(0)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
    * Tests currently fail (see below)
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Fixes #15148

This changeset introduces a new plugin to help Fastlane interface with the Amazon Appstore App Submission API, much like `supply` does with the Google Play Store API.

This pull request is currently a work-in-progress with some changes soon to come from @joshdholtz to help tie things into Fastlane plugin ecosystem.

### Testing Steps

Testing steps are coming soon, and unit tests are currently unhappy due to the use of a new `ActionSets` namespace (this is part of what @joshdholtz will be helping with).
