### PR TITLE
Update deprecated CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ workflows:
           ruby_version: 'fastlanetools/ci:0.3.0'
       - lint_source_code:
           name: 'Lint source code'
-          ruby_version: 'circleci/ruby:2.6'
+          ruby_version: 'cimg/ruby:2.6'
       - modules_load_up_tests:
           name: 'Modules load up tests'
-          ruby_version: 'circleci/ruby:2.6'
+          ruby_version: 'cimg/ruby:2.6'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
As part of CircleCI's [Legacy Convenience Image Deprecation](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034), we need to change the image namespace.

The new images should be "faster, more efficient, and most importantly, more reliable".

### Description
Update CircleCI yml to point to new images.

### Testing Steps
Observe all green builds on GitHub (hopefully)