### PR TITLE
Add request retry with backoff when encountring 429 errors

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -202,7 +202,7 @@ module Spaceship
         end
         puts(error) if Spaceship::Globals.verbose?
         Kernel.sleep(backoff)
-        backoff = backoff * 2
+        backoff *= 2
         retry
       end
 

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -138,11 +138,11 @@ describe Spaceship::ConnectAPI::APIClient do
         expect(client).to receive(:request).twice.and_call_original
         expect do
           client.get('')
-        end.to_not raise_error
+        end.to_not(raise_error)
       end
 
       it 'sleeps until limit is reached on 429' do
-        body = JSON.generate({"errors": [{"title": "The request rate limit has been reached.", "details": "We've received too many requests for this API. Please wait and try again or slow down your request rate."}]})
+        body = JSON.generate({ "errors": [{ "title": "The request rate limit has been reached.", "details": "We've received too many requests for this API. Please wait and try again or slow down your request rate." }] })
         stub_client_request(client.hostname, 429, body)
 
         expect(Kernel).to receive(:sleep).exactly(12).times

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -126,6 +126,31 @@ describe Spaceship::ConnectAPI::APIClient do
         client.get('')
       end.to raise_error(Spaceship::AccessForbiddenError)
     end
+
+    describe 'with_retry' do
+      it 'sleeps on 429' do
+        stub_request(:get, client.hostname).
+          to_return(status: 429).then.
+          to_return(status: 200, body: "")
+
+        expect(Kernel).to receive(:sleep).once.with(1)
+        expect(client).to receive(:handle_response).once
+        expect(client).to receive(:request).twice.and_call_original
+        expect do
+          client.get('')
+        end.to_not raise_error
+      end
+
+      it 'sleeps until limit is reached on 429' do
+        body = JSON.generate({"errors": [{"title": "The request rate limit has been reached.", "details": "We've received too many requests for this API. Please wait and try again or slow down your request rate."}]})
+        stub_client_request(client.hostname, 429, body)
+
+        expect(Kernel).to receive(:sleep).exactly(12).times
+        expect do
+          client.get('')
+        end.to raise_error(Spaceship::ConnectAPI::APIClient::TooManyRequestsError, "Too many requests, giving up after backing off for > 3600 seconds.")
+      end
+    end
   end
 
   describe "#handle_error" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Fixes #13841

This PR attempts to handle 429 "Too Many Requests" errors when using the App Store Connect API. The default request quota offered by the App Store Connect API is 3600 / hour. Requests will back off, with doubling delays, until 3600 seconds is reach after which it will give up.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
