### PR TITLE
Remove dupe comment latest_testflight_build_number

### DIFF
--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -26,8 +26,8 @@ module Fastlane
 
       def self.details
         [
-          "Provides a way to have `increment_build_number` be based on the latest build you uploaded to iTC.",
-          "Fetches the most recent build number from TestFlight based on the version number. Provides a way to have `increment_build_number` be based on the latest build you uploaded to iTC."
+          "Fetches the most recent build number from TestFlight based on the version number.",
+          "Provides a way to base `increment_build_number` on the latest build you uploaded to ASC."
         ].join("\n")
       end
 


### PR DESCRIPTION
Documentation comment for `latest_testflight_build_number` had the same sentence twice ("Provides a way to have `increment_build_number` be based on the latest build you uploaded to iTC."), plus reworded a bit and changed iTC to ASC since the former is not a thing anymore.

What you see currently at https://docs.fastlane.tools/actions/latest_testflight_build_number/:

<img width="954" alt="image" src="https://user-images.githubusercontent.com/2942298/190925069-705e8df7-5f14-47d3-bfaf-8ecbd085b59e.png">

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Noticed duplicate language in the documentation comment on the website.

### Description
Removed the duplicate documentation comment. Reworded the comment as well to remove reference to iTunes Connect (which is now called App Store Connect) and to be a bit more concise. 

### Testing Steps
Ran items in checklist.