### PR TITLE
[infra] changelog will now show github usernames which makes contributors stand out more in releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -343,12 +343,47 @@ private_lane :send_mac_app_ci_reminder do
   end
 end
 
+desc "Generate changelog from GitHub compare and PR data for mentioning GitHub usernames in release notes"
+private_lane :github_changelog do |options|
+  old_version = options[:old_version] || current_version
+  path = "/repos/fastlane/fastlane/compare/#{old_version}...HEAD"
+
+  # Get all commits from previous version (tag) to HEAD
+  resp = github_api(path: path)
+  body = JSON.parse(resp[:body])
+  commits = body["commits"].reverse
+
+  formatted = commits.map do |commit|
+    # Default to commit message info
+    message = commit["commit"]["message"].lines.first.strip
+    name = commit["commit"]["author"]["name"]
+    username = commit["author"]["login"]
+
+    # Get pull request associate with commit message
+    sha = commit["sha"]
+    pr_resp = github_api(path: "/search/issues?q=repo:fastlane/fastlane+is:pr+base:master+SHA:#{sha}")
+    body = JSON.parse(pr_resp[:body])
+    items = body["items"]
+
+    if items.size == 1
+      item = items.first
+      message = "#{item['title']} (##{item['number']})"
+      username = item["user"]["login"]
+    else
+      UI.user_error!("Cannot generate changelog. Multiple commits found for #{sha}")
+    end
+
+    "* #{message} via #{name} (@#{username})"
+  end.join("\n")
+
+  formatted
+end
+
 desc "Print out the changelog since the last tagged release and open the GitHub page with the changes"
 lane :show_changelog do |options|
   old_version = options[:old_version] || current_version
 
-  changes = sh("git log --pretty='* %s via %aN' #{old_version}...HEAD --no-merges ..", log: $verbose).gsub("\n\n", "\n")
-  changes.gsub!("[WIP]", "") # sometimes a [WIP] is merged
+  changes = github_changelog(old_version: old_version)
 
   github_diff_url = "https://github.com/fastlane/fastlane/compare/#{old_version}...master"
   sh("open #{github_diff_url}")


### PR DESCRIPTION
### Motivation and Context
GitHub releases will now contributors in a special section in a release when their username's are tagged in the release notes

### Description
- Replaced the git command that was previously generating release notes
- New process:
  - Gets commits, message, and name (similar to previous implementation) from GitHub compare API
  - Searches for commit SHA in fastlane repo that was merged into master to generate changelog message from::
    - PR title
    - PR author username
    - PR number

This goal of this new process is to:
1. Use PR title as changelog instead of commit message
2. Also mention the username

## Example

I updated the last release with the changeling generated by this PR

<img width="1437" alt="Screen Shot 2022-04-24 at 9 54 03 PM" src="https://user-images.githubusercontent.com/401294/165013048-cbdc5bf4-ba4a-400d-9e64-a031254284fc.png">
