### PR TITLE
[spaceship] implement resolution center API in Spaceship::ConnectAPI

### DIFF
--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -68,7 +68,10 @@ require 'spaceship/connect_api/models/reset_ratings_request'
 require 'spaceship/connect_api/models/sandbox_tester'
 require 'spaceship/connect_api/models/territory'
 
-require 'spaceship/connect_api/models/resolution_center_threads'
+require 'spaceship/connect_api/models/resolution_center_message'
+require 'spaceship/connect_api/models/resolution_center_thread'
+require 'spaceship/connect_api/models/review_rejection'
+require 'spaceship/connect_api/models/actor'
 
 module Spaceship
   class ConnectAPI

--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -68,6 +68,8 @@ require 'spaceship/connect_api/models/reset_ratings_request'
 require 'spaceship/connect_api/models/sandbox_tester'
 require 'spaceship/connect_api/models/territory'
 
+require 'spaceship/connect_api/models/resolution_center_threads'
+
 module Spaceship
   class ConnectAPI
     # Defined in the App Store Connect API docs:

--- a/spaceship/lib/spaceship/connect_api/models/actor.rb
+++ b/spaceship/lib/spaceship/connect_api/models/actor.rb
@@ -1,0 +1,26 @@
+require_relative '../model'
+module Spaceship
+  class ConnectAPI
+    class Actor
+      include Spaceship::ConnectAPI::Model
+
+      attr_accessor :actor_type
+      attr_accessor :user_first_name
+      attr_accessor :user_last_name
+      attr_accessor :user_email
+      attr_accessor :api_key_id
+
+      attr_mapping({
+        actorType: 'actor_type',
+        userFirstName: 'user_first_name',
+        userLastName: 'user_last_name',
+        userEmail: 'user_email',
+        apiKeyId: 'api_key_id'
+      })
+
+      def self.type
+        return 'actors'
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/connect_api/models/resolution_center_message.rb
+++ b/spaceship/lib/spaceship/connect_api/models/resolution_center_message.rb
@@ -1,0 +1,29 @@
+require_relative '../model'
+require_relative './actor'
+require_relative './review_rejection'
+
+module Spaceship
+  class ConnectAPI
+    class ResolutionCenterMessage
+      include Spaceship::ConnectAPI::Model
+
+      attr_accessor :message_body
+      attr_accessor :created_date
+      attr_accessor :rejections
+      attr_accessor :from_actor
+
+      attr_mapping({
+        messageBody: 'message_body',
+        createdDate: 'created_date',
+
+        # includes
+        rejections: 'rejections',
+        fromActor: 'from_actor'
+      })
+
+      def self.type
+        return 'resolutionCenterMessages'
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/connect_api/models/resolution_center_thread.rb
+++ b/spaceship/lib/spaceship/connect_api/models/resolution_center_thread.rb
@@ -1,0 +1,56 @@
+require_relative '../model'
+
+module Spaceship
+  class ConnectAPI
+    class ResolutionCenterThread
+      include Spaceship::ConnectAPI::Model
+
+      attr_accessor :state
+      attr_accessor :can_developer_add_node
+      attr_accessor :objectionable_content
+      attr_accessor :thread_type
+      attr_accessor :created_date
+      attr_accessor :last_message_response_date
+
+      attr_accessor :resolution_center_messages
+      attr_accessor :app_store_version
+
+      module ThreadType
+        REJECTION_BINARY = 'REJECTION_BINARY'
+        REJECTION_METADATA = 'REJECTION_METADATA'
+        REJECTION_REVIEW_SUBMISSION = 'REJECTION_REVIEW_SUBMISSION'
+        APP_MESSAGE_ARC = 'APP_MESSAGE_ARC'
+        APP_MESSAGE_ARB = 'APP_MESSAGE_ARB'
+        APP_MESSAGE_COMM = 'APP_MESSAGE_COMM'
+      end
+
+      attr_mapping({
+        state: 'state',
+        canDeveloperAddNote: 'can_developer_add_node',
+        objectionableContent: 'objectionable_content',
+        threadType: 'thread_type',
+        createdDate: 'created_date',
+        lastMessageResponseDate: 'last_message_response_date',
+
+        # includes
+        resolutionCenterMessages: 'resolution_center_messages',
+        appStoreVersion: 'app_store_version'
+      })
+
+      def self.type
+        return "resolutionCenterThreads"
+      end
+
+      #
+      # API
+      #
+
+      def self.all(client: nil, filter:, includes: nil)
+        client ||= Spaceship::ConnectAPI
+        resps = client.get_resolution_center_threads(filter: filter, includes: includes).all_pages
+        return resps.flat_map(&:to_models)
+      end
+
+    end
+  end
+end

--- a/spaceship/lib/spaceship/connect_api/models/resolution_center_thread.rb
+++ b/spaceship/lib/spaceship/connect_api/models/resolution_center_thread.rb
@@ -62,7 +62,6 @@ module Spaceship
         resp = client.get_review_rejection(filter: { 'resolutionCenterMessage.resolutionCenterThread': id }, includes: includes)
         return resp.to_models
       end
-
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/resolution_center_thread.rb
+++ b/spaceship/lib/spaceship/connect_api/models/resolution_center_thread.rb
@@ -51,6 +51,18 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
+      def fetch_messages(client: nil, filter: {}, includes: nil)
+        client ||= Spaceship::ConnectAPI
+        resps = client.get_resolution_center_messages(thread_id: id, filter: filter, includes: includes).all_pages
+        return resps.flat_map(&:to_models)
+      end
+
+      def fetch_rejection_reasons(client: nil, includes: nil)
+        client ||= Spaceship::ConnectAPI
+        resp = client.get_review_rejection(filter: { 'resolutionCenterMessage.resolutionCenterThread': id }, includes: includes)
+        return resp.to_models
+      end
+
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/review_rejection.rb
+++ b/spaceship/lib/spaceship/connect_api/models/review_rejection.rb
@@ -1,0 +1,19 @@
+require_relative '../model'
+
+module Spaceship
+  class ConnectAPI
+    class ReviewRejection
+      include Spaceship::ConnectAPI::Model
+
+      attr_accessor :reasons
+
+      attr_mapping({
+        reasons: 'reasons'
+      })
+
+      def self.type
+        return 'reviewRejections'
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/connect_api/models/review_submission.rb
+++ b/spaceship/lib/spaceship/connect_api/models/review_submission.rb
@@ -69,6 +69,18 @@ module Spaceship
         resp = client.post_review_submission_item(review_submission_id: id, app_store_version_id: app_store_version_id)
         return resp.to_models.first
       end
+
+      def fetch_resolution_center_threads(client: nil)
+        client ||= Spaceship::ConnectAPI
+        resp = client.get_resolution_center_threads(filter: {reviewSubmission: id}, includes: 'reviewSubmission')
+        return resp.to_models
+      end
+
+      def latest_resolution_center_messages(client: nil)
+        client ||= Spaceship::ConnectAPI
+        threads = fetch_resolution_center_threads(client: client)
+        threads.first.fetch_messages(client: client)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/models/review_submission.rb
+++ b/spaceship/lib/spaceship/connect_api/models/review_submission.rb
@@ -72,7 +72,7 @@ module Spaceship
 
       def fetch_resolution_center_threads(client: nil)
         client ||= Spaceship::ConnectAPI
-        resp = client.get_resolution_center_threads(filter: {reviewSubmission: id}, includes: 'reviewSubmission')
+        resp = client.get_resolution_center_threads(filter: { reviewSubmission: id }, includes: 'reviewSubmission')
         return resp.to_models
       end
 

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -1252,6 +1252,15 @@ module Spaceship
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
           tunes_request_client.get("territories", params)
         end
+
+        #
+        # resolutionCenter
+        #
+
+        def get_resolution_center_threads(filter:, includes: nil)
+          params = tunes_request_client.build_params(filter: filter, includes: includes)
+          tunes_request_client.get('resolutionCenterThreads', params)
+        end
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -1256,7 +1256,7 @@ module Spaceship
         #
         # resolutionCenter
         #
-        
+
         def get_resolution_center_threads(filter: {}, includes: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes)
           tunes_request_client.get('resolutionCenterThreads', params)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -1256,6 +1256,10 @@ module Spaceship
         #
         # resolutionCenter
         #
+        # As of 2022-11-11:
+        # This is not official available throught the App Store Connect API using an API Key.
+        # This is only works with Apple ID auth.
+        #
 
         def get_resolution_center_threads(filter: {}, includes: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes)

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -1256,10 +1256,20 @@ module Spaceship
         #
         # resolutionCenter
         #
-
-        def get_resolution_center_threads(filter:, includes: nil)
+        
+        def get_resolution_center_threads(filter: {}, includes: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes)
           tunes_request_client.get('resolutionCenterThreads', params)
+        end
+
+        def get_resolution_center_messages(thread_id:, filter: {}, includes: nil)
+          params = tunes_request_client.build_params(filter: filter, includes: includes)
+          tunes_request_client.get("resolutionCenterThreads/#{thread_id}/resolutionCenterMessages", params)
+        end
+
+        def get_review_rejection(filter: {}, includes: nil)
+          params = tunes_request_client.build_params(filter: filter, includes: includes)
+          tunes_request_client.get("reviewRejections", params)
         end
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Old resolution center code is implemented in the old Spaceship::Tunes endpoints, which sometimes does not return the expected messages properly due to some recent changes in appstore connect. The new calls are being made using the same endpoint as the rest of the Appstore Connect APIs, which have been implemented here following the standard format in spaceship.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Previous implementation for retrieving resolution center comments for appstore and beta submissions were using the old private api endpoint https://appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/ra/apps/:app_id/platforms/ios/resolutionCenter?v=latest

New implementation is based on sniffing the traffic in Appstore Connect, which now uses the Appstore Connect APIs, although they have not been published in the API documentation yet and is not accessible using the api key.
e.g. base endpoint for threads is https://appstoreconnect.apple.com/iris/v1/resolutionCenterThreads

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
```ruby
# Get threads
Spaceship::ConnectAPI::ResolutionCenterThread.all filter: { appStoreVersion: version.id }

# Get threads with associated messages
Spaceship::ConnectAPI::ResolutionCenterThread.all filter: { appStoreVersion: version.id }, includes: 'resolutionCenterMessages'

# Get messages from thread with associated actors
thread = Spaceship::ConnectAPI::ResolutionCenterThread.all filter: { appStoreVersion: version.id }
thread.fetch_messages includes: 'rejections,fromActors'
```