### PR TITLE
Notarization - Printing log on error

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -115,6 +115,7 @@ module Fastlane
             UI.user_error!("Could not notarize package with message '#{log_request_response}'")
           else
             UI.user_error!("Could not notarize package. To see the error, please set 'print_log' to true.")
+          end
         else
           UI.crash!("Could not notarize package with status '#{notarization_info['status']}'")
         end

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -100,7 +100,7 @@ module Fastlane
             UI.success("Successfully notarized and stapled package")
           end
         when 'Invalid'
-          if submission_id && print_log:
+          if submission_id && print_log
             log_request_parts = [
               "xcrun notarytool log #{submission_id}",
             ] + auth_parts
@@ -113,7 +113,7 @@ module Fastlane
               }
             )
             UI.user_error!("Could not notarize package with message '#{log_request_response}'")
-          else:
+          else
             UI.user_error!("Could not notarize package. To see the error, please set 'print_log' to true.")
         else
           UI.crash!("Could not notarize package with status '#{notarization_info['status']}'")

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -114,7 +114,7 @@ module Fastlane
             )
             UI.user_error!("Could not notarize package with message '#{log_request_response}'")
           else
-            UI.user_error!("Could not notarize package with message '#{notarization_info['statusSummary']}'")
+            UI.user_error!("Could not notarize package. To see the error, please set 'print_log' to true.")
           end
         else
           UI.crash!("Could not notarize package with status '#{notarization_info['status']}'")

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -114,7 +114,7 @@ module Fastlane
             )
             UI.user_error!("Could not notarize package with message '#{log_request_response}'")
           else
-            UI.user_error!("Could not notarize package. To see the error, please set 'print_log' to true.")
+            UI.user_error!("Could not notarize package with message '#{notarization_info['statusSummary']}'")
           end
         else
           UI.crash!("Could not notarize package with status '#{notarization_info['status']}'")

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -85,9 +85,9 @@ module Fastlane
         notarization_info = JSON.parse(submit_response)
 
         # Staple
+        submission_id = notarization_info["id"]
         case notarization_info['status']
         when 'Accepted'
-          submission_id = notarization_info["id"]
           UI.success("Successfully uploaded package to notarization service with request identifier #{submission_id}")
 
           if skip_stapling
@@ -100,7 +100,21 @@ module Fastlane
             UI.success("Successfully notarized and stapled package")
           end
         when 'Invalid'
-          UI.user_error!("Could not notarize package with message '#{notarization_info['statusSummary']}'")
+          if submission_id && print_log:
+            log_request_parts = [
+              "xcrun notarytool log #{submission_id}",
+            ] + auth_parts
+            log_request_command = log_request_parts.join(' ')
+            log_request_response = Actions.sh(
+              log_request_command,
+              log: verbose,
+              error_callback: lambda { |msg|
+                UI.error("Error requesting the notarization log: #{msg}")
+              }
+            )
+            UI.user_error!("Could not notarize package with message '#{log_request_response}'")
+          else:
+            UI.user_error!("Could not notarize package. To see the error, please set 'print_log' to true.")
         else
           UI.crash!("Could not notarize package with status '#{notarization_info['status']}'")
         end

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -102,7 +102,7 @@ module Fastlane
         when 'Invalid'
           if submission_id && print_log
             log_request_parts = [
-              "xcrun notarytool log #{submission_id}",
+              "xcrun notarytool log #{submission_id}"
             ] + auth_parts
             log_request_command = log_request_parts.join(' ')
             log_request_response = Actions.sh(

--- a/fastlane/spec/actions_specs/notarize_spec.rb
+++ b/fastlane/spec/actions_specs/notarize_spec.rb
@@ -108,7 +108,7 @@ describe Fastlane do
                   asc_provider: '#{asc_provider}',
                 )
               end").runner.execute(:test)
-            end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not notarize package with message 'Archive contains critical validation errors'")
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not notarize package. To see the error, please set 'print_log' to true.")
           end
         end
       end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

When the notarization is failing via `altool` there is no useful information printed.
Resolves #21608 and #20578 .

### Description

Using `xcrun altool log` to request additional info about the error.

### Testing Steps

-
