### PR TITLE
[spaceship] throw error after three failed logins

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -112,6 +112,10 @@ module Spaceship
         puts("check out #{two_factor_url}")
       end
 
+      if depth >= 3
+        raise Tunes::Error.new, "Unable to verify 2FA code after 3 attempts.  Exiting to avoid lockout."
+      end
+
       # "verification code" has already be pushed to devices
 
       security_code = response.body["securityCode"]


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
This change prevents Fastlane from locking an Apple account when run in CI - see #20707 
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #20707 
-->

### Description
<!-- Describe your changes in detail. -->
This change utilizes the unused local `depth` variable to stop Fastlane from looping login attempts until the API returns something Fastlane can actually catch.
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
Testing in progress: Using an old FASTLANE_SESSION and providing incorrect 2FA details to trigger a retry, expecting it to throw an error after three attempts.
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
