### PR TITLE
[deliver] fix bug when canceling a rejected submission

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -245,13 +245,9 @@ module Deliver
         UI.message("Review submission cancellation has been requested")
 
         # An app version won't get removed from review instantly
-        # Polling until app version has a state of DEVELOPER_REJECT
+        # Polling until there is no longer an in-progress version
         loop do
-          version = app.get_edit_app_store_version(platform: platform)
-          if version.app_store_state == Spaceship::ConnectAPI::AppStoreVersion::AppStoreState::DEVELOPER_REJECTED
-            break
-          end
-
+          break if app.get_in_progress_review_submission(platform: platform).nil?
           UI.message("Waiting for cancellation to take effect...")
           sleep(15)
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Resolves #20128

### Description
When executing `.get_in_progress_review_submission.cancel_submission` and the app submission is successfully canceled,  `.app_store_state` of the canceled app version remains as `REJECTED`

Current code expects it to change to `DEVELOPER_REJECTED` which never happens, causing the loop described in #20128

Since the app store state of an app is `REJECTED` both before and after its submission is successfully canceled, this change instead relies on `.get_in_progress_review_submission` returning nil to break the polling loop. `.get_in_progress_review_submission` returning not nil is what initiates the code block in the first place.
