### PR TITLE
[deliver] fetch live app info if no edit info is present, fixing scenario of having both macOS and iOS apps present

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -211,7 +211,7 @@ module Deliver
       store_version_worker.start
 
       # Update app info localizations
-      unless app_info_localizations.nil?
+      if app_info_localizations
         app_info_worker = FastlaneCore::QueueWorker.new do |app_info_localization|
           attributes = localized_info_attributes_by_locale[app_info_localization.locale]
           if attributes

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -90,7 +90,7 @@ module Deliver
 
       app_store_version_localizations = verify_available_version_languages!(options, app, enabled_languages) unless options[:edit_live]
       app_info = fetch_edit_app_info(app)
-      app_info_localizations = verify_available_info_languages!(options, app, app_info, enabled_languages) unless options[:edit_live] || !updating_localised_app_info?(options, app, app_info)
+      app_info_localizations = verify_available_info_languages!(options, app, app_info, enabled_languages) unless options[:edit_live] || !updating_localized_app_info?(options, app, app_info)
 
       if options[:edit_live]
         # not all values are editable when using live_version
@@ -497,7 +497,7 @@ module Deliver
     # Finding languages to enable
     def verify_available_info_languages!(options, app, app_info, languages)
       unless app_info
-        UI.user_error!("Cannot update languages - could not find an editable info")
+        UI.user_error!("Cannot update languages - could not find an editable App info. Verify that your app is in one of the editable states in App Store Connect")
         return
       end
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -461,7 +461,7 @@ module Deliver
 
     # Checking if the metadata to update includes localised App Info
     def updating_localised_app_info?(options, app, app_info)
-      app_info = fetch_live_app_info(app) unless app_info
+      app_info ||= fetch_live_app_info(app)
       unless app_info
         UI.important("Can't find edit or live App info. Skipping upload.")
         return false

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -89,7 +89,7 @@ module Deliver
       enabled_languages = detect_languages(options)
 
       app_store_version_localizations = verify_available_version_languages!(options, app, enabled_languages) unless options[:edit_live]
-      app_info_localizations = verify_available_info_languages!(options, app, enabled_languages) unless options[:edit_live] or !is_updating_app_info(options)
+      app_info_localizations = verify_available_info_languages!(options, app, enabled_languages) unless options[:edit_live] || !is_updating_app_info(options)
 
       if options[:edit_live]
         # not all values are editable when using live_version
@@ -457,7 +457,7 @@ module Deliver
         return true unless options[key].nil?
       end
 
-      return false 
+      return false
     end
 
     # Finding languages to enable

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -89,7 +89,8 @@ module Deliver
       enabled_languages = detect_languages(options)
 
       app_store_version_localizations = verify_available_version_languages!(options, app, enabled_languages) unless options[:edit_live]
-      app_info_localizations = verify_available_info_languages!(options, app, enabled_languages) unless options[:edit_live] || !updating_localised_app_info?(options, app)
+      app_info = fetch_edit_app_info(app)
+      app_info_localizations = verify_available_info_languages!(options, app, app_info, enabled_languages) unless options[:edit_live] || !updating_localised_app_info?(options, app, app_info)
 
       if options[:edit_live]
         # not all values are editable when using live_version
@@ -224,7 +225,6 @@ module Deliver
       end
 
       # Update categories
-      app_info = fetch_edit_app_info(app)
       if app_info
         category_id_map = {}
 
@@ -460,8 +460,8 @@ module Deliver
     end
 
     # Checking if the metadata to update includes localised App Info
-    def updating_localised_app_info?(options, app)
-      app_info = fetch_edit_app_info(app) || fetch_live_app_info(app)
+    def updating_localised_app_info?(options, app, app_info)
+      app_info = fetch_live_app_info(app) unless app_info
       unless app_info
         UI.important("Can't find edit or live App info. Skipping upload.")
         return false
@@ -495,9 +495,7 @@ module Deliver
     end
 
     # Finding languages to enable
-    def verify_available_info_languages!(options, app, languages)
-      app_info = fetch_edit_app_info(app)
-
+    def verify_available_info_languages!(options, app, app_info, languages)
       unless app_info
         UI.user_error!("Cannot update languages - could not find an editable info")
         return

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -463,7 +463,7 @@ module Deliver
     def updating_localised_app_info?(options, app)
       app_info = fetch_edit_app_info(app) || fetch_live_app_info(app)
       unless app_info
-        UI.important('Can\'t find edit or live App info. Skipping upload.')
+        UI.important("Can't find edit or live App info. Skipping upload.")
         return false
       end
       localizations = app_info.get_app_info_localizations

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -490,7 +490,7 @@ module Deliver
         end
       end
 
-      UI.message('No changes to localised App Info detected. Skipping upload.')
+      UI.message('No changes to localized App Info detected. Skipping upload.')
       return false
     end
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -478,7 +478,6 @@ module Deliver
         end
 
         current.each do |language, value|
-          next unless value.to_s.length > 0
           strip_value = value.to_s.strip
           next if strip_value.empty?
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -497,7 +497,7 @@ module Deliver
     # Finding languages to enable
     def verify_available_info_languages!(options, app, app_info, languages)
       unless app_info
-        UI.user_error!("Cannot update languages - could not find an editable App info. Verify that your app is in one of the editable states in App Store Connect")
+        UI.user_error!("Cannot update languages - could not find an editable 'App Info'. Verify that your app is in one of the editable states in App Store Connect")
         return
       end
 

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -222,7 +222,7 @@ module Deliver
       app_info_worker.start
 
       # Update categories
-      app_info = fetch_edit_app_info(app)
+      app_info = fetch_edit_app_info(app) || fetch_live_app_info(app)
       if app_info
         category_id_map = {}
 
@@ -437,6 +437,12 @@ module Deliver
       end
     end
 
+    def fetch_live_app_info(app, wait_time: 10)
+      retry_if_nil("Cannot find live app info", wait_time: wait_time) do
+        app.fetch_live_app_info
+      end
+    end
+
     def retry_if_nil(message, tries: 5, wait_time: 10)
       loop do
         tries -= 1
@@ -453,7 +459,7 @@ module Deliver
 
     # Finding languages to enable
     def verify_available_info_languages!(options, app, languages)
-      app_info = fetch_edit_app_info(app)
+      app_info = fetch_edit_app_info(app) || fetch_live_app_info(app)
 
       unless app_info
         UI.user_error!("Cannot update languages - could not find an editable info")

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -222,6 +222,11 @@ module Deliver
       app_info_worker.start
 
       # Update categories
+      # When there are iOS and macOS implementations of the same app,
+      # fetch_edit_app_info will fail when trying to fetch data for one platform
+      # if the other is in not editable state.
+      # We still keep fetch_edit_app_info as first option to make sure
+      # latest data is fetched when apps are in an editable state.
       app_info = fetch_edit_app_info(app) || fetch_live_app_info(app)
       if app_info
         category_id_map = {}
@@ -459,6 +464,11 @@ module Deliver
 
     # Finding languages to enable
     def verify_available_info_languages!(options, app, languages)
+      # When there are iOS and macOS implementations of the same app,
+      # fetch_edit_app_info will fail when trying to fetch data for one platform
+      # if the other is in not editable state.
+      # We still keep fetch_edit_app_info as first option to make sure
+      # latest data is fetched when apps are in an editable state.
       app_info = fetch_edit_app_info(app) || fetch_live_app_info(app)
 
       unless app_info

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -460,7 +460,7 @@ module Deliver
     end
 
     # Checking if the metadata to update includes localised App Info
-    def updating_localised_app_info?(options, app, app_info)
+    def updating_localized_app_info?(options, app, app_info)
       app_info ||= fetch_live_app_info(app)
       unless app_info
         UI.important("Can't find edit or live App info. Skipping upload.")

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -490,7 +490,7 @@ module Deliver
         end
       end
 
-      UI.important('No changes to localised App Info detected. Skipping upload.')
+      UI.message('No changes to localised App Info detected. Skipping upload.')
       return false
     end
 

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -244,7 +244,6 @@ describe Deliver::UploadMetadata do
         expect(version).to receive(:get_app_store_version_localizations).and_return([version_localization_en])
 
         # Get app infos
-        expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
         expect(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
       end
 
@@ -263,7 +262,6 @@ describe Deliver::UploadMetadata do
           expect(version).to receive(:update).with(attributes: {})
 
           # Get app info
-          expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
           expect(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
 
           # Get app info localization English (Used to compare with data to upload)

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -494,7 +494,7 @@ describe Deliver::UploadMetadata do
         expect(app_info_localization_en).to receive(:name).and_return('App name')
 
         # Fail because app info can't be updated
-        expect(FastlaneCore::UI).to receive(:user_error!).with('Cannot update languages - could not find an editable App info. Verify that your app is in one of the editable states in App Store Connect').and_call_original
+        expect(FastlaneCore::UI).to receive(:user_error!).with('Cannot update languages - could not find an editable 'App Info'. Verify that your app is in one of the editable states in App Store Connect').and_call_original
 
         # Get app info localization in English (used to compare with data to upload)
         expect { uploader.upload(options) }.to raise_error(FastlaneCore::Interface::FastlaneError)

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -437,10 +437,8 @@ describe Deliver::UploadMetadata do
 
           # Get number of versions (used for if whats_new should be sent)
           expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
-
           expect(version).to receive(:update).with(attributes: {})
 
-          # Get app info localization in English (used to compare with data to upload)
           uploader.upload(options)
         end
 
@@ -462,7 +460,6 @@ describe Deliver::UploadMetadata do
           # Get app info localization in English (used to compare with data to upload)
           expect(app_info_localization_en).to receive(:name).and_return("App name")
 
-          # Get app info localization in English (used to compare with data to upload)
           uploader.upload(options)
         end
       end

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -494,7 +494,7 @@ describe Deliver::UploadMetadata do
         expect(app_info_localization_en).to receive(:name).and_return('App name')
 
         # Fail because app info can't be updated
-        expect(FastlaneCore::UI).to receive(:user_error!).with('Cannot update languages - could not find an editable 'App Info'. Verify that your app is in one of the editable states in App Store Connect').and_call_original
+        expect(FastlaneCore::UI).to receive(:user_error!).with("Cannot update languages - could not find an editable 'App Info'. Verify that your app is in one of the editable states in App Store Connect").and_call_original
 
         # Get app info localization in English (used to compare with data to upload)
         expect { uploader.upload(options) }.to raise_error(FastlaneCore::Interface::FastlaneError)

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -270,7 +270,7 @@ describe Deliver::UploadMetadata do
           expect(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
 
           # Get app info localization English (Used to compare with data to upload)
-          expect(app_info_localization_en).to receive(:name).and_return("")
+          expect(app_info_localization_en).to receive(:name).and_return('App Name')
 
           # Update version localization
           expect(version_localization_en).to receive(:update).with(attributes: {
@@ -458,7 +458,7 @@ describe Deliver::UploadMetadata do
           expect(version).to receive(:update).with(attributes: {})
 
           # Get app info localization in English (used to compare with data to upload)
-          expect(app_info_localization_en).to receive(:name).and_return("App name")
+          expect(app_info_localization_en).to receive(:name).and_return('App name')
 
           uploader.upload(options)
         end
@@ -491,10 +491,10 @@ describe Deliver::UploadMetadata do
         expect(version).to receive(:get_app_store_version_localizations).and_return([version_localization_en])
 
         # Get app info localization in English (used to compare with data to upload)
-        expect(app_info_localization_en).to receive(:name).and_return("App name")
+        expect(app_info_localization_en).to receive(:name).and_return('App name')
 
         # Fail because app info can't be updated
-        expect(FastlaneCore::UI).to receive(:user_error!).with("Cannot update languages - could not find an editable info").and_call_original
+        expect(FastlaneCore::UI).to receive(:user_error!).with('Cannot update languages - could not find an editable App info. Verify that your app is in one of the editable states in App Store Connect').and_call_original
 
         # Get app info localization in English (used to compare with data to upload)
         expect { uploader.upload(options) }.to raise_error(FastlaneCore::Interface::FastlaneError)

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -257,10 +257,17 @@ describe Deliver::UploadMetadata do
               description: { "en-US" => "App description" }
           }
 
-          # Get number of verions (used for if whats_new should be sent)
+          # Get number of versions (used for if whats_new should be sent)
           expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
 
           expect(version).to receive(:update).with(attributes: {})
+
+          # Get app info
+          expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
+          expect(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
+          
+          # Get app info localization English (Used to compare with data to upload)
+          expect(app_info_localization_en).to receive(:name).and_return("")
 
           # Update version localization
           expect(version_localization_en).to receive(:update).with(attributes: {

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -265,7 +265,7 @@ describe Deliver::UploadMetadata do
           # Get app info
           expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
           expect(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
-          
+
           # Get app info localization English (Used to compare with data to upload)
           expect(app_info_localization_en).to receive(:name).and_return("")
 

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -162,6 +162,7 @@ describe Deliver::UploadMetadata do
              locale: 'en-US')
     end
     let(:app_info) { double('app_info') }
+    let(:live_app_info) { nil }
     let(:app_info_localization_en) do
       double('app_info_localization_en',
              locale: 'en-US')
@@ -237,14 +238,18 @@ describe Deliver::UploadMetadata do
         # Verify available languages
         expect(app).to receive(:id).and_return(id)
         expect(app).to receive(:get_edit_app_store_version).and_return(version)
-        expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
+        expect(uploader).to receive(:fetch_edit_app_info).and_return(app_info)
 
         # Get versions
         expect(app).to receive(:get_edit_app_store_version).and_return(version)
         expect(version).to receive(:get_app_store_version_localizations).and_return([version_localization_en])
 
         # Get app infos
-        expect(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
+        if app_info
+          expect(app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
+        else
+          expect(live_app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
+        end
       end
 
       context "normal metadata" do
@@ -416,6 +421,86 @@ describe Deliver::UploadMetadata do
 
           uploader.upload(options)
         end
+      end
+
+      context "with no editable app info" do
+        let(:live_app_info) { double('app_info') }
+        let(:app_info) { nil }
+        it 'no new app info provided by user' do
+          options = {
+              platform: "ios",
+              metadata_path: metadata_path,
+          }
+
+          # Get live ap info
+          expect(app).to receive(:fetch_live_app_info).and_return(live_app_info)
+
+          # Get number of versions (used for if whats_new should be sent)
+          expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+
+          expect(version).to receive(:update).with(attributes: {})
+
+          # Get app info localization English (Used to compare with data to upload)
+          uploader.upload(options)
+        end
+
+        it 'same app info as live version' do
+          options = {
+              platform: "ios",
+              metadata_path: metadata_path,
+              name: { "en-US" => "App name" }
+          }
+
+          # Get live ap info
+          expect(app).to receive(:fetch_live_app_info).and_return(live_app_info)
+
+          # Get number of versions (used for if whats_new should be sent)
+          expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+
+          expect(version).to receive(:update).with(attributes: {})
+
+          # Get app info localization English (Used to compare with data to upload)
+          expect(app_info_localization_en).to receive(:name).and_return("App name")
+
+          # Get app info localization English (Used to compare with data to upload)
+          uploader.upload(options)
+        end
+      end
+    end
+
+    context "fail when not allowed to update" do
+      let(:live_app_info) { double('app_info') }
+      let(:app_info) { nil }
+      it 'different app info than live version' do
+        options = {
+            platform: "ios",
+            metadata_path: metadata_path,
+            name: { "en-US" => "New app name" }
+        }
+
+        allow(Deliver).to receive(:cache).and_return({ app: app })
+
+        allow(uploader).to receive(:set_review_information)
+        allow(uploader).to receive(:set_review_attachment_file)
+        allow(uploader).to receive(:set_app_rating)
+
+        # Get app info
+        expect(uploader).to receive(:fetch_edit_app_info).and_return(app_info)
+        expect(app).to receive(:fetch_live_app_info).and_return(live_app_info)
+        expect(live_app_info).to receive(:get_app_info_localizations).and_return([app_info_localization_en])
+
+        # Get versions
+        expect(app).to receive(:get_edit_app_store_version).and_return(version)
+        expect(version).to receive(:get_app_store_version_localizations).and_return([version_localization_en])
+
+        # Get app info localization English (Used to compare with data to upload)
+        expect(app_info_localization_en).to receive(:name).and_return("App name")
+
+        # Fail because app info can't be updated
+        expect(FastlaneCore::UI).to receive(:user_error!).with("Cannot update languages - could not find an editable info").and_call_original
+
+        # Get app info localization English (Used to compare with data to upload)
+        expect { uploader.upload(options) }.to raise_error(FastlaneCore::Interface::FastlaneError)
       end
     end
   end

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -432,7 +432,7 @@ describe Deliver::UploadMetadata do
               metadata_path: metadata_path,
           }
 
-          # Get live ap info
+          # Get live app info
           expect(app).to receive(:fetch_live_app_info).and_return(live_app_info)
 
           # Get number of versions (used for if whats_new should be sent)
@@ -440,7 +440,7 @@ describe Deliver::UploadMetadata do
 
           expect(version).to receive(:update).with(attributes: {})
 
-          # Get app info localization English (Used to compare with data to upload)
+          # Get app info localization in English (used to compare with data to upload)
           uploader.upload(options)
         end
 
@@ -451,7 +451,7 @@ describe Deliver::UploadMetadata do
               name: { "en-US" => "App name" }
           }
 
-          # Get live ap info
+          # Get live app info
           expect(app).to receive(:fetch_live_app_info).and_return(live_app_info)
 
           # Get number of versions (used for if whats_new should be sent)
@@ -459,10 +459,10 @@ describe Deliver::UploadMetadata do
 
           expect(version).to receive(:update).with(attributes: {})
 
-          # Get app info localization English (Used to compare with data to upload)
+          # Get app info localization in English (used to compare with data to upload)
           expect(app_info_localization_en).to receive(:name).and_return("App name")
 
-          # Get app info localization English (Used to compare with data to upload)
+          # Get app info localization in English (used to compare with data to upload)
           uploader.upload(options)
         end
       end
@@ -493,13 +493,13 @@ describe Deliver::UploadMetadata do
         expect(app).to receive(:get_edit_app_store_version).and_return(version)
         expect(version).to receive(:get_app_store_version_localizations).and_return([version_localization_en])
 
-        # Get app info localization English (Used to compare with data to upload)
+        # Get app info localization in English (used to compare with data to upload)
         expect(app_info_localization_en).to receive(:name).and_return("App name")
 
         # Fail because app info can't be updated
         expect(FastlaneCore::UI).to receive(:user_error!).with("Cannot update languages - could not find an editable info").and_call_original
 
-        # Get app info localization English (Used to compare with data to upload)
+        # Get app info localization in English (used to compare with data to upload)
         expect { uploader.upload(options) }.to raise_error(FastlaneCore::Interface::FastlaneError)
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
When an app has an iOS and a macOS implementation, Deliver fails to upload one of the apps if the other one is under review:
- ASC returns no edit_app_info if one of the app is submitted for review and this makes Deliver fail. 
- Uploading only platform specific info for the other platform is actually a valid operation in ASC. Deliver fails because it can't fetch edit_app_info data, not because it can't upload the new data.  
- Since uploading only platform specific info is a valid flow in ASC, Deliver should allow to perform it. 

Resolves #17321
Resolves #21003

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->
This PR updates `update_metadata` so that it fetches `live_app_info` if it can't find `edit_app_info`. 
- If no app is under review, edit_app_info will be fetched, so no changes from the current behaviour for most cases. 
- If one platform is under review, fetching `live_app_info` as a backup solution will allow the upload flow to continue. The flow will succeed if the user uploads only platform specific metadata, or fail later if they try to upload something that can't be modified in this state. 


### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
_To test this specific scenario:_
1. Create an app with an iOS and a macOS implementation.
2. Submit a new version of the iOS app for review. 
3. When the iOS app is _waiting for review_, upload metadata (you can also try and upload binary and screenshots as well, but the issue is specific to metadata, so no need to do it) for a new version of the macOS app: 
```
bundle exec fastlane deliver run --force \
  --platform osx \
  --skip_binary_upload true \
  --skip_screenshots true \
  --submit_for_review false \
  --skip_metadata false \
  --automatic_release false \
  --username <your username> \
  --app_identifier <your app identifier>
```
and verify that it works. 

_Minimum regression testing:_
1. Test that upload a single iOS app still works. 
2. Test that  trying to upload new metadata for an app/platform that has been submitted for review fails. 