### PR TITLE
Adding G7 certificate to WWDRCA list

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -35,6 +35,11 @@ WWDRCA_CERTIFICATES = [
     alias: 'G6',
     sha256: 'bdd4ed6e74691f0c2bfd01be0296197af1379e0418e2d300efa9c3bef642ca30',
     url: 'https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer'
+  },
+  {
+    alias: 'G7',
+    sha256: '0f570d7502373a2102e2106faaa8fa4844944a07ee676198484f4d6ce15bea47',
+    url: 'https://www.apple.com/certificateauthority/AppleWWDRCAG7.cer'
   }
 ]
 

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -61,6 +61,7 @@ describe FastlaneCore do
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G4')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G5')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G6')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G7')
         FastlaneCore::CertChecker.install_missing_wwdr_certificates
       end
 
@@ -68,6 +69,7 @@ describe FastlaneCore do
         allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5'])
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G1')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G6')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G7')
         FastlaneCore::CertChecker.install_missing_wwdr_certificates
       end
 
@@ -112,13 +114,13 @@ describe FastlaneCore do
           `ls`
 
           keychain = "keychain with spaces.keychain"
-          cmd = %r{curl -f -o (([A-Z]\:)?\/.+) https://www\.apple\.com/certificateauthority/AppleWWDRCAG6\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
+          cmd = %r{curl -f -o (([A-Z]\:)?\/.+) https://www\.apple\.com/certificateauthority/AppleWWDRCAG7\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
           require "open3"
 
           expect(Open3).to receive(:capture3).with(cmd).and_return(["", "", success_status])
           expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G1', 'G2', 'G3', 'G4', 'G5'])
+          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G1', 'G2', 'G3', 'G4', 'G5', 'G6'])
           expect(FastlaneCore::CertChecker.install_missing_wwdr_certificates).to be(1)
         end
 
@@ -129,13 +131,13 @@ describe FastlaneCore do
           stub_const('ENV', { "FASTLANE_WWDR_USE_HTTP1_AND_RETRIES" => "true" })
 
           keychain = "keychain with spaces.keychain"
-          cmd = %r{curl --http1.1 --retry 3 --retry-all-errors -f -o (([A-Z]\:)?\/.+) https://www\.apple\.com/certificateauthority/AppleWWDRCAG6\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
+          cmd = %r{curl --http1.1 --retry 3 --retry-all-errors -f -o (([A-Z]\:)?\/.+) https://www\.apple\.com/certificateauthority/AppleWWDRCAG7\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
           require "open3"
 
           expect(Open3).to receive(:capture3).with(cmd).and_return(["", "", success_status])
           expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G1', 'G2', 'G3', 'G4', 'G5'])
+          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G1', 'G2', 'G3', 'G4', 'G5', 'G6'])
           expect(FastlaneCore::CertChecker.install_missing_wwdr_certificates).to be(1)
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Apple recently released a new Worldwide Developer Relations intermediate certificate. This change adds the new certificate to the `WWDRCA_CERTIFICATES` list so it can be automatically installed on systems when it is missing.

https://www.apple.com/certificateauthority/

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
