### PR TITLE
[spaceship] Fix Apple ID 2FA with SMS

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -61,9 +61,17 @@ module Spaceship
 
       # Send token to server to get a valid session
       r = request(:post) do |req|
-        req.url("https://idmsa.apple.com/appleauth/auth/verify/device/#{device_id}/securitycode")
+        req.url("https://idmsa.apple.com/appleauth/auth/verify/phone/securitycode")
         req.headers['Content-Type'] = 'application/json'
-        req.body = { "code" => code.to_s }.to_json
+        req.body = {
+          "phoneNumber": {
+            "id": device_id
+          },
+          "securityCode": {
+            "code" => code.to_s
+          },
+          "mode": "sms"
+        }.to_json
         update_request_headers(req)
       end
 


### PR DESCRIPTION
### Motivation and Context

Fixes #21071 

### Description

- Looks like Apple changed the endpoint for submitting 2FA codes
- Any previous sessions that attempted to be used were causing lockout (https://github.com/fastlane/fastlane/issues/21071#issuecomment-1442168994)

- [x] Fix for SMS
- [ ] Fix for Apple device code

_More info coming soon_

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-fix-apple-id-2fa"
```
