### PR TITLE
fixed log message to indicate correct statement

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -163,7 +163,7 @@ module Pilot
       # Verify the build has all the includes that we need
       # and fetch a new build if not
       if build && (!build.app || !build.build_beta_detail || !build.pre_release_version)
-        UI.important("Build did include information for app, build beta detail and pre release version")
+        UI.important("Build did not include either information for app, build beta detail or pre release version")
         UI.important("Fetching a new build with all the information needed")
         build = Spaceship::ConnectAPI::Build.get(build_id: build.id)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
I got confused by this log: "Build did include information for app, build beta detail and pre release version", when the distribution was failing because of missing build.build_beta_detail
according to line 165, the log should indicate the opposite, that either build.app, build.build_beta_detail or build.pre_release_version is missing

### Description
changed the log to indicate the opposite of what it is currently indicating according to line 165

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
