### PR TITLE
[match] remove redundant fetching of profile devices and certificates

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -337,7 +337,7 @@ module Match
       portal_profile = all_profiles.detect { |i| i.uuid == uuid }
 
       if portal_profile
-        profile_device_count = portal_profile.fetch_all_devices.count
+        profile_device_count = portal_profile.devices.count
 
         device_classes =
           case platform
@@ -418,7 +418,7 @@ module Match
       #   * For portal certificates, we filter out the expired one but includes a new certificate;
       #   * Profile still contains an expired certificate and is valid.
       # Thus, we need to check the validity of profile certificates too.
-      profile_certs_count = portal_profile.fetch_all_certificates.select(&:valid?).count
+      profile_certs_count = portal_profile.certificates.select(&:valid?).count
 
       certificate_types =
         case platform

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -292,7 +292,7 @@ describe Match do
 
       before do
         allow(profile).to receive(:uuid).and_return(uuid)
-        allow(profile).to receive(:fetch_all_devices).and_return([profile_device])
+        allow(profile).to receive(:devices).and_return([profile_device])
       end
 
       it "device is enabled" do

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -15,6 +15,7 @@ module Spaceship
 
       attr_accessor :bundle_id
       attr_accessor :certificates
+      attr_accessor :devices
 
       attr_mapping({
         "name" => "name",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
match is slow when running in edit mode. I found out that when the match checks device count and development certificates validity. match downloads a provisioning profile from the portal with devices and certificates payload and additionally sends two more requests to the portal to fetch devices and certificates once again. There is no need to fetch remote info twice.

### Description
Changes allow match to use devices & certificates info from the first request from the received provisioning profile. As a result, the are 2x decrease in requests sent to App Store Connect API when checking if the provisioning profile must be updated.

### Testing Steps
run match.