### PR TITLE
[deliver] Capturing NoMethodError exception when fetching live app info

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -484,7 +484,11 @@ module Deliver
           app_info_locale = localizations.find { |l| l.locale == language }
           next if app_info_locale.nil?
 
-          current_value = app_info_locale.public_send(key.to_sym)
+          begin
+            current_value = app_info_locale.public_send(key.to_sym)
+          rescue NoMethodError
+            next
+          end
 
           return true if current_value != strip_value
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

The recent [commit c4ed1a42](https://github.com/fastlane/fastlane/commit/c4ed1a425cfca787905e9cf3ae6f9182a804162c) throws an error if a field is missing.

### Description

In some cases, the app info might be missing some fields and the execution throws an error

### Testing Steps

N/A