### PR TITLE
fix(match): make git_private_key path absolute

### DIFF
--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -59,10 +59,18 @@ module Match
         self.clone_branch_directly = clone_branch_directly
         self.git_basic_authorization = git_basic_authorization
         self.git_bearer_authorization = git_bearer_authorization
-        self.git_private_key = git_private_key
+        self.git_private_key = convert_private_key_path_to_absolute(git_private_key)
 
         self.type = type if type
         self.platform = platform if platform
+      end
+
+      def convert_private_key_path_to_absolute(git_private_key)
+        if !git_private_key.nil? && File.file?(File.expand_path(git_private_key))
+          File.expand_path(git_private_key).shellescape.to_s
+        else
+          git_private_key
+        end
       end
 
       def prefixed_working_directory

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -157,7 +157,7 @@ describe Match do
       it "wraps the git command in ssh-agent shell when using a private key file" do
         path = Dir.mktmpdir # to have access to the actual path
         expect(Dir).to receive(:mktmpdir).and_return(path)
-        expect(File).to receive(:file?).and_return(true)
+        expect(File).to receive(:file?).twice.and_return(true)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = false
         private_key = "#{path}/fastlane.match.id_dsa"
@@ -194,7 +194,7 @@ describe Match do
       it "wraps the git command in ssh-agent shell when using a raw private key" do
         path = Dir.mktmpdir # to have access to the actual path
         expect(Dir).to receive(:mktmpdir).and_return(path)
-        expect(File).to receive(:file?).and_return(false)
+        expect(File).to receive(:file?).twice.and_return(false)
         git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
         shallow_clone = false
         private_key = "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When sending a path to a `git_private_key` (instead of key content), it fails when it tries to push changes to repository with error 
```
ssh-agent bash -c 'ssh-add - <<< "id_rsa"; git push origin master'
Error loading key "(stdin)": invalid format
```
Resolves #19266 

### Description
I first noticed issue when `readonly` was set to `true` and `git_private_key: 'id_rsa'` in CI. It was able to clone the repo but it failed when trying to push changes back to repo. The problem started [here](https://github.com/fastlane/fastlane/blob/master/match/lib/match/storage/git_storage.rb#L165). When it tried push the change, it couldn't find the file so it used the content of `git_private_key` as private key (which was `id_rsa`) and it failed. Next thing I tried is to check what `Dir.pwd`is when it clones and tries to push change and found out that when pushing changes, it [changes](https://github.com/fastlane/fastlane/blob/master/match/lib/match/storage/interface.rb#L59) directory to where it cloned the repo. 

So for a solution I've made sure that the during initialization `git_private_key` is always defined as absolute path instead of relative.  

### Testing Steps
If you checkout the `master` and set `readonly` to `true` and provide `git_private_key` as a path (ie. `id_rsa`) instead sending private key content, it will fail when it tries to push new certificates/profiles back to repository.

Checking out this branch, the problem is resolved.
