### PR TITLE
Fix multiplatform iOS builds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.3)
+    CFPropertyList (3.0.6)
+      rexml
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     artifactory (3.0.15)
@@ -340,12 +341,13 @@ GEM
     xcode-install (2.6.8)
       claide (>= 0.9.1, < 1.1.0)
       fastlane (>= 2.1.0, < 3.0.0)
-    xcodeproj (1.19.0)
+    xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
+      rexml (~> 3.2.4)
     xcov (1.4.3)
       fastlane (>= 2.82.0, < 3.0.0)
       multipart-post

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -306,7 +306,7 @@ module FastlaneCore
     def watchos?
       supported_platforms.include?(:watchOS)
     end
-    
+
     def multiplatform?
       supported_platforms.count > 1
     end

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -306,6 +306,10 @@ module FastlaneCore
     def watchos?
       supported_platforms.include?(:watchOS)
     end
+    
+    def multiplatform?
+      supported_platforms.count > 1
+    end
 
     def supported_platforms
       supported_platforms = build_settings(key: "SUPPORTED_PLATFORMS")

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -209,6 +209,10 @@ describe FastlaneCore do
         expect(@project.ios?).to eq(true)
       end
 
+      it "#multiplatform?", requires_xcode: true do
+        expect(@project.multiplatform?).to eq(false)
+      end
+
       it "#tvos?", requires_xcode: true do
         expect(@project.tvos?).to eq(false)
       end
@@ -249,6 +253,10 @@ describe FastlaneCore do
       it "#tvos?", requires_xcode: true do
         expect(@project.tvos?).to eq(false)
       end
+      
+      it "#multiplatform?", requires_xcode: true do
+        expect(@project.multiplatform?).to eq(false)
+      end
 
       it "schemes", requires_xcodebuild: true do
         expect(@project.schemes).to eq(["Mac"])
@@ -271,6 +279,10 @@ describe FastlaneCore do
 
       it "#tvos?", requires_xcode: true do
         expect(@project.tvos?).to eq(true)
+      end
+
+      it "#multiplatform?", requires_xcode: true do
+        expect(@project.multiplatform?).to eq(false)
       end
 
       it "schemes", requires_xcodebuild: true do
@@ -298,6 +310,10 @@ describe FastlaneCore do
 
       it "#tvos?", requires_xcode: true do
         expect(@project.tvos?).to eq(true)
+      end
+
+      it "#multiplatform?", requires_xcode: true do
+        expect(@project.multiplatform?).to eq(true)
       end
 
       it "schemes", requires_xcodebuild: true do

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -253,7 +253,7 @@ describe FastlaneCore do
       it "#tvos?", requires_xcode: true do
         expect(@project.tvos?).to eq(false)
       end
-      
+
       it "#multiplatform?", requires_xcode: true do
         expect(@project.multiplatform?).to eq(false)
       end

--- a/gym/examples/multiplatform/Example.xcodeproj/project.pbxproj
+++ b/gym/examples/multiplatform/Example.xcodeproj/project.pbxproj
@@ -1,0 +1,355 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		92AA5B812A2CDDBA008F2263 /* MultiplatformApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AA5B802A2CDDBA008F2263 /* MultiplatformApp.swift */; };
+		92AA5B832A2CDDBA008F2263 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92AA5B822A2CDDBA008F2263 /* ContentView.swift */; };
+		92AA5B852A2CDDBB008F2263 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 92AA5B842A2CDDBB008F2263 /* Assets.xcassets */; };
+		92AA5B892A2CDDBB008F2263 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 92AA5B882A2CDDBB008F2263 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		92AA5B7D2A2CDDBA008F2263 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		92AA5B802A2CDDBA008F2263 /* MultiplatformApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiplatformApp.swift; sourceTree = "<group>"; };
+		92AA5B822A2CDDBA008F2263 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		92AA5B842A2CDDBB008F2263 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		92AA5B862A2CDDBB008F2263 /* Multiplatform.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Multiplatform.entitlements; sourceTree = "<group>"; };
+		92AA5B882A2CDDBB008F2263 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		92AA5B7A2A2CDDBA008F2263 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		92AA5B742A2CDDBA008F2263 = {
+			isa = PBXGroup;
+			children = (
+				92AA5B7F2A2CDDBA008F2263 /* Example */,
+				92AA5B7E2A2CDDBA008F2263 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		92AA5B7E2A2CDDBA008F2263 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				92AA5B7D2A2CDDBA008F2263 /* Example.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		92AA5B7F2A2CDDBA008F2263 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				92AA5B802A2CDDBA008F2263 /* MultiplatformApp.swift */,
+				92AA5B822A2CDDBA008F2263 /* ContentView.swift */,
+				92AA5B842A2CDDBB008F2263 /* Assets.xcassets */,
+				92AA5B862A2CDDBB008F2263 /* Multiplatform.entitlements */,
+				92AA5B872A2CDDBB008F2263 /* Preview Content */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		92AA5B872A2CDDBB008F2263 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				92AA5B882A2CDDBB008F2263 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		92AA5B7C2A2CDDBA008F2263 /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 92AA5B8C2A2CDDBB008F2263 /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				92AA5B792A2CDDBA008F2263 /* Sources */,
+				92AA5B7A2A2CDDBA008F2263 /* Frameworks */,
+				92AA5B7B2A2CDDBA008F2263 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Example;
+			productName = Multiplatform;
+			productReference = 92AA5B7D2A2CDDBA008F2263 /* Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		92AA5B752A2CDDBA008F2263 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1430;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					92AA5B7C2A2CDDBA008F2263 = {
+						CreatedOnToolsVersion = 14.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 92AA5B782A2CDDBA008F2263 /* Build configuration list for PBXProject "Example" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 92AA5B742A2CDDBA008F2263;
+			productRefGroup = 92AA5B7E2A2CDDBA008F2263 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				92AA5B7C2A2CDDBA008F2263 /* Example */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		92AA5B7B2A2CDDBA008F2263 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				92AA5B892A2CDDBB008F2263 /* Preview Assets.xcassets in Resources */,
+				92AA5B852A2CDDBB008F2263 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		92AA5B792A2CDDBA008F2263 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				92AA5B832A2CDDBA008F2263 /* ContentView.swift in Sources */,
+				92AA5B812A2CDDBA008F2263 /* MultiplatformApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		92AA5B8A2A2CDDBB008F2263 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		92AA5B8B2A2CDDBB008F2263 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		92AA5B8D2A2CDDBB008F2263 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Example/Multiplatform.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Example/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.app.Multiplatform;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		92AA5B8E2A2CDDBB008F2263 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Example/Multiplatform.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Example/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.app.Multiplatform;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		92AA5B782A2CDDBA008F2263 /* Build configuration list for PBXProject "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				92AA5B8A2A2CDDBB008F2263 /* Debug */,
+				92AA5B8B2A2CDDBB008F2263 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		92AA5B8C2A2CDDBB008F2263 /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				92AA5B8D2A2CDDBB008F2263 /* Debug */,
+				92AA5B8E2A2CDDBB008F2263 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 92AA5B752A2CDDBA008F2263 /* Project object */;
+}

--- a/gym/examples/multiplatform/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/gym/examples/multiplatform/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:/Users/zach/code/github/forks/fastlane/gym/examples/multiplatform/Example.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/gym/examples/multiplatform/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/gym/examples/multiplatform/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/gym/examples/multiplatform/Example/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/gym/examples/multiplatform/Example/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/gym/examples/multiplatform/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/gym/examples/multiplatform/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,63 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/gym/examples/multiplatform/Example/Assets.xcassets/Contents.json
+++ b/gym/examples/multiplatform/Example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/gym/examples/multiplatform/Example/ContentView.swift
+++ b/gym/examples/multiplatform/Example/ContentView.swift
@@ -1,0 +1,26 @@
+//
+//  ContentView.swift
+//  Multiplatform
+//
+//  Created by Zach Waugh on 6/4/23.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundColor(.accentColor)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/gym/examples/multiplatform/Example/Multiplatform.entitlements
+++ b/gym/examples/multiplatform/Example/Multiplatform.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/gym/examples/multiplatform/Example/MultiplatformApp.swift
+++ b/gym/examples/multiplatform/Example/MultiplatformApp.swift
@@ -1,0 +1,17 @@
+//
+//  MultiplatformApp.swift
+//  Multiplatform
+//
+//  Created by Zach Waugh on 6/4/23.
+//
+
+import SwiftUI
+
+@main
+struct MultiplatformApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/gym/examples/multiplatform/Example/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/gym/examples/multiplatform/Example/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/gym/lib/gym/module.rb
+++ b/gym/lib/gym/module.rb
@@ -27,8 +27,8 @@ module Gym
 
     def building_for_ios?
       if Gym.project.mac?
-        # Can be building for iOS if mac project and catalyst
-        return building_mac_catalyst_for_ios?
+        # Can be building for iOS if mac project and catalyst or multiplatform and set to iOS
+        return building_mac_catalyst_for_ios? || building_multiplatform_for_ios?
       else
         # Can be iOS project and build for mac if catalyst
         return false if building_mac_catalyst_for_mac?
@@ -43,6 +43,9 @@ module Gym
         # Can be a mac project and not build mac if catalyst
         return building_mac_catalyst_for_mac?
       else
+        # Can be mac project but multiplatform and building for iOS
+        return false if building_multiplatform_for_ios?
+
         return Gym.project.mac?
       end
     end
@@ -53,6 +56,14 @@ module Gym
 
     def building_mac_catalyst_for_mac?
       Gym.project.supports_mac_catalyst? && Gym.config[:catalyst_platform] == "macos"
+    end
+
+    def building_multiplatform_for_ios?
+      Gym.project.multiplatform? && Gym.project.ios? && (Gym.config[:sdk] == "iphoneos" || Gym.config[:sdk] == "iphonesimulator")
+    end
+
+    def building_multiplatform_for_mac?
+      Gym.project.multiplatform? && Gym.project.mac? && Gym.config[:sdk] == "macosx"
     end
 
     def export_destination_upload?

--- a/gym/spec/platform_detection_spec.rb
+++ b/gym/spec/platform_detection_spec.rb
@@ -1,0 +1,27 @@
+describe Gym do
+  it "detects when a multiplatform project is building for iOS", requires_xcodebuild: true do
+    options = { project: "./gym/examples/multiplatform/Example.xcodeproj", sdk: "iphoneos" }
+    Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+    expect(Gym.project.multiplatform?).to eq(true)
+    expect(Gym.project.ios?).to eq(true)
+    expect(Gym.project.mac?).to eq(true)
+    
+    expect(Gym.building_for_mac?).to eq(false)
+    expect(Gym.building_for_ios?).to eq(true)
+    expect(Gym.building_multiplatform_for_ios?).to eq(true)
+  end
+
+  it "detects when a multiplatform project is building for macOS", requires_xcodebuild: true do
+    options = { project: "./gym/examples/multiplatform/Example.xcodeproj", sdk: "macosx" }
+    Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+    expect(Gym.project.multiplatform?).to eq(true)
+    expect(Gym.project.ios?).to eq(true)
+    expect(Gym.project.mac?).to eq(true)
+
+    expect(Gym.building_for_ios?).to eq(false)
+    expect(Gym.building_for_mac?).to eq(true)
+    expect(Gym.building_multiplatform_for_mac?).to eq(true)
+  end
+end

--- a/gym/spec/platform_detection_spec.rb
+++ b/gym/spec/platform_detection_spec.rb
@@ -6,7 +6,7 @@ describe Gym do
     expect(Gym.project.multiplatform?).to eq(true)
     expect(Gym.project.ios?).to eq(true)
     expect(Gym.project.mac?).to eq(true)
-    
+
     expect(Gym.building_for_mac?).to eq(false)
     expect(Gym.building_for_ios?).to eq(true)
     expect(Gym.building_multiplatform_for_ios?).to eq(true)


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Currently using a multiplatform Xcode project (Xcode > New Project > Multiplatform App) will fail to build for iOS from fastlane using `build_app` with a `PKG invalid` error. The reason is the platform check for whether to do an iOS build `Gym.building_for_ios?` returns `false`, so it attempts to build an iOS app like a macOS app.

- Closes https://github.com/fastlane/fastlane/issues/21308
- Closes https://github.com/fastlane/fastlane/issues/20768

### Description
This fixes the above error by explicitly checking for cases where we might be a multiplatform app (e.g. multiple `SUPPORTED_PLATFORM` properties) and checking which `sdk` is being used. I'm not sure if this is the correct fix, I couldn't find good documentation on the right way to choose a platform to build for a multiplatform app using `xcodebuild`. Passing the `sdk: "iphoneos"` or `sdk: "macosx"` option seemed to work though, so I'm expecting that is required and what we need to check. If there is alternative way to inform `xcodebuild` about the platform, I'm happy to change the check.

I added a new example project created using the Multiplatform App template and some related tests. I'm not a Ruby programmer and not familiar with the codebase, so let me know if there is a better way to do any (or all) of this. 