### PR TITLE
[dependency] relax `multipart_post` dependency version requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ PATH
       json (< 3.0.0)
       jwt (>= 2.1.0, < 3)
       mini_magick (>= 4.9.4, < 5.0.0)
-      multipart-post (~> 2.0.0)
+      multipart-post (>= 2.0.0, < 3.0.0)
       naturally (~> 2.2)
       optparse (~> 0.1.1)
       plist (>= 3.1.0, < 4.0.0)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -78,7 +78,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('plist', '>= 3.1.0', '< 4.0.0') # Needed for set_build_number_repository and get_info_plist_value actions
   spec.add_dependency('CFPropertyList', '>= 2.3', '< 4.0.0') # Needed to be able to read binary plist format
   spec.add_dependency('addressable', '>= 2.8', '< 3.0.0') # Support for URI templates
-  spec.add_dependency('multipart-post', '~> 2.0.0') # Needed for uploading builds to appetize
+  spec.add_dependency('multipart-post', '>= 2.0.0', '< 3.0.0') # Needed for uploading builds to appetize
   spec.add_dependency('word_wrap', '~> 1.0.0') # to add line breaks for tables with long strings
 
   spec.add_dependency('optparse', '~> 0.1.1') # Used to parse options with Commander


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

The gem `multipart_post` is currently set to `~> 2.0.0` on fastlane. Since `2.0.0` is the only version released on the `2.0` series, it effectively locks `multipart_post` to `2.0.0` which is a version that was released in 2013. When users bundle fastlane with other dependencies (for instance with the [web_translate_it](https://github.com/webtranslateit/webtranslateit) gem which requires a newer version of `multipart_post`), running `bundle` fails. See https://github.com/webtranslateit/webtranslateit/issues/212 and https://github.com/webtranslateit/webtranslateit/issues/220

We’ve mitigated the issue on our end by relaxing our dependency to multipart_post to let users use older versions, but this almost 10 years old dependency should be updated on your side as well.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I've relaxed the dependency on `multipart_post` in the gemspec file. I've checked where multipart_post is used on the code and I haven’t noted any changes required in the code.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
