### PR TITLE
Fix accessing first element of nil array in upload_price_tier

### DIFF
--- a/deliver/lib/deliver/upload_price_tier.rb
+++ b/deliver/lib/deliver/upload_price_tier.rb
@@ -21,7 +21,7 @@ module Deliver
       # Need to get prices from the app's relationships
       # Prices from app's relationship doess not have price tier so need to fetch app price with price tier relationship
       app_prices = app.prices
-      if app_prices.first
+      if app_prices && app_prices.first
         app_price = Spaceship::ConnectAPI.get_app_price(app_price_id: app_prices.first.id, includes: "priceTier").first
         old_price = app_price.price_tier.id
       else

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -160,9 +160,7 @@ module Spaceship
             included << {
               type: "appPrices",
               id: "${price1}",
-              attributes: {
-                startDate: nil
-              },
+              attributes: {},
               relationships: {
                 app: {
                   data: {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #21199

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
Error "undefined method `first' for nil:NilClass" indicates attempting to treat nil as an array. Adding pre-condition to check if the array is not nil fixes that. Also the startDate attribute of the resource appPrices in spaceship does not exist anymore and must be removed.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Calling the deliver action for apps with unspecified prices now works as expected. 
