### PR TITLE
[spaceship] fix `fastlane init` and temporarily retrofitting `Spaceship::Tunes::Application.find`

### DIFF
--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -387,7 +387,7 @@ module Fastlane
     def verify_app_exists_itc!
       UI.user_error!("No app identifier provided") if self.app_identifier.to_s.length == 0
       UI.message("Checking if the app '#{self.app_identifier}' exists on App Store Connect...")
-      app = Spaceship::Tunes::Application.find(self.app_identifier)
+      app = Spaceship::ConnectAPI::App.find(self.app_identifier)
       if app.nil?
         UI.error("Looks like the app '#{self.app_identifier}' isn't available on #{'App Store Connect'.bold.underline}")
         UI.error("for the team ID '#{self.itc_team_id}' on Apple ID '#{self.user}'")

--- a/spaceship/lib/spaceship/connect_api/response.rb
+++ b/spaceship/lib/spaceship/connect_api/response.rb
@@ -22,13 +22,18 @@ module Spaceship
         return links["next"]
       end
 
-      def next_page
+      def next_page(&block)
         url = next_url
         return nil if url.nil?
-        return client.get(url)
+
+        if block_given?
+          return yield(url)
+        else
+          return client.get(url)
+        end
       end
 
-      def next_pages(count: 1)
+      def next_pages(count: 1, &block)
         if !count.nil? && count < 0
           count = 0
         end
@@ -38,7 +43,7 @@ module Spaceship
 
         resp = self
         loop do
-          resp = resp.next_page
+          resp = resp.next_page(&block)
           break if resp.nil?
           responses << resp
           counter += 1
@@ -49,8 +54,8 @@ module Spaceship
         return responses
       end
 
-      def all_pages
-        return next_pages(count: nil)
+      def all_pages(&block)
+        return next_pages(count: nil, &block)
       end
 
       def to_models

--- a/spaceship/lib/spaceship/connect_api/response.rb
+++ b/spaceship/lib/spaceship/connect_api/response.rb
@@ -22,13 +22,17 @@ module Spaceship
         return links["next"]
       end
 
-      def next_page
+      def next_page(&block)
         url = next_url
         return nil if url.nil?
-        return client.get(url)
+        if block_given?
+          return yield(url)
+        else
+          return client.get(url)
+        end
       end
 
-      def next_pages(count: 1)
+      def next_pages(count: 1, &block)
         if !count.nil? && count < 0
           count = 0
         end
@@ -38,7 +42,7 @@ module Spaceship
 
         resp = self
         loop do
-          resp = resp.next_page
+          resp = resp.next_page(&block)
           break if resp.nil?
           responses << resp
           counter += 1
@@ -49,8 +53,8 @@ module Spaceship
         return responses
       end
 
-      def all_pages
-        return next_pages(count: nil)
+      def all_pages(&block)
+        return next_pages(count: nil, &block)
       end
 
       def to_models

--- a/spaceship/lib/spaceship/connect_api/response.rb
+++ b/spaceship/lib/spaceship/connect_api/response.rb
@@ -22,18 +22,13 @@ module Spaceship
         return links["next"]
       end
 
-      def next_page(&block)
+      def next_page
         url = next_url
         return nil if url.nil?
-
-        if block_given?
-          return yield(url)
-        else
-          return client.get(url)
-        end
+        return client.get(url)
       end
 
-      def next_pages(count: 1, &block)
+      def next_pages(count: 1)
         if !count.nil? && count < 0
           count = 0
         end
@@ -43,7 +38,7 @@ module Spaceship
 
         resp = self
         loop do
-          resp = resp.next_page(&block)
+          resp = resp.next_page
           break if resp.nil?
           responses << resp
           counter += 1
@@ -54,8 +49,8 @@ module Spaceship
         return responses
       end
 
-      def all_pages(&block)
-        return next_pages(count: nil, &block)
+      def all_pages
+        return next_pages(count: nil)
       end
 
       def to_models

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -9,7 +9,7 @@ require_relative 'errors'
 require_relative 'iap_subscription_pricing_tier'
 require_relative 'pricing_tier'
 require_relative 'territory'
-require_relative '../connect_api/models/app'
+# require_relative '../connect_api/models/app'
 module Spaceship
   # rubocop:disable Metrics/ClassLength
   class TunesClient < Spaceship::Client
@@ -255,34 +255,34 @@ module Spaceship
     #####################################################
 
     def applications
-      apps = Spaceship::ConnectAPI::App.all
-      apps.map do |asc_app|
-        platforms = (asc_app.app_store_versions || []).map(&:platform).uniq.map do |asc_platform|
-          case asc_platform
-          when "TV_OS"
-            "appletvos"
-          when "MAC_OS"
-            "osx"
-          when "IOS"
-            "ios"
-          else
-            raise "Cannot find a matching platform for '#{asc_platform}'}"
-          end
-        end
+      # apps = Spaceship::ConnectAPI::App.all
+      # apps.map do |asc_app|
+      #   platforms = (asc_app.app_store_versions || []).map(&:platform).uniq.map do |asc_platform|
+      #     case asc_platform
+      #     when "TV_OS"
+      #       "appletvos"
+      #     when "MAC_OS"
+      #       "osx"
+      #     when "IOS"
+      #       "ios"
+      #     else
+      #       raise "Cannot find a matching platform for '#{asc_platform}'}"
+      #     end
+      #   end
 
-        {
-          'adamId' => asc_app.id,
-          'name' => asc_app.name,
-          'vendorId' => "",
-          'bundleId' => asc_app.bundle_id,
-          'lastModifiedDate' => nil,
-          'issuesCount' => nil,
-          'iconUrl' => nil,
-          'versionSets' => platforms.map do |platform|
-            { 'type' => 'app', 'platformString' => platform }
-          end
-        }
-      end
+      #   {
+      #     'adamId' => asc_app.id,
+      #     'name' => asc_app.name,
+      #     'vendorId' => "",
+      #     'bundleId' => asc_app.bundle_id,
+      #     'lastModifiedDate' => nil,
+      #     'issuesCount' => nil,
+      #     'iconUrl' => nil,
+      #     'versionSets' => platforms.map do |platform|
+      #       { 'type' => 'app', 'platformString' => platform }
+      #     end
+      #   }
+      # end
     end
 
     def app_details(app_id)

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -9,7 +9,7 @@ require_relative 'errors'
 require_relative 'iap_subscription_pricing_tier'
 require_relative 'pricing_tier'
 require_relative 'territory'
-require_relative '../connect_api/model/app'
+require_relative '../connect_api/models/app'
 module Spaceship
   # rubocop:disable Metrics/ClassLength
   class TunesClient < Spaceship::Client

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -255,6 +255,17 @@ module Spaceship
     #####################################################
 
     def applications
+      # This legacy endpoint went offline around July 7th, 2022. This is a rough attempt
+      # at retrofitting using the newer App Store Connect API endpoints
+      #
+      # This could all be done easily with Spaceship::ConnectAPI::App.find but there were a lot of
+      # circular dependency issues that were very difficult to solve because. Spaceship::Tunes would be
+      # using Spaceship::ConnectAPI which uses Spaceship::Tunes
+      #
+      # However, using Spaceship::ConnectAPI::Response works. This will fetch multiple pages of app
+      # if it needs to
+      #
+      # https://github.com/fastlane/fastlane/pull/20480
       r = request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?include=appStoreVersions,prices")
       response = Spaceship::ConnectAPI::Response.new(
         body: r.body,

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -9,7 +9,7 @@ require_relative 'errors'
 require_relative 'iap_subscription_pricing_tier'
 require_relative 'pricing_tier'
 require_relative 'territory'
-require_relative '../connect/response'
+require_relative '../connect_api/response'
 # require_relative '../connect_api/models/app'
 module Spaceship
   # rubocop:disable Metrics/ClassLength

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -255,6 +255,12 @@ module Spaceship
     #####################################################
 
     def applications
+      # Doing this real bad puts for now until a more formal deprecation logic can get made
+      puts("Spaceship::Tunes::Application.all is deprecated")
+      puts("  It's using a temporary patch to keep it from raising an error but things may not work correctly")
+      puts("  Please consider switching to Spaceship::ConnectAPI if you can")
+      puts("  For more details - https://github.com/fastlane/fastlane/pull/20480")
+
       # This legacy endpoint went offline around July 7th, 2022. This is a rough attempt
       # at retrofitting using the newer App Store Connect API endpoints
       #

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -9,8 +9,7 @@ require_relative 'errors'
 require_relative 'iap_subscription_pricing_tier'
 require_relative 'pricing_tier'
 require_relative 'territory'
-# require_relative '../connect_api/model'
-# require_relative '../connect_api/response'
+require_relative '../connect_api/model/app'
 module Spaceship
   # rubocop:disable Metrics/ClassLength
   class TunesClient < Spaceship::Client
@@ -256,25 +255,7 @@ module Spaceship
     #####################################################
 
     def applications
-      #      require_relative '../connect_api/response'
-      #      r = request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?include=appStoreVersions,prices&limit=10")
-      #      response = Spaceship::ConnectAPI::Response.new(
-      #        body: r.body,
-      #        status: r.status,
-      #        headers: r.headers,
-      #        client: nil
-      #      )
-      #
-      #      apps = response.all_pages do |url|
-      #        r = request(:get, url)
-      #        Spaceship::ConnectAPI::Response.new(
-      #          body: r.body,
-      #          status: r.status,
-      #          headers: r.headers,
-      #          client: nil
-      #        )
-      #      end.flat_map(&:to_models)
-
+      apps = Spaceship::ConnectAPI::App.all
       apps.map do |asc_app|
         platforms = (asc_app.app_store_versions || []).map(&:platform).uniq.map do |asc_platform|
           case asc_platform

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -9,6 +9,7 @@ require_relative 'errors'
 require_relative 'iap_subscription_pricing_tier'
 require_relative 'pricing_tier'
 require_relative 'territory'
+require_relative '../connect/response'
 # require_relative '../connect_api/models/app'
 module Spaceship
   # rubocop:disable Metrics/ClassLength

--- a/spaceship/spec/base_spec.rb
+++ b/spaceship/spec/base_spec.rb
@@ -19,7 +19,7 @@ describe Spaceship::Base do
 
     it "prints out references" do
       Spaceship::Tunes.login
-      app = Spaceship::Application.all.first
+      app = Spaceship::Application.all.find { |a| a.apple_id == "898536088" }
       v = app.live_version
       output = v.inspect
       expect(output).to include("Tunes::AppVersion")

--- a/spaceship/spec/connect_api/fixtures/testflight/apps.json
+++ b/spaceship/spec/connect_api/fixtures/testflight/apps.json
@@ -1,188 +1,1239 @@
 {
-    "data" : [ {
-      "type" : "apps",
-      "id" : "123456789",
-      "attributes" : {
-        "name" : "FastlaneTest",
-        "bundleId" : "com.joshholtz.FastlaneTest",
-        "sku" : "SKU_SKU_SKU_SKU",
-        "primaryLocale" : "en-US",
-        "removed" : false,
-        "isAAG" : false
-      },
-      "relationships" : {
-        "betaTesters" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/betaTesters",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/betaTesters"
-          }
-        },
-        "betaGroups" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/betaGroups",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/betaGroups"
-          }
-        },
-        "appStoreVersions" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/appStoreVersions",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/appStoreVersions"
-          }
-        },
-        "preReleaseVersions" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/preReleaseVersions",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/preReleaseVersions"
-          }
-        },
-        "betaAppLocalizations" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/betaAppLocalizations",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/betaAppLocalizations"
-          }
-        },
-        "builds" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/builds",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/builds"
-          }
-        },
-        "betaLicenseAgreement" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/betaLicenseAgreement",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/betaLicenseAgreement"
-          }
-        },
-        "betaAppReviewDetail" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/betaAppReviewDetail",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/betaAppReviewDetail"
-          }
-        },
-        "appStoreVersionMetrics" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/appStoreVersionMetrics",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/appStoreVersionMetrics"
-          }
-        },
-        "betaReviewMetrics" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/betaReviewMetrics",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/betaReviewMetrics"
-          }
-        },
-        "provider" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/provider",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/provider"
-          }
-        },
-        "appInfos" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/relationships/appInfos",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789/appInfos"
-          }
+  "data" : [ {
+    "type" : "apps",
+    "id" : "123456789",
+    "attributes" : {
+      "name" : "FastlaneTest",
+      "bundleId" : "com.joshholtz.FastlaneTest",
+      "sku" : "SKU_SKU_SKU_SKU",
+      "primaryLocale" : "en-US",
+      "removed" : false,
+      "isAAG" : false
+    },
+    "relationships" : {
+      "ciProduct" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/ciProduct",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/ciProduct"
         }
       },
-      "links" : {
-        "self" : "https://appstoreconnect.apple.com/iris/v1/apps/123456789"
+      "betaTesters" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/betaTesters"
+        }
+      },
+      "betaGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/betaGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/betaGroups"
+        }
+      },
+      "appStoreVersions" : {
+        "meta" : {
+          "paging" : {
+            "total" : 1,
+            "limit" : 10
+          }
+        },
+        "data" : [ {
+          "type" : "appStoreVersions",
+          "id" : "2c2e7526-bde0-4878-b04b-89d20dd2a692"
+        } ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/appStoreVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/appStoreVersions"
+        }
+      },
+      "preReleaseVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/preReleaseVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/preReleaseVersions"
+        }
+      },
+      "betaAppLocalizations" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/betaAppLocalizations",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/betaAppLocalizations"
+        }
+      },
+      "builds" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/builds",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/builds"
+        }
+      },
+      "betaLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/betaLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/betaLicenseAgreement"
+        }
+      },
+      "betaAppReviewDetail" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/betaAppReviewDetail",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/betaAppReviewDetail"
+        }
+      },
+      "appInfos" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/appInfos",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/appInfos"
+        }
+      },
+      "appClips" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/appClips",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/appClips"
+        }
+      },
+      "appPricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/appPricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/appPricePoints"
+        }
+      },
+      "pricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/pricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/pricePoints"
+        }
+      },
+      "endUserLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/endUserLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/endUserLicenseAgreement"
+        }
+      },
+      "preOrder" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/preOrder",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/preOrder"
+        }
+      },
+      "prices" : {
+        "meta" : {
+          "paging" : {
+            "total" : 0,
+            "limit" : 10
+          }
+        },
+        "data" : [ ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/prices",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/prices"
+        }
+      },
+      "appPriceSchedule" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/appPriceSchedule",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/appPriceSchedule"
+        }
+      },
+      "availableTerritories" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/availableTerritories",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/availableTerritories"
+        }
+      },
+      "appAvailability" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/appAvailability",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/appAvailability"
+        }
+      },
+      "inAppPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/inAppPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/inAppPurchases"
+        }
+      },
+      "subscriptionGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/subscriptionGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/subscriptionGroups"
+        }
+      },
+      "gameCenterEnabledVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/gameCenterEnabledVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/gameCenterEnabledVersions"
+        }
+      },
+      "perfPowerMetrics" : {
+        "links" : {
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/perfPowerMetrics"
+        }
+      },
+      "appCustomProductPages" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/appCustomProductPages",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/appCustomProductPages"
+        }
+      },
+      "inAppPurchasesV2" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/inAppPurchasesV2",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/inAppPurchasesV2"
+        }
+      },
+      "promotedPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/promotedPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/promotedPurchases"
+        }
+      },
+      "appEvents" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/appEvents",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/appEvents"
+        }
+      },
+      "reviewSubmissions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/reviewSubmissions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/reviewSubmissions"
+        }
+      },
+      "subscriptionGracePeriod" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/subscriptionGracePeriod",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/subscriptionGracePeriod"
+        }
+      },
+      "customerReviews" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/relationships/customerReviews",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/123456789/customerReviews"
+        }
       }
-    }, {
-      "type" : "apps",
-      "id" : "987654321",
-      "attributes" : {
-        "name" : "FastlaneTest 2",
+    },
+    "links" : {
+      "self" : "https://api.appstoreconnect.apple.com/v1/apps/123456789"
+    }
+  }, {
+    "type" : "apps",
+    "id" : "987654321",
+    "attributes" : {
+      "name" : "FastlaneTest 2",
         "bundleId" : "com.joshholtz.FastlaneTest2",
         "sku" : "SKU_SKU",
         "primaryLocale" : "en-US",
         "removed" : false,
         "isAAG" : false
-      },
-      "relationships" : {
-        "betaTesters" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/betaTesters",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/betaTesters"
-          }
-        },
-        "betaGroups" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/betaGroups",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/betaGroups"
-          }
-        },
-        "appStoreVersions" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/appStoreVersions",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/appStoreVersions"
-          }
-        },
-        "preReleaseVersions" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/preReleaseVersions",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/preReleaseVersions"
-          }
-        },
-        "betaAppLocalizations" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/betaAppLocalizations",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/betaAppLocalizations"
-          }
-        },
-        "builds" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/builds",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/builds"
-          }
-        },
-        "betaLicenseAgreement" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/betaLicenseAgreement",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/betaLicenseAgreement"
-          }
-        },
-        "betaAppReviewDetail" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/betaAppReviewDetail",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/betaAppReviewDetail"
-          }
-        },
-        "appStoreVersionMetrics" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/appStoreVersionMetrics",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/appStoreVersionMetrics"
-          }
-        },
-        "betaReviewMetrics" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/betaReviewMetrics",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/betaReviewMetrics"
-          }
-        },
-        "provider" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/provider",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/provider"
-          }
-        },
-        "appInfos" : {
-          "links" : {
-            "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/relationships/appInfos",
-            "related" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321/appInfos"
-          }
+    },
+    "relationships" : {
+      "ciProduct" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/ciProduct",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/ciProduct"
         }
       },
-      "links" : {
-        "self" : "https://appstoreconnect.apple.com/iris/v1/apps/987654321"
+      "betaTesters" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/betaTesters"
+        }
+      },
+      "betaGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/betaGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/betaGroups"
+        }
+      },
+      "appStoreVersions" : {
+        "meta" : {
+          "paging" : {
+            "total" : 1,
+            "limit" : 10
+          }
+        },
+        "data" : [ {
+          "type" : "appStoreVersions",
+          "id" : "9e70d45f-bfc2-43a6-ab98-09fad49459f1"
+        } ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/appStoreVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/appStoreVersions"
+        }
+      },
+      "preReleaseVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/preReleaseVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/preReleaseVersions"
+        }
+      },
+      "betaAppLocalizations" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/betaAppLocalizations",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/betaAppLocalizations"
+        }
+      },
+      "builds" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/builds",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/builds"
+        }
+      },
+      "betaLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/betaLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/betaLicenseAgreement"
+        }
+      },
+      "betaAppReviewDetail" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/betaAppReviewDetail",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/betaAppReviewDetail"
+        }
+      },
+      "appInfos" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/appInfos",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/appInfos"
+        }
+      },
+      "appClips" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/appClips",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/appClips"
+        }
+      },
+      "appPricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/appPricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/appPricePoints"
+        }
+      },
+      "pricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/pricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/pricePoints"
+        }
+      },
+      "endUserLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/endUserLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/endUserLicenseAgreement"
+        }
+      },
+      "preOrder" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/preOrder",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/preOrder"
+        }
+      },
+      "prices" : {
+        "meta" : {
+          "paging" : {
+            "total" : 0,
+            "limit" : 10
+          }
+        },
+        "data" : [ ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/prices",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/prices"
+        }
+      },
+      "appPriceSchedule" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/appPriceSchedule",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/appPriceSchedule"
+        }
+      },
+      "availableTerritories" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/availableTerritories",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/availableTerritories"
+        }
+      },
+      "appAvailability" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/appAvailability",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/appAvailability"
+        }
+      },
+      "inAppPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/inAppPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/inAppPurchases"
+        }
+      },
+      "subscriptionGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/subscriptionGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/subscriptionGroups"
+        }
+      },
+      "gameCenterEnabledVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/gameCenterEnabledVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/gameCenterEnabledVersions"
+        }
+      },
+      "perfPowerMetrics" : {
+        "links" : {
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/perfPowerMetrics"
+        }
+      },
+      "appCustomProductPages" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/appCustomProductPages",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/appCustomProductPages"
+        }
+      },
+      "inAppPurchasesV2" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/inAppPurchasesV2",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/inAppPurchasesV2"
+        }
+      },
+      "promotedPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/promotedPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/promotedPurchases"
+        }
+      },
+      "appEvents" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/appEvents",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/appEvents"
+        }
+      },
+      "reviewSubmissions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/reviewSubmissions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/reviewSubmissions"
+        }
+      },
+      "subscriptionGracePeriod" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/subscriptionGracePeriod",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/subscriptionGracePeriod"
+        }
+      },
+      "customerReviews" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/relationships/customerReviews",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/987654321/customerReviews"
+        }
       }
-    } ],
-    "links" : {
-      "self" : "https://appstoreconnect.apple.com/iris/v1/apps?limit=2"
     },
-    "meta" : {
-      "paging" : {
-        "total" : 22,
-        "limit" : 2
+    "links" : {
+      "self" : "https://api.appstoreconnect.apple.com/v1/apps/987654321"
+    }
+  }, {
+    "type" : "apps",
+    "id" : "1013943394",
+    "attributes" : {
+      "name" : "FastlaneTest 3",
+        "bundleId" : "com.joshholtz.FastlaneTest3",
+        "sku" : "SKU_SKU",
+        "primaryLocale" : "en-US",
+        "removed" : false,
+        "isAAG" : false
+    },
+    "relationships" : {
+      "ciProduct" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/ciProduct",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/ciProduct"
+        }
+      },
+      "betaTesters" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/betaTesters"
+        }
+      },
+      "betaGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/betaGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/betaGroups"
+        }
+      },
+      "appStoreVersions" : {
+        "meta" : {
+          "paging" : {
+            "total" : 1,
+            "limit" : 10
+          }
+        },
+        "data" : [ {
+          "type" : "appStoreVersions",
+          "id" : "9e70d45f-bfc2-43a6-ab98-09fad49459f1"
+        } ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/appStoreVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/appStoreVersions"
+        }
+      },
+      "preReleaseVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/preReleaseVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/preReleaseVersions"
+        }
+      },
+      "betaAppLocalizations" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/betaAppLocalizations",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/betaAppLocalizations"
+        }
+      },
+      "builds" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/builds",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/builds"
+        }
+      },
+      "betaLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/betaLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/betaLicenseAgreement"
+        }
+      },
+      "betaAppReviewDetail" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/betaAppReviewDetail",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/betaAppReviewDetail"
+        }
+      },
+      "appInfos" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/appInfos",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/appInfos"
+        }
+      },
+      "appClips" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/appClips",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/appClips"
+        }
+      },
+      "appPricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/appPricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/appPricePoints"
+        }
+      },
+      "pricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/pricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/pricePoints"
+        }
+      },
+      "endUserLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/endUserLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/endUserLicenseAgreement"
+        }
+      },
+      "preOrder" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/preOrder",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/preOrder"
+        }
+      },
+      "prices" : {
+        "meta" : {
+          "paging" : {
+            "total" : 0,
+            "limit" : 10
+          }
+        },
+        "data" : [ ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/prices",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/prices"
+        }
+      },
+      "appPriceSchedule" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/appPriceSchedule",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/appPriceSchedule"
+        }
+      },
+      "availableTerritories" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/availableTerritories",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/availableTerritories"
+        }
+      },
+      "appAvailability" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/appAvailability",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/appAvailability"
+        }
+      },
+      "inAppPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/inAppPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/inAppPurchases"
+        }
+      },
+      "subscriptionGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/subscriptionGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/subscriptionGroups"
+        }
+      },
+      "gameCenterEnabledVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/gameCenterEnabledVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/gameCenterEnabledVersions"
+        }
+      },
+      "perfPowerMetrics" : {
+        "links" : {
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/perfPowerMetrics"
+        }
+      },
+      "appCustomProductPages" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/appCustomProductPages",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/appCustomProductPages"
+        }
+      },
+      "inAppPurchasesV2" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/inAppPurchasesV2",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/inAppPurchasesV2"
+        }
+      },
+      "promotedPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/promotedPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/promotedPurchases"
+        }
+      },
+      "appEvents" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/appEvents",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/appEvents"
+        }
+      },
+      "reviewSubmissions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/reviewSubmissions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/reviewSubmissions"
+        }
+      },
+      "subscriptionGracePeriod" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/subscriptionGracePeriod",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/subscriptionGracePeriod"
+        }
+      },
+      "customerReviews" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/relationships/customerReviews",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394/customerReviews"
+        }
       }
+    },
+    "links" : {
+      "self" : "https://api.appstoreconnect.apple.com/v1/apps/1013943394"
+    }
+  }, {
+    "type" : "apps",
+    "id" : "898536088",
+    "attributes" : {
+      "name" : "App Name 1",
+        "bundleId" : "net.sunapps.107",
+        "sku" : "SKU_SKU",
+        "primaryLocale" : "en-US",
+        "removed" : false,
+        "isAAG" : false
+    },
+    "relationships" : {
+      "ciProduct" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/ciProduct",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/ciProduct"
+        }
+      },
+      "betaTesters" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/betaTesters"
+        }
+      },
+      "betaGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/betaGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/betaGroups"
+        }
+      },
+      "appStoreVersions" : {
+        "meta" : {
+          "paging" : {
+            "total" : 1,
+            "limit" : 10
+          }
+        },
+        "data" : [ {
+          "type" : "appStoreVersions",
+          "id" : "9e70d45f-bfc2-43a6-ab98-09fad49459f1"
+        } ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/appStoreVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/appStoreVersions"
+        }
+      },
+      "preReleaseVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/preReleaseVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/preReleaseVersions"
+        }
+      },
+      "betaAppLocalizations" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/betaAppLocalizations",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/betaAppLocalizations"
+        }
+      },
+      "builds" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/builds",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/builds"
+        }
+      },
+      "betaLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/betaLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/betaLicenseAgreement"
+        }
+      },
+      "betaAppReviewDetail" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/betaAppReviewDetail",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/betaAppReviewDetail"
+        }
+      },
+      "appInfos" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/appInfos",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/appInfos"
+        }
+      },
+      "appClips" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/appClips",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/appClips"
+        }
+      },
+      "appPricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/appPricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/appPricePoints"
+        }
+      },
+      "pricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/pricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/pricePoints"
+        }
+      },
+      "endUserLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/endUserLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/endUserLicenseAgreement"
+        }
+      },
+      "preOrder" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/preOrder",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/preOrder"
+        }
+      },
+      "prices" : {
+        "meta" : {
+          "paging" : {
+            "total" : 0,
+            "limit" : 10
+          }
+        },
+        "data" : [ ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/prices",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/prices"
+        }
+      },
+      "appPriceSchedule" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/appPriceSchedule",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/appPriceSchedule"
+        }
+      },
+      "availableTerritories" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/availableTerritories",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/availableTerritories"
+        }
+      },
+      "appAvailability" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/appAvailability",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/appAvailability"
+        }
+      },
+      "inAppPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/inAppPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/inAppPurchases"
+        }
+      },
+      "subscriptionGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/subscriptionGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/subscriptionGroups"
+        }
+      },
+      "gameCenterEnabledVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/gameCenterEnabledVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/gameCenterEnabledVersions"
+        }
+      },
+      "perfPowerMetrics" : {
+        "links" : {
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/perfPowerMetrics"
+        }
+      },
+      "appCustomProductPages" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/appCustomProductPages",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/appCustomProductPages"
+        }
+      },
+      "inAppPurchasesV2" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/inAppPurchasesV2",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/inAppPurchasesV2"
+        }
+      },
+      "promotedPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/promotedPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/promotedPurchases"
+        }
+      },
+      "appEvents" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/appEvents",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/appEvents"
+        }
+      },
+      "reviewSubmissions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/reviewSubmissions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/reviewSubmissions"
+        }
+      },
+      "subscriptionGracePeriod" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/subscriptionGracePeriod",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/subscriptionGracePeriod"
+        }
+      },
+      "customerReviews" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/relationships/customerReviews",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/898536088/customerReviews"
+        }
+      }
+    },
+    "links" : {
+      "self" : "https://api.appstoreconnect.apple.com/v1/apps/898536088"
+    }
+  },{
+    "type" : "apps",
+    "id" : "1000000000",
+    "attributes" : {
+      "name" : "FastlaneTest 5",
+        "bundleId" : "com.joshholtz.FastlaneTest5",
+        "sku" : "SKU_SKU",
+        "primaryLocale" : "en-US",
+        "removed" : false,
+        "isAAG" : false
+    },
+    "relationships" : {
+      "ciProduct" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/ciProduct",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/ciProduct"
+        }
+      },
+      "betaTesters" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/betaTesters"
+        }
+      },
+      "betaGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/betaGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/betaGroups"
+        }
+      },
+      "appStoreVersions" : {
+        "meta" : {
+          "paging" : {
+            "total" : 1,
+            "limit" : 10
+          }
+        },
+        "data" : [ {
+          "type" : "appStoreVersions",
+          "id" : "9e70d45f-bfc2-43a6-ab98-09fad49459f1"
+        } ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/appStoreVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/appStoreVersions"
+        }
+      },
+      "preReleaseVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/preReleaseVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/preReleaseVersions"
+        }
+      },
+      "betaAppLocalizations" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/betaAppLocalizations",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/betaAppLocalizations"
+        }
+      },
+      "builds" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/builds",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/builds"
+        }
+      },
+      "betaLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/betaLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/betaLicenseAgreement"
+        }
+      },
+      "betaAppReviewDetail" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/betaAppReviewDetail",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/betaAppReviewDetail"
+        }
+      },
+      "appInfos" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/appInfos",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/appInfos"
+        }
+      },
+      "appClips" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/appClips",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/appClips"
+        }
+      },
+      "appPricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/appPricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/appPricePoints"
+        }
+      },
+      "pricePoints" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/pricePoints",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/pricePoints"
+        }
+      },
+      "endUserLicenseAgreement" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/endUserLicenseAgreement",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/endUserLicenseAgreement"
+        }
+      },
+      "preOrder" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/preOrder",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/preOrder"
+        }
+      },
+      "prices" : {
+        "meta" : {
+          "paging" : {
+            "total" : 0,
+            "limit" : 10
+          }
+        },
+        "data" : [ ],
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/prices",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/prices"
+        }
+      },
+      "appPriceSchedule" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/appPriceSchedule",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/appPriceSchedule"
+        }
+      },
+      "availableTerritories" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/availableTerritories",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/availableTerritories"
+        }
+      },
+      "appAvailability" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/appAvailability",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/appAvailability"
+        }
+      },
+      "inAppPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/inAppPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/inAppPurchases"
+        }
+      },
+      "subscriptionGroups" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/subscriptionGroups",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/subscriptionGroups"
+        }
+      },
+      "gameCenterEnabledVersions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/gameCenterEnabledVersions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/gameCenterEnabledVersions"
+        }
+      },
+      "perfPowerMetrics" : {
+        "links" : {
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/perfPowerMetrics"
+        }
+      },
+      "appCustomProductPages" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/appCustomProductPages",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/appCustomProductPages"
+        }
+      },
+      "inAppPurchasesV2" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/inAppPurchasesV2",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/inAppPurchasesV2"
+        }
+      },
+      "promotedPurchases" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/promotedPurchases",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/promotedPurchases"
+        }
+      },
+      "appEvents" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/appEvents",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/appEvents"
+        }
+      },
+      "reviewSubmissions" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/reviewSubmissions",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/reviewSubmissions"
+        }
+      },
+      "subscriptionGracePeriod" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/subscriptionGracePeriod",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/subscriptionGracePeriod"
+        }
+      },
+      "customerReviews" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/relationships/customerReviews",
+          "related" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000/customerReviews"
+        }
+      }
+    },
+    "links" : {
+      "self" : "https://api.appstoreconnect.apple.com/v1/apps/1000000000"
+    }
+  }],
+  "included" : [ {
+    "type" : "appStoreVersions",
+    "id" : "2c2e7526-bde0-4878-b04b-89d20dd2a692",
+    "attributes" : {
+      "platform" : "IOS",
+      "versionString" : "1.0",
+      "appStoreState" : "PREPARE_FOR_SUBMISSION",
+      "copyright" : null,
+      "releaseType" : "AFTER_APPROVAL",
+      "earliestReleaseDate" : null,
+      "usesIdfa" : null,
+      "downloadable" : true,
+      "createdDate" : "2022-07-18T11:17:21-07:00"
+    },
+    "relationships" : {
+      "ageRatingDeclaration" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/ageRatingDeclaration",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/ageRatingDeclaration"
+        }
+      },
+      "appStoreVersionLocalizations" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/appStoreVersionLocalizations",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/appStoreVersionLocalizations"
+        }
+      },
+      "build" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/build",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/build"
+        }
+      },
+      "appStoreVersionPhasedRelease" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/appStoreVersionPhasedRelease",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/appStoreVersionPhasedRelease"
+        }
+      },
+      "routingAppCoverage" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/routingAppCoverage",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/routingAppCoverage"
+        }
+      },
+      "appStoreReviewDetail" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/appStoreReviewDetail",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/appStoreReviewDetail"
+        }
+      },
+      "appStoreVersionSubmission" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/appStoreVersionSubmission",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/appStoreVersionSubmission"
+        }
+      },
+      "idfaDeclaration" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/idfaDeclaration",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/idfaDeclaration"
+        }
+      },
+      "appClipDefaultExperience" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/appClipDefaultExperience",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/appClipDefaultExperience"
+        }
+      },
+      "appStoreVersionExperiments" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/appStoreVersionExperiments",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/appStoreVersionExperiments"
+        }
+      },
+      "customerReviews" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/relationships/customerReviews",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692/customerReviews"
+        }
+      }
+    },
+    "links" : {
+      "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/2c2e7526-bde0-4878-b04b-89d20dd2a692"
+    }
+  }, {
+    "type" : "appStoreVersions",
+    "id" : "9e70d45f-bfc2-43a6-ab98-09fad49459f1",
+    "attributes" : {
+      "platform" : "IOS",
+      "versionString" : "1.0",
+      "appStoreState" : "PREPARE_FOR_SUBMISSION",
+      "copyright" : null,
+      "releaseType" : "AFTER_APPROVAL",
+      "earliestReleaseDate" : null,
+      "usesIdfa" : null,
+      "downloadable" : true,
+      "createdDate" : "2022-06-14T19:38:26-07:00"
+    },
+    "relationships" : {
+      "ageRatingDeclaration" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/ageRatingDeclaration",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/ageRatingDeclaration"
+        }
+      },
+      "appStoreVersionLocalizations" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/appStoreVersionLocalizations",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/appStoreVersionLocalizations"
+        }
+      },
+      "build" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/build",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/build"
+        }
+      },
+      "appStoreVersionPhasedRelease" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/appStoreVersionPhasedRelease",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/appStoreVersionPhasedRelease"
+        }
+      },
+      "routingAppCoverage" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/routingAppCoverage",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/routingAppCoverage"
+        }
+      },
+      "appStoreReviewDetail" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/appStoreReviewDetail",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/appStoreReviewDetail"
+        }
+      },
+      "appStoreVersionSubmission" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/appStoreVersionSubmission",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/appStoreVersionSubmission"
+        }
+      },
+      "idfaDeclaration" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/idfaDeclaration",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/idfaDeclaration"
+        }
+      },
+      "appClipDefaultExperience" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/appClipDefaultExperience",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/appClipDefaultExperience"
+        }
+      },
+      "appStoreVersionExperiments" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/appStoreVersionExperiments",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/appStoreVersionExperiments"
+        }
+      },
+      "customerReviews" : {
+        "links" : {
+          "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/relationships/customerReviews",
+          "related" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1/customerReviews"
+        }
+      }
+    },
+    "links" : {
+      "self" : "https://api.appstoreconnect.apple.com/v1/appStoreVersions/9e70d45f-bfc2-43a6-ab98-09fad49459f1"
+    }
+  } ],
+  "links" : {
+    "self" : "https://api.appstoreconnect.apple.com/v1/apps?include=appStoreVersions%2Cprices",
+    "next" : null
+  },
+  "meta" : {
+    "paging" : {
+      "total" : 2,
+      "limit" : 2
     }
   }
+}

--- a/spaceship/spec/connect_api/models/app_spec.rb
+++ b/spaceship/spec/connect_api/models/app_spec.rb
@@ -16,7 +16,7 @@ describe Spaceship::ConnectAPI::App do
       response = Spaceship::ConnectAPI.get_apps
       expect(response).to be_an_instance_of(Spaceship::ConnectAPI::Response)
 
-      expect(response.count).to eq(2)
+      expect(response.count).to eq(5)
       response.each do |model|
         expect(model).to be_an_instance_of(Spaceship::ConnectAPI::App)
       end

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -18,6 +18,18 @@ class ConnectAPIStubbing
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps").
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 
+        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?include=appStoreVersions,prices").
+          with(
+            headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Spaceship 2.207.0',
+            'X-Csrf-Itc' => '[asc-ui]'
+          }
+).
+          to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
+
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?filter%5BbundleId%5D=com.joshholtz.FastlaneTest&include=appStoreVersions,prices").
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -21,13 +21,12 @@ class ConnectAPIStubbing
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?include=appStoreVersions,prices").
           with(
             headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'User-Agent' => 'Spaceship 2.207.0',
-            'X-Csrf-Itc' => '[asc-ui]'
-          }
-).
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'User-Agent' => 'Spaceship 2.207.0',
+              'X-Csrf-Itc' => 'itc'
+            }
+          ).
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?filter%5BbundleId%5D=com.joshholtz.FastlaneTest&include=appStoreVersions,prices").

--- a/spaceship/spec/du/du_client_spec.rb
+++ b/spaceship/spec/du/du_client_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::DUClient, :du do
   before { Spaceship::Tunes.login }
 
   let(:client) { Spaceship::AppVersion.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
   let(:contentProviderId) { "4321" }
   let(:ssoTokenForImage) { "sso token for image" }
   let(:version) { app.edit_version }

--- a/spaceship/spec/tunes/app_analytics_spec.rb
+++ b/spaceship/spec/tunes/app_analytics_spec.rb
@@ -4,7 +4,7 @@ require 'pp'
 describe Spaceship::Tunes::AppAnalytics do
   before { Spaceship::Tunes.login }
 
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
 
   describe "App Analytics Grabbed Properly" do
     it "accesses live analytics details" do

--- a/spaceship/spec/tunes/app_details_spec.rb
+++ b/spaceship/spec/tunes/app_details_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::Tunes::AppDetails do
   before { Spaceship::Tunes.login }
 
   let(:client) { Spaceship::AppVersion.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
 
   describe "App Details are properly loaded" do
     it "contains all the relevant information" do

--- a/spaceship/spec/tunes/app_ratings_spec.rb
+++ b/spaceship/spec/tunes/app_ratings_spec.rb
@@ -1,6 +1,6 @@
 describe Spaceship::Tunes::AppRatings do
   before { Spaceship::Tunes.login }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
   let(:client) { Spaceship::Application.client }
 
   describe "successfully loads rating summary" do

--- a/spaceship/spec/tunes/app_submission_spec.rb
+++ b/spaceship/spec/tunes/app_submission_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::AppSubmission do
   before { Spaceship::Tunes.login }
 
   let(:client) { Spaceship::AppSubmission.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
 
   describe "successfully creates a new app submission" do
     it "generates a new app submission from App Store Connect response" do

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::AppVersion, all: true do
   before { Spaceship::Tunes.login }
 
   let(:client) { Spaceship::AppVersion.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
 
   describe "successfully loads and parses the app version" do
     it "inspect works" do
@@ -243,7 +243,7 @@ describe Spaceship::AppVersion, all: true do
   end
 
   describe "Modifying the app version" do
-    let(:version) { Spaceship::Application.all.first.edit_version }
+    let(:version) { app.edit_version }
 
     it "doesn't allow modification of localized properties without the language" do
       begin
@@ -725,7 +725,7 @@ describe Spaceship::AppVersion, all: true do
   end
 
   describe "Modifying the app live version" do
-    let(:version) { Spaceship::Application.all.first.live_version }
+    let(:version) { app.live_version }
 
     describe "Generate promo codes", focus: true do
       it "fetches remaining promocodes" do
@@ -751,7 +751,6 @@ describe Spaceship::AppVersion, all: true do
   describe "Validate attachment file" do
     before { Spaceship::Tunes.login }
     let(:client) { Spaceship::AppVersion.client }
-    let(:app) { Spaceship::Application.all.first }
     describe "successfully loads and parses the app version and attachment" do
       it "contains the right information" do
         TunesStubbing.itc_stub_app_attachment

--- a/spaceship/spec/tunes/application_spec.rb
+++ b/spaceship/spec/tunes/application_spec.rb
@@ -1,33 +1,28 @@
 describe Spaceship::Application do
   before { Spaceship::Tunes.login }
   let(:client) { Spaceship::Application.client }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
 
   describe "successfully loads and parses all apps" do
     it "inspect works" do
-      expect(Spaceship::Application.all.first.inspect).to include("Tunes::Application")
+      expect(app.inspect).to include("Tunes::Application")
     end
 
     it "the number is correct" do
-      expect(Spaceship::Application.all.count).to eq(8)
+      expect(Spaceship::Application.all.count).to eq(5)
     end
 
     it "parses application correctly" do
-      app = Spaceship::Application.all.first
-
       expect(app.apple_id).to eq('898536088')
       expect(app.name).to eq('App Name 1')
       expect(app.platform).to eq('ios')
-      expect(app.vendor_id).to eq('107')
       expect(app.bundle_id).to eq('net.sunapps.107')
-      expect(app.last_modified).to eq(1_435_685_244_000)
-      expect(app.issues_count).to eq(0)
-      expect(app.app_icon_preview_url).to eq('https://is5-ssl.mzstatic.com/image/thumb/Purple3/v4/78/7c/b5/787cb594-04a3-a7ba-ac17-b33d1582ebc9/mzl.dbqfnkxr.png/340x340bb-80.png')
 
       expect(app.raw_data['versionSets'].count).to eq(1)
     end
 
     it "#url" do
-      expect(Spaceship::Application.all.first.url).to eq('https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088')
+      expect(app.url).to eq('https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/898536088')
     end
 
     describe "#find" do
@@ -126,18 +121,17 @@ describe Spaceship::Application do
     describe "#resolution_center" do
       it "when the app was rejected" do
         TunesStubbing.itc_stub_resolution_center
-        result = Spaceship::Tunes::Application.all.first.resolution_center
+        result = app.resolution_center
         expect(result['appNotes']['threads'].first['messages'].first['body']).to include('Your app declares support for audio in the UIBackgroundModes')
       end
 
       it "when the app was not rejected" do
         TunesStubbing.itc_stub_resolution_center_valid
-        expect(Spaceship::Tunes::Application.all.first.resolution_center).to eq({ "sectionErrorKeys" => [], "sectionInfoKeys" => [], "sectionWarningKeys" => [], "replyConstraints" => { "minLength" => 1, "maxLength" => 4000 }, "appNotes" => { "threads" => [] }, "betaNotes" => { "threads" => [] }, "appMessages" => { "threads" => [] } })
+        expect(app.resolution_center).to eq({ "sectionErrorKeys" => [], "sectionInfoKeys" => [], "sectionWarningKeys" => [], "replyConstraints" => { "minLength" => 1, "maxLength" => 4000 }, "appNotes" => { "threads" => [] }, "betaNotes" => { "threads" => [] }, "appMessages" => { "threads" => [] } })
       end
     end
 
     describe "#builds" do
-      let(:app) { Spaceship::Application.all.first }
       let(:mock_client) { double('MockClient') }
 
       require 'spec_helper'
@@ -200,7 +194,6 @@ describe Spaceship::Application do
     describe "Access app_versions" do
       describe "#edit_version" do
         it "returns the edit version if there is an edit version" do
-          app = Spaceship::Application.all.first
           v = app.edit_version
           expect(v.class).to eq(Spaceship::AppVersion)
           expect(v.application).to eq(app)
@@ -211,14 +204,13 @@ describe Spaceship::Application do
 
       describe "#latest_version" do
         it "returns the edit_version if available" do
-          app = Spaceship::Application.all.first
           expect(app.latest_version.class).to eq(Spaceship::Tunes::AppVersion)
         end
       end
 
       describe "#live_version" do
         it "there is always a live version" do
-          v = Spaceship::Application.all.first.live_version
+          v = app.live_version
           expect(v.class).to eq(Spaceship::AppVersion)
           expect(v.is_live).to eq(true)
         end
@@ -232,30 +224,10 @@ describe Spaceship::Application do
           expect(app.latest_version.is_live).to eq(false)
         end
       end
-
-      describe "BUNDLES" do
-        let(:bundle) { Spaceship::Application.find(928_444_013) }
-        it "can find a bundle" do
-          expect(bundle.raw_data['type']).to eq("iOS App Bundle")
-        end
-
-        it "fails to find the edit_version of a bundle" do
-          expect do
-            bundle.edit_version
-          end.to raise_error('We do not support BUNDLE types right now')
-        end
-
-        it "fails to find the live_version of a bundle" do
-          expect do
-            bundle.live_version
-          end.to raise_error('We do not support BUNDLE types right now')
-        end
-      end
     end
 
     describe "Create new version" do
       it "raises an exception if there already is a new version" do
-        app = Spaceship::Application.all.first
         expect do
           app.create_version!('0.1')
         end.to raise_error("Cannot create a new version for this app as there already is an `edit_version` available")
@@ -264,7 +236,6 @@ describe Spaceship::Application do
 
     describe "Version history" do
       it "Parses history" do
-        app = Spaceship::Application.all.first
         history = app.versions_history
         expect(history.count).to eq(9)
 
@@ -293,8 +264,6 @@ describe Spaceship::Application do
     end
 
     describe "Promo codes" do
-      let(:app) { Spaceship::Application.all.first }
-
       it "fetches remaining promocodes" do
         promocodes = app.promocodes
         expect(promocodes.count).to eq(1)
@@ -330,7 +299,6 @@ describe Spaceship::Application do
     end
 
     describe "#availability" do
-      let(:app) { Spaceship::Application.all.first }
       before { TunesStubbing.itc_stub_app_pricing_intervals }
 
       it "inspect works" do
@@ -340,7 +308,6 @@ describe Spaceship::Application do
     end
 
     describe "#update_availability" do
-      let(:app) { Spaceship::Application.all.first }
       before { TunesStubbing.itc_stub_app_pricing_intervals }
 
       it "inspect works" do
@@ -354,7 +321,6 @@ describe Spaceship::Application do
     end
 
     describe "#update_price_tier" do
-      let(:app) { Spaceship::Application.all.first }
       let(:effective_date) { 1_525_488_436 }
       before { TunesStubbing.itc_stub_app_pricing_intervals }
 

--- a/spaceship/spec/tunes/availability_spec.rb
+++ b/spaceship/spec/tunes/availability_spec.rb
@@ -3,7 +3,7 @@ describe Spaceship::Tunes::Availability do
   before { TunesStubbing.itc_stub_app_pricing_intervals }
 
   let(:client) { Spaceship::AppVersion.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
 
   describe "availability" do
     it "inspect works" do

--- a/spaceship/spec/tunes/iap_detail_spec.rb
+++ b/spaceship/spec/tunes/iap_detail_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::Tunes::IAPDetail do
   before { TunesStubbing.itc_stub_iap }
   before { Spaceship::Tunes.login }
   let(:client) { Spaceship::Application.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
   let(:detailed) { app.in_app_purchases.find("go.find.me").edit }
 
   describe "Details of an IAP" do

--- a/spaceship/spec/tunes/iap_families_spec.rb
+++ b/spaceship/spec/tunes/iap_families_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::Tunes::IAPFamilies do
   before { TunesStubbing.itc_stub_iap }
   before { Spaceship::Tunes.login }
   let(:client) { Spaceship::Application.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
   let(:purchase) { app.in_app_purchases }
   describe "Subscription Families" do
     it "Loads IAP Families List" do

--- a/spaceship/spec/tunes/iap_family_details_spec.rb
+++ b/spaceship/spec/tunes/iap_family_details_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::Tunes::IAPFamilyList do
   before { TunesStubbing.itc_stub_iap }
   before { Spaceship::Tunes.login }
   let(:client) { Spaceship::Application.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
   let(:purchase) { app.in_app_purchases }
   describe "IAP FamilyDetail" do
     it "Creates a Object" do

--- a/spaceship/spec/tunes/iap_family_list_spec.rb
+++ b/spaceship/spec/tunes/iap_family_list_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::Tunes::IAPFamilyList do
   before { TunesStubbing.itc_stub_iap }
   before { Spaceship::Tunes.login }
   let(:client) { Spaceship::Application.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
   let(:purchase) { app.in_app_purchases }
   describe "IAP FamilyList" do
     it "Creates a Object" do

--- a/spaceship/spec/tunes/iap_list_spec.rb
+++ b/spaceship/spec/tunes/iap_list_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::Tunes::IAPList do
   before { TunesStubbing.itc_stub_iap }
   before { Spaceship::Tunes.login }
   let(:client) { Spaceship::Application.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
   let(:purchase) { app.in_app_purchases }
   describe "IAPList" do
     it "Creates a Object" do

--- a/spaceship/spec/tunes/iap_spec.rb
+++ b/spaceship/spec/tunes/iap_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::Tunes::IAP do
   before { TunesStubbing.itc_stub_iap }
   before { Spaceship::Tunes.login }
   let(:client) { Spaceship::Tunes.client }
-  let(:app) { Spaceship::Application.all.first }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
 
   describe "returns all purchases" do
     it "returns as IAPList" do

--- a/spaceship/spec/tunes/iap_subscription_pricing_tier_spec.rb
+++ b/spaceship/spec/tunes/iap_subscription_pricing_tier_spec.rb
@@ -2,8 +2,8 @@ describe Spaceship::Tunes::IAPSubscriptionPricingTier do
   before { TunesStubbing.itc_stub_iap }
   before { Spaceship::Tunes.login }
 
-  let(:client)        { Spaceship::AppVersion.client }
-  let(:app)           { Spaceship::Application.all.first }
+  let(:client) { Spaceship::AppVersion.client }
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
   let(:pricing_tiers) { client.subscription_pricing_tiers(app.apple_id) }
 
   describe "In-App-Purchase Subscription Pricing Tier" do

--- a/spaceship/spec/tunes/language_item_spec.rb
+++ b/spaceship/spec/tunes/language_item_spec.rb
@@ -3,33 +3,35 @@ describe Spaceship::Tunes::LanguageItem do
     Spaceship::Tunes.login
   end
 
+  let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
+
   describe "language code inspection" do
     it "prints out all languages with their values" do
-      str = Spaceship::Application.all.first.edit_version.description.inspect
+      str = app.edit_version.description.inspect
       expect(str).to eq("German: My title\nEnglish: Super Description here\n")
     end
 
     it "localCode is also used for language keys" do
       # details.name uses `localCode` instead of `languages`
-      keys = Spaceship::Application.all.first.details.name.keys
+      keys = app.details.name.keys
       expect(keys).to eq(["en-US", "de-DE"])
     end
 
     it "localCode is also used for inspect method" do
       # details.name uses `localeCode` instead of `languages`
-      inspect_string = Spaceship::Application.all.first.details.name.inspect
+      inspect_string = app.details.name.inspect
       expect(inspect_string).to eq("en-US: Updated by fastlane\nde-DE: why new itc 2\n")
     end
 
     it "localCode is also used for get_lang method" do
       # details.name uses `localeCode` instead of `languages`
-      english_name = Spaceship::Application.all.first.details.name["en-US"]
+      english_name = app.details.name["en-US"]
       expect(english_name).to eq("Updated by fastlane")
     end
 
     it "ensure test data is setup as expected" do
       # details.name uses `localeCode` instead of `languages`, so no nodes should exist for `languages`
-      original_array = Spaceship::Application.all.first.details.name.original_array
+      original_array = app.details.name.original_array
       locale_node = original_array.flat_map { |value| value["localeCode"] }
       languages_node = original_array.each_with_object([]) do |value, languages|
         language = value["languages"]

--- a/spaceship/spec/tunes/member_spec.rb
+++ b/spaceship/spec/tunes/member_spec.rb
@@ -10,7 +10,7 @@ describe Spaceship::Tunes::Members do
 
       member = Spaceship::Members.find("hjanuschka+no-accept@gmail.com")
       expect(member.has_all_apps).to eq(false)
-      expect(member.selected_apps.first.name).to eq("App Name 1")
+      expect(member.selected_apps.find { |a| a.apple_id == "898536088" }.name).to eq("App Name 1")
     end
 
     it "checks if invitation is accepted" do

--- a/spaceship/spec/tunes/tunes_permissions_spec.rb
+++ b/spaceship/spec/tunes/tunes_permissions_spec.rb
@@ -1,7 +1,7 @@
 describe Spaceship::Tunes do
   describe "InsufficientPermissions" do
     before { Spaceship::Tunes.login }
-    let(:app) { Spaceship::Application.all.first }
+    let(:app) { Spaceship::Application.all.find { |a| a.apple_id == "898536088" } }
 
     it "raises an appropriate App Store Connect error when user doesn't have enough permission to do something" do
       stub_request(:post, "https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/898536088/platforms/ios/versions/812106519").


### PR DESCRIPTION
### Motivation and Context

- Fixes #20444
- Provides temporary work around for `Spaceship::Tunes::Application.find`
  - Maybe fixes [issue on App Center](https://twitter.com/appcenterstatus/status/1545000909473648640?s=21&t=m_tP4urguSgPP9MOkU65Mg )

---

### Description

❌ The legacy Apple endpoint that `Spaceship::Tunes::Application.find` used is no longer available 

This was not an issue for anything inside of _fastlane_ (besides `fastlane init` still accidentally using it).

#### Fix 1 - `fastlane init`

This was the easy fix. `setup_ios.rb` now uses `Spaceship::ConnectAPI::App.find` instead. This uses the more stable Apple API now.

#### Fix 2 - Retrofit `Spaceship::Tunes::Application.find`

Because some users (and I think App Center) still want/need to use `Spaceship::Tunes` for in-app purchase things, I have done by best to retrofit `Spaceship::Tunes:: Application.find` by power it with `Spaceship::ConnectAPI::App.find`.

It's not a perfect fit because not all of the data is available but it will at least find the app and be able to give the app name, id and platforms.

---

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-fix-init"
```

---

### Other Notes

‼️ IT IS STILL HIGHLY RECOMMEND TO USE STOP USING `Spaceship::Tunes` START USING `Spaceship::ConnectAPI` if you can

⚠️ However, there is not official `Spaceship::ConnectAPI` support for in-app purchases (yet) but I'm working on it. You can follow along with progress on this issue for now - https://github.com/fastlane/fastlane/issues/20477