### PR TITLE
[Ruby] Ruby 2.6 is now the minimum (dropping Ruby 2.5)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,10 @@ jobs:
       - *cache_restore_bundler
 
       - run:
+          name: Install Python
+          command: |
+            brew install python@3.8
+      - run:
           name: Setup Build
           command: |
             gem update --system

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,10 +203,6 @@ jobs:
       - *cache_restore_bundler
 
       - run:
-          name: Install Python
-          command: |
-            brew install python@3.8
-      - run:
           name: Setup Build
           command: |
             gem update --system
@@ -286,7 +282,7 @@ workflows:
           ruby_version: '2.7'
       - validate_documentation:
           name: 'Validate Documentation'
-          ruby_version: 'circleci/ruby:2.6'
+          ruby_version: 'fastlanetools/ci:0.3.0'
       - lint_source_code:
           name: 'Lint source code'
           ruby_version: 'circleci/ruby:2.6'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,10 +255,6 @@ workflows:
   build:
     jobs:
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 11.7.0, Ruby 2.5)'
-          xcode_version: '11.7.0'
-          ruby_version: '2.5'
-      - tests_macos:
           name: 'Execute tests on macOS (Xcode 11.7.0, Ruby 2.6)'
           xcode_version: '11.7.0'
           ruby_version: '2.6'
@@ -286,10 +282,10 @@ workflows:
           ruby_version: '2.7'
       - validate_documentation:
           name: 'Validate Documentation'
-          ruby_version: 'circleci/ruby:2.5'
+          ruby_version: 'circleci/ruby:2.6'
       - lint_source_code:
           name: 'Lint source code'
-          ruby_version: 'circleci/ruby:2.5'
+          ruby_version: 'circleci/ruby:2.6'
       - modules_load_up_tests:
           name: 'Modules load up tests'
-          ruby_version: 'circleci/ruby:2.5'
+          ruby_version: 'circleci/ruby:2.6'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
   - ./rubocop/is_string_usage.rb
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: enable
   Include:
     - '**/*.rb'
@@ -23,6 +23,12 @@ AllCops:
     - '**/lib/assets/MatchfileTemplate'
     - '**/spec/fixtures/broken_files/broken_file.rb'
     - '**/*.provisionprofile'
+
+Lint/ErbNewArguments:
+  Enabled: false
+
+Style/SlicingWithRange:
+  Enabled: false
 
 Style/MultipleComparison:
   Enabled: false

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/fastlane/fastlane"
   }
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.files = Dir.glob("*/lib/**/*", File::FNM_DOTMATCH) + Dir["fastlane/swift/**/*"] + Dir["bin/*"] + Dir["*/README.md"] + %w(README.md LICENSE .yardopts) - Dir["fastlane/lib/fastlane/actions/device_grid/assets/*"] - Dir["fastlane/lib/fastlane/actions/docs/assets/*"]
   spec.bindir = "bin"

--- a/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
+++ b/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.6'
 
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency


### PR DESCRIPTION
### Motivation and Context

Ruby 2.5 has been end-of-lifed 1 year and 2 months ago on March 31st, 2021.

Some of our dependencies are bumping to a minimum of Ruby 2.6 which causes some rough installations. Specifically, `signet`'s latest release of `0.17` no longer supports Ruby 2.5 and `signet` is used by a bunch of Google gems.

### Description

- Bumped `fastlane.gemspec` to minimum Ruby 2.6
- Bumped `.rubocop.yml` to target of Ruby 2.6
- Updated CircleCI to no longer have a Ruby 2.5
- Updated plugin template to use Ruby 2.6
