### PR TITLE
[notarize] preserve meta-data and symlinks

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -23,7 +23,7 @@ module Fastlane
         if File.extname(package_path) == '.app'
           compressed_package_path = "#{package_path}.zip"
           Actions.sh(
-            "ditto -c -k --rsrc --keepParent \"#{package_path}\" \"#{compressed_package_path}\"",
+            "ditto -c -k --rsrc --sequesterRsrc --keepParent \"#{package_path}\" \"#{compressed_package_path}\"",
             log: verbose
           )
 


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
When using `notarize` the implementation of `ditto` causes the archived app to be different in comparison to the original one , the current way it's being done doesn't preserve meta data or symlinks. 
This lead to the app being damaged after running notarize. 

Resolves #20828

### Description
<!-- Describe your changes in detail. -->
Adding an extra parameter to the ditto command `--sequesterRsrc` fixes this issue .
https://ss64.com/osx/ditto.html
<!-- Please describe in detail how you tested your changes. -->
To test it i compared the output app with the original one previously it showed these changes 

```shell
diff -q -r original.app produced.app

Only in produced.app/Contents/Frameworks/Factory_32A9B87E1196645F_PackageProduct.framework: ._Factory_32A9B87E1196645F_PackageProduct
Only in produced.app/Contents/Frameworks/Factory_32A9B87E1196645F_PackageProduct.framework: ._Resources
Only in produced.app/Contents/Frameworks/Factory_32A9B87E1196645F_PackageProduct.framework/Versions: ._Current
Only in produced.app/Contents/Frameworks/Paddle.framework: ._Paddle
``` 
after the fix it showed none. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
`diff -q -r produced.app original.app`
If needed i could provide a copy of the app bundle with the issue.