### PR TITLE
[ci] Only run all mac jobs on master and version bump branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,12 @@ orbs:
     shellcheck: circleci/shellcheck@2.2.2 # brew install shellcheck stopped working so using this
 
 aliases:
+  - &important-branches
+    filters:
+      branches:
+        only:
+          - main
+          - /^version\-bump\-.*/
   # common - cache
   - &cache_restore_git
     restore_cache:
@@ -258,16 +264,19 @@ workflows:
           name: 'Execute tests on macOS (Xcode 11.7.0, Ruby 2.6)'
           xcode_version: '11.7.0'
           ruby_version: '2.6'
+          <<: *important-branches
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 12.5.1, Ruby 2.7)'
           xcode_version: '12.5.1'
           ruby_version: '2.7'
           ruby_opt: -W:deprecated
+          <<: *important-branches
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.0.0, Ruby 3.0)'
           xcode_version: '13.0.0'
           ruby_version: '3.0'
           ruby_opt: -W:deprecated
+          <<: *important-branches
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.0.0, Ruby 3.1)'
           xcode_version: '13.0.0'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ aliases:
     filters:
       branches:
         only:
-          - main
+          - master
           - /^version\-bump\-.*/
   # common - cache
   - &cache_restore_git


### PR DESCRIPTION
### Motivation and Context

We ran out of CircleCI credits last month for macOS jobs so trying to lighten our ussage a little bit.

### Description

Only run full macOS suite on `master` and `version-bump-<x.y.x>` branches.

