### PR TITLE
[match][sigh][cert] Added checking hash of installed wwdr certificates

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -84,8 +84,10 @@ module FastlaneCore
     def self.wwdr_certificate_installed?
       certificate_name = "Apple Worldwide Developer Relations Certification Authority"
       certificate_hash = "SHA-256 hash: BDD4ED6E74691F0C2BFD01BE0296197AF1379E0418E2D300EFA9C3BEF642CA30"
+
       keychain = wwdr_keychain
       response = Helper.backticks("security find-certificate -a -c '#{certificate_name}' -Z #{keychain.shellescape} | grep ^SHA-256", print: FastlaneCore::Globals.verbose?)
+
       certs = response.split("\n")
       certs.include?(certificate_hash)
     end

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -83,10 +83,11 @@ module FastlaneCore
 
     def self.wwdr_certificate_installed?
       certificate_name = "Apple Worldwide Developer Relations Certification Authority"
+      certificate_hash = "SHA-256 hash: BDD4ED6E74691F0C2BFD01BE0296197AF1379E0418E2D300EFA9C3BEF642CA30"
       keychain = wwdr_keychain
-      response = Helper.backticks("security find-certificate -a -c '#{certificate_name}' #{keychain.shellescape}", print: FastlaneCore::Globals.verbose?)
-      certs = response.split("keychain: \"#{keychain}\"").drop(1)
-      certs.count >= 1
+      response = Helper.backticks("security find-certificate -a -c '#{certificate_name}' -Z #{keychain.shellescape} | grep ^SHA-256", print: FastlaneCore::Globals.verbose?)
+      certs = response.split("\n")
+      certs.include?(certificate_hash)
     end
 
     def self.install_wwdr_certificate


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
On different machines can be installed different wwdr certificates, but that certificates have same name "Apple Worldwide Developer Relations Certification Authority"
And It can be a problem in case:
On "new machine" fastlane will install the latest wwdr certificate https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer
On "old machine" fastlane wouldn't install the latest wwdr certificate if other wwdr certificate exists
If provision profiles was created "old machine" than code sign on "old machine" will be successful, but on "new machine" code sign will be failed

### Description
- Added collecting hashes of installed wwdr certificates. Bash command for printing hash took from example `man security> find-certificate -a -c MyName -Z login.keychain | grep ^SHA-256`
- Replaced checking count on checking exists hash `SHA-256 hash: BDD4ED6E74691F0C2BFD01BE0296197AF1379E0418E2D300EFA9C3BEF642CA30` of certificate https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer

### Testing Steps
1. Remove all wwdr certificates from keychain
2. Install any wwdr certificates (for example https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer, https://developer.apple.com/certificationauthority/AppleWWDRCA.cer)
3. Run with `--verbose` lane where `match` install provision profiles and certificates
4. Take a look on debug log to see, `fastlane` install the latest wwdr certificate https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer