### PR TITLE
[fastlane] search plugins in bundler transitive dependencies as well

### DIFF
--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -23,6 +23,12 @@ module Fastlane
       nil
     end
 
+    def lockfile_path
+      Bundler::SharedHelpers.default_lockfile.to_s
+    rescue Bundler::GemfileNotFound
+      nil
+    end
+
     def pluginfile_path
       if FastlaneCore::FastlaneFolder.path
         return File.join(FastlaneCore::FastlaneFolder.path, PLUGINFILE_NAME)
@@ -54,8 +60,9 @@ module Fastlane
     # Returns an array of gems that are added to the Gemfile or Pluginfile
     def available_gems
       return [] unless gemfile_path
-      dsl = Bundler::Dsl.evaluate(gemfile_path, nil, true)
-      return dsl.dependencies.map(&:name)
+      dsl = Bundler::Dsl.evaluate(gemfile_path, lockfile_path, true)
+      dependencies = collect_bundler_runtime_dependencies([], dsl).uniq
+      return dependencies.map(&:name)
     end
 
     # Returns an array of fastlane plugins that are added to the Gemfile or Pluginfile
@@ -393,6 +400,22 @@ module Fastlane
         version_number: version_number,
         actions: references
       }
+    end
+
+    private
+
+    # recursively collect runtime dependencies
+    def collect_bundler_runtime_dependencies(collection, source)
+      runtime_deps = source.dependencies.select { |d| d.type == :runtime }
+      # prevent potential infinite recursion. Should never happen. Better safe than sorry.
+      runtime_deps -= collection
+      collection.concat(runtime_deps)
+      runtime_deps.each do |d|
+        collect_bundler_runtime_dependencies(collection, d.to_spec)
+      rescue Gem::MissingSpecError
+        # ignoring unresolvable dependencies
+      end
+      collection
     end
   end
 end

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/Gemfile
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/Gemfile
@@ -1,0 +1,4 @@
+source("https://rubygems.org")
+
+gem "dependency_with_plugins", path: "dependency_with_plugins/"
+gem "fastlane", path: "../../../../.."

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/Gemfile
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/Gemfile
@@ -1,0 +1,3 @@
+source("https://rubygems.org")
+
+gemspec

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.name        = 'dependency_with_plugins'
   spec.version     = '1.0.0'
-  spec.authors     = ["Fastlane team"]
+  spec.authors     = ["fastlane team"]
 
   spec.required_ruby_version = '>= 2.6'
 

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name        = 'dependency_with_plugins'
+  spec.version     = '1.0.0'
+  spec.authors     = ["Fastlane team"]
+
+  spec.required_ruby_version = '>= 2.5'
+
+  spec.summary = "fake gem for fastlane tests"
+
+  spec.add_dependency('fastlane')
+  spec.add_dependency('fastlane-plugin-appcenter')
+end

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version     = '1.0.0'
   spec.authors     = ["Fastlane team"]
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.summary = "fake gem for fastlane tests"
 

--- a/fastlane/spec/fixtures/plugins/GemfileWithLock
+++ b/fastlane/spec/fixtures/plugins/GemfileWithLock
@@ -1,0 +1,5 @@
+source("https://rubygems.org")
+
+gem "fastlane-plugin-appcenter"
+gem "fastlane_core"
+gem "hemal"

--- a/fastlane/spec/fixtures/plugins/GemfileWithLock.lock
+++ b/fastlane/spec/fixtures/plugins/GemfileWithLock.lock
@@ -1,0 +1,47 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colored (1.2)
+    commander (4.6.0)
+      highline (~> 2.0.0)
+    credentials_manager (0.16.4)
+      colored
+      commander (>= 4.3.5)
+      highline (>= 1.7.1)
+      security
+    excon (0.92.3)
+    fastlane-plugin-appcenter (2.0.0)
+    fastlane_core (0.59.0)
+      colored
+      commander (>= 4.4.0, <= 5.0.0)
+      credentials_manager (>= 0.16.2, < 1.0.0)
+      excon (>= 0.45.0, < 1.0)
+      gh_inspector (>= 1.0.1, < 2.0.0)
+      highline (>= 1.7.2)
+      json
+      multi_json
+      plist (>= 3.1.0, < 4.0.0)
+      rubyzip (~> 1.1.6)
+      terminal-table (>= 1.4.5, < 2.0.0)
+    gh_inspector (1.1.3)
+    hemal (0.0.1)
+    highline (2.0.3)
+    json (2.6.2)
+    multi_json (1.15.0)
+    plist (3.6.0)
+    rubyzip (1.1.7)
+    security (0.1.5)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.8.0)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  fastlane-plugin-appcenter
+  fastlane_core
+  hemal
+
+BUNDLED WITH
+   2.3.13

--- a/fastlane/spec/plugins_specs/plugin_manager_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_manager_spec.rb
@@ -26,6 +26,7 @@ describe Fastlane do
 
       it "returns all fastlane plugins with no fastlane_core" do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/Pluginfile1")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
         expect(plugin_manager.available_gems).to eq(["fastlane-plugin-xcversion", "fastlane_core", "hemal"])
       end
     end
@@ -38,13 +39,32 @@ describe Fastlane do
 
       it "returns all fastlane plugins with no fastlane_core" do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/Pluginfile1")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
         expect(plugin_manager.available_plugins).to eq(["fastlane-plugin-xcversion"])
+      end
+
+      it "returns all fastlane plugins with no fastlane_core and a gemfile lock" do
+        allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/GemfileWithLock")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return("./fastlane/spec/fixtures/plugins/GemfileWithLock.lock")
+        expect(plugin_manager.available_plugins).to eq(["fastlane-plugin-appcenter"])
+      end
+
+      # full integration test
+      it "returns all fastlane plugins found in transitive dependencies" do
+        Bundler.with_unbundled_env do
+          Dir.chdir("fastlane/spec/fixtures/plugins/GemfileWithDeps") do
+            `bundle install`
+            output = `bundle exec fastlane lanes`
+            expect(output.include?("fastlane-plugin-appcenter")).to be true
+          end
+        end
       end
     end
 
     describe "#plugin_is_added_as_dependency?" do
       before do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/Pluginfile1")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
       end
 
       it "returns true if a plugin is available" do
@@ -65,11 +85,13 @@ describe Fastlane do
     describe "#plugins_attached?" do
       it "returns true if plugins are attached" do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/GemfileWithAttached")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
         expect(plugin_manager.plugins_attached?).to eq(true)
       end
 
       it "returns false if plugins are not attached" do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/GemfileWithoutAttached")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
         expect(plugin_manager.plugins_attached?).to eq(false)
       end
     end
@@ -85,6 +107,7 @@ describe Fastlane do
     describe "#update_dependencies!" do
       before do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/Pluginfile1")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
       end
 
       it "execs out the correct command" do

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -14,7 +14,18 @@ UI = FastlaneCore::UI
 unless ENV["DEBUG"]
   fastlane_tests_tmpdir = "#{Dir.tmpdir}/fastlane_tests"
   $stdout.puts("Changing stdout to #{fastlane_tests_tmpdir}, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)")
+  $orig_stdout = $stdout
   $stdout = File.open(fastlane_tests_tmpdir, "w")
+end
+
+# for troubleshooting CI issues on specific tests
+def with_orig_stdout(&block)
+  $orig_stdout.puts("Temporarily re-enabling standard stdout")
+  $stdout, $orig_stdout = $orig_stdout, $stdout
+  yield
+ensure
+  $stdout, $orig_stdout = $orig_stdout, $stdout
+  $orig_stdout.puts("Standard stdout re-disabled")
 end
 
 if FastlaneCore::Helper.mac?

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -18,7 +18,16 @@ unless ENV["DEBUG"]
   $stdout = File.open(fastlane_tests_tmpdir, "w")
 end
 
-# for troubleshooting CI issues on specific tests
+# By default the CI test setup hides the standard output/stderr.
+#
+# Sometimes we wish to enable the original stdout/stderr programmatically in a given test, especially on CI.
+# We can then use the following method to wrap the test code.
+#
+# it 'uses standard test output' do
+#   with_orig_stdout do
+#     ... your test
+#   end
+# end
 def with_orig_stdout(&block)
   $orig_stdout.puts("Temporarily re-enabling standard stdout")
   $stdout, $orig_stdout = $orig_stdout, $stdout


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Today we use import_from_git to import a shared Fastfile/actions. This has several drawbacks, one of which being that we must add all the plugins this shared fastfile uses inside all projects that use `import_from_git`.

We wish to convert this shared repository into a Gem, and add all required plugins as gem dependency to the gem. 

Unfortunately right now the plugin search doesn't look at transitive dependencies. So this PR fixes this.

The next step is to add another feature `import_from_gem` as alternative to `import_from_git` (see #20294).

### Description

### Testing Steps
