### PR TITLE
[Regression][fastlane] Fixed fastlane command issue when tool name not provided

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -78,7 +78,7 @@ module Fastlane
         tool_name = ARGV.first ? ARGV.first.downcase : nil
 
         tool_name = process_emojis(tool_name)
-        tool_name = map_aliased_tools(tool_name)
+        tool_name = map_aliased_tools(tool_name) unless tool_name.nil?
 
         if tool_name && Fastlane::TOOLS.include?(tool_name.to_sym) && !available_lanes.include?(tool_name.to_sym)
           # Triggering a specific tool

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -78,7 +78,7 @@ module Fastlane
         tool_name = ARGV.first ? ARGV.first.downcase : nil
 
         tool_name = process_emojis(tool_name)
-        tool_name = map_aliased_tools(tool_name) unless tool_name.nil?
+        tool_name = map_aliased_tools(tool_name)
 
         if tool_name && Fastlane::TOOLS.include?(tool_name.to_sym) && !available_lanes.include?(tool_name.to_sym)
           # Triggering a specific tool
@@ -142,7 +142,7 @@ module Fastlane
           "capture_ios_screenshots": "snapshot",
           "upload_to_play_store": "supply"
         }
-        return map[tool_name.to_sym] || tool_name
+        return map[tool_name&.to_sym] || tool_name
       end
 
       # Since loading dotenv should respect additional environments passed using


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Resolves #20292
- The Fastlane command without tool-name is broken, after this [PR](https://github.com/fastlane/fastlane/pull/20287) 
- Please see the above issue for more details

### Description
- Handle condition if tool_name is `nil`, basically skip the tool_name mapped look-up if nil.

### Testing Steps

- Update `Gemfile` to 👇 and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "crazymanish-fastlane-tools-name-fix"
```
- Try to run Fastlane command without tool-name i.e
```ruby
bundle exec fastlane
```

