### PR TITLE
[match] suppress null byte message

### DIFF
--- a/match/lib/match/utils.rb
+++ b/match/lib/match/utils.rb
@@ -37,9 +37,14 @@ module Match
 
     def self.get_cert_info(cer_certificate)
       # can receive a certificate path or the file data
-      if File.exist?(cer_certificate)
-        cer_certificate = File.binread(cer_certificate)
+      begin
+        if File.exist?(cer_certificate)
+          cer_certificate = File.binread(cer_certificate)
+        end
+      rescue ArgumentError
+        # cert strings have null bytes; suppressing output
       end
+
       cert = OpenSSL::X509::Certificate.new(cer_certificate)
 
       # openssl output:


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
https://github.com/fastlane/fastlane/pull/20187/ introduced the ability to pass either a file path or the raw cert data to `self.get_cert_info`. It works by calling `File.exist?` which prints a harmless error message when a cert is passed in:

```
ERROR [2022-07-20 09:52:59.80]: get_cert_info: path name contains null byte
```

This PR suppresses the message and resolves #20489.

### Description
Catches the error when it's raised and does nothing.

I tested the changes by running `match` and observed that the error message no longer prints.

### Testing Steps
Run match; notice the error message is gone.