### PR TITLE
[action][ensure_git_status_clean] new ignore_files option for explicitly ignoring files

### DIFF
--- a/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
+++ b/fastlane/lib/fastlane/actions/ensure_git_status_clean.rb
@@ -7,12 +7,35 @@ module Fastlane
     # Raises an exception and stop the lane execution if the repo is not in a clean state
     class EnsureGitStatusCleanAction < Action
       def self.run(params)
+        # Build command
         if params[:ignored]
           ignored_mode = params[:ignored]
           ignored_mode = 'no' if ignored_mode == 'none'
-          repo_status = Actions.sh("git status --porcelain --ignored='#{ignored_mode}'")
+          command = "git status --porcelain --ignored='#{ignored_mode}'"
         else
-          repo_status = Actions.sh("git status --porcelain")
+          command = "git status --porcelain"
+        end
+
+        # Don't log if manually ignoring files as it will emulate output later
+        print_output = params[:ignore_files].nil?
+        repo_status = Actions.sh(command, log: print_output)
+
+        # Manual post processing trying to ignore certain file paths
+        if (ignore_files = params[:ignore_files])
+          repo_status = repo_status.lines.reject do |line|
+            path = line.split(' ').last
+            was_found = ignore_files.include?(path)
+
+            UI.message("Ignoring '#{path}'") if was_found
+
+            was_found
+          end.join("")
+
+          # Emulate the output format of `git status --porcelain`
+          UI.command(command)
+          repo_status.lines.each do |line|
+            UI.message("▸ " + line.chomp.magenta)
+          end
         end
 
         repo_clean = repo_status.empty?
@@ -86,7 +109,12 @@ module Fastlane
                                          modes = %w(traditional none matching)
 
                                          UI.user_error!("Unsupported mode, must be: #{modes}") unless modes.include?(mode)
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :ignore_files,
+                                       env_name: "FL_ENSURE_GIT_STATUS_CLEAN_IGNORE_FILES",
+                                       description: "Array of files to ignore",
+                                       optional: true,
+                                       type: Array)
         ]
       end
 


### PR DESCRIPTION
### Motivation and Context

Sometimes you just want to ensure a clean git status but allow some files that change like a `Gemfile.lock` or `package-log.json`

### Description

Added new `ignore_files` param to `ensure_git_status_clean` that takes an array of files path strings to ignore

<img width="1283" alt="Screenshot 2023-05-16 at 8 34 13 PM" src="https://github.com/fastlane/fastlane/assets/401294/18814257-6163-4057-a858-715b3676e9ba">

