### PR TITLE
[deliver] Don't require IDFA info for submission

### DIFF
--- a/deliver/lib/deliver/submit_for_review.rb
+++ b/deliver/lib/deliver/submit_for_review.rb
@@ -131,25 +131,7 @@ module Deliver
         updated_idfa = true
       end
 
-      # Error if uses_idfa not set
-      if version.uses_idfa.nil?
-        message = [
-          "Use of Advertising Identifier (IDFA) is required to submit",
-          "Add information to the :submission_information option...",
-          "  Docs: http://docs.fastlane.tools/actions/deliver/#compliance-and-idfa-settings",
-          "  Example: submission_information: { add_id_info_uses_idfa: false }",
-          "  Example: submission_information: {",
-          "    add_id_info_uses_idfa: true,",
-          "    add_id_info_serves_ads: false,",
-          "    add_id_info_tracks_install: true,",
-          "    add_id_info_tracks_action: true,",
-          "    add_id_info_limits_tracking: true",
-          "  }",
-          "  Example CLI:",
-          "    --submission_information \"{\\\"add_id_info_uses_idfa\\\": false}\""
-        ].join("\n")
-        UI.user_error!(message)
-      end
+      return if version.uses_idfa.nil?
 
       # Create, update, or delete IDFA declaration
       if uses_idfa == false


### PR DESCRIPTION

Since the replacement of IDFA information with the more detailed
privacy information, the IDFA information is no longer required for
submission. This patch removes the requirement. Since the App Store
Connect APIs for IDFA information are still available, the code is
kept for now and if the info is passed to fastlane, it will be uploaded
as before.

The APIs for IDFA Declarations have been deprecated in App Store Connect
API version 1.5 and removed in App Store Connect API version 2.0.

Release Notes App Store Connect API v1.5: https://developer.apple.com/documentation/appstoreconnectapi/app_store_connect_api_release_notes/app_store_connect_api_version_1_5_release_notes

Release Notes App Store Connect API v2.0: https://developer.apple.com/documentation/appstoreconnectapi/app_store_connect_api_release_notes/app_store_connect_api_version_2_0_release_notes