### PR TITLE
[match] fix match nuke not deleting decrypted files

### DIFF
--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -50,7 +50,7 @@ describe Fastlane do
             FASTFILE
             `git add .`
             `git commit --message "Version 1"`
-            `git tag "1"`
+            `git tag "1" --message "Version 1"`
 
             File.write('fastlane/FastfileExtra', <<-FASTFILE)
               lane :works_extra do
@@ -59,7 +59,7 @@ describe Fastlane do
             FASTFILE
             `git add .`
             `git commit --message "Version 2"`
-            `git tag "2"`
+            `git tag "2" --message "Version 2"`
 
             File.write('FastfileRoot', <<-FASTFILE)
               lane :works_root do
@@ -68,7 +68,7 @@ describe Fastlane do
             FASTFILE
             `git add .`
             `git commit --message "Version 3"`
-            `git tag "3"`
+            `git tag "3" --message "Version 3"`
 
             `mkdir fastlane/actions`
             FileUtils.mkdir_p('fastlane/actions')
@@ -89,7 +89,7 @@ describe Fastlane do
             FASTFILE
             `git add .`
             `git commit --message "Version 4"`
-            `git tag "4"`
+            `git tag "4" --message "Version 4"`
 
             `git checkout tags/2 -b version-2.1 2>&1`
             File.write('fastlane/Fastfile', <<-FASTFILE)
@@ -183,7 +183,7 @@ describe Fastlane do
             FASTFILE
             `git add .`
             `git commit --message "Version 5"`
-            `git tag "5"`
+            `git tag "5" --message "Version 5"`
           end
 
           allow(UI).to receive(:message)
@@ -259,7 +259,7 @@ describe Fastlane do
             FASTFILE
             `git add .`
             `git commit --message "Version 6"`
-            `git tag "6"`
+            `git tag "6" --message "Version 6"`
           end
 
           allow(UI).to receive(:message)

--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -42,6 +42,8 @@ module Match
       message = "[fastlane] Changed passphrase"
       files_to_commit = encryption.encrypt_files(password: new_password)
       storage.save_changes!(files_to_commit: files_to_commit, custom_message: message)
+    ensure
+      storage.clear_changes if storage
     end
 
     def self.ensure_ui_interactive

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -155,7 +155,8 @@ module Match
         FastlaneCore::CommanderGenerator.new.generate(Match::Options.available_options, command: c)
 
         c.action do |args, options|
-          Match::Migrate.new.migrate(options)
+          params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
+          Match::Migrate.new.migrate(params)
         end
       end
 

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -155,7 +155,7 @@ module Match
         FastlaneCore::CommanderGenerator.new.generate(Match::Options.available_options, command: c)
 
         c.action do |args, options|
-          Match::Migrate.new.migrate(args, options)
+          Match::Migrate.new.migrate(options)
         end
       end
 

--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -144,6 +144,8 @@ module Match
       # Encrypt and commit
       encryption.encrypt_files if encryption
       storage.save_changes!(files_to_commit: files_to_commit)
+    ensure
+      storage.clear_changes if storage
     end
 
     def ensure_valid_file_path(file_path, file_description, file_extension, optional: false)

--- a/match/lib/match/migrate.rb
+++ b/match/lib/match/migrate.rb
@@ -1,4 +1,3 @@
-require_relative 'options'
 require_relative 'spaceship_ensure'
 require_relative 'encryption'
 require_relative 'storage'
@@ -7,8 +6,7 @@ require 'fileutils'
 
 module Match
   class Migrate
-    def migrate(options)
-      params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
+    def migrate(params)
       loaded_matchfile = params.load_configuration_file("Matchfile")
 
       ensure_parameters_are_valid(params)

--- a/match/lib/match/migrate.rb
+++ b/match/lib/match/migrate.rb
@@ -7,7 +7,7 @@ require 'fileutils'
 
 module Match
   class Migrate
-    def migrate(args, options)
+    def migrate(options)
       params = FastlaneCore::Configuration.create(Match::Options.available_options, options.__hash__)
       loaded_matchfile = params.load_configuration_file("Matchfile")
 

--- a/match/lib/match/migrate.rb
+++ b/match/lib/match/migrate.rb
@@ -86,6 +86,9 @@ module Match
       UI.success("You can also remove the `git_url`, as well as any other git related configurations from your Fastfile and Matchfile")
       UI.message("")
       UI.input("Please make sure to read the above and confirm with enter")
+    ensure
+      google_cloud_storage.clear_changes if google_cloud_storage
+      git_storage.clear_changes if git_storage
     end
 
     def api_token(params)

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -103,6 +103,8 @@ module Match
       else
         UI.success("No relevant certificates or provisioning profiles found, nothing to nuke here :)")
       end
+    ensure
+      self.storage.clear_changes if self.storage
     end
 
     # Be smart about optional values here

--- a/match/spec/change_password_spec.rb
+++ b/match/spec/change_password_spec.rb
@@ -1,0 +1,43 @@
+describe Match do
+  describe Match::ChangePassword do
+    before do
+      stub_const('ENV', { "MATCH_PASSWORD" => '2"QAHg@v(Qp{=*n^' })
+    end
+
+    it "deletes decrypted files at the end", requires_security: true do
+      git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+      values = {
+        app_identifier: "tools.fastlane.app",
+        type: "appstore",
+        git_url: git_url,
+        shallow_clone: true,
+        username: "flapple@something.com"
+      }
+
+      config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+      repo_dir = Dir.mktmpdir
+
+      fake_storage = "fake_storage"
+      expect(Match::Storage::GitStorage).to receive(:configure).with(
+        git_url: git_url,
+        shallow_clone: true,
+        skip_docs: false,
+        git_branch: "master",
+        git_full_name: nil,
+        git_user_email: nil,
+        clone_branch_directly: false
+      ).and_return(fake_storage)
+
+      allow(fake_storage).to receive(:download)
+      allow(fake_storage).to receive(:working_directory).and_return(repo_dir)
+      allow(fake_storage).to receive(:save_changes!)
+
+      allow(Match::ChangePassword).to receive(:ensure_ui_interactive)
+      allow(FastlaneCore::Helper).to receive(:ask_password).and_return("")
+
+      expect(fake_storage).to receive(:clear_changes)
+
+      Match::ChangePassword.update(params: config)
+    end
+  end
+end

--- a/match/spec/importer_spec.rb
+++ b/match/spec/importer_spec.rb
@@ -58,6 +58,8 @@ describe Match do
         ]
       )
 
+      expect(fake_storage).to receive(:clear_changes)
+
       Match::Importer.new.import_cert(config, cert_path: cert_path, p12_path: p12_path, profile_path: ios_profile_path)
     end
 
@@ -75,6 +77,8 @@ describe Match do
         ]
       )
 
+      expect(fake_storage).to receive(:clear_changes)
+
       Match::Importer.new.import_cert(config, cert_path: cert_path, p12_path: p12_path, profile_path: osx_profile_path)
     end
 
@@ -91,6 +95,8 @@ describe Match do
           File.join(repo_dir, "certs", "distribution", "#{mock_cert.id}.p12")
         ]
       )
+
+      expect(fake_storage).to receive(:clear_changes)
 
       Match::Importer.new.import_cert(config, cert_path: cert_path, p12_path: p12_path)
     end
@@ -110,6 +116,8 @@ describe Match do
           File.join(repo_dir, "certs", "developer_id_application", "#{mock_cert.id}.p12")
         ]
       )
+
+      expect(fake_storage).to receive(:clear_changes)
 
       Match::Importer.new.import_cert(developer_id_config, cert_path: cert_path, p12_path: p12_path)
     end

--- a/match/spec/migrate_spec.rb
+++ b/match/spec/migrate_spec.rb
@@ -1,0 +1,54 @@
+describe Match do
+  describe Match::Migrate do
+    before do
+      stub_const('ENV', { "MATCH_PASSWORD" => '2"QAHg@v(Qp{=*n^' })
+    end
+
+    it "deletes decrypted files at the end", requires_security: true do
+      git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+      values = {
+        app_identifier: "tools.fastlane.app",
+        type: "appstore",
+        git_url: git_url,
+        shallow_clone: true,
+        username: "flapple@something.com"
+      }
+
+      config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+      repo_dir = Dir.mktmpdir
+
+      fake_google_cloud_storage = "fake_google_cloud_storage"
+      expect(Match::Storage::GoogleCloudStorage).to receive(:configure).with(
+        google_cloud_bucket_name: nil,
+        google_cloud_keys_file: nil,
+        google_cloud_project_id: nil
+      ).and_return(fake_google_cloud_storage)
+
+      allow(fake_google_cloud_storage).to receive(:download)
+      allow(fake_google_cloud_storage).to receive(:save_changes!)
+      allow(fake_google_cloud_storage).to receive(:bucket_name).and_return("")
+
+      fake_git_storage = "fake_git_storage"
+      expect(Match::Storage::GitStorage).to receive(:configure).with(
+        git_url: git_url,
+        shallow_clone: true,
+        git_branch: "master",
+        clone_branch_directly: false
+      ).and_return(fake_git_storage)
+
+      allow(fake_git_storage).to receive(:download)
+      allow(fake_git_storage).to receive(:working_directory).and_return(repo_dir)
+
+      spaceship = "spaceship"
+      allow(spaceship).to receive(:team_id).and_return("team_id")
+      allow(Match::SpaceshipEnsure).to receive(:new).and_return(spaceship)
+
+      allow(UI).to receive(:input)
+
+      expect(fake_google_cloud_storage).to receive(:clear_changes)
+      expect(fake_git_storage).to receive(:clear_changes)
+
+      Match::Migrate.new.migrate(config)
+    end
+  end
+end

--- a/match/spec/nuke_spec.rb
+++ b/match/spec/nuke_spec.rb
@@ -1,0 +1,69 @@
+describe Match do
+  describe Match::Nuke do
+    before do
+      allow(Spaceship::ConnectAPI).to receive(:login).and_return(nil)
+      allow(Spaceship::ConnectAPI).to receive(:client).and_return("client")
+      allow(Spaceship::ConnectAPI.client).to receive(:in_house?).and_return(false)
+      allow(Spaceship::ConnectAPI.client).to receive(:portal_team_id).and_return(nil)
+
+      stub_const('ENV', { "MATCH_PASSWORD" => '2"QAHg@v(Qp{=*n^' })
+    end
+
+    it "deletes decrypted files at the end", requires_security: true do
+      git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+      values = {
+        app_identifier: "tools.fastlane.app",
+        type: "appstore",
+        git_url: git_url,
+        shallow_clone: true,
+        username: "flapple@something.com"
+      }
+
+      config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+      repo_dir = Dir.mktmpdir
+
+      fake_storage = "fake_storage"
+      expect(Match::Storage::GitStorage).to receive(:configure).with(
+        git_url: git_url,
+        shallow_clone: true,
+        skip_docs: false,
+        git_branch: "master",
+        git_full_name: nil,
+        git_user_email: nil,
+
+        git_private_key: nil,
+        git_basic_authorization: nil,
+        git_bearer_authorization: nil,
+
+        clone_branch_directly: false,
+        google_cloud_bucket_name: "",
+        google_cloud_keys_file: "",
+        google_cloud_project_id: "",
+        s3_region: "",
+        s3_access_key: "",
+        s3_secret_access_key: "",
+        s3_bucket: "",
+        s3_object_prefix: "",
+        gitlab_project: nil,
+        team_id: nil
+      ).and_return(fake_storage)
+
+      allow(fake_storage).to receive(:download)
+      allow(fake_storage).to receive(:working_directory).and_return(repo_dir)
+
+      nuke = Match::Nuke.new
+
+      allow(nuke).to receive(:prepare_list)
+      allow(nuke).to receive(:filter_by_cert)
+      allow(nuke).to receive(:print_tables)
+
+      allow(nuke).to receive(:certs).and_return([])
+      allow(nuke).to receive(:profiles).and_return([])
+      allow(nuke).to receive(:files).and_return([])
+
+      expect(fake_storage).to receive(:clear_changes)
+
+      nuke.run(config, type: config[:type])
+    end
+  end
+end

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -7,6 +7,8 @@ describe Match do
       allow(value).to receive(:success?).and_return(true)
       allow(thread).to receive(:value).and_return(value)
 
+      allow(FastlaneCore::UI).to receive(:interactive?).and_return(false)
+
       allow(Security::InternetPassword).to receive(:find).and_return(nil)
 
       allow(FastlaneCore::Helper).to receive(:backticks).with('security -h | grep set-key-partition-list', print: false).and_return('    set-key-partition-list               Set the partition list of a key.')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

I noticed that running `fastlane match nuke` and cancelling it (answering `n` to "Do you really want to nuke everything listed above? (y/n)") causes the decrypted git repo to remain in the temp folder, which I personally think it's a security issue.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I added an `ensure` block that deletes it, similar to the `runner.rb` file.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Add
```ruby
gem 'fastlane', git: 'https://github.com/revolter/fastlane.git', branch: 'security/match-nuke-cancel-decrypted-files'
```
to your `Gemfile`, and run `bundle install` to apply the changes.

Then run `bundle exec fastlane match nuke development`, then press `n`, and see that a folder like `/var/folders/73/rlp8bl_x5lg1vbv1xbz159d40000gn/T/d20221021-22249-cq51af` still exists, which contains the decrypted certificates and profiles.
