### PR TITLE
[scan] fix scan build_for_testing when using RelativeToDerivedData build location

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -496,7 +496,7 @@ module Scan
                                     description: "Allows for override of the default `xcodebuild` command",
                                     type: String,
                                     optional: true,
-                                    default_value: "env NSUnbufferedIO=YES xcodebuild"),
+                                    default_value: "env NSUnbufferedIO=YES xcodebuild -IDEBuildLocationStyle=Unique"),
         FastlaneCore::ConfigItem.new(key: :cloned_source_packages_path,
                                     env_name: "SCAN_CLONED_SOURCE_PACKAGES_PATH",
                                     description: "Sets a custom path for Swift Package Manager dependencies",


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Resolves #19632 

### Description
Described in the issue

### Testing Steps
Described in the issue