### PR TITLE
Add import support bash and zsh autocomplete

### DIFF
--- a/fastlane/lib/assets/completions/completion.bash
+++ b/fastlane/lib/assets/completions/completion.bash
@@ -4,21 +4,26 @@ _fastlane_complete() {
   COMPREPLY=()
   local word="${COMP_WORDS[COMP_CWORD]}"
   local completions=""
-  local file
 
   # look for Fastfile either in this directory or fastlane/ then grab the lane names
   if [[ -e "Fastfile" ]]; then
-    file="Fastfile"
+    dir="."
   elif [[ -e "fastlane/Fastfile" ]]; then
-    file="fastlane/Fastfile"
+    dir="fastlane"
   elif [[ -e ".fastlane/Fastfile" ]]; then
-    file=".fastlane/Fastfile"
+    dir=".fastlane"
   else
     return 1
   fi
-
-  # parse 'beta' out of 'lane :beta do', etc
-  completions="$(sed -En 's/^[ 	]*lane +:([^ 	]+).*$/\1/p' "$file")"
+  local imported_files=('Fastfile')
+  # parse imports and grab lane names
+  imported_files+=($(cd $dir && sed -En "s/^[ 	]*import\([\"']([^\"']+)[\"']\)[ 	]*$/\1/p" "Fastfile"))
+  for imported_file in "${imported_files[@]}"; do
+    if [[ -e "$dir/$imported_file" ]]; then
+      # parse 'beta' out of 'lane :beta do', etc
+      completions+=$(cd $dir && sed -En 's/^[ 	]*lane +:([^ 	]+).*$/\1/p' "$imported_file")
+    fi
+  done
   completions="$completions update_fastlane"
 
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )

--- a/fastlane/lib/assets/completions/completion.zsh
+++ b/fastlane/lib/assets/completions/completion.zsh
@@ -6,17 +6,23 @@ _fastlane_complete() {
 
   # look for Fastfile either in this directory or fastlane/ then grab the lane names
   if [[ -e "Fastfile" ]] then
-    file="Fastfile"
+    dir="."
   elif [[ -e "fastlane/Fastfile" ]] then
-    file="fastlane/Fastfile"
+    dir="fastlane"
   elif [[ -e ".fastlane/Fastfile" ]] then
-    file=".fastlane/Fastfile"
+    dir=".fastlane"
   else
     return 1
   fi
-
-  # parse 'beta' out of 'lane :beta do', etc
-  completions="$(sed -En 's/^[ 	]*lane +:([^ 	]+).*$/\1/p' "$file")"
+  local imported_files=('Fastfile')
+  # parse imports and grab lane names
+  imported_files+=($(cd $dir && sed -En "s/^[ 	]*import\([\"']([^\"']+)[\"']\)[ 	]*$/\1/p" "Fastfile"))
+  for imported_file in "${imported_files[@]}"; do
+    if [[ -e "$dir/$imported_file" ]] then
+      # parse 'beta' out of 'lane :beta do', etc
+      completions+=$(cd $dir && sed -En 's/^[ 	]*lane +:([^ 	]+).*$/\1/p' "$imported_file")
+    fi
+  done
   completions="$completions update_fastlane"
 
   reply=( "${=completions}" )


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added relevant unit tests.

### Motivation and Context

In previous implementation the imports, like:
```
  import("../../../FastfileGlobal")
```
or
```
  import('../../../FastfileGlobal')
```
were ignored, and the lanes were not added for autocompletion. This patch is fixing it, and autocompletion is working correctly also for imported lanes.

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
