### PR TITLE
Fix test being potentially muddied by local ENV

### DIFF
--- a/fastlane/spec/actions_specs/upload_symbols_to_sentry_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_sentry_spec.rb
@@ -1,6 +1,11 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "sentry" do
+      before do
+        # Prevent ENV vars that might be defined in the developer's machine to muddy the test environment
+        allow(ENV).to receive(:[]).and_return(nil)
+      end
+
       it "fails with no API key or auth token" do
         dsym_path_1 = './fastlane/spec/fixtures/dSYM/Themoji.dSYM.zip'
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

When running `bundle exec rspec`, if you have an environment variable like `SENTRY_AUTH_TOKEN` defined in your local environment (e.g. via your `~/.zshrc`), its value will be picked up when running `rspec`, and that will make the expectations of the `upload_symbols_to_sentry` spec fail.

This is because the spec is testing cases where the user did _not_ provide a token (and expect the action to raise an error in such cases), but when you have the ENV var defined on your Mac, it makes the action being run by the test picking it up as the token so the action doesn't fail and the test doesn't test what's expected of it.

### Description

Stub `ENV#[]` to return `nil` for all those tests so that it does not risk being polluted by the local environment when `bundle exec rspec` is being run.

_PS: Note that I suspect many other specs are subject to a similar issue of accidentally picking up the local environment. This is just the only one that kept causing me trouble because I happen to have `SENTRY_AUTH_TOKEN` defined in my `~/.zshrc`, but I'm sure if I had other env vars associated with some actions' `ConfigItem(env: …)` defined in my local env that would make other tests fail for the same reason. That being said, I don't have the bandwidth to investigate all the potential cases where this could happen, so I figured I'd just fix the one that caused me trouble (and let others apply a similar patch in the other specs if they encounter a similar issue on their end on other test cases)_

### Testing Steps

Run the following:
```
export SENTRY_AUTH_TOKEN=abc
bundle exec rspec
```

If you run these lines on `master` (before this PR) you should end up with the following test failure:
```
Failed examples:

rspec ./fastlane/spec/actions_specs/upload_symbols_to_sentry_spec.rb:4 # Fastlane Fastlane::FastFile sentry fails with no API key or auth token
rspec ./fastlane/spec/actions_specs/upload_symbols_to_sentry_spec.rb:32 # Fastlane Fastlane::FastFile sentry returns uploaded dSYM path using API key
rspec ./fastlane/spec/actions_specs/upload_symbols_to_sentry_spec.rb:60 # Fastlane Fastlane::FastFile sentry returns uploaded dSYM paths
```

If you run those same lines on this PR's branch, those tests should now pass.