### PR TITLE
[ensure_git_status_clean] fix incorrect "ignored" param handling

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -75,7 +75,11 @@ module Fastlane
                                        type: Boolean),
           FastlaneCore::ConfigItem.new(key: :ignored,
                                        env_name: "FL_ENSURE_GIT_STATUS_CLEAN_IGNORED_FILE",
-                                       description: "The handling mode of the ignored files. The available options are: `'traditional'`, `'none'` (default) and `'matching'`. Specifying `'none'` to this parameter is the same as not specifying the parameter at all, which means that no ignored file will be used to check if the repo is dirty or not. Specifying `'traditional'` or `'matching'` causes some ignored files to be used to check if the repo is dirty or not (more info in the official docs: https://git-scm.com/docs/git-status#Documentation/git-status.txt---ignoredltmodegt)",
+                                       description: [
+                                         "The handling mode of the ignored files. The available options are: `'traditional'`, `'none'` (default) and `'matching'`.",
+                                         "Specifying `'none'` to this parameter is the same as not specifying the parameter at all, which means that no ignored file will be used to check if the repo is dirty or not.",
+                                         "Specifying `'traditional'` or `'matching'` causes some ignored files to be used to check if the repo is dirty or not (more info in the official docs: https://git-scm.com/docs/git-status#Documentation/git-status.txt---ignoredltmodegt)"
+                                       ].join(" "),
                                        optional: true,
                                        verify_block: proc do |value|
                                          mode = value.to_s

--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -76,7 +76,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :ignored,
                                        env_name: "FL_ENSURE_GIT_STATUS_CLEAN_IGNORED_FILE",
                                        description: "The ignored files handling mode if the repo is dirty. The available options are: 'traditional', 'none' (default) and 'matching'",
-                                       optional: true)
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         mode = value.to_s
+                                         modes = %w(traditional none matching)
+
+                                         UI.user_error!("Unsupported mode, must be: #{modes}") unless modes.include?(mode)
+                                       end)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -9,6 +9,7 @@ module Fastlane
       def self.run(params)
         if params[:ignored]
           ignored_mode = params[:ignored]
+          ignored_mode = 'no' if ignored_mode == 'none'
           repo_status = Actions.sh("git status --porcelain --ignored='#{ignored_mode}'")
         else
           repo_status = Actions.sh("git status --porcelain")
@@ -74,7 +75,7 @@ module Fastlane
                                        type: Boolean),
           FastlaneCore::ConfigItem.new(key: :ignored,
                                        env_name: "FL_ENSURE_GIT_STATUS_CLEAN_IGNORED_FILE",
-                                       description: "The ignored files handling mode if the repo is dirty. The available options are: 'traditional', 'no' (default) and 'matching'",
+                                       description: "The ignored files handling mode if the repo is dirty. The available options are: 'traditional', 'none' (default) and 'matching'",
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -8,8 +8,8 @@ module Fastlane
     class EnsureGitStatusCleanAction < Action
       def self.run(params)
         if params[:ignored]
-          ignored_file = params[:ignored]
-          repo_status = Actions.sh("git status --porcelain --ignored #{ignored_file}")
+          ignored_mode = params[:ignored]
+          repo_status = Actions.sh("git status --porcelain --ignored #{ignored_mode}")
         else
           repo_status = Actions.sh("git status --porcelain")
         end

--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -75,7 +75,7 @@ module Fastlane
                                        type: Boolean),
           FastlaneCore::ConfigItem.new(key: :ignored,
                                        env_name: "FL_ENSURE_GIT_STATUS_CLEAN_IGNORED_FILE",
-                                       description: "The ignored files handling mode if the repo is dirty. The available options are: 'traditional', 'none' (default) and 'matching'",
+                                       description: "The handling mode of the ignored files. The available options are: `'traditional'`, `'none'` (default) and `'matching'`. Specifying `'none'` to this parameter is the same as not specifying the parameter at all, which means that no ignored file will be used to check if the repo is dirty or not. Specifying `'traditional'` or `'matching'` causes some ignored files to be used to check if the repo is dirty or not (more info in the official docs: https://git-scm.com/docs/git-status#Documentation/git-status.txt---ignoredltmodegt)",
                                        optional: true,
                                        verify_block: proc do |value|
                                          mode = value.to_s

--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -74,7 +74,7 @@ module Fastlane
                                        type: Boolean),
           FastlaneCore::ConfigItem.new(key: :ignored,
                                        env_name: "FL_ENSURE_GIT_STATUS_CLEAN_IGNORED_FILE",
-                                       description: "The flag whether to ignore file the git status if the repo is dirty",
+                                       description: "The ignored files handling mode if the repo is dirty. The available options are: 'traditional', 'no' (default) and 'matching'",
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -9,7 +9,7 @@ module Fastlane
       def self.run(params)
         if params[:ignored]
           ignored_mode = params[:ignored]
-          repo_status = Actions.sh("git status --porcelain --ignored #{ignored_mode}")
+          repo_status = Actions.sh("git status --porcelain --ignored='#{ignored_mode}'")
         else
           repo_status = Actions.sh("git status --porcelain")
         end

--- a/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
@@ -87,11 +87,11 @@ describe Fastlane do
             end
           end
 
-          context "no" do
+          context "none" do
             it "outputs error message without ignored files" do
               expect(FastlaneCore::UI).to receive(:user_error!).with("Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.\nUncommitted changes:\nM fastlane/lib/fastlane/actions/ensure_git_status_clean.rb")
               Fastlane::FastFile.new.parse("lane :test do
-                ensure_git_status_clean(show_uncommitted_changes: true, ignored: 'no')
+                ensure_git_status_clean(show_uncommitted_changes: true, ignored: 'none')
               end").runner.execute(:test)
             end
           end

--- a/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
@@ -27,7 +27,7 @@ describe Fastlane do
 
         context "with show_uncommitted_changes flag" do
           context "true" do
-            it "outputs reach error message" do
+            it "outputs rich error message" do
               expect(FastlaneCore::UI).to receive(:user_error!).with("Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.\nUncommitted changes:\nM fastlane/lib/fastlane/actions/ensure_git_status_clean.rb")
               Fastlane::FastFile.new.parse("lane :test do
                 ensure_git_status_clean(show_uncommitted_changes: true)
@@ -56,7 +56,7 @@ describe Fastlane do
 
         context "with show_diff flag" do
           context "true" do
-            it "outputs reach error message" do
+            it "outputs rich error message" do
               expect(FastlaneCore::UI).to receive(:user_error!).with("Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.\nGit diff: \n+ \"this is a new line\"")
               Fastlane::FastFile.new.parse("lane :test do
                 ensure_git_status_clean(show_diff: true)

--- a/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
@@ -53,6 +53,7 @@ describe Fastlane do
             end").runner.execute(:test)
           end
         end
+
         context "with show_diff flag" do
           context "true" do
             it "outputs reach error message" do
@@ -70,15 +71,6 @@ describe Fastlane do
                 ensure_git_status_clean(show_diff: false)
               end").runner.execute(:test)
             end
-          end
-        end
-
-        context "without show_uncommitted_changes flag" do
-          it "outputs short error message" do
-            expect(FastlaneCore::UI).to receive(:user_error!).with("Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.")
-            Fastlane::FastFile.new.parse("lane :test do
-              ensure_git_status_clean
-            end").runner.execute(:test)
           end
         end
       end

--- a/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
+++ b/fastlane/spec/actions_specs/ensure_git_status_clean_spec.rb
@@ -46,7 +46,7 @@ describe Fastlane do
         end
 
         context "without show_uncommitted_changes flag" do
-          it "outputs short error message with full diff" do
+          it "outputs short error message" do
             expect(FastlaneCore::UI).to receive(:user_error!).with("Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.")
             Fastlane::FastFile.new.parse("lane :test do
               ensure_git_status_clean


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Fixes #19818.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

See also: https://git-scm.com/docs/git-status#Documentation/git-status.txt---ignoredltmodegt

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

- Replace
  ```ruby
  gem 'fastlane'
  ```
  with
  ```ruby
  gem 'fastlane', git: 'https://github.com/fastlane/fastlane.git', branch: 'fix/unclear-param-documentation'
  ```
  in your `Gemfile`.
- Run `bundle install`
- Run `bundle exec fastlane run ensure_git_status_clean`