### PR TITLE
[match] extract the certificate name from provisioning profiles

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -304,6 +304,12 @@ module Match
                                                                            platform: params[:platform]),
                              parsed["TeamIdentifier"].first)
 
+      cert_info = Utils.get_cert_info(parsed["DeveloperCertificates"].first.string).to_h
+      Utils.fill_environment(Utils.environment_variable_name_certificate_name(app_identifier: app_identifier,
+                                                                                        type: prov_type,
+                                                                                    platform: params[:platform]),
+                             cert_info["Common Name"])
+
       Utils.fill_environment(Utils.environment_variable_name_profile_name(app_identifier: app_identifier,
                                                                                     type: prov_type,
                                                                                 platform: params[:platform]),

--- a/match/lib/match/table_printer.rb
+++ b/match/lib/match/table_printer.rb
@@ -33,7 +33,8 @@ module Match
         Utils.environment_variable_name(app_identifier: app_identifier, type: type, platform: platform) => "Profile UUID",
         Utils.environment_variable_name_profile_name(app_identifier: app_identifier, type: type, platform: platform) => "Profile Name",
         Utils.environment_variable_name_profile_path(app_identifier: app_identifier, type: type, platform: platform) => "Profile Path",
-        Utils.environment_variable_name_team_id(app_identifier: app_identifier, type: type, platform: platform) => "Development Team ID"
+        Utils.environment_variable_name_team_id(app_identifier: app_identifier, type: type, platform: platform) => "Development Team ID",
+        Utils.environment_variable_name_certificate_name(app_identifier: app_identifier, type: type, platform: platform) => "Certificate Name"
       }.each do |env_key, name|
         rows << [name, env_key, ENV[env_key]]
       end

--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -31,8 +31,16 @@ module Match
       (base_environment_variable_name(app_identifier: app_identifier, type: type, platform: platform) + ["profile-path"]).join("_")
     end
 
-    def self.get_cert_info(cer_certificate_path)
-      cert = OpenSSL::X509::Certificate.new(File.binread(cer_certificate_path))
+    def self.environment_variable_name_certificate_name(app_identifier: nil, type: nil, platform: :ios)
+      (base_environment_variable_name(app_identifier: app_identifier, type: type, platform: platform) + ["certificate-name"]).join("_")
+    end
+
+    def self.get_cert_info(cer_certificate)
+      # can receive a certificate path or the file data
+      if File.exist?(cer_certificate)
+        cer_certificate = File.binread(cer_certificate)
+      end
+      cert = OpenSSL::X509::Certificate.new(cer_certificate)
 
       # openssl output:
       # subject= /UID={User ID}/CN={Certificate Name}/OU={Certificate User}/O={Organisation}/C={Country}

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -96,6 +96,7 @@ describe Match do
           expect(spaceship).to receive(:certificates_exists).and_return(true)
           expect(spaceship).to receive(:profile_exists).and_return(true)
           expect(spaceship).to receive(:bundle_identifier_exists).and_return(true)
+          expect(Match::Utils).to receive(:get_cert_info).and_return([["Common Name", "fastlane certificate name"]])
 
           Match::Runner.new.run(config)
 
@@ -108,6 +109,8 @@ describe Match do
           profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/98264c6b-5151-4349-8d0f-66691e48ae35.mobileprovision')
           expect(ENV[Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app",
                                                                          type: "appstore")]).to eql(profile_path)
+          expect(ENV[Match::Utils.environment_variable_name_certificate_name(app_identifier: "tools.fastlane.app",
+                                                                             type: "appstore")]).to eql("fastlane certificate name")
         end
 
         it "uses existing certificates and profiles if they exist", requires_security: true do
@@ -178,6 +181,8 @@ describe Match do
           expect(spaceship).to receive(:certificates_exists).and_return(true)
           expect(spaceship).to receive(:profile_exists).and_return(true)
           expect(spaceship).to receive(:bundle_identifier_exists).and_return(true)
+          expect(Match::Utils).to receive(:get_cert_info)
+          expect(Match::Utils).to receive(:get_cert_info).and_return([["Common Name", "fastlane certificate name"]])
 
           allow(Match::Utils).to receive(:is_cert_valid?).and_return(true)
 
@@ -192,6 +197,8 @@ describe Match do
           profile_path = File.expand_path('~/Library/MobileDevice/Provisioning Profiles/736590c3-dfe8-4c25-b2eb-2404b8e65fb8.mobileprovision')
           expect(ENV[Match::Utils.environment_variable_name_profile_path(app_identifier: "tools.fastlane.app",
                                                                          type: "appstore")]).to eql(profile_path)
+          expect(ENV[Match::Utils.environment_variable_name_certificate_name(app_identifier: "tools.fastlane.app",
+                                                                             type: "appstore")]).to eql("fastlane certificate name")
         end
 
         it "fails because of an outdated certificate", requires_security: true do

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -142,6 +142,11 @@ describe Match do
         expect(result).to eq("sigh_tools.fastlane.app_appstore_profile-path")
       end
 
+      it "#environment_variable_name_certificate_name uses the correct env variable" do
+        result = Match::Utils.environment_variable_name_certificate_name(app_identifier: "tools.fastlane.app", type: "appstore")
+        expect(result).to eq("sigh_tools.fastlane.app_appstore_certificate-name")
+      end
+
       it "pre-fills the environment" do
         my_key = "my_test_key"
         uuid = "my_uuid"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Helps with #20165 (would not close it, but it would help make those updates)
I'd like to be able to automatically configure the code sign identity, provisioning profile name, and team id for my targets when using different provisioning profile types (eg enterprise vs appstore).

While we already have ways to get the profile name and team id via match, I've had to write additional code to extract the certificate name. This PR parses the certificate name during the match steps and populates an environment variable to make that name accessible.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

- Added `Match::Util.environment_variable_name_certificate_name` to generate an env variable with the postfix "certificate-name". 
- Updated `Match::Util.get_cert_info` to allow it to parse the certificate name directly out of certificate data rather than just the certificate path
- Update `Match::Runner.fetch_provisioning_profile` to make it use the updated util functions and populate an environment variable with the certificate name associated with each provisioning profile

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Try running match and installing some profiles, and check that the certificate name associated with each provisioning profile is populated.