### PR TITLE
[Fastlane.Swift] Allow overriding LaneFileProtocol lifecycles when subclassing LaneFile

### DIFF
--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -39,6 +39,10 @@ open class LaneFile: NSObject, LaneFileProtocol {
     private static func trimLaneWithOptionsFromName(laneName: String) -> String {
         return String(laneName.prefix(laneName.count - 12))
     }
+    
+    open func beforeAll(with lane: String) {}
+    
+    open func afterAll(with lane: String) {}
 
     open func onError(currentLane: String, errorInfo _: String, errorClass _: String?, errorMessage _: String?) {
         LaneFile.onErrorCalled.insert(currentLane)

--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -40,7 +40,7 @@ open class LaneFile: NSObject, LaneFileProtocol {
         return String(laneName.prefix(laneName.count - 12))
     }
 
-    public func onError(currentLane: String, errorInfo _: String, errorClass _: String?, errorMessage _: String?) {
+    open func onError(currentLane: String, errorInfo _: String, errorClass _: String?, errorMessage _: String?) {
         LaneFile.onErrorCalled.insert(currentLane)
     }
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves #21849

When using [Fastlane.Swift](https://docs.fastlane.tools/getting-started/ios/fastlane-swift/) in the context of a Swift Package the `LaneFileProtocol` lifecycles such as `beforeAll`, `onError` and `afterAll` can not be overridden by a subclass of `LaneFile`.

<details>
<summary>Package.swift</summary>

```swift
// swift-tools-version: 5.6

import PackageDescription

let package = Package(
    name: "FastlaneSwiftPackage",
    products: [
        .executable(
            name: "FastlaneSwiftPackage",
            targets: [
                "FastlaneSwiftPackage"
            ]
        )
    ],
    dependencies: [
        .package(
            url: "https://github.com/fastlane/fastlane",
            .exact("2.209.0")
        )
    ],
    targets: [
        .executableTarget(
            name: "FastlaneSwiftPackage",
            dependencies: [
                .product(
                    name: "Fastlane",
                    package: "fastlane"
                )
            ]
        )
    ]
)
```

</details>

```swift
import Foundation
import Fastlane

@main
class Fastfile: LaneFile {
    
    static func main() {
        Main().run(with: Fastfile())
    }
    
    // ❌ Method does not override any method from its superclass
    override func beforeAll(
        with lane: String
    ) {
        super.beforeAll(with: lane)
    }
    
    // ❌ Overriding non-open instance method outside of its defining module
    override func onError(
        currentLane: String,
        errorInfo: String,
        errorClass: String?,
        errorMessage: String?
    ) {
        super.onError(
            currentLane: currentLane,
            errorInfo: errorInfo,
            errorClass: errorClass,
            errorMessage: errorMessage
        )
    }
    
    // ❌ Method does not override any method from its superclass
    override func afterAll(
        with lane: String
    ) {
        super.afterAll(with: lane)
    }
    
}
```

### Description
This PR changes the modifier of the `onError` function of the `LaneFile` from `public` to `open` to fix the `Overriding non-open instance method outside of its defining module` error (https://github.com/fastlane/fastlane/commit/b9dba0a6ee4c6c91fa23742ec8ea21eec1f6cfbe).

Additionally, the `beforeAll` and `afterAll` lifecycles have been added as `open` functions to the `LaneFile` to fix the `Method does not override any method from its superclass` error (https://github.com/fastlane/fastlane/commit/f4f53803e3738d1ee9b49af31e17155c27f5161e).