### PR TITLE
[spaceship] allow to specify fetched fields

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -87,13 +87,14 @@ module Spaceship
         return @token.nil?
       end
 
-      def build_params(filter: nil, includes: nil, limit: nil, sort: nil, cursor: nil)
+      def build_params(filter: nil, includes: nil, fields: nil, limit: nil, sort: nil, cursor: nil)
         params = {}
 
         filter = filter.delete_if { |k, v| v.nil? } if filter
 
         params[:filter] = filter if filter && !filter.empty?
         params[:include] = includes if includes
+        params[:fields] = fields if fields
         params[:limit] = limit if limit
         params[:sort] = sort if sort
         params[:cursor] = cursor if cursor

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -39,15 +39,15 @@ module Spaceship
       # API
       #
 
-      def self.all(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+      def self.all(client: nil, filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
-        resps = client.get_bundle_ids(filter: filter, includes: includes).all_pages
+        resps = client.get_bundle_ids(filter: filter, includes: includes, fields: fields, limit: nil, sort: nil).all_pages
         return resps.flat_map(&:to_models)
       end
 
-      def self.find(identifier, includes: nil, client: nil)
+      def self.find(identifier, includes: nil, fields: nil, client: nil)
         client ||= Spaceship::ConnectAPI
-        return all(client: client, filter: { identifier: identifier }, includes: includes).find do |app|
+        return all(client: client, filter: { identifier: identifier }, includes: includes, fields: fields).find do |app|
           app.identifier == identifier
         end
       end

--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -79,9 +79,9 @@ module Spaceship
       # API
       #
 
-      def self.all(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+      def self.all(client: nil, filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
-        resps = client.get_certificates(filter: filter, includes: includes).all_pages
+        resps = client.get_certificates(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort).all_pages
         return resps.flat_map(&:to_models)
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -51,9 +51,9 @@ module Spaceship
       # API
       #
 
-      def self.all(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+      def self.all(client: nil, filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
-        resps = client.get_devices(filter: filter, includes: includes).all_pages
+        resps = client.get_devices(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort).all_pages
         return resps.flat_map(&:to_models)
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -69,9 +69,9 @@ module Spaceship
       # API
       #
 
-      def self.all(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+      def self.all(client: nil, filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
-        resps = client.get_profiles(filter: filter, includes: includes).all_pages
+        resps = client.get_profiles(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort).all_pages
         return resps.flat_map(&:to_models)
       end
 

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -17,8 +17,8 @@ module Spaceship
         # bundleIds
         #
 
-        def get_bundle_ids(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = provisioning_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+        def get_bundle_ids(filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
+          params = provisioning_request_client.build_params(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort)
           provisioning_request_client.get("bundleIds", params)
         end
 
@@ -129,8 +129,8 @@ module Spaceship
         # certificates
         #
 
-        def get_certificates(profile_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
-          params = provisioning_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+        def get_certificates(profile_id: nil, filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
+          params = provisioning_request_client.build_params(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort)
           if profile_id.nil?
             provisioning_request_client.get("certificates", params)
           else
@@ -164,8 +164,8 @@ module Spaceship
         # devices
         #
 
-        def get_devices(profile_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
-          params = provisioning_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+        def get_devices(profile_id: nil, filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
+          params = provisioning_request_client.build_params(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort)
           if profile_id.nil?
             provisioning_request_client.get("devices", params)
           else
@@ -213,8 +213,8 @@ module Spaceship
         # profiles
         #
 
-        def get_profiles(filter: {}, includes: nil, limit: nil, sort: nil)
-          params = provisioning_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+        def get_profiles(filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
+          params = provisioning_request_client.build_params(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort)
           provisioning_request_client.get("profiles", params)
         end
 
@@ -251,6 +251,12 @@ module Spaceship
           }
 
           provisioning_request_client.post("profiles", body)
+        end
+
+        def get_profile_bundle_id(profile_id: nil)
+          raise "Profile id is nil" if profile_id.nil?
+
+          provisioning_request_client.get("profiles/#{profile_id}/bundleId")
         end
 
         def delete_profile(profile_id: nil)

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -13,6 +13,7 @@ describe Spaceship::ConnectAPI::APIClient do
       let(:one_filter) { { build: "123" } }
       let(:two_filters) { { build: "123", app: "321" } }
       let(:includes) { "model.attribute" }
+      let(:fields) { { a: 'aField', b: 'bField1,bField2' } }
       let(:limit) { "30" }
       let(:sort) { "asc" }
 
@@ -47,6 +48,13 @@ describe Spaceship::ConnectAPI::APIClient do
         })
       end
 
+      it 'builds params with fields' do
+        params = client.build_params(fields: fields)
+        expect(params).to eq({
+          fields: fields
+        })
+      end
+
       it 'builds params with limit' do
         params = client.build_params(limit: limit)
         expect(params).to eq({
@@ -61,11 +69,12 @@ describe Spaceship::ConnectAPI::APIClient do
         })
       end
 
-      it 'builds params with one filter, includes, limit, and sort' do
-        params = client.build_params(filter: one_filter, includes: includes, limit: limit, sort: sort)
+      it 'builds params with one filter, includes, fields, limit, and sort' do
+        params = client.build_params(filter: one_filter, includes: includes, fields: fields, limit: limit, sort: sort)
         expect(params).to eq({
           filter: one_filter,
           include: includes,
+          fields: fields,
           limit: limit,
           sort: sort
         })


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Currently, I'm working on `match` optimization. I've figured out that `match` fetches certificates with all fields, including enormous `certificateContent` and `csrContent`, and match doesn't need them.
A reduced amount of fetched fields leads to faster response generation and faster transmission to the client.

### Description

Changes are really small, I just added a `fields` parameter to the api_client, certificate, device, bundle id and profile.

### Testing Steps

`Spaceship::ConnectAPI::Device.all(fields: 'platform,status')`