### PR TITLE
[import_from_git] fixed git checkout being superfluously executed

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -345,9 +345,12 @@ module Fastlane
               Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard && git rebase")
             end
           else
-            # https://stackoverflow.com/a/11489642/865175
-            current_tag_sed = 's/^\([^^~]\{1,\}\)\(\^0\)\{0,1\}$/\1/p'
-            current_tag = Actions.sh("cd #{clone_folder.shellescape} && git name-rev --name-only --tags --no-undefined HEAD | sed -n '#{current_tag_sed}'").strip
+            begin
+              # https://stackoverflow.com/a/1593574/865175
+              current_tag = Actions.sh("cd #{clone_folder.shellescape} && git describe --exact-match --tags HEAD").strip
+            rescue
+              current_tag = nil
+            end
 
             if !version.nil? && current_tag != version
               Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -345,7 +345,13 @@ module Fastlane
               Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard && git rebase")
             end
           else
-            Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")
+            # https://stackoverflow.com/a/11489642/865175
+            current_tag_sed = 's/^\([^^~]\{1,\}\)\(\^0\)\{0,1\}$/\1/p'
+            current_tag = Actions.sh("cd #{clone_folder.shellescape} && git name-rev --name-only --tags --no-undefined HEAD | sed -n '#{current_tag_sed}'").strip
+
+            if !version.nil? && current_tag != version
+              Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")
+            end
           end
 
           # Knowing that we check out all the files and directories when the

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -273,7 +273,7 @@ describe Fastlane do
           end").runner.execute(:test)
         end
 
-        it "doesn't superfluously executes checkout" do
+        it "doesn't superfluously execute checkout" do
           allow(UI).to receive(:message)
           expect(UI).to receive(:message).with(caching_message)
           expect(UI).to receive(:important).with('Works until v6')

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -273,6 +273,21 @@ describe Fastlane do
           end").runner.execute(:test)
         end
 
+        it "doesn't superfluously executes checkout" do
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
+          expect(UI).to receive(:important).with('Works until v6')
+          allow(Fastlane::Actions).to receive(:sh).and_call_original
+
+          Fastlane::FastFile.new.parse("lane :test do
+            import_from_git(url: '#{source_directory_path}', version: '6', cache_path: '#{cache_directory_path}')
+
+            works
+          end").runner.execute(:test)
+
+          expect(Fastlane::Actions).not_to have_received(:sh).with(/git checkout/)
+        end
+
         after :all do
           ENV.delete("FORCE_SH_DURING_TESTS")
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

If the cached repository is already checked out at the tag corresponding to the specified version, `git checkout` will not be executed anymore.

This should improve the performance a bit, but more importantly, if fixes an issue that I had, which is, executing it in parallel caused the error
```
fatal: Unable to create '/Users/revolt/.cache/fastlane/imported/Fastlane.git/.git/index.lock': File exists.

Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again. If it still fails, a git process
may have crashed in this repository earlier:
remove the file manually to continue.
```
to be thrown some times.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
