### PR TITLE
[produce][spaceship] Add team id when updating bundle capability API

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -1,5 +1,7 @@
 require_relative '../model'
 require_relative './bundle_id_capability'
+require_relative '../../portal/portal_client'
+
 module Spaceship
   class ConnectAPI
     class BundleId
@@ -85,7 +87,7 @@ module Spaceship
         raise "capability_type is required " if capability_type.nil?
 
         client ||= Spaceship::ConnectAPI
-        resp = client.patch_bundle_id_capability(bundle_id_id: id, seed_id: seed_id, enabled: enabled, capability_type: capability_type, settings: settings)
+        resp = client.patch_bundle_id_capability(bundle_id_id: id, team_id: Spaceship::Portal.client.team_id, enabled: enabled, capability_type: capability_type, settings: settings)
         return resp.to_models.first
       end
     end

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -86,13 +86,13 @@ module Spaceship
           provisioning_request_client.post("bundleIdCapabilities", body)
         end
 
-        def patch_bundle_id_capability(bundle_id_id:, seed_id:, enabled: false, capability_type:, settings: [])
+        def patch_bundle_id_capability(bundle_id_id:, team_id:, enabled: false, capability_type:, settings: [])
           body = {
             data: {
               type: "bundleIds",
               id: bundle_id_id,
               attributes: {
-                teamId: seed_id
+                teamId: team_id
               },
               relationships: {
                 bundleIdCapabilities: {

--- a/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
@@ -61,42 +61,42 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
     describe "bundleId Capability" do
       context 'patch_bundle_id_capability' do
         it 'should make a request to turn APP_ATTEST on' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::APP_ATTEST)
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::APP_ATTEST)
         end
         it 'should make a request to turn APP_ATTEST off' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: false, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::APP_ATTEST)
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: false, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::APP_ATTEST)
         end
         it 'should make a request to turn ACCESS_WIFI on' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ACCESS_WIFI_INFORMATION)
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ACCESS_WIFI_INFORMATION)
         end
         it 'should make a request to turn ACCESS_WIFI off' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: false, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ACCESS_WIFI_INFORMATION)
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: false, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ACCESS_WIFI_INFORMATION)
         end
         it 'should make a request to turn DATA_PROTECTION complete' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::DATA_PROTECTION,
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::DATA_PROTECTION,
 settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings::DATA_PROTECTION_PERMISSION_LEVEL, options: [ { key: Spaceship::ConnectAPI::BundleIdCapability::Options::COMPLETE_PROTECTION } ] }])
         end
         it 'should make a request to turn DATA_PROTECTION unless_open' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::DATA_PROTECTION,
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::DATA_PROTECTION,
 settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings::DATA_PROTECTION_PERMISSION_LEVEL, options: [ { key: Spaceship::ConnectAPI::BundleIdCapability::Options::PROTECTED_UNLESS_OPEN } ] }])
         end
         it 'should make a request to turn DATA_PROTECTION until_first_auth' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::DATA_PROTECTION,
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::DATA_PROTECTION,
 settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings::DATA_PROTECTION_PERMISSION_LEVEL, options: [ { key: Spaceship::ConnectAPI::BundleIdCapability::Options::PROTECTED_UNTIL_FIRST_USER_AUTH } ] }])
         end
         it 'should make a request to turn DATA_PROTECTION off' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: false, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::DATA_PROTECTION)
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: false, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::DATA_PROTECTION)
         end
         it 'should make a request to turn ICLOUD xcode6_compatible' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ICLOUD,
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ICLOUD,
 settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings::ICLOUD_VERSION, options: [ { key: Spaceship::ConnectAPI::BundleIdCapability::Options::XCODE_5 } ] }])
         end
         it 'should make a request to turn ICLOUD xcode5_compatible' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ICLOUD,
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: true, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ICLOUD,
 settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings::ICLOUD_VERSION, options: [ { key: Spaceship::ConnectAPI::BundleIdCapability::Options::XCODE_6 } ] }])
         end
         it 'should make a request to turn ICLOUD off' do
-          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "XXXXXXXXXX", enabled: false, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ICLOUD)
+          client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", team_id: "XXXXXXXXXX", enabled: false, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ICLOUD)
         end
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
Resolves #21012

### Description
The function "patch_bundle_id_capability" takes parameter "seed_id" and get assigned to "teamId" inside attributes object. 

`def patch_bundle_id_capability(bundle_id_id:, seed_id:, enabled: false, capability_type:, settings: [])
          body = {
            data: {
              type: "bundleIds",
              id: bundle_id_id,
              attributes: {
                teamId: seed_id
              },
              relationships: {
                bundleIdCapabilities: {
                  data: [
                    {
                      type: "bundleIdCapabilities",
                      attributes: {
                          enabled: enabled,
                          settings: settings
                      },
                      relationships: {
                        capability: {
                          data: {
                              type: "capabilities",
                              id: capability_type
                            }
                        }
                      }
                    }
                  ]
                }
              }
            }
          }`

The above case is always not correct, especially when team id is not equal to app id prefix. Apple returns app id prefix as seed_id here and fastlane throws the below error:

"This request is forbidden for security reasons - Unable to find a team with the given Team ID 'XXXXXXXX' to which you belong."

Hence, I have set the team_id here instead of seed_id

### Testing Steps

`fastlane produce enable_services --username <username> --app_identifier <app id> --team_id <team id>  --associated-domains`

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
