### PR TITLE
[spaceship] Add beta tester metric properties to beta tester object

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/beta_tester.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_tester.rb
@@ -15,6 +15,15 @@ module Spaceship
       attr_accessor :beta_tester_metrics
       attr_accessor :builds
 
+      attr_accessor :install_count
+      attr_accessor :crash_count
+      attr_accessor :session_count
+      attr_accessor :beta_tester_state
+      attr_accessor :last_modified_date
+      attr_accessor :remove_after_date
+      attr_accessor :installed_cf_bundle_short_version_string
+      attr_accessor :installed_cf_bundle_version
+
       attr_mapping({
         "firstName" => "first_name",
         "lastName" => "last_name",
@@ -25,7 +34,16 @@ module Spaceship
         "apps" => "apps",
         "betaGroups" => "beta_groups",
         "betaTesterMetrics" => "beta_tester_metrics",
-        "builds" => "builds"
+        "builds" => "builds",
+
+        "installCount" => "install_count",
+        "crashCount" => "crash_count",
+        "sessionCount" => "session_count",
+        "betaTesterState" => "beta_tester_state",
+        "lastModifiedDate" => "last_modified_date",
+        "removeAfterDate" => "remove_after_date",
+        "installedCfBundleShortVersionString" => "installed_cf_bundle_short_version_string",
+        "installedCfBundleVersion" => "installed_cf_bundle_version"
       })
 
       def self.type


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

I was using [the clean_testflight_testers](https://github.com/fastlane-community/fastlane-plugin-clean_testflight_testers) plugin, and found that recently it stopped working -- it was crashing because it wasn't finding any `beta_tester_metrics`. I looked at the data that was being [returned by the API on the line where it fetches the testers](https://github.com/fastlane-community/fastlane-plugin-clean_testflight_testers/blob/3bc691c35a4118d51cb6b84578893a617d6c2e99/lib/fastlane/plugin/clean_testflight_testers/actions/clean_testflight_testers_action.rb#L21), and sure enough, many of my users did not have beta tester metrics!

```
{"id":"c84e6162-7325-4d78-b4e9-26cd1d98dc35","first_name":"Anonymous","last_name":null,"email":null,"invite_type":"PUBLIC_LINK","beta_tester_metrics":[]},
```

I looked at the API call that App Store Connect was making to itself in the browser, and it looks like this data was moved out of the `betaTesterMetrics` object, and right into the `betaTester` object:

<img width="40%" src="https://github.com/fastlane/fastlane/assets/1579644/2e6b8c8c-c994-452d-8dd1-ab828a849929">

### Description

I added some of the extra parameters to the `BetaTester` class so that I could get the data directly from the tester objects.

### Testing Steps

I have a modified version of the plugin linked above that I am using to better suit our user removal criteria. But you can do a similar thing by making a few changes:

* Remove the `includes: "betaTesterMetrics"` parameter from the spaceship call
* Remove this line `tester_metrics = current_tester.beta_tester_metrics.first` and just use `current_tester` instead of `tester_metrics`
* Comment out the `tester_metrics.session_count == 0`. This was moved to a new `betaTesterUsages` object that I didn't need, nor really know how to add:
<img width="40%" alt="image" src="https://github.com/fastlane/fastlane/assets/1579644/43ade0ef-d3b5-4f6b-b534-6668d1ad96a5">

i think that plugin should work now