### PR TITLE
Update custom `metadata_path` example to actual default value. 

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -98,7 +98,7 @@ deliver
 deliver(
   submit_for_review: true,
   force: true,
-  metadata_path: "./metadata"
+  metadata_path: "./fastlane/metadata"
 )
 ```
 


### PR DESCRIPTION
### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Current `./metadata` example can be easily misinterpreted to mean that `metadata_path` is relative to `fastlane/` directory and not the project root directory.


### Description
Update custom `metadata_path` example to actual default value. 

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
