### PR TITLE
[spaceship] update `Spaceship::ConnectAPI::User` model to include `delete!` method

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/user.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user.rb
@@ -62,6 +62,11 @@ module Spaceship
         resp = client.get_user_visible_apps(user_id: id, limit: limit)
         return resp.to_models
       end
+
+      def delete!(client: nil)
+        client ||= Spaceship::ConnectAPI
+        client.delete_user(user_id: id)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/user.rb
+++ b/spaceship/lib/spaceship/connect_api/models/user.rb
@@ -57,15 +57,15 @@ module Spaceship
         return all(client: client, filter: { email: email }, includes: includes)
       end
 
+      def delete!(client: nil)
+        client ||= Spaceship::ConnectAPI
+        client.delete_user(user_id: id)
+      end
+
       def get_visible_apps(client: nil, limit: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.get_user_visible_apps(user_id: id, limit: limit)
         return resp.to_models
-      end
-
-      def delete!(client: nil)
-        client ||= Spaceship::ConnectAPI
-        client.delete_user(user_id: id)
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I've been using fastlane and Spaceship to script some batch operations for managing our App Store Connect user access since the web-ui kind of sucks for anything other than one-off changes 😄 

While doing so, I needed to delete some old accounts but noticed that while `Spaceship::ConnectAPI::Users::API` defines a `delete_user` method, it's not exposed on `Spaceship::ConnectAPI::User model` like it is for `UserInvitation`.

https://github.com/fastlane/fastlane/blob/eb4584e0394c1fecccd70d4313260f4707f2af80/spaceship/lib/spaceship/connect_api/users/users.rb#L26-L29

### Description

In this change, I define a new `delete!` method in an almost identical way to `UserInvitation.delete!`

### Testing Steps

N/A