### PR TITLE
[fastlane_core] New FASTLANE_WWDR_USE_HTTP1_AND_RETRIES env (feature flag) to use http 1.1 and retries when installing WWDC certs to fix some CI failures

### DIFF
--- a/fastlane/lib/fastlane/features.rb
+++ b/fastlane/lib/fastlane/features.rb
@@ -5,3 +5,6 @@
 
 FastlaneCore::Feature.register(env_var: 'FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS',
                                description: 'Use a newly implemented screenshots synchronization logic')
+
+FastlaneCore::Feature.register(env_var: 'FASTLANE_WWDR_USE_HTTP1_AND_RETRIES',
+                               description: 'Adds --http1.1 and --retry 3 --retry-all-errors to the curl command to download WWDR certificates')


### PR DESCRIPTION
### Motivation and Context

Fixes #20960 

Hopefully 😬🤞 

### Description

New `FASTLANE_WWDR_USE_HTTP1_AND_RETRIES` environment variable (feature flag) to add `--http1.1 --retry 3 --retry-all-errors` onto the `curl` command for downloading and install WWDR certificates

#### To use...

Set `FASTLANE_WWDR_USE_HTTP1_AND_RETRIES=true` in a `.env` file or in your CI's environment variable section
