### PR TITLE
Fix olympus session request error after skipping 2FA Upgrade

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -533,7 +533,8 @@ module Spaceship
 
           if try_upgrade_2fa_later(response)
             store_cookie
-            fetch_olympus_session
+            #Since last week of 05/2023, olympus session cannot be fetch without a 2FA configured Account. Skipping this request avoid Fastlane crash.
+            #fetch_olympus_session
             return true
           end
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -533,8 +533,6 @@ module Spaceship
 
           if try_upgrade_2fa_later(response)
             store_cookie
-            #Since last week of 05/2023, olympus session cannot be fetch without a 2FA configured Account. Skipping this request avoid Fastlane crash.
-            #fetch_olympus_session
             return true
           end
 


### PR DESCRIPTION
Related issue : #21301 

Since last week of 05/2023, requests to : https://appstoreconnect.apple.com/olympus/v1/session are now rejected if account is not configured with 2FA. 
Skipping this request avoid non 2FA account to get stuck without authentication.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Non 2FA accounts can't use fastlane in CI since 2 weeks now.
<!-- If it fixes an open issue, please link to the issue following this format:
-->
Resolves #21301 
### Description
<!-- Describe your changes in detail. -->
Comment the request to olympus/session after completing skip 2FA upgrade.
<!-- Please describe in detail how you tested your changes. -->
Publish the fix in my git then rebuild my CI docker image pointing fastlane gem to this git and make sure all is working as before.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
