### PR TITLE
[pilot] app_version and app_build should not be fetched from a local IPA or PKG when distribute_only is set

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -108,10 +108,10 @@ module Pilot
 
     def wait_for_build_processing_to_be_complete(return_when_build_appears = false)
       platform = fetch_app_platform
-      if config[:ipa] && platform != "osx"
+      if config[:ipa] && platform != "osx" && !config[:distribute_only]
         app_version = FastlaneCore::IpaFileAnalyser.fetch_app_version(config[:ipa])
         app_build = FastlaneCore::IpaFileAnalyser.fetch_app_build(config[:ipa])
-      elsif config[:pkg]
+      elsif config[:pkg] && !config[:distribute_only]
         app_version = FastlaneCore::PkgFileAnalyser.fetch_app_version(config[:pkg])
         app_build = FastlaneCore::PkgFileAnalyser.fetch_app_build(config[:pkg])
       else

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -468,6 +468,24 @@ describe "Build Manager" do
       fake_build_manager.wait_for_build_processing_to_be_complete
     end
 
+    it "wait given :distribute_only" do
+      options = { pkg: "some_path.pkg", build_number: "234", app_version: "2.3.4", distribute_only: true }
+      fake_build_manager.instance_variable_set(:@config, options)
+
+      expect(fake_build_manager).to receive(:fetch_app_platform)
+      expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_version))
+      expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
+      expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_version))
+      expect(FastlaneCore::PkgFileAnalyser).to_not(receive(:fetch_app_build))
+
+      fake_build = double
+      expect(fake_build).to receive(:app_version).and_return("2.3.4")
+      expect(fake_build).to receive(:version).and_return("234")
+      expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+      fake_build_manager.wait_for_build_processing_to_be_complete
+    end
+
     it "wait given :ipa and :pkg and platform ios" do
       options = { ipa: "some_path.ipa", pkg: "some_path.pkg" }
       fake_build_manager.instance_variable_set(:@config, options)
@@ -497,20 +515,6 @@ describe "Build Manager" do
       expect(FastlaneCore::IpaFileAnalyser).to_not(receive(:fetch_app_build))
       expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_version).and_return("1.2.3")
       expect(FastlaneCore::PkgFileAnalyser).to receive(:fetch_app_build).and_return("123")
-
-      fake_build = double
-      expect(fake_build).to receive(:app_version).and_return("1.2.3")
-      expect(fake_build).to receive(:version).and_return("123")
-      expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
-
-      fake_build_manager.wait_for_build_processing_to_be_complete
-    end
-
-    it "wait given :app_version and :build_number" do
-      options = { app_version: "1.2.3", build_number: "123" }
-      fake_build_manager.instance_variable_set(:@config, options)
-
-      expect(fake_build_manager).to receive(:fetch_app_platform)
 
       fake_build = double
       expect(fake_build).to receive(:app_version).and_return("1.2.3")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
🔑
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #20479

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

As mentioned in the title and the linked issue, a local IPA or PKG should not override the info provided to the command if `distribute_only` is set.

My particular test case used a repo with an iOS and macOS target, and an older macOS `.pkg` file sitting in the repo. When I ran the command from the linked issue, I ended up waiting for an iOS build with the version number on the old macOS `.pkg`, even though I passed the correct `build_number` to the command. With this change, the `distribute_only` argument will cause the code to fall through to the step where `build_number` is picked up from the `config`.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
