### PR TITLE
Fix issue with releases containing retained versions (#20997)

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -128,7 +128,7 @@ module Supply
       UI.user_error!("Unable to find the requested track - '#{Supply.config[:track]}'") unless track
       UI.user_error!("Unable to find the requested release on track - '#{Supply.config[:track]}'") unless release
 
-      version_code = release.version_codes.first
+      version_code = release.version_codes.max
 
       UI.message("Updating #{version_code}'s rollout to '#{Supply.config[:rollout]}' on track '#{Supply.config[:track]}'...")
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR aims to resolve #20997

### Description
When a release in the Google Play Store contains a retained version, `update_rollout` is failing to complete the rollout as it is sending the retained version to the Google Publisher API.
Updated the code to always pick the biggest version code as that will always correspond with the latest release

### Testing Steps
1- Release a new version to the Google Play Store retaining the previous version

<img width="1377" alt="Screenshot 2023-01-17 at 6 06 02 pm" src="https://user-images.githubusercontent.com/2457743/212832373-a1f6eaaf-bdab-43f8-9eff-04697ea0200f.png">

2- Complete the rollout for that version
```
supply(
          track: options[:track],
          rollout: options: 1.0,
          skip_upload_apk: true,
          skip_upload_metadata: true,
          skip_upload_images: true,
          skip_upload_screenshots: true,
          skip_upload_changelogs: true,
          skip_upload_aab: true,
          package_name: options[:package]
        )
```
