### PR TITLE
Update `fakefs` to fix test failures on Ruby 3.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.103.0)
-    fakefs (1.9.0)
+    fakefs (1.8.0)
     faraday (1.4.1)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
@@ -371,7 +371,7 @@ DEPENDENCIES
   coveralls (~> 0.8.13)
   danger (~> 8.0)
   danger-junit (~> 1.0)
-  fakefs (~> 1.9)
+  fakefs (= 1.8)
   fastlane!
   fastlane-plugin-clubmate
   fastlane-plugin-ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.103.0)
-    fakefs (1.2.3)
+    fakefs (1.9.0)
     faraday (1.4.1)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
@@ -371,7 +371,7 @@ DEPENDENCIES
   coveralls (~> 0.8.13)
   danger (~> 8.0)
   danger-junit (~> 1.0)
-  fakefs (~> 1.2)
+  fakefs (~> 1.9)
   fastlane!
   fastlane-plugin-clubmate
   fastlane-plugin-ruby

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -116,7 +116,7 @@ Gem::Specification.new do |spec|
   # Development only
   spec.add_development_dependency('climate_control', '~> 0.2.0')
   spec.add_development_dependency('coveralls', '~> 0.8.13')
-  spec.add_development_dependency('fakefs', '~> 1.9')
+  spec.add_development_dependency('fakefs', '1.8') # 1.9+ requires Ruby >=2.7, while fastlane uses a `required_ruby_version` of `>= 2.6``
   spec.add_development_dependency('pry-byebug')
   spec.add_development_dependency('pry-rescue')
   spec.add_development_dependency('pry-stack_explorer')

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -116,7 +116,7 @@ Gem::Specification.new do |spec|
   # Development only
   spec.add_development_dependency('climate_control', '~> 0.2.0')
   spec.add_development_dependency('coveralls', '~> 0.8.13')
-  spec.add_development_dependency('fakefs', '~> 1.2')
+  spec.add_development_dependency('fakefs', '~> 1.9')
   spec.add_development_dependency('pry-byebug')
   spec.add_development_dependency('pry-rescue')
   spec.add_development_dependency('pry-stack_explorer')


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

We kept having ``NameError: undefined method `=~' for class `FakeFS::Pathname'`` errors when running the tests (`bundle exec rspec`) in Ruby 3.2.2 on our Macs.

### Description

Updating `fakefs` fixed those failures that happened running `bundle exec rspec` on the repo in Ruby 3.2.2.

Initially I updated `fakefs` to its latest `~> 1.x` version, which was `1.9`. But then I later noticed (thanks, CI) that `fakefs 1.9` requires Ruby `>= 2.7`, while fastlane still supports Ruby `2.6` (`spec.required_ruby_version = '>= 2.6'`), so I ended up forcing using `fakefs 1.8`, which is the latest version of that gem that supports Ruby 2.6 (>=2.4).

PS: At some point we probably want to add Ruby 3.2.2 to our array of Ruby versions tested by CI, but that's improvements for another PR (I think @rogerluan already tried a while ago and encountered some hiccups while trying so paused his work on this?)

### Testing Steps

Run:
```
rbenv local 3.2.2
bundle exec rspec
```

And ensure that you don't get errors related to `FakeFS::Pathname` like the ones below (that we had before the update):
```
An error occurred while loading ./deliver/spec/[…]_spec.rb.
Failure/Error: undef =~

NameError:
  undefined method `=~' for class `FakeFS::Pathname'
# ./deliver/spec/loader_spec.rb:2:in `require'
# ./deliver/spec/loader_spec.rb:2:in `<top (required)>'
/Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/fakefs-1.2.3/lib/fakefs/pathname.rb:16: warning: already initialized constant FakeFS::Pathname::TO_PATH
/Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/fakefs-1.2.3/lib/fakefs/pathname.rb:16: warning: previous definition of TO_PATH was here
/Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/fakefs-1.2.3/lib/fakefs/pathname.rb:18: warning: already initialized constant FakeFS::Pathname::SAME_PATHS
/Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/fakefs-1.2.3/lib/fakefs/pathname.rb:18: warning: previous definition of SAME_PATHS was here
/Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/fakefs-1.2.3/lib/fakefs/pathname.rb:114: warning: already initialized constant FakeFS::Pathname::SEPARATOR_LIST
/Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/fakefs-1.2.3/lib/fakefs/pathname.rb:114: warning: previous definition of SEPARATOR_LIST was here
/Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/fakefs-1.2.3/lib/fakefs/pathname.rb:115: warning: already initialized constant FakeFS::Pathname::SEPARATOR_PAT
/Users/me/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/fakefs-1.2.3/lib/fakefs/pathname.rb:115: warning: previous definition of SEPARATOR_PAT was here
```