### PR TITLE
[pem] fixed "\x82" from ASCII-8BIT to UTF-8 when saving .p12 files to disk

### DIFF
--- a/pem/lib/pem/manager.rb
+++ b/pem/lib/pem/manager.rb
@@ -81,7 +81,7 @@ module PEM
           p12_cert_path = File.join(output_path, "#{filename_base}.p12")
           p12_password = PEM.config[:p12_password] == "" ? nil : PEM.config[:p12_password]
           p12 = OpenSSL::PKCS12.create(p12_password, certificate_type, pkey, x509_certificate)
-          File.write(p12_cert_path, p12.to_der)
+          File.write(p12_cert_path, p12.to_der.force_encoding("UTF-8"))
           UI.message("p12 certificate: ".green + Pathname.new(p12_cert_path).realpath.to_s)
         end
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

As I was writing code to generate .p12 files, I faced this error:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/8419048/170161590-aa62806c-d970-4892-8774-569d0dfe42be.png">

…even though my `env` was correct:

| Variable | Value       |   |
| -------- | ----------- | - |
| LANG     | en_US.UTF-8 | ✅ |
| LC_ALL   | en_US.UTF-8 | ✅ |
| LANGUAGE | en_US.UTF-8 | ✅ |

### Description

This PR just copies the same strategy applied here https://github.com/fastlane/fastlane/pull/17446 to fix this very same issue.
After applying the fix, the result was successful:

<img width="695" alt="image" src="https://user-images.githubusercontent.com/8419048/170162302-2fbe00af-c4ad-418c-beec-7345408009dd.png">

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem 'fastlane', git: 'https://github.com/fastlane/fastlane.git', branch: 'rogerluan-fix-pem-encoding'
```

And run `bundle install` to apply the changes.

Then run the following command:

```ruby
lane :generate_push_certificate do
  username = prompt(text: "Enter your username (e.g. email@example.com): ")
  password = "test"
  get_push_certificate(
    force: true, # create a new profile, even if the old one is still valid
    development: true,
    app_identifier: "com.test.test",
    username: username,
    p12_password: password,
    save_private_key: true,
    new_profile: proc do |profile_path| # this block gets called when a new profile was generated
      puts profile_path # the absolute path to the new PEM file
      # insert the code to upload the PEM file to the server
    end
  )
end
```