### PR TITLE
[spaceship] fix some errors not being shown to the user

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -333,7 +333,10 @@ module Spaceship
           formatted_errors << "Unknown error"
         end
 
-        return formatted_errors
+        return {
+          'errors' => formatted_errors,
+          'resultString' => formatted_errors
+        }
       end
 
       private


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

For example, if you use the `upload_to_testflight` action, and then specify an existing app name, it will output only this:

```
[17:13:36]: App Name: <redacted>
[17:13:38]: Creating new app '<redacted>' on App Store Connect
[17:13:38]: Sending language name is deprecated. 'English' has been mapped to 'en-US'.
[17:13:38]: Please enter one of available languages: ["ar-SA", "ca", "cs", "da", "de-DE", "el", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi", "fr-CA", "fr-FR", "he", "hi", "hr", "hu", "id", "it", "ja", "ko", "ms", "nl-NL", "no", "pl", "pt-BR", "pt-PT", "ro", "ru", "sk", "sv", "th", "tr", "uk", "vi", "zh-Hans", "zh-Hant"]
[17:13:40]:
[17:13:40]: It looks like something went wrong when we tried to create your app on the Apple Developer Portal
[17:13:40]: Would you like to try again (y)? If you enter (n), fastlane will fall back to the manual setup (y/n)
```

but now, it will output this:

```
[17:23:07]: App Name: <redacted>
[17:23:09]: Creating new app '<redacted>' on App Store Connect
[17:23:09]: Sending language name is deprecated. 'English' has been mapped to 'en-US'.
[17:23:09]: Please enter one of available languages: ["ar-SA", "ca", "cs", "da", "de-DE", "el", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi", "fr-CA", "fr-FR", "he", "hi", "hr", "hu", "id", "it", "ja", "ko", "ms", "nl-NL", "no", "pl", "pt-BR", "pt-PT", "ro", "ru", "sk", "sv", "th", "tr", "uk", "vi", "zh-Hans", "zh-Hant"]
[17:23:11]: ["Apple provided the following error info:", "The provided entity includes an attribute with a value that has already been used on a different account. - The App Name you entered is already being used. If you have trademark rights to this name and would like it released for your use, submit a claim. - /included/1/name"]
[17:23:11]: It looks like something went wrong when we tried to create your app on the Apple Developer Portal
[17:23:11]: Would you like to try again (y)? If you enter (n), fastlane will fall back to the manual setup (y/n)
```

<details>
<summary>Diff</summary>

```diff
 [17:13:36]: App Name: <redacted>
 [17:13:38]: Creating new app '<redacted>' on App Store Connect
 [17:13:38]: Sending language name is deprecated. 'English' has been mapped to 'en-US'.
 [17:13:38]: Please enter one of available languages: ["ar-SA", "ca", "cs", "da", "de-DE", "el", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi", "fr-CA", "fr-FR", "he", "hi", "hr", "hu", "id", "it", "ja", "ko", "ms", "nl-NL", "no", "pl", "pt-BR", "pt-PT", "ro", "ru", "sk", "sv", "th", "tr", "uk", "vi", "zh-Hans", "zh-Hant"]
-[17:13:40]:
+[17:23:11]: ["Apple provided the following error info:", "The provided entity includes an attribute with a value that has already been used on a different account. - The App Name you entered is already being used. If you have trademark rights to this name and would like it released for your use, submit a claim. - /included/1/name"]
 [17:13:40]: It looks like something went wrong when we tried to create your app on the Apple Developer Portal
 [17:13:40]: Would you like to try again (y)? If you enter (n), fastlane will fall back to the manual setup (y/n)
```
</details>

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I really am not sure if this is the correct fix, but I don't know nor understand the error reporting part of fastlane.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
