### PR TITLE
[spaceship] Remove unused params in ConnectAPI::Device

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -61,7 +61,7 @@ module Spaceship
       # @param platform [String] The platform of the device.
       # @param include_disabled [Bool] Whether to include disable devices. false by default.
       # @return (Device) Find a device based on the UDID of the device. nil if no device was found.
-      def self.find_by_udid(device_udid, client: nil, platform: nil, include_disabled: false)
+      def self.find_by_udid(device_udid, client: nil, include_disabled: false)
         self.all(client: client).find do |device|
           device.udid.casecmp(device_udid) == 0 && (include_disabled ? true : device.enabled?)
         end
@@ -70,10 +70,9 @@ module Spaceship
       # @param client [ConnectAPI] ConnectAPI client.
       # @param name [String] The name to be assigned to the device, if it needs to be created.
       # @param platform [String] The platform of the device.
-      # @param include_disabled [Bool] Whether to include disable devices. false by default.
       # @return (Device) Find a device based on the UDID of the device. If no device was found,  nil if no device was found.
-      def self.find_or_create(device_udid, client: nil, name: nil, platform: nil, include_disabled: false)
-        existing = self.find_by_udid(device_udid, client: client, platform: platform)
+      def self.find_or_create(device_udid, client: nil, name: nil, platform: nil)
+        existing = self.find_by_udid(device_udid, client: client)
         return existing if existing
         return self.create(client: client, name: name, platform: platform, udid: device_udid)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
- `find_by_udid` takes a `platform` param which is never used
- `find_or_create` takes an `include_disabled` param which is never used

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
This PR deletes them since they don't do anything.

Fastlane doesn't call them but these may be (very minor) breaking changes for anyone calling these methods manually so we should be sure to mention it in the release notes.


### Testing Steps
Just run rspec and the existing tests continue to pass since the parameters are never used by any code path.