### PR TITLE
fix(beta): updating to use previous wait behavior for ios

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -129,7 +129,7 @@ module Pilot
         return_when_build_appears: return_when_build_appears,
         return_spaceship_testflight_build: false,
         select_latest: config[:distribute_only],
-        wait_for_build_beta_detail_processing: true
+        wait_for_build_beta_detail_processing: platform != "ios"
       )
 
       unless latest_build.app_version == app_version && latest_build.version == app_build


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I am currently working on getting one of my iOS apps distributed via Testflight both internally and externally. I originally posted a discussion [here](https://github.com/fastlane/fastlane/discussions/20640). 

This pr is an attempt at resolving the issue I am encountering where even though the build is showing up in AppStore connect as fully processed, Fastlane still sees it as processing.

### Description

This pr adjusts the change that was made in https://github.com/fastlane/fastlane/pull/19296 to only check the `buildBetaDetails` if the platform is not OSX.  It is not clear to me if this is a recent change to AppStore connect API causing this or something else. 


### Testing Steps

Use a step in a Fastlane lane similar to:

```ruby
    #upload to testflight for our internal apps store connect nightly builds.
    upload_to_testflight(
      skip_waiting_for_build_processing: false,
      groups: ['Nightly Internal Builds'],
      submit_beta_review: false,
      ipa: BITRISE_IPA_PATH
    )
```
