### PR TITLE
[match][sigh] prefer default keychain during wwdr cert installation

### DIFF
--- a/fake testers_file_path
+++ b/fake testers_file_path
@@ -1,1 +1,0 @@
-First,Last,Email,Groups,Installed Version,Install Date

--- a/fake testers_file_path
+++ b/fake testers_file_path
@@ -1,0 +1,1 @@
+First,Last,Email,Groups,Installed Version,Install Date

--- a/fastlane/lib/fastlane/actions/import_certificate.rb
+++ b/fastlane/lib/fastlane/actions/import_certificate.rb
@@ -58,7 +58,7 @@ module Fastlane
 
       def self.example_code
         [
-          'import_certificate(certificate_path: "certs/AppleWWDRCA.cer")',
+          'import_certificate(certificate_path: "certs/AppleWWDRCA6.cer")',
           'import_certificate(
             certificate_path: "certs/dist.p12",
             certificate_password: ENV["CERTIFICATE_PASSWORD"] || "default"

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -22,7 +22,7 @@ module FastlaneCore
     end
 
     def self.installed_identies(in_keychain: nil)
-      install_wwdr_certificates unless wwdr_certificates_installed?
+      install_wwdr_certificate unless wwdr_certificate_installed?
 
       available = list_available_identities(in_keychain: in_keychain)
       # Match for this text against word boundaries to avoid edge cases around multiples of 10 identities!
@@ -81,7 +81,7 @@ module FastlaneCore
       `#{commands.join(' ')}`
     end
 
-    def self.wwdr_certificates_installed?
+    def self.wwdr_certificate_installed?
       certificate_name = "Apple Worldwide Developer Relations Certification Authority"
       keychain = wwdr_keychain
       response = Helper.backticks("security find-certificate -a -c '#{certificate_name}' #{keychain.shellescape}", print: FastlaneCore::Globals.verbose?)

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -86,7 +86,7 @@ module FastlaneCore
       keychain = wwdr_keychain
       response = Helper.backticks("security find-certificate -a -c '#{certificate_name}' #{keychain.shellescape}", print: FastlaneCore::Globals.verbose?)
       certs = response.split("keychain: \"#{keychain}\"").drop(1)
-      certs.count == 2
+      certs.count == 1
     end
 
     def self.install_wwdr_certificate

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -124,8 +124,8 @@ module FastlaneCore
 
     def self.wwdr_keychain
       priority = [
-        "security list-keychains -d user",
-        "security default-keychain -d user"
+        "security default-keychain -d user",
+        "security list-keychains -d user"
       ]
       priority.each do |command|
         keychains = Helper.backticks(command, print: FastlaneCore::Globals.verbose?).split("\n")

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -86,7 +86,7 @@ module FastlaneCore
       keychain = wwdr_keychain
       response = Helper.backticks("security find-certificate -a -c '#{certificate_name}' #{keychain.shellescape}", print: FastlaneCore::Globals.verbose?)
       certs = response.split("keychain: \"#{keychain}\"").drop(1)
-      certs.count == 1
+      certs.count >= 1
     end
 
     def self.install_wwdr_certificate

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -90,10 +90,7 @@ module FastlaneCore
     end
 
     def self.install_wwdr_certificate
-      install_wwdr_certificate('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')
-    end
-
-    def self.install_wwdr_certificate(url)
+      url = 'https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer'
       file = Tempfile.new(File.basename(url))
       filename = file.path
       keychain = wwdr_keychain

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -90,7 +90,6 @@ module FastlaneCore
     end
 
     def self.install_wwdr_certificates
-      install_wwdr_certificate('https://developer.apple.com/certificationauthority/AppleWWDRCA.cer')
       install_wwdr_certificate('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')
     end
 

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -89,7 +89,7 @@ module FastlaneCore
       certs.count == 2
     end
 
-    def self.install_wwdr_certificates
+    def self.install_wwdr_certificate
       install_wwdr_certificate('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')
     end
 

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -91,7 +91,7 @@ module FastlaneCore
 
     def self.install_wwdr_certificates
       install_wwdr_certificate('https://developer.apple.com/certificationauthority/AppleWWDRCA.cer')
-      install_wwdr_certificate('https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer')
+      install_wwdr_certificate('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')
     end
 
     def self.install_wwdr_certificate(url)

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -2,7 +2,7 @@ describe FastlaneCore do
   describe FastlaneCore::CertChecker do
     describe '#installed_identies' do
       it 'should print an error when no local code signing identities are found' do
-        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificates_installed?).and_return(true)
+        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
         expect(FastlaneCore::UI).to receive(:error).with(/There are no local code signing identities found/)
 
@@ -10,7 +10,7 @@ describe FastlaneCore do
       end
 
       it 'should not be fooled by 10 local code signing identities available' do
-        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificates_installed?).and_return(true)
+        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
         expect(FastlaneCore::UI).not_to(receive(:error))
 
@@ -18,10 +18,10 @@ describe FastlaneCore do
       end
     end
 
-    describe '#install_wwdr_certificates' do
+    describe '#install_wwdr_certificate' do
       it 'should install only the latest official WWDR certificate' do
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with(/AppleWWDRCAG6/)
-        FastlaneCore::CertChecker.install_wwdr_certificates
+        FastlaneCore::CertChecker.install_wwdr_certificate
       end
     end
 
@@ -34,7 +34,7 @@ describe FastlaneCore do
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
         expect(FastlaneCore::Helper).to receive(:backticks).with(name_regex, anything).and_return("")
 
-        FastlaneCore::CertChecker.wwdr_certificates_installed?
+        FastlaneCore::CertChecker.wwdr_certificate_installed?
       end
 
       it 'uses the correct command to import it' do

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -19,7 +19,7 @@ describe FastlaneCore do
     end
 
     describe '#install_wwdr_certificates' do
-      it 'should install all the official WWDR certificates' do
+      it 'should install only the latest official WWDR certificate' do
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with(/AppleWWDRCAG6/)
         FastlaneCore::CertChecker.install_wwdr_certificates
       end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -20,8 +20,7 @@ describe FastlaneCore do
 
     describe '#install_wwdr_certificates' do
       it 'should install all the official WWDR certificates' do
-        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with(/AppleWWDRCA/)
-        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with(/AppleWWDRCAG3/)
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with(/AppleWWDRCAG6/)
         FastlaneCore::CertChecker.install_wwdr_certificates
       end
     end
@@ -43,13 +42,13 @@ describe FastlaneCore do
         `ls`
 
         keychain = "keychain with spaces.keychain"
-        cmd = %r{curl -f -o (([A-Z]\:)?\/.+) https://developer\.apple\.com/certificationauthority/AppleWWDRCA.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
+        cmd = %r{curl -f -o (([A-Z]\:)?\/.+) https://www\.apple\.com/certificateauthority/AppleWWDRCAG6\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
         require "open3"
 
         expect(Open3).to receive(:capture3).with(cmd).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-        expect(FastlaneCore::CertChecker.install_wwdr_certificate('https://developer.apple.com/certificationauthority/AppleWWDRCA.cer')).to be(true)
+        expect(FastlaneCore::CertChecker.install_wwdr_certificate('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')).to be(true)
       end
     end
   end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -20,7 +20,7 @@ describe FastlaneCore do
 
     describe '#install_wwdr_certificate' do
       it 'should install only the latest official WWDR certificate' do
-        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with(/AppleWWDRCAG6/)
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate)
         FastlaneCore::CertChecker.install_wwdr_certificate
       end
     end
@@ -48,7 +48,7 @@ describe FastlaneCore do
         expect(Open3).to receive(:capture3).with(cmd).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-        expect(FastlaneCore::CertChecker.install_wwdr_certificate('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')).to be(true)
+        expect(FastlaneCore::CertChecker.install_wwdr_certificate()).to be(true)
       end
     end
   end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -48,7 +48,7 @@ describe FastlaneCore do
         expect(Open3).to receive(:capture3).with(cmd).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-        expect(FastlaneCore::CertChecker.install_wwdr_certificate()).to be(true)
+        expect(FastlaneCore::CertChecker.install_wwdr_certificate).to be(true)
       end
     end
   end

--- a/match/spec/encryption/openssl_spec.rb
+++ b/match/spec/encryption/openssl_spec.rb
@@ -25,6 +25,7 @@ describe Match do
     end
 
     it "raises an exception if invalid password is passed" do
+      stub_const('ENV', { "MATCH_PASSWORD" => '2"QAHg@v(Qp{=*n^' })
       @e.encrypt_files
       expect(File.read(@full_path)).to_not(eq(@content))
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When there are multiple keychains WWDR cert is installed in random place.
During search it takes first output from `list-keychains` instead of default one.
https://developer.apple.com/support/certificates/
https://developer.apple.com/support/expiration/

### Description
* expired cert got removed to do not introduce conflicts
* latest cert was added 
* changed priority so default keychain is taken as first

### Testing Steps
1. Create new keychain without any cert
2. Run with `--verbose` lane where `match` install Provision Profile and it's certs. 
3. Take a look on debug log to see if it's using correct keychain for installation WWDR cert.