### PR TITLE
[Fastlane.swift] add `withParameters: [String: String]` parameter to `beforeAll()` function

### DIFF
--- a/fastlane/swift/LaneFileProtocol.swift
+++ b/fastlane/swift/LaneFileProtocol.swift
@@ -15,14 +15,14 @@ public protocol LaneFileProtocol: AnyObject {
     static func runLane(from fastfile: LaneFile?, named lane: String, with parameters: [String: String]) -> Bool
 
     func recordLaneDescriptions()
-    func beforeAll(with lane: String)
+    func beforeAll(with lane: String, withParameters: [String: String])
     func afterAll(with lane: String)
     func onError(currentLane: String, errorInfo: String, errorClass: String?, errorMessage: String?)
 }
 
 public extension LaneFileProtocol {
     var fastlaneVersion: String { return "" } // Defaults to "" because that means any is fine
-    func beforeAll(with _: String) {} // No-op by default
+    func beforeAll(with _: String, withParameters _: [String: String]) {} // No-op by default
     func afterAll(with _: String) {} // No-op by default
     func recordLaneDescriptions() {} // No-op by default
 }
@@ -135,7 +135,7 @@ open class LaneFile: NSObject, LaneFileProtocol {
         }
 
         // Call all methods that need to be called before we start calling lanes.
-        fastfileInstance.beforeAll(with: lane)
+        fastfileInstance.beforeAll(with: lane, withParameters: parameters)
 
         // We need to catch all possible errors here and display a nice message.
         _ = fastfileInstance.perform(NSSelectorFromString(laneMethod), with: parameters)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999-->

While migrating our existing ruby `fastfile` to fastlane.swift, I recognized a missing parameter within the `beforeAll(with lane: String)` function.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I added a new parameter called `withParameters` to the `beforeAll(with lane: String)` function. This results in `beforeAll(with lane: String)` being changed to `beforeAll(with lane: String, withParameters: [String: String])`

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I implemented the `beforeAll(with lane: String, withParameters: [String: String])` function in our project and successfully got the information I needed.
