### PR TITLE
[match] add imports, fix linting errors, rename env variable

### DIFF
--- a/match/lib/match/encryption.rb
+++ b/match/lib/match/encryption.rb
@@ -19,7 +19,7 @@ module Match
             params[:keychain_name] = params[:s3_bucket]
             return Encryption::OpenSSL.configure(params)
           },
-          "gitlab_secure_files" => lambda { |params| 
+          "gitlab_secure_files" => lambda { |params|
             return nil
           }
         }

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -225,7 +225,7 @@ module Match
 
         # Storage: GitLab Secure Files
         FastlaneCore::ConfigItem.new(key: :gitlab_project,
-                                     env_name: "GITLAB_PROJECT",
+                                     env_name: "MATCH_GITLAB_PROJECT",
                                      description: "GitLab Project Path (i.e. 'gitlab-org/gitlab')",
                                      optional: true),
 

--- a/match/lib/match/storage.rb
+++ b/match/lib/match/storage.rb
@@ -20,7 +20,7 @@ module Match
           },
           "gitlab_secure_files" => lambda { |params|
             return Storage::GitLabSecureFiles.configure(params)
-          },
+          }
         }
       end
 

--- a/match/lib/match/storage/gitlab/client.rb
+++ b/match/lib/match/storage/gitlab/client.rb
@@ -1,3 +1,8 @@
+require 'net/http/post/multipart'
+require 'securerandom'
+
+require_relative '../../module'
+require_relative './secure_file'
 
 module Match
   module Storage
@@ -51,7 +56,7 @@ module Match
         end
 
         def find_file_by_name(name)
-          files.select{|secure_file| secure_file.file.name == name}.first
+          files.select { |secure_file| secure_file.file.name == name }.first
         end
 
         def upload_file(current_file, target_file)

--- a/match/lib/match/storage/gitlab/secure_file.rb
+++ b/match/lib/match/storage/gitlab/secure_file.rb
@@ -1,8 +1,12 @@
+require 'open-uri'
+
+require_relative '../../module'
+
 module Match
   module Storage
     class GitLab
       class SecureFile
-        attr_reader :client, :file 
+        attr_reader :client, :file
 
         def initialize(file:, client:)
           @file   = OpenStruct.new(file)
@@ -20,7 +24,7 @@ module Match
         def destination_file_path
           filename = @file.name.split('/').last
 
-          @file.name.gsub(filename, '').gsub(/^\//, '')
+          @file.name.gsub(filename, '').gsub(%r{^/}, '')
         end
 
         def valid_checksum?(file)
@@ -56,7 +60,6 @@ module Match
 
           @client.execute_request(url, request)
         end
-
       end
     end
   end

--- a/match/spec/storage/gitlab/client_spec.rb
+++ b/match/spec/storage/gitlab/client_spec.rb
@@ -1,9 +1,12 @@
 describe Match do
   describe Match::Storage::GitLab::Client do
-    subject { described_class.new(
-      api_v4_url: 'https://gitlab.example.com/api/v4', 
-      project_id: 'sample/project',
-      private_token: 'abc123') }
+    subject {
+      described_class.new(
+        api_v4_url: 'https://gitlab.example.com/api/v4',
+        project_id: 'sample/project',
+        private_token: 'abc123'
+    )
+    }
 
     describe '#base_url' do
       it 'returns the expected base_url for the given configuration' do
@@ -14,8 +17,8 @@ describe Match do
     describe '#authentication_key' do
       it 'returns the job_token header key if job_token defined' do
         client = described_class.new(
-          api_v4_url: 'https://gitlab.example.com/api/v4', 
-          project_id: 'sample/project', 
+          api_v4_url: 'https://gitlab.example.com/api/v4',
+          project_id: 'sample/project',
           job_token: 'abc123'
         )
         expect(client.authentication_key).to eq('JOB-TOKEN')
@@ -23,38 +26,38 @@ describe Match do
 
       it 'returns private_token header key if private_key defined and job_token is not defined' do
         client = described_class.new(
-          api_v4_url: 'https://gitlab.example.com/api/v4', 
-          project_id: 'sample/project', 
+          api_v4_url: 'https://gitlab.example.com/api/v4',
+          project_id: 'sample/project',
           private_token: 'xyz123'
         )
-        expect(client.authentication_key).to eq('PRIVATE-TOKEN')      
+        expect(client.authentication_key).to eq('PRIVATE-TOKEN')
       end
 
       it 'returns the job_token header key if both job_token and private_token are defined, and prints a warning to the logs' do
         expect_any_instance_of(FastlaneCore::Shell).to receive(:important).with("JOB_TOKEN and PRIVATE_TOKEN both defined, using JOB_TOKEN to execute this job.")
 
         client = described_class.new(
-          api_v4_url: 'https://gitlab.example.com/api/v4', 
-          project_id: 'sample/project', 
-          job_token: 'abc123', 
+          api_v4_url: 'https://gitlab.example.com/api/v4',
+          project_id: 'sample/project',
+          job_token: 'abc123',
           private_token: 'xyz123'
         )
-        expect(client.authentication_key).to eq('JOB-TOKEN')      
+        expect(client.authentication_key).to eq('JOB-TOKEN')
       end
 
       it 'returns nil if job_token and private_token are both undefined' do
         client = described_class.new(
-          api_v4_url: 'https://gitlab.example.com/api/v4', 
+          api_v4_url: 'https://gitlab.example.com/api/v4',
           project_id: 'sample/project'
         )
-        expect(client.authentication_key).to be_nil           
+        expect(client.authentication_key).to be_nil
       end
     end
 
     describe '#authentication_value' do
       it 'returns the job_token value if job_token defined' do
         client = described_class.new(
-          api_v4_url: 'https://gitlab.example.com/api/v4', 
+          api_v4_url: 'https://gitlab.example.com/api/v4',
           project_id: 'sample/project',
           job_token: 'abc123'
         )
@@ -63,43 +66,43 @@ describe Match do
 
       it 'returns private_token value if private_key defined and job_token is not defined' do
         client = described_class.new(
-          api_v4_url: 'https://gitlab.example.com/api/v4', 
+          api_v4_url: 'https://gitlab.example.com/api/v4',
           project_id: 'sample/project',
           private_token: 'xyz123'
         )
-        expect(client.authentication_value).to eq('xyz123')      
+        expect(client.authentication_value).to eq('xyz123')
       end
 
       it 'returns the job_token value if both job_token and private_token are defined, and prints a warning to the logs' do
         expect_any_instance_of(FastlaneCore::Shell).to receive(:important).with("JOB_TOKEN and PRIVATE_TOKEN both defined, using JOB_TOKEN to execute this job.")
 
         client = described_class.new(
-          api_v4_url: 'https://gitlab.example.com/api/v4', 
+          api_v4_url: 'https://gitlab.example.com/api/v4',
           project_id: 'sample/project',
-          job_token: 'abc123', 
+          job_token: 'abc123',
           private_token: 'xyz123'
         )
-        expect(client.authentication_value).to eq('abc123')      
+        expect(client.authentication_value).to eq('abc123')
       end
 
       it 'returns nil if job_token and private_token are both undefined' do
         client = described_class.new(
-          api_v4_url: 'https://gitlab.example.com/api/v4', 
+          api_v4_url: 'https://gitlab.example.com/api/v4',
           project_id: 'sample/project'
         )
-        expect(client.authentication_value).to be_nil           
+        expect(client.authentication_value).to be_nil
       end
-    end    
+    end
 
     describe '#files' do
       it 'returns an array of secure files for a project' do
         response = [
           { id: 1, name: 'file1' },
-          { id: 2, name: 'file2' },
+          { id: 2, name: 'file2' }
         ].to_json
 
         stub_request(:get, /gitlab.example.com/).
-          with(headers: {'PRIVATE-TOKEN'=>'abc123'}).
+          with(headers: { 'PRIVATE-TOKEN' => 'abc123' }).
           to_return(status: 200, body: response)
 
         files = subject.files
@@ -109,18 +112,18 @@ describe Match do
 
       it 'returns an empty array if there are results' do
         stub_request(:get, /gitlab.example.com/).
-          with(headers: {'PRIVATE-TOKEN'=>'abc123'}).
+          with(headers: { 'PRIVATE-TOKEN' => 'abc123' }).
           to_return(status: 200, body: [].to_json)
 
-        expect(subject.files.count).to be(0)      
+        expect(subject.files.count).to be(0)
       end
 
       it 'raises an exception for a non-json response' do
         stub_request(:get, /gitlab.example.com/).
-          with(headers: {'PRIVATE-TOKEN'=>'abc123'}).
+          with(headers: { 'PRIVATE-TOKEN' => 'abc123' }).
           to_return(status: 200, body: 'foo')
 
-        expect{ subject.files }.to raise_error(JSON::ParserError)
+        expect { subject.files }.to raise_error(JSON::ParserError)
       end
     end
 

--- a/match/spec/storage/gitlab/secure_file_spec.rb
+++ b/match/spec/storage/gitlab/secure_file_spec.rb
@@ -3,19 +3,22 @@ describe Match do
   describe Match::Storage::GitLab::SecureFile do
     let(:client) {
       Match::Storage::GitLab::Client.new(
-        api_v4_url: 'https://gitlab.example.com/api/v4', 
+        api_v4_url: 'https://gitlab.example.com/api/v4',
         project_id: 'sample/project',
-        private_token: 'abc123')
+        private_token: 'abc123'
+)
     }
 
-    subject { described_class.new(
-      file: file, 
-      client: client)
+    subject {
+      described_class.new(
+        file: file,
+        client: client
+)
     }
 
     describe '#file_url' do
       context 'returns the expected file_url for the given configuration' do
-        let(:file) { {id: 1} }
+        let(:file) { { id: 1 } }
 
         it { expect(subject.file_url).to eq('https://gitlab.example.com/api/v4/projects/sample%2Fproject/secure_files/1') }
       end
@@ -23,19 +26,19 @@ describe Match do
 
     describe '#destination_file_path' do
       context 'strips the leading / if supplied' do
-        let(:file) { {name: '/a/b/c/myfile'} }
+        let(:file) { { name: '/a/b/c/myfile' } }
 
         it { expect(subject.destination_file_path).to eq('a/b/c/') }
       end
 
       context 'strips the file name from the path' do
-        let(:file) { {name: 'a/b/c/myfile'} }
+        let(:file) { { name: 'a/b/c/myfile' } }
 
         it { expect(subject.destination_file_path).to eq('a/b/c/') }
       end
 
       context 'returns an empty string if no path is given' do
-        let(:file) { {name: 'myfile'} }
+        let(:file) { { name: 'myfile' } }
 
         it { expect(subject.destination_file_path).to eq('') }
       end
@@ -43,9 +46,9 @@ describe Match do
 
     describe '#create_subfolders' do
       context 'with a supplied sub-folder path' do
-        let(:file) { {name: 'a/b/c/myfile'} }
+        let(:file) { { name: 'a/b/c/myfile' } }
 
-        it 'creates the necessary sub-folders' do 
+        it 'creates the necessary sub-folders' do
           expect(FileUtils).to receive(:mkdir_p).with(Dir.pwd + '/a/b/c/')
 
           subject.create_subfolders(Dir.pwd)
@@ -53,7 +56,7 @@ describe Match do
       end
 
       context 'with no sub-folders in the path' do
-        let(:file) { {name: 'myfile'} }
+        let(:file) { { name: 'myfile' } }
 
         it 'does not create subfolders' do
           expect(FileUtils).to receive(:mkdir_p).with(Dir.pwd + '/')
@@ -64,11 +67,11 @@ describe Match do
     end
 
     describe '#valid_checksum?' do
-      let(:file) { {checksum: checksum} }
+      let(:file) { { checksum: checksum } }
 
       context 'when the checksum supplied matches the checksum of the file ' do
         let(:file_contents) { 'hello' }
-        let(:file) { {checksum: Digest::SHA256.hexdigest(file_contents)} }
+        let(:file) { { checksum: Digest::SHA256.hexdigest(file_contents) } }
 
         it 'returns true' do
           tempfile = Tempfile.new
@@ -81,12 +84,12 @@ describe Match do
 
       context 'when the checksum supplied does not match the checksum of the file' do
         let(:file_contents) { 'hello' }
-        let(:file) { {checksum: 'foo'} }
+        let(:file) { { checksum: 'foo' } }
 
         it 'reuturns false' do
           tempfile = Tempfile.new
           tempfile.write(file_contents)
-          tempfile.close 
+          tempfile.close
 
           expect(subject.valid_checksum?(tempfile.path)).to be false
         end
@@ -94,15 +97,15 @@ describe Match do
     end
 
     describe '#delete' do
-      let(:file) { {id: 1} }
-    
+      let(:file) { { id: 1 } }
+
       it 'sends the delete request to the client' do
         url = URI(subject.file_url)
-  
+
         expect_any_instance_of(Match::Storage::GitLab::Client).to receive(:execute_request).with(url, anything)
-  
+
         subject.delete
       end
     end
   end
-end 
+end

--- a/match/spec/storage/gitlab_secure_files_storage_spec.rb
+++ b/match/spec/storage/gitlab_secure_files_storage_spec.rb
@@ -21,7 +21,7 @@ describe Match do
         files_to_upload.each do |file_name|
           expect(file).to receive(:open).with(file_name)
         end
-      
+
         subject.upload_files(files_to_upload: files_to_upload)
       end
 
@@ -42,7 +42,7 @@ describe Match do
 
       let(:secure_files) do
         file_names.map.with_index do |file_name, index|
-          Match::Storage::GitLab::SecureFile.new(file: {id: index, name: file_name}, client: subject.gitlab_client) 
+          Match::Storage::GitLab::SecureFile.new(file: { id: index, name: file_name }, client: subject.gitlab_client)
         end
       end
 
@@ -53,7 +53,7 @@ describe Match do
       end
 
       it 'deletes files with correct paths' do
-        secure_files.each_with_index do |secure_file, index|          
+        secure_files.each_with_index do |secure_file, index|
           expect(subject.gitlab_client).to receive(:find_file_by_name).with(file_names[index]).and_return(secure_file)
           expect(secure_file.file.name).to eq(file_names[index])
           expect(secure_file).to receive(:delete)
@@ -73,18 +73,18 @@ describe Match do
 
       let(:secure_files) do
         file_names.map.with_index do |file_name, index|
-          Match::Storage::GitLab::SecureFile.new(file: {id: index, name: file_name}, client: subject.gitlab_client) 
+          Match::Storage::GitLab::SecureFile.new(file: { id: index, name: file_name }, client: subject.gitlab_client)
         end
       end
 
       it 'downloads to correct working directory' do
         expect(subject.gitlab_client).to receive(:files).and_return(secure_files)
 
-        secure_files.each_with_index do |secure_file, index|          
+        secure_files.each_with_index do |secure_file, index|
           expect(secure_file.file.name).to eq(file_names[index])
           expect(secure_file).to receive(:download).with(working_directory)
         end
-        
+
         subject.download
       end
     end


### PR DESCRIPTION
### Motivation and Context

Cleanup from #20386 where some CI jobs didn't run lint errors weren't caught 

### Description

- Lots of fixes from rubocop
- Added some missing imports
- Renamed environment variable from `GITLAB_PROJECT` to `MATCH_GITLAB_PROJECT`
