### PR TITLE
Allow overriding the architecture to run xcodebuild under

### DIFF
--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -267,10 +267,11 @@ module Fastlane
 
         output_result = ""
 
+        override_architecture_prefix = params[:xcodebuild_architecture] ? "arch -#{params[:xcodebuild_architecture]} " : ""
         # In some cases the simulator is not booting up in time
         # One way to solve it is to try to rerun it for one more time
         begin
-          output_result = Actions.sh "set -o pipefail && xcodebuild #{xcodebuild_args} #{pipe_command}"
+          output_result = Actions.sh "set -o pipefail && #{override_architecture_prefix}xcodebuild #{xcodebuild_args} #{pipe_command}"
         rescue => ex
           exit_status = $?.exitstatus
 
@@ -383,8 +384,9 @@ module Fastlane
           ['scheme', 'The scheme to build'],
           ['build_settings', 'Hash of additional build information'],
           ['xcargs', 'Pass additional xcodebuild options'],
-          ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
+          ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
+          ['xcodebuild_architecture', 'Allows to set the architecture that `xcodebuild` is run with, for example to force it to run under Rosetta on an Apple Silicon mac'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
           ['xcpretty_utf', 'Specifies xcpretty should use utf8 when reporting builds. This has no effect when raw_buildlog is specified.']
@@ -437,6 +439,7 @@ module Fastlane
           ['build_settings', 'Hash of additional build information'],
           ['xcargs', 'Pass additional xcodebuild options'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
+          ['xcodebuild_architecture', 'Allows to set the architecture that `xcodebuild` is run with, for example to force it to run under Rosetta on an Apple Silicon mac'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
@@ -529,6 +532,7 @@ module Fastlane
           ['build_settings', 'Hash of additional build information'],
           ['xcargs', 'Pass additional xcodebuild options'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
+          ['xcodebuild_architecture', 'Allows to set the architecture that `xcodebuild` is run with, for example to force it to run under Rosetta on an Apple Silicon mac'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
@@ -571,6 +575,7 @@ module Fastlane
           ['build_settings', 'Hash of additional build information'],
           ['xcargs', 'Pass additional xcodebuild options'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
+          ['xcodebuild_architecture', 'Allows to set the architecture that `xcodebuild` is run with, for example to force it to run under Rosetta on an Apple Silicon mac'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],
@@ -621,6 +626,7 @@ module Fastlane
           ['destination_timeout', 'The timeout for connecting to the simulator, in seconds'],
           ['enable_code_coverage', 'Turn code coverage on or off when testing. eg. true|false. Requires Xcode 7+'],
           ['output_style', 'Set the output format to one of: :standard (Colored UTF8 output, default), :basic (black & white ASCII output)'],
+          ['xcodebuild_architecture', 'Allows to set the architecture that `xcodebuild` is run with, for example to force it to run under Rosetta on an Apple Silicon mac'],
           ['buildlog_path', 'The path where the xcodebuild.log will be created, by default it is created in ~/Library/Logs/fastlane/xcbuild'],
           ['raw_buildlog', 'Set to true to see xcodebuild raw output. Default value is false'],
           ['xcpretty_output', 'specifies the output type for xcpretty. eg. \'test\', or \'simple\''],

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -560,6 +560,44 @@ describe Fastlane do
       end
     end
 
+    describe 'overriding xcodebuild architecture' do
+      it 'does not override the architecture if the option is not present' do
+        result = Fastlane::FastFile.new.parse("lane :build do
+          xcodebuild(
+            scheme: 'MyApp',
+            workspace: 'MyApp.xcworkspace',
+          )
+        end").runner.execute(:build)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "xcodebuild " \
+          + "-scheme \"MyApp\" " \
+          + "-workspace \"MyApp.xcworkspace\" " \
+          + "| tee '#{build_log_path}' | xcpretty --color --simple"
+        )
+      end
+
+      it 'overrides the architecture with what is specified if the option is present' do
+        result = Fastlane::FastFile.new.parse("lane :build do
+          xcodebuild(
+            scheme: 'MyApp',
+            workspace: 'MyApp.xcworkspace',
+            xcodebuild_architecture: 'x86_64'
+          )
+        end").runner.execute(:build)
+
+        expect(result).to eq(
+          "set -o pipefail && " \
+          + "arch -x86_64 " \
+          + "xcodebuild " \
+          + "-scheme \"MyApp\" " \
+          + "-workspace \"MyApp.xcworkspace\" " \
+          + "| tee '#{build_log_path}' | xcpretty --color --simple"
+        )
+      end
+    end
+
     describe "test code coverage" do
       it "code coverage is enabled" do
         result = Fastlane::FastFile.new.parse("lane :test do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. (N/A) 

### Motivation and Context

This allows users to set explicitly what architecture to run xcodebuild as. For example, fastlane might be running under Rosetta, but `xcodebuild` should be running natively, or fastlane might be running natively but `xcodebuild` should be running under Rosetta.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

With a simple test app: 

```
fastlane run xcodebuild scheme:Test project:Test.xcodeproj xcodebuild_architecture:x86_64 destination:"platform=iOS Simulator,name=iPhone 11"
[✔] 🚀
[13:32:19]: ------------------------
[13:32:19]: --- Step: xcodebuild ---
[13:32:19]: ------------------------
[13:32:19]: For a more detailed xcodebuild log open /Users/wallman/Library/Logs/fastlane/xcbuild/2022-05-25/67935/xcodebuild.log
[13:32:19]: $ set -o pipefail && arch -x86_64 xcodebuild -scheme "Test" -project "Test.xcodeproj" -destination "platform=iOS Simulator,name=iPhone 11" | tee '/Users/wallman/Library/Logs/fastlane/xcbuild/2022-05-25/67935/xcodebuild.log' | xcpretty --color --simple
[13:32:21]: ▸ Build Succeeded
▸ Build Succeeded
```

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

N/A