### PR TITLE
[action][register_devices] Add ability to enable/disable device

### DIFF
--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -1,5 +1,6 @@
 require 'credentials_manager'
 
+
 module Fastlane
   module Actions
     class RegisterDevicesAction < Action

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -1,6 +1,5 @@
 require 'credentials_manager'
 
-
 module Fastlane
   module Actions
     class RegisterDevicesAction < Action


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context
Add the ability to enable/disable the device


<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->


### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
