### PR TITLE
[supply] allow tracks without releases in `Client.track_version_codes`

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -481,7 +481,7 @@ module Supply
           current_edit.id,
           track
         )
-        return result.releases.flat_map(&:version_codes) || []
+        return result.releases&.flat_map(&:version_codes) || []
       rescue Google::Apis::ClientError => e
         return [] if e.status_code == 404 && (e.to_s.include?("trackEmpty") || e.to_s.include?("Track not found"))
         raise


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #21500

### Description

When a track on Google Play has been created but still has no release the `result.releases` received by the client is Nil. The current code doesn't handle this condition and fails.

### Testing Steps

I looked but couldn't find any test for this pieces of code I modified.
However the modification is trivial.