### PR TITLE
[docs] add link to Spaceship Debugging docs from Tooling and Debugging docs

### DIFF
--- a/ToolsAndDebugging.md
+++ b/ToolsAndDebugging.md
@@ -94,5 +94,8 @@ To run the newly created script, run
 SPACESHIP_DEBUG=1 bundle exec rake debug
 ```
 
+### Additional Information
+See also the [Debugging _spaceship_](spaceship/docs/Debugging.md) documentation.
+
 <!--Links-->
 [first-pr]: YourFirstPR.md


### PR DESCRIPTION
When looking for documentation on the Spaceship proxy options, I realized the Spaceship debugging docs link to the main debugging documentation, but not vice-versa. This would have been helpful to discover the `SPACESHIP_PROXY` option sooner, and will hopefully help others.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When searching for documentation on how to use an HTTP proxy to debug fastlane, I discovered the `SPACESHIP_DEBUG` environment variable from the [Tools and Debugging](https://github.com/fastlane/fastlane/blob/master/ToolsAndDebugging.md#debugging-and-patching-spaceship-issues) docs, but not the `SPACESHIP_PROXY`, which solved my particular issue.

After discovering `SPACESHIP_PROXY` in the code, I discovered the [spaceship-specific debugging docs](https://github.com/fastlane/fastlane/blob/master/spaceship/docs/Debugging.md), which does list it.

From some Googling it seems others also are having trouble finding these settings, so linking the docs together might help visibility.

### Description
Added a section in `ToolsAndDebugging.md` to refer to `spaceship/docs/Debugging.md` as a source of additional debugging information.

### Testing Steps
Preview `ToolsAndDebugging.md` and ensure the link opens to `spaceship/docs/Debugging.md` correctly.