### PR TITLE
Sigh resign entitlements per single app extension

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -163,7 +163,7 @@ fi
 
 ORIGINAL_FILE="$1"
 CERTIFICATE="$2"
-ENTITLEMENTS=
+ENTITLEMENTS=()
 BUNDLE_IDENTIFIER=""
 DISPLAY_NAME=""
 KEYCHAIN=""
@@ -173,6 +173,7 @@ BUNDLE_VERSION=
 KEYCHAIN_PATH=
 RAW_PROVISIONS=()
 PROVISIONS_BY_ID=()
+ENTITLEMENTS_BY_ID=()
 DEFAULT_PROVISION=""
 TEMP_DIR="_floatsignTemp"
 USE_APP_ENTITLEMENTS=""
@@ -193,7 +194,7 @@ while [ "$1" != "" ]; do
             ;;
         -e | --entitlements )
             shift
-            ENTITLEMENTS="$1"
+            ENTITLEMENTS+=("$1")
             ;;
         -d | --display-name )
             shift
@@ -242,6 +243,11 @@ while [ "$1" != "" ]; do
     shift
 done
 
+function entitlementsNotEmpty { 
+    (( "${#ENTITLEMENTS[@]}" ))
+}
+    
+
 KEYCHAIN_FLAG=
 if [ -n "$KEYCHAIN_PATH" ]; then
     KEYCHAIN_FLAG="--keychain $KEYCHAIN_PATH"
@@ -259,7 +265,7 @@ done
 log "Original file: '$ORIGINAL_FILE'"
 log "Certificate: '$CERTIFICATE'"
 [[ -n "${DISPLAY_NAME}" ]] && log "Specified display name: '$DISPLAY_NAME'"
-[[ -n "${ENTITLEMENTS}" ]] && log "Specified signing entitlements: '$ENTITLEMENTS'"
+entitlementsNotEmpty && log "Specified signing entitlement files: '${ENTITLEMENTS[@]}'"
 [[ -n "${BUNDLE_IDENTIFIER}" ]] && log "Specified bundle identifier: '$BUNDLE_IDENTIFIER'"
 [[ -n "${KEYCHAIN}" ]] && log "Specified keychain to use: '$KEYCHAIN'"
 [[ -n "${VERSION_NUMBER}" ]] && log "Specified version number to use: '$VERSION_NUMBER'"
@@ -273,7 +279,7 @@ log "Certificate: '$CERTIFICATE'"
 [[ -n "$VERSION_NUMBER" && (-n "$SHORT_VERSION" || -n "$BUNDLE_VERSION") ]] && error "versionNumber option cannot be used in combination with shortVersion or bundleVersion options"
 
 # Check that --use-app-entitlements and -e, --entitlements are not used at the same time
-[[ -n "${USE_APP_ENTITLEMENTS}" && -n ${ENTITLEMENTS} ]] && error "--use-app-entitlements option cannot be used in combination with -e, --entitlements option."
+[[ -n "${USE_APP_ENTITLEMENTS}" ]] && entitlementsNotEmpty && error "--use-app-entitlements option cannot be used in combination with -e, --entitlements option."
 
 # Check output file name
 if [ -z "$NEW_FILE" ]; then
@@ -360,6 +366,39 @@ function bundle_id_for_provision {
     checkStatus
     echo "${FULL_BUNDLE_ID#*.}"
 }
+
+function entitlement_for_bundle_id {
+
+    local NEEDLE_BUNDLE_ID="$1"
+
+    for ARG in "${ENTITLEMENTS_BY_ID[@]}"; do
+        local BUNDLE_ID="${ARG%%=*}"
+        if [ "$BUNDLE_ID" = "$NEEDLE_BUNDLE_ID" ]; then
+            echo "${ARG#*=}"
+            break
+        fi
+    done
+
+}
+
+# Add given entitlement file and bundle identifier to the search list
+function add_entitlement {
+
+    local ENTITLEMENT_FILE="$1"
+
+    local FULL_BUNDLE_ID=$(PlistBuddy -c 'Print :application-identifier' "$ENTITLEMENT_FILE")
+    checkStatus
+    local BUNDLE_ID="${FULL_BUNDLE_ID#*.}"
+
+    log "Using bundle id $BUNDLE_ID for entitlement file $ENTITLEMENT_FILE"
+    
+    ENTITLEMENTS_BY_ID+=("$BUNDLE_ID=$ENTITLEMENT_FILE")
+}
+
+# Load bundle identifiers from entitlement files
+for ARG in "${ENTITLEMENTS[@]}"; do
+    add_entitlement "$ARG"
+done
 
 # Add given provisioning profile and bundle identifier to the search list
 function add_provision_for_bundle_id {
@@ -461,6 +500,13 @@ function resign {
 
     log "Current bundle identifier is: '$CURRENT_BUNDLE_IDENTIFIER'"
     log "New bundle identifier will be: '$BUNDLE_IDENTIFIER'"
+
+    local ENTITLEMENT_FILE="$(entitlement_for_bundle_id "$BUNDLE_IDENTIFIER")"
+
+    if [[ "$ENTITLEMENT_FILE" == "" ]]
+    then
+        error "No matching entitlement file found for new bundle identifier $BUNDLE_IDENTIFIER. Specify an entitlement file with the -e option that has an app-identifier equal to $BUNDLE_IDENTIFIER"
+    fi
 
     # Update the CFBundleDisplayName property in the Info.plist if a new name has been provided
     if [ "${DISPLAY_NAME}" != "" ]; then
@@ -598,10 +644,10 @@ function resign {
         fi
     done
 
-    if [ "$ENTITLEMENTS" != "" ]; then
+    if entitlementsNotEmpty; then
         if [ -n "$APP_IDENTIFIER_PREFIX" ]; then
             # sanity check the 'application-identifier' is present in the provided entitlements and matches the provisioning profile value
-            ENTITLEMENTS_APP_ID_PREFIX=$(PlistBuddy -c "Print :application-identifier" "$ENTITLEMENTS" | grep -E '^[A-Z0-9]*' -o | tr -d '\n')
+            ENTITLEMENTS_APP_ID_PREFIX=$(PlistBuddy -c "Print :application-identifier" "$ENTITLEMENT_FILE" | grep -E '^[A-Z0-9]*' -o | tr -d '\n')
             if [ "$ENTITLEMENTS_APP_ID_PREFIX" == "" ]; then
                 error "Provided entitlements file is missing a value for the required 'application-identifier' key"
             elif [ "$ENTITLEMENTS_APP_ID_PREFIX" != "$APP_IDENTIFIER_PREFIX" ]; then
@@ -611,7 +657,7 @@ function resign {
 
         if [ -n "$TEAM_IDENTIFIER" ]; then
             # sanity check the 'com.apple.developer.team-identifier' is present in the provided entitlements and matches the provisioning profile value
-            ENTITLEMENTS_TEAM_IDENTIFIER=$(PlistBuddy -c "Print :com.apple.developer.team-identifier" "$ENTITLEMENTS" | tr -d '\n')
+            ENTITLEMENTS_TEAM_IDENTIFIER=$(PlistBuddy -c "Print :com.apple.developer.team-identifier" "$ENTITLEMENT_FILE" | tr -d '\n')
             if [ "$ENTITLEMENTS_TEAM_IDENTIFIER" == "" ]; then
                 error "Provided entitlements file is missing a value for the required 'com.apple.developer.team-identifier' key"
             elif [ "$ENTITLEMENTS_TEAM_IDENTIFIER" != "$TEAM_IDENTIFIER" ]; then
@@ -620,12 +666,12 @@ function resign {
         fi
 
         log "Resigning application using certificate: '$CERTIFICATE'"
-        log "and entitlements: $ENTITLEMENTS"
+        log "and entitlements: $ENTITLEMENT_FILE"
         if [[ "${XCODE_VERSION/.*/}" -lt 10 ]]; then
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
-            cp -f "$ENTITLEMENTS" "$APP_PATH/archived-expanded-entitlements.xcent"
+            cp -f "$ENTITLEMENT_FILE" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
-        /usr/bin/codesign ${VERBOSE} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$ENTITLEMENTS" "$APP_PATH"
+        /usr/bin/codesign ${VERBOSE} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$ENTITLEMENT_FILE" "$APP_PATH"
         checkStatus
     elif  [[ -n "${USE_APP_ENTITLEMENTS}" ]]; then
         # Extract entitlements from provisioning profile and from the app binary

--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -108,7 +108,9 @@ module Sigh
                  'The path may be prefixed with a identifier in order to determine which provisioning profile should be used on which app.',
                  &multiple_values_option_proc(c, "provisioning_profile", &proc { |value| value.split('=', 2) }))
         c.option('-d', '--display_name STRING', String, 'Display name to use')
-        c.option('-e', '--entitlements PATH', String, 'The path to the entitlements file to use.')
+        c.option('-e', '--entitlements PATH', String, 'The path to the entitlements file to use.' \
+                 'Can be provided multiple times if the application contains nested applications and app extensions, which need their own entitlements file. ',
+                 &multiple_values_option_proc(c, "entitlements"))
         c.option('--short_version STRING', String, 'Short version string to force binary and all nested binaries to use (CFBundleShortVersionString).')
         c.option('--bundle_version STRING', String, 'Bundle version to force binary and all nested binaries to use (CFBundleVersion).')
         c.option('--use_app_entitlements', 'Extract app bundle codesigning entitlements and combine with entitlements from new provisionin profile.')

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -42,8 +42,7 @@ module Sigh
 
       # validate that we have valid values for all these params, we don't need to check signing_identity because `find_signing_identity` will only ever return a valid value
       validate_params(resign_path, ipa, provisioning_profiles)
-      entitlements = "-e #{entitlements.shellescape}" if entitlements
-
+      entitlements = create_entitlements_options(entitlements) if entitlements
       provisioning_options = create_provisioning_options(provisioning_profiles)
       version = "-n #{version}" if version
       display_name = "-d #{display_name.shellescape}" if display_name
@@ -132,6 +131,19 @@ module Sigh
       return signing_identity if identities.keys.include?(signing_identity)
       identities.key(signing_identity)
     end
+
+   def create_entitlements_options(entitlements)
+      # entitlements is passed as an array (to be able to resign extensions/nested apps):
+      # (resign.sh also takes "-e /folder/mobile.mobileprovision" as a param)
+      #   [
+      #        "/folder/mobile.mobileprovision"
+      #   ]
+      entitlements.map do |entitlement|
+        entitlement_file = File.expand_path(entitlement)
+        "-e #{entitlement_file.shellescape}"
+      end.join(' ')
+   end
+
 
     def create_provisioning_options(provisioning_profiles)
       # provisioning_profiles is passed either a hash (to be able to resign extensions/nested apps):

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -132,7 +132,7 @@ module Sigh
       identities.key(signing_identity)
     end
 
-   def create_entitlements_options(entitlements)
+    def create_entitlements_options(entitlements)
       # entitlements is passed as an array (to be able to resign extensions/nested apps):
       # (resign.sh also takes "-e /folder/mobile.mobileprovision" as a param)
       #   [
@@ -142,8 +142,7 @@ module Sigh
         entitlement_file = File.expand_path(entitlement)
         "-e #{entitlement_file.shellescape}"
       end.join(' ')
-   end
-
+    end
 
     def create_provisioning_options(provisioning_profiles)
       # provisioning_profiles is passed either a hash (to be able to resign extensions/nested apps):


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #20922

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
resign.sh is patched to allow specifying multiple entitlements files. The patch takes the app-identifier from the files and when it resigns an app extension it uses the correct entitlement file. In this way, one can specify an entitlements file for the main app and one for each app extensions.

Given that resign.sh does many things, I payed attention to use the final bundle identifier that the resign() function uses. Specifically, I use the `$BUNDLE_IDENTIFIER` after the function prints the following logs:
```
     log "Current bundle identifier is: '$CURRENT_BUNDLE_IDENTIFIER'"
     log "New bundle identifier will be: '$BUNDLE_IDENTIFIER'"
```
Please, review if this is correct.

I tested with my app and it works.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
