### PR TITLE
[fastlane] allows aliased tool names (build_app, sync_code_signing, etc) to run from CLI

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -78,6 +78,9 @@ module Fastlane
         tool_name = ARGV.first ? ARGV.first.downcase : nil
 
         tool_name = process_emojis(tool_name)
+        tool_name = map_aliased_tools(tool_name)
+
+        puts "tool_name: #{tool_name}"
 
         if tool_name && Fastlane::TOOLS.include?(tool_name.to_sym) && !available_lanes.include?(tool_name.to_sym)
           # Triggering a specific tool
@@ -123,6 +126,25 @@ module Fastlane
         end
       ensure
         FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)
+      end
+
+      def map_aliased_tools(tool_name)
+        map = {
+          "get_certificates": "cert",
+          "upload_to_app_store": "deliver",
+          "frame_screenshots": "frameit",
+          "build_app": "gym",
+          "build_ios_app": "gym",
+          "build_mac_app": "gym",
+          "sync_code_signing": "match",
+          "get_push_certificate": "pem",
+          "check_app_store_metadata": "precheck",
+          "capture_android_screenshots": "screengrab",
+          "get_provisioning_profile": "sigh",
+          "capture_ios_screenshots": "snapshot",
+          "upload_to_play_store": "supply"
+        }
+        return map[tool_name.to_sym] || tool_name
       end
 
       # Since loading dotenv should respect additional environments passed using

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -80,8 +80,6 @@ module Fastlane
         tool_name = process_emojis(tool_name)
         tool_name = map_aliased_tools(tool_name)
 
-        puts "tool_name: #{tool_name}"
-
         if tool_name && Fastlane::TOOLS.include?(tool_name.to_sym) && !available_lanes.include?(tool_name.to_sym)
           # Triggering a specific tool
           # This happens when the users uses things like

--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -20,6 +20,16 @@ describe Fastlane::CLIToolsDistributor do
         Fastlane::CLIToolsDistributor.take_off
       end
     end
+
+    it "runs a separate aliased tool when the tool is available and the name is not used in a lane" do
+      FastlaneSpec::Env.with_ARGV(["build_app"]) do
+        require 'gym/options'
+        require 'gym/commands_generator'
+        expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileUseToolNameAsLane").at_least(:once)
+        expect(Gym::CommandsGenerator).to receive(:start).and_return(nil)
+        Fastlane::CLIToolsDistributor.take_off
+      end
+    end
   end
 
   describe "update checking" do


### PR DESCRIPTION
### Motivation and Context
Fixes #20240

Tools have aliases that are named for the function they perform. Example: `gym` is aliased as `build_app` and `build_ios_app`.
However, these aliased names could not get run like `fastlane build_app` like you can with `fastlane gym`.

### Description
This fixes the missing functionality by adding a mapping of alias names to tool names.
