### PR TITLE
[pilot][deliver] Fix how to encode base64 p8 key on deliver and pilot

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -278,10 +278,8 @@ module Deliver
                   { key_id: api_token.key_id, issuer_id: api_token.issuer_id, key: api_token.key_raw }
                 elsif !options[:api_key].nil?
                   api_key = options[:api_key].transform_keys(&:to_sym).dup
-                  if api_key[:is_key_content_base64]
-                    # key is still base 64 style if api_key is loaded from option
-                    api_key[:key] = Base64.decode64(api_key[:key])
-                  end
+                  # key is still base 64 style if api_key is loaded from option                    
+                  api_key[:key] = Base64.decode64(api_key[:key]) if api_key[:is_key_content_base64]
                   api_key
                 end
 

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -278,7 +278,7 @@ module Deliver
                   { key_id: api_token.key_id, issuer_id: api_token.issuer_id, key: api_token.key_raw }
                 elsif !options[:api_key].nil?
                   api_key = options[:api_key].transform_keys(&:to_sym).dup
-                  # key is still base 64 style if api_key is loaded from option                    
+                  # key is still base 64 style if api_key is loaded from option
                   api_key[:key] = Base64.decode64(api_key[:key]) if api_key[:is_key_content_base64]
                   api_key
                 end

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -275,9 +275,14 @@ module Deliver
       api_token = Spaceship::ConnectAPI.token
       api_key = if options[:api_key].nil? && !api_token.nil?
                   # Load api key info if user set api_key_path, not api_key
-                  { key_id: api_token.key_id, issuer_id: api_token.issuer_id, key: api_token.key_raw, is_key_content_base64: api_token.is_key_content_base64 }
+                  { key_id: api_token.key_id, issuer_id: api_token.issuer_id, key: api_token.key_raw }
                 elsif !options[:api_key].nil?
-                  options[:api_key].transform_keys(&:to_sym)
+                  api_key = options[:api_key].transform_keys(&:to_sym).dup
+                  if api_key[:is_key_content_base64]
+                    # key is still base 64 style if api_key is loaded from option
+                    api_key[:key] = Base64.decode64(api_key[:key])
+                  end
+                  api_key
                 end
 
       unless api_token.nil?

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -877,8 +877,7 @@ module FastlaneCore
       api_key[:key_dir] = Dir.mktmpdir("deliver-")
       # Specified p8 needs to be generated to call altool
       File.open(File.join(api_key[:key_dir], "AuthKey_#{api_key[:key_id]}.p8"), "wb") do |p8|
-        key_content = api_key[:is_key_content_base64] ? Base64.decode64(api_key[:key]) : api_key[:key]
-        p8.write(key_content)
+        p8.write(api_key[:key])
       end
       api_key
     end

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -391,9 +391,14 @@ module Pilot
       api_token = Spaceship::ConnectAPI.token
       api_key = if options[:api_key].nil? && !api_token.nil?
                   # Load api key info if user set api_key_path, not api_key
-                  { key_id: api_token.key_id, issuer_id: api_token.issuer_id, key: api_token.key_raw, is_key_content_base64: api_token.is_key_content_base64 }
+                  { key_id: api_token.key_id, issuer_id: api_token.issuer_id, key: api_token.key_raw }
                 elsif !options[:api_key].nil?
-                  options[:api_key].transform_keys(&:to_sym)
+                  api_key = options[:api_key].transform_keys(&:to_sym).dup
+                  if api_key[:is_key_content_base64]
+                    # key is still base 64 style if api_key is loaded from option
+                    api_key[:key] = Base64.decode64(api_key[:key])
+                  end
+                  api_key
                 end
 
       unless api_token.nil?

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -394,10 +394,8 @@ module Pilot
                   { key_id: api_token.key_id, issuer_id: api_token.issuer_id, key: api_token.key_raw }
                 elsif !options[:api_key].nil?
                   api_key = options[:api_key].transform_keys(&:to_sym).dup
-                  if api_key[:is_key_content_base64]
-                    # key is still base 64 style if api_key is loaded from option
-                    api_key[:key] = Base64.decode64(api_key[:key])
-                  end
+                  # key is still base 64 style if api_key is loaded from option
+                  api_key[:key] = Base64.decode64(api_key[:key]) if api_key[:is_key_content_base64]
                   api_key
                 end
 

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -22,7 +22,6 @@ module Spaceship
       attr_reader :expiration
 
       attr_reader :key_raw
-      attr_reader :is_key_content_base64
 
       # Temporary attribute not needed to create the JWT text
       # There is no way to determine if the team associated with this
@@ -72,19 +71,17 @@ module Spaceship
           key: OpenSSL::PKey::EC.new(key),
           key_raw: key,
           duration: duration,
-          in_house: in_house,
-          is_key_content_base64: is_key_content_base64
+          in_house: in_house
         )
       end
 
-      def initialize(key_id: nil, issuer_id: nil, key: nil, key_raw: nil, duration: nil, in_house: nil, is_key_content_base64: nil)
+      def initialize(key_id: nil, issuer_id: nil, key: nil, key_raw: nil, duration: nil, in_house: nil)
         @key_id = key_id
         @key = key
         @key_raw = key_raw
         @issuer_id = issuer_id
         @duration = duration
         @in_house = in_house
-        @is_key_content_base64 = is_key_content_base64
 
         @duration ||= DEFAULT_TOKEN_DURATION
         @duration = @duration.to_i if @duration


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves #20663 

Currently transporter class tries to decode Base64 not only encoded key but also not encoded key (e.g. loaded token from `Spaceship::ConnectAPI.token`). It causes #20663 

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
Test with api_key like below

```rb
pilot(
  api_key: { 
    key_id: "xxx", 
    issuer_id: "xxx", 
    key: "E ... ==", # base 64 encoded key
    is_key_content_base64: true,
  }
)

# and

pilot(
  api_key_path: "api.json"
)

'''
// api.json
{
  "key_id: "xxx", 
  "issuer_id": "xxx", 
  "key": "E ... ==", # base 64 encoded key
  "is_key_content_base64": true,
}
'''
```