### PR TITLE
[action] add error handling for `xcodes` when running the `installed` cmd

### DIFF
--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -37,6 +37,10 @@ module Fastlane
         command << "installed"
         command << "'#{version}'"
 
+        # `installed <version>` will either return the path to the given
+        # version or fail because the version can't be found.
+        #
+        # Store the path if we get one, fail the action otherwise.
         xcode_path = Actions.sh(command.join(" ")) do |status, result, sh_command|
           formatted_result = result.chomp
 
@@ -44,10 +48,11 @@ module Fastlane
             UI.user_error!("Command `#{sh_command}` failed with status #{status.exitstatus} and message: #{formatted_result}")
           end
 
-          # Prints something like /Applications/Xcode-14.app
           formatted_result
         end
 
+        # If the command succeeded, `xcode_path` will be something like:
+        # /Applications/Xcode-14.app
         xcode_developer_path = File.join(xcode_path, "/Contents/Developer")
 
         UI.message("Setting Xcode version '#{version}' at '#{xcode_path}' for all build steps")

--- a/fastlane/lib/fastlane/actions/xcodes.rb
+++ b/fastlane/lib/fastlane/actions/xcodes.rb
@@ -36,8 +36,18 @@ module Fastlane
         command << binary
         command << "installed"
         command << "'#{version}'"
-        # Prints something like /Applications/Xcode-14.app
-        xcode_path = Actions.sh(command.join(" ")).strip
+
+        xcode_path = Actions.sh(command.join(" ")) do |status, result, sh_command|
+          formatted_result = result.chomp
+
+          unless status.success?
+            UI.user_error!("Command `#{sh_command}` failed with status #{status.exitstatus} and message: #{formatted_result}")
+          end
+
+          # Prints something like /Applications/Xcode-14.app
+          formatted_result
+        end
+
         xcode_developer_path = File.join(xcode_path, "/Contents/Developer")
 
         UI.message("Setting Xcode version '#{version}' at '#{xcode_path}' for all build steps")

--- a/fastlane/spec/actions_specs/xcodes_spec.rb
+++ b/fastlane/spec/actions_specs/xcodes_spec.rb
@@ -37,12 +37,14 @@ describe Fastlane do
         end
       end
 
-      it "doesn't invoke 'update' nor 'install' when select_for_current_build_only argument is true" do
-        expect(Fastlane::Actions).to_not(receive(:sh).with(/--update|--install/))
-        expect(Fastlane::Actions).to receive(:sh).with(/installed/)
-        Fastlane::FastFile.new.parse("lane :test do
-          xcodes(version: '14', select_for_current_build_only: true)
-        end").runner.execute(:test)
+      context "when select_for_current_build_only is true" do
+        it "doesn't invoke 'update' nor 'install'" do
+          expect(Fastlane::Actions).to_not(receive(:sh).with(/--update|--install/))
+          expect(Fastlane::Actions).to receive(:sh).with(/installed/)
+          Fastlane::FastFile.new.parse("lane :test do
+            xcodes(version: '14', select_for_current_build_only: true)
+          end").runner.execute(:test)
+        end
       end
 
       it "passes any received string to the command if xcodes_args is passed" do


### PR DESCRIPTION
### Motivation and Context

This changes the `xcodes` call for that branch to the `Actions.sh` block version so that we can trap any error and bubble it up to the user.

The previous version would have otherwise crashed. More details below.

This change will help users migrate from `ensure_xcode_version(version: '14')` to `xcodes(version: '14', select_for_current_build_only: true)`

### Description

When trying the `xcodes` in place of `ensure_xcode_version` for a version not installed, I experienced a crash. The reason for it was that `xcodes installed <version>` exits with 1 if the version is not installed which made its caller in Fastlane raise 

```
fastlane_core/lib/fastlane_core/ui/interface.rb:153:in 

shell_error!': \e[31m[!] Exit status of command '/opt/homebrew/bin/xcodes installed '14.0'' was 1 instead of 0. (FastlaneCore::Interface::FastlaneShellError)
```

<details>
<summary>Full crash log</summary>


```
[14:11:07]: --------------------
[14:11:07]: --- Step: xcodes ---
[14:11:07]: --------------------
[14:11:07]: Running xcodes version 1.1.0
[14:11:07]: $ /opt/homebrew/bin/xcodes installed '14.0'
[14:11:07]: ▸ 14.0 is not installed.
...
+------------------+--------------------------+
[14:11:07]: Exit status of command '/opt/homebrew/bin/xcodes installed '14.0'' was 1 instead of 0.
14.0 is not installed.

[14:11:07]: fastlane finished with errors
...
	 4: from /Users/gio/Developer/a8c/wcios/vendor/bundle/ruby/2.7.0/gems/fastlane-2.211.0/fastlane/lib/fastlane/actions/xcodes.rb:40:in `run'
	 3: from /Users/gio/Developer/a8c/wcios/vendor/bundle/ruby/2.7.0/gems/fastlane-2.211.0/fastlane/lib/fastlane/helper/sh_helper.rb:12:in `sh'
	 2: from /Users/gio/Developer/a8c/wcios/vendor/bundle/ruby/2.7.0/gems/fastlane-2.211.0/fastlane/lib/fastlane/helper/sh_helper.rb:80:in `sh_control_output'
	 1: from /Users/gio/Developer/a8c/wcios/vendor/bundle/ruby/2.7.0/gems/fastlane-2.211.0/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in `method_missing'
/Users/gio/Developer/a8c/wcios/vendor/bundle/ruby/2.7.0/gems/fastlane-2.211.0/fastlane_core/lib/fastlane_core/ui/interface.rb:153:in `shell_error!': \e[31m[!] Exit status of command '/opt/homebrew/bin/xcodes installed '14.0'' was 1 instead of 0. (FastlaneCore::Interface::FastlaneShellError)
14.0 is not installed.
\e[0m
```

</details>

To deal with it, I passed a block to `Action.sh` to handle the error, if any.

### Testing Steps

I added a unit test for the failing behavior. 

The fix can also be verified locally with a lane such as

```ruby
lane :test_for_xcodes do
  version = '10' # or any version not installed on the machine running the test
  xcodes(version: version, select_for_current_build_only: true)
end
```

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Next steps

The approach could be carried over to the other `xcodes` invocations via `sh`. I didn't do it in here to keep the PR focused at addressing one specific crash and to get validation on the approach itself.

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. – Not necessary

