### PR TITLE
[xcodes] fix issue where `xcodes` action wouldn't accept beta versions of Xcode

### DIFF
--- a/fastlane/lib/fastlane/helper/xcodes_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodes_helper.rb
@@ -18,9 +18,6 @@ module Fastlane
       module Verify
         def self.requirement(req)
           UI.user_error!("Version must be specified") if req.nil? || req.to_s.strip.size == 0
-          Gem::Requirement.new(req.to_s)
-        rescue Gem::Requirement::BadRequirementError
-          UI.user_error!("The requirement '#{req}' is not a valid RubyGems style requirement")
         end
       end
     end

--- a/fastlane/spec/actions_specs/xcversion_spec.rb
+++ b/fastlane/spec/actions_specs/xcversion_spec.rb
@@ -18,16 +18,6 @@ describe Fastlane do
           double("XcodeInstall::Xcode", version: "7.3", path: "/Test/Xcode7.3")
         end
 
-        context "with an invalid requirement" do
-          it "raises an error" do
-            expect do
-              Fastlane::FastFile.new.parse("lane :test do
-                xcversion version: '= aaaa'
-              end").runner.execute(:test)
-            end.to raise_error("The requirement '= aaaa' is not a valid RubyGems style requirement")
-          end
-        end
-
         context "with a valid requirement" do
           before do
             require "xcode/install"

--- a/fastlane/spec/helper/xcodes_helper_spec.rb
+++ b/fastlane/spec/helper/xcodes_helper_spec.rb
@@ -45,22 +45,6 @@ describe Fastlane::Helper::XcodesHelper do
           expect { subject.class::Verify.requirement(argument) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'Version must be specified')
         end
       end
-
-      context "when argument is not in RubyGems style" do
-        let(:argument) { "banana" }
-
-        it "raises user error" do
-          expect { subject.class::Verify.requirement(argument) }.to raise_error(FastlaneCore::Interface::FastlaneError, "The requirement '#{argument}' is not a valid RubyGems style requirement")
-        end
-      end
-
-      context "when argument is in RubyGems style" do
-        let(:argument) { "1.2.3" }
-
-        it "returns Gem::Requirement instance" do
-          expect(subject.class::Verify.requirement(argument)).to be_an_instance_of(Gem::Requirement)
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Checklist

- [x]  I've run bundle exec rspec from the root directory to see all new and existing tests pass
- [x]  I've followed the fastlane code style and run bundle exec rubocop -a to ensure the code style is valid
- [x]  I see several green ci/circleci builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x]  I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x]  I've updated the documentation if necessary.

Motivation and Context

Try to fix #21369 xcodes does not allow "15.0 Beta 5" as version.