### PR TITLE
#20533 Improve error message when unable to find mac app path

### DIFF
--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -285,7 +285,7 @@ module Gym
         app_path = Dir[File.join(BuildCommandGenerator.archive_path, "Products", "Applications", "*.app")].last
       end
 
-      UI.crash!("Couldn't find application in '#{BuildCommandGenerator.archive_path}'") unless File.exist?(app_path)
+      UI.crash!("Couldn't find application in '#{BuildCommandGenerator.archive_path}'") unless app_path && File.exist?(app_path)
 
       joined_app_path = File.join(Gym.config[:output_directory], File.basename(app_path))
       FileUtils.rm_rf(joined_app_path)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Improves the error message from #20533 

### Description
Guards against passing a `nil` `app_path` into `File.exists?`, which will throw an unfriendly error.

### Testing Steps
- In some manner, produce a mac build that doesn't generate a `.app` file in the correct place
- Previously, you'd get an unhelpful error message about `nil`. With this, you'll no longer get the message