### PR TITLE
[match] improve Match::CommandsGenerator's decrypt option unit test

### DIFF
--- a/match/spec/commands_generator_spec.rb
+++ b/match/spec/commands_generator_spec.rb
@@ -73,6 +73,9 @@ describe Match::CommandsGenerator do
   describe ":decrypt option handling" do
     def expect_githelper_clone_with(git_url, shallow_clone, git_branch)
       fake_storage = "fake_storage"
+      fake_working_directory = "fake_working_directory"
+      fake_encryption = "fake_encryption"
+
       expect(Match::Storage::GitStorage).to receive(:configure).with({
         git_url: git_url,
         shallow_clone: shallow_clone,
@@ -81,11 +84,16 @@ describe Match::CommandsGenerator do
       }).and_return(fake_storage)
 
       expect(fake_storage).to receive(:download)
-      allow(fake_storage).to receive(:working_directory).and_return("yolo_path")
+      allow(fake_storage).to receive(:working_directory).and_return(fake_working_directory)
       allow(fake_storage).to receive(:keychain_name).and_return("https://github.com/fastlane/certs")
 
-      expect(FastlaneCore::UI).to receive(:success).with(/Successfully decrypted certificates/)
-      expect(FastlaneCore::UI).to receive(:success).with(/Repo is at/)
+      expect(Match::Encryption).to receive(:for_storage_mode).with("git", {
+        git_url: git_url,
+        working_directory: fake_working_directory
+      }).and_return(fake_encryption)
+
+      expect(fake_encryption).to receive(:decrypt_files)
+      expect(FastlaneCore::UI).to receive(:success).with("Repo is at: '#{fake_working_directory}'")
     end
 
     it "can use the git_url short flag from tool options" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `Match::CommandsGenerator's` **decrypt option** unit-test was calling the `real Match::Encryption` call with fake/stub input, which is not doing much but just one success message.

### Description
- In this PR, Improved test. Now using `fake/mock Match::Encryption` call instead of real
- With mock/fake Match::Encryption we are still checking `expect(fake_encryption).to receive(:decrypt_files)` to ensure that `decrypt_files` call is made 

### Testing Steps
- CI jobs should be green
