### PR TITLE
[pilot][deliver] fix private method clone' called for #<Hash> on uploading app 

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -873,7 +873,7 @@ module FastlaneCore
 
     # Create .p8 file from api_key and provide api key info which contains .p8 file path
     def api_key_with_p8_file_path(original_api_key)
-      api_key = original_api_key.clone
+      api_key = original_api_key.dup
       api_key[:key_dir] = Dir.mktmpdir("deliver-")
       # Specified p8 needs to be generated to call altool
       File.open(File.join(api_key[:key_dir], "AuthKey_#{api_key[:key_id]}.p8"), "wb") do |p8|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes: https://github.com/fastlane/fastlane/pull/20631#issuecomment-1247998588 by https://github.com/fastlane/fastlane/pull/20631#issuecomment-1248022225

### Description
Use dup instead of clone when copying api_key

### Testing Steps
run 


I tested by pure project with below fastfile

```rb
default_platform(:ios)

platform :ios do
  desc "Description of what the lane does"
  lane :custom_lane do
    xcode_select("/Applications/Xcode_14.app")
    # add actions here: https://docs.fastlane.tools/actions
    build_app(
      scheme: "EmptyTestApp",
      configuration: "Release",
      export_options: {
        provisioningProfiles: {
          "com.freddi.testapp.EmptyTestApp" => "release",
        },
      },
      silent: true,
      clean: true
    )
    deliver(
      submit_for_review: false,
      automatic_release: false,
      force: true, # Skip HTMl report verification
      skip_metadata: true,
      skip_screenshots: true,
      skip_binary_upload: false
    )
    # pilot(
    #  username: "test@test.com"
    # )
  end
end
```