### PR TITLE
Add upload_timeout option for DeployGate upload

### DIFF
--- a/fastlane/lib/fastlane/actions/deploygate.rb
+++ b/fastlane/lib/fastlane/actions/deploygate.rb
@@ -17,7 +17,7 @@ module Fastlane
         require 'faraday'
         require 'faraday_middleware'
 
-        connection = Faraday.new(url: DEPLOYGATE_URL_BASE, request: { timeout: 120 }) do |builder|
+        connection = Faraday.new(url: DEPLOYGATE_URL_BASE, request: { timeout: options[:upload_timeout] }) do |builder|
           builder.request(:multipart)
           builder.request(:json)
           builder.response(:json, content_type: /\bjson$/)
@@ -164,7 +164,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :distribution_name,
                                        optional: true,
                                        env_name: "DEPLOYGATE_DISTRIBUTION_NAME",
-                                       description: "Target Distribution Name")
+                                       description: "Target Distribution Name"),
+          FastlaneCore::ConfigItem.new(key: :upload_timeout,
+                                       optional: true,
+                                       env_name: "DEPLOYGATE_UPLOAD_TIMEOUT",
+                                       type: Integer,
+                                       default_value: 120,
+                                       description: "Timeout seconds at DeployGate upload")
         ]
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
![image](https://user-images.githubusercontent.com/1461214/216494410-279b6c98-6f80-4dae-aecd-b4ab6ec6c6b4.png)

A timeout error occurs when uploading binaries larger than 3 GB to DeployGate.
DeployGate upload timeout value is hard-coded at 120 and cannot be changed.

### Description
Add a timeout value option for uploading to DeployGate.

### Testing Steps
Specify the timeout parameter when `deploygate` is run.
```
deploygate(
  api_token: "...",
  user: "target username or organization name",
  ipa: "./ipa_file.ipa",
  message: "Build #{lane_context[SharedValues::BUILD_NUMBER]}",
  distribution_key: "(Optional) Target Distribution Key",
  distribution_name: "(Optional) Target Distribution Name",
  timeout: 300 # (Optional)
)
```