### PR TITLE
[action] Adding no overwrite and local only options to the pod repo push command

### DIFF
--- a/fastlane/lib/fastlane/actions/pod_push.rb
+++ b/fastlane/lib/fastlane/actions/pod_push.rb
@@ -59,6 +59,14 @@ module Fastlane
           command << "--synchronous"
         end
 
+        if params[:no_overwrite]
+          command << "--no-overwrite"
+        end
+
+        if params[:local_only]
+          command << "--local-only"
+        end
+
         result = Actions.sh(command.join(' '))
         UI.success("Successfully pushed Podspec ⬆️ ")
         return result
@@ -143,7 +151,17 @@ module Fastlane
                                        description: "If validation depends on other recently pushed pods, synchronize",
                                        optional: true,
                                        type: Boolean,
-                                       env_name: "FL_POD_PUSH_SYNCHRONOUS")
+                                       env_name: "FL_POD_PUSH_SYNCHRONOUS"),
+          FastlaneCore::ConfigItem.new(key: :no_overwrite,
+                                       description: "Disallow pushing that would overwrite an existing spec",
+                                       optional: true,
+                                       type: Boolean,
+                                       env_name: "FL_POD_PUSH_NO_OVERWRITE"),
+          FastlaneCore::ConfigItem.new(key: :local_only,
+                                       description: "Does not perform the step of pushing REPO to its remote",
+                                       optional: true,
+                                       type: Boolean,
+                                       env_name: "FL_POD_PUSH_LOCAL_ONLY")
         ]
       end
 

--- a/fastlane/spec/actions_specs/pod_push_spec.rb
+++ b/fastlane/spec/actions_specs/pod_push_spec.rb
@@ -107,6 +107,22 @@ describe Fastlane do
 
         expect(result).to eq("pod trunk push --synchronous")
       end
+
+      it "generates the correct pod push command with the no overwrite parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_push(no_overwrite: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod trunk push --no-overwrite")
+      end
+
+      it "generates the correct pod push command with the local only parameter" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          pod_push(local_only: true)
+        end").runner.execute(:test)
+
+        expect(result).to eq("pod trunk push --local-only")
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The PR adds new parameters to the Cocoapods command `pod repo push` that were missing from the Fastlane action but were present on the Cocoapods command.

### Description
Two new options are being added to the `pod repo push` command:
no_overwrite, which disallows pushing a spec that would overwrite an existing one
local_only, which skips the step of pushing to its remote, basically acting like a dry run.

### Testing Steps
I've follow the rules found on https://github.com/fastlane/fastlane/blob/master/Testing.md. I've also tested the command locally, and found no issues.
