### PR TITLE
[match][sigh] speed up profiles fetching by adding name filter to the API calls

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -282,12 +282,14 @@ module Match
       end
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]
+      name = parsed["Name"]
 
       if params[:output_path]
         FileUtils.cp(profile, params[:output_path])
       end
 
       if spaceship && !spaceship.profile_exists(type: prov_type,
+                                                name: name,
                                                 username: params[:username],
                                                 uuid: uuid,
                                                 platform: params[:platform])
@@ -352,8 +354,10 @@ module Match
 
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]
+      name = parsed["Name"]
 
-      all_profiles = Spaceship::ConnectAPI::Profile.all(includes: "devices")
+      # Filtering by name allows us to filter out profiles way faster than querying all profiles
+      all_profiles = Spaceship::ConnectAPI::Profile.all(filter: { name: name }, includes: "devices")
       portal_profile = all_profiles.detect { |i| i.uuid == uuid }
 
       if portal_profile
@@ -427,8 +431,10 @@ module Match
 
       parsed = FastlaneCore::ProvisioningProfile.parse(profile, keychain_path)
       uuid = parsed["UUID"]
+      name = parsed["Name"]
 
-      all_profiles = Spaceship::ConnectAPI::Profile.all(includes: "certificates")
+      # Filtering by name allows us to filter out profiles way faster than querying all profiles
+      all_profiles = Spaceship::ConnectAPI::Profile.all(filter: { name: name }, includes: "certificates")
       portal_profile = all_profiles.detect { |i| i.uuid == uuid }
 
       return false unless portal_profile

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -74,11 +74,13 @@ module Match
       UI.user_error!("To reset the certificates of your Apple account, you can use the `fastlane match nuke` feature, more information on https://docs.fastlane.tools/actions/match/")
     end
 
-    def profile_exists(type: nil, username: nil, uuid: nil, platform: nil)
+    def profile_exists(type: nil, name: nil, username: nil, uuid: nil, platform: nil)
       # App Store Connect API does not allow filter of profile by platform or uuid (as of 2020-07-30)
       # Need to fetch all profiles and search for uuid on client side
       # But we can filter provisioning profiles based on their type (this, in general way faster than getting all profiles)
-      filter = { profileType: Match.profile_types(type).join(",") } if type
+      filter = {}
+      filter[:profileType] = Match.profile_types(type).join(",") if type
+      filter[:name] = name if name
       found = Spaceship::ConnectAPI::Profile.all(filter: filter).find do |profile|
         profile.uuid == uuid
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Speeding up some queries on AppStoreConnectAPI

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

When running `match` and `sigh` commands, and there's a need for searching specific provisioning profiles, the current general pattern is to search for all profiles by calling `Spaceship::ConnectAPI::Profile.all` and filter later i.e.
```
all_profiles = Spaceship::ConnectAPI::Profile.all(includes: "devices")
```

In this PR we're adding additional filtering when querying `ConnectAPI` which greatly reduces request times.
```
all_profiles = Spaceship::ConnectAPI::Profile.all(filter: { name: name}, includes: "devices")
```

These queries are running multiple times during `sigh`/`match` tools so decreasing time even for a few seconds will get a great improvement in speed 

### Important notes
- While it seems that profile can simply be renamed, and have the same `uuid`, it's not actually true. When the profile is renamed, its `uuid` changes as well. 
- There's no visible way to require exact name matching when querying, so we're always adding later checks and not relying on names only. For example, if "Profile" is searched, "Profile1" and "Profile2" will be returned.

### Some numbers
Numbers greatly depend on the portal size, these are numbers for a real one (~200 profiles, 50 certs)
Querying all profiles (without specifying name) was taking from 60 to 150 seconds.
Adding name filtering decreased fetching time by almost 25x times 😮 
```
INFO [2023-01-29 01:46:11.10]: Time for fetching all profiles Without names: 125.897404
INFO [2023-01-29 01:46:12.57]: Time for fetching all profiles with names: 1.467258
INFO [2023-01-29 01:48:43.37]: Time for fetching all profiles Without names: 150.727023
INFO [2023-01-29 01:48:49.80]: Time for fetching all profiles: 6.429851
```


### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Basically, `sigh` and `match` should work exactly the same.