### PR TITLE
[action][update_info_plist] improve the plist file-path option validation check

### DIFF
--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -80,7 +80,7 @@ module Fastlane
                                        description: "Path to info plist",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("Invalid plist file") unless value.end_with?(".plist")
+                                         UI.user_error!("Invalid plist file") unless value.downcase.end_with?(".plist")
                                        end),
           FastlaneCore::ConfigItem.new(key: :scheme,
                                        env_name: "FL_UPDATE_PLIST_APP_SCHEME",

--- a/fastlane/lib/fastlane/actions/update_info_plist.rb
+++ b/fastlane/lib/fastlane/actions/update_info_plist.rb
@@ -80,7 +80,7 @@ module Fastlane
                                        description: "Path to info plist",
                                        optional: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("Invalid plist file") unless value[-6..-1].casecmp(".plist").zero?
+                                         UI.user_error!("Invalid plist file") unless value.end_with?(".plist")
                                        end),
           FastlaneCore::ConfigItem.new(key: :scheme,
                                        env_name: "FL_UPDATE_PLIST_APP_SCHEME",


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
- Plist file-path Validation block was using range `[-6..-1]` which is a kind of magical number range for non-ruby developer

### Description
- Improve the plist file-path option validation check using `value.end_with?(".plist")` which is more readable, i hope 😍

### Testing Steps
- N/A