### PR TITLE
[screengrab] fix formatting of the `screengrab` / `capture_android_screenshots` docs

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
+++ b/fastlane/lib/fastlane/actions/docs/capture_android_screenshots.md
@@ -25,6 +25,7 @@ gem install fastlane
 ```
 
 ##### Gradle dependency
+
 ```java
 androidTestImplementation 'tools.fastlane:screengrab:x.x.x'
 ```
@@ -60,17 +61,23 @@ Ensure that the following permissions exist in your **src/debug/AndroidManifest.
 ##### Configuring your <a href="#ui-tests">UI Tests</a> for Screenshots
 
 1. Add `LocaleTestRule` to your tests class to handle automatic switching of locales.
+
    If you're using Java use:
+   
    ```java
    @ClassRule
    public static final LocaleTestRule localeTestRule = new LocaleTestRule();
    ```
+   
    If you're using Kotlin use:
+   
    ```kotlin
    @Rule @JvmField
    val localeTestRule = LocaleTestRule()
    ```
+   
    The `@JvmField` annotation is important. It won't work like this:
+   
    ```kotlin
    companion object {
        @get:ClassRule
@@ -84,6 +91,7 @@ Ensure that the following permissions exist in your **src/debug/AndroidManifest.
 - Then, before running `fastlane screengrab` you'll need a debug and test apk
   - You can create your APKs manually with `./gradlew assembleDebug assembleAndroidTest`
   - You can also create a lane and use `build_android_app`:
+
     ```ruby
     desc "Build debug and test APK for screenshots"
     lane :build_and_screengrab do
@@ -163,7 +171,9 @@ fastlane action screengrab
 Check out [Testing UI for a Single App](http://developer.android.com/training/testing/ui-testing/espresso-testing.html) for an introduction to using Espresso for UI testing.
 
 ##### Example UI Test Class (Using JUnit4)
+
 Java:
+
 ```java
 @RunWith(JUnit4.class)
 public class JUnit4StyleTests {
@@ -182,9 +192,10 @@ public class JUnit4StyleTests {
         Screengrab.screenshot("after_button_click");
     }
 }
-
 ```
+
 Kotlin:
+
 ```kotlin
 @RunWith(JUnit4.class)
 class JUnit4StyleTests {
@@ -203,7 +214,6 @@ class JUnit4StyleTests {
         Screengrab.screenshot("after_button_click")
     }
 }
-
 ```
 
 There is an [example project](https://github.com/fastlane/fastlane/tree/master/screengrab/example/src/androidTest/java/tools/fastlane/localetester) showing how to use JUnit 3 or 4 and Espresso with the screengrab Java library to capture screenshots during a UI test run.
@@ -224,6 +234,7 @@ Note: the clean status bar feature is only supported on devices with *API level 
 
 You can enable and disable the clean status bar at any moment during your tests.
 In most cases you probably want to do this in the @BeforeClass and @AfterClass methods.
+
 ```java
 @BeforeClass
 public static void beforeAll() {
@@ -238,6 +249,7 @@ public static void afterAll() {
 
 Have a look at the methods of the `CleanStatusBar` class to customize the status bar even more.
 You could for example show the Bluetooth icon and the LTE text.
+
 ```java
 new CleanStatusBar()
     .setBluetoothState(BluetoothState.DISCONNECTED)
@@ -283,6 +295,7 @@ if (extras != null) {
 For some apps, it is helpful to know when _screengrab_ is running so that you can display specific data for your screenshots. For iOS fastlane users, this is much like "FASTLANE_SNAPSHOT". In order to do this, you'll need to have at least two product flavors of your app.
 
 Add two product flavors to the app-level build.gradle file:
+
 ```
 android {
 ...
@@ -300,6 +313,7 @@ android {
 ```
 
 Check for the existence of that flavor (i.e screengrab) in your app code as follows in order to use mock data or customize data for screenshots:
+
 ```
 if (BuildConfig.FLAVOR == "screengrab") {
     System.out.println("screengrab is running!");
@@ -307,14 +321,17 @@ if (BuildConfig.FLAVOR == "screengrab") {
 ```
 
 When running _screengrab_, do the following to build the flavor you want as well as the test apk. Note that you use "assembleFlavor_name" where Flavor_name is the flavor name, capitalized (i.e. Screengrab).
+
 ```
 ./gradlew assembleScreengrab assembleAndroidTest
 ```
 
 Run _screengrab_:
+
 ```
 fastlane screengrab
 ```
+
 _screengrab_ will ask you to select the debug and test apps (which you can then add to your Screengrabfile to skip this step later).
 
 The debug apk should be somewhere like this:


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The generated HTML for this page renders some of the code blocks incorrectly.

<img width="946" alt="image" src="https://user-images.githubusercontent.com/216089/186396525-d985ebc2-0521-485f-9ce2-0919f9430851.png">

### Description

Hopefully, by adding newlines before those code blocks it will fix the issue in the HTML generated by mkdocs.

### Testing Steps

> **Warning**: I did NOT run `mkdocs` on the resulting file to check that it actually solves the issue on the generated HTML (as I don't have mkdocs installed and I'm a bit short on time today to install it).

A reviewer could [try to do that first](https://github.com/fastlane/docs#installation-of-mkdocs) though, to confirm the changes in this PR fix the formatting issue.