### PR TITLE
Explicit beta group access to all builds at creation

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app.rb
@@ -387,7 +387,7 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def create_beta_group(client: nil, group_name: nil, is_internal_group: false, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
+      def create_beta_group(client: nil, group_name: nil, is_internal_group: false, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false, has_access_to_all_builds: nil)
         client ||= Spaceship::ConnectAPI
         resps = client.create_beta_group(
           app_id: id,
@@ -395,7 +395,8 @@ module Spaceship
           is_internal_group: is_internal_group,
           public_link_enabled: public_link_enabled,
           public_link_limit: public_link_limit,
-          public_link_limit_enabled: public_link_limit_enabled
+          public_link_limit_enabled: public_link_limit_enabled,
+          has_access_to_all_builds: has_access_to_all_builds
         ).all_pages
         return resps.flat_map(&:to_models).first
       end

--- a/spaceship/lib/spaceship/connect_api/models/beta_group.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_group.rb
@@ -13,6 +13,7 @@ module Spaceship
       attr_accessor :public_link_limit
       attr_accessor :public_link
       attr_accessor :beta_testers
+      attr_accessor :has_access_to_all_builds
 
       attr_mapping({
         "name" => "name",
@@ -23,7 +24,8 @@ module Spaceship
         "publicLinkLimitEnabled" => "public_link_limit_enabled",
         "publicLinkLimit" => "public_link_limit",
         "publicLink" => "public_link",
-        "betaTesters" => "beta_testers"
+        "betaTesters" => "beta_testers",
+        "hasAccessToAllBuilds" => "has_access_to_all_builds",
       })
 
       def self.type

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -204,13 +204,14 @@ module Spaceship
           test_flight_request_client.delete("builds/#{build_id}/relationships/betaGroups", nil, body)
         end
 
-        def create_beta_group(app_id: nil, group_name: nil, is_internal_group: false, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
+        def create_beta_group(app_id: nil, group_name: nil, is_internal_group: false, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false, has_access_to_all_builds: nil)
+          has_access_to_all_builds = is_internal_group ? true : false if has_access_to_all_builds.nil?
           body = {
             data: {
               attributes: {
                 name: group_name,
                 isInternalGroup: is_internal_group,
-                hasAccessToAllBuilds: is_internal_group ? true : false, # Undocumented of 2021-08-02 in ASC API docs and ASC Open API spec. This is the default behavior on App Store Connect and does work with both Apple ID and API Token
+                hasAccessToAllBuilds: has_access_to_all_builds, # Undocumented of 2021-08-02 in ASC API docs and ASC Open API spec. This is the default behavior on App Store Connect and does work with both Apple ID and API Token
                 publicLinkEnabled: public_link_enabled,
                 publicLinkLimit: public_link_limit,
                 publicLinkLimitEnabled: public_link_limit_enabled

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -205,7 +205,12 @@ module Spaceship
         end
 
         def create_beta_group(app_id: nil, group_name: nil, is_internal_group: false, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false, has_access_to_all_builds: nil)
-          has_access_to_all_builds = is_internal_group ? true : false if has_access_to_all_builds.nil?
+          if is_internal_group
+            has_access_to_all_builds = true if has_access_to_all_builds.nil?
+          else
+            # Access to all builds is only for internal groups
+            has_access_to_all_builds = nil
+          end
           body = {
             data: {
               attributes: {

--- a/spaceship/spec/connect_api/fixtures/testflight/beta_create_group.json
+++ b/spaceship/spec/connect_api/fixtures/testflight/beta_create_group.json
@@ -10,7 +10,8 @@
         "publicLinkId" : "abcd1234",
         "publicLinkLimitEnabled" : false,
         "publicLinkLimit" : 10000,
-        "publicLink" : "https://testflight.apple.com/join/abcd1234"
+        "publicLink" : "https://testflight.apple.com/join/abcd1234",
+        "hasAccessToAllBuilds" : null
       }
     }
 }

--- a/spaceship/spec/connect_api/models/app_spec.rb
+++ b/spaceship/spec/connect_api/models/app_spec.rb
@@ -91,6 +91,26 @@ describe Spaceship::ConnectAPI::App do
 
       model = app.create_beta_group(group_name: "Brand New Group", public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
       expect(model.id).to eq("123456789")
+      expect(model.is_internal_group).to eq(false)
+      expect(model.has_access_to_all_builds).to be_nil
+
+      # `has_access_to_all_builds` is ignored for external groups
+      model = app.create_beta_group(group_name: "Brand New Group", public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false, has_access_to_all_builds: true)
+      expect(model.id).to eq("123456789")
+      expect(model.is_internal_group).to eq(false)
+      expect(model.has_access_to_all_builds).to be_nil
+
+      # `has_access_to_all_builds` is set to `true` by default for internal groups
+      model = app.create_beta_group(group_name: "Brand New Group", is_internal_group: true, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false)
+      expect(model.id).to eq("123456789")
+      expect(model.is_internal_group).to eq(true)
+      expect(model.has_access_to_all_builds).to eq(true)
+
+      # `has_access_to_all_builds` can be set to `false` for internal groups
+      model = app.create_beta_group(group_name: "Brand New Group", is_internal_group: true, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false, has_access_to_all_builds: false)
+      expect(model.id).to eq("123456789")
+      expect(model.is_internal_group).to eq(true)
+      expect(model.has_access_to_all_builds).to eq(false)
     end
 
     it '#get_review_submissions' do

--- a/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_stubbing.rb
@@ -67,8 +67,16 @@ class ConnectAPIStubbing
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/betaGroups").
           to_return(status: 200, body: read_fixture_file('beta_groups.json'), headers: { 'Content-Type' => 'application/json' })
 
+        created_beta_group = JSON.parse(read_fixture_file('beta_create_group.json'))
         stub_request(:post, "https://appstoreconnect.apple.com/iris/v1/betaGroups").
-          to_return(status: 200, body: read_fixture_file('beta_create_group.json'), headers: { 'Content-Type' => 'application/json' })
+          to_return { |request|
+            request_body = JSON.parse(request.body)
+            response_body = created_beta_group.dup
+            %w{isInternalGroup hasAccessToAllBuilds}.each do |attribute|
+              response_body["data"]["attributes"][attribute] = request_body["data"]["attributes"][attribute]
+            end
+            { status: 200, body: JSON.dump(response_body), headers: { 'Content-Type' => 'application/json' } }
+          }
 
         stub_request(:delete, "https://appstoreconnect.apple.com/iris/v1/betaGroups/123456789").
           to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

When creating a beta group, the App Store Connect API let you specify if this new group has access to all existing builds or not, but fastlane did not let you specify it, setting it to `true` for internal groups, and `false` for external ones.

I wanted to be able to create internal groups that do not have access to existing builds.

<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

This change lets you explicitly specify if the new group has access to all existing builds or not. If you do not specify this new parameter, the behavior is the same as before.

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
