### PR TITLE
Ignoring case sensitive when requesting SMS

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -164,7 +164,7 @@ module Spaceship
         body = { "securityCode" => { "code" => code.to_s } }.to_json
 
         # User exited by entering `sms` and wants to choose phone number for SMS
-        if code == 'sms'
+        if code.casecmp?("sms")
           code_type = 'phone'
           body = request_two_factor_code_from_phone_choose(response.body["trustedPhoneNumbers"], code_length)
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Even that documentation guides users to use 'sms', I have noticed that some people would like to use 'SMS' for acronyms like this one. Removing case sensitivity doesn't allow other strings, but helps for non-precise people.

### Description
<!-- Describe your changes in detail. -->
In /fastlane/spaceship/lib/spaceship/two_step_or_factor_client.rb line 167 
From
`if code == 'sms'`
To
`if code.casecmp?("sms")`

<!-- Please describe in detail how you tested your changes. -->
Before any changes, 
`bundle exec fastlane spaceauth -u <your_email>`
And check that you are able to order SMS 2FA code.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
`bundle exec fastlane spaceauth -u <your_email>`
And when reaching
`Please enter the 6 digit code:`
You can type any variant of 'sms', like 'sms',  'smS',  'sMs',  'sMS', 'Sms',  'SmS',  'SMs',  'SMS'
When testing variants, running 
`rm -rf ~/.fastlane/spaceship/<your_email>/cookie`
deletes a cookie and on next run you are triggered again with 2FA query. 

Also, non-valid value, like an 'asdf', still works giving expected error: 
`Exception type: Spaceship::UnauthorizedAccessError`