### PR TITLE
[action][update_project_provisioning] redownload AppleIncRootCertificate.cer if file size is 0.

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -19,7 +19,7 @@ module Fastlane
         UI.user_error!("Could not find path to project config '#{project_file_path}'. Pass the path to your project (not workspace)!") unless File.exist?(project_file_path)
 
         # download certificate
-        unless File.exist?(params[:certificate])
+        unless File.exist?(params[:certificate]) && File.size(params[:certificate]) > 0
           UI.message("Downloading root certificate from (#{ROOT_CERTIFICATE_URL}) to path '#{params[:certificate]}'")
           File.open(params[:certificate], "w:ASCII-8BIT") do |file|
             file.write(FastlaneCore::Helper.open_uri(ROOT_CERTIFICATE_URL, "rb").read)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
If the certificate download fails for the first time, a certificate file of size 0 is created. After that, update_project_provisioning uses a certificate file of size 0, which fails.

### Description
Check file size if file exist.