### PR TITLE
Let FastlanePty detect when externally invoked programs crash, harden it when using popen, and expose process statuses.

### DIFF
--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -21,62 +21,54 @@ module FastlaneCore
 
   class FastlanePty
     def self.spawn(command, &block)
-      begin
-        spawn_with_pty(command, &block)
-      rescue LoadError
-        spawn_with_popen(command, &block)
-      end
+      spawn_with_pty(command, &block)
+    rescue LoadError
+      spawn_with_popen(command, &block)
     end
 
     def self.spawn_with_pty(command, &block)
-      begin
-        require 'pty'
-        PTY.spawn(command) do |command_stdout, command_stdin, pid|
+      require 'pty'
+      PTY.spawn(command) do |command_stdout, command_stdin, pid|
+        begin
+          yield(command_stdout, command_stdin, pid)
+        rescue Errno::EIO
+          # Exception ignored intentionally.
+          # https://stackoverflow.com/questions/10238298/ruby-on-linux-pty-goes-away-without-eof-raises-errnoeio
+          # This is expected on some linux systems, that indicates that the subcommand finished
+          # and we kept trying to read, ignore it
+        ensure
           begin
-            yield(command_stdout, command_stdin, pid)
-          rescue Errno::EIO
-            # Exception ignored intentionally.
-            # https://stackoverflow.com/questions/10238298/ruby-on-linux-pty-goes-away-without-eof-raises-errnoeio
-            # This is expected on some linux systems, that indicates that the subcommand finished
-            # and we kept trying to read, ignore it
-          ensure
-            begin
-              Process.wait(pid)
-            rescue Errno::ECHILD, PTY::ChildExited
-              # The process might have exited.
-            end
+            Process.wait(pid)
+          rescue Errno::ECHILD, PTY::ChildExited
+            # The process might have exited.
           end
         end
-        status = self.process_status
-        raise StandardError, "Process crashed" if status.signaled?
-        status.exitstatus
-      rescue StandardError => e
-        # Wrapping any error in FastlanePtyError to allow
-        # callers to see and use $?.exitstatus that
-        # would usually get returned
-        status = self.process_status
-        raise FastlanePtyError.new(e, status.exitstatus || e.exit_status, status)
       end
+      status = self.process_status
+      raise StandardError, "Process crashed" if status.signaled?
+      status.exitstatus
+    rescue StandardError => e
+      # Wrapping any error in FastlanePtyError to allow callers to see and use
+      # $?.exitstatus that would usually get returned
+      status = self.process_status
+      raise FastlanePtyError.new(e, status.exitstatus || e.exit_status, status)
     end
 
     def self.spawn_with_popen(command, &block)
       status = nil
-      begin
-        require 'open3'
-        Open3.popen2e(command) do |command_stdin, command_stdout, p| # note the inversion
-          status = p.value
-          yield(command_stdout, command_stdin, status.pid)
-          command_stdin.close
-          command_stdout.close
-          raise StandardError, "Process crashed" if status.signaled?
-          status.exitstatus
-        end
-      rescue StandardError => e
-        # Wrapping any error in FastlanePtyError to allow
-        # callers to see and use $?.exitstatus that
-        # would usually get returned
-        raise FastlanePtyError.new(e, status.exitstatus || e.exit_status, status)
+      require 'open3'
+      Open3.popen2e(command) do |command_stdin, command_stdout, p| # note the inversion
+        status = p.value
+        yield(command_stdout, command_stdin, status.pid)
+        command_stdin.close
+        command_stdout.close
+        raise StandardError, "Process crashed" if status.signaled?
+        status.exitstatus
       end
+    rescue StandardError => e
+      # Wrapping any error in FastlanePtyError to allow callers to see and use
+      # $?.exitstatus that would usually get returned
+      raise FastlanePtyError.new(e, status.exitstatus || e.exit_status, status)
     end
 
     # to ease mocking

--- a/fastlane_core/spec/crasher/README.md
+++ b/fastlane_core/spec/crasher/README.md
@@ -1,0 +1,3 @@
+A program that crashes, used to test corner cases in FastlanePty
+
+gcc -o crasher main.c

--- a/fastlane_core/spec/crasher/main.c
+++ b/fastlane_core/spec/crasher/main.c
@@ -1,0 +1,12 @@
+#include<stdio.h>
+#include<signal.h>
+#include<unistd.h> 
+#include<stdlib.h>
+int main()
+{
+    sigset_t act;
+    sigemptyset(&act);
+    sigfillset(&act);
+    sigprocmask(SIG_UNBLOCK,&act,NULL);
+    abort();
+}

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -1,0 +1,30 @@
+describe FastlaneCore do
+  describe FastlaneCore::FastlanePty do
+    describe "spawn" do
+      it 'executes a simple command successfully' do
+        @all_lines = []
+
+        exit_status = FastlaneCore::FastlanePty.spawn('echo foo') do |command_stdout, command_stdin, pid|
+          command_stdout.each do |line|
+            @all_lines << line
+          end
+        end
+        expect(exit_status).to eq(0)
+        expect(@all_lines).to eq(["foo\r\n"])
+      end
+
+      it 'doesn t return -1 if an exception was raised in the block' do
+        @all_lines = []
+
+        exception = StandardError.new
+        expect {
+          exit_status = FastlaneCore::FastlanePty.spawn('echo foo') do |command_stdout, command_stdin, pid|
+            raise exception
+          end
+        }.to raise_error(FastlaneCore::FastlanePtyError) { |error|
+          expect(error.exit_status).to eq(0) # command was success but output handling failed
+        }
+      end
+    end
+  end
+end

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -14,8 +14,6 @@ describe FastlaneCore do
       end
 
       it 'doesn t return -1 if an exception was raised in the block in PTY.spawn' do
-        @all_lines = []
-
         exception = StandardError.new
         expect {
           exit_status = FastlaneCore::FastlanePty.spawn('echo foo') do |command_stdout, command_stdin, pid|
@@ -30,8 +28,6 @@ describe FastlaneCore do
         expect(FastlaneCore::FastlanePty).to receive(:require).with("pty").and_raise(LoadError)
         allow(FastlaneCore::FastlanePty).to receive(:require).with("open3").and_call_original
         allow(FastlaneCore::FastlanePty).to receive(:open3)
-
-        @all_lines = []
 
         exception = StandardError.new
         expect {

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -6,14 +6,31 @@ describe FastlaneCore do
 
         exit_status = FastlaneCore::FastlanePty.spawn('echo foo') do |command_stdout, command_stdin, pid|
           command_stdout.each do |line|
-            @all_lines << line
+            @all_lines << line.chomp
           end
         end
         expect(exit_status).to eq(0)
-        expect(@all_lines).to eq(["foo\r\n"])
+        expect(@all_lines).to eq(["foo"])
       end
 
-      it 'doesn t return -1 if an exception was raised in the block' do
+      it 'doesn t return -1 if an exception was raised in the block in PTY.spawn' do
+        @all_lines = []
+
+        exception = StandardError.new
+        expect {
+          exit_status = FastlaneCore::FastlanePty.spawn('echo foo') do |command_stdout, command_stdin, pid|
+            raise exception
+          end
+        }.to raise_error(FastlaneCore::FastlanePtyError) { |error|
+          expect(error.exit_status).to eq(0) # command was success but output handling failed
+        }
+      end
+
+      it 'doesn t return -1 if an exception was raised in the block in Open3.popen2e' do
+        expect(FastlaneCore::FastlanePty).to receive(:require).with("pty").and_raise(LoadError)
+        allow(FastlaneCore::FastlanePty).to receive(:require).with("open3").and_call_original
+        allow(FastlaneCore::FastlanePty).to receive(:open3)
+
         @all_lines = []
 
         exception = StandardError.new

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -53,7 +53,6 @@ describe FastlaneCore do
         expect {
           exit_status = FastlaneCore::FastlanePty.spawn("a path of a crasher exec") do |command_stdout, command_stdin, pid|
           end
-          UI.message(exit_status)
         }.to raise_error(FastlaneCore::FastlanePtyError) { |error|
           expect(error.exit_status).to eq(-1) # command was forced to -1
         }


### PR DESCRIPTION
While looking into #21536, I noticed that tests seem to be missing on FastlanePty. Adding some

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

Here's the test that is failing https://github.com/fastlane/fastlane/pull/21618/commits/e31a1d13ee0325cfb4a324b8ff6502934073cefe