### PR TITLE
[fastlane][ci] Bump the latest version of CircleCI Xcode for unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,8 +273,8 @@ workflows:
           ruby_version: '3.0'
           ruby_opt: -W:deprecated
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 13.0.0, Ruby 3.1)'
-          xcode_version: '13.0.0'
+          name: 'Execute tests on macOS (Xcode 13.4.0, Ruby 3.1)'
+          xcode_version: '13.4.0'
           ruby_version: '3.1'
           ruby_opt: -W:deprecated
       - tests_ubuntu:


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
- Unit tests were running on the Old Xcode version.

### Description
- Bump the latest version of CircleCI Xcode for unit tests
- Now combination is: latest `ruby 3.1` + latest `Xcode 13.4`

### Screenshot
<img width="600" alt="Schermafbeelding 2022-06-05 om 10 43 37 PM" src="https://user-images.githubusercontent.com/5364500/172069988-7ff6f6b0-6143-4f80-9352-a3ab544988d5.png">
