### PR TITLE
[Fastlane.swift] Show http error message from AppStore

### DIFF
--- a/fastlane/swift/SocketClient.swift
+++ b/fastlane/swift/SocketClient.swift
@@ -310,7 +310,7 @@ extension SocketClient: StreamDelegate {
             LaneFile.fastfileInstance?.onError(currentLane: ArgumentProcessor(args: CommandLine.arguments).currentLane, errorInfo: failureInformation.joined(), errorClass: failureClass, errorMessage: failureMessage)
             socketDelegate?.commandExecuted(serverResponse: .serverError) {
                 $0.writeSemaphore.signal()
-                self.handleFailure(message: failureInformation)
+                self.handleFailure(message: failureMessage.map {m in [m] + failureInformation} ?? failureInformation)
             }
 
         case let .parseFailure(failureInformation):


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Currently, Fastlane swift only shows a ruby stacktrace when a http error message rises, which is useless:
```
[1655712352.510837]: error encountered while executing command:
serverError
[1655712352.5108562]: Encountered a problem: FastlaneCore::Interface::FastlaneError:
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane_core/lib/fastlane_core/ui/interface.rb:141:in `user_error!'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in `method_missing'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/pilot/lib/pilot/build_manager.rb:19:in `upload'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/actions/upload_to_testflight.rb:34:in `run'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/runner.rb:263:in `block (2 levels) in execute_action'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/actions/actions_helper.rb:69:in `execute_action'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/runner.rb:255:in `block in execute_action'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/runner.rb:229:in `chdir'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/runner.rb:229:in `execute_action'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server_action_command_executor.rb:73:in `run'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server_action_command_executor.rb:42:in `execute'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server.rb:181:in `execute_action_command'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server.rb:176:in `process_action_command'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server.rb:123:in `handle_action_command'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server.rb:86:in `parse_and_execute_command'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server.rb:62:in `block in receive_and_process_commands'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server.rb:49:in `loop'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server.rb:49:in `receive_and_process_commands'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server.rb:158:in `listen'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/server/socket_server.rb:38:in `start'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/commands_generator.rb:167:in `block (2 levels) in run'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in `run!'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/commands_generator.rb:354:in `run'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/commands_generator.rb:43:in `start'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane/lib/fastlane/cli_tools_distributor.rb:123:in `take_off'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/bin/fastlane:23:in `<top (required)>'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/bin/fastlane:25:in `load'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/bin/fastlane:25:in `<main>'
[1655712352.5108628]: Done running lane: deliverAppStore 🚀
```

### Description
With this change, the important http message "No ipa or pkg file given" is added to the beginning of the error output, too.
```
[1655712352.510837]: error encountered while executing command:
serverError
[1655712352.5108562]: Encountered a problem: No ipa or pkg file given
FastlaneCore::Interface::FastlaneError:
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane_core/lib/fastlane_core/ui/interface.rb:141:in `user_error!'
/Users/julian/.brew/Cellar/fastlane/2.206.2/libexec/gems/fastlane-2.206.2/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in `method_missing'
```

