### PR TITLE
Warning when `has_access_to_all_builds` is specified for external group

### DIFF
--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -208,7 +208,7 @@ module Spaceship
           if is_internal_group
             has_access_to_all_builds = true if has_access_to_all_builds.nil?
           else
-            # Access to all builds is only for internal groups
+            UI.important("has_access_to_all_builds is only for internal groups") unless has_access_to_all_builds.nil?
             has_access_to_all_builds = nil
           end
           body = {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Asked to add warning in PR review: https://github.com/fastlane/fastlane/pull/21478#discussion_r1306900915

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
Add warning when explicitly specifying `has_access_to_all_builds` when creating an external beta group/

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
