### PR TITLE
[action][danger] add GitHub Enterprise flags

### DIFF
--- a/fastlane/lib/fastlane/actions/danger.rb
+++ b/fastlane/lib/fastlane/actions/danger.rb
@@ -25,6 +25,8 @@ module Fastlane
         cmd << "pr #{pr}" if pr
 
         ENV['DANGER_GITHUB_API_TOKEN'] = params[:github_api_token] if params[:github_api_token]
+        ENV['DANGER_GITHUB_HOST'] = params[:github_enterprise_host] if params[:github_enterprise_host]
+        ENV['DANGER_GITHUB_API_BASE_URL'] = params[:github_enterprise_api_base_url] if params[:github_enterprise_api_base_url]
 
         Actions.sh(cmd.join(' '))
       end
@@ -63,6 +65,18 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :github_api_token,
                                        env_name: "FL_DANGER_GITHUB_API_TOKEN",
                                        description: "GitHub API token for danger",
+                                       sensitive: true,
+                                       code_gen_sensitive: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :github_enterprise_host,
+                                       env_name: "FL_DANGER_GITHUB_ENTERPRISE_HOST",
+                                       description: "GitHub host URL for GitHub Enterprise",
+                                       sensitive: true,
+                                       code_gen_sensitive: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :github_enterprise_api_base_url,
+                                       env_name: "FL_DANGER_GITHUB_ENTERPRISE_API_BASE_URL",
+                                       description: "GitHub API base URL for GitHub Enterprise",
                                        sensitive: true,
                                        code_gen_sensitive: true,
                                        optional: true),

--- a/fastlane/spec/actions_specs/danger_spec.rb
+++ b/fastlane/spec/actions_specs/danger_spec.rb
@@ -38,6 +38,24 @@ describe Fastlane do
         expect(ENV['DANGER_GITHUB_API_TOKEN']).to eq("1234")
       end
 
+      it "sets github enterprise host" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(github_enterprise_host: 'test.de')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger")
+        expect(ENV['DANGER_GITHUB_HOST']).to eq("test.de")
+      end
+
+      it "sets github enterprise api base url" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(github_enterprise_api_base_url: 'https://test.de/api/v3')
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger")
+        expect(ENV['DANGER_GITHUB_API_BASE_URL']).to eq("https://test.de/api/v3")
+      end
+
       it "appends danger_id" do
         result = Fastlane::FastFile.new.parse("lane :test do
           danger(danger_id: 'unit-tests')
@@ -117,6 +135,23 @@ describe Fastlane do
 
         expect(result).to eq("bundle exec danger --head=master")
       end
+
+      it "appends fail-if-no-pr flag when set" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(fail_if_no_pr: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger --fail-if-no-pr=true")
+      end
+
+      it "does not append fail-if-no-pr flag when unset" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          danger(fail_if_no_pr: false)
+        end").runner.execute(:test)
+
+        expect(result).to eq("bundle exec danger")
+      end
+
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This PR adds missing configurations for using the `danger` action with GitHub Enterprise. This is a nice addition and makes it possible to omit the manual setting of Danger related environment variables before executing fastlane. 

### Description
This PR adds the corresponding ConfigItems and set the corresponding environment variables based on https://danger.systems/guides/getting_started.html#enterprise-github
Additionally I saw that there were no tests present for the `fail-if-no-pr` flag, so I also added them. 

### Testing Steps

1. Checkout and install the following fastlane’s branch.
2. Use the Danger action and test that the GitHub Enterprose environment variables are set correctly.
