### PR TITLE
add `FL_GIT_BRANCH_DONT_USE_ENV_VARS` env var to `git_branch`

### DIFF
--- a/fastlane/lib/fastlane/actions/git_branch.rb
+++ b/fastlane/lib/fastlane/actions/git_branch.rb
@@ -16,7 +16,7 @@ module Fastlane
       end
 
       def self.details
-        "If no branch could be found, this action will return an empty string. This is a wrapper for the internal action Actions.git_branch"
+        "If no branch could be found, this action will return an empty string. If `FL_GIT_BRANCH_DONT_USE_ENV_VARS` is `true`, it'll ignore CI ENV vars. This is a wrapper for the internal action Actions.git_branch"
       end
 
       def self.available_options

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -121,7 +121,10 @@ module Fastlane
 
     # Returns the current git branch, or "HEAD" if it's not checked out to any branch
     # Can be replaced using the environment variable `GIT_BRANCH`
+    # unless `FL_GIT_BRANCH_DONT_USE_ENV_VARS` is `true`
     def self.git_branch
+      return self.git_branch_name_using_HEAD if FastlaneCore::Env.truthy?('FL_GIT_BRANCH_DONT_USE_ENV_VARS')
+
       env_name = SharedValues::GIT_BRANCH_ENV_VARS.find { |env_var| FastlaneCore::Env.truthy?(env_var) }
       ENV.fetch(env_name.to_s) do
         self.git_branch_name_using_HEAD

--- a/fastlane/spec/actions_specs/git_branch_spec.rb
+++ b/fastlane/spec/actions_specs/git_branch_spec.rb
@@ -13,6 +13,24 @@ describe Fastlane::Actions::GitBranchAction do
     end
   end
 
+  describe "CI set ENV values but FL_GIT_BRANCH_DONT_USE_ENV_VARS is true" do
+    Fastlane::Actions::SharedValues::GIT_BRANCH_ENV_VARS.each do |env_var|
+      it "gets the value from Git directly with #{env_var}" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with("git rev-parse --abbrev-ref HEAD", log: false)
+          .and_return("branch-name-from-git")
+
+        FastlaneSpec::Env.with_env_values(env_var => "#{env_var}-branch-name", 'FL_GIT_BRANCH_DONT_USE_ENV_VARS' => 'true') do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_branch
+          end").runner.execute(:test)
+
+          expect(result).to eq("branch-name-from-git")
+        end
+      end
+    end
+  end
+
   describe "with no CI set ENV values" do
     it "gets the value from Git directly" do
       expect(Fastlane::Actions).to receive(:sh)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
The current `git_branch` action and its relevant helper uses environment variables to modify the output. This may make things easier to work with in most cases, but there are some cases where it's important that it returns the actual git branch. Consider the scenario where a CI job is triggered from `main` branch, but the job creates a `release/x.y` branch and acts on that - for example, by using the [ensure_git_branch](https://docs.fastlane.tools/actions/ensure_git_branch/#ensure_git_branch) action. The current implementation of `git_branch` in such a case will continue to return the `main` branch.

It's possible to work around this issue, and that's what we have done for a while by using our own `git_branch` action. However, fastlane actions are interconnected and if we keep going down that route, we'll have to keep re-implementing more actions. We are hoping that this proposal will avoid the issue all together.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

This PR adds `FL_GIT_BRANCH_DONT_USE_ENV_VARS ` environment variable which - when `true` - will directly return the git branch instead of using the values from `GIT_BRANCH_ENV_VARS`.

Adding a new environment variable to discard the usage of environment variables feels a little off. However, within the project structure, this seems like the most consistent and cleanest solution to the problem.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I've added a new unit test that should cover the new case. While writing this test, I've combined the approach from existing tests to make it consistent.
