### PR TITLE
[fastlane_core] fix WWDR certificates import flow

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -146,7 +146,7 @@ module FastlaneCore
 
     def self.install_wwdr_certificate(cert_alias)
       url = WWDRCA_CERTIFICATES.find { |c| c[:alias] == cert_alias }.fetch(:url)
-      file = Tempfile.new(File.basename(url))
+      file = Tempfile.new([File.basename(url, ".cer"), ".cer"])
       filename = file.path
       keychain = wwdr_keychain
       keychain = "-k #{keychain.shellescape}" unless keychain.empty?

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -107,7 +107,7 @@ describe FastlaneCore do
           `ls`
 
           keychain = "keychain with spaces.keychain"
-          cmd = %r{curl -f -o (([A-Z]\:)?\/.+) https://www\.apple\.com/certificateauthority/AppleWWDRCAG6\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
+          cmd = %r{curl -f -o (([A-Z]\:)?\/.+\.cer) https://www\.apple\.com/certificateauthority/AppleWWDRCAG6\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
           require "open3"
 
           expect(Open3).to receive(:capture3).with(cmd).and_return(["", "", success_status])
@@ -124,7 +124,7 @@ describe FastlaneCore do
           stub_const('ENV', { "FASTLANE_WWDR_USE_HTTP1_AND_RETRIES" => "true" })
 
           keychain = "keychain with spaces.keychain"
-          cmd = %r{curl --http1.1 --retry 3 --retry-all-errors -f -o (([A-Z]\:)?\/.+) https://www\.apple\.com/certificateauthority/AppleWWDRCAG6\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
+          cmd = %r{curl --http1.1 --retry 3 --retry-all-errors -f -o (([A-Z]\:)?\/.+\.cer) https://www\.apple\.com/certificateauthority/AppleWWDRCAG6\.cer && security import \1 -k #{Regexp.escape(keychain.shellescape)}}
           require "open3"
 
           expect(Open3).to receive(:capture3).with(cmd).and_return(["", "", success_status])


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
When `fastlane` installs the WWDR certificate it performs it in next steps:
- Download certificate (i.e. AppleWWDRCAG6.cer)
- Add random suffix  (i.e AppleWWDRCAG6.cer20230109-941-zd7vp8)
- Try to import certificate `security import AppleWWDRCAG6.cer20230109-941-zd7vp8`

The issue what we found is that macOS `security` tool would treat some extensions as a part of expected format
So, when generated extension contains strings like `p8` or `p7` and also contains `-` symbol, it treats it as a fromat type
This means, that if generated suffix will contain these strings, `security` won't be able to import a certificate, even if is valid one.

Here are some examples (with the same contents)
| Crt Name | Status | Error |
|-|-|-|
| tmp.cer | ✅ | |
| tmpp8.cer | ✅ | |
| tmp.cerp8 | ❌  | security: SecKeychainItemImport: Unknown format in import. |
| tmp.cerXXXXXp8XXX | ❌ | security: SecKeychainItemImport: Unknown format in import. |

Resolves #20960, #5259

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

Instead of generating suffix to the extension, suffix to the filename is generated instead:
| Name | Value |
|-| -|
| Previous |  tmp.cerDDDDDD-XXXX-RANDOM | 
| Current  |  tmpDDDDDD-XXXX-RANDOM.cer |  

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

### Funny calculations 🎲 
- There are 2176782336 random suffixes (6 symbols, a-z0-9 (36 values)
- There are 8398080 strings with `p8` in them 
- There is 8398080/2176782336 = 0,00385802 probability to fail (~0,3858 %) when importing 1 cert
- We have about 2,29 % probability when importing 6 of them

### Thanks
- @nekrich  for the prepared code and fixed tests :)