### PR TITLE
The word phrasing used has been standardized.

### DIFF
--- a/fastlane/lib/assets/AppfileTemplate
+++ b/fastlane/lib/assets/AppfileTemplate
@@ -1,5 +1,5 @@
 # app_identifier("[[APP_IDENTIFIER]]") # The bundle identifier of your app
-# apple_id("[[APPLE_ID]]") # Your Apple email address
+# apple_id("[[APPLE_ID]]") # Your Apple Developer Portal username
 
 [[TEAMS]]
 # For more information about the Appfile, see:

--- a/fastlane/lib/assets/AppfileTemplate.swift
+++ b/fastlane/lib/assets/AppfileTemplate.swift
@@ -1,5 +1,5 @@
 var appIdentifier: String { return "[[APP_IDENTIFIER]]" } // The bundle identifier of your app
-var appleID: String { return "[[APPLE_ID]]" } // Your Apple email address
+var appleID: String { return "[[APPLE_ID]]" } // Your Apple Developer Portal username
 
 [[TEAMS]]
 

--- a/fastlane/swift/Appfile.swift
+++ b/fastlane/swift/Appfile.swift
@@ -2,7 +2,7 @@
 // Copyright (c) 2022 FastlaneTools
 
 var appIdentifier: String { return "" } // The bundle identifier of your app
-var appleID: String { return "" } // Your Apple email address
+var appleID: String { return "" } // Your Apple Developer Portal username
 
 var teamID: String { return "" } // Developer Portal Team ID
 var itcTeam: String? { return nil } // App Store Connect Team ID (may be nil if no team)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Description
Only the word phrasing used has been standardized.

### Testing Steps
N/A