### PR TITLE
Mark Nexus password as a sensitive field

### DIFF
--- a/fastlane/lib/fastlane/actions/nexus_upload.rb
+++ b/fastlane/lib/fastlane/actions/nexus_upload.rb
@@ -139,6 +139,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :password,
                                        env_name: "FL_NEXUS_PASSWORD",
                                        description: "Nexus password",
+                                       sensitive: true,
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :ssl_verify,
                                        env_name: "FL_NEXUS_SSL_VERIFY",


### PR DESCRIPTION
### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass - these were failing before I made my changes (may be my setup). `bundle exec rspec ./fastlane/spec/actions_specs/nexus_upload_spec.rb` worked
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary. - N/A
- [ ] I've added or updated relevant unit tests. - N/A (I think)

### Motivation and Context

When prompted for the Nexus password, `nexus_upload` was printing out what the user entered.

### Description

Marked field as sensitive.

### Testing Steps

Ran `bundle exec fastlane run nexus_upload` to confirm asterisks printed rather than the password after the change.
Existing tests for nexus_upload still pass, I can't see how I'd test the addition of the sensitive flag.
