### PR TITLE
[spaceship] implements new hashcash header in auth flow

### DIFF
--- a/spaceship/lib/spaceship.rb
+++ b/spaceship/lib/spaceship.rb
@@ -3,6 +3,7 @@ require_relative 'spaceship/base'
 require_relative 'spaceship/client'
 require_relative 'spaceship/provider'
 require_relative 'spaceship/launcher'
+require_relative 'spaceship/hashcash'
 
 # Middleware
 require_relative 'spaceship/stats_middleware'

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -18,6 +18,7 @@ require_relative 'tunes/errors'
 require_relative 'globals'
 require_relative 'provider'
 require_relative 'stats_middleware'
+require_relative 'hashcash'
 
 Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
 
@@ -490,6 +491,11 @@ module Spaceship
           modified_cookie.gsub!(unescaped_important_cookie, escaped_important_cookie)
         end
 
+        # Fixes issue https://github.com/fastlane/fastlane/issues/21071
+        # On 2023-02-23, Apple added a custom implementation
+        # of hashcash to their auth flow
+        hashcash = self.fetch_hashcash
+
         response = request(:post) do |req|
           req.url("https://idmsa.apple.com/appleauth/auth/signin")
           req.body = data.to_json
@@ -498,6 +504,7 @@ module Spaceship
           req.headers['X-Apple-Widget-Key'] = self.itc_service_key
           req.headers['Accept'] = 'application/json, text/javascript'
           req.headers["Cookie"] = modified_cookie if modified_cookie
+          req.headers["X-APPLE-HC"] = hashcash if hashcash
         end
       rescue UnauthorizedAccessError
         raise InvalidUserCredentialsError.new, "Invalid username and password combination. Used '#{user}' as the username."
@@ -544,6 +551,21 @@ module Spaceship
       end
     end
     # rubocop:enable Metrics/PerceivedComplexity
+
+    def fetch_hashcash
+      response = request(:get, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=#{self.itc_service_key}")
+      headers = response.headers
+
+      bits = headers["x-apple-hc-bits"]
+      challenge = headers["x-apple-hc-challenge"]
+
+      if bits.nil? || challenge.nil?
+        puts("Unable to find 'x-apple-hc-bits' and 'x-apple-hc-challenge' to make hashcash")
+        return nil
+      end
+
+      return Spaceship::Hashcash.make(bits: bits, challenge: challenge)
+    end
 
     # Get the `itctx` from the new (22nd May 2017) API endpoint "olympus"
     # Update (29th March 2019) olympus migrates to new appstoreconnect API

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -494,6 +494,7 @@ module Spaceship
         # Fixes issue https://github.com/fastlane/fastlane/issues/21071
         # On 2023-02-23, Apple added a custom implementation
         # of hashcash to their auth flow
+        # hashcash = nil
         hashcash = self.fetch_hashcash
 
         response = request(:post) do |req|
@@ -504,7 +505,7 @@ module Spaceship
           req.headers['X-Apple-Widget-Key'] = self.itc_service_key
           req.headers['Accept'] = 'application/json, text/javascript'
           req.headers["Cookie"] = modified_cookie if modified_cookie
-          req.headers["X-APPLE-HC"] = hashcash if hashcash
+          req.headers["X-Apple-HC"] = hashcash if hashcash
         end
       rescue UnauthorizedAccessError
         raise InvalidUserCredentialsError.new, "Invalid username and password combination. Used '#{user}' as the username."
@@ -556,11 +557,11 @@ module Spaceship
       response = request(:get, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=#{self.itc_service_key}")
       headers = response.headers
 
-      bits = headers["x-apple-hc-bits"]
-      challenge = headers["x-apple-hc-challenge"]
+      bits = headers["X-Apple-HC-Bits"]
+      challenge = headers["X-Apple-HC-Challenge"]
 
       if bits.nil? || challenge.nil?
-        puts("Unable to find 'x-apple-hc-bits' and 'x-apple-hc-challenge' to make hashcash")
+        puts("Unable to find 'X-Apple-HC-Bits' and 'X-Apple-HC-Challenge' to make hashcash")
         return nil
       end
 

--- a/spaceship/lib/spaceship/hashcash.rb
+++ b/spaceship/lib/spaceship/hashcash.rb
@@ -1,0 +1,52 @@
+require 'digest'
+
+module Spaceship
+  module Hashcash
+    # This App Store Connect hashcash spec was generously donated by...
+    #
+    #                         __  _
+    #    __ _  _ __   _ __   / _|(_)  __ _  _   _  _ __  ___  ___
+    #   / _` || '_ \ | '_ \ | |_ | | / _` || | | || '__|/ _ \/ __|
+    #  | (_| || |_) || |_) ||  _|| || (_| || |_| || |  |  __/\__ \
+    #   \__,_|| .__/ | .__/ |_|  |_| \__, | \__,_||_|   \___||___/
+    #         |_|    |_|             |___/
+    #
+    #
+    # <summary>
+    #             1:11:20230223170600:4d74fb15eb23f465f1f6fcbf534e5877::6373
+    # X-APPLE-HC: 1:11:20230223170600:4d74fb15eb23f465f1f6fcbf534e5877::6373
+    #             ^  ^      ^                       ^                     ^
+    #             |  |      |                       |                     +-- Counter
+    #             |  |      |                       +-- Resource
+    #             |  |      +-- Date YYMMDD[hhmm[ss]]
+    #             |  +-- Bits (number of leading zeros)
+    #             +-- Version
+    #
+    # We can't use an off-the-shelf Hashcash because Apple's implementation is not quite the same as the spec/convention.
+    #  1. The spec calls for a nonce called "Rand" to be inserted between the Ext and Counter. They don't do that at all.
+    #  2. The Counter conventionally encoded as base-64 but Apple just uses the decimal number's string representation.
+    #
+    # Iterate from Counter=0 to Counter=N finding an N that makes the SHA1(X-APPLE-HC) lead with Bits leading zero bits
+    #
+    #
+    # We get the "Resource" from the X-Apple-HC-Challenge header and Bits from X-Apple-HC-Bits
+    #
+    # </summary>
+    def self.make(bits:, challenge:)
+      version = 1
+      date = Time.now.strftime("%Y%m%d%H%M%S")
+
+      counter = 0
+      loop do
+        hc = [
+          version, bits, date, challenge, ":#{counter}"
+        ].join(":")
+
+        if Digest::SHA1.digest(hc).unpack1('B*')[0, bits.to_i].to_i == 0
+          return hc
+        end
+        counter += 1
+      end
+    end
+  end
+end

--- a/spaceship/spec/hashcash_spec.rb
+++ b/spaceship/spec/hashcash_spec.rb
@@ -1,0 +1,15 @@
+describe Spaceship::Hashcash do
+  it "makes hashcash with 11 bits" do
+    allow_any_instance_of(Time).to receive(:strftime).and_return("20230223170600")
+
+    sha = Spaceship::Hashcash.make(bits: "11", challenge: "4d74fb15eb23f465f1f6fcbf534e5877")
+    expect(sha).to eq("1:11:20230223170600:4d74fb15eb23f465f1f6fcbf534e5877::6373")
+  end
+
+  it "finds hashcash with 12 bits" do
+    allow_any_instance_of(Time).to receive(:strftime).and_return("20230223213732")
+
+    sha = Spaceship::Hashcash.make(bits: "12", challenge: "f8b58554b2f22960fc0dc99aea342276")
+    expect(sha).to eq("1:12:20230223213732:f8b58554b2f22960fc0dc99aea342276::2381")
+  end
+end

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -13,7 +13,6 @@ describe Spaceship::Client do
     end
 
     it 'raises an exception if authentication failed' do
-      allow(subject).to receive(:itc_service_key).and_return("12345")
       expect do
         subject.login('bad-username', 'bad-password')
       end.to raise_exception(Spaceship::Client::InvalidUserCredentialsError)

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -13,6 +13,7 @@ describe Spaceship::Client do
     end
 
     it 'raises an exception if authentication failed' do
+      allow(subject).to receive(:itc_service_key).and_return("12345")
       expect do
         subject.login('bad-username', 'bad-password')
       end.to raise_exception(Spaceship::Client::InvalidUserCredentialsError)

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -1,7 +1,6 @@
 describe Spaceship::TunesClient do
   describe '#login' do
     it 'raises an exception if authentication failed' do
-      allow(subject).to receive(:itc_service_key).and_return("12345")
       expect do
         subject.login('bad-username', 'bad-password')
       end.to raise_exception(Spaceship::Client::InvalidUserCredentialsError, "Invalid username and password combination. Used 'bad-username' as the username.")
@@ -10,7 +9,6 @@ describe Spaceship::TunesClient do
 
   describe 'client' do
     it 'exposes the session cookie' do
-      allow(subject).to receive(:itc_service_key).and_return("12345")
       begin
         subject.login('bad-username', 'bad-password')
       rescue Spaceship::Client::InvalidUserCredentialsError

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -1,6 +1,7 @@
 describe Spaceship::TunesClient do
   describe '#login' do
     it 'raises an exception if authentication failed' do
+      allow(subject).to receive(:itc_service_key).and_return("12345")
       expect do
         subject.login('bad-username', 'bad-password')
       end.to raise_exception(Spaceship::Client::InvalidUserCredentialsError, "Invalid username and password combination. Used 'bad-username' as the username.")
@@ -9,6 +10,7 @@ describe Spaceship::TunesClient do
 
   describe 'client' do
     it 'exposes the session cookie' do
+      allow(subject).to receive(:itc_service_key).and_return("12345")
       begin
         subject.login('bad-username', 'bad-password')
       rescue Spaceship::Client::InvalidUserCredentialsError
@@ -21,6 +23,11 @@ describe Spaceship::TunesClient do
     subject { Spaceship::Tunes.client }
     let(:username) { 'spaceship@krausefx.com' }
     let(:password) { 'so_secret' }
+
+    before(:each) do
+      # Don't need to test hashcash here
+      allow_any_instance_of(Spaceship::Client).to receive(:fetch_hashcash)
+    end
 
     it 'has authType is sa' do
       response = double

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -31,6 +31,8 @@ class TunesStubbing
         to_return(status: 200, body: "", headers: {})
 
       # Actual login
+      stub_request(:get, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=12345").
+        to_return(status: 200, body: '', headers: { 'x-apple-hc-bits' => "12", 'x-apple-hc-challenge' => "f8b58554b2f22960fc0dc99aea342276" })
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").
         with(body: { "accountName" => "spaceship@krausefx.com", "password" => "so_secret", "rememberMe" => true }.to_json).
         to_return(status: 200, body: '{}', headers: { 'Set-Cookie' => "myacinfo=abcdef;" })

--- a/spaceship/spec/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/tunes/tunes_stubbing.rb
@@ -31,7 +31,7 @@ class TunesStubbing
         to_return(status: 200, body: "", headers: {})
 
       # Actual login
-      stub_request(:get, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=12345").
+      stub_request(:get, "https://idmsa.apple.com/appleauth/auth/signin?widgetKey=e0abc").
         to_return(status: 200, body: '', headers: { 'x-apple-hc-bits' => "12", 'x-apple-hc-challenge' => "f8b58554b2f22960fc0dc99aea342276" })
       stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin").
         with(body: { "accountName" => "spaceship@krausefx.com", "password" => "so_secret", "rememberMe" => true }.to_json).


### PR DESCRIPTION
### Motivation and Context

Fixes #21071

### Description

Apple requires the `X-APPLE-HC` header when signing in to `https://idmsa.apple.com/appleauth/auth/signin`. Leaving out this header results in forbidden access and possible Apple ID account lockout.

`X-APPLE-HC` uses a customer implementation of http://www.hashcash.org/

1. GET to `https://idmsa.apple.com/appleauth/auth/signin`
2. Use response headers `x-apple-hc-bits` and `x-apple-hc-challenge` to make hashcash
3. Set hashcash to `X-APPLE-HC` header on login

And big big thank you to [Ariel Michaeli](https://twitter.com/arielmichaeli) and his team at [Appfigures](https://appfigures.com) for sharing Apple's hashcash spec with us so ❤️ 

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "joshdholtz-implement-hashcash"
```
