### PR TITLE
[match] Fixes missing job-token error in GitLab storage mode

### DIFF
--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -239,6 +239,14 @@ module Match
                                       default_value: 'https://gitlab.com',
                                       description: "GitLab Host (i.e. 'https://gitlab.com')",
                                       optional: true),
+        FastlaneCore::ConfigItem.new(key: :job_token,
+                                      env_name: "CI_JOB_TOKEN",
+                                      description: "GitLab CI_JOB_TOKEN",
+                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :private_token,
+                                      env_name: "PRIVATE_TOKEN",
+                                      description: "GitLab Access Token",
+                                      optional: true),
 
         # Keychain
         FastlaneCore::ConfigItem.new(key: :keychain_name,

--- a/match/spec/storage/gitlab_secure_files_spec.rb
+++ b/match/spec/storage/gitlab_secure_files_spec.rb
@@ -129,4 +129,65 @@ describe Match do
       end
     end
   end
+
+  describe 'Runner Configuration' do
+    let(:available_options) { Match::Options.available_options }
+    let(:base_options) {
+      {
+        storage_mode: 'gitlab_secure_files',
+        gitlab_project: 'test/project',
+        readonly: true,
+        skip_provisioning_profiles: true,
+        app_identifier: 'fake-app-identifier'
+      }
+    }
+    let(:configuration) {
+      FastlaneCore::Configuration.create(available_options, base_options)
+    }
+    let(:runner) {
+      Match::Runner.new.run(configuration)
+    }
+
+    before do
+      allow_any_instance_of(Match::Runner).to receive(:fetch_certificate)
+      expect(Match::Storage::GitLab::Client).to receive_message_chain(:new, :prompt_for_access_token)
+      expect(Match::Storage::GitLab::Client).to receive_message_chain(:new, :files).and_return([])
+    end
+
+    it 'allows the optional job_token param' do
+      base_options[:job_token] = 'foo'
+
+      expect(runner).to be true
+      expect(configuration.fetch(:storage_mode)).to eq('gitlab_secure_files')
+      expect(configuration.fetch(:job_token)).to eq('foo')
+      expect(configuration.fetch(:private_token)).to be nil
+    end
+
+    it 'allows the optional private_token param' do
+      base_options[:private_token] = 'bar'
+
+      expect(runner).to be true
+      expect(configuration.fetch(:storage_mode)).to eq('gitlab_secure_files')
+      expect(configuration.fetch(:job_token)).to be nil
+      expect(configuration.fetch(:private_token)).to eq('bar')
+    end
+
+    it 'uses the PRIVATE_TOKEN ENV variable when supplied' do
+      stub_const('ENV', ENV.to_hash.merge('PRIVATE_TOKEN' => 'env-private'))
+
+      expect(runner).to be true
+      expect(configuration.fetch(:storage_mode)).to eq('gitlab_secure_files')
+      expect(configuration.fetch(:job_token)).to be nil
+      expect(configuration.fetch(:private_token)).to eq('env-private')
+    end
+
+    it 'uses the CI_JOB_TOKEN ENV variable when supplied' do
+      stub_const('ENV', ENV.to_hash.merge('CI_JOB_TOKEN' => 'env-job'))
+
+      expect(runner).to be true
+      expect(configuration.fetch(:storage_mode)).to eq('gitlab_secure_files')
+      expect(configuration.fetch(:job_token)).to eq('env-job')
+      expect(configuration.fetch(:private_token)).to be nil
+    end
+  end
 end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

This PR fixes the error reported in https://github.com/fastlane/fastlane/pull/21018#issuecomment-1723340393 related to the GitLab Secure Files Fastlane Match storage backend. 

### Description

The error was introduced in this change https://github.com/fastlane/fastlane/pull/21018 which added an additional configuration keys check that didn't exist before. This issue is resolved by adding the optional configuration keys to the global configuration object so that the keys can be validated correctly. 

### Testing Steps

Tested locally and added automated tests. 
