### PR TITLE
[match] Check validity of provisioning profile certificates when `force_for_new_certificates` option is provided

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -419,7 +419,12 @@ module Match
 
       return false unless portal_profile
 
-      profile_certs_count = portal_profile.fetch_all_certificates.count
+      # When a certificate expires (not revoked) provisioning profile stays valid.
+      # And if we regenerate certificate count will not differ:
+      #   * For portal certificates, we filter out the expired one but includes a new certificate;
+      #   * Profile still contains an expired certificate and is valid.
+      # Thus, we need to check the validity of profile certificates too.
+      profile_certs_count = portal_profile.fetch_all_certificates.select(&:valid?).count
 
       certificate_types =
         case platform


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When a certificate expires (not revoked) provisioning profile stays valid.
And if we regenerate certificate count will not differ:
* For portal certificates, we filter out the expired one but includes a new certificate;
* Profile still contains an expired certificate and is valid.
Thus, we need to check the validity of profile certificates too.

It's my bad that I wasn't counting that the provisioning profile stays valid when certificates expire.

### Description
Simplty add `.select(&:valid?)` 😅

### Testing Steps
* Get the certificate contained in the provisioning profile expired 🤷
* `match(force_for_new_certificates: true)`
