### PR TITLE
Support aab upload with actions for deploygate

### DIFF
--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -43,12 +43,12 @@ module Fastlane
 
         api_token = options[:api_token]
         user_name = options[:user]
-        binary = options[:ipa] || options[:apk]
+        binary = options[:ipa] || options[:apk] || options[:aab]
         upload_options = options.values.select do |key, _|
           [:message, :distribution_key, :release_note, :disable_notify, :distribution_name].include?(key)
         end
 
-        UI.user_error!('missing `ipa` and `apk`. deploygate action needs least one.') unless binary
+        UI.user_error!('missing `ipa`, `apk` and `aab`. deploygate action needs least one.') unless binary
 
         return binary if Helper.test?
 
@@ -142,6 +142,15 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find apk file at path '#{value}'") unless File.exist?(value)
                                        end),
+          FastlaneCore::ConfigItem.new(key: :aab,
+                                       env_name: "DEPLOYGATE_AAB_PATH",
+                                       description: "Path to your AAB file",
+                                       default_value: Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
+                                       default_value_dynamic: true,
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find aab file at path '#{value}'") unless File.exist?(value)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :message,
                                        env_name: "DEPLOYGATE_MESSAGE",
                                        description: "Release Notes",
@@ -190,6 +199,14 @@ module Fastlane
             api_token: "...",
             user: "target username or organization name",
             apk: "./apk_file.apk",
+            message: "Build #{lane_context[SharedValues::BUILD_NUMBER]}",
+            distribution_key: "(Optional) Target Distribution Key",
+            distribution_name: "(Optional) Target Distribution Name"
+          )',
+          'deploygate(
+            api_token: "...",
+            user: "target username or organization name",
+            aab: "./aab_file.aab",
             message: "Build #{lane_context[SharedValues::BUILD_NUMBER]}",
             distribution_key: "(Optional) Target Distribution Key",
             distribution_name: "(Optional) Target Distribution Name"

--- a/fastlane/spec/actions_specs/deploygate_spec.rb
+++ b/fastlane/spec/actions_specs/deploygate_spec.rb
@@ -41,7 +41,7 @@ describe Fastlane do
               user: 'deploygate'
             })
           end").runner.execute(:test)
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'missing `ipa` and `apk`. deploygate action needs least one.')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'missing `ipa`, `apk` and `aab`. deploygate action needs least one.')
       end
 
       it "raises an error if the given ipa path was not found" do
@@ -66,6 +66,18 @@ describe Fastlane do
             })
           end").runner.execute(:test)
         end.to raise_error(FastlaneCore::Interface::FastlaneError, "Couldn't find apk file at path './fastlane/nonexistent'")
+      end
+
+      it "raises an error if the given aab path was not found" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            deploygate({
+              api_token: 'testistest',
+              user: 'deploygate',
+              aab: './fastlane/nonexistent'
+            })
+          end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, "Couldn't find aab file at path './fastlane/nonexistent'")
       end
 
       it "works with valid parameters" do

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -3942,6 +3942,7 @@ public func deliver(apiKeyPath: OptionalConfigValue<String?> = .fastlaneDefault(
    - user: Target username or organization name
    - ipa: Path to your IPA file. Optional if you use the _gym_ or _xcodebuild_ action
    - apk: Path to your APK file
+   - aab: Path to your AAB file
    - message: Release Notes
    - distributionKey: Target Distribution Key
    - releaseNote: Release note for distribution page
@@ -3955,6 +3956,7 @@ public func deploygate(apiToken: String,
                        user: String,
                        ipa: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                        apk: OptionalConfigValue<String?> = .fastlaneDefault(nil),
+                       aab: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                        message: String = "No changelog provided",
                        distributionKey: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                        releaseNote: OptionalConfigValue<String?> = .fastlaneDefault(nil),
@@ -3965,6 +3967,7 @@ public func deploygate(apiToken: String,
     let userArg = RubyCommand.Argument(name: "user", value: user, type: nil)
     let ipaArg = ipa.asRubyArgument(name: "ipa", type: nil)
     let apkArg = apk.asRubyArgument(name: "apk", type: nil)
+    let aabArg = aab.asRubyArgument(name: "aab", type: nil)
     let messageArg = RubyCommand.Argument(name: "message", value: message, type: nil)
     let distributionKeyArg = distributionKey.asRubyArgument(name: "distribution_key", type: nil)
     let releaseNoteArg = releaseNote.asRubyArgument(name: "release_note", type: nil)
@@ -3974,6 +3977,7 @@ public func deploygate(apiToken: String,
                                           userArg,
                                           ipaArg,
                                           apkArg,
+                                          aabArg,
                                           messageArg,
                                           distributionKeyArg,
                                           releaseNoteArg,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

DeployGate API support AAB upload in [docs](https://docs.deploygate.com/reference/upload).
I fix a fastlane action for deploygate to support aab upload.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->


Add aab option to upload aab file with deploygate action.
Fix document for deploygate action.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I have tested aab upload with fastlane actions.

```ruby
# In fastlane/fastlane/Fastfile

desc "Runs deploygate upload api with aab"
lane :dg do |options|
  deploygate(
    api_token: "...",
    user: "...",
    aab: "/tmp/app-debug.aab",
    message: "Build #{lane_context[SharedValues::BUILD_NUMBER]}"
  )
end
```

```shell
$ bundle exec fastlane dg
```

- results

<img width="300" src="https://user-images.githubusercontent.com/24446183/192430625-2ce57589-a3a5-4573-9016-1cc624d216d7.png">