### PR TITLE
[deliver] allow for case insensitive comparison when determining whether a screenshot is an iPad Pro 3rd Gen one

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -334,7 +334,7 @@ module Deliver
         "iPad Pro (12.9-inch) (5th generation)", # Default simulator has this name
         "IPAD_PRO_3GEN_129", # Screenshots downloaded from App Store Connect has this name
         "ipadPro129" # Legacy: screenshots downloaded from iTunes Connect used to have this name
-      ].any? { |key| filename.include?(key) }
+      ].any? { |key| filename.downcase.include?(key.downcase) }
       if is_3rd_gen
         if screen_size == ScreenSize::IOS_IPAD_PRO
           return ScreenSize::IOS_IPAD_PRO_12_9


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

I think this has no drawbacks and it cost me an hour of debugging because we started naming our screenshots `iPadPro129` instead of `ipadPro129` without realizing... 😅 

### Description

No extra context, just see the motivation and context ☝️ 🙏 

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem 'fastlane', git: 'https://github.com/fastlane/fastlane.git', branch: 'rogerluan-user-friendly-iPad-3rd-gen-names'
```

And run `bundle install` to apply the changes. 