### PR TITLE
[match] fixes set up bugs when using GitLab Secure Files as a Match storage backend

### DIFF
--- a/match/lib/match/setup.rb
+++ b/match/lib/match/setup.rb
@@ -34,7 +34,7 @@ module Match
     end
 
     def storage_options
-      return ["git", "google_cloud", "s3"]
+      return ["git", "google_cloud", "s3", "gitlab_secure_files"]
     end
   end
 end

--- a/match/lib/match/storage/gitlab/client.rb
+++ b/match/lib/match/storage/gitlab/client.rb
@@ -69,7 +69,23 @@ module Match
               "name" => target_file
             )
 
-            execute_request(url, request)
+            response = execute_request(url, request)
+
+            log_upload_error(response, target_file) if response.code != "201"
+          end
+        end
+
+        def log_upload_error(response, target_file)
+          begin
+            response_body = JSON.parse(response.body)
+          rescue JSON::ParserError
+            response_body = response.body
+          end
+
+          if response_body["message"]["name"] == ["has already been taken"]
+            UI.error("#{target_file} already exists in GitLab project #{@project_id}, file not uploaded")
+          else
+            UI.error("Upload error for #{target_file}: #{response_body}")
           end
         end
 

--- a/match/lib/match/storage/gitlab/client.rb
+++ b/match/lib/match/storage/gitlab/client.rb
@@ -82,7 +82,7 @@ module Match
             response_body = response.body
           end
 
-          if response_body["message"]["name"] == ["has already been taken"]
+          if response_body["message"] && (response_body["message"]["name"] == ["has already been taken"])
             UI.error("#{target_file} already exists in GitLab project #{@project_id}, file not uploaded")
           else
             UI.error("Upload error for #{target_file}: #{response_body}")

--- a/match/lib/match/storage/gitlab/secure_file.rb
+++ b/match/lib/match/storage/gitlab/secure_file.rb
@@ -43,8 +43,7 @@ module Match
                 saved_file.write(data.read)
               end
 
-              # Set file mode to read-only
-              FileUtils.chmod('u=r,go-r', destination_file)
+              FileUtils.chmod('u=rw,go-r', destination_file)
             end
 
             UI.crash!("Checksum validation failed for #{@file.name}") unless valid_checksum?(destination_file)

--- a/match/lib/match/storage/gitlab_secure_files.rb
+++ b/match/lib/match/storage/gitlab_secure_files.rb
@@ -15,6 +15,7 @@ module Match
     # Store the code signing identities in GitLab Secure Files
     class GitLabSecureFiles < Interface
       attr_reader :gitlab_client
+      attr_reader :project_id
       attr_reader :readonly
       attr_reader :username
       attr_reader :team_id

--- a/match/lib/match/storage/gitlab_secure_files.rb
+++ b/match/lib/match/storage/gitlab_secure_files.rb
@@ -173,7 +173,9 @@ module Match
       # This method must return the content of the Matchfile
       # that should be generated
       def generate_matchfile_content(template: nil)
-        return "gitlab_project(\"#{self.project_id}\")"
+        project = UI.input("What is your GitLab Project (i.e. gitlab-org/gitlab): ")
+
+        return "gitlab_project(\"#{project}\")"
       end
     end
   end

--- a/match/lib/match/storage/gitlab_secure_files.rb
+++ b/match/lib/match/storage/gitlab_secure_files.rb
@@ -162,7 +162,7 @@ module Match
       end
 
       def skip_docs
-        false
+        true
       end
 
       def list_files(file_name: "", file_ext: "")

--- a/match/spec/storage/gitlab/client_spec.rb
+++ b/match/spec/storage/gitlab/client_spec.rb
@@ -127,5 +127,23 @@ describe Match do
       end
     end
 
+    describe '#log_upload_error' do
+      it 'logs a custom error message when the file name has already been taken' do
+        expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("foo already exists in GitLab project sample/project, file not uploaded")
+
+        response_body = { message: { name: ["has already been taken" ] } }.to_json
+        response = OpenStruct.new(code: "400", body: response_body)
+        target_file = 'foo'
+        subject.log_upload_error(response, target_file)
+      end
+
+      it 'logs the returned error message on all other errors' do
+        expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: a generic error message")
+
+        response = OpenStruct.new(code: "500", body: "a generic error message")
+        target_file = 'foo'
+        subject.log_upload_error(response, target_file)
+      end
+    end
   end
 end

--- a/match/spec/storage/gitlab/client_spec.rb
+++ b/match/spec/storage/gitlab/client_spec.rb
@@ -137,7 +137,25 @@ describe Match do
         subject.log_upload_error(response, target_file)
       end
 
-      it 'logs the returned error message on all other errors' do
+      it 'logs the returned error message when an unexpected JSON response is returned' do
+        expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: {\"message\"=>{\"bar\"=>\"baz\"}}")
+
+        response_body = { message: { bar: "baz" } }.to_json
+        response = OpenStruct.new(code: "500", body: response_body)
+        target_file = 'foo'
+        subject.log_upload_error(response, target_file)
+      end
+
+      it 'logs the returned error message when an unexpected JSON response is returned' do
+        expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: {\"foo\"=>{\"bar\"=>\"baz\"}}")
+
+        response_body = { foo: { bar: "baz" } }.to_json
+        response = OpenStruct.new(code: "500", body: response_body)
+        target_file = 'foo'
+        subject.log_upload_error(response, target_file)
+      end
+
+      it 'logs the returned error message when a non-JSON response is returned' do
         expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: a generic error message")
 
         response = OpenStruct.new(code: "500", body: "a generic error message")

--- a/match/spec/storage/gitlab_secure_files_storage_spec.rb
+++ b/match/spec/storage/gitlab_secure_files_storage_spec.rb
@@ -88,5 +88,17 @@ describe Match do
         subject.download
       end
     end
+
+    describe '#human_readable_description' do
+      it 'returns the correct human readable description for the configured storage mode' do
+        expect(subject.human_readable_description).to eq('GitLab Secure Files Storage [fake-project]')
+      end
+    end
+
+    describe '#generate_matchfile_content' do
+      it 'returns the correct match file contents for the configured storage mode' do
+        expect(subject.generate_matchfile_content).to eq('gitlab_project("fake-project")')
+      end
+    end
   end
 end

--- a/match/spec/storage/gitlab_secure_files_storage_spec.rb
+++ b/match/spec/storage/gitlab_secure_files_storage_spec.rb
@@ -97,6 +97,8 @@ describe Match do
 
     describe '#generate_matchfile_content' do
       it 'returns the correct match file contents for the configured storage mode' do
+        expect(FastlaneCore::UI).to receive(:input).once.and_return("fake-project")
+
         expect(subject.generate_matchfile_content).to eq('gitlab_project("fake-project")')
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change fixes an error when attempting to upload files via Match to GitLab Secure Files. The error is caused when `human_readable_description` is called during the logging process.

This change also fixes some bugs in the set up process `fastlane match init`, and adds better error handling for file upload errors.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
