### PR TITLE
[fastlane_core] install all Apple WWDR Intermediate Certificates

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -82,7 +82,7 @@ module FastlaneCore
     end
 
     def self.installed_wwdr_certificates
-      certificate_name = "Apple Worldwide Developer Relations Certification Authority"
+      certificate_name = "Apple Worldwide Developer Relations"
 
       # Find all installed WWDRCA certificates
       installed_certs = []
@@ -104,7 +104,7 @@ module FastlaneCore
 
     def self.install_missing_wwdr_certificates
       # Install all Worldwide Developer Relations Intermediate Certificates listed here: https://www.apple.com/certificateauthority/
-      missing = ['Apple Worldwide Developer Relations', 'G2', 'G3', 'G4', 'G5', 'G6'] - installed_wwdr_certificates
+      missing = ['Apple Worldwide Developer Relations', 'Apple Certification Authority', 'G3', 'G4', 'G5', 'G6'] - installed_wwdr_certificates
       missing.each do |ou|
         install_wwdr_certificate(ou)
       end
@@ -112,8 +112,11 @@ module FastlaneCore
     end
 
     def self.install_wwdr_certificate(ou)
-      if ou == 'Apple Worldwide Developer Relations'
+      case ou
+      when 'Apple Worldwide Developer Relations' # G1
         url = "https://developer.apple.com/certificationauthority/AppleWWDRCA.cer"
+      when 'Apple Certification Authority' # G2
+        url = "https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer"
       else
         url = "https://www.apple.com/certificateauthority/AppleWWDRCA#{ou}.cer"
       end

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -104,7 +104,7 @@ module FastlaneCore
 
     def self.install_missing_wwdr_certificates
       # Install all Worldwide Developer Relations Intermediate Certificates listed here: https://www.apple.com/certificateauthority/
-      missing = %w[G2 G3 G4 G5 G6] - installed_wwdr_certificates
+      missing = ['Apple Worldwide Developer Relations', 'G2', 'G3', 'G4', 'G5', 'G6'] - installed_wwdr_certificates
       missing.each do |ou|
         install_wwdr_certificate(ou)
       end
@@ -112,7 +112,11 @@ module FastlaneCore
     end
 
     def self.install_wwdr_certificate(ou)
-      url = "https://www.apple.com/certificateauthority/AppleWWDRCA#{ou}.cer"
+      if ou == 'Apple Worldwide Developer Relations'
+        url = "https://developer.apple.com/certificationauthority/AppleWWDRCA.cer"
+      else
+        url = "https://www.apple.com/certificateauthority/AppleWWDRCA#{ou}.cer"
+      end
       file = Tempfile.new(File.basename(url))
       filename = file.path
       keychain = wwdr_keychain

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -96,19 +96,9 @@ module FastlaneCore
         end
       end
 
-      # Get "Subject" of the installed WWDRCA certificates
-      return installed_certs.map do |pem|
-        # An example of this command output:
-        #  subject= /CN=Apple Worldwide Developer Relations Certification Authority/OU=G6/O=Apple Inc./C=US
-        Helper.backticks("echo '#{pem}' | /usr/bin/openssl x509 -noout -subject -inform pem")
-              .lines
-              .find { |line| line.start_with?('subject=') }
-              .sub('subject=', '')
-              .split('/')
-              .map { |part| part.split('=') }
-              .select { |pair| pair.count == 2 }
-              .to_h
-              .fetch('OU')
+      # Get 'organisational unit' of the installed WWDRCA certificates
+      installed_certs.map do |pem|
+        OpenSSL::X509::Certificate.new(pem).subject.to_a.find { |part| part[0] == 'OU' }[1]
       end
     end
 

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -21,8 +21,14 @@ describe FastlaneCore do
     describe '#installed_wwdr_certificates' do
       it "should return installed certificate's OrganizationalUnit" do
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return('login.keychain')
+
         allow(FastlaneCore::Helper).to receive(:backticks).with(/security find-certificate/).and_return("-----BEGIN CERTIFICATE-----\nG6\n-----END CERTIFICATE-----\n")
-        allow(FastlaneCore::Helper).to receive(:backticks).with(/openssl x509/).and_return("subject= /CN=Apple Worldwide Developer Relations Certification Authority/OU=G6/O=Apple Inc./C=US\n")
+
+        cert = OpenSSL::X509::Certificate.new
+        cert_subject = OpenSSL::X509::Name.parse('/CN=Apple Worldwide Developer Relations Certification Authority/OU=G6/O=Apple Inc./C=US')
+        allow(cert).to receive(:subject).and_return(cert_subject)
+        allow(OpenSSL::X509::Certificate).to receive(:new).and_return(cert)
+
         expect(FastlaneCore::CertChecker.installed_wwdr_certificates).to eq(['G6'])
       end
     end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -2,7 +2,7 @@ describe FastlaneCore do
   describe FastlaneCore::CertChecker do
     describe '#installed_identies' do
       it 'should print an error when no local code signing identities are found' do
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(%w[G2 G3 G4 G5 G6])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Worldwide Developer Relations', 'G2', 'G3', 'G4', 'G5', 'G6'])
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
         expect(FastlaneCore::UI).to receive(:error).with(/There are no local code signing identities found/)
 
@@ -10,7 +10,7 @@ describe FastlaneCore do
       end
 
       it 'should not be fooled by 10 local code signing identities available' do
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(%w[G2 G3 G4 G5 G6])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Worldwide Developer Relations', 'G2', 'G3', 'G4', 'G5', 'G6'])
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
         expect(FastlaneCore::UI).not_to(receive(:error))
 
@@ -36,6 +36,7 @@ describe FastlaneCore do
     describe '#install_missing_wwdr_certificates' do
       it 'should install all official WWDR certificates' do
         allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return([])
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('Apple Worldwide Developer Relations')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G2')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G3')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G4')
@@ -46,8 +47,31 @@ describe FastlaneCore do
 
       it 'should install the missing official WWDR certificate' do
         allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(%w[G2 G3 G4 G5])
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('Apple Worldwide Developer Relations')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G6')
         FastlaneCore::CertChecker.install_missing_wwdr_certificates
+      end
+
+      it 'should download the WWDR certificate from correct URL' do
+        allow(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return('login.keychain')
+
+        expect(Open3).to receive(:capture3).with(include('https://developer.apple.com/certificationauthority/AppleWWDRCA.cer')).and_return("")
+        FastlaneCore::CertChecker.install_wwdr_certificate('Apple Worldwide Developer Relations')
+
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer')).and_return("")
+        FastlaneCore::CertChecker.install_wwdr_certificate('G2')
+
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer')).and_return("")
+        FastlaneCore::CertChecker.install_wwdr_certificate('G3')
+
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer')).and_return("")
+        FastlaneCore::CertChecker.install_wwdr_certificate('G4')
+
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG5.cer')).and_return("")
+        FastlaneCore::CertChecker.install_wwdr_certificate('G5')
+
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')).and_return("")
+        FastlaneCore::CertChecker.install_wwdr_certificate('G6')
       end
     end
 
@@ -74,7 +98,7 @@ describe FastlaneCore do
         expect(Open3).to receive(:capture3).with(cmd).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(%w[G2 G3 G4 G5])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Worldwide Developer Relations', 'G2', 'G3', 'G4', 'G5'])
         expect(FastlaneCore::CertChecker.install_missing_wwdr_certificates).to be(1)
       end
     end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -2,7 +2,7 @@ describe FastlaneCore do
   describe FastlaneCore::CertChecker do
     describe '#installed_identies' do
       it 'should print an error when no local code signing identities are found' do
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Worldwide Developer Relations', 'G2', 'G3', 'G4', 'G5', 'G6'])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Worldwide Developer Relations', 'Apple Certification Authority', 'G3', 'G4', 'G5', 'G6'])
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
         expect(FastlaneCore::UI).to receive(:error).with(/There are no local code signing identities found/)
 
@@ -10,7 +10,7 @@ describe FastlaneCore do
       end
 
       it 'should not be fooled by 10 local code signing identities available' do
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Worldwide Developer Relations', 'G2', 'G3', 'G4', 'G5', 'G6'])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Worldwide Developer Relations', 'Apple Certification Authority', 'G3', 'G4', 'G5', 'G6'])
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
         expect(FastlaneCore::UI).not_to(receive(:error))
 
@@ -37,7 +37,7 @@ describe FastlaneCore do
       it 'should install all official WWDR certificates' do
         allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return([])
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('Apple Worldwide Developer Relations')
-        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G2')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('Apple Certification Authority')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G3')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G4')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G5')
@@ -46,7 +46,7 @@ describe FastlaneCore do
       end
 
       it 'should install the missing official WWDR certificate' do
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(%w[G2 G3 G4 G5])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Certification Authority', 'G3', 'G4', 'G5'])
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('Apple Worldwide Developer Relations')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G6')
         FastlaneCore::CertChecker.install_missing_wwdr_certificates
@@ -59,7 +59,7 @@ describe FastlaneCore do
         FastlaneCore::CertChecker.install_wwdr_certificate('Apple Worldwide Developer Relations')
 
         expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer')).and_return("")
-        FastlaneCore::CertChecker.install_wwdr_certificate('G2')
+        FastlaneCore::CertChecker.install_wwdr_certificate('Apple Certification Authority')
 
         expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer')).and_return("")
         FastlaneCore::CertChecker.install_wwdr_certificate('G3')
@@ -98,7 +98,7 @@ describe FastlaneCore do
         expect(Open3).to receive(:capture3).with(cmd).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Worldwide Developer Relations', 'G2', 'G3', 'G4', 'G5'])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['Apple Worldwide Developer Relations', 'Apple Certification Authority', 'G3', 'G4', 'G5'])
         expect(FastlaneCore::CertChecker.install_missing_wwdr_certificates).to be(1)
       end
     end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -2,7 +2,7 @@ describe FastlaneCore do
   describe FastlaneCore::CertChecker do
     describe '#installed_identies' do
       it 'should print an error when no local code signing identities are found' do
-        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(%w[G2 G3 G4 G5 G6])
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
         expect(FastlaneCore::UI).to receive(:error).with(/There are no local code signing identities found/)
 
@@ -10,7 +10,7 @@ describe FastlaneCore do
       end
 
       it 'should not be fooled by 10 local code signing identities available' do
-        allow(FastlaneCore::CertChecker).to receive(:wwdr_certificate_installed?).and_return(true)
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(%w[G2 G3 G4 G5 G6])
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
         expect(FastlaneCore::UI).not_to(receive(:error))
 
@@ -18,10 +18,30 @@ describe FastlaneCore do
       end
     end
 
-    describe '#install_wwdr_certificate' do
-      it 'should install only the latest official WWDR certificate' do
-        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate)
-        FastlaneCore::CertChecker.install_wwdr_certificate
+    describe '#installed_wwdr_certificates' do
+      it "should return installed certificate's OrganizationalUnit" do
+        expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return('login.keychain')
+        allow(FastlaneCore::Helper).to receive(:backticks).with(/security find-certificate/).and_return("-----BEGIN CERTIFICATE-----\nG6\n-----END CERTIFICATE-----\n")
+        allow(FastlaneCore::Helper).to receive(:backticks).with(/openssl x509/).and_return("subject= /CN=Apple Worldwide Developer Relations Certification Authority/OU=G6/O=Apple Inc./C=US\n")
+        expect(FastlaneCore::CertChecker.installed_wwdr_certificates).to eq(['G6'])
+      end
+    end
+
+    describe '#install_missing_wwdr_certificates' do
+      it 'should install all official WWDR certificates' do
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return([])
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G2')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G3')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G4')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G5')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G6')
+        FastlaneCore::CertChecker.install_missing_wwdr_certificates
+      end
+
+      it 'should install the missing official WWDR certificate' do
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(%w[G2 G3 G4 G5])
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G6')
+        FastlaneCore::CertChecker.install_missing_wwdr_certificates
       end
     end
 
@@ -32,9 +52,9 @@ describe FastlaneCore do
 
       it 'should shell escape keychain names when checking for installation' do
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(name_regex, anything).and_return("")
+        expect(FastlaneCore::Helper).to receive(:backticks).with(name_regex).and_return("")
 
-        FastlaneCore::CertChecker.wwdr_certificate_installed?
+        FastlaneCore::CertChecker.installed_wwdr_certificates
       end
 
       it 'uses the correct command to import it' do
@@ -48,7 +68,8 @@ describe FastlaneCore do
         expect(Open3).to receive(:capture3).with(cmd).and_return("")
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-        expect(FastlaneCore::CertChecker.install_wwdr_certificate).to be(true)
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(%w[G2 G3 G4 G5])
+        expect(FastlaneCore::CertChecker.install_missing_wwdr_certificates).to be(1)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #20509

### Description

Short summary: install all Apple WWDR "Intermediate Certificates", rather than only [a specific one](https://github.com/fastlane/fastlane/blob/1e45f926121d91b0410e2345d7ce6860622937f6/fastlane_core/lib/fastlane_core/cert_checker.rb#L96) which is "G6" currently.

https://github.com/fastlane/fastlane/pull/20448 changed which WWDRCA certificates that fastlane installs. As you can see in [this diff](https://github.com/fastlane/fastlane/pull/20448/files#diff-605d869e313da5ef9f0c402845a4911eed5f8afc4ef45382210f237fceae498aL92), fastlane used to install "G1" and "G3" certificates (these names are taken from https://www.apple.com/certificateauthority/), but now fastlane (2.208.0 to be specific) only installs "G6". This change caused a code signing issue in the app I work on. I reported this regression in https://github.com/fastlane/fastlane/issues/20509 (Initially I incorrectly suspected that the cause was the certificates installation keychain which was also changed in the PR mentioned before).

After some investigation, I found the root cause is missing the right WWDRCA certificate—[simply changing G6 to G3](https://github.com/fastlane/fastlane/commit/8f8f8cb1b7a8dfb371000e8c3b41f6623924b561) worked in my case.

I don't really know how Xcode's CodeSign looks up the certificates, I also don't know whether installing another certificate works for all cases (maybe in some other case, Xcode wants G2? I don't know...). But installing _all_ "Intermediate Certificates" that are listed on [this Apple website](https://www.apple.com/certificateauthority/) shouldn't be harmful. And that's what I've implemented in this PR. This PR doesn't introduce breaking changes—G6 certificate is still installed, along with a bunch of other similar certificates.

<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Pull down this PR code, navigate to the project directory, run below command, all WWDRCA certificates should be installed to the default keychain.
```
bundle exec ruby -e "require 'shellwords'; require 'fastlane_core/cert_checker'; puts FastlaneCore::CertChecker.install_missing_wwdr_certificates"
```
