### PR TITLE
[gym] Add show build timing summary option

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -39,6 +39,7 @@ module Gym
         options << "-destination '#{config[:destination]}'" if config[:destination]
         options << "-archivePath #{archive_path.shellescape}" unless config[:skip_archive]
         options << "-resultBundlePath '#{result_bundle_path}'" if config[:result_bundle]
+        options << "-showBuildTimingSummary" if config[:build_timing_summary]
         if config[:use_system_scm] && !options.include?("-scmProvider system")
           options << "-scmProvider system"
         end

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -239,6 +239,12 @@ module Gym
                                      default_value: Fastlane::Helper::XcodebuildFormatterHelper.xcbeautify_installed? ? 'xcbeautify' : 'xcpretty',
                                      default_value_dynamic: true),
 
+        FastlaneCore::ConfigItem.new(key: :build_timing_summary,
+                                     env_name: "GYM_BUILD_TIMING_SUMMARY",
+                                     description: "Create a build timing summary.",
+                                     type: Boolean,
+                                     optional: false),
+
         # xcpretty
         FastlaneCore::ConfigItem.new(key: :disable_xcpretty,
                                      env_name: "DISABLE_XCPRETTY",

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -241,9 +241,9 @@ module Gym
 
         FastlaneCore::ConfigItem.new(key: :build_timing_summary,
                                      env_name: "GYM_BUILD_TIMING_SUMMARY",
-                                     description: "Create a build timing summary.",
+                                     description: "Create a build timing summary",
                                      type: Boolean,
-                                     optional: false),
+                                     optional: true),
 
         # xcpretty
         FastlaneCore::ConfigItem.new(key: :disable_xcpretty,

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -243,6 +243,7 @@ module Gym
                                      env_name: "GYM_BUILD_TIMING_SUMMARY",
                                      description: "Create a build timing summary",
                                      type: Boolean,
+                                     default_value: false,
                                      optional: true),
 
         # xcpretty

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -145,14 +145,14 @@ describe Gym do
       expect(result).to_not(include("-scmProvider system"))
     end
 
-    it "adds -showBuildTimingSummary flag when option is set" do
+    it "adds -showBuildTimingSummary flag when option is set", requires_xcodebuild: true do
       options = { project: "./gym/examples/standard/Example.xcodeproj", build_timing_summary: true }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
       result = Gym::BuildCommandGenerator.generate
       expect(result).to include("-showBuildTimingSummary")
     end
 
-    it "the -showBuildTimingSummary is not added by default" do
+    it "the -showBuildTimingSummary is not added by default", requires_xcodebuild: true do
       options = { project: "./gym/examples/standard/Example.xcodeproj" }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
       result = Gym::BuildCommandGenerator.generate

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -145,6 +145,20 @@ describe Gym do
       expect(result).to_not(include("-scmProvider system"))
     end
 
+    it "adds -showBuildTimingSummary flag when option is set" do
+      options = { project: "./gym/examples/standard/Example.xcodeproj", build_timing_summary: true }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+      result = Gym::BuildCommandGenerator.generate
+      expect(result).to include("-showBuildTimingSummary")
+    end
+
+    it "the -showBuildTimingSummary is not added by default" do
+      options = { project: "./gym/examples/standard/Example.xcodeproj" }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+      result = Gym::BuildCommandGenerator.generate
+      expect(result).to_not(include("-showBuildTimingSummary"))
+    end
+
     it "uses the correct build command when `skip_archive` is used", requires_xcodebuild: true do
       log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/gym/ExampleProductName-Example.log")
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently, there is no way to run `xcodebuild` with the `showBuildTimingSummary ` option using the `gym` command. 

This option is provides a breakdown of how long each task in the build process takes and can come in very handy to collect metrics on CI.

### Description
This PR adds an optional flag to the `gym` command and, if set, it adds the `showBuildTimingSummary` option to `xcodebuild`.

I tested it by changing my project's `Gemfile` to point to the local version of `fastlane` with these changes. 

When running `fastlane build_with_summary` and inspecting the logs, the `Build Timing Summary` section is present:
```ruby
  lane : build_with_summary do
    default_platform(:ios)

    # Build with timing summary
    gym(
      project: "TestFastlane.xcodeproj",
      derived_data_path: "./derived-data",
      output_directory: "./build",
      export_method: "development",
      skip_profile_detection: true,
      export_options: {
        provisioningProfiles: { 
          "dev.polpiella.TestFastlane" => "Pol's App Development"
        }
      },
      clean: true,
      skip_archive: true,
      build_timing_summary: true,
      buildlog_path: "."
    )
  end
``` 
**output**

```
Build Timing Summary

SwiftCompile (2 tasks) | 5.695 seconds
SwiftEmitModule (1 task) | 1.788 seconds
Ld (1 task) | 0.119 seconds
CopySwiftLibs (1 task) | 0.069 seconds
CodeSign (1 task) | 0.047 seconds
SwiftDriver (1 task) | 0.034 seconds
RegisterExecutionPolicyException (1 task) | 0.008 seconds
WriteAuxiliaryFile (12 tasks) | 0.005 seconds
CompileAssetCatalog (1 task) | 0.004 seconds
ProcessInfoPlistFile (1 task) | 0.002 seconds
Copy (4 tasks) | 0.002 seconds
ProcessProductPackagingDER (1 task) | 0.002 seconds
SwiftMergeGeneratedHeaders (1 task) | 0.001 seconds
Touch (1 task) | 0.001 seconds
ExtractAppIntentsMetadata (1 task) | 0.001 seconds
SwiftDriver Compilation Requirements (1 task) | 0.000 seconds
ProcessProductPackaging (2 tasks) | 0.000 seconds
Validate (1 task) | 0.000 seconds
SwiftDriver Compilation (1 task) | 0.000 seconds
ValidateDevelopmentAssets (1 task) | 0.000 seconds
```


### Testing Steps
Run `gym` with both `skip_archive` and `build_timing_summary` set to `true`. The reason why we need `skip_archive` set to `true` is that `xcodebuild` does not show the timing summary with the `archive` command.
