### PR TITLE
Fix fastlane action template warnings reported by Rubocop

### DIFF
--- a/fastlane/lib/assets/custom_action_template.rb
+++ b/fastlane/lib/assets/custom_action_template.rb
@@ -39,7 +39,7 @@ module Fastlane
                                        # a short description of this parameter
                                        description: 'API Token for [[NAME_CLASS]]',
                                        verify_block: proc do |value|
-                                         unless (value and not value.empty?)
+                                         unless value && !value.empty?
                                            UI.user_error!("No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`")
                                          end
                                          # UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)

--- a/fastlane/lib/assets/custom_action_template.rb
+++ b/fastlane/lib/assets/custom_action_template.rb
@@ -37,8 +37,8 @@ module Fastlane
                                        env_name: 'FL_[[NAME_UP]]_API_TOKEN', # The name of the environment variable
                                        description: 'API Token for [[NAME_CLASS]]', # a short description of this parameter
                                        verify_block: proc do |value|
-                                          UI.user_error!("No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`") unless (value and not value.empty?)
-                                          # UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                         UI.user_error!("No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`") unless (value and not value.empty?)
+                                         # UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :development,
                                        env_name: 'FL_[[NAME_UP]]_DEVELOPMENT',

--- a/fastlane/lib/assets/custom_action_template.rb
+++ b/fastlane/lib/assets/custom_action_template.rb
@@ -7,7 +7,7 @@ module Fastlane
     class [[NAME_CLASS]] < Action
       def self.run(params)
         # fastlane will take care of reading in the parameter and fetching the environment variable:
-        UI.message "Parameter API Token: #{params[:api_token]}"
+        UI.message("Parameter API Token: #{params[:api_token]}")
 
         # sh "shellcommand ./path"
 

--- a/fastlane/lib/assets/custom_action_template.rb
+++ b/fastlane/lib/assets/custom_action_template.rb
@@ -34,17 +34,23 @@ module Fastlane
         # Below a few examples
         [
           FastlaneCore::ConfigItem.new(key: :api_token,
-                                       env_name: 'FL_[[NAME_UP]]_API_TOKEN', # The name of the environment variable
-                                       description: 'API Token for [[NAME_CLASS]]', # a short description of this parameter
+                                       # The name of the environment variable
+                                       env_name: 'FL_[[NAME_UP]]_API_TOKEN',
+                                       # a short description of this parameter
+                                       description: 'API Token for [[NAME_CLASS]]',
                                        verify_block: proc do |value|
-                                         UI.user_error!("No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`") unless (value and not value.empty?)
+                                         unless (value and not value.empty?)
+                                           UI.user_error!("No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`")
+                                         end
                                          # UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :development,
                                        env_name: 'FL_[[NAME_UP]]_DEVELOPMENT',
                                        description: 'Create a development certificate instead of a distribution one',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       # true: verifies the input is a string, false: every kind of value
+                                       is_string: false,
+                                       # the default value if the user didn't provide one
+                                       default_value: false)
         ]
       end
 

--- a/fastlane/lib/assets/custom_action_template.rb
+++ b/fastlane/lib/assets/custom_action_template.rb
@@ -19,13 +19,13 @@ module Fastlane
       #####################################################
 
       def self.description
-        "A short description with <= 80 characters of what this action does"
+        'A short description with <= 80 characters of what this action does'
       end
 
       def self.details
         # Optional:
         # this is your chance to provide a more detailed description of this action
-        "You can use this action to do cool things..."
+        'You can use this action to do cool things...'
       end
 
       def self.available_options
@@ -34,15 +34,15 @@ module Fastlane
         # Below a few examples
         [
           FastlaneCore::ConfigItem.new(key: :api_token,
-                                       env_name: "FL_[[NAME_UP]]_API_TOKEN", # The name of the environment variable
-                                       description: "API Token for [[NAME_CLASS]]", # a short description of this parameter
+                                       env_name: 'FL_[[NAME_UP]]_API_TOKEN', # The name of the environment variable
+                                       description: 'API Token for [[NAME_CLASS]]', # a short description of this parameter
                                        verify_block: proc do |value|
                                           UI.user_error!("No API token for [[NAME_CLASS]] given, pass using `api_token: 'token'`") unless (value and not value.empty?)
                                           # UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :development,
-                                       env_name: "FL_[[NAME_UP]]_DEVELOPMENT",
-                                       description: "Create a development certificate instead of a distribution one",
+                                       env_name: 'FL_[[NAME_UP]]_DEVELOPMENT',
+                                       description: 'Create a development certificate instead of a distribution one',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
                                        default_value: false) # the default value if the user didn't provide one
         ]
@@ -62,7 +62,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ["Your GitHub/Twitter Name"]
+        ['Your GitHub/Twitter Name']
       end
 
       def self.is_supported?(platform)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When the new default action is created, the rubocop is complaing about wrong code style. The purpose of this PR is to fix the most easy to fix warnings, to improve user experience of end users (less warnings to fix).

Steps to introduce:
1. Go to fastlane directory
2. Create new custom action
```
 $ fastlane new_action
```
3. setup rubocop
4. Run rubocop


### Description
With this PR, several trivial warnings were fixed: `Layout/IndentationWidth`, `Style/StringLiterals`, `Style/MethodCallWithArgsParentheses`, `Layout/LineLength`, `Style/ParenthesesAroundCondition`, `Style/AndOr` and `Style/Not`. As  a result once developer create default action, it will have less updates to be complient with RuboCop.
