### PR TITLE
[precheck] print the HTTP status as the failure reason when it's not 200

### DIFF
--- a/precheck/lib/precheck/rules/unreachable_urls_rule.rb
+++ b/precheck/lib/precheck/rules/unreachable_urls_rule.rb
@@ -33,7 +33,7 @@ module Precheck
             connection.use(FaradayMiddleware::FollowRedirects)
             connection.adapter(:net_http)
           end
-          return RuleReturn.new(validation_state: Precheck::VALIDATION_STATES[:failed], failure_data: url) unless request.head.status == 200
+          return RuleReturn.new(validation_state: Precheck::VALIDATION_STATES[:failed], failure_data: "HTTP #{request.head.status}: #{url}") unless request.head.status == 200
         rescue StandardError => e
           UI.verbose("URL #{url} not reachable 😵: #{e.message}")
           # I can only return :fail here, but I also want to return #{url}

--- a/precheck/spec/rules/unreachable_urls_rule_spec.rb
+++ b/precheck/spec/rules/unreachable_urls_rule_spec.rb
@@ -42,22 +42,22 @@ module Precheck
 
         result = rule.check_item(item)
         expect(result.status).to eq(VALIDATION_STATES[:failed])
-        expect(result.rule_return.failure_data).to eq("http://fastlane.tools")
+        expect(result.rule_return.failure_data).to eq("HTTP 500: http://fastlane.tools")
 
         setup_url_rule_mock(return_status: 404)
         result = rule.check_item(item)
         expect(result.status).to eq(VALIDATION_STATES[:failed])
-        expect(result.rule_return.failure_data).to eq("http://fastlane.tools")
+        expect(result.rule_return.failure_data).to eq("HTTP 404: http://fastlane.tools")
 
         setup_url_rule_mock(return_status: 409)
         result = rule.check_item(item)
         expect(result.status).to eq(VALIDATION_STATES[:failed])
-        expect(result.rule_return.failure_data).to eq("http://fastlane.tools")
+        expect(result.rule_return.failure_data).to eq("HTTP 409: http://fastlane.tools")
 
         setup_url_rule_mock(return_status: 403)
         result = rule.check_item(item)
         expect(result.status).to eq(VALIDATION_STATES[:failed])
-        expect(result.rule_return.failure_data).to eq("http://fastlane.tools")
+        expect(result.rule_return.failure_data).to eq("HTTP 403: http://fastlane.tools")
       end
 
       it "fails if not optional and URL is nil" do


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Any status code different than 200 would simply print the failing URL. But when that URL works fine for us, users, that's confusing. Showing explicitly what was the HTTP code received by fastlane's faraday script helps a lot identifying what the issue is.

### Description

N/A

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem 'fastlane', git: 'https://github.com/fastlane/fastlane.git', branch: 'rogerluan-improve-precheck-failure-reason'
```

And run `bundle install` to apply the changes. 

Here's a demo/sample:

![image](https://user-images.githubusercontent.com/8419048/218919132-7717cd65-0158-478b-ba4c-fe5a7d8a055a.png)