### PR TITLE
[action] add `xcodes` action, deprecating `xcversion` and `xcode-install`

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/build_app.md
+++ b/fastlane/lib/fastlane/actions/docs/build_app.md
@@ -74,7 +74,7 @@ That's all you need to build your application. If you want more control, here ar
 fastlane gym --workspace "Example.xcworkspace" --scheme "AppName" --clean
 ```
 
-If you need to use a different Xcode installation, use `xcode-select` or define `DEVELOPER_DIR`:
+If you need to use a different Xcode installation, use `[xcodes](http://docs.fastlane.tools/actions/xcodes)` or define `DEVELOPER_DIR`:
 
 ```no-highlight
 DEVELOPER_DIR="/Applications/Xcode6.2.app" fastlane gym
@@ -150,7 +150,7 @@ build_app(
   scheme: "Release",
   export_method: "app-store",
   export_options: {
-    provisioningProfiles: { 
+    provisioningProfiles: {
       "com.example.bundleid" => "Provisioning Profile Name",
       "com.example.bundleid2" => "Provisioning Profile Name 2"
     }
@@ -184,10 +184,10 @@ end
 error do |lane, exception|
   slack(
     # message with short human friendly message
-    message: exception.to_s, 
-    success: false, 
+    message: exception.to_s,
+    success: false,
     # Output containing extended log output
-    payload: { "Output" => exception.error_info.to_s } 
+    payload: { "Output" => exception.error_info.to_s }
   )
 end
 ```

--- a/fastlane/lib/fastlane/actions/docs/build_app.md
+++ b/fastlane/lib/fastlane/actions/docs/build_app.md
@@ -74,7 +74,7 @@ That's all you need to build your application. If you want more control, here ar
 fastlane gym --workspace "Example.xcworkspace" --scheme "AppName" --clean
 ```
 
-If you need to use a different Xcode installation, use `[xcodes](http://docs.fastlane.tools/actions/xcodes)` or define `DEVELOPER_DIR`:
+If you need to use a different Xcode installation, use `[xcodes](https://docs.fastlane.tools/actions/xcodes)` or define `DEVELOPER_DIR`:
 
 ```no-highlight
 DEVELOPER_DIR="/Applications/Xcode6.2.app" fastlane gym

--- a/fastlane/lib/fastlane/actions/docs/run_tests.md
+++ b/fastlane/lib/fastlane/actions/docs/run_tests.md
@@ -100,7 +100,7 @@ That's all you need to run your tests. If you want more control, here are some a
 fastlane scan --workspace "Example.xcworkspace" --scheme "AppName" --device "iPhone 6" --clean
 ```
 
-If you need to use a different Xcode install, use `xcode-select` or define `DEVELOPER_DIR`:
+If you need to use a different Xcode install, use `[xcodes](http://docs.fastlane.tools/actions/xcodes)` or define `DEVELOPER_DIR`:
 
 ```no-highlight
 DEVELOPER_DIR="/Applications/Xcode6.2.app" scan

--- a/fastlane/lib/fastlane/actions/docs/run_tests.md
+++ b/fastlane/lib/fastlane/actions/docs/run_tests.md
@@ -100,7 +100,7 @@ That's all you need to run your tests. If you want more control, here are some a
 fastlane scan --workspace "Example.xcworkspace" --scheme "AppName" --device "iPhone 6" --clean
 ```
 
-If you need to use a different Xcode install, use `[xcodes](http://docs.fastlane.tools/actions/xcodes)` or define `DEVELOPER_DIR`:
+If you need to use a different Xcode install, use `[xcodes](https://docs.fastlane.tools/actions/xcodes)` or define `DEVELOPER_DIR`:
 
 ```no-highlight
 DEVELOPER_DIR="/Applications/Xcode6.2.app" scan

--- a/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
@@ -2,6 +2,7 @@ module Fastlane
   module Actions
     class EnsureXcodeVersionAction < Action
       def self.run(params)
+        # TODO: Deprecate this action by adding strict and non-strict version check capabilities to `xcodes` action, now that the `xcode-install` gem has been sunset.
         Actions.verify_gem!('xcode-install')
         required_version = params[:version]
         strict = params[:strict]

--- a/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
+++ b/fastlane/lib/fastlane/actions/ensure_xcode_version.rb
@@ -2,7 +2,6 @@ module Fastlane
   module Actions
     class EnsureXcodeVersionAction < Action
       def self.run(params)
-        # TODO: Deprecate this action by adding strict and non-strict version check capabilities to `xcodes` action, now that the `xcode-install` gem has been sunset.
         Actions.verify_gem!('xcode-install')
         required_version = params[:version]
         strict = params[:strict]

--- a/fastlane/lib/fastlane/actions/xcode_install.rb
+++ b/fastlane/lib/fastlane/actions/xcode_install.rb
@@ -105,7 +105,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://github.com/RobotsAndPencils/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/master/MIGRATION.md)"
+        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://docs.fastlane.tools/actions/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/master/MIGRATION.md)"
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/xcode_install.rb
+++ b/fastlane/lib/fastlane/actions/xcode_install.rb
@@ -105,7 +105,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://github.com/RobotsAndPencils/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/main/MIGRATION.md)"
+        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://github.com/RobotsAndPencils/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/master/MIGRATION.md)"
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/xcode_install.rb
+++ b/fastlane/lib/fastlane/actions/xcode_install.rb
@@ -101,7 +101,11 @@ module Fastlane
       end
 
       def self.category
-        :building
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://github.com/RobotsAndPencils/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/main/MIGRATION.md)"
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/xcode_select.rb
+++ b/fastlane/lib/fastlane/actions/xcode_select.rb
@@ -40,7 +40,7 @@ module Fastlane
       def self.details
         [
           "Select and build with the Xcode installed at the provided path.",
-          "Use the `xcversion` action if you want to select an Xcode:",
+          "Use the `xcodes` action if you want to select an Xcode:",
           "- Based on a version specifier or",
           "- You don't have known, stable paths, as may happen in a CI environment."
         ].join("\n")

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -61,9 +61,6 @@ module Fastlane
       end
 
       def self.available_options
-        user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)
-        user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
-
         [
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_XCODE_VERSION",

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -115,7 +115,7 @@ module Fastlane
 
       def self.output
         [
-          ['XCODES_XCODE_PATH', 'The path to the newly installed Xcode']
+          ['XCODES_XCODE_PATH', 'The path to the newly installed Xcode version']
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -23,24 +23,21 @@ module Fastlane
 
         if (xcodes_args = params[:xcodes_args])
           command << xcodes_args
-          shell_command = command.join(' ')
-          Actions.sh(shell_command)
+          Actions.sh(command.join(" "))
         elsif !params[:select_for_current_build_only]
           command << "install"
           command << "'#{version}'"
           command << "--update" if params[:update_list]
           command << "--select"
-          shell_command = command.join(' ')
-          Actions.sh(shell_command)
+          Actions.sh(command.join(" "))
         end
 
         command = []
         command << binary
         command << "installed"
         command << "'#{version}'"
-        shell_command = command.join(' ')
         # Prints something like /Applications/Xcode-14.app
-        xcode_path = Actions.sh(shell_command).strip
+        xcode_path = Actions.sh(command.join(" ")).strip
         xcode_developer_path = xcode_path + "/Contents/Developer/"
 
         UI.message("Setting Xcode version '#{version}' at '#{xcode_path}' for all build steps")

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -38,7 +38,7 @@ module Fastlane
         command << "'#{version}'"
         # Prints something like /Applications/Xcode-14.app
         xcode_path = Actions.sh(command.join(" ")).strip
-        xcode_developer_path = xcode_path + "/Contents/Developer/"
+        xcode_developer_path = xcode_path + "/Contents/Developer"
 
         UI.message("Setting Xcode version '#{version}' at '#{xcode_path}' for all build steps")
         ENV["DEVELOPER_DIR"] = xcode_developer_path

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -35,7 +35,7 @@ module Fastlane
 
         # Prints something like /Applications/Xcode-14.app/Contents/Developer/
         xcode_path = FastlaneCore::Helper.xcode_path
-        UI.message("Using Xcode #{params[:version]} on path '#{xcode_path.chomp("/Contents/Developer/")}'")
+        UI.message("Using Xcode #{params[:version]} on path '#{xcode_path.chomp('/Contents/Developer/')}'")
         ENV["DEVELOPER_DIR"] = xcode_path
         Actions.lane_context[SharedValues::XCODE_INSTALL_XCODE_PATH] = xcode_path
         return xcode_path

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -11,7 +11,7 @@ module Fastlane
         ENV["XCODES_PASSWORD"] = params[:password]
         binary = params[:binary_path]
         select_only = params[:select_only]
-        if update_list = params[:update_list] && !select_only
+        if params[:update_list] && !select_only
           command = []
           command << binary
           command << "update"
@@ -21,7 +21,7 @@ module Fastlane
         end
         command = []
         command << binary
-        if xcodes_args = params[:xcodes_args]
+        if (xcodes_args = params[:xcodes_args])
           command << xcodes_args
         elsif select_only
           command << "select"

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -60,7 +60,11 @@ module Fastlane
       end
 
       def self.details
-        "Makes sure a specific version of Xcode is installed. If that's not the case, it will automatically be downloaded by [xcodes](https://github.com/RobotsAndPencils/xcodes). This will make sure to use the correct Xcode version for later actions."
+        [
+          "Makes sure a specific version of Xcode is installed. If that's not the case, it will automatically be downloaded by [xcodes](https://github.com/RobotsAndPencils/xcodes).",
+          "This will make sure to use the correct Xcode version for later actions.",
+          "Note that this action depends on [xcodes](https://github.com/RobotsAndPencils/xcodes) CLI, so make sure you have it installed in your environment. For the installation guide, see: https://github.com/RobotsAndPencils/xcodes#installation"
+        ].join("\n")
       end
 
       def self.available_options
@@ -103,6 +107,7 @@ module Fastlane
                                        default_value: Helper::XcodesHelper.find_xcodes_binary_path,
                                        default_value_dynamic: true,
                                        verify_block: proc do |value|
+                                         UI.user_error!("'xcodes' doesn't seem to be installed. Please follow the installation guide at https://github.com/RobotsAndPencils/xcodes#installation before proceeding") if value.empty?
                                          UI.user_error!("Couldn't find xcodes binary at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :xcodes_args,

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -38,7 +38,7 @@ module Fastlane
         command << "'#{version}'"
         # Prints something like /Applications/Xcode-14.app
         xcode_path = Actions.sh(command.join(" ")).strip
-        xcode_developer_path = xcode_path + "/Contents/Developer"
+        xcode_developer_path = File.join(xcode_path, "/Contents/Developer")
 
         UI.message("Setting Xcode version '#{version}' at '#{xcode_path}' for all build steps")
         ENV["DEVELOPER_DIR"] = xcode_developer_path

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -10,7 +10,8 @@ module Fastlane
         ENV["XCODES_USERNAME"] = params[:username]
         ENV["XCODES_PASSWORD"] = params[:password]
         binary = params[:binary_path]
-        if update_list = params[:update_list]
+        select_only = params[:select_only]
+        if update_list = params[:update_list] && !select_only
           command = []
           command << binary
           command << "update"
@@ -22,6 +23,9 @@ module Fastlane
         command << binary
         if xcodes_args = params[:xcodes_args]
           command << xcodes_args
+        elsif select_only
+          command << "select"
+          command << "'#{params[:version]}'"
         else
           command << "install"
           command << "'#{params[:version]}'"
@@ -78,6 +82,11 @@ module Fastlane
                                        description: "Whether the list of available Xcode versions should be updated before running the install command",
                                        type: Boolean,
                                        default_value: true),
+          FastlaneCore::ConfigItem.new(key: :select_only,
+                                       env_name: "FL_XCODES_SELECT_ONLY",
+                                       description: "Whether the action should just select the version passed, instead of installing it if needed. When true, if the version isn't installed, an error will be raised",
+                                       type: Boolean,
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :binary_path,
                                        env_name: "FL_XCODES_BINARY_PATH",
                                        description: "Where the xcodes binary lives on your system (full path)",

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -10,7 +10,7 @@ module Fastlane
         xcodes_raw_version = Actions.sh("#{binary} version", log: false)
         xcodes_version = Gem::Version.new(xcodes_raw_version)
         UI.message("Running xcodes version #{xcodes_version}")
-        UI.user_error!("xcodes action requires the minimum version of xcodes binary to be v1.1.0. Please update xcodes. If you installed it via Homebrew, this can be done via 'brew upgrade xcodes'") if xcodes_version < "1.1.0"
+        UI.user_error!("xcodes action requires the minimum version of xcodes binary to be v1.1.0. Please update xcodes. If you installed it via Homebrew, this can be done via 'brew upgrade xcodes'") if xcodes_version < Gem::Version.new("1.1.0")
 
         version = params[:version]
         command = []

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -1,0 +1,131 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      XCODE_INSTALL_XCODE_PATH = :XCODE_INSTALL_XCODE_PATH
+    end
+
+    class XcodesAction < Action
+      def self.run(params)
+        # Provide xcodes with the necessary env vars
+        ENV["XCODES_USERNAME"] = params[:username]
+        ENV["XCODES_PASSWORD"] = params[:password]
+        binary = params[:binary_path]
+        if update_list = params[:update_list]
+          command = []
+          command << binary
+          command << "update"
+          shell_command = command.join(' ')
+          UI.message("Available versions:")
+          Actions.sh(shell_command)
+        end
+        command = []
+        command << binary
+        if xcodes_args = params[:xcodes_args]
+          command << xcodes_args
+        else
+          command << "install"
+          command << "'#{params[:version]}'"
+        end
+        shell_command = command.join(' ')
+        Actions.sh(shell_command)
+
+        # Prints something like /Applications/Xcode-14.app/Contents/Developer/
+        xcode_path = FastlaneCore::Helper.xcode_path
+        UI.message("Using Xcode #{params[:version]} on path '#{xcode_path.chomp("/Contents/Developer/")}'")
+        ENV["DEVELOPER_DIR"] = xcode_path
+        Actions.lane_context[SharedValues::XCODE_INSTALL_XCODE_PATH] = xcode_path
+        return xcode_path
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Make sure a certain version of Xcode is installed, installing it only if needed"
+      end
+
+      def self.details
+        "Makes sure a specific version of Xcode is installed. If that's not the case, it will automatically be downloaded by [xcodes](https://github.com/RobotsAndPencils/xcodes). This will make sure to use the correct Xcode version for later actions."
+      end
+
+      def self.available_options
+        user = CredentialsManager::AppfileConfig.try_fetch_value(:apple_dev_portal_id)
+        user ||= CredentialsManager::AppfileConfig.try_fetch_value(:apple_id)
+
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       env_name: "FL_XCODE_VERSION",
+                                       description: "The version number of the version of Xcode to install. Defaults to the value specified in the .xcode-version file",
+                                       default_value: Helper::XcodesHelper.read_xcode_version_file,
+                                       default_value_dynamic: true,
+                                       verify_block: Helper::XcodesHelper::Verify.method(:requirement)),
+          FastlaneCore::ConfigItem.new(key: :username,
+                                       short_option: "-u",
+                                       env_names: ["FL_XCODES_USERNAME", "XCODES_USERNAME"],
+                                       description: "Your Apple ID username",
+                                       default_value: user,
+                                       default_value_dynamic: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :password,
+                                       short_option: "-p",
+                                       env_names: ["FASTLANE_PASSWORD", "XCODES_PASSWORD"],
+                                       description: "Your Apple ID password",
+                                       code_gen_sensitive: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :update_list,
+                                       env_name: "FL_XCODES_UPDATE_LIST",
+                                       description: "Whether the list of available Xcode versions should be updated before running the install command",
+                                       type: Boolean,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :binary_path,
+                                       env_name: "FL_XCODES_BINARY_PATH",
+                                       description: "Where the xcodes binary lives on your system (full path)",
+                                       default_value: Helper::XcodesHelper.find_xcodes_binary_path,
+                                       default_value_dynamic: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find xcodes binary at path '#{value}'") unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :xcodes_args,
+                                       env_name: "FL_XCODES_ARGS",
+                                       description: "Pass in xcodes command line arguments directly. When present, other parameters are ignored and only this parameter is used to build the command to be executed",
+                                       type: :shell_string,
+                                       optional: true)
+        ]
+      end
+
+      def self.output
+        [
+          ['XCODE_INSTALL_XCODE_PATH', 'The path to the newly installed Xcode']
+        ]
+      end
+
+      def self.return_value
+        "The path to the newly installed Xcode version"
+      end
+
+      def self.return_type
+        :string
+      end
+
+      def self.authors
+        ["rogerluan"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.example_code
+        [
+          'xcodes(version: "14.1")',
+          'xcodes # When missing, the version value defaults to the value specified in the .xcode-version file'
+        ]
+      end
+
+      def self.category
+        :building
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -10,7 +10,12 @@ module Fastlane
         xcodes_raw_version = Actions.sh("#{binary} version", log: false)
         xcodes_version = Gem::Version.new(xcodes_raw_version)
         UI.message("Running xcodes version #{xcodes_version}")
-        UI.user_error!("xcodes action requires the minimum version of xcodes binary to be v1.1.0. Please update xcodes. If you installed it via Homebrew, this can be done via 'brew upgrade xcodes'") if xcodes_version < Gem::Version.new("1.1.0")
+        if xcodes_version < Gem::Version.new("1.1.0")
+          UI.user_error!([
+            "xcodes action requires the minimum version of xcodes binary to be v1.1.0.",
+            "Please update xcodes. If you installed it via Homebrew, this can be done via 'brew upgrade xcodes'"
+          ].join(" "))
+        end
 
         version = params[:version]
         command = []
@@ -75,7 +80,10 @@ module Fastlane
                                        default_value: true),
           FastlaneCore::ConfigItem.new(key: :select_for_current_build_only,
                                        env_name: "FL_XCODES_SELECT_FOR_CURRENT_BUILD_ONLY",
-                                       description: "When true, it won't attempt to install an Xcode version, just find the installed Xcode version that best matches the passed version argument, and select it for the current build steps. It doesn't change the global Xcode version (e.g. via 'xcrun xcode-select'), which would require sudo permissions — when this option is true, this action doesn't require sudo permissions",
+                                       description: [
+                                         "When true, it won't attempt to install an Xcode version, just find the installed Xcode version that best matches the passed version argument, and select it for the current build steps.",
+                                         "It doesn't change the global Xcode version (e.g. via 'xcrun xcode-select'), which would require sudo permissions — when this option is true, this action doesn't require sudo permissions"
+                                       ].join(" "),
                                        type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :binary_path,

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -6,9 +6,6 @@ module Fastlane
 
     class XcodesAction < Action
       def self.run(params)
-        # Provide xcodes with the necessary env vars
-        ENV["XCODES_USERNAME"] = params[:username]
-        ENV["XCODES_PASSWORD"] = params[:password]
         binary = params[:binary_path]
         select_for_current_build_only = params[:select_for_current_build_only]
         version = params[:version]
@@ -78,19 +75,6 @@ module Fastlane
                                        default_value: Helper::XcodesHelper.read_xcode_version_file,
                                        default_value_dynamic: true,
                                        verify_block: Helper::XcodesHelper::Verify.method(:requirement)),
-          FastlaneCore::ConfigItem.new(key: :username,
-                                       short_option: "-u",
-                                       env_names: ["FL_XCODES_USERNAME", "XCODES_USERNAME"],
-                                       description: "Your Apple ID username",
-                                       default_value: user,
-                                       default_value_dynamic: true,
-                                       optional: true),
-          FastlaneCore::ConfigItem.new(key: :password,
-                                       short_option: "-p",
-                                       env_names: ["FASTLANE_PASSWORD", "XCODES_PASSWORD"],
-                                       description: "Your Apple ID password",
-                                       code_gen_sensitive: true,
-                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :update_list,
                                        env_name: "FL_XCODES_UPDATE_LIST",
                                        description: "Whether the list of available Xcode versions should be updated before running the install command",

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -7,28 +7,24 @@ module Fastlane
     class XcodesAction < Action
       def self.run(params)
         binary = params[:binary_path]
-        select_for_current_build_only = params[:select_for_current_build_only]
+        xcodes_raw_version = Actions.sh("#{binary} version", log: false)
+        xcodes_version = Gem::Version.new(xcodes_raw_version)
+        UI.message("Running xcodes version #{xcodes_version}")
+        UI.user_error!("xcodes action requires the minimum version of xcodes binary to be v1.1.0. Please update xcodes. If you installed it via Homebrew, this can be done via 'brew upgrade xcodes'") if xcodes_version < "1.1.0"
+
         version = params[:version]
-        if params[:update_list] && !select_for_current_build_only
-          command = []
-          command << binary
-          command << "update"
-          shell_command = command.join(' ')
-          UI.message("Available versions:")
-          Actions.sh(shell_command)
-        end
+        command = []
+        command << binary
 
         if (xcodes_args = params[:xcodes_args])
-          command = []
-          command << binary
           command << xcodes_args
           shell_command = command.join(' ')
           Actions.sh(shell_command)
-        elsif !select_for_current_build_only
-          command = []
-          command << binary
+        elsif !params[:select_for_current_build_only]
           command << "install"
           command << "'#{version}'"
+          command << "--update" if params[:update_list]
+          command << "--select"
           shell_command = command.join(' ')
           Actions.sh(shell_command)
         end

--- a/fastlane/lib/fastlane/actions/xcversion.rb
+++ b/fastlane/lib/fastlane/actions/xcversion.rb
@@ -58,7 +58,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://github.com/RobotsAndPencils/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/main/MIGRATION.md)"
+        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://github.com/RobotsAndPencils/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/master/MIGRATION.md)"
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/xcversion.rb
+++ b/fastlane/lib/fastlane/actions/xcversion.rb
@@ -58,7 +58,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://github.com/RobotsAndPencils/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/master/MIGRATION.md)"
+        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://docs.fastlane.tools/actions/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/master/MIGRATION.md)"
       end
     end
   end

--- a/fastlane/lib/fastlane/actions/xcversion.rb
+++ b/fastlane/lib/fastlane/actions/xcversion.rb
@@ -34,7 +34,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_XCODE_VERSION",
-                                       description: "The version of Xcode to select specified as a Gem::Version requirement string (e.g. '~> 7.1.0')",
+                                       description: "The version of Xcode to select specified as a Gem::Version requirement string (e.g. '~> 7.1.0'). Defaults to the value specified in the .xcode-version file ",
                                        default_value: Helper::XcodesHelper.read_xcode_version_file,
                                        default_value_dynamic: true,
                                        verify_block: Helper::XcodesHelper::Verify.method(:requirement))
@@ -48,7 +48,8 @@ module Fastlane
       def self.example_code
         [
           'xcversion(version: "8.1") # Selects Xcode 8.1.0',
-          'xcversion(version: "~> 8.1.0") # Selects the latest installed version from the 8.1.x set'
+          'xcversion(version: "~> 8.1.0") # Selects the latest installed version from the 8.1.x set',
+          'xcversion # When missing, the version value defaults to the value specified in the .xcode-version file'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/xcversion.rb
+++ b/fastlane/lib/fastlane/actions/xcversion.rb
@@ -15,16 +15,6 @@ module Fastlane
         ENV["DEVELOPER_DIR"] = File.join(xcode.path, "/Contents/Developer")
       end
 
-      def self.read_xcode_version_file
-        xcode_version_paths = Dir.glob(".xcode-version")
-
-        if xcode_version_paths.first
-          return File.read(xcode_version_paths.first).strip
-        end
-
-        return nil
-      end
-
       def self.description
         "Select an Xcode to use by version specifier"
       end
@@ -45,9 +35,9 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: "FL_XCODE_VERSION",
                                        description: "The version of Xcode to select specified as a Gem::Version requirement string (e.g. '~> 7.1.0')",
-                                       default_value: self.read_xcode_version_file,
+                                       default_value: Helper::XcodesHelper.read_xcode_version_file,
                                        default_value_dynamic: true,
-                                       verify_block: Helper::XcversionHelper::Verify.method(:requirement))
+                                       verify_block: Helper::XcodesHelper::Verify.method(:requirement))
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/xcversion.rb
+++ b/fastlane/lib/fastlane/actions/xcversion.rb
@@ -53,7 +53,11 @@ module Fastlane
       end
 
       def self.category
-        :building
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        "The xcode-install gem, which this action depends on, has been sunset. Please migrate to [xcodes](https://github.com/RobotsAndPencils/xcodes). You can find a migration guide here: [xcpretty/xcode-install/MIGRATION.md](https://github.com/xcpretty/xcode-install/blob/main/MIGRATION.md)"
       end
     end
   end

--- a/fastlane/lib/fastlane/helper/xcodes_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodes_helper.rb
@@ -1,0 +1,28 @@
+module Fastlane
+  module Helper
+    class XcodesHelper
+      def self.read_xcode_version_file
+        xcode_version_paths = Dir.glob(".xcode-version")
+
+        if xcode_version_paths.first
+          return File.read(xcode_version_paths.first).strip
+        end
+
+        return nil
+      end
+
+      def self.find_xcodes_binary_path
+        `which xcodes`.strip
+      end
+
+      module Verify
+        def self.requirement(req)
+          UI.user_error!("Version must be specified") if req.nil? || req.to_s.strip.size == 0
+          Gem::Requirement.new(req.to_s)
+        rescue Gem::Requirement::BadRequirementError
+          UI.user_error!("The requirement '#{req}' is not a valid RubyGems style requirement")
+        end
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/helper/xcodes_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodes_helper.rb
@@ -12,7 +12,7 @@ module Fastlane
       end
 
       def self.find_xcodes_binary_path
-        Actions.sh("which xcodes", log: false).strip
+        `which xcodes`.strip
       end
 
       module Verify

--- a/fastlane/lib/fastlane/helper/xcodes_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodes_helper.rb
@@ -12,7 +12,7 @@ module Fastlane
       end
 
       def self.find_xcodes_binary_path
-        `which xcodes`.strip
+        Actions.sh("which xcodes", log: false).strip
       end
 
       module Verify

--- a/fastlane/lib/fastlane/helper/xcversion_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcversion_helper.rb
@@ -11,15 +11,6 @@ module Fastlane
           req.satisfied_by?(Gem::Version.new(xcode.version))
         end
       end
-
-      module Verify
-        def self.requirement(req)
-          UI.user_error!("Version must be specified") if req.nil? || req.to_s.strip.size == 0
-          Gem::Requirement.new(req.to_s)
-        rescue Gem::Requirement::BadRequirementError
-          UI.user_error!("The requirement '#{req}' is not a valid RubyGems style requirement")
-        end
-      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/xcodes_spec.rb
+++ b/fastlane/spec/actions_specs/xcodes_spec.rb
@@ -32,6 +32,15 @@ describe Fastlane do
         end
       end
 
+      it "doesn't invoke 'update' nor 'install', and invokes 'select', when select_only argument is true" do
+        expect(Fastlane::Actions).to_not receive(:sh).with("#{xcodes_binary_path} update")
+        expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} select '14'")
+        expect(Fastlane::Actions).to_not receive(:sh).with("#{xcodes_binary_path} install '14'")
+        Fastlane::FastFile.new.parse("lane :test do
+          xcodes(version: '14', select_only: true)
+        end").runner.execute(:test)
+      end
+
       it "passes any received string to the command if xcodes_args is passed" do
         random_string = "xcodes compiles pikachu into a mewtwo"
         allow(Fastlane::Actions).to receive(:sh).and_call_original

--- a/fastlane/spec/actions_specs/xcodes_spec.rb
+++ b/fastlane/spec/actions_specs/xcodes_spec.rb
@@ -1,0 +1,97 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "xcodes" do
+      let(:xcode_path) { "/valid/path/to/xcode.app/Contents/Developer/" }
+      let(:xcodes_binary_path) { "/path/to/bin/xcodes" }
+
+      before(:each) do
+        allow(FastlaneCore::Helper).to receive(:xcode_path).and_return(xcode_path)
+        allow(Fastlane::Helper::XcodesHelper).to receive(:find_xcodes_binary_path).and_return(xcodes_binary_path)
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(xcodes_binary_path).and_return(true)
+      end
+
+      after(:each) do
+        ENV.delete("DEVELOPER_DIR")
+      end
+
+      describe "update_list argument" do
+        it "invokes update command when true" do
+          expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} update")
+          expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} install '14'")
+          Fastlane::FastFile.new.parse("lane :test do
+            xcodes(version: '14', update_list: true)
+          end").runner.execute(:test)
+        end
+
+        it "doesn't invoke update command when false" do
+          expect(Fastlane::Actions).to_not(receive(:sh).with("#{xcodes_binary_path} update"))
+          Fastlane::FastFile.new.parse("lane :test do
+            xcodes(version: '14', update_list: false)
+          end").runner.execute(:test)
+        end
+      end
+
+      it "passes any received string to the command if xcodes_args is passed" do
+        random_string = "xcodes compiles pikachu into a mewtwo"
+        allow(Fastlane::Actions).to receive(:sh).and_call_original
+        expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} #{random_string}")
+        Fastlane::FastFile.new.parse("lane :test do
+          xcodes(version: '14', xcodes_args: '#{random_string}')
+        end").runner.execute(:test)
+      end
+
+      it "invokes install command when xcodes_args is not passed" do
+        expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} update")
+        expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} install '14'")
+        Fastlane::FastFile.new.parse("lane :test do
+          xcodes(version: '14')
+        end").runner.execute(:test)
+      end
+
+      context "when no params are passed" do
+        describe ".xcode-version file is present" do
+          before do
+            allow(Fastlane::Helper::XcodesHelper).to receive(:read_xcode_version_file).and_return("14")
+          end
+
+          it "doesn't raise error" do
+            expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} update")
+            expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} install '14'")
+            Fastlane::FastFile.new.parse("lane :test do
+              xcodes
+            end").runner.execute(:test)
+          end
+        end
+
+        describe ".xcode-version file is not present" do
+          before do
+            allow(Fastlane::Helper::XcodesHelper).to receive(:read_xcode_version_file).and_return(nil)
+          end
+
+          it "raises error" do
+            expect do
+              Fastlane::FastFile.new.parse("lane :test do
+                xcodes
+              end").runner.execute(:test)
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, "Version must be specified")
+          end
+        end
+      end
+
+      it "sets the DEVELOPER_DIR environment variable" do
+        Fastlane::FastFile.new.parse("lane :test do
+          xcodes(version: '14')
+        end").runner.execute(:test)
+        expect(ENV["DEVELOPER_DIR"]).to eq(xcode_path)
+      end
+
+      it "sets the SharedValues::XCODE_INSTALL_XCODE_PATH lane context" do
+        Fastlane::FastFile.new.parse("lane :test do
+          xcodes(version: '14')
+        end").runner.execute(:test)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::XCODE_INSTALL_XCODE_PATH]).to eql(xcode_path)
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/xcodes_spec.rb
+++ b/fastlane/spec/actions_specs/xcodes_spec.rb
@@ -33,9 +33,9 @@ describe Fastlane do
       end
 
       it "doesn't invoke 'update' nor 'install', and invokes 'select', when select_only argument is true" do
-        expect(Fastlane::Actions).to_not receive(:sh).with("#{xcodes_binary_path} update")
+        expect(Fastlane::Actions).to_not(receive(:sh).with("#{xcodes_binary_path} update"))
         expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} select '14'")
-        expect(Fastlane::Actions).to_not receive(:sh).with("#{xcodes_binary_path} install '14'")
+        expect(Fastlane::Actions).to_not(receive(:sh).with("#{xcodes_binary_path} install '14'"))
         Fastlane::FastFile.new.parse("lane :test do
           xcodes(version: '14', select_only: true)
         end").runner.execute(:test)

--- a/fastlane/spec/actions_specs/xcodes_spec.rb
+++ b/fastlane/spec/actions_specs/xcodes_spec.rb
@@ -2,7 +2,7 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "xcodes" do
       let(:xcode_path) { "/valid/path/to/xcode.app" }
-      let(:xcode_developer_path) { "#{xcode_path}/Contents/Developer/" }
+      let(:xcode_developer_path) { "#{xcode_path}/Contents/Developer" }
       let(:xcodes_binary_path) { "/path/to/bin/xcodes" }
       let(:valid_xcodes_version) { "1.1.0" }
       let(:outdated_xcodes_version) { "1.0.0" }

--- a/fastlane/spec/actions_specs/xcodes_spec.rb
+++ b/fastlane/spec/actions_specs/xcodes_spec.rb
@@ -4,6 +4,8 @@ describe Fastlane do
       let(:xcode_path) { "/valid/path/to/xcode.app" }
       let(:xcode_developer_path) { "#{xcode_path}/Contents/Developer/" }
       let(:xcodes_binary_path) { "/path/to/bin/xcodes" }
+      let(:valid_xcodes_version) { "1.1.0" }
+      let(:outdated_xcodes_version) { "1.0.0" }
 
       before(:each) do
         allow(Fastlane::Helper::XcodesHelper).to receive(:find_xcodes_binary_path).and_return(xcodes_binary_path)
@@ -11,6 +13,7 @@ describe Fastlane do
         allow(File).to receive(:exist?).with(xcodes_binary_path).and_return(true)
         allow(Fastlane::Actions).to receive(:sh).and_call_original
         allow(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} installed '14'").and_return(xcode_path)
+        allow(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} version", { log: false }).and_return(valid_xcodes_version)
       end
 
       after(:each) do
@@ -19,15 +22,15 @@ describe Fastlane do
 
       describe "update_list argument" do
         it "invokes update command when true" do
-          expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} update")
-          expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} install '14'")
+          expect(Fastlane::Actions).to receive(:sh).with(/--update/)
           Fastlane::FastFile.new.parse("lane :test do
             xcodes(version: '14', update_list: true)
           end").runner.execute(:test)
         end
 
         it "doesn't invoke update command when false" do
-          expect(Fastlane::Actions).to_not(receive(:sh).with("#{xcodes_binary_path} update"))
+          expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} install '14' --select")
+          expect(Fastlane::Actions).to_not receive(:sh).with(/--update/)
           Fastlane::FastFile.new.parse("lane :test do
             xcodes(version: '14', update_list: false)
           end").runner.execute(:test)
@@ -35,8 +38,8 @@ describe Fastlane do
       end
 
       it "doesn't invoke 'update' nor 'install' when select_for_current_build_only argument is true" do
-        expect(Fastlane::Actions).to_not(receive(:sh).with("#{xcodes_binary_path} update"))
-        expect(Fastlane::Actions).to_not(receive(:sh).with("#{xcodes_binary_path} install '14'"))
+        expect(Fastlane::Actions).to_not receive(:sh).with(/--update|--install/)
+        expect(Fastlane::Actions).to receive(:sh).with(/installed/)
         Fastlane::FastFile.new.parse("lane :test do
           xcodes(version: '14', select_for_current_build_only: true)
         end").runner.execute(:test)
@@ -44,7 +47,6 @@ describe Fastlane do
 
       it "passes any received string to the command if xcodes_args is passed" do
         random_string = "xcodes compiles pikachu into a mewtwo"
-        allow(Fastlane::Actions).to receive(:sh).and_call_original
         expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} #{random_string}")
         Fastlane::FastFile.new.parse("lane :test do
           xcodes(version: '14', xcodes_args: '#{random_string}')
@@ -52,8 +54,8 @@ describe Fastlane do
       end
 
       it "invokes install command when xcodes_args is not passed" do
-        expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} update")
-        expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} install '14'")
+        expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} install '14' --update --select")
+        expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} installed '14'")
         Fastlane::FastFile.new.parse("lane :test do
           xcodes(version: '14')
         end").runner.execute(:test)
@@ -66,8 +68,7 @@ describe Fastlane do
           end
 
           it "doesn't raise error" do
-            expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} update")
-            expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} install '14'")
+            expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} installed '14'")
             Fastlane::FastFile.new.parse("lane :test do
               xcodes
             end").runner.execute(:test)
@@ -101,6 +102,15 @@ describe Fastlane do
           xcodes(version: '14')
         end").runner.execute(:test)
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::XCODES_XCODE_PATH]).to eql(xcode_developer_path)
+      end
+
+      it "raises error when using an xcodes version earlier than v1.1.0" do
+        allow(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} version", { log: false }).and_return(outdated_xcodes_version)
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            xcodes(version: '14')
+          end").runner.execute(:test)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, /minimum version(?:.*)1.1.0(?:.*)please update(?:.*)brew upgrade xcodes/i)
       end
     end
   end

--- a/fastlane/spec/actions_specs/xcodes_spec.rb
+++ b/fastlane/spec/actions_specs/xcodes_spec.rb
@@ -30,7 +30,7 @@ describe Fastlane do
 
         it "doesn't invoke update command when false" do
           expect(Fastlane::Actions).to receive(:sh).with("#{xcodes_binary_path} install '14' --select")
-          expect(Fastlane::Actions).to_not receive(:sh).with(/--update/)
+          expect(Fastlane::Actions).to_not(receive(:sh).with(/--update/))
           Fastlane::FastFile.new.parse("lane :test do
             xcodes(version: '14', update_list: false)
           end").runner.execute(:test)
@@ -38,7 +38,7 @@ describe Fastlane do
       end
 
       it "doesn't invoke 'update' nor 'install' when select_for_current_build_only argument is true" do
-        expect(Fastlane::Actions).to_not receive(:sh).with(/--update|--install/)
+        expect(Fastlane::Actions).to_not(receive(:sh).with(/--update|--install/))
         expect(Fastlane::Actions).to receive(:sh).with(/installed/)
         Fastlane::FastFile.new.parse("lane :test do
           xcodes(version: '14', select_for_current_build_only: true)

--- a/fastlane/spec/helper/xcodes_helper_spec.rb
+++ b/fastlane/spec/helper/xcodes_helper_spec.rb
@@ -1,5 +1,5 @@
 describe Fastlane::Helper::XcodesHelper do
-  describe "#read_xcode_version_file" do
+  describe ".read_xcode_version_file" do
     let(:xcode_version_path) { ".xcode-version" }
 
     context ".xcode-version file exists" do
@@ -24,7 +24,7 @@ describe Fastlane::Helper::XcodesHelper do
     end
   end
 
-  describe "#find_xcodes_binary_path" do
+  describe ".find_xcodes_binary_path" do
     it "returns the binary path when it's installed" do
       expect(subject.class).to receive(:find_xcodes_binary_path).and_return("/path/to/bin/xcodes")
       expect(subject.class.find_xcodes_binary_path).to eq("/path/to/bin/xcodes")
@@ -37,7 +37,7 @@ describe Fastlane::Helper::XcodesHelper do
   end
 
   describe "Verify" do
-    describe "#requirement" do
+    describe ".requirement" do
       context "when argument is missing or empty" do
         let(:argument) { nil }
 

--- a/fastlane/spec/helper/xcodes_helper_spec.rb
+++ b/fastlane/spec/helper/xcodes_helper_spec.rb
@@ -1,0 +1,66 @@
+describe Fastlane::Helper::XcodesHelper do
+  describe "#read_xcode_version_file" do
+    let(:xcode_version_path) { ".xcode-version" }
+
+    context ".xcode-version file exists" do
+      before do
+        allow(Dir).to receive(:glob).with(".xcode-version").and_return([xcode_version_path])
+        allow(File).to receive(:read).with(xcode_version_path).and_return("14")
+      end
+
+      it "return its content" do
+        expect(subject.class.read_xcode_version_file).to eq("14")
+      end
+    end
+
+    context "no .xcode-version file exists" do
+      before do
+        allow(Dir).to receive(:glob).with(".xcode-version").and_return([])
+      end
+
+      it "return nil" do
+        expect(subject.class.read_xcode_version_file).to eq(nil)
+      end
+    end
+  end
+
+  describe "#find_xcodes_binary_path" do
+    it "returns the binary path when it's installed" do
+      expect(subject.class).to receive(:find_xcodes_binary_path).and_return("/opt/homebrew/bin/xcodes")
+      expect(subject.class.find_xcodes_binary_path).to eq("/opt/homebrew/bin/xcodes")
+    end
+
+    it "returns a string that doesn't point to a file that exists, when it's not installed" do
+      expect(subject.class).to receive(:find_xcodes_binary_path).and_return("xcodes not found")
+      expect(File.exist?(subject.class.find_xcodes_binary_path)).to eq(false)
+    end
+  end
+
+  describe "Verify" do
+    describe "#requirement" do
+      context "when argument is missing or empty" do
+        let(:argument) { nil }
+
+        it "raise user error" do
+          expect { subject.class::Verify.requirement(nil) }.to raise_error(FastlaneCore::Interface::FastlaneError, /Version must be specified/)
+        end
+      end
+
+      context "when argument is not in RubyGems style" do
+        let(:argument) { "banana" }
+
+        it "raise user error" do
+          expect { subject.class::Verify.requirement(argument) }.to raise_error(FastlaneCore::Interface::FastlaneError, "The requirement '#{argument}' is not a valid RubyGems style requirement")
+        end
+      end
+
+      context "when argument is in RubyGems style" do
+        let(:argument) { "1.2.3" }
+
+        it "return Gem::Requirement instance" do
+          expect(subject.class::Verify.requirement(argument)).to be_an_instance_of(Gem::Requirement)
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/helper/xcodes_helper_spec.rb
+++ b/fastlane/spec/helper/xcodes_helper_spec.rb
@@ -8,7 +8,7 @@ describe Fastlane::Helper::XcodesHelper do
         allow(File).to receive(:read).with(xcode_version_path).and_return("14")
       end
 
-      it "return its content" do
+      it "returns its content" do
         expect(subject.class.read_xcode_version_file).to eq("14")
       end
     end
@@ -18,7 +18,7 @@ describe Fastlane::Helper::XcodesHelper do
         allow(Dir).to receive(:glob).with(".xcode-version").and_return([])
       end
 
-      it "return nil" do
+      it "returns nil" do
         expect(subject.class.read_xcode_version_file).to eq(nil)
       end
     end
@@ -26,11 +26,11 @@ describe Fastlane::Helper::XcodesHelper do
 
   describe "#find_xcodes_binary_path" do
     it "returns the binary path when it's installed" do
-      expect(subject.class).to receive(:find_xcodes_binary_path).and_return("/opt/homebrew/bin/xcodes")
-      expect(subject.class.find_xcodes_binary_path).to eq("/opt/homebrew/bin/xcodes")
+      expect(subject.class).to receive(:find_xcodes_binary_path).and_return("/path/to/bin/xcodes")
+      expect(subject.class.find_xcodes_binary_path).to eq("/path/to/bin/xcodes")
     end
 
-    it "returns a string that doesn't point to a file that exists, when it's not installed" do
+    it "returns an error message instead of a valid path when it's not installed" do
       expect(subject.class).to receive(:find_xcodes_binary_path).and_return("xcodes not found")
       expect(File.exist?(subject.class.find_xcodes_binary_path)).to eq(false)
     end
@@ -41,15 +41,15 @@ describe Fastlane::Helper::XcodesHelper do
       context "when argument is missing or empty" do
         let(:argument) { nil }
 
-        it "raise user error" do
-          expect { subject.class::Verify.requirement(nil) }.to raise_error(FastlaneCore::Interface::FastlaneError, /Version must be specified/)
+        it "raises user error" do
+          expect { subject.class::Verify.requirement(argument) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'Version must be specified')
         end
       end
 
       context "when argument is not in RubyGems style" do
         let(:argument) { "banana" }
 
-        it "raise user error" do
+        it "raises user error" do
           expect { subject.class::Verify.requirement(argument) }.to raise_error(FastlaneCore::Interface::FastlaneError, "The requirement '#{argument}' is not a valid RubyGems style requirement")
         end
       end
@@ -57,7 +57,7 @@ describe Fastlane::Helper::XcodesHelper do
       context "when argument is in RubyGems style" do
         let(:argument) { "1.2.3" }
 
-        it "return Gem::Requirement instance" do
+        it "returns Gem::Requirement instance" do
           expect(subject.class::Verify.requirement(argument)).to be_an_instance_of(Gem::Requirement)
         end
       end

--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -160,13 +160,13 @@ module FastlaneCore
       import_command = "curl -f -o #{filename} #{url} && security import #{filename} #{keychain}"
       UI.verbose("Installing WWDR Cert: #{import_command}")
 
-      stdout, stderr, _status = Open3.capture3(import_command)
+      stdout, stderr, status = Open3.capture3(import_command)
       if FastlaneCore::Globals.verbose?
         UI.command_output(stdout)
         UI.command_output(stderr)
       end
 
-      unless $?.success?
+      unless status.success?
         UI.verbose("Failed to install WWDR Certificate, checking output to see why")
         # Check the command output, WWDR might already exist
         unless /The specified item already exists in the keychain./ =~ stderr

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -1,5 +1,14 @@
 describe FastlaneCore do
   describe FastlaneCore::CertChecker do
+    let(:success_status) {
+      class ProcessStatusMock
+      end
+
+      allow_any_instance_of(ProcessStatusMock).to receive(:success?).and_return(true)
+
+      ProcessStatusMock.new
+    }
+
     describe '#installed_identies' do
       it 'should print an error when no local code signing identities are found' do
         allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G1', 'G2', 'G3', 'G4', 'G5', 'G6'])
@@ -65,22 +74,22 @@ describe FastlaneCore do
       it 'should download the WWDR certificate from correct URL' do
         allow(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return('login.keychain')
 
-        expect(Open3).to receive(:capture3).with(include('https://developer.apple.com/certificationauthority/AppleWWDRCA.cer')).and_return("")
+        expect(Open3).to receive(:capture3).with(include('https://developer.apple.com/certificationauthority/AppleWWDRCA.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('G1')
 
-        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer')).and_return("")
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('G2')
 
-        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer')).and_return("")
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('G3')
 
-        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer')).and_return("")
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('G4')
 
-        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG5.cer')).and_return("")
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG5.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('G5')
 
-        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')).and_return("")
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('G6')
       end
     end
@@ -105,7 +114,7 @@ describe FastlaneCore do
         cmd = %r{curl -f -o (([A-Z]\:)?\/.+) https://www\.apple\.com/certificateauthority/AppleWWDRCAG6\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
         require "open3"
 
-        expect(Open3).to receive(:capture3).with(cmd).and_return("")
+        expect(Open3).to receive(:capture3).with(cmd).and_return(["", "", success_status])
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
         allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G1', 'G2', 'G3', 'G4', 'G5'])

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version.rb
@@ -112,7 +112,7 @@ module Spaceship
 
       # @deprecated
       def fetch_age_rating_declaration(client: nil)
-        raise 'AppStoreVersion no longer as AgeRatingDeclaration as of App Store Connect API 1.3 - Use AppInfo instead'
+        raise 'AppStoreVersion no longer has AgeRatingDeclaration as of App Store Connect API 1.3 - Use AppInfo instead'
       end
 
       #

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
@@ -19,16 +19,16 @@ module Spaceship
       attr_accessor :app_preview_sets
 
       attr_mapping({
-        "description" =>  "description",
-        "locale" =>  "locale",
-        "keywords" =>  "keywords",
-        "marketingUrl" =>  "marketing_url",
-        "promotionalText" =>  "promotional_text",
-        "supportUrl" =>  "support_url",
-        "whatsNew" =>  "whats_new",
+        "description" => "description",
+        "locale" => "locale",
+        "keywords" => "keywords",
+        "marketingUrl" => "marketing_url",
+        "promotionalText" => "promotional_text",
+        "supportUrl" => "support_url",
+        "whatsNew" => "whats_new",
 
-        "appScreenshotSets" =>  "app_screenshot_sets",
-        "appPreviewSets" =>  "app_preview_sets"
+        "appScreenshotSets" => "app_screenshot_sets",
+        "appPreviewSets" => "app_preview_sets"
       })
 
       def self.type


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

With the planned sunset of `xcode-install` (aka `xcversion`) gem (https://github.com/xcpretty/xcode-install/issues/467), a new action was needed to support `xcodes`.

### Description

This PR depends on https://github.com/RobotsAndPencils/xcodes/pull/220 and https://github.com/RobotsAndPencils/xcodes/pull/182 merge & release so the `installed` option with specified version is available, as well as `--install` and `--select` arguments for the `install` option.

These PRs were later merged & released under v1.1.0 https://github.com/RobotsAndPencils/xcodes/releases/tag/1.1.0, so v1.1.0 of xcodes is required to use and test this feature.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem 'fastlane', git: 'https://github.com/fastlane/fastlane.git', branch: 'rogerluan-xcodes'
```

And run `bundle install` to apply the changes. 

Then switch your implementation of `xcversion` and `xcode_install` according to the migration guide which can be found here: https://github.com/xcpretty/xcode-install/blob/master/MIGRATION.md

Any and every testing is highly appreciated! I did very limited testing only 🙇 

<img width="734" alt="image" src="https://user-images.githubusercontent.com/8419048/191257574-7dd145a1-744a-48b0-956a-d1cb99a124c0.png">

<img width="604" alt="image" src="https://user-images.githubusercontent.com/8419048/199222112-c97e908b-2a5a-41c7-b414-6aa59ed36bbb.png">
