### PR TITLE
Fixes slack message failure for username

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -20,6 +20,7 @@ module Fastlane
           if options[:channel].to_s.length > 0
             channel = options[:channel]
             channel = ('#' + options[:channel]) unless ['#', '@'].include?(channel[0]) # send message to channel by default
+            (channel[0] = '') if channel[0] == '@'
           end
 
           username = options[:use_webhook_configured_username_and_icon] ? nil : options[:username]


### PR DESCRIPTION
Slack messages are failing when sent with "@" appended to the username. As "#" is required to send the message to a channel. Added this hotfix to remove the "@" prefix  from the username

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes slack message failure for username

### Description
Slack messages are failing when sent with "@" appended to the username. As "#" is required to send the message to a channel. Added this hotfix to remove the "@" prefix  from the username


### Testing Steps
For testing, you can try to send a slack message to specific usernames and channels