### PR TITLE
[trainer] fix ERB.new() deprecation warnings

### DIFF
--- a/trainer/lib/trainer/junit_generator.rb
+++ b/trainer/lib/trainer/junit_generator.rb
@@ -15,7 +15,7 @@ module Trainer
 
       lib_path = Trainer::ROOT
       xml_path = File.join(lib_path, "lib/assets/junit.xml.erb")
-      xml = ERB.new(File.read(xml_path), nil, '<>').result(binding) # http://www.rrn.dk/rubys-erb-templating-system
+      xml = ERB.new(File.read(xml_path), trim_mode: '<>').result(binding) # http://www.rrn.dk/rubys-erb-templating-system
 
       xml = xml.gsub('system_', 'system-').delete("\e") # Jenkins can not parse 'ESC' symbol
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
When using Ruby 3.1.2, `junit_generator.rb` produces a deprecation warning:
```
[2022-07-06T10:56:48.836Z] /Users/redacted/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/fastlane-2.207.0/trainer/lib/trainer/junit_generator.rb:18: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
[2022-07-06T10:56:48.836Z] /Users/redacted/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/fastlane-2.207.0/trainer/lib/trainer/junit_generator.rb:18: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```
### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This updates the syntax of ERB.new to the new version, which should be handled even by the oldest Ruby version this project supports (https://ruby-doc.org/stdlib-2.6/libdoc/erb/rdoc/ERB.html).
