### PR TITLE
[match] developer id installer profile for the accessible environments

### DIFF
--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -80,6 +80,10 @@ module Match
         certificate_type = [
           Spaceship::ConnectAPI::Certificate::CertificateType::MAC_INSTALLER_DISTRIBUTION
         ].join(',')
+      when :developer_id_installer
+        certificate_type = [
+          Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_INSTALLER
+        ].join(',')
       else
         UI.user_error!("Cert type '#{cert_type}' is not supported")
       end

--- a/match/lib/match/module.rb
+++ b/match/lib/match/module.rb
@@ -11,7 +11,7 @@ module Match
   DESCRIPTION = "Easily sync your certificates and profiles across your team"
 
   def self.environments
-    return %w(appstore adhoc development enterprise developer_id mac_installer_distribution)
+    return %w(appstore adhoc development enterprise developer_id mac_installer_distribution developer_id_installer)
   end
 
   def self.storage_modes


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
-->
Currently match doesn't allow to import `developer_id_installer`
This PR allows importing this type of certificate

This is practically a replica of the https://github.com/fastlane/fastlane/pull/17561 but for developer id certificate.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Let's say we want to have Developer ID Installer Certificate Type for MacOS.
From the documentation, we could see, that in order to perform this, we need to have match cal that will look like this
```
match(
	keychain_name: ENV['KEYCHAIN_NAME'], 
	keychain_password: keychain_password,
	additional_cert_types: ['developer_id_installer'], 
	readonly: true,
	generate_apple_certs: false,
	type: 'developer_id',
	git_url: "https://rep.ur",
	git_branch: 'branch',
	app_identifier: ["identifier1", "identifier2"]
)
```
The issue is that there's no way to import `developer_id_installer` cert type, since it is not supported by match import

```
bundle exec fastlane match import \
  --platform 'macos' \
  --type "developer_id_installer" \
  --team_id 'XXXX' \
  --team_name 'My Team' \
  --app_identifier 'My app id \
  --git_branch 'branch' \
  --verbose
```

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
- Create a Developer ID Installer Certificate
- Prepare `.cer` and `.p12` files
- Import profile using the command above
- try to run `match` with `developer_id_installer` type certificate
- Certificate should be successfully imported to the specified keychain