### PR TITLE
[scan] replace the `simctl boot` command with `simctl bootstatus`, potentially fixing signal kill before running tests

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -204,9 +204,9 @@ module FastlaneCore
         return unless os_type == "iOS"
         return if self.state == 'Booted'
 
+        # Boot the simulator and wait for it to finish booting
         UI.message("Booting #{self}")
-
-        `xcrun simctl boot #{self.udid} 2>/dev/null`
+        `xcrun simctl bootstatus #{self.udid} -b &> /dev/null`
         self.state = 'Booted'
       end
 

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -512,6 +512,14 @@ describe FastlaneCore do
 
         device.disable_slide_to_type
       end
+
+      it "boots the simulator" do
+        device = FastlaneCore::DeviceManager::Device.new(os_type: "iOS", os_version: "13.0", is_simulator: true, state: nil)
+
+        device.boot
+
+        expect(device.state).to eq('Booted')
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Resolves https://github.com/fastlane/fastlane/issues/21025
Resolves https://github.com/fastlane/fastlane/issues/20341

### Details

Sometimes on CI, the `scan` action fails with `Early unexpected exit, operation never finished bootstrapping - no restart will be attempted. (Underlying Error: Test crashed with signal kill before starting test execution.` error message. This problem disappears if hard-booting the simulator and waiting for it to launch before running the `scan` action. 

So if we use the `simctl bootstatus` command instead of `boot` to load the simulator as part of the `scan` action, it will potentially solve this issue (at least it solves it for me). Keep in mind, that this will still require users to pass `:prelaunch_simulator` option to make it work: 

```ruby
scan(prelaunch_simulator: true)
```

To see the difference between `bootstatus` and `boot` use `xcrun simctl help` command, e.g.: `xcrun simctl help bootstatus`.

### Testing

To test this branch, modify your Gemfile as:

```ruby
gem 'fastlane', git: 'https://github.com/testableapple/fastlane.git', branch: 'wait-for-simulator-to-boot-before-scanning'
```

And run `bundle install` to apply the changes. 