### PR TITLE
Update a bit of the documentation of install_on_device.rb

### DIFF
--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -68,7 +68,7 @@ module Fastlane
       end
 
       def self.details
-        "Installs the ipa on the device. If no id is given, the first found iOS device will be used. Works via USB or Wi-Fi. This requires `ios-deploy` to be installed. Please have a look at [ios-deploy](https://github.com/ios-control/ios-deploy). To quickly install it, use `npm -g i ios-deploy`"
+        "Installs the ipa on the device. If no id is given, the first found iOS device will be used. Works via USB or Wi-Fi. This requires `ios-deploy` to be installed. Please have a look at [ios-deploy](https://github.com/ios-control/ios-deploy). To quickly install it, use `brew install ios-deploy`"
       end
 
       def self.is_supported?(platform)


### PR DESCRIPTION
It seems that the ios-deploy project's README.md suggests the use of `brew` over `npm` for installing their package since 2019. https://github.com/ios-control/ios-deploy/commit/3714fc19f5b93e60e586b667363af1784cac0e50

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Documentation includes outdated instructions

### Description
Change the method of installation of the `ios-deploy` package suggested by fastlane documentation.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
