### PR TITLE
[trainer] Don't fail if a document_location_in_creating_workspace doesn't have a url

### DIFF
--- a/trainer/lib/trainer/xcresult.rb
+++ b/trainer/lib/trainer/xcresult.rb
@@ -391,7 +391,7 @@ module Trainer
 
       def failure_message
         new_message = self.message
-        if self.document_location_in_creating_workspace
+        if self.document_location_in_creating_workspace && self.document_location_in_creating_workspace.url
           file_path = self.document_location_in_creating_workspace.url.gsub("file://", "")
           new_message += " (#{file_path})"
         end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Fixes a regression with Xcode 15 beta 4.

### Description

I added a check to ensure `document_location_in_creating_workspace.url` isn't nil before attempting to use it. Xcode 15 beta 4 is returning failures that don't have a file URL. Here's the xcresulttool output of the relevant part:

```
        {
          "_type" : {
            "_name" : "TestFailureIssueSummary",
            "_supertype" : {
              "_name" : "IssueSummary"
            }
          },
          "documentLocationInCreatingWorkspace" : {
            "_type" : {
              "_name" : "DocumentLocation"
            },
            "concreteTypeName" : {
              "_type" : {
                "_name" : "String"
              },
              "_value" : "DVTTextDocumentLocation"
            }
          },
          "issueType" : {
            "_type" : {
              "_name" : "String"
            },
            "_value" : "Uncategorized"
          },
          "message" : {
            "_type" : {
              "_name" : "String"
            },
            "_value" : "Crash: xctest (89330) <external symbol>. libsystem_c.dylib: abort() called"
          },
          "testCaseName" : {
            "_type" : {
              "_name" : "String"
            },
            "_value" : "-[xxx xxx]"
          }
        },
```

### Testing Steps

I ran the built-in tests for trainer and verified the change works on our failing xcresult bundle.