### PR TITLE
[fastlane_core] remove expired WWDR G1 certificate from cert_checker

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -7,11 +7,6 @@ require_relative 'helper'
 # WWDR Intermediate Certificates in https://www.apple.com/certificateauthority/
 WWDRCA_CERTIFICATES = [
   {
-    alias: 'G1',
-    sha256: 'ce057691d730f89ca25e916f7335f4c8a15713dcd273a658c024023f8eb809c2',
-    url: 'https://developer.apple.com/certificationauthority/AppleWWDRCA.cer'
-  },
-  {
     alias: 'G2',
     sha256: '9ed4b3b88c6a339cf1387895bda9ca6ea31a6b5ce9edf7511845923b0c8ac94c',
     url: 'https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer'

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -11,7 +11,7 @@ describe FastlaneCore do
 
     describe '#installed_identies' do
       it 'should print an error when no local code signing identities are found' do
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G1', 'G2', 'G3', 'G4', 'G5', 'G6'])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5', 'G6'])
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     0 valid identities found\n")
         expect(FastlaneCore::UI).to receive(:error).with(/There are no local code signing identities found/)
 
@@ -19,7 +19,7 @@ describe FastlaneCore do
       end
 
       it 'should not be fooled by 10 local code signing identities available' do
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G1', 'G2', 'G3', 'G4', 'G5', 'G6'])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5', 'G6'])
         allow(FastlaneCore::CertChecker).to receive(:list_available_identities).and_return("     10 valid identities found\n")
         expect(FastlaneCore::UI).not_to(receive(:error))
 
@@ -55,7 +55,6 @@ describe FastlaneCore do
     describe '#install_missing_wwdr_certificates' do
       it 'should install all official WWDR certificates' do
         allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return([])
-        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G1')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G2')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G3')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G4')
@@ -66,16 +65,12 @@ describe FastlaneCore do
 
       it 'should install the missing official WWDR certificate' do
         allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5'])
-        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G1')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G6')
         FastlaneCore::CertChecker.install_missing_wwdr_certificates
       end
 
       it 'should download the WWDR certificate from correct URL' do
         allow(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return('login.keychain')
-
-        expect(Open3).to receive(:capture3).with(include('https://developer.apple.com/certificationauthority/AppleWWDRCA.cer')).and_return(["", "", success_status])
-        FastlaneCore::CertChecker.install_wwdr_certificate('G1')
 
         expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('G2')
@@ -118,7 +113,7 @@ describe FastlaneCore do
           expect(Open3).to receive(:capture3).with(cmd).and_return(["", "", success_status])
           expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G1', 'G2', 'G3', 'G4', 'G5'])
+          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5'])
           expect(FastlaneCore::CertChecker.install_missing_wwdr_certificates).to be(1)
         end
 


### PR DESCRIPTION
🔑<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->


### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.

### Motivation and Context
Last february the G1 intermediate WWDR certificate expired. The CertChecker still tries to install it, when it is not installed. This PR removes the G1 cert from Fastlane.
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Removed the G1 item from the array in the CertChecker. Updated tests so they don't reference /check the item anymore

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
