### PR TITLE
[snapshot] use empty string to blank out operator name by default

### DIFF
--- a/snapshot/lib/snapshot/options.rb
+++ b/snapshot/lib/snapshot/options.rb
@@ -133,7 +133,7 @@ module Snapshot
                                      is_string: false),
         FastlaneCore::ConfigItem.new(key: :override_status_bar_arguments,
                                      env_name: 'SNAPSHOT_OVERRIDE_STATUS_BAR_ARGUMENTS',
-                                     description: "Fully customize the status bar by setting each option here. See `xcrun simctl status_bar --help`",
+                                     description: "Fully customize the status bar by setting each option here. Requires `override_status_bar` to be set to `true`. See `xcrun simctl status_bar --help`",
                                      optional: true,
                                      type: String),
         FastlaneCore::ConfigItem.new(key: :localize_simulator,

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -135,7 +135,10 @@ module Snapshot
       if arguments.nil? || arguments.empty?
         # The time needs to be passed as ISO8601 so the simulator formats it correctly
         time = Time.new(2007, 1, 9, 9, 41, 0)
-        arguments = "--time #{time.iso8601} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --cellularBars 4 --batteryState charged --batteryLevel 100"
+
+        # If you don't override the operator name, you'll get "Carrier" in the status bar on no-notch devices such as iPhone 8. Pass an empty string to blank it out.
+
+        arguments = "--time #{time.iso8601} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --operatorName '' --cellularBars 4 --batteryState charged --batteryLevel 100"
       end
 
       Helper.backticks("xcrun simctl status_bar #{device_udid} override #{arguments} &> /dev/null")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
(made edits in the GitHub web UI; I'll check out the code and run these checks and update this)

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

If you don't pass `--operatorName` to `xcrun simctl status_bar`, it defaults to "Carrier". This change makes it blank instead, which matches Apple's marketing screenshots.

Note: on some older simulators, it may be necessary to pass a zero-width space `\u200D` instead of an empty string, but iOS 15.5 (and possibly earlier) seem to support an empty string to blank out the carrier.

### Description

Use an empty string explicitly instead of using the default. Tested locally with `xcrun simctl` to verify the correct parameters.

### Testing Steps

Probably easier to just test with simctl. This will produce a good status bar (just the cellular section; leaving out the other parameters for brevity):

```sh
xcrun simctl status_bar booted override --operatorName "" --cellularMode active
```

![Simulator Screen Shot - iPhone 8 - 2022-07-03 at 16 20 55](https://user-images.githubusercontent.com/464574/177056087-a07331a7-edae-4538-b9ad-8238304cbd0b.png)

Whereas this produces "Carrier" in the screenshot:

```sh
xcrun simctl status_bar booted override --cellularMode active
```

![Simulator Screen Shot - iPhone 8 - 2022-07-03 at 16 20 51](https://user-images.githubusercontent.com/464574/177056096-7eb83606-1e9e-4789-9569-d3057a18c27d.png)