### PR TITLE
[scan] Stop require `project` when providing `xctestrun` path

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -15,8 +15,8 @@ module Scan
 
       prevalidate
 
-      # Detect the project if not SPM package
-      if Scan.config[:package_path].nil?
+      # Detect the project if not SPM package and not running with: test_without_building and xctestrun
+      if Scan.config[:package_path].nil? && !(Scan.config[:test_without_building] && Scan.config[:xctestrun])
         FastlaneCore::Project.detect_projects(config)
         Scan.project = FastlaneCore::Project.new(config)
 

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -36,6 +36,52 @@ describe Scan do
       end
     end
 
+    describe 'test without building' do
+      describe 'does not attempt to detect FastlaneCore::Project' do
+        it 'with :test_without_building true and :xctestrun given', requires_xcodebuild: true do
+          options = {
+            test_without_building: true,
+            xctestrun: "./scan/examples/standard/DerivedData/Build/testplan.xctestrun"
+          }
+
+          expect(FastlaneCore::Project).to_not(receive(:detect_projects))
+
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        end
+      end
+
+      describe 'detects FastlaneCore::Project' do
+        before do
+          # Mocks input from detect_projects
+          @project = FastlaneCore::Project.new({
+            project: "./scan/examples/standard/app.xcodeproj"
+          })
+        end
+
+        it 'with :test_without_building true and no :xctestrun given', requires_xcodebuild: true do
+          options = {
+            test_without_building: true
+          }
+
+          expect(FastlaneCore::Project).to receive(:detect_projects)
+          expect(FastlaneCore::Project).to receive(:new).and_return(@project)
+
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        end
+
+        it 'with :test_without_building false', requires_xcodebuild: true do
+          options = {
+            test_without_building: false
+          }
+
+          expect(FastlaneCore::Project).to receive(:detect_projects)
+          expect(FastlaneCore::Project).to receive(:new).and_return(@project)
+
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+        end
+      end
+    end
+
     describe 'Xcode config handling' do
       before do
         options = { project: "./scan/examples/standard/app.xcodeproj" }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
The problem exist when you want to run `scan` with `test_without_building` and `xctestrun`. Fastlane doesn't allow to do so and require `project` parameter. It's inconvinient on CI when previous job runs `scan` with `build_for_testing` and test job doesn't have access to whole project file, it only has derived data and `xctestrun` files.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Add a check if `xctestrun` parameter is set and in this case omit detecting project path.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
