### PR TITLE
[Feature] import from gem action

### DIFF
--- a/fastlane/lib/fastlane/actions/import_from_gem.rb
+++ b/fastlane/lib/fastlane/actions/import_from_gem.rb
@@ -1,0 +1,54 @@
+module Fastlane
+  module Actions
+    class ImportFromGemAction < Action
+      def self.run(params)
+        # in fast_file.rb
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Import fastfile/actions from a gem, alternative to import_from_git"
+      end
+
+      # def self.details
+      # end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :gem_name,
+                                       optional: false,
+                                       type: String,
+                                       default_value: "",
+                                       description: "The gem to import Fastfile and actions from"),
+          FastlaneCore::ConfigItem.new(key: :paths,
+                                       description: "The path(s) of the Fastfile in the repository",
+                                       default_value: ['fastlane/Fastfile*'],
+                                       optional: true)
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+
+      def self.output
+        [
+        ]
+      end
+
+      def self.return_value
+      end
+
+      def self.authors
+        ["lacostej/jeromel@kahoot.com"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -397,6 +397,24 @@ module Fastlane
       end
     end
 
+    # @param gem_name [String] The name of the gem to import
+    # @param paths [Array] the list of pattern to expand matching fastfiles to import
+    def import_from_gem(gem_name: nil, paths: ["fastlane/Fastfile*"])
+      UI.message("Importing from gem: #{gem_name}")
+      rubygem = Bundler.rubygems.find_name(gem_name).first
+      raise "Couldn't find gem #{gem_name}" unless rubygem
+
+      gem_path = rubygem.full_gem_path
+
+      fastfiles = paths.map { |r| Dir.glob("#{gem_path}/#{r}") }.flatten
+      raise "No fastfiles found. #{paths}" if fastfiles.empty?
+
+      fastfiles.map do |file_path|
+        UI.message("Importing #{file_path}")
+        import(file_path)
+      end
+    end
+
     #####################################################
     # @!group Versioning helpers
     #####################################################

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -23,6 +23,12 @@ module Fastlane
       nil
     end
 
+    def lockfile_path
+      Bundler::SharedHelpers.default_lockfile.to_s
+    rescue Bundler::GemfileNotFound
+      nil
+    end
+
     def pluginfile_path
       if FastlaneCore::FastlaneFolder.path
         return File.join(FastlaneCore::FastlaneFolder.path, PLUGINFILE_NAME)
@@ -54,8 +60,9 @@ module Fastlane
     # Returns an array of gems that are added to the Gemfile or Pluginfile
     def available_gems
       return [] unless gemfile_path
-      dsl = Bundler::Dsl.evaluate(gemfile_path, nil, true)
-      return dsl.dependencies.map(&:name)
+      dsl = Bundler::Dsl.evaluate(gemfile_path, lockfile_path, true)
+      dependencies = collect_bundler_runtime_dependencies([], dsl).uniq
+      return dependencies.map(&:name)
     end
 
     # Returns an array of fastlane plugins that are added to the Gemfile or Pluginfile
@@ -393,6 +400,22 @@ module Fastlane
         version_number: version_number,
         actions: references
       }
+    end
+
+    private
+
+    # recursively collect runtime dependencies
+    def collect_bundler_runtime_dependencies(collection, source)
+      runtime_deps = source.dependencies.select { |d| d.type == :runtime }
+      # prevent potential infinite recursion. Should never happen. Better safe than sorry.
+      runtime_deps -= collection
+      collection.concat(runtime_deps)
+      runtime_deps.each do |d|
+        collect_bundler_runtime_dependencies(collection, d.to_spec)
+      rescue Gem::MissingSpecError
+        # ignoring unresolvable dependencies
+      end
+      collection
     end
   end
 end

--- a/fastlane/spec/actions_specs/import_from_gem_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_gem_spec.rb
@@ -1,0 +1,35 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "import_from_spec" do
+      it "raises an exception when no gem is given" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_gem
+          end").runner.execute(:test)
+        end.to raise_error("Please pass a gem name to the `import_from_gem` action")
+      end
+
+      it "loads all fastfile paths specified and find the lanes" do
+        Bundler.with_unbundled_env do
+          Dir.chdir("fastlane/spec/fixtures/plugins/ImportFromGem") do
+            `bundle install`
+            output = `bundle exec fastlane lanes`
+            expect(output.index("----- fastlane first")).not_to eq(nil)
+            expect(output.index("----- fastlane second")).not_to eq(nil)
+          end
+        end
+      end
+
+      it "runs imported actions from an imported gem" do
+        Bundler.with_unbundled_env do
+          Dir.chdir("fastlane/spec/fixtures/plugins/ImportFromGem") do
+            `bundle install`
+            output = `bundle exec fastlane first`
+            expect(output.index("Step: example_action")).not_to eq(nil)
+            expect(output.index("App automation done right")).not_to eq(nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/import_from_gem_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_gem_spec.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "import_from_spec" do
@@ -12,6 +14,8 @@ describe Fastlane do
       it "loads all fastfile paths specified and find the lanes" do
         Bundler.with_unbundled_env do
           Dir.chdir("fastlane/spec/fixtures/plugins/ImportFromGem") do
+            path = Dir.mktmpdir
+            `bundle config set --local path #{path}`
             `bundle install`
             output = `bundle exec fastlane lanes`
             expect(output.index("----- fastlane first")).not_to eq(nil)
@@ -23,6 +27,8 @@ describe Fastlane do
       it "runs imported actions from an imported gem" do
         Bundler.with_unbundled_env do
           Dir.chdir("fastlane/spec/fixtures/plugins/ImportFromGem") do
+            path = Dir.mktmpdir
+            `bundle config set --local path #{path}`
             `bundle install`
             output = `bundle exec fastlane first`
             expect(output.index("Step: example_action")).not_to eq(nil)

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/.gitignore
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/Gemfile
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/Gemfile
@@ -1,0 +1,4 @@
+source("https://rubygems.org")
+
+gem "dependency_with_plugins", path: "dependency_with_plugins/"
+gem "fastlane", path: "../../../../.."

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/Gemfile
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/Gemfile
@@ -1,0 +1,3 @@
+source("https://rubygems.org")
+
+gemspec

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
 
   spec.summary = "fake gem for fastlane tests"
 
+  spec.files = Dir.glob("fastlane/**/*", File::FNM_DOTMATCH)
+
   spec.add_dependency('fastlane')
   spec.add_dependency('fastlane-plugin-appcenter')
 end

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.name        = 'dependency_with_plugins'
   spec.version     = '1.0.0'
-  spec.authors     = ["Fastlane team"]
+  spec.authors     = ["fastlane team"]
 
   spec.required_ruby_version = '>= 2.6'
 

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name        = 'dependency_with_plugins'
+  spec.version     = '1.0.0'
+  spec.authors     = ["Fastlane team"]
+
+  spec.required_ruby_version = '>= 2.5'
+
+  spec.summary = "fake gem for fastlane tests"
+
+  spec.add_dependency('fastlane')
+  spec.add_dependency('fastlane-plugin-appcenter')
+end

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/dependency_with_plugins.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version     = '1.0.0'
   spec.authors     = ["Fastlane team"]
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.summary = "fake gem for fastlane tests"
 

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/fastlane/Fastfile
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/fastlane/Fastfile
@@ -1,0 +1,4 @@
+lane :first do
+  UI.message("first fastfile")
+  example_action
+end

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/fastlane/Fastfile.other
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/fastlane/Fastfile.other
@@ -1,0 +1,3 @@
+lane :second do
+  UI.message("second fastfile")
+end

--- a/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/fastlane/actions/example_action.rb
+++ b/fastlane/spec/fixtures/plugins/GemfileWithDeps/dependency_with_plugins/fastlane/actions/example_action.rb
@@ -1,0 +1,16 @@
+module Fastlane
+  module Actions
+    class ExampleActionAction < Action
+      def self.run(params)
+        UI.message("App automation done right")
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.available_options
+      end
+    end
+  end
+end

--- a/fastlane/spec/fixtures/plugins/GemfileWithLock
+++ b/fastlane/spec/fixtures/plugins/GemfileWithLock
@@ -1,0 +1,5 @@
+source("https://rubygems.org")
+
+gem "fastlane-plugin-appcenter"
+gem "fastlane_core"
+gem "hemal"

--- a/fastlane/spec/fixtures/plugins/GemfileWithLock.lock
+++ b/fastlane/spec/fixtures/plugins/GemfileWithLock.lock
@@ -1,0 +1,47 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colored (1.2)
+    commander (4.6.0)
+      highline (~> 2.0.0)
+    credentials_manager (0.16.4)
+      colored
+      commander (>= 4.3.5)
+      highline (>= 1.7.1)
+      security
+    excon (0.92.3)
+    fastlane-plugin-appcenter (2.0.0)
+    fastlane_core (0.59.0)
+      colored
+      commander (>= 4.4.0, <= 5.0.0)
+      credentials_manager (>= 0.16.2, < 1.0.0)
+      excon (>= 0.45.0, < 1.0)
+      gh_inspector (>= 1.0.1, < 2.0.0)
+      highline (>= 1.7.2)
+      json
+      multi_json
+      plist (>= 3.1.0, < 4.0.0)
+      rubyzip (~> 1.1.6)
+      terminal-table (>= 1.4.5, < 2.0.0)
+    gh_inspector (1.1.3)
+    hemal (0.0.1)
+    highline (2.0.3)
+    json (2.6.2)
+    multi_json (1.15.0)
+    plist (3.6.0)
+    rubyzip (1.1.7)
+    security (0.1.5)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.8.0)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  fastlane-plugin-appcenter
+  fastlane_core
+  hemal
+
+BUNDLED WITH
+   2.3.13

--- a/fastlane/spec/fixtures/plugins/ImportFromGem/.gitignore
+++ b/fastlane/spec/fixtures/plugins/ImportFromGem/.gitignore
@@ -1,0 +1,2 @@
+fastlane/README.md
+Gemfile.lock

--- a/fastlane/spec/fixtures/plugins/ImportFromGem/Gemfile
+++ b/fastlane/spec/fixtures/plugins/ImportFromGem/Gemfile
@@ -1,0 +1,4 @@
+source("https://rubygems.org")
+
+gem "dependency_with_plugins", path: "../GemfileWithDeps/dependency_with_plugins/"
+gem "fastlane", path: "../../../../.."

--- a/fastlane/spec/fixtures/plugins/ImportFromGem/fastlane/Fastfile
+++ b/fastlane/spec/fixtures/plugins/ImportFromGem/fastlane/Fastfile
@@ -1,0 +1,1 @@
+import_from_gem(gem_name: "dependency_with_plugins")

--- a/fastlane/spec/plugins_specs/plugin_manager_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_manager_spec.rb
@@ -26,6 +26,7 @@ describe Fastlane do
 
       it "returns all fastlane plugins with no fastlane_core" do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/Pluginfile1")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
         expect(plugin_manager.available_gems).to eq(["fastlane-plugin-xcversion", "fastlane_core", "hemal"])
       end
     end
@@ -38,13 +39,32 @@ describe Fastlane do
 
       it "returns all fastlane plugins with no fastlane_core" do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/Pluginfile1")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
         expect(plugin_manager.available_plugins).to eq(["fastlane-plugin-xcversion"])
+      end
+
+      it "returns all fastlane plugins with no fastlane_core and a gemfile lock" do
+        allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/GemfileWithLock")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return("./fastlane/spec/fixtures/plugins/GemfileWithLock.lock")
+        expect(plugin_manager.available_plugins).to eq(["fastlane-plugin-appcenter"])
+      end
+
+      # full integration test
+      it "returns all fastlane plugins found in transitive dependencies" do
+        Bundler.with_unbundled_env do
+          Dir.chdir("fastlane/spec/fixtures/plugins/GemfileWithDeps") do
+            `bundle install`
+            output = `bundle exec fastlane lanes`
+            expect(output.include?("fastlane-plugin-appcenter")).to be true
+          end
+        end
       end
     end
 
     describe "#plugin_is_added_as_dependency?" do
       before do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/Pluginfile1")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
       end
 
       it "returns true if a plugin is available" do
@@ -65,11 +85,13 @@ describe Fastlane do
     describe "#plugins_attached?" do
       it "returns true if plugins are attached" do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/GemfileWithAttached")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
         expect(plugin_manager.plugins_attached?).to eq(true)
       end
 
       it "returns false if plugins are not attached" do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/GemfileWithoutAttached")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
         expect(plugin_manager.plugins_attached?).to eq(false)
       end
     end
@@ -85,6 +107,7 @@ describe Fastlane do
     describe "#update_dependencies!" do
       before do
         allow(Bundler::SharedHelpers).to receive(:default_gemfile).and_return("./fastlane/spec/fixtures/plugins/Pluginfile1")
+        allow(Bundler::SharedHelpers).to receive(:default_lockfile).and_return(nil)
       end
 
       it "execs out the correct command" do

--- a/fastlane/spec/plugins_specs/plugin_manager_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_manager_spec.rb
@@ -53,6 +53,8 @@ describe Fastlane do
       it "returns all fastlane plugins found in transitive dependencies" do
         Bundler.with_unbundled_env do
           Dir.chdir("fastlane/spec/fixtures/plugins/GemfileWithDeps") do
+            path = Dir.mktmpdir
+            `bundle config set --local path #{path}`
             `bundle install`
             output = `bundle exec fastlane lanes`
             expect(output.include?("fastlane-plugin-appcenter")).to be true

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -21,6 +21,7 @@ describe Fastlane do
           testfairy
           ipa
           import_from_git
+          import_from_gem
           hockey
           deploygate
           crashlytics

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -14,7 +14,18 @@ UI = FastlaneCore::UI
 unless ENV["DEBUG"]
   fastlane_tests_tmpdir = "#{Dir.tmpdir}/fastlane_tests"
   $stdout.puts("Changing stdout to #{fastlane_tests_tmpdir}, set `DEBUG` environment variable to print to stdout (e.g. when using `pry`)")
+  $orig_stdout = $stdout
   $stdout = File.open(fastlane_tests_tmpdir, "w")
+end
+
+# for troubleshooting CI issues on specific tests
+def with_orig_stdout(&block)
+  $orig_stdout.puts("Temporarily re-enabling standard stdout")
+  $stdout, $orig_stdout = $orig_stdout, $stdout
+  yield
+ensure
+  $stdout, $orig_stdout = $orig_stdout, $stdout
+  $orig_stdout.puts("Standard stdout re-disabled")
 end
 
 if FastlaneCore::Helper.mac?

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -18,7 +18,16 @@ unless ENV["DEBUG"]
   $stdout = File.open(fastlane_tests_tmpdir, "w")
 end
 
-# for troubleshooting CI issues on specific tests
+# By default the CI test setup hides the standard output/stderr.
+#
+# Sometimes we wish to enable the original stdout/stderr programmatically in a given test, especially on CI.
+# We can then use the following method to wrap the test code.
+#
+# it 'uses standard test output' do
+#   with_orig_stdout do
+#     ... your test
+#   end
+# end
 def with_orig_stdout(&block)
   $orig_stdout.puts("Temporarily re-enabling standard stdout")
   $stdout, $orig_stdout = $orig_stdout, $stdout


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This builds on top of #20293

We wish to replace `import_from_git` with this new action to use gem files to package the shared Fastfile and its dependencies. Together with the transitive dependencies it simplifies the use of a shared Fastfile.

We modify our repository containing our shared Gemfile by
* replacing our shared repo's Gemfile by a gemspec
* moving all Plugins into the gemspec file
* replacing the `fastlane_version "x.y.z"` in the shared Fastfile with a proper version constraint in the gemspec. For consumer projects, bundler will resolve the right dependency when needed

For our consumer projects this gives the following results:
* the project's gemfile contains a single dependency to the shared Gem (instead of one
```
gem 'name_of_gem', git: 'URL_GIT_REPO'
```
* we remove from the Pluginfile all dependencies now managed by bundler
* we replace our Fastfile import from

```
import_from_git(url: "URL_GIT_REPO", dependencies: [...])
```
to
```
import_from_gem(gem_name: "name_of_gem")
```

Extra benefits: builds are now reproducible. Updating the shared fastfile requires doing an update in the corresponding user projects.
 
I am opening this for discussion and can clean the code, add tests as needed.

Who can provide some feedback on this? @joshdholtz maybe?

### Description

### Testing Steps
