### PR TITLE
Increase limit for build query in distribute to handle multiple platforms

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -157,7 +157,7 @@ module Pilot
           end
         end
         platform = Spaceship::ConnectAPI::Platform.map(fetch_app_platform)
-        build ||= Spaceship::ConnectAPI::Build.all(app_id: app.id, version: app_version, build_number: build_number, sort: "-uploadedDate", platform: platform, limit: 1).first
+        build ||= Spaceship::ConnectAPI::Build.all(app_id: app.id, version: app_version, build_number: build_number, sort: "-uploadedDate", platform: platform, limit: Spaceship::ConnectAPI::Platform.size).first
       end
 
       # Verify the build has all the includes that we need


### PR DESCRIPTION
The platform condition is filtered on the client side, so enough builds need to be returned to find the correct platform.


### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context

When using `fastlane pilot distribute --app_platform` fastlane only queries for one result even though the platform param needs to query on the client side. This makes sure enough entries are returned to do the client side filtering.

### Description

Increases the limit of the query from `1` to `Spaceship::ConnectAPI::Platform.size`.


### Testing Steps

Have a build that has several platforms and try to distribute them separately on testflight.