### PR TITLE
[spaceship] decrease App Store Connect API token `issued-at-time` to prevent server rejection

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -184,7 +184,7 @@ module Spaceship
         if tries.zero?
           raise error
         else
-          msg = "Token has expired or has been revoked! Trying to refresh..."
+          msg = "Token has expired, issued-at-time is in the future, or has been revoked! Trying to refresh..."
           puts(msg) if Spaceship::Globals.verbose?
           @token.refresh!
           retry

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -100,7 +100,8 @@ module Spaceship
 
         payload = {
           iss: issuer_id,
-          iat: now.to_i,
+          # reduce the issued-at-time in case our time is slighly ahead of apple's servers, which causes the token to be rejected
+          iat: now.to_i - 60,
           exp: @expiration.to_i,
           aud: 'appstoreconnect-v1'
         }

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -100,7 +100,7 @@ module Spaceship
 
         payload = {
           iss: issuer_id,
-          # reduce the issued-at-time in case our time is slighly ahead of apple's servers, which causes the token to be rejected
+          # Reduce the issued-at-time in case our time is slighly ahead of Apple's servers, which causes the token to be rejected.
           iat: now.to_i - 60,
           exp: @expiration.to_i,
           aud: 'appstoreconnect-v1'

--- a/spaceship/spec/connect_api/token_spec.rb
+++ b/spaceship/spec/connect_api/token_spec.rb
@@ -205,7 +205,7 @@ describe Spaceship::ConnectAPI::Token do
       payload, header = JWT.decode(token.text, key, true, { algorithm: 'ES256' })
 
       expect(payload['iss']).to eq(issuer_id)
-      expect(payload['iat']).to eq(Time.now.to_i)
+      expect(payload['iat']).to be < Time.now.to_i
       expect(payload['aud']).to eq('appstoreconnect-v1')
       expect(payload['exp']).to be > Time.now.to_i
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

I have observed sporatic failures with delivering builds to testflight that result in an error message like this:

> Authentication credentials are missing or invalid. - Provide a properly configured and signed bearer token, and make sure that it has not expired. Learn more about Generating Tokens for API Requests https://developer.apple.com/go/?id=api-generating-tokens

After much debugging and with <a href="https://github.com/fastlane/fastlane/issues/20516#issuecomment-1552609002">this tip</a> I confirmed that my machine time was slightly ahead of Apple's servers which caused the AppStore Connect token to be rejected as the issued-at-time was in the future.

Similar issues have been reported in #20516 and #21109.

Syncing servers to Apple's servers (using ntp.apple.com) is one solution to this problem, however, not everyone is able or willing to sync their system's clocks to Apple's (and Apple's servers might be out-of-sync!) so a more robust and permanent solution is needed.

### Description

By reducing the issued-at-time (iat) in the jwt token, the token will only be rejected if a machine is over a minute in the future. (This value could of course, be increased, but one minute seems like a good starting point.)

Additionally, this fix also addresses a minor race condition in the unit tests where the issued time was being compared to the current time - which would fail if the clock second changed from the time when the token was generated to when the test was run.

### Testing Steps

To reproduce this issue, add 60 seconds to the `iat` value in the payload in: https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/connect_api/token.rb#L103 Attempting to perform any action that requires a token with spaceship will fail.

For example:

```
api_key = app_store_connect_api_key(
  key_id: "xxx",
  issuer_id: "xxx",
  key_filepath: "xxx.p8",
  duration: 1200, # optional (maximum 1200)
  in_house: false # optional but may be required if using match/sigh
)

latest_testflight_build_number(api_key: api_key, app_identifier: "xxx")
```

Repeat the command by removing 60 seconds from iat and it should pass.

