### PR TITLE
[docs] fix typo `practies` → `practices` based on feedback from fastlane/docs

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -441,7 +441,7 @@ fastlane deliver submit_build --build_number 830 --submission_information "{\"ex
 
 ### App Privacy Details
 
-Starting on December 8, 2020, Apple announced that developers are required to provide app privacy details that will help users understand an app's privacy practies. _deliver_ does not allow for updating of this information but this can be done with the _upload_app_privacy_details_to_app_store_ action. More information on [Uploading App Privacy Details](https://docs.fastlane.tools/uploading-app-privacy-details)
+Starting on December 8, 2020, Apple announced that developers are required to provide app privacy details that will help users understand an app's privacy practices. _deliver_ does not allow for updating of this information but this can be done with the _upload_app_privacy_details_to_app_store_ action. More information on [Uploading App Privacy Details](https://docs.fastlane.tools/uploading-app-privacy-details)
 
 # Credentials
 


### PR DESCRIPTION
### Motivation and Context

Fix typo identified here: https://github.com/fastlane/docs/pull/1219