### PR TITLE
Remove deprecated attributes from apps requests

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -59,7 +59,7 @@ module Spaceship
       })
 
       ESSENTIAL_INCLUDES = [
-        "appStoreVersions",
+        "appStoreVersions"
       ].join(",")
 
       def self.type

--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -54,12 +54,12 @@ module Spaceship
         "contentRightsDeclaration" => "content_rights_declaration",
 
         "appStoreVersions" => "app_store_versions",
+        # This attribute is already deprecated. It will be removed in a future release.
         "prices" => "prices"
       })
 
       ESSENTIAL_INCLUDES = [
         "appStoreVersions",
-        "prices"
       ].join(",")
 
       def self.type

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -272,7 +272,7 @@ module Spaceship
       # if it needs to
       #
       # https://github.com/fastlane/fastlane/pull/20480
-      r = request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?include=appStoreVersions,prices")
+      r = request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?include=appStoreVersions")
       response = Spaceship::ConnectAPI::Response.new(
         body: r.body,
         status: r.status,

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -18,10 +18,10 @@ class ConnectAPIStubbing
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps").
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 
-        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?include=appStoreVersions,prices").
+        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?include=appStoreVersions").
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 
-        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?filter%5BbundleId%5D=com.joshholtz.FastlaneTest&include=appStoreVersions,prices").
+        stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps?filter%5BbundleId%5D=com.joshholtz.FastlaneTest&include=appStoreVersions").
           to_return(status: 200, body: read_fixture_file('apps.json'), headers: { 'Content-Type' => 'application/json' })
 
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/apps/123456789").


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

closes #21125

This PR fixes this issue.
[Listing apps fails, due to the recent pricing update on App Store? · Issue #21125 · fastlane/fastlane](https://github.com/fastlane/fastlane/issues/21125)

### Description

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

Since App Store Connect API 2.3([released on March 2023](https://developer.apple.com/news/releases/?id=03092023b)), `App.prices` has been deprecated. 
https://developer.apple.com/documentation/appstoreconnectapi/app/relationships/prices

After this version, the following 409 error is returned when requested with including`prices` attributes.

```
The resource 'appPrices' cannot be viewed, created or updated. Please view and create 'manualPrices' using the resource 'appPriceSchedules'.
```

However, `prices` are always included as an essential attribute.

This PR removes `prices` from `ESSENTIAL_INCLUDES`.

### Testing Steps

1. Enable scheduled prices for your app on AppStore Connect
2. Execute the following lane

```ruby
lane :app_version do
  app_store_connect_api_key 
  app_store_build_number
end
```

### Discussion

This PR is just a hotfix. We need to support the new price API to fetch prices.

The current response mock is old. So we have to update this to follow the latest API spec.
https://github.com/fastlane/fastlane/blob/0c06ab0d8049b1c4012dc5305b190c7f5f825de1/spaceship/spec/connect_api/fixtures/testflight/apps.json#L113