### PR TITLE
[match] Fixes Gitlab Secure Files API limit

### DIFF
--- a/match/lib/match/storage/gitlab/client.rb
+++ b/match/lib/match/storage/gitlab/client.rb
@@ -40,6 +40,8 @@ module Match
         def files
           @files ||= begin
             url = URI.parse(base_url)
+            # 100 is maximum number of Secure files available on Gitlab https://docs.gitlab.com/ee/api/secure_files.html
+            url.query = [url.query, "per_page=100"].compact.join('&')
 
             request = Net::HTTP::Get.new(url.request_uri)
 

--- a/match/spec/storage/gitlab/client_spec.rb
+++ b/match/spec/storage/gitlab/client_spec.rb
@@ -118,6 +118,15 @@ describe Match do
         expect(subject.files.count).to be(0)
       end
 
+      it 'requests 100 files from the API' do
+        stub_request(:get, /gitlab.example.com/).
+          to_return(status: 200, body: [].to_json)
+
+        files = subject.files
+
+        assert_requested(:get, /gitlab.example.com/, query: "per_page=100")
+      end
+
       it 'raises an exception for a non-json response' do
         stub_request(:get, /gitlab.example.com/).
           with(headers: { 'PRIVATE-TOKEN' => 'abc123' }).


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR finishes the changes that were started in https://github.com/fastlane/fastlane/pull/21205

Resolves https://github.com/fastlane/fastlane/issues/21204

This change fixes an issue for those people who have many different certs/provision profiles/keys stored on Gitlab in a "Secure files" section. The api used currently by Fastlane does not take into account paging and it's capable of downloading only 20 such files instead of all of them (max 100). This leads to signing issues as some files might be missing.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
