### PR TITLE
[deliver] "use_live_version" option for "download_metadata" action

### DIFF
--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -170,7 +170,11 @@ module Deliver
           require 'deliver/setup'
           app = Deliver.cache[:app]
           platform = Spaceship::ConnectAPI::Platform.map(options[:platform])
-          v = app.get_latest_app_store_version(platform: platform)
+          if options[:use_live_version]
+            v = app.get_live_app_store_version(platform: platform)
+          else
+            v = app.get_latest_app_store_version(platform: platform)
+          end
           if options[:app_version].to_s.length > 0
             v = app.get_live_app_store_version(platform: platform) if v.version_string != options[:app_version]
             if v.nil? || v.version_string != options[:app_version]


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
We want to download and compare metadata for live and latest versions of iOS app in App Store.
Usually we copy metadata from a live version to a new upcoming version and then track changes made by our marketing team.

### Description
Added support of `use_live_version` option for Deliver's `download_metadata` action.
