### PR TITLE
[scan] fix scan failing to return results when there are test failures

### DIFF
--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -71,13 +71,7 @@ module Fastlane
       def self.available_options
         require 'scan'
 
-        FastlaneCore::CommanderGenerator.new.generate(Scan::Options.available_options) + [
-          FastlaneCore::ConfigItem.new(key: :fail_build,
-                                       env_name: "SCAN_FAIL_BUILD",
-                                       description: "Should this step stop the build if the tests fail? Set this to false if you're using trainer",
-                                       type: Boolean,
-                                       default_value: true)
-        ]
+        FastlaneCore::CommanderGenerator.new.generate(Scan::Options.available_options)
       end
 
       def self.output

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -522,7 +522,12 @@ module Scan
                                     env_name: 'SCAN_NUMBER_OF_RETRIES',
                                     description: "The number of times a test can fail",
                                     type: Integer,
-                                    default_value: 0)
+                                    default_value: 0),
+        FastlaneCore::ConfigItem.new(key: :fail_build,
+                                    env_name: "SCAN_FAIL_BUILD",
+                                    description: "Should this step stop the build if the tests fail? Set this to false if you're using trainer",
+                                    type: Boolean,
+                                    default_value: true)
 
       ]
     end

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -313,7 +313,11 @@ module Scan
       end
 
       unless tests_exit_status == 0
-        UI.test_failure!("Test execution failed. Exit status: #{tests_exit_status}")
+        if Scan.config[:fail_build]
+          UI.test_failure!("Test execution failed. Exit status: #{tests_exit_status}")
+        else
+          UI.error("Test execution failed. Exit status: #{tests_exit_status}")
+        end
       end
 
       open_report

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -305,7 +305,11 @@ module Scan
       if number_of_failures > 0
         open_report
 
-        UI.test_failure!("Tests have failed")
+        if Scan.config[:fail_build]
+          UI.test_failure!("Tests have failed")
+        else
+          UI.error("Tests have failed")
+        end
       end
 
       unless tests_exit_status == 0

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -93,6 +93,39 @@ describe Scan do
         end
       end
 
+      describe "when handling result" do
+        it "returns output if fail_build is false", requires_xcodebuild: true do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            output_directory: '/tmp/scan_results',
+            project: './scan/examples/standard/app.xcodeproj',
+            fail_build: false
+          })
+
+          # This is a needed side effect from running TestCommandGenerator which is not done in this test
+          Scan.cache[:result_bundle_path] = '/tmp/scan_results/test.xcresults'
+
+          allow(Trainer::TestParser).to receive(:auto_convert).and_return({
+            "some/path": {
+              successful: true,
+              number_of_tests: 10,
+              number_of_failures: 1,
+              number_of_tests_excluding_retries: 10,
+              number_of_failures_excluding_retries: 1,
+              number_of_retries: 0
+            }
+          })
+
+          expect(@scan.handle_results(0)).to eq({
+            number_of_tests: 10,
+            number_of_failures: 1,
+            number_of_skipped: 0,
+            number_of_tests_excluding_retries: 10,
+            number_of_failures_excluding_retries: 1,
+            number_of_retries: 0
+        })
+        end
+      end
+
       describe "with scan option :disable_xcpretty set to true" do
         it "does not generate a temp junit report", requires_xcodebuild: true do
           Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {


### PR DESCRIPTION
When using test_failure! method it causes scan to skip sending the output even if `fail_build` is set to false

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #20236

### Description
* While the exception is caught when `fail_build` option is set to false, it still causes the results to not be sent to consumers.
* To fix this I moved the `fail_build` definition from `run_tests` to `scan` and then used the value of `fail_build` to determine whether to raise the exception or to just post a ui error.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Added a unit test to confirm that with `fail_build` set to false it returns the output from the action and that the output contains the correct values.
