### PR TITLE
Ability to clear purchase history for a sandbox tester

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/sandbox_tester.rb
+++ b/spaceship/lib/spaceship/connect_api/models/sandbox_tester.rb
@@ -62,6 +62,11 @@ module Spaceship
         client ||= Spaceship::ConnectAPI
         client.delete_sandbox_tester(sandbox_tester_id: id)
       end
+
+      def clear_purchase_history(client: nil)
+        client ||= Spaceship::ConnectAPI
+        client.clear_sandbox_tester_purchase_history(sandbox_tester_id: id)
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -1244,6 +1244,27 @@ module Spaceship
           tunes_request_client.delete("sandboxTesters/#{sandbox_tester_id}", params)
         end
 
+        def clear_sandbox_tester_purchase_history(sandbox_tester_id: nil)
+          relationships = {
+            sandboxTesters: {
+              data: [
+                {
+                  type: "sandboxTesters",
+                  id: sandbox_tester_id
+                }
+              ]
+            }
+          }
+          body = {
+            data: {
+              type: "sandboxTestersClearPurchaseHistoryRequest",
+              relationships: relationships
+            }
+          }
+          url_or_path = tunes_request_client.token.nil? ? "sandboxTestersClearPurchaseHistoryRequest" : "https://api.appstoreconnect.apple.com/v2/sandboxTestersClearPurchaseHistoryRequest"
+          tunes_request_client.post(url_or_path, body)
+        end
+
         #
         # territories
         #


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

#21243 
An I/F to clear purchase history for a sandbox tester is missing. This PR implements this feature via App Store Connect.

### Testing Steps

I debugged using `bundle exec fastlane spaceship` commnad.

```ruby
Spaceship::ConnectAPI::Client.login(...)

# With Apple ID Login
tester = Spaceship::ConnectAPI::SandboxTester.all.first
tester.clear_purchase_history

# With App Store Connect API Token
Spaceship::ConnectAPI::token = Spaceship::ConnectAPI::Token.create(...)
tester.clear_purchase_history
```
