### PR TITLE
[frameit] faceook.design moved to design.facebook.com

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/frame_screenshots.md
@@ -60,7 +60,7 @@ Here is a nice gif, that shows _frameit_ in action:
 <h5 align="center">The <em>frameit</em> 2.0 update was kindly sponsored by <a href="https://mindnode.com/">MindNode</a>, seen in the screenshots above.</h5>
 
 
-The first time that _frameit_ is executed the frames will be downloaded automatically. Originally the frames are coming from [Facebook frameset](http://facebook.design/devices) and they are kept on [this repo](https://github.com/fastlane/frameit-frames).
+The first time that _frameit_ is executed the frames will be downloaded automatically. Originally the frames are coming from [Facebook frameset](https://design.facebook.com/toolsandresources/devices/) and they are kept on [this repo](https://github.com/fastlane/frameit-frames).
 
 More information about this process and how to update the frames can be found [here](https://github.com/fastlane/fastlane/tree/master/frameit/frames_generator)
 

--- a/frameit/frames_generator/README.md
+++ b/frameit/frames_generator/README.md
@@ -1,6 +1,6 @@
 # Prepare and upload new device frames
 
-Starting in October 2016 we are now using the [Facebook frameset](http://facebook.design/devices) and hosting the device frame resources since Apple sometimes has removed / changed some of the old images making framing a moving target.
+Starting in October 2016 we are now using the [Facebook frameset](https://design.facebook.com/toolsandresources/devices/) and hosting the device frame resources since Apple sometimes has removed / changed some of the old images making framing a moving target.
 
 To run the wizard to prepare new device assets, just run `rake` in this directory.
 

--- a/frameit/lib/frameit/frame_downloader.rb
+++ b/frameit/lib/frameit/frame_downloader.rb
@@ -53,7 +53,7 @@ module Frameit
 
     def print_disclaimer
       UI.header("Device frames disclaimer")
-      UI.important("All used device frames are available via Facebook Design: http://facebook.design/devices")
+      UI.important("All used device frames are available via Facebook Design: https://design.facebook.com/toolsandresources/devices/")
       UI.message("----------------------------------------")
       UI.message("While Facebook has redrawn and shares these assets for the benefit")
       UI.message("of the design community, Facebook does not own any of the underlying")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The https certificate for https://facebook.design is no longer valid. The new website is https://design.facebook.com/
