### PR TITLE
Adding access token prompt for GitLab Secure Files Match

### DIFF
--- a/match/lib/match/storage/gitlab/client.rb
+++ b/match/lib/match/storage/gitlab/client.rb
@@ -69,32 +69,56 @@ module Match
               "name" => target_file
             )
 
-            response = execute_request(url, request)
-
-            log_upload_error(response, target_file) if response.code != "201"
+            execute_request(url, request, target_file)
           end
         end
 
-        def log_upload_error(response, target_file)
-          begin
-            response_body = JSON.parse(response.body)
-          rescue JSON::ParserError
-            response_body = response.body
-          end
-
-          if response_body["message"] && (response_body["message"]["name"] == ["has already been taken"])
-            UI.error("#{target_file} already exists in GitLab project #{@project_id}, file not uploaded")
-          else
-            UI.error("Upload error for #{target_file}: #{response_body}")
-          end
-        end
-
-        def execute_request(url, request)
+        def execute_request(url, request, target_file = nil)
           request[authentication_key] = authentication_value
 
           http = Net::HTTP.new(url.host, url.port)
           http.use_ssl = url.instance_of?(URI::HTTPS)
-          http.request(request)
+
+          begin
+            response = http.request(request)
+          rescue Errno::ECONNREFUSED, SocketError => message
+            UI.user_error!("GitLab connection error: #{message}")
+          end
+
+          unless response.kind_of?(Net::HTTPSuccess)
+            handle_response_error(response, target_file)
+          end
+
+          response
+        end
+
+        def handle_response_error(response, target_file = nil)
+          error_prefix      = "GitLab storage error:"
+          file_debug_string = "File: #{target_file}" unless target_file.nil?
+          api_debug_string  = "API: #{@api_v4_url}"
+          debug_info        = "(#{[file_debug_string, api_debug_string].compact.join(', ')})"
+
+          begin
+            parsed = JSON.parse(response.body)
+          rescue JSON::ParserError
+          end
+
+          if parsed && parsed["message"] && (parsed["message"]["name"] == ["has already been taken"])
+            error_handler = :error
+            error = "#{target_file} already exists in GitLab project #{@project_id}, file not uploaded"
+          else
+            error_handler = :user_error!
+            error = "#{response.code}: #{response.body}"
+          end
+          error_message = [error_prefix, error, debug_info].join(' ')
+
+          UI.send(error_handler, error_message)
+        end
+
+        def prompt_for_access_token
+          unless authentication_key
+            @private_token = UI.input("Please supply a GitLab personal or project access token: ")
+          end
         end
       end
     end

--- a/match/lib/match/storage/gitlab_secure_files.rb
+++ b/match/lib/match/storage/gitlab_secure_files.rb
@@ -47,7 +47,8 @@ module Match
           team_id: params[:team_id],
           team_name: params[:team_name],
           api_key_path: params[:api_key_path],
-          api_key: params[:api_key]
+          api_key: params[:api_key],
+          gitlab_host: params[:gitlab_host]
         )
       end
 
@@ -60,7 +61,8 @@ module Match
                      team_id: nil,
                      team_name: nil,
                      api_key_path: nil,
-                     api_key: nil)
+                     api_key: nil,
+                     gitlab_host: nil)
 
         @readonly = readonly
         @username = username
@@ -68,6 +70,7 @@ module Match
         @team_name = team_name
         @api_key_path = api_key_path
         @api_key = api_key
+        @gitlab_host = gitlab_host
 
         @job_token = job_token
         @private_token = private_token
@@ -95,6 +98,8 @@ module Match
       end
 
       def download
+        gitlab_client.prompt_for_access_token
+
         # Check if we already have a functional working_directory
         return if @working_directory
 

--- a/match/spec/storage/gitlab/client_spec.rb
+++ b/match/spec/storage/gitlab/client_spec.rb
@@ -127,41 +127,146 @@ describe Match do
       end
     end
 
-    describe '#log_upload_error' do
-      it 'logs a custom error message when the file name has already been taken' do
-        expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("foo already exists in GitLab project sample/project, file not uploaded")
+    # describe '#log_upload_error' do
+    #   it 'logs a custom error message when the file name has already been taken' do
+    #     expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("foo already exists in GitLab project sample/project, file not uploaded")
+
+    #     response_body = { message: { name: ["has already been taken" ] } }.to_json
+    #     response = OpenStruct.new(code: "400", body: response_body)
+    #     target_file = 'foo'
+    #     subject.log_upload_error(response, target_file)
+    #   end
+
+    #   it 'logs the returned error message when an unexpected JSON response is returned' do
+    #     expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: {\"message\"=>{\"bar\"=>\"baz\"}}")
+
+    #     response_body = { message: { bar: "baz" } }.to_json
+    #     response = OpenStruct.new(code: "500", body: response_body)
+    #     target_file = 'foo'
+    #     subject.log_upload_error(response, target_file)
+    #   end
+
+    #   it 'logs the returned error message when an unexpected JSON response is returned' do
+    #     expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: {\"foo\"=>{\"bar\"=>\"baz\"}}")
+
+    #     response_body = { foo: { bar: "baz" } }.to_json
+    #     response = OpenStruct.new(code: "500", body: response_body)
+    #     target_file = 'foo'
+    #     subject.log_upload_error(response, target_file)
+    #   end
+
+    #   it 'logs the returned error message when a non-JSON response is returned' do
+    #     expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: a generic error message")
+
+    #     response = OpenStruct.new(code: "500", body: "a generic error message")
+    #     target_file = 'foo'
+    #     subject.log_upload_error(response, target_file)
+    #   end
+    # end
+
+    describe '#prompt_for_access_token' do
+      it 'prompts the users for an access token if authentication is not supplied' do
+        client = described_class.new(
+          api_v4_url: 'https://gitlab.example.com/api/v4',
+          project_id: 'sample/project'
+        )
+        expect(UI).to receive(:input).with('Please supply a GitLab personal or project access token: ')
+        client.prompt_for_access_token
+      end
+
+      it 'does not prompt the user for an access token when a job token is supplied' do
+        client = described_class.new(
+          api_v4_url: 'https://gitlab.example.com/api/v4',
+          project_id: 'sample/project',
+          job_token: 'abc123'
+        )
+        expect(UI).not_to receive(:input)
+        client.prompt_for_access_token
+      end
+
+      it 'does not prompt the user for an access token when a private token is supplied' do
+        client = described_class.new(
+          api_v4_url: 'https://gitlab.example.com/api/v4',
+          project_id: 'sample/project',
+          private_token: 'xyz123'
+        )
+        expect(UI).not_to receive(:input)
+        client.prompt_for_access_token
+      end
+    end
+
+    def error_response_formatter(string, file = nil)
+      if file
+        "GitLab storage error: #{string} (File: #{file}, API: https://gitlab.example.com/api/v4)"
+      else
+        "GitLab storage error: #{string} (API: https://gitlab.example.com/api/v4)"
+      end
+    end
+
+    describe '#handle_response_error' do
+      it 'returns a non-fatal error message when the file name has already been taken' do
+        expected_error = "foo already exists in GitLab project sample/project, file not uploaded"
+        expected_error_type = :error
 
         response_body = { message: { name: ["has already been taken" ] } }.to_json
         response = OpenStruct.new(code: "400", body: response_body)
         target_file = 'foo'
-        subject.log_upload_error(response, target_file)
+
+        expect(UI).to receive(expected_error_type).with(error_response_formatter(expected_error, target_file))
+
+        subject.handle_response_error(response, target_file)
       end
 
-      it 'logs the returned error message when an unexpected JSON response is returned' do
-        expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: {\"message\"=>{\"bar\"=>\"baz\"}}")
+      it 'returns a fatal error message when an unexpected JSON response is supplied with a target file' do
+        expected_error = "500: {\"message\":{\"bar\":\"baz\"}}"
+        expected_error_type = :user_error!
 
         response_body = { message: { bar: "baz" } }.to_json
         response = OpenStruct.new(code: "500", body: response_body)
         target_file = 'foo'
-        subject.log_upload_error(response, target_file)
+
+        expect(UI).to receive(expected_error_type).with(error_response_formatter(expected_error, target_file))
+
+        subject.handle_response_error(response, target_file)
       end
 
-      it 'logs the returned error message when an unexpected JSON response is returned' do
-        expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: {\"foo\"=>{\"bar\"=>\"baz\"}}")
+      it 'returns a fatal error message when an unexpected JSON response is supplied without a target file' do
+        expected_error = "500: {\"message\":{\"bar\":\"baz\"}}"
+        expected_error_type = :user_error!
 
-        response_body = { foo: { bar: "baz" } }.to_json
+        response_body = { message: { bar: "baz" } }.to_json
         response = OpenStruct.new(code: "500", body: response_body)
         target_file = 'foo'
-        subject.log_upload_error(response, target_file)
+
+        expect(UI).to receive(expected_error_type).with(error_response_formatter(expected_error))
+
+        subject.handle_response_error(response)
       end
 
-      it 'logs the returned error message when a non-JSON response is returned' do
-        expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: a generic error message")
+      it 'returns a fatal error message when a non-JSON response is supplied with a target file' do
+        expected_error = "500: a generic error message"
+        expected_error_type = :user_error!
 
         response = OpenStruct.new(code: "500", body: "a generic error message")
         target_file = 'foo'
-        subject.log_upload_error(response, target_file)
+
+        expect(UI).to receive(expected_error_type).with(error_response_formatter(expected_error, target_file))
+
+        subject.handle_response_error(response, target_file)
       end
+
+      it 'returns a fatal error message when a non-JSON response is supplied without a target file' do
+        expected_error = "500: a generic error message"
+        expected_error_type = :user_error!
+
+        response = OpenStruct.new(code: "500", body: "a generic error message")
+        target_file = 'foo'
+
+        expect(UI).to receive(expected_error_type).with(error_response_formatter(expected_error))
+
+        subject.handle_response_error(response)
+      end
+
     end
   end
 end

--- a/match/spec/storage/gitlab/client_spec.rb
+++ b/match/spec/storage/gitlab/client_spec.rb
@@ -127,43 +127,6 @@ describe Match do
       end
     end
 
-    # describe '#log_upload_error' do
-    #   it 'logs a custom error message when the file name has already been taken' do
-    #     expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("foo already exists in GitLab project sample/project, file not uploaded")
-
-    #     response_body = { message: { name: ["has already been taken" ] } }.to_json
-    #     response = OpenStruct.new(code: "400", body: response_body)
-    #     target_file = 'foo'
-    #     subject.log_upload_error(response, target_file)
-    #   end
-
-    #   it 'logs the returned error message when an unexpected JSON response is returned' do
-    #     expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: {\"message\"=>{\"bar\"=>\"baz\"}}")
-
-    #     response_body = { message: { bar: "baz" } }.to_json
-    #     response = OpenStruct.new(code: "500", body: response_body)
-    #     target_file = 'foo'
-    #     subject.log_upload_error(response, target_file)
-    #   end
-
-    #   it 'logs the returned error message when an unexpected JSON response is returned' do
-    #     expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: {\"foo\"=>{\"bar\"=>\"baz\"}}")
-
-    #     response_body = { foo: { bar: "baz" } }.to_json
-    #     response = OpenStruct.new(code: "500", body: response_body)
-    #     target_file = 'foo'
-    #     subject.log_upload_error(response, target_file)
-    #   end
-
-    #   it 'logs the returned error message when a non-JSON response is returned' do
-    #     expect_any_instance_of(FastlaneCore::Shell).to receive(:error).with("Upload error for foo: a generic error message")
-
-    #     response = OpenStruct.new(code: "500", body: "a generic error message")
-    #     target_file = 'foo'
-    #     subject.log_upload_error(response, target_file)
-    #   end
-    # end
-
     describe '#prompt_for_access_token' do
       it 'prompts the users for an access token if authentication is not supplied' do
         client = described_class.new(


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The authentication part of the GitLab Match storage backend can be confusing and the error messages are hard to understand. As reported in: https://github.com/fastlane/fastlane/issues/20525

### Description

This change adds better error messaging as well as a prompt to supply the access token when it can't be found. 

![Xnapper-2023-05-15-14 34 45](https://github.com/fastlane/fastlane/assets/36847/fd78d104-6704-451b-b811-4eb357f64818)

![Xnapper-2023-05-15-14 27 03](https://github.com/fastlane/fastlane/assets/36847/7b61f803-3bf0-4591-9842-de95e731b764)


### Testing Steps

1. To render the prompt, run `fastlane match` with `gitlab_secure_files` configured as the storage backend.
2. To render the error, run `PRIVATE_TOKEN=foo fastlane match` with `gitlab_secure_files` configured as the storage backend.
