### PR TITLE
Add thread_timestamp option to slack action to reply a message

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -31,6 +31,7 @@ module Fastlane
           post_message(
             channel: channel,
             username: username,
+            thread_timestamp: options[:thread_timestamp],
             attachments: [slack_attachment],
             link_names: link_names,
             icon_url: icon_url,
@@ -38,10 +39,11 @@ module Fastlane
           )
         end
 
-        def post_message(channel:, username:, attachments:, link_names:, icon_url:, fail_on_error:)
+        def post_message(channel:, username:, thread_timestamp:, attachments:, link_names:, icon_url:, fail_on_error:)
           @notifier.post_to_legacy_incoming_webhook(
             channel: channel,
             username: username,
+            thread_timestamp: thread_timestamp,
             link_names: link_names,
             icon_url: icon_url,
             attachments: attachments
@@ -246,6 +248,11 @@ module Fastlane
                                        description: "Find and link channel names and usernames (true/false)",
                                        optional: true,
                                        default_value: false,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :thread_timestamp,
+                                       env_name: "FL_SLACK_THREAD_TIMESTAMP",
+                                       description: "Timestamp of the message to reply",
+                                       optional: true,
                                        type: Boolean)
         ]
       end

--- a/fastlane/lib/fastlane/notification/slack.rb
+++ b/fastlane/lib/fastlane/notification/slack.rb
@@ -11,12 +11,13 @@ module Fastlane
       # Overriding channel, icon_url and username is only supported in legacy incoming webhook.
       # Also note that the use of attachments has been discouraged by Slack, in favor of Block Kit.
       # https://api.slack.com/legacy/custom-integrations/messaging/webhooks
-      def post_to_legacy_incoming_webhook(channel:, username:, attachments:, link_names:, icon_url:)
+      def post_to_legacy_incoming_webhook(channel:, username:, thread_timestamp:, attachments:, link_names:, icon_url:)
         @client.post(@webhook_url) do |request|
           request.headers['Content-Type'] = 'application/json'
           request.body = {
             channel: channel,
             username: username,
+            thread_ts: thread_timestamp,
             icon_url: icon_url,
             attachments: attachments,
             link_names: link_names

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -50,6 +50,7 @@ module Scan
         slack_url: Scan.config[:slack_url].to_s,
         success: results[:build_errors].to_i == 0 && results[:failures].to_i == 0,
         username: username,
+        thread_timestamp: Scan.config[:thread_timestamp],
         icon_url: icon_url,
         payload: {},
         default_payloads: Scan.config[:slack_default_payloads],


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
I added a **thread_timestamp** parameter to the [slack action](fastlane/blob/master/fastlane/lib/fastlane/actions/slack.rb), which allows sending a slack message to a channel or a person, to respond to messages.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I tested the changes using the code below
```
slack(
  message: 'Hello world',
  channel: '#test',
  thread_id: '1660900429.928609',
  slack_url: 'https://hooks.slack.com/services/XXXXXXXX',
  success: true,
  use_webhook_configured_username_and_icon: true
)
```

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
