### PR TITLE
[action][sh] fix undefined sh_enabled? method when using Action.sh from a plugin Action

### DIFF
--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -42,7 +42,7 @@ module Fastlane
 
       result = ''
       exit_status = nil
-      if Helper.sh_enabled?
+      if FastlaneCore::Helper.sh_enabled?
         # The argument list is passed directly to Open3.popen2e, which
         # handles the variadic argument list in the same way as Kernel#spawn.
         # (http://ruby-doc.org/core-2.4.2/Kernel.html#method-i-spawn) or


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
When calling `sh` action from a plugin Action helper, I get an error `undefined method ``sh_enabled?`` for Fastlane::Actions::Helper:Class (NoMethodError if Helper.sh_enabled?...`


### Description
Explicitly specify the full path to the `FastlaneCore` module when calling `Helper.sh_enabled?` method.

### Testing Steps
🤷