### PR TITLE
[frameit] facebook.design doesn't work anymore

### DIFF
--- a/frameit/frames_generator/Rakefile
+++ b/frameit/frames_generator/Rakefile
@@ -88,7 +88,7 @@ task(:generate_device_frames) do
 
   puts("Download and extract the latest devices from Facebook")
   puts("")
-  puts("  https://facebook.design/devices")
+  puts("  https://design.facebook.com/toolsandresources/devices/")
   puts("")
   confirm
   puts("Currently the script renames iPad files according to the following scheme:")


### PR DESCRIPTION

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
facebook.design doesn't work anymore


### Description
replaced facebook.design with design.facebook.com

