### PR TITLE
[trainer] report run destination as testsuite properties

### DIFF
--- a/trainer/lib/assets/junit.xml.erb
+++ b/trainer/lib/assets/junit.xml.erb
@@ -7,11 +7,17 @@
 <testsuites tests="<%= number_of_tests %>" failures="<%= number_of_failures %>">
   <% @results.each do |testsuite| %>
     <testsuite name=<%= (testsuite[:target_name].nil? ? testsuite[:test_name] : testsuite[:target_name]).encode(:xml => :attr) %> tests="<%= testsuite[:number_of_tests_excluding_retries] %>" failures="<%= testsuite[:number_of_failures_excluding_retries] %>" <% if testsuite[:number_of_skipped] %>skipped="<%= testsuite[:number_of_skipped] %>" <% end %>time="<%= testsuite[:duration] %>">
-      <% unless testsuite[:configuration_name].nil? %>
-        <properties>
-          <property name="Configuration" value="<%= testsuite[:configuration_name] %>"/>
-        </properties>
-      <% end %>
+        <% unless testsuite[:configuration_name].nil? && testsuite[:destination_name].nil? && testsuite[:destination_os_version].nil? %><properties>
+          <% unless testsuite[:configuration_name].nil? %>
+            <property name="Configuration" value="<%= testsuite[:configuration_name] %>"/>
+          <% end %>
+          <% unless testsuite[:destination_name].nil? %>
+            <property name="Destination name" value="<%= testsuite[:destination_name] %>"/>
+          <% end %>
+          <% unless testsuite[:destination_os_version].nil? %>
+            <property name="Destination OS version" value="<%= testsuite[:destination_os_version] %>"/>
+          <% end %>
+        </properties><% end %>
       <% testsuite[:tests].each do |test| %>
         <testcase classname=<%= test[:test_group].encode(:xml => :attr) %> name=<%= test[:name].encode(:xml => :attr) %> time="<%= test[:duration] %>">
           <% (test[:failures] || []).each do |failure| %>

--- a/trainer/lib/trainer/xcresult.rb
+++ b/trainer/lib/trainer/xcresult.rb
@@ -222,6 +222,44 @@ module Trainer
       end
     end
 
+    # - ActionSDKRecord
+    #   * Kind: object
+    #   * Properties:
+    #     + identifier: String
+    #     + name: String
+    #     + operatingSystemVersion: String
+    class ActionSDKRecord < AbstractObject
+      attr_accessor :identifier
+      attr_accessor :name
+      attr_accessor :operating_system_version
+
+      def initialize(data)
+        self.identifier = fetch_value(data, "identifier")
+        self.name = fetch_value(data, "name")
+        self.operating_system_version = fetch_value(data, "operatingSystemVersion")
+        super
+      end
+    end
+
+    # - ActionRunDestinationRecord
+    #   * Kind: object
+    #   * Properties:
+    #     + displayName: String
+    #     + localComputerRecord: ActionDeviceRecord
+    #     + targetArchitecture: String
+    #     + targetDeviceRecord: ActionDeviceRecord
+    #     + targetSDKRecord: ActionSDKRecord
+    class ActionRunDestinationRecord < AbstractObject
+      attr_accessor :display_name
+      attr_accessor :target_sdk_record
+
+      def initialize(data)
+        self.display_name = fetch_value(data, "displayName")
+        self.target_sdk_record = ActionSDKRecord.new(data["targetSDKRecord"])
+        super
+      end
+    end
+
     # - ActionRecord
     #   * Kind: object
     #   * Properties:
@@ -239,12 +277,14 @@ module Trainer
       attr_accessor :title
       attr_accessor :build_result
       attr_accessor :action_result
+      attr_accessor :run_destination
       def initialize(data)
         self.scheme_command_name = fetch_value(data, "schemeCommandName")
         self.scheme_task_name = fetch_value(data, "schemeTaskName")
         self.title = fetch_value(data, "title")
         self.build_result = ActionResult.new(data["buildResult"])
         self.action_result = ActionResult.new(data["actionResult"])
+        self.run_destination = ActionRunDestinationRecord.new(data["runDestination"])
         super
       end
     end

--- a/trainer/spec/fixtures/XCResult.junit
+++ b/trainer/spec/fixtures/XCResult.junit
@@ -2,14 +2,18 @@
 <testsuites tests="7" failures="2">
     <testsuite name="TestUITests" tests="1" failures="0" skipped="0" time="16.05245804786682">
         <properties>
-          <property name="Configuration" value="Test Scheme Action"/>
+            <property name="Configuration" value="Test Scheme Action"/>
+            <property name="Destination name" value="iPhone 6 - 10.3"/>
+            <property name="Destination OS version" value="13.0"/>
         </properties>
         <testcase classname="TestUITests" name="testExample()" time="16.05245804786682">
         </testcase>
     </testsuite>
     <testsuite name="TestThisDude" tests="6" failures="2" skipped="0" time="0.5279300212860107">
         <properties>
-          <property name="Configuration" value="Test Scheme Action"/>
+            <property name="Configuration" value="Test Scheme Action"/>
+            <property name="Destination name" value="iPhone 6 - 10.3"/>
+            <property name="Destination OS version" value="13.0"/>
         </properties>
         <testcase classname="TestTests" name="testExample()" time="0.0005381107330322266">
         </testcase>

--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -97,6 +97,8 @@ describe Trainer do
                                   target_name: "TestUITests",
                                   test_name: "TestUITests",
                                   configuration_name: "Test Scheme Action",
+                                  destination_name: "iPhone 6 - 10.3",
+                                  destination_os_version: "13.0",
                                   duration: 16.05245804786682,
                                   tests: [
                                     {
@@ -120,6 +122,8 @@ describe Trainer do
                                   target_name: "TestThisDude",
                                   test_name: "TestThisDude",
                                   configuration_name: "Test Scheme Action",
+                                  destination_name: "iPhone 6 - 10.3",
+                                  destination_os_version: "13.0",
                                   duration: 0.5279300212860107,
                                   tests: [
                                     {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
When running fastlane over multiple destinations (aka, devices and OS versions) it's impossible to know in the final report which destination failed.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
The information about the destination is already available in the xcresult bundle, but it was ignored during the parsing. This PR introduces the basic types and hooks them into the parsing flow.
That allow the action type to have access to the test suites (`test_ref`) and the run_destination. However, the code needed refactoring as it was processing everything in batch ignoring on what test suite it belonged to. Thus, the code was refactor to process each test suite as a single unit, allowing to pass the run destination information along.
Then the template was updated to reflect the new properties in the test suite if they are available.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
All unit tests and fixtures were updated to reflect the new changes.