### PR TITLE
[spaceship] add methods to rename and disable/enable devices

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -93,11 +93,10 @@ module Spaceship
       # @param client [ConnectAPI] ConnectAPI client.
       # @param enabled [Boolean] New enabled value. true - if device must be enabled, `false` - to disable device. nil if no status change needed.
       # @param new_name [String] A new name for the device. nil if no name change needed.
-      # @param platform [String] The platform of the device.
       # @return (Device) Modified device based on the UDID of the device. nil if no device was found.
-      def self.modify(device_udid, client: nil, enabled: nil, new_name: nil, platform: nil)
+      def self.modify(device_udid, client: nil, enabled: nil, new_name: nil)
         client ||= Spaceship::ConnectAPI
-        existing = self.find_by_udid(device_udid, client: client, platform: platform, include_disabled: true)
+        existing = self.find_by_udid(device_udid, client: client, include_disabled: true)
         return nil if existing.nil?
 
         enabled = existing.enabled? if enabled.nil?
@@ -111,27 +110,24 @@ module Spaceship
 
       # @param device_udid [String] Device Provisioning UDID that needs to be enabled.
       # @param client [ConnectAPI] ConnectAPI client.
-      # @param platform [String] The platform of the device.
       # @return (Device) Modified device based on the UDID of the device. nil if no device was found.
-      def self.enable(device_udid, client: nil, platform: nil)
-        self.modify(device_udid, client: client, enabled: true, platform: platform)
+      def self.enable(device_udid, client: nil)
+        self.modify(device_udid, client: client, enabled: true)
       end
 
       # @param device_udid [String] Device Provisioning UDID that needs to be disabled.
       # @param client [ConnectAPI] ConnectAPI client.
-      # @param platform [String] The platform of the device.
       # @return (Device) Modified device based on the UDID of the device. nil if no device was found.
-      def self.disable(device_udid, client: nil, platform: nil)
-        self.modify(device_udid, client: client, enabled: false, platform: platform)
+      def self.disable(device_udid, client: nil)
+        self.modify(device_udid, client: client, enabled: false)
       end
 
       # @param device_udid [String] Device Provisioning UDID that needs to be renamed.
       # @param new_name [String] A new name for the device.
       # @param client [ConnectAPI] ConnectAPI client.
-      # @param platform [String] The platform of the device.
       # @return (Device) Modified device based on the UDID of the device. nil if no device was found.
-      def self.rename(device_udid, new_name, client: nil, platform: nil)
-        self.modify(device_udid, client: client, new_name: new_name, platform: platform)
+      def self.rename(device_udid, new_name, client: nil)
+        self.modify(device_udid, client: client, new_name: new_name)
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -103,8 +103,9 @@ module Spaceship
         enabled = existing.enabled? if enabled.nil?
         new_name ||= existing.name
         return existing if existing.name == new_name && existing.enabled? == enabled
+        new_status = enabled ? Status::ENABLED : Status::DISABLED
 
-        resp = client.patch_device(id: existing.id, new_name: new_name, status: enabled ? Status::ENABLED : Status::DISABLED)
+        resp = client.patch_device(id: existing.id, new_name: new_name, status: new_status)
         return resp.to_models.first
       end
 

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -190,6 +190,25 @@ module Spaceship
           provisioning_request_client.post("devices", body)
         end
 
+        def patch_device(id: nil, status: nil, new_name: nil)
+          raise "Device id is nil" if id.nil?
+
+          attributes = {
+            name: new_name,
+            status: status
+          }
+
+          body = {
+            data: {
+              attributes: attributes,
+              id: id,
+              type: "devices"
+            }
+          }
+
+          provisioning_request_client.patch("devices/#{id}", body)
+        end
+
         #
         # profiles
         #

--- a/spaceship/spec/connect_api/fixtures/provisioning/device_disable.json
+++ b/spaceship/spec/connect_api/fixtures/provisioning/device_disable.json
@@ -1,0 +1,26 @@
+{
+    "data" : {
+      "id": "123456789",
+      "type": "devices",
+      "attributes": {
+        "addedDate" : "2018-10-10T01:43:27.000+0000",
+        "serialNumber" : null,
+        "description" : null,
+        "platform" : "IOS",
+        "name" : "Josh's iPhone",
+        "deviceClass" : "IPHONE",
+        "model" : "iPhone 8",
+        "udid" : "184098239048390489012849018",
+        "platformName" : "iOS",
+        "responseId" : "03514686-0a76-401e-80d5-7f23845fcd16",
+        "status" : "DISABLED",
+        "devicePlatformLabel" : "iPhone"
+      },
+      "links": {
+        "self": "https://developer.apple.com:443/services-account/v1/devices/123456789"
+      }
+    },
+    "links": {
+      "self": "https://developer.apple.com:443/services-account/v1/devices/123456789"
+    }
+}

--- a/spaceship/spec/connect_api/fixtures/provisioning/device_enable.json
+++ b/spaceship/spec/connect_api/fixtures/provisioning/device_enable.json
@@ -1,0 +1,26 @@
+{
+    "data" : {
+      "id": "13371337",
+      "type": "devices",
+      "attributes": {
+        "addedDate" : "2020-12-14T11:46:42.000+0000",
+        "serialNumber" : null,
+        "description" : null,
+        "platform" : "IOS",
+        "name" : "Roger's iPhone",
+        "deviceClass" : "IPHONE",
+        "model" : "iPhone XS",
+        "udid" : "5233342324433534345354534",
+        "platformName" : "iOS",
+        "responseId" : "91ad3a67-c3c5-4ec2-b31d-879f683badbd",
+        "status" : "ENABLED",
+        "devicePlatformLabel" : "iPhone"
+      },
+      "links": {
+        "self": "https://developer.apple.com:443/services-account/v1/devices/13371337"
+      }
+    },
+    "links": {
+      "self": "https://developer.apple.com:443/services-account/v1/devices/13371337"
+    }
+}

--- a/spaceship/spec/connect_api/fixtures/provisioning/device_rename.json
+++ b/spaceship/spec/connect_api/fixtures/provisioning/device_rename.json
@@ -1,0 +1,26 @@
+{
+    "data" : {
+      "id": "987654321",
+      "type": "devices",
+      "attributes": {
+        "addedDate" : "2018-11-23T16:22:00.000+0000",
+        "serialNumber" : null,
+        "description" : null,
+        "platform" : "IOS",
+        "name" : "renamed device",
+        "deviceClass" : "APPLE_TV",
+        "model" : "Apple TV (4th generation)",
+        "udid" : "5843758273957239847298374982",
+        "platformName" : "iOS",
+        "responseId" : "03514686-0a76-401e-80d5-7f23845fcd16",
+        "status" : "ENABLED",
+        "devicePlatformLabel" : "Apple TV"
+      },
+      "links": {
+        "self": "https://developer.apple.com:443/services-account/v1/devices/987654321"
+      }
+    },
+    "links": {
+      "self": "https://developer.apple.com:443/services-account/v1/devices/987654321"
+    }
+}

--- a/spaceship/spec/connect_api/models/device_spec.rb
+++ b/spaceship/spec/connect_api/models/device_spec.rb
@@ -51,5 +51,27 @@ describe Spaceship::ConnectAPI::Device do
       expect(existing_device.enabled?).to eq(false)
       expect(existing_device.udid).to eq(udid)
     end
+
+    it '#enable an existing disabled udid' do
+      udid = "5233342324433534345354534"
+      existing_device = Spaceship::ConnectAPI::Device.enable(udid)
+      expect(existing_device.enabled?).to eq(true)
+      expect(existing_device.udid).to eq(udid)
+    end
+
+    it '#disable an existing disabled udid' do
+      udid = "184098239048390489012849018"
+      existing_device = Spaceship::ConnectAPI::Device.disable(udid)
+      expect(existing_device.enabled?).to eq(false)
+      expect(existing_device.udid).to eq(udid)
+    end
+
+    it '#rename an existing disabled udid' do
+      udid = "5843758273957239847298374982"
+      new_name = "renamed device"
+      existing_device = Spaceship::ConnectAPI::Device.rename(udid, new_name)
+      expect(existing_device.name).to eq(new_name)
+      expect(existing_device.udid).to eq(udid)
+    end
   end
 end

--- a/spaceship/spec/connect_api/provisioning/provisioning_stubbing.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_stubbing.rb
@@ -91,6 +91,15 @@ class ConnectAPIStubbing
       def stub_devices
         stub_request(:post, "https://developer.apple.com/services-account/v1/devices").
           to_return(status: 200, body: read_fixture_file('devices.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
+
+        stub_request(:patch, "https://developer.apple.com/services-account/v1/devices/13371337").
+          to_return(status: 200, body: read_fixture_file('device_enable.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
+
+        stub_request(:patch, "https://developer.apple.com/services-account/v1/devices/123456789").
+          to_return(status: 200, body: read_fixture_file('device_disable.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
+
+        stub_request(:patch, "https://developer.apple.com/services-account/v1/devices/987654321").
+          to_return(status: 200, body: read_fixture_file('device_rename.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
       end
 
       def stub_profiles


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
We want to fully automate device management on the Developer Portal, which includes renaming, enabling, and disabling devices.

### Description
Implemented App Store Connect APIs [Modify a Registered Device PATCH request](https://developer.apple.com/documentation/appstoreconnectapi/modify_a_registered_device).

### Testing Steps
```ruby
Spaceship::ConnectAPI::Device.disable("udid")
Spaceship::ConnectAPI::Device.enable("udid")
Spaceship::ConnectAPI::Device.rename("udid", "new name")
```
