### PR TITLE
[core] Fix unescaped \

### DIFF
--- a/fastlane_core/spec/ipa_upload_package_builder_spec.rb
+++ b/fastlane_core/spec/ipa_upload_package_builder_spec.rb
@@ -20,7 +20,7 @@ describe FastlaneCore do
       end
 
       it 'returns true for all special characters' do
-        special_chars = %w[! @ # $ % ^ & * ( ) + = [ ] " ' ; : < > ? / \ | { } , ~ `]
+        special_chars = %w[! @ # $ % ^ & * ( ) + = [ ] " ' ; : < > ? / \\ | { } , ~ `]
 
         special_chars.each do |c|
           is_valid = special_chars?("something_#{c}.ipa")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

I just stumbled upon this likely typo. Without the additional backslash we'd end up making `(space)|` a special string instead of `\` and `|`.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
