### PR TITLE
[upload_symbols_to_crashlytics] [tiny PR] Fail lane if dsyms upload fails

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -69,13 +69,9 @@ module Fastlane
         end
         command << "-p #{params[:platform] == 'appletvos' ? 'tvos' : params[:platform]}"
         command << File.expand_path(path).shellescape
-        begin
-          command_to_execute = command.join(" ")
-          UI.verbose("upload_dsym using command: #{command_to_execute}")
-          Actions.sh(command_to_execute, log: params[:debug])
-        rescue => ex
-          UI.error(ex.to_s) # it fails, however we don't want to fail everything just for this
-        end
+        command_to_execute = command.join(" ")
+        UI.verbose("upload_dsym using command: #{command_to_execute}")
+        Actions.sh(command_to_execute, log: params[:debug])
       end
 
       def self.find_api_token(params)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Uploading dsyms to crashlytics after a build is critical, because dsyms may not be able to be uploaded later: the machine that performed the build may remove the generated archive after the build is completed. Successfully making a build without uploading dsyms is highly risky, because such build may be released to production, and without dsyms it will silently stop reporting crashes. This commit purposely fails the build in cases where dsym upload fails

Resolves #19213

