### PR TITLE
[deliver] fix typo caused by string concatenation

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -164,8 +164,7 @@ module Deliver
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :sync_screenshots,
                                      env_name: "DELIVER_SYNC_SCREENSHOTS",
-                                     description: "Sync screenshots with local ones. This is currently beta option" \
-                                                  "so set true to 'FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS' environment variable as well",
+                                     description: "Sync screenshots with local ones. This is currently beta option so set true to 'FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS' environment variable as well",
                                      type: Boolean,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :submit_for_review,


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Supersedes https://github.com/fastlane/docs/pull/1173

### Description

Just fixing a typo caused by string concatenation.

### Testing Steps

N/A
