### PR TITLE
[docs][run_tests] fix typo and improve phrasing of documentation

### DIFF
--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -57,7 +57,7 @@ module Fastlane
       end
 
       def self.return_value
-        'Outputs has of results with :number_of_tests, :number_of_failures, :number_of_retries, :number_of_tests_excluding_retries, :number_of_failures_excluding_retries'
+        'Outputs hash of results with the following keys: :number_of_tests, :number_of_failures, :number_of_retries, :number_of_tests_excluding_retries, :number_of_failures_excluding_retries'
       end
 
       def self.return_type


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves https://github.com/fastlane/docs/issues/1176

### Description

Fix typo + improve wording.
