### PR TITLE
[increment_version_number] Fixed `agvtool` sometimes deleting project.pbxproj

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -37,6 +37,7 @@ module Fastlane
           UI.verbose(version_format_error(current_version)) unless current_version =~ version_regex
 
           # Specific version
+          UI.user_error!(version_number_format_error(params[:version_number])) unless params[:version_number] =~ version_regex
           next_version_number = params[:version_number]
         else
           UI.user_error!(version_format_error(current_version)) unless current_version =~ version_regex
@@ -90,6 +91,10 @@ module Fastlane
 
       def self.version_format_error(version)
         "Your current version (#{version}) does not respect the format A or A.B or A.B.C"
+      end
+
+      def self.version_number_format_error(version)
+        "The version_number parameter (#{version}) does not respect the format A or A.B or A.B.C"
       end
 
       def self.version_token_error

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -149,6 +149,14 @@ describe Fastlane do
           end.to raise_error("Your current version (#{version}) does not respect the format A or A.B or A.B.C")
         end
       end
+
+      it "raises an exception when version_number is not formatted as a SemVer" do
+        expect do
+          Fastlane::FastFile.new.parse("lane :test do
+            increment_version_number(version_number: 'release/1.2.3')
+          end").runner.execute(:test)
+        end.to raise_error("The version_number parameter (release/1.2.3) does not respect the format A or A.B or A.B.C")
+      end
     end
   end
 end


### PR DESCRIPTION
This commit fixes an issue with `agvtool` sometimes deleting the `project.pbxproj`.
If the version number contains a '/', `agvtool` will trigger a `sed` error, and erase the `.pbxproj` file.
So I make sure that the `version_number` is SemVer formatted before running `agvtool`.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
We stumbled upon this bug when setting the `version_number` to the git branch `release/1.2.3` instead of the git tag `1.2.3`
```ruby
increment_version_number(version_number: 'release/1.2.3')
```
`agvtool` errored with:
> [15:02:39]: ▸ Setting CFBundleShortVersionString of project OUR_PROJECT to:
> [15:02:39]: ▸ release/1.2.3.
> [15:02:39]: ▸ sed: 1: "/<key>CFBundleShortVers ...": bad flag in substitute command: '_'

and emptied the contents of the `project.pbxproj`.
You can reproduce the damage by running:
```bash
# DO NOT RUN THIS
agvtool new-marketing-version release/1.2.3 # DANGER
```
### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
I added a SemVer check on the `version_number` variable before running `agvtool new-marketing-version`.
And I added a test to make sure it works.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
```bash
bundle exec rspec ./fastlane/spec/actions_specs/increment_version_number_action_spec.rb
```
