### PR TITLE
[snapshot] Add missing iPod touch to Generated Snapshot Reports

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -132,7 +132,7 @@ module Snapshot
         'iPad Pro (12.9-inch)' => 'iPad Pro (12.9-inch)',
         'iPad Pro (12.9 inch)' => 'iPad Pro (12.9-inch)', # iOS 10.3.1 simulator
         'iPad Pro' => 'iPad Pro (12.9-inch)', # iOS 9.3 simulator
-        'iPod touch (7th generation)' => 'iPod touch (7th generation)', 
+        'iPod touch (7th generation)' => 'iPod touch (7th generation)',
         'Apple TV 1080p' => 'Apple TV',
         'Apple TV 4K (at 1080p)' => 'Apple TV 4K (at 1080p)',
         'Apple TV 4K' => 'Apple TV 4K',

--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -132,6 +132,7 @@ module Snapshot
         'iPad Pro (12.9-inch)' => 'iPad Pro (12.9-inch)',
         'iPad Pro (12.9 inch)' => 'iPad Pro (12.9-inch)', # iOS 10.3.1 simulator
         'iPad Pro' => 'iPad Pro (12.9-inch)', # iOS 9.3 simulator
+        'iPod touch (7th generation)' => 'iPod touch (7th generation)', 
         'Apple TV 1080p' => 'Apple TV',
         'Apple TV 4K (at 1080p)' => 'Apple TV 4K (at 1080p)',
         'Apple TV 4K' => 'Apple TV 4K',


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
I noticed reviewing our generated snapshot images that although the iPod touch (testing smallest screen size still supported) screenshots were generated, they were not included in the output HTML file.

### Description
Added missing `iPod touch (7th generation)` simulator name to the definitions used to output generated HTML files.
