### PR TITLE
[fastlane-core][scan] added destination param support inside the `xcodebuild` command

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -356,7 +356,7 @@ module FastlaneCore
       # This xcodebuild bug is fixed in Xcode 8.3 so 'clean' it's not necessary anymore
       # See: https://github.com/fastlane/fastlane/pull/5626
       if FastlaneCore::Helper.xcode_at_least?('8.3')
-        command = "xcodebuild -showBuildSettings #{xcodebuild_parameters.join(' ')}#{build_xcodebuild_destination}"
+        command = "xcodebuild -showBuildSettings #{xcodebuild_parameters.join(' ')}#{xcodebuild_destination_parameter}"
       else
         command = "xcodebuild clean -showBuildSettings #{xcodebuild_parameters.join(' ')}"
       end
@@ -365,24 +365,25 @@ module FastlaneCore
 
     def build_xcodebuild_resolvepackagedependencies_command
       return nil if options[:skip_package_dependencies_resolution]
-      command = "xcodebuild -resolvePackageDependencies #{xcodebuild_parameters.join(' ')}#{build_xcodebuild_destination}"
+      command = "xcodebuild -resolvePackageDependencies #{xcodebuild_parameters.join(' ')}#{xcodebuild_destination_parameter}"
       command
     end
 
-    def build_xcodebuild_destination
-      # Xcode13+ xcodebuild command 'without destination param' generates annoying warnings
+    def xcodebuild_destination_parameter
+      # Xcode13+ xcodebuild command 'without destination parameter' generates annoying warnings
       # See: https://github.com/fastlane/fastlane/issues/19579
-      destination = ""
+      destination_parameter = ""
       xcode_at_least_13 = FastlaneCore::Helper.xcode_at_least?("13")
       if xcode_at_least_13 && options[:destination]
         begin
-          destination = " " + "-destination #{options[:destination].shellescape}"
+          destination_parameter = " " + "-destination #{options[:destination].shellescape}"
         rescue => ex
-          # we really don't care about destination warnings if something goes wrong with shellescape
-          UI.important("Failed to set destination for xcodebuild command: #{ex}")
+          # xcodebuild command can continue without destination parameter, so
+          # we really don't care about this exception if something goes wrong with shellescape
+          UI.important("Failed to set destination parameter for xcodebuild command: #{ex}")
         end
       end
-      destination
+      destination_parameter
     end
 
     # Get the build settings for our project

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -377,7 +377,7 @@ module FastlaneCore
       if xcode_at_least_13 && options[:destination]
         begin
           destination = " " + "-destination #{options[:destination].shellescape}"
-        rescue=> ex
+        rescue => ex
           # we really don't care about destination warnings if something goes wrong with shellescape
           UI.important("Failed to set destination for xcodebuild command: #{ex}")
         end

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -342,6 +342,13 @@ module FastlaneCore
         proj << "-disableAutomaticPackageResolution"
       end
 
+      # Xcode13+ xcodebuild command 'without destination param' generates annoying warnings
+      # See: https://github.com/fastlane/fastlane/issues/19579
+      xcode_at_least_13 = FastlaneCore::Helper.xcode_at_least?("13")
+      if xcode_at_least_13 && options[:destination]
+        proj << "-destination #{options[:destination].shellescape}"
+      end
+
       return proj
     end
 

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -603,18 +603,18 @@ describe FastlaneCore do
           it 'generates an xcodebuild -showBuildSettings command that includes destination', requires_xcode: true do
             project = FastlaneCore::Project.new({
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
-              destination: "name=iPhone 13 Pro Max"
+              destination: "FakeDestination"
             })
-            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination name\\=iPhone\\ 13\\ Pro\\ Max"
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination FakeDestination"
             expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
           end
 
           it 'generates an xcodebuild -resolvePackageDependencies command that includes destination' do
             project = FastlaneCore::Project.new({
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
-              destination: "name=iPhone 13 Pro Max"
+              destination: "FakeDestination"
               })
-            command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination name\\=iPhone\\ 13\\ Pro\\ Max"
+            command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination FakeDestination"
             expect(project.build_xcodebuild_resolvepackagedependencies_command).to eq(command)
           end
         end
@@ -649,7 +649,7 @@ describe FastlaneCore do
           it 'generates an xcodebuild -showBuildSettings command that does not include destination', requires_xcode: true do
             project = FastlaneCore::Project.new({
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
-              destination: "name=iPhone 13 Pro Max"
+              destination: "FakeDestination"
             })
             command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
             expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
@@ -658,7 +658,7 @@ describe FastlaneCore do
           it 'generates an xcodebuild -resolvePackageDependencies command that does not include destination' do
             project = FastlaneCore::Project.new({
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
-              destination: "name=iPhone 13 Pro Max"
+              destination: "FakeDestination"
               })
             command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
             expect(project.build_xcodebuild_resolvepackagedependencies_command).to eq(command)

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -591,6 +591,100 @@ describe FastlaneCore do
       end
     end
 
+    describe "xcodebuild destination parameter" do
+      context "when xcode version is at_least 13" do
+        before(:each) do
+          allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("8.3").and_return(true)
+          allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("11.0").and_return(true)
+          allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("13").and_return(true)
+        end
+
+        context "when destination parameter is provided in options" do
+          it 'generates an xcodebuild -showBuildSettings command that includes destination', requires_xcode: true do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+              destination: "name=iPhone 13 Pro Max"
+            })
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination name\\=iPhone\\ 13\\ Pro\\ Max"
+            expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+          end
+
+          it 'generates an xcodebuild -resolvePackageDependencies command that includes destination' do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+              destination: "name=iPhone 13 Pro Max"
+              })
+            command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination name\\=iPhone\\ 13\\ Pro\\ Max"
+            expect(project.build_xcodebuild_resolvepackagedependencies_command).to eq(command)
+          end
+        end
+
+        context "when destination parameter is not provided in options" do
+          it 'generates an xcodebuild -showBuildSettings command that does not include destination', requires_xcode: true do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            })
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+          end
+
+          it 'generates an xcodebuild -resolvePackageDependencies command that does not include destination' do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+              })
+            command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            expect(project.build_xcodebuild_resolvepackagedependencies_command).to eq(command)
+          end
+        end
+      end
+
+      context "when xcode version is less than 13" do
+        before(:each) do
+          allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("8.3").and_return(true)
+          allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("11.0").and_return(true)
+          allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("13").and_return(false)
+        end
+
+        context "when destination parameter is provided in options" do
+          it 'generates an xcodebuild -showBuildSettings command that does not include destination', requires_xcode: true do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+              destination: "name=iPhone 13 Pro Max"
+            })
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+          end
+
+          it 'generates an xcodebuild -resolvePackageDependencies command that does not include destination' do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+              destination: "name=iPhone 13 Pro Max"
+              })
+            command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            expect(project.build_xcodebuild_resolvepackagedependencies_command).to eq(command)
+          end
+        end
+
+        context "when destination parameter is not provided in options" do
+          it 'generates an xcodebuild -showBuildSettings command that does not include destination', requires_xcode: true do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            })
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+          end
+
+          it 'generates an xcodebuild -resolvePackageDependencies command that does not include destination' do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+              })
+            command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            expect(project.build_xcodebuild_resolvepackagedependencies_command).to eq(command)
+          end
+        end
+      end
+    end
+
     describe "#project_paths" do
       it "works with basic projects" do
         project = FastlaneCore::Project.new({

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -328,6 +328,7 @@ describe FastlaneCore do
         options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
         @project = FastlaneCore::Project.new(options)
         allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("11.0").and_return(false)
+        allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("13").and_return(false)
         expect(FastlaneCore::Helper).to receive(:xcode_at_least?).with("8.3").and_return(true)
         command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
         expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 3, retries: 3, print: true }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
@@ -338,6 +339,7 @@ describe FastlaneCore do
         options = { project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" }
         @project = FastlaneCore::Project.new(options)
         allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("11.0").and_return(false)
+        allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("13").and_return(false)
         expect(FastlaneCore::Helper).to receive(:xcode_at_least?).with("8.3").and_return(false)
         command = "xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
         expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 3, retries: 3, print: true }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
@@ -565,6 +567,7 @@ describe FastlaneCore do
       it 'build_settings() should not add SPM path if Xcode < 11' do
         allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("8.3").and_return(true)
         expect(FastlaneCore::Helper).to receive(:xcode_at_least?).with("11.0").and_return(false)
+        expect(FastlaneCore::Helper).to receive(:xcode_at_least?).with("13").and_return(false)
         project = FastlaneCore::Project.new({
           project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
           cloned_source_packages_path: "./path/to/resolve"

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -209,6 +209,12 @@ module Scan
 
     def self.detect_destination
       if Scan.config[:destination]
+        # No need to show below warnings message(s) for xcode13+, because
+        # Apple recommended to have destination in all xcodebuild commands
+        # otherwise, Apple will generate warnings in console logs
+        # see: https://github.com/fastlane/fastlane/issues/19579
+        return if Helper.xcode_at_least?("13.0")
+
         UI.important("It's not recommended to set the `destination` value directly")
         UI.important("Instead use the other options available in `fastlane scan --help`")
         UI.important("Using your value '#{Scan.config[:destination]}' for now")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- Resolves #19579
- Xcode13+ **xcodebuild command** `'without destination param'` generates annoying warnings

### Description
- Start supporting `'destination param'` for Xcode13+ **xcodebuild command**

### Testing Steps

- Update `Gemfile` to 👇 and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "crazymanish-xcodebuild-destination-param-fix"
```
- Try to run unit tests using `scan`
```ruby
scan(destination: "name=iPhone 13 Pro Max,OS=15.4") # adjust it based on your Xcode version.
```

## DemoApp for testing
- Open/UnZip [DemoApp.zip](https://github.com/fastlane/fastlane/files/8952930/DemoApp.zip) 
- Goto terminal for DemoApp folder location
- `bundle exec fastlane run_unit_test` # this will show warning similar to original issue
- later
- To test fix: `bundle exec fastlane run_unit_test_with_destination` # should not show warnings

### Demo screenshot
<img width="857" alt="Schermafbeelding 2022-06-21 om 10 39 24 PM" src="https://user-images.githubusercontent.com/5364500/174901212-d9af3cbc-6f8e-478c-937b-be3b2c697312.png">
 