### PR TITLE
[snapshot] add the iPhone 14 devices for the HTML report page

### DIFF
--- a/snapshot/lib/snapshot/reports_generator.rb
+++ b/snapshot/lib/snapshot/reports_generator.rb
@@ -84,6 +84,10 @@ module Snapshot
       {
         # snapshot in Xcode 9 saves screenshots with the SIMULATOR_DEVICE_NAME
         # which includes spaces
+        'iPhone 14 Pro Max' => "iPhone 14 Pro Max",
+        'iPhone 14 Pro' => "iPhone 14 Pro",
+        'iPhone 14 Plus' => "iPhone 14 Plus",
+        'iPhone 14' => "iPhone 14",
         'iPhone 13 Pro Max' => "iPhone 13 Pro Max",
         'iPhone 13 Pro' => "iPhone 13 Pro",
         'iPhone 13 mini' => "iPhone 13 mini",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
- Resolves #20950

### Description
- add the iPhone 14 devices for the HTML report page

### Screenshot

<img width="190" alt="Screenshot 2022-12-26 at 11 16 54" src="https://user-images.githubusercontent.com/5364500/209538031-27580fe7-53ce-4699-a032-7f22d48a99e7.png">
