### PR TITLE
Added rollout percentages to version names for supply

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -441,7 +441,13 @@ module Supply
           current_edit.id,
           track
         )
-        return result.releases.flat_map(&:version_codes) || []
+        return result.releases.flat_map{|i| 
+          if i.user_fraction.nil?
+            "#{i.version_codes[0]} (100%)"
+          else
+            "#{i.version_codes[0]} (#{i.user_fraction.to_f * 100}%)"
+          end
+        } || []
       rescue Google::Apis::ClientError => e
         return [] if e.status_code == 404 && (e.to_s.include?("trackEmpty") || e.to_s.include?("Track not found"))
         raise


### PR DESCRIPTION
### Checklist
Ok going to be honest...
I dont know ruby, like at all, Im an android developer and ruby seems like jibberish...
However i've wanted this feature for ages (the ability to see the android play store builds WITH their respective rollout percentages) so i thought id give it a try myself and i have got it to work eventually with a lot of stress hahaha!

Anyway I tried doing the checklist, running the tests with `rspec` and doing the rubucop thing but i couldnt get any of it working... So I know this is not a great PR but hopefully the TINY code change speaks for itself...
Im happy to write tests and do whatever needs to be done to get the checks to past but on my own im struggling to do anything and i've already sank a bunch of hours into this, so hopefully the code change is  and someone can maybe help me get the tests and the rubucop thing working in order to really make this PR legit.

Sorry about this but i think this repo would value actual things produced and value instead of being held back and taking ages to learn a language and env that ill never likely use again after this PR hahhaa. I come with only the best intentions and i guess a little selfish intentions as i want this feature so bad: the ability to get the rollout percentages of the builds available in the tracks on the play store for android.

Please let me know what i can do to make this a reality :) <3 thanks for the awesome tool btw
