### PR TITLE
[spaceship] portal account getTeams API call

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -435,6 +435,18 @@ module Spaceship
     #####################################################
     # @!group Team
     #####################################################
+
+    def describe_teams
+      response = request(:post) do |req|
+        req.url("/services-account/#{PROTOCOL_VERSION}/account/getTeams")
+        req.body = {
+          includeInMigrationTeams: 1
+        }.to_json
+        req.headers['Content-Type'] = 'application/json'
+      end
+      parse_response(response)
+    end
+
     def team_members
       response = request(:post) do |req|
         req.url("/services-account/#{PROTOCOL_VERSION}/account/getTeamMembers")

--- a/spaceship/spec/portal/fixtures/getTeams.json
+++ b/spaceship/spec/portal/fixtures/getTeams.json
@@ -1,0 +1,80 @@
+{
+  "creationTimestamp": "2023-02-02T20:38:44Z",
+  "resultCode": 0,
+  "userLocale": "en_US",
+  "devices": [],
+  "teamAddresses": [],
+  "teams": [
+    {
+      "teamId": "E3XWH3A9EA",
+      "name": "bFAN Sports",
+      "status": "active",
+      "phone": "1-800-000-0000",
+      "address": {
+        "city": "Paris",
+        "state": "Paris",
+        "country": "France",
+        "countryCode": "FR",
+        "postalCode": "75016",
+        "team": {
+          "extendedTeamAttributes": {},
+          "xcodeFreeOnly": false,
+          "score": 0
+        },
+        "streetAddress1": "6 Rue Claude Farrère"
+      },
+      "entityType": "c",
+      "paymentPlatform": 1,
+      "agent": {
+        "personId": 11479239097,
+        "firstName": "John",
+        "lastName": "Doe",
+        "email": "info@bfansports.com",
+        "developerStatus": "active",
+        "cipsAccess": true,
+        "satoriBypass": false,
+        "eligibleForSatori": false,
+        "enrollmentOnApp": false,
+        "paymentPlatform": null,
+        "fssRecommendation": null,
+        "fssDate": null,
+        "fssNameProcessed": null,
+        "fssConvKitStatus": null,
+        "fssConvKitScore": null,
+        "fssRiskingHonorFlag": false,
+        "fssRiskingOverrideAction": null,
+        "fssRiskingOverrideDate": null,
+        "showFssRiskingOverrideApprove": false,
+        "showFssRiskingOverrideReject": false,
+        "showFssRiskingOverrideReset": false,
+        "fssRiskingErrors": null,
+        "isIDVerificationRequired": false,
+        "isCountryUpdateRequired": false,
+        "hcmStatus": null,
+        "hcmStatusModifiedDate": null,
+        "teamMemberId": "7UH2ND2MMQ"
+      },
+      "program": {
+        "type": "ad19",
+        "name": "Apple Developer Program",
+        "autoRenew": true,
+        "dateExpires": 1698364799000,
+        "status": "active",
+        "autoRenewPrice": "99&euro;"
+      },
+      "userRoles": [
+        "Admin"
+      ],
+      "teamMemberId": "W7KVBW875V",
+      "adminCount": 3,
+      "memberCount": 0,
+      "serverCount": 0,
+      "nextDeviceResetDate": 1698364799000,
+      "isFeeWaiverApproved": false,
+      "isMDMVendor": false,
+      "acceptedLatestAgreement": true,
+      "appRenewalEligibility": "eligible"
+    }
+  ],
+  "developers": []
+}

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -340,6 +340,20 @@ the developer website<a/>.<br />"
         expect(response.first).to eq(expected_first_message)
       end
     end
+
+    describe '#describe_teams' do
+      it 'returns the description of the available teams' do
+        response = subject.describe_teams
+        teams = response['teams']
+        expect(teams).to be_instance_of(Array)
+        teams.each do |team|
+          program = team['program']
+          expect(program['dateExpires']).to be_instance_of(Integer)
+          expect(['active', 'expired']).to include(program['status'])
+        end
+      end
+    end
+
   end
 
   describe 'keys api' do

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -239,6 +239,11 @@ class PortalStubbing
     end
 
     def adp_stub_persons
+      # Describe all Apple Developer teams
+      stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/getTeams").
+        with(body: "{\"includeInMigrationTeams\":1}").
+        to_return(status: 200, body: adp_read_fixture_file("getTeams.json"), headers: { 'Content-Type' => 'application/json' })
+
       # get all members
       stub_request(:post, "https://developer.apple.com/services-account/QH65B2/account/getTeamMembers").
         with(body: "{\"teamId\":\"XXXXXXXXXX\"}").


### PR DESCRIPTION
Added an API call to the [Spaceship Portal client](./spaceship/lib/spaceship/portal/portal_client.rb) that describes the Apple development teams, including the annual developer membership expiration date.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

At [bFAN Sports](https://www.bfansports.com) we have 70+ Apple Developer accounts ([1 per client](https://www.bfansports.com/clients)). 
It's pretty hard to keep track of the yearly Apple Developer renewal date, and we can't always auto-renew. Keeping track manually by visiting the [account membership details](https://developer.apple.com/account#MembershipDetailsCard) is too time consuming at this scale. And missing a renewal would mean our app [will no longer be available for download](https://developer.apple.com/support/renewal).
This API call solves our issue by programmatically getting the details of all of our Apple Developer accounts.

It partly resolves this closed issue #7000.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

I added a method called `describe_teams` in the Spaceship Portal client. It describes the Apple development teams, including the annual developer membership expiration date.
This API call was extracted from the [account membership details page](https://developer.apple.com/account#MembershipDetailsCard).
I couldn’t name it `teams` because that's already taken (and way more useful), and `get_teams` triggers [Rubocop](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/AccessorMethodName). I'm open to naming changes that would avoid confusion.

*Note: Our fixture [getTeams.json](./spaceship/spec/portal/fixtures/getTeams.json) contains 76 Apple Developer accounts, but I had to heavily redact the sensitive information. We can discuss in private if you are interested in the full API call response.*

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
```bash
bundle exec rspec ./spaceship/spec/portal/portal_client_spec.rb -e "#describe_teams"
```

### Example usage
Here is how to generate a CSV to track Apple Developer membership expiration:
```ruby
desc "Generate Apple Developer Expiration Report"
lane :apple_developer_expiration_report do
  csv = CSV.open("apple_developer_expiration_report.csv", "w")
  csv << ["Team Name", "Team ID", "Team Expiration Date", "Team Status"]
  spaceship_portal_client = Spaceship::Portal.login(ENV["FASTLANE_USER"], ENV["FASTLANE_PASSWORD"])
  teams = spaceship_portal_client.describe_teams["teams"]
  teams.each do |team|
    team_name = team["name"]
    team_id = team["teamId"]
    team_expiration_date = Time.at(0, team["program"]["dateExpires"], :millisecond).strftime("%Y-%m-%d")
    team_status = team["program"]["status"]
    csv << [team_name, team_id, team_expiration_date, team_status]
  end
  csv.close
end
```
