### PR TITLE
[spaceship] update buildDeliveries request to use app id in path

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -362,9 +362,8 @@ module Spaceship
       def get_build_deliveries(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
         filter ||= {}
-        filter[:app] = id
 
-        resps = client.get_build_deliveries(filter: filter, includes: includes, limit: limit, sort: sort).all_pages
+        resps = client.get_build_deliveries(app_id: id, filter: filter, includes: includes, limit: limit, sort: sort).all_pages
         return resps.flat_map(&:to_models)
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/build_delivery.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build_delivery.rb
@@ -27,7 +27,8 @@ module Spaceship
       def self.all(client: nil, app_id: nil, version: nil, build_number: nil)
         client ||= Spaceship::ConnectAPI
         resps = client.get_build_deliveries(
-          filter: { app: app_id, cfBundleShortVersionString: version, cfBundleVersion: build_number },
+          app_id: app_id,
+          filter: { cfBundleShortVersionString: version, cfBundleVersion: build_number },
           limit: 1
         ).all_pages
         return resps.flat_map(&:to_models)

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -448,9 +448,9 @@ module Spaceship
         # buildDeliveries
         #
 
-        def get_build_deliveries(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_build_deliveries(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("buildDeliveries", params)
+          test_flight_request_client.get("apps/#{app_id}/buildDeliveries", params)
         end
 
         #

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -448,7 +448,7 @@ module Spaceship
         # buildDeliveries
         #
 
-        def get_build_deliveries(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_build_deliveries(app_id:, filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
           test_flight_request_client.get("apps/#{app_id}/buildDeliveries", params)
         end

--- a/spaceship/spec/connect_api/fixtures/testflight/build_deliveries.json
+++ b/spaceship/spec/connect_api/fixtures/testflight/build_deliveries.json
@@ -8,20 +8,12 @@
         "platform" : "IOS",
         "uploadedDate" : "2019-05-06T20:14:37-07:00"
       },
-      "relationships" : {
-        "app" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/buildDeliveries/123456789/relationships/app",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/buildDeliveries/123456789/app"
-          }
-        }
-      },
       "links" : {
-        "self" : "https://appstoreconnect.apple.com/iris/v1/buildDeliveries/123456789"
+        "self" : "https://appstoreconnect.apple.com/iris/v1/apps/1234/buildDeliveries/123456789"
       }
     } ],
     "links" : {
-      "self" : "https://appstoreconnect.apple.com/iris/v1/buildDeliveries?filter%5Bplatform%5D=IOS&filter%5Bapp%5D=1460622096"
+      "self" : "https://appstoreconnect.apple.com/iris/v1/apps/1234/buildDeliveries?filter%5Bplatform%5D=IOS&filter%5Bapp%5D=1460622096"
     },
     "meta" : {
       "paging" : {

--- a/spaceship/spec/connect_api/fixtures/testflight/build_delivery.json
+++ b/spaceship/spec/connect_api/fixtures/testflight/build_delivery.json
@@ -8,19 +8,11 @@
         "platform" : "IOS",
         "uploadedDate" : "2019-05-06T20:14:37-07:00"
       },
-      "relationships" : {
-        "app" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/buildDeliveries/123456789/relationships/app",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/buildDeliveries/123456789/app"
-          }
-        }
-      },
       "links" : {
-        "self" : "https://appstoreconnect.apple.com/iris/v1/buildDeliveries/123456789"
+        "self" : "https://appstoreconnect.apple.com/iris/v1/apps/1234/buildDeliveries/123456789"
       }
     },
     "links" : {
-      "self" : "https://appstoreconnect.apple.com/iris/v1/buildDeliveries/123456789"
+      "self" : "https://appstoreconnect.apple.com/iris/v1/apps/1234/buildDeliveries/123456789"
     }
   }

--- a/spaceship/spec/connect_api/models/build_delivery_spec.rb
+++ b/spaceship/spec/connect_api/models/build_delivery_spec.rb
@@ -3,7 +3,7 @@ describe Spaceship::ConnectAPI::BuildDelivery do
 
   describe '#Spaceship::ConnectAPI' do
     it '#get_build_deliveries' do
-      response = Spaceship::ConnectAPI.get_build_deliveries
+      response = Spaceship::ConnectAPI.get_build_deliveries(app_id: "1234")
       expect(response).to be_an_instance_of(Spaceship::ConnectAPI::Response)
 
       expect(response.count).to eq(1)

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -773,7 +773,8 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "buildDeliveries" do
       context 'get_build_deliveries' do
-        let(:path) { "buildDeliveries" }
+        let(:app_id) { "123" }
+        let(:path) { "apps/#{app_id}/buildDeliveries" }
         let(:version) { "189" }
         let(:default_params) { {} }
 
@@ -781,14 +782,14 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
           params = {}
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock).and_return(req_mock)
-          client.get_build_deliveries
+          client.get_build_deliveries(app_id: app_id)
         end
 
         it 'succeeds with filter' do
           params = { filter: { version: version } }
           req_mock = test_request_params(path, params.merge(default_params))
           expect(client).to receive(:request).with(:get).and_yield(req_mock).and_return(req_mock)
-          client.get_build_deliveries(**params)
+          client.get_build_deliveries(app_id: app_id, **params)
         end
       end
     end

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -87,7 +87,7 @@ class ConnectAPIStubbing
       end
 
       def stub_build_deliveries
-        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/buildDeliveries").
+        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps/1234/buildDeliveries").
           to_return(status: 200, body: read_fixture_file('build_deliveries.json'), headers: { 'Content-Type' => 'application/json' })
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #20239

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
`fastlane pilot builds` fails because `buildDeliveries` request fails with:

`[!] The request could not be completed because: (Spaceship::AccessForbiddenError)
	The given operation is not allowed - The resource 'buildDeliveries' does not allow 'GET_COLLECTION'. Allowed operations are: GET_INSTANCE`

It seems that url path for request on AppStore Connect was changed from `/buildDeliveries` (with app id passed in a filter)  to `/apps/<app_id>/buildDeliveries`.

Tested by calling `bundle exec fastlane pilot builds` just after build is uploaded to AppStore Connect when it's still not visible in Testflight and after a while when it is visible in Testflight in `Processing` state

### Testing Steps
Update Gemfile and run bundle install
```ruby
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "lucgrabowski-build-deliveries-request-update"
```
