### PR TITLE
Add support for keyword arguments for lanes in Ruby 3

### DIFF
--- a/fastlane/lib/fastlane/lane.rb
+++ b/fastlane/lib/fastlane/lane.rb
@@ -29,7 +29,7 @@ module Fastlane
       block_expects_keywords = !block.nil? && block.parameters.any? { |type, _| [:key, :keyreq].include?(type) }
       # Conversion of the `Hash` parameters passed by `#call` into keywords has to be explicit in Ruby 3
       # https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
-      self.block = block_expects_keywords ? Proc.new { |options| block.call(**options) } : block
+      self.block = block_expects_keywords ? proc { |options| block.call(**options) } : block
       self.is_private = is_private
     end
 

--- a/fastlane/lib/fastlane/lane.rb
+++ b/fastlane/lib/fastlane/lane.rb
@@ -24,10 +24,10 @@ module Fastlane
       self.platform = platform
       self.name = name
       self.description = description
-      # We want to support both lanes expecting a `Hash` (like `lane :foo do |options|`), and lanes expecting
+      # We want to support _both_ lanes expecting a `Hash` (like `lane :foo do |options|`), and lanes expecting
       # keyword parameters (like `lane :foo do |param1:, param2:, param3: 'default value'|`)
       block_expects_keywords = !block.nil? && block.parameters.any? { |type, _| [:key, :keyreq].include?(type) }
-      # Conversion of the `Hash` parameters passed by `#call` into keywords has to be explicit in Ruby 3
+      # Conversion of the `Hash` parameters (passed by `Lane#call`) into keywords has to be explicit in Ruby 3
       # https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
       self.block = block_expects_keywords ? proc { |options| block.call(**options) } : block
       self.is_private = is_private

--- a/fastlane/lib/fastlane/lane.rb
+++ b/fastlane/lib/fastlane/lane.rb
@@ -24,11 +24,19 @@ module Fastlane
       self.platform = platform
       self.name = name
       self.description = description
-      self.block = block
+      # We want to support both lanes expecting a `Hash` (like `lane :foo do |options|`), and lanes expecting
+      # keyword parameters (like `lane :foo do |param1:, param2:, param3: 'default value'|`)
+      block_expects_keywords = !block.nil? && block.parameters.any? { |type, _| [:key, :keyreq].include?(type) }
+      # Conversion of the `Hash` parameters passed by `#call` into keywords has to be explicit in Ruby 3
+      # https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
+      self.block = block_expects_keywords ? Proc.new { |options| block.call(**options) } : block
       self.is_private = is_private
     end
 
     # Execute this lane
+    #
+    # @param [Hash] parameters The Hash of parameters to pass to the lane
+    #
     def call(parameters)
       block.call(parameters || {})
     end

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -15,7 +15,7 @@ module Fastlane
 
     # This will take care of executing **one** lane. That's when the user triggers a lane from the CLI for example
     # This method is **not** executed when switching a lane
-    # @param lane_name The name of the lane to execute
+    # @param lane The name of the lane to execute
     # @param platform The name of the platform to execute
     # @param parameters [Hash] The parameters passed from the command line to the lane
     def execute(lane, platform = nil, parameters = nil)

--- a/fastlane/spec/fixtures/fastfiles/FastfileLaneKeywordParams
+++ b/fastlane/spec/fixtures/fastfiles/FastfileLaneKeywordParams
@@ -1,0 +1,13 @@
+platform :ios do
+  lane :lane_no_param do
+    'No parameter'
+  end
+
+  lane :lane_hash_param do |options|
+    "name: #{options[:name].inspect}; version: #{options[:version].inspect}; interactive: #{options[:interactive].inspect}"
+  end
+
+  lane :lane_kw_params do |name:, version:, interactive: true|
+    "name: #{name.inspect}; version: #{version.inspect}; interactive: #{interactive.inspect}"
+  end
+end

--- a/fastlane/spec/runner_spec.rb
+++ b/fastlane/spec/runner_spec.rb
@@ -68,24 +68,32 @@ describe Fastlane do
         end
       end
 
-
       context 'when a lane expects its parameters as keywords' do
+        def keywords_list(list)
+          # The way keyword lists appear in error messages is different in Windows, so we need this hack to make tests pass in AppVeyor too
+          if FastlaneCore::Helper.windows?
+            list.map(&:to_s).join(', ') # On windows, keyword names don't show the `:` prefix in error messages
+          else
+            list.map(&:inspect).join(', ') # On other platforms, they do have `:` in front or keyword names
+          end
+        end
+
         it 'fails when calling the lane with no parameter at all' do
           expect do
             @ff.runner.execute(:lane_kw_params, :ios)
-          end.to raise_error(ArgumentError, 'missing keywords: :name, :version')
+          end.to raise_error(ArgumentError, "missing keywords: #{keywords_list(%i[name version])}")
         end
 
         it 'fails when calling the lane with missing parameters' do
           expect do
             @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', interactive: true })
-          end.to raise_error(ArgumentError, 'missing keyword: :version')
+          end.to raise_error(ArgumentError, "missing keyword: #{keywords_list(%i[version])}")
         end
 
         it 'fails when calling the lane with extra parameters' do
           expect do
             @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', version: '12.3', interactive: true, unexpected: 42 })
-          end.to raise_error(ArgumentError, 'unknown keyword: :unexpected')
+          end.to raise_error(ArgumentError, "unknown keyword: #{keywords_list(%i[unexpected])}")
         end
 
         it 'takes all parameters into account when all are passed explicitly' do

--- a/fastlane/spec/runner_spec.rb
+++ b/fastlane/spec/runner_spec.rb
@@ -110,6 +110,16 @@ describe Fastlane do
           result = @ff.runner.execute(:lane_kw_params, :ios, { version: "12.3", interactive: true, name: 'test' })
           expect(result).to eq('name: "test"; version: "12.3"; interactive: true')
         end
+
+        it 'allows a required parameter to receive a nil value' do
+          result = @ff.runner.execute(:lane_kw_params, :ios, { name: nil, version: "12.3", interactive: true })
+          expect(result).to eq('name: nil; version: "12.3"; interactive: true')
+        end
+
+        it 'allows a default value to be overridden with a nil value' do
+          result = @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', version: "12.3", interactive: nil })
+          expect(result).to eq('name: "test"; version: "12.3"; interactive: nil')
+        end
       end
     end
   end

--- a/fastlane/spec/runner_spec.rb
+++ b/fastlane/spec/runner_spec.rb
@@ -84,7 +84,7 @@ describe Fastlane do
           end.to raise_error(ArgumentError, "missing keywords: #{keywords_list(%i[name version])}")
         end
 
-        it 'fails when calling the lane with missing parameters' do
+        it 'fails when calling the lane with some missing parameters' do
           expect do
             @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', interactive: true })
           end.to raise_error(ArgumentError, "missing keyword: #{keywords_list(%i[version])}")
@@ -97,17 +97,17 @@ describe Fastlane do
         end
 
         it 'takes all parameters into account when all are passed explicitly' do
-          result = @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', version: "12.3", interactive: true })
-          expect(result).to eq('name: "test"; version: "12.3"; interactive: true')
+          result = @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', version: "12.3", interactive: false })
+          expect(result).to eq('name: "test"; version: "12.3"; interactive: false')
         end
 
-        it 'use default values of parameters not provided explicitly' do
+        it 'uses default values of parameters not provided explicitly' do
           result = @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', version: "12.3" })
           expect(result).to eq('name: "test"; version: "12.3"; interactive: true')
         end
 
         it 'allows parameters to be provided in arbitrary order' do
-          result = @ff.runner.execute(:lane_kw_params, :ios, { version: "12.3", name: 'test', interactive: true })
+          result = @ff.runner.execute(:lane_kw_params, :ios, { version: "12.3", interactive: true, name: 'test' })
           expect(result).to eq('name: "test"; version: "12.3"; interactive: true')
         end
       end

--- a/fastlane/spec/runner_spec.rb
+++ b/fastlane/spec/runner_spec.rb
@@ -70,9 +70,9 @@ describe Fastlane do
 
       context 'when a lane expects its parameters as keywords' do
         def keywords_list(list)
-          # The way keyword lists appear in error messages is different in Windows, so we need this hack to make tests pass in AppVeyor too
-          if FastlaneCore::Helper.windows?
-            list.map(&:to_s).join(', ') # On windows, keyword names don't show the `:` prefix in error messages
+          # The way keyword lists appear in error messages is different in Windows & Linux vs macOS
+          if FastlaneCore::Helper.windows? || FastlaneCore::Helper.linux?
+            list.map(&:to_s).join(', ') # On Windows and Linux, keyword names don't show the `:` prefix in error messages
           else
             list.map(&:inspect).join(', ') # On other platforms, they do have `:` in front or keyword names
           end

--- a/fastlane/spec/runner_spec.rb
+++ b/fastlane/spec/runner_spec.rb
@@ -20,6 +20,7 @@ describe Fastlane do
       it "doesn't show private lanes" do
         expect(@ff.runner.available_lanes).to_not(include('android such_private'))
       end
+
       describe "step_name override" do
         it "handle overriding of step_name" do
           allow(Fastlane::Actions).to receive(:execute_action).with('Let it Frame')
@@ -29,6 +30,77 @@ describe Fastlane do
           allow(Fastlane::Actions).to receive(:execute_action).with('frameit')
 
           @ff.runner.execute_action(:frameit, Fastlane::Actions::FrameitAction, [{}])
+        end
+      end
+    end
+
+    describe "#execute" do
+      before do
+        @ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileLaneKeywordParams')
+      end
+
+      context 'when a lane does not expect any parameter' do
+        it 'accepts calling the lane with no parameter' do
+          result = @ff.runner.execute(:lane_no_param, :ios)
+          expect(result).to eq('No parameter')
+        end
+
+        it 'accepts calling the lane with arbitrary (unused) parameter' do
+          result = @ff.runner.execute(:lane_no_param, :ios, { unused1: 42, unused2: true })
+          expect(result).to eq('No parameter')
+        end
+      end
+
+      context 'when a lane expects its parameters as a Hash' do
+        it 'accepts calling the lane with no parameter at all' do
+          result = @ff.runner.execute(:lane_hash_param, :ios)
+          expect(result).to eq('name: nil; version: nil; interactive: nil')
+        end
+
+        it 'accepts calling the lane with less parameters than used by the lane' do
+          result = @ff.runner.execute(:lane_hash_param, :ios, { version: '12.3' })
+          expect(result).to eq('name: nil; version: "12.3"; interactive: nil')
+        end
+
+        it 'accepts calling the lane with more parameters than used by the lane' do
+          result = @ff.runner.execute(:lane_hash_param, :ios, { name: 'test', version: '12.3', interactive: true, unused: 42 })
+          expect(result).to eq('name: "test"; version: "12.3"; interactive: true')
+        end
+      end
+
+
+      context 'when a lane expects its parameters as keywords' do
+        it 'fails when calling the lane with no parameter at all' do
+          expect do
+            @ff.runner.execute(:lane_kw_params, :ios)
+          end.to raise_error(ArgumentError, 'missing keywords: :name, :version')
+        end
+
+        it 'fails when calling the lane with missing parameters' do
+          expect do
+            @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', interactive: true })
+          end.to raise_error(ArgumentError, 'missing keyword: :version')
+        end
+
+        it 'fails when calling the lane with extra parameters' do
+          expect do
+            @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', version: '12.3', interactive: true, unexpected: 42 })
+          end.to raise_error(ArgumentError, 'unknown keyword: :unexpected')
+        end
+
+        it 'takes all parameters into account when all are passed explicitly' do
+          result = @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', version: "12.3", interactive: true })
+          expect(result).to eq('name: "test"; version: "12.3"; interactive: true')
+        end
+
+        it 'use default values of parameters not provided explicitly' do
+          result = @ff.runner.execute(:lane_kw_params, :ios, { name: 'test', version: "12.3" })
+          expect(result).to eq('name: "test"; version: "12.3"; interactive: true')
+        end
+
+        it 'allows parameters to be provided in arbitrary order' do
+          result = @ff.runner.execute(:lane_kw_params, :ios, { version: "12.3", name: 'test', interactive: true })
+          expect(result).to eq('name: "test"; version: "12.3"; interactive: true')
         end
       end
     end

--- a/fastlane/spec/runner_spec.rb
+++ b/fastlane/spec/runner_spec.rb
@@ -78,7 +78,7 @@ describe Fastlane do
           end
         end
 
-        it 'fails when calling the lane with no parameter at all' do
+        it 'fails when calling the lane with required parameters not being passed' do
           expect do
             @ff.runner.execute(:lane_kw_params, :ios)
           end.to raise_error(ArgumentError, "missing keywords: #{keywords_list(%i[name version])}")


### PR DESCRIPTION
## Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

## Motivation and Context

In Ruby 2, when a method or a block expects keyword parameters, calling that method with a `Hash` (whose keys matches those keyword parameters) was valid and resulted in Ruby 2.x making an implicit conversion. In Ruby 3, that conversion has to be explicit (see [this official article](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)).

As a result, while writing lanes using keyword parameter syntax like below works in Ruby 2, it stopped working when running Fastlane in Ruby 3:

```ruby
lane :kwparams do |name:, version:, interactive: true|
  UI.message("name: #{name}")
  UI.message("version: #{version}")
  UI.message("interactive: #{interactive}")
end

# Which is way more explicit, readable, and less verbose than the more common form
# that most people use when they don't know the keyword syntax exists for blocks
lane :hashparams do |options|
  UI.message("name: #{options[:name]}")
  UI.message("version: #{options[:version]}")
  UI.message("interactive: #{options[:interactive] || true}")
end
```


## Description

This PR allows back the usage of keyword syntax in lanes block' parameters in Ruby 3, by detecting if the block provided to the lane expects at least one keyword (as opposed to just expecting a single positional parameter expected to be a Hash), and if so use the double-splat operator `**options` to make an explicit conversion of the `options` `Hash` (that our internal implementation passes to `lane.call`) into a keyword list before calling the lane's provided block.

Note: because the code actively _checks_ if the block expects keywords or not, this change is not breaking, but just additive (i.e. the `lane :foo do |options|` syntax expecting a `Hash` will still work too)

## Benefits of using the (sadly lesser-known) keyword syntax in your lanes

Note that this feature of using keyword parameters in lane blocks has always been working in Ruby 2, even though not many _fastlane_ users might have known about it. As such, this PR simply makes it so this already-existing support for it in Ruby 2 doesn't break in Ruby 3.

Some benefits of using the keyword syntax for blocks in general (and for _fastlane_ lane parameters in particular):

 - It's self-documenting the parameters that the lane accepts
 - Ruby will detect and error if you pass the wrong/unexpected parameter name. For example, `kwparams(name: 'oops', version_name: 'bad')` will make Ruby complain about `version_name` being an unexpected parameter for that `kwparams` lane (indeed, it should be `version:`, not `version_name:`).
 - Likewise, if you forget to pass a required parameter (one that doesn't have a default value), Ruby will also complain
 - Speaking of: this provides built-in support for default values of parameters of your lanes (e.g. see `interactive: true` in example above)

While on the contrary, if you use Hash parameters (e.g. `do |options| …`), you'll get none of those benefits, and as a result:

 - It's generally harder to see at a glance what are the options that the lane is supposed to accept (you have to read the code to know, or make sure your lane documentation is always up-to-date)
 - Default values have to be handled at the lane's implementation level (`options[:interactive] || true`)
 - If you accidentally pass incorrect options or make a typo in one of the options passed to your lane, it will likely result in obscure or easy-to-miss issues (with e.g. `options[:artifacts]` silently returning `nil` without any warning or error if you accidentally used `artefacts` instead of `artifacts` at call site)

## Testing Steps

Check that CI passes on `bundle exec rspec` in **both** Ruby 2 and Ruby 3.

Alternatively, if you want to test this locally:
 - Checkout the first commit of this PR (1381e1a57b6d1143c3cb98e5069d204fe50f8206), which contains the unit tests/specs for that use case but not yet the fix.
 - Switch to using Ruby 2.x (e.g. `rbenv local 2.7.4`).
 - Run `bundle exec rspec  fastlane/spec/runner_spec.rb`, and check there is no error.
 - Switch to using Ruby 3.x (e.g. `rbenv local 3.2.2`).
 - Run `bundle exec rspec fastlane/spec/runner_spec.rb`, and observe that the tests which are running the `lane_kw_params` lane of our test Fastfile are crashing with `ArgumentError: missing keywords: :name, :version` — because Ruby 3 doesn't do the implicit conversion of the `Hash` to keyword parameters so the method is called with one positional argument (the `Hash`) but no keyword argument.
 - Checkout the tip of this PR's branch, to now include the commit that contains the fix (6891acc18b99e3f1976d2b44fd453ccaca8d7c41)
 - Run `bundle exec rspec  fastlane/spec/runner_spec.rb` again, and observe how the tests are now passing again.