### PR TITLE
[spaceship] For App Store Connect API 2.4, beta_tester_metrics is empty, update beta_tester attr

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/beta_tester.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_tester.rb
@@ -14,7 +14,7 @@ module Spaceship
       attr_accessor :beta_groups
       attr_accessor :beta_tester_metrics
       attr_accessor :builds
-      
+
       attr_accessor :isDeleted
       attr_accessor :beta_tester_state
       attr_accessor :last_modified_date

--- a/spaceship/lib/spaceship/connect_api/models/beta_tester.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_tester.rb
@@ -14,6 +14,19 @@ module Spaceship
       attr_accessor :beta_groups
       attr_accessor :beta_tester_metrics
       attr_accessor :builds
+      
+      attr_accessor :isDeleted
+      attr_accessor :beta_tester_state
+      attr_accessor :last_modified_date
+      attr_accessor :installedCfBundleShortVersionString
+      attr_accessor :installedCfBundleVersion
+      attr_accessor :removeAfterDate
+      attr_accessor :latestExpiringCfBundleShortVersionString
+      attr_accessor :latestExpiringCfBundleVersionString
+      attr_accessor :installedDevice
+      attr_accessor :installedOsVersion
+      attr_accessor :installedDevicePlatform
+      attr_accessor :installedAppPlatform
 
       attr_mapping({
         "firstName" => "first_name",
@@ -25,7 +38,20 @@ module Spaceship
         "apps" => "apps",
         "betaGroups" => "beta_groups",
         "betaTesterMetrics" => "beta_tester_metrics",
-        "builds" => "builds"
+        "builds" => "builds",
+
+        "isDeleted" => "isDeleted",
+        "betaTesterState" => "beta_tester_state",
+        "lastModifiedDate" => "last_modified_date",
+        "installedCfBundleShortVersionString" => "installedCfBundleShortVersionString",
+        "installedCfBundleVersion" => "installedCfBundleVersion",
+        "removeAfterDate" => "removeAfterDate",
+        "latestExpiringCfBundleShortVersionString" => "latestExpiringCfBundleShortVersionString",
+        "latestExpiringCfBundleVersionString" => "latestExpiringCfBundleVersionString",
+        "installedDevice" => "installedDevice",
+        "installedOsVersion" => "installedOsVersion",
+        "installedDevicePlatform" => "installedDevicePlatform",
+        "installedAppPlatform" => "installedAppPlatform"
       })
 
       def self.type


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Due to changes in App Store Connect API 2.4, beta_tester_metrics for betaTesters in Spaceship are invalid, resulting in Tester status information no longer being available, beta_tester_metrics is empty.

### Description
Based on the betaTesters interface (appstoreconnect.apple.com/iris/v1/betaTesters), updated beta_tester.

### Testing Steps
```ruby
user_id = params[:user_id].to_s
user_password = params[:user_password].to_s
ios_app_id = params[:ios_app_id].to_s
team_id = params[:portal_team_id].to_s
itc_team_id = params[:itc_team_id].to_s

client = Spaceship::ConnectAPI::Client.login(user_id, user_password, portal_team_id: team_id, tunes_team_id: itc_team_id)
puts 'ConnectAPI login success🎉'

puts "#{DateTime.now.to_time} Start getting a list of testers, take a cup of tea🍵……"
testers = client.get_beta_testers(filter: { apps: ios_app_id, isDeleted: false },
                                  includes: 'betaTesterMetrics', 
                                  sort: 'betaTesterMetrics.betaTesterState', 
                                  limit: 10)

testers.each do |tester|
  unless tester.respond_to?(:beta_tester_state)
    puts "\n\n~~~~~~~~~~ 🏃Exception skip: illegal BetaTester data ~~~~~~~~~~"
  end

  puts "TesterID：#{tester.id.to_s} state-#{tester.beta_tester_state}"
end
```
