### PR TITLE
[aciton][setup_ci] added timeout param into setup_ci

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_ci.rb
@@ -12,7 +12,7 @@ module Fastlane
           setup_output_paths
         end
 
-        setup_keychain
+        setup_keychain(params)
       end
 
       def self.should_run?(params)
@@ -23,7 +23,7 @@ module Fastlane
         params[:provider] || (Helper.is_circle_ci? ? 'circleci' : nil)
       end
 
-      def self.setup_keychain
+      def self.setup_keychain(params)
         unless Helper.mac?
           UI.message("Skipping Keychain setup on non-macOS CI Agent")
           return
@@ -43,7 +43,7 @@ module Fastlane
           name: keychain_name,
           default_keychain: true,
           unlock: true,
-          timeout: 3600,
+          timeout: params[:timeout],
           lock_when_sleeps: true,
           password: "",
           add_to_search_list: true
@@ -103,7 +103,12 @@ module Fastlane
                                          # Validate both 'travis' and 'circleci' for backwards compatibility, even
                                          # though only the latter receives special treatment by this action
                                          UI.user_error!("A given CI provider '#{value}' is not supported. Available CI providers: 'travis', 'circleci'") unless ["travis", "circleci"].include?(value)
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+                                       env_name: "FL_SETUP_CI_TIMEOUT",
+                                       description: "Set a custom timeout in seconds for keychain.  Set `0` if you want to specify 'no time-out'",
+                                       type: Integer,
+                                       default_value: 3600)
         ]
       end
 
@@ -119,6 +124,10 @@ module Fastlane
         [
           'setup_ci(
             provider: "circleci"
+          )',
+          'setup_ci(
+            provider: "circleci",
+            timeout: 0
           )'
         ]
       end

--- a/fastlane/spec/actions_specs/setup_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_ci_spec.rb
@@ -117,7 +117,7 @@ describe Fastlane do
           stub_const("ENV", { "MATCH_KEYCHAIN_NAME" => "anything" })
           allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
           expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup as a keychain was already specified")
-          described_class.setup_keychain
+          described_class.setup_keychain(timeout: 3600)
         end
       end
 
@@ -129,17 +129,17 @@ describe Fastlane do
         end
 
         it "sets the MATCH_KEYCHAIN_NAME env var" do
-          described_class.setup_keychain
+          described_class.setup_keychain(timeout: 3600)
           expect(ENV["MATCH_KEYCHAIN_NAME"]).to eql("fastlane_tmp_keychain")
         end
 
         it "sets the MATCH_KEYCHAIN_PASSWORD env var" do
-          described_class.setup_keychain
+          described_class.setup_keychain(timeout: 3600)
           expect(ENV["MATCH_KEYCHAIN_PASSWORD"]).to eql("")
         end
 
         it "sets the MATCH_READONLY env var" do
-          described_class.setup_keychain
+          described_class.setup_keychain(timeout: 3600)
           expect(ENV["MATCH_READONLY"]).to eql("true")
         end
       end
@@ -150,7 +150,7 @@ describe Fastlane do
           allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
           allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
           expect(Fastlane::UI).to receive(:message).with("Skipping Keychain setup on non-macOS CI Agent")
-          described_class.setup_keychain
+          described_class.setup_keychain(timeout: 3600)
         end
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
I have been facing a problem in my ci-cd system where with a long Fastlane run the keychain created with the action setup_ci after and hour start giving problems on the execution of the command codesigning. It seems to happen because the timeout of the keychain created on the setup_ci action is hardcoded to 3600, it seems logic and useful to me to have an option to pass a parameter to the action with which we could increase/decrease or set as no timeout to this timeout option. So I have done my best to add an optional parameter to setup_ci with is `timeout` that have the same behavior than the timeout from the create_keychain action that is used under the hood.
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
Add new timeout optional parameter to setup_ci action to customize the timeout of the keychain that is created under the hood. By default this parameter sets as right now is behaving with the 3600 seconds.
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
Execute the `setup_ci` action with a timeout parameter value.
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
