### PR TITLE
[supply] add new SUPPLY_UPLOAD_MAX_RETRIES env var to attempt to solve failed Google API calls

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -78,6 +78,7 @@ module Supply
     private
 
     def call_google_api
+      tries_left ||= (ENV["SUPPLY_UPLOAD_MAX_RETRIES"] || 0).to_i
       yield if block_given?
     rescue Google::Apis::Error => e
       error = begin
@@ -92,7 +93,13 @@ module Supply
         message = e.body
       end
 
-      UI.user_error!("Google Api Error: #{e.message} - #{message}")
+      if tries_left.positive?
+        UI.error("Google Api Error: #{e.message} - #{message} - Retrying...")
+        tries_left -= 1
+        retry
+      else
+        UI.user_error!("Google Api Error: #{e.message} - #{message}")
+      end
     end
   end
 

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -8,23 +8,47 @@ describe Supply do
         to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
     end
 
-    it "displays error messages from the API" do
-      stub_request(:post, "https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/test-app/edits/1/listings/en-US/icon").
-        to_return(status: 403, body: '{"error":{"message":"Ensure project settings are enabled."}}', headers: { 'Content-Type' => 'application/json' })
+    describe "displays error messages from the API" do
+      it "with no retries" do
+        stub_request(:post, "https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/test-app/edits/1/listings/en-US/icon").
+          to_return(status: 403, body: '{"error":{"message":"Ensure project settings are enabled."}}', headers: { 'Content-Type' => 'application/json' })
 
-      expect(UI).to receive(:user_error!).with("Google Api Error: Invalid request - Ensure project settings are enabled.")
+        expect(UI).to receive(:user_error!).with("Google Api Error: Invalid request - Ensure project settings are enabled.").once
 
-      current_edit = double
-      allow(current_edit).to receive(:id).and_return(1)
+        current_edit = double
+        allow(current_edit).to receive(:id).and_return(1)
 
-      client = Supply::Client.new(service_account_json: StringIO.new(service_account_file), params: { timeout: 1 })
-      allow(client).to receive(:ensure_active_edit!)
-      allow(client).to receive(:current_edit).and_return(current_edit)
+        client = Supply::Client.new(service_account_json: StringIO.new(service_account_file), params: { timeout: 1 })
+        allow(client).to receive(:ensure_active_edit!)
+        allow(client).to receive(:current_edit).and_return(current_edit)
 
-      client.begin_edit(package_name: 'test-app')
-      client.upload_image(image_path: fixture_file("playstore-icon.png"),
-                          image_type: "icon",
-                            language: "en-US")
+        client.begin_edit(package_name: 'test-app')
+        client.upload_image(image_path: fixture_file("playstore-icon.png"),
+                            image_type: "icon",
+                              language: "en-US")
+      end
+
+      it "with 5 retries" do
+        stub_const("ENV", { 'SUPPLY_UPLOAD_MAX_RETRIES' => 5 })
+
+        stub_request(:post, "https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/test-app/edits/1/listings/en-US/icon").
+          to_return(status: 403, body: '{"error":{"message":"Ensure project settings are enabled."}}', headers: { 'Content-Type' => 'application/json' })
+
+        expect(UI).to receive(:error).with("Google Api Error: Invalid request - Ensure project settings are enabled. - Retrying...").exactly(5).times
+        expect(UI).to receive(:user_error!).with("Google Api Error: Invalid request - Ensure project settings are enabled.").once
+
+        current_edit = double
+        allow(current_edit).to receive(:id).and_return(1)
+
+        client = Supply::Client.new(service_account_json: StringIO.new(service_account_file), params: { timeout: 1 })
+        allow(client).to receive(:ensure_active_edit!)
+        allow(client).to receive(:current_edit).and_return(current_edit)
+
+        client.begin_edit(package_name: 'test-app')
+        client.upload_image(image_path: fixture_file("playstore-icon.png"),
+                            image_type: "icon",
+                              language: "en-US")
+      end
     end
 
     describe "AndroidPublisher" do

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -13,8 +13,6 @@ describe Supply do
         stub_request(:post, "https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/test-app/edits/1/listings/en-US/icon").
           to_return(status: 403, body: '{"error":{"message":"Ensure project settings are enabled."}}', headers: { 'Content-Type' => 'application/json' })
 
-        expect(UI).to receive(:user_error!).with("Google Api Error: Invalid request - Ensure project settings are enabled.").once
-
         current_edit = double
         allow(current_edit).to receive(:id).and_return(1)
 
@@ -23,9 +21,11 @@ describe Supply do
         allow(client).to receive(:current_edit).and_return(current_edit)
 
         client.begin_edit(package_name: 'test-app')
-        client.upload_image(image_path: fixture_file("playstore-icon.png"),
-                            image_type: "icon",
-                              language: "en-US")
+        expect {
+          client.upload_image(image_path: fixture_file("playstore-icon.png"),
+                              image_type: "icon",
+                                language: "en-US")
+        }.to raise_error(FastlaneCore::Interface::FastlaneError, "Google Api Error: Invalid request - Ensure project settings are enabled.")
       end
 
       it "with 5 retries" do
@@ -35,7 +35,6 @@ describe Supply do
           to_return(status: 403, body: '{"error":{"message":"Ensure project settings are enabled."}}', headers: { 'Content-Type' => 'application/json' })
 
         expect(UI).to receive(:error).with("Google Api Error: Invalid request - Ensure project settings are enabled. - Retrying...").exactly(5).times
-        expect(UI).to receive(:user_error!).with("Google Api Error: Invalid request - Ensure project settings are enabled.").once
 
         current_edit = double
         allow(current_edit).to receive(:id).and_return(1)
@@ -45,9 +44,11 @@ describe Supply do
         allow(client).to receive(:current_edit).and_return(current_edit)
 
         client.begin_edit(package_name: 'test-app')
-        client.upload_image(image_path: fixture_file("playstore-icon.png"),
-                            image_type: "icon",
-                              language: "en-US")
+        expect {
+          client.upload_image(image_path: fixture_file("playstore-icon.png"),
+                              image_type: "icon",
+                                language: "en-US")
+        }.to raise_error(FastlaneCore::Interface::FastlaneError, "Google Api Error: Invalid request - Ensure project settings are enabled.")
       end
     end
 


### PR DESCRIPTION
### Motivation and Context

Somewhat fixes #21507

Applying the patch made by @AliSoftware mentioned https://github.com/fastlane/fastlane/issues/21507#issuecomment-1721417442

### Description

Added new `SUPPLY_UPLOAD_MAX_RETRIES` env variable to retry failed Google API requests to attempt to "fix" uploads from erroring

```sh
SUPPLY_UPLOAD_MAX_RETRIES=5 fastlane your_lane
```
