### PR TITLE
[match] Have Match download Apple's Developer ID intermediate certificates

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -30,6 +30,16 @@ WWDRCA_CERTIFICATES = [
     alias: 'G6',
     sha256: 'bdd4ed6e74691f0c2bfd01be0296197af1379e0418e2d300efa9c3bef642ca30',
     url: 'https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer'
+  },
+  {
+    alias: 'DEV-ID-G1',
+    sha256: '7afc9d01a62f03a2de9637936d4afe68090d2de18d03f29c88cfb0b1ba63587f',
+    url: 'https://www.apple.com/certificateauthority/DeveloperIDCA.cer'
+  },
+  {
+    alias: 'DEV-ID-G2',
+    sha256: 'f16cd3c54c7f83cea4bf1a3e6a0819c8aaa8e4a1528fd144715f350643d2df3a',
+    url: 'https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer'
   }
 ]
 

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -60,12 +60,15 @@ describe FastlaneCore do
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G4')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G5')
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G6')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('DEV-ID-G1')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('DEV-ID-G2')
         FastlaneCore::CertChecker.install_missing_wwdr_certificates
       end
 
       it 'should install the missing official WWDR certificate' do
-        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5'])
+        allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5', 'DEV-ID-G2'])
         expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('G6')
+        expect(FastlaneCore::CertChecker).to receive(:install_wwdr_certificate).with('DEV-ID-G1')
         FastlaneCore::CertChecker.install_missing_wwdr_certificates
       end
 
@@ -86,6 +89,12 @@ describe FastlaneCore do
 
         expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/AppleWWDRCAG6.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('G6')
+
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/DeveloperIDCA.cer')).and_return(["", "", success_status])
+        FastlaneCore::CertChecker.install_wwdr_certificate('DEV-ID-G1')
+        
+        expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer')).and_return(["", "", success_status])
+        FastlaneCore::CertChecker.install_wwdr_certificate('DEV-ID-G2')
       end
     end
 
@@ -113,7 +122,7 @@ describe FastlaneCore do
           expect(Open3).to receive(:capture3).with(cmd).and_return(["", "", success_status])
           expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5'])
+          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5', 'DEV-ID-G1', 'DEV-ID-G2'])
           expect(FastlaneCore::CertChecker.install_missing_wwdr_certificates).to be(1)
         end
 
@@ -130,7 +139,7 @@ describe FastlaneCore do
           expect(Open3).to receive(:capture3).with(cmd).and_return(["", "", success_status])
           expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
 
-          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5'])
+          allow(FastlaneCore::CertChecker).to receive(:installed_wwdr_certificates).and_return(['G2', 'G3', 'G4', 'G5', 'DEV-ID-G1', 'DEV-ID-G2'])
           expect(FastlaneCore::CertChecker.install_missing_wwdr_certificates).to be(1)
         end
       end

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -92,7 +92,7 @@ describe FastlaneCore do
 
         expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/DeveloperIDCA.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('DEV-ID-G1')
-        
+
         expect(Open3).to receive(:capture3).with(include('https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer')).and_return(["", "", success_status])
         FastlaneCore::CertChecker.install_wwdr_certificate('DEV-ID-G2')
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When using `match` to sign a Mac app, that is to be published via a notarized `dmg` file, a `Developer ID` certificate is used to sign the app.
And just like when signing apps for the AppStore, with distribution certificates, a Apple WWDR certificate is needed in the keychain to validate the certificate chain.

So Apple's two developer ID intermediate certificates, from [Apples Certificate Authority Page](https://www.apple.com/certificateauthority/) has been added to the existing list of WWDR certificates

### Description
- Added the two Developer ID certificates to the list of WWDR certificates in `cert_checker.rb`
- Added specs to verify installation of said certificates
