### PR TITLE
[match][sigh][spaceship] add support for offline Apple provisioning profiles

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -406,6 +406,10 @@ If you're not using `Fastfile`, you can also use the `force_for_new_devices` opt
 fastlane match adhoc --force_for_new_devices
 ```
 
+##### Offline profile use
+
+If your profile requires the 'Offline support (7 day validity)' setting for use without Internet, use `offline_profile: true` to add this permission to generated profiles.
+
 ##### Templates (aka: custom entitlements)
 
 Match can generate profiles that contain custom entitlements by passing in the entitlement's name with the `template_name` parameter.

--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -91,6 +91,7 @@ module Match
         fail_on_name_taken: params[:fail_on_name_taken],
         include_all_certificates: params[:include_all_certificates],
         include_mac_in_profiles: params[:include_mac_in_profiles],
+        offline_profile: params[:offline_profile],
       }
 
       values[:platform] = params[:platform]

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -336,6 +336,11 @@ module Match
                                      description: "Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing",
                                      type: Boolean,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :offline_profile,
+                                     env_name: "MATCH_OFFLINE_PROFILE",
+                                     description: "Enable profile with 'Offline Support' (7 day validity)",
+                                     type: Boolean,
+                                     default_value: false),
 
         # other
         FastlaneCore::ConfigItem.new(key: :verbose,

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -59,6 +59,11 @@ module Sigh
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier),
                                      default_value_dynamic: true),
+        FastlaneCore::ConfigItem.new(key: :offline_profile,
+                                     env_name: "SIGH_OFFLINE_PROFILE",
+                                     description: "Enable profile with 'Offline Support' (7 day validity)",
+                                     is_string: false,
+                                     default_value: false),
 
         # App Store Connect API
         FastlaneCore::ConfigItem.new(key: :api_key_path,

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -187,7 +187,8 @@ module Sigh
         bundle_id_id: bundle_id.id,
         certificate_ids: certificates_to_use.map(&:id),
         device_ids: devices_to_use.map(&:id),
-        template_name: Sigh.config[:template_name]
+        template_name: Sigh.config[:template_name],
+        is_offline_profile: Sigh.config[:offline_profile]
       )
 
       profile

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -75,7 +75,7 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
+      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil, is_offline_profile: false)
         client ||= Spaceship::ConnectAPI
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,
@@ -84,7 +84,8 @@ module Spaceship
           attributes: {
             name: name,
             profileType: profile_type,
-            templateName: template_name
+            templateName: template_name,
+            isOfflineProfile: is_offline_profile
           }
         )
         return resp.to_models.first


### PR DESCRIPTION

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`sync_code_signing` had no support for Apple's profile setting 'Offline support (7 day validity)' for Development-type Apple Provisioning Profiles. This setting is relatively new and only visible newer Apple Developer accounts.

This made it impossible to create Development-type Apple Profiles for use on devices without Internet access.

This PR enables setting of this Offline support setting (disabled by default per the Apple Developer website behaviour).

### Description
* Adds `offline_profile: true/false` option to the Match and Sigh modules
* Adds `isOfflineProfile` argument to the Apple API call for creating profiles via Spaceship

Changes tested on offline-type Development Apple Profile.

### Testing Steps
Using a newer Apple Development account (with 'Offline support (7 day validity)' setting on Provisioning Profiles):

1. Create a `sync_code_signing` configuration to create/update a profile with `offline_profile` unspecified (or false)
1. Login to the Apple Developer account website and observe that the offline support setting is 'No' for the Profile (click 'Edit' on a profile to review this setting)
1. Recreate the configuration with `offline_profile: true`
1. Observe that the setting is 'Yes' on the Apple Developer website