### PR TITLE
[spaceship] Allow for removing app from sale by updating territories

### DIFF
--- a/deliver/lib/deliver/upload_price_tier.rb
+++ b/deliver/lib/deliver/upload_price_tier.rb
@@ -12,7 +12,9 @@ module Deliver
       app = Deliver.cache[:app]
 
       attributes = {}
-      territory_ids = []
+
+      # Check App update method to understand how to use territory_ids.
+      territory_ids = nil # nil won't update app's territory_ids, empty array would remove app from sale.
 
       # As of 2020-09-14:
       # Official App Store Connect does not have an endpoint to get app prices for an app

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -101,6 +101,8 @@ module Spaceship
         return client.get_app(app_id: app_id, includes: includes).first
       end
 
+      # Updates app attributes, price tier and availability of an app in territories
+      # Check Tunes patch_app method for explanation how to use territory_ids parameter to not remove app from sale by mistake
       def update(client: nil, attributes: nil, app_price_tier_id: nil, territory_ids: nil)
         client ||= Spaceship::ConnectAPI
         attributes = reverse_attr_mapping(attributes)

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -102,11 +102,11 @@ module Spaceship
       end
 
       # Updates app attributes, price tier and availability of an app in territories
-      # Check Tunes patch_app method for explanation how to use territory_ids parameter to not remove app from sale by mistake
-      def update(client: nil, attributes: nil, app_price_tier_id: nil, territory_ids: nil)
+      # Check Tunes patch_app method for explanation how to use territory_ids parameter with allow_removing_from_sale to remove app from sale
+      def update(client: nil, attributes: nil, app_price_tier_id: nil, territory_ids: nil, allow_removing_from_sale: false)
         client ||= Spaceship::ConnectAPI
         attributes = reverse_attr_mapping(attributes)
-        return client.patch_app(app_id: id, attributes: attributes, app_price_tier_id: app_price_tier_id, territory_ids: territory_ids)
+        return client.patch_app(app_id: id, attributes: attributes, app_price_tier_id: app_price_tier_id, territory_ids: territory_ids, allow_removing_from_sale: allow_removing_from_sale)
       end
 
       #

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -134,7 +134,7 @@ module Spaceship
           tunes_request_client.post("apps", body)
         end
 
-        # Updates app attributes, price tier, visibility in regions or countries. 
+        # Updates app attributes, price tier, visibility in regions or countries.
         # Use territory_ids with allow_removing_from_sale to remove app from sale
         # @param territory_ids updates app visibility in regions or countries.
         #   Possible values:

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -173,10 +173,10 @@ module Spaceship
           end
 
           # Territories
-          territories_data = (territory_ids || []).map do |id|
-            { type: "territories", id: id }
-          end
-          unless territories_data.empty?
+          unless territory_ids.nil?
+            territories_data = (territory_ids).map do |id|
+              { type: "territories", id: id }
+            end
             relationships[:availableTerritories] = {
               data: territories_data
             }

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -134,6 +134,11 @@ module Spaceship
           tunes_request_client.post("apps", body)
         end
 
+        # @param territory_ids updates app visibility in regions or countries.
+        #   Possible values:
+        #   empty array will remove app from sale,
+        #   array with territory ids will set availability to territories with those ids,
+        #   nil will leave app availability on AppStore as is
         def patch_app(app_id: nil, attributes: {}, app_price_tier_id: nil, territory_ids: nil)
           relationships = {}
           included = []

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -134,12 +134,15 @@ module Spaceship
           tunes_request_client.post("apps", body)
         end
 
+        # Updates app attributes, price tier, visibility in regions or countries. 
+        # Use territory_ids with allow_removing_from_sale to remove app from sale
         # @param territory_ids updates app visibility in regions or countries.
         #   Possible values:
-        #   empty array will remove app from sale,
+        #   empty array will remove app from sale if allow_removing_from_sale is true,
         #   array with territory ids will set availability to territories with those ids,
         #   nil will leave app availability on AppStore as is
-        def patch_app(app_id: nil, attributes: {}, app_price_tier_id: nil, territory_ids: nil)
+        # @param allow_removing_from_sale allows for removing app from sale when territory_ids is an empty array
+        def patch_app(app_id: nil, attributes: {}, app_price_tier_id: nil, territory_ids: nil, allow_removing_from_sale: false)
           relationships = {}
           included = []
 
@@ -182,9 +185,11 @@ module Spaceship
             territories_data = territory_ids.map do |id|
               { type: "territories", id: id }
             end
-            relationships[:availableTerritories] = {
-              data: territories_data
-            }
+            if !territories_data.empty? || allow_removing_from_sale
+              relationships[:availableTerritories] = {
+                data: territories_data
+              }
+            end
           end
 
           # Data

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -174,7 +174,7 @@ module Spaceship
 
           # Territories
           unless territory_ids.nil?
-            territories_data = (territory_ids).map do |id|
+            territories_data = territory_ids.map do |id|
               { type: "territories", id: id }
             end
             relationships[:availableTerritories] = {


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
There are 3 discussions with questions about removing apps from sale: https://github.com/fastlane/fastlane/discussions/19040, https://github.com/fastlane/fastlane/discussions/17032, https://github.com/fastlane/fastlane/discussions/19375
This change allows for removing an app from sale by updating a list of territories.
```ruby
app = ... # fetch app
# 
app.update(attributes:{ "availableInNewTerritories": false }, territory_ids:[], allow_removing_from_sale: true) 
```
### Description
It was not possible to remove app from all territories as app update method expected either `nil` or an array of `territory_ids` with at least one territory id.

Just for explain use of `availableInNewTerritories`: 
`availableInNewTerritories` attribute is responsible for `New Countries or Regions` checkbox
<img width="482" alt="available in new territories" src="https://user-images.githubusercontent.com/34243011/170453754-a8708976-d3db-4007-be3a-9a39df2d54b4.png">

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Tested by removing an app from sale using code above in `irb`