### PR TITLE
[fastlane_core] sanitized filename(s) and randomized prefix for -assetFile when uploading binaries to Testflight/App Store

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -552,8 +552,8 @@ module FastlaneCore
 
       actual_dir = if can_use_asset_path && !force_itmsp
                      # The asset gets deleted upon completion so copying to a temp directory
-                     # (with randomized filename, for multibyte-mixed filename upload fails)
-                     new_file_name = "#{SecureRandom.uuid}#{File.extname(asset_path)}"
+                     # (with sanitized filename and randomized prefix, for multibyte-mixed filename upload fails)
+                     new_file_name = SecureRandom.uuid+'.'+File.basename(asset_path).gsub(/[^0-9A-Za-z_\.-]+/, '')
                      tmp_asset_path = File.join(Dir.tmpdir, new_file_name)
                      FileUtils.cp(asset_path, tmp_asset_path)
                      tmp_asset_path

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -553,7 +553,7 @@ module FastlaneCore
       actual_dir = if can_use_asset_path && !force_itmsp
                      # The asset gets deleted upon completion so copying to a temp directory
                      # (with sanitized filename and randomized prefix, for multibyte-mixed filename upload fails)
-                     new_file_name = SecureRandom.uuid+'.'+File.basename(asset_path).gsub(/[^0-9A-Za-z_\.-]+/, '')
+                     new_file_name = SecureRandom.uuid + '.' + File.basename(asset_path).gsub(/[^0-9A-Za-z_\.-]+/, '')
                      tmp_asset_path = File.join(Dir.tmpdir, new_file_name)
                      FileUtils.cp(asset_path, tmp_asset_path)
                      tmp_asset_path

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -13,7 +13,7 @@ describe FastlaneCore do
     end
 
     def shell_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.my_app.ipa" : "-f /tmp/my.app.id.itmsp"
 
       escaped_password = password.shellescape
       unless FastlaneCore::Helper.windows?
@@ -94,7 +94,7 @@ describe FastlaneCore do
     end
 
     def java_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, classpath: true, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.my_app.ipa" : "-f /tmp/my.app.id.itmsp"
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -189,7 +189,7 @@ describe FastlaneCore do
     end
 
     def java_upload_command_9(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.my_app.ipa" : "-f /tmp/my.app.id.itmsp"
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -258,7 +258,7 @@ describe FastlaneCore do
     end
 
     def xcrun_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.my_app.ipa" : "-f /tmp/my.app.id.itmsp"
 
       [
         ("ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}" if jwt.nil?),


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The TestFlight Build Metadata value `Original File Name` is the only (almost) freeform mechanism to link builds back to repository version and CI build that generated them.

For example, our build generates IPAs of the below form to ensure that we can always trace from the build back to the repo, even if tagging in the repo failed.

```
commit-${GITHUB_SHA}.run-${GITHUB_RUN_ID}.attempt-${GITHUB_RUN_ATTEMPT}.ipa
```

Resolves #13802


### Description

The change replaces the file extension used from the asset_path with the full basename, sanitized using itmsTransporter's rules:

> The filename .ipa in the package contains an invalid character(s). The valid characters are: A-Z, a-z, 0-9, dash, period, underscore, but the name cannot start with a dash, period, or underscore

This has been tested directly against TestFlight.


### Testing Steps

1. Run `pilot` in the normal way
2. Find your build in TestFlight
3. Go to the `Build Metadata` tab
4. Find the `Original File Name` value

Instead of `f4998acd-a4cb-47cc-b8b5-314d77532d72.ipa` the value will be something like `f4998acd-a4cb-47cc-b8b5-314d77532d72.HelloWorld.ipa` where `Hello World 🌏.ipa` was the initial IPA basename.