### PR TITLE
[docs][match] fix typos, improve wording, incorporate improvements to match documentation examples

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -212,7 +212,7 @@ fastlane match development
 
 <img src="/img/actions/match_appstore_small.gif" width="550" />
 
-This will create a new certificate and provisioning profile (if required) and store them in your selected storage.  
+This will create a new certificate and provisioning profile (if required) and store them in your selected storage.
 If you previously ran _match_ with the configured storage it will automatically install the existing profiles from your storage.
 
 The provisioning profiles are installed in `~/Library/MobileDevice/Provisioning Profiles` while the certificates and private keys are installed in your Keychain.
@@ -512,8 +512,10 @@ Please be careful when using this option and ensure the certificates and profile
 If you want to manually decrypt a file you can.
 
 ```no-highlight
-openssl aes-256-cbc -k "<password>" -in "<fileYouWantToDecryptPath>" -out "<decryptedFilePath>" -a -d
+openssl aes-256-cbc -k "<password>" -in "<fileYouWantToDecryptPath>" -out "<decryptedFilePath>" -a -d -md [md5|sha256]
 ```
+
+_**Note:** You may need to swap double quotes `"` for single quotes `'` if your match password contains an exclamation mark `!`._
 
 #### Export Distribution Certificate and Private Key as Single .p12 File
 

--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -80,7 +80,7 @@ module Gym
         if Gym.config[:disable_xcpretty] || formatter == ''
           UI.verbose("Not using an xcodebuild formatter")
         elsif !options.empty?
-          UI.important("Detected legacy xcpretty being used so formatting wth xcpretty")
+          UI.important("Detected legacy xcpretty being used, so formatting with xcpretty")
           UI.important("Option(s) used: #{options.join(', ')}")
           pipe += pipe_xcpretty
         elsif formatter == 'xcpretty'

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -132,7 +132,7 @@ module Scan
       if formatter == ''
         UI.verbose("Not using an xcodebuild formatter")
       elsif !options.empty?
-        UI.important("Detected legacy xcpretty being used so formatting wth xcpretty")
+        UI.important("Detected legacy xcpretty being used, so formatting with xcpretty")
         UI.important("Option(s) used: #{options.join(', ')}")
         pipe << pipe_xcpretty
       elsif formatter == 'xcpretty'

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -34,7 +34,7 @@ module Snapshot
         if Snapshot.config[:disable_xcpretty] || formatter == ''
           UI.verbose("Not using an xcodebuild formatter")
         elsif !options.empty?
-          UI.important("Detected legacy xcpretty being used so formatting wth xcpretty")
+          UI.important("Detected legacy xcpretty being used, so formatting with xcpretty")
           UI.important("Option(s) used: #{options.join(', ')}")
           pipe += pipe_xcpretty
         elsif formatter == 'xcpretty'


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)

### Motivation and Context

Incorporate the changes made to https://github.com/fastlane/docs/pull/1196, which were applied to a file in the `/generated/` dir and I didn't notice.

cc @tylermilner 😊 

### Description

Just simple docs improvements.

### Testing Steps

N/A