### PR TITLE
DRAFT: Add support for slather's new --ymlfile option

### DIFF
--- a/fastlane/lib/fastlane/actions/slather.rb
+++ b/fastlane/lib/fastlane/actions/slather.rb
@@ -35,7 +35,8 @@ module Fastlane
           binary_basename: '--binary-basename',
           arch: '--arch',
           source_files: '--source-files',
-          decimals: '--decimals'
+          decimals: '--decimals',
+          ymlfile: '--ymlfile'
       }.freeze
 
       def self.run(params)
@@ -51,8 +52,8 @@ module Fastlane
         sh(command)
       end
 
-      def self.has_config_file
-        File.file?('.slather.yml')
+      def self.has_config_file?(params)
+        params[:ymlfile] ? File.file?(params[:ymlfile]) : File.file?('.slather.yml')
       end
 
       def self.slather_version
@@ -64,12 +65,20 @@ module Fastlane
         Gem::Version.new('2.4.1') <= Gem::Version.new(slather_version)
       end
 
+      def self.ymlfile_available?
+        Gem::Version.new('2.8.0') <= Gem::Version.new(slather_version)
+      end
+
       def self.validate_params!(params)
         if params[:configuration]
           UI.user_error!('configuration option is available since version 2.4.1') unless configuration_available?
         end
 
-        if params[:proj] || has_config_file
+        if params[:ymlfile]
+          UI.user_error!('ymlfile option is available since version 2.8.0') unless ymlfile_available?
+        end
+
+        if params[:proj] || has_config_file?(params)
           true
         else
           UI.user_error!("You have to provide a project with `:proj` or use a .slather.yml")
@@ -285,6 +294,10 @@ module Fastlane
                                       description: "The amount of decimals to use for % coverage reporting",
                                       skip_type_validation: true, # allow Integer, String
                                       default_value: false,
+                                      optional: true),
+          FastlaneCore::ConfigItem.new(key: :ymlfile,
+                                      env_name: "FL_SLATHER_YMLFILE",
+                                      description: "Relative path to a file used in place of '.slather.yml'",
                                       optional: true)
         ]
       end

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -10282,6 +10282,7 @@ public func slackTrainStart(distance: Int = 5,
    - arch: Specify which architecture the binary file is in. Needed for universal binaries
    - sourceFiles: A Dir.glob compatible pattern used to limit the lookup to specific source files. Ignored in gcov mode
    - decimals: The amount of decimals to use for % coverage reporting
+   - ymlfile: Relative path to a file used in place of '.slather.yml'
 
  Slather works with multiple code coverage formats, including Xcode 7 code coverage.
  Slather is available at [https://github.com/SlatherOrg/slather](https://github.com/SlatherOrg/slather).
@@ -10317,7 +10318,8 @@ public func slather(buildDirectory: OptionalConfigValue<String?> = .fastlaneDefa
                     binaryFile: OptionalConfigValue<[String]?> = .fastlaneDefault(nil),
                     arch: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                     sourceFiles: OptionalConfigValue<Bool> = .fastlaneDefault(false),
-                    decimals: OptionalConfigValue<Bool> = .fastlaneDefault(false))
+                    decimals: OptionalConfigValue<Bool> = .fastlaneDefault(false)),
+                    ymlfile: OptionalConfigValue<String?> = .fastlaneDefault(nil)
 {
     let buildDirectoryArg = buildDirectory.asRubyArgument(name: "build_directory", type: nil)
     let projArg = proj.asRubyArgument(name: "proj", type: nil)
@@ -10351,6 +10353,7 @@ public func slather(buildDirectory: OptionalConfigValue<String?> = .fastlaneDefa
     let archArg = arch.asRubyArgument(name: "arch", type: nil)
     let sourceFilesArg = sourceFiles.asRubyArgument(name: "source_files", type: nil)
     let decimalsArg = decimals.asRubyArgument(name: "decimals", type: nil)
+    let ymlfileArg = ymlfile.asRubyArgument(name: "ymlfile", type: nil)
     let array: [RubyCommand.Argument?] = [buildDirectoryArg,
                                           projArg,
                                           workspaceArg,
@@ -10382,7 +10385,8 @@ public func slather(buildDirectory: OptionalConfigValue<String?> = .fastlaneDefa
                                           binaryFileArg,
                                           archArg,
                                           sourceFilesArg,
-                                          decimalsArg]
+                                          decimalsArg,
+                                          ymlfileArg]
     let args: [RubyCommand.Argument] = array
         .filter { $0?.value != nil }
         .compactMap { $0 }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

To be able to use slather from fastlane for a repo that has more than one .xcodeproj, [slather needs to add support for custom ymlfiles](https://github.com/SlatherOrg/slather/pull/550). One that PR is released by Slather, this PR can be updated and merged to support that param from fastlane. 

https://github.com/fastlane/fastlane/discussions/21612

### Description

- Added `ymlfile` support to the Fastlane.swift `slather` function. 
- Added `--ymlfile` output to the `slather` action.
  - only allow `ymlfile` use for slather 2.8.0+ (This number will need to be changed if the slather release is a different version; latest is currently 2.7.5)
  - when checking for a config file, check the path of the `ymlfile` if provided and the regular `.slather.yml` if not.
- added `validate_params` and `ymlfile_available` tests to the test spec. 
- Updated other tests to include the `ymlfile` param.

### Testing Steps

`bundle exec rspec` and `bundle exec rubocop -a` are passing.
In the spec, the `it "works with all parameters"` test is generating the correct slather commandline with the new param.
