### PR TITLE
[frameit] add Device Google Pixel 5

### DIFF
--- a/frameit/lib/frameit/device_types.rb
+++ b/frameit/lib/frameit/device_types.rb
@@ -50,6 +50,7 @@ module Frameit
     MIDNIGHT ||= "Midnight"
     STARLIGHT ||= "Starlight"
     SIERRA ||= "Sierra"
+    SORTA_SAGE ||= "Sorta Sage"
 
     def self.all_colors
       Color.constants.map { |c| Color.const_get(c).upcase.gsub(' ', '_') }
@@ -85,6 +86,7 @@ module Frameit
     # Google Pixel 4's priority should be higher than Samsung Galaxy S10+ (priority 8):
     GOOGLE_PIXEL_4 ||= Frameit::Device.new("google-pixel-4", "Google Pixel 4", 9, [[1080, 2280], [2280, 1080]], 444, Color::JUST_BLACK, Platform::ANDROID)
     GOOGLE_PIXEL_4_XL ||= Frameit::Device.new("google-pixel-4-xl", "Google Pixel 4 XL", 9, [[1440, 3040], [3040, 1440]], 537, Color::JUST_BLACK, Platform::ANDROID)
+    GOOGLE_PIXEL_5 ||= Frameit::Device.new("google-pixel-5", "Google Pixel 5", 10, [[1080, 2340], [2340, 1080]], 432, Color::JUST_BLACK, Platform::ANDROID)
     HTC_ONE_A9 ||= Frameit::Device.new("htc-one-a9", "HTC One A9", 6, [[1080, 1920], [1920, 1080]], 441, Color::BLACK, Platform::ANDROID)
     HTC_ONE_M8 ||= Frameit::Device.new("htc-one-m8", "HTC One M8", 3, [[1080, 1920], [1920, 1080]], 441, Color::BLACK, Platform::ANDROID)
     HUAWEI_P8 ||= Frameit::Device.new("huawei-p8", "Huawei P8", 5, [[1080, 1920], [1920, 1080]], 424, Color::BLACK, Platform::ANDROID)

--- a/frameit/spec/device_spec.rb
+++ b/frameit/spec/device_spec.rb
@@ -56,6 +56,12 @@ describe Frameit::Device do
     end
 
     describe "valid Android screen sizes" do
+
+      it "should detect Google Pixel 5 in portrait and landscape based on priority" do
+        expect_screen_size_from_file("pixel-portrait{1080x2340}.png", Platform::ANDROID).to eq(Devices::GOOGLE_PIXEL_5)
+        expect_screen_size_from_file("pixel-landscape{2340x1080}.png", Platform::ANDROID).to eq(Devices::GOOGLE_PIXEL_5)
+      end
+
       it "should detect Google Pixel 3 XL in portrait and landscape based on priority" do
         expect_screen_size_from_file("pixel-portrait{1440x2960}.png", Platform::ANDROID).to eq(Devices::GOOGLE_PIXEL_3_XL)
         expect_screen_size_from_file("pixel-landscape{2960x1440}.png", Platform::ANDROID).to eq(Devices::GOOGLE_PIXEL_3_XL)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Adds support for Google Pixel 5 device with correct resolution and with colors `Just Black` and `Sorta Sage`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Related: https://github.com/fastlane/frameit-frames/pull/27

Also added the color `Sorta Sage`, but there is an issue where the file is not found, as there is a wrong character in the filename. See below:

<img width="518" alt="Bildschirmfoto 2022-06-17 um 11 07 08" src="https://user-images.githubusercontent.com/3984453/174266487-bbad680b-1f8e-4aff-b9fd-80161cbd37c7.png">

When changing the filename to a regular whitespace, everything works as expected. This should be fixed in `https://github.com/fastlane/frameit-frames` 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

To test this branch, modify your Gemfile as:

gem "fastlane", :git => "https://github.com/denrase/fastlane.git", :branch => "denrase-support-pixel-5"
And run bundle install to apply the changes.
