### PR TITLE
[Fastlane.swift] fix Unexpected duplicate tasks error message in Fastlane Swift

### DIFF
--- a/fastlane/lib/fastlane/swift_runner_upgrader.rb
+++ b/fastlane/lib/fastlane/swift_runner_upgrader.rb
@@ -232,16 +232,19 @@ module Fastlane
     # adds new copy files build phase to fastlane_runner_target
     def add_missing_copy_phase!(dry_run: false)
       # Check if upgrade is needed
-      # If fastlane copy files build phase exists already, we don't need any more changes to the Xcode project
-      phase_copy_sign = self.fastlane_runner_target.copy_files_build_phases.select { |phase_copy| phase_copy.name == "FastlaneRunnerCopySigned" }.first
 
-      old_phase_copy_sign = self.fastlane_runner_target.shell_script_build_phases.select { |phase_copy| phase_copy.shell_script == "cd \"${SRCROOT}\"\ncd ../..\ncp \"${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}\" .\n" }.first
+      # Check if Copy Files build phase contains FastlaneRunner target.
+      phase_copy_sign = self.fastlane_runner_target.copy_files_build_phases.map(&:files).flatten.select { |file| file.display_name == "FastlaneRunner" }.first
+
+      # If fastlane copy files build phase exists already, we don't need any more changes to the Xcode project
+      phase_copy_sign = self.fastlane_runner_target.copy_files_build_phases.select { |phase_copy| phase_copy.name == "FastlaneRunnerCopySigned" }.first unless phase_copy_sign
 
       return true if dry_run && phase_copy_sign.nil?
 
       return false if dry_run
 
       # Proceed to upgrade
+      old_phase_copy_sign = self.fastlane_runner_target.shell_script_build_phases.select { |phase_copy| phase_copy.shell_script == "cd \"${SRCROOT}\"\ncd ../..\ncp \"${TARGET_BUILD_DIR}/${EXECUTABLE_PATH}\" .\n" }.first
       old_phase_copy_sign.remove_from_project unless old_phase_copy_sign.nil?
 
       unless phase_copy_sign


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves [#999999](https://github.com/fastlane/fastlane/issues/20104)
-->

Resolves https://github.com/fastlane/fastlane/issues/20104

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

As mentioned in https://github.com/fastlane/fastlane/issues/20104#issuecomment-1149786264, the issue is about having two build phases that copy `FastlaneRunner` target. 

To fix this problem, we added additional logic to check if `Copy Files` build phase already contains `FastlaneRunner` target. If it does, we will not add redundant `FastlaneRunnerCopySigned` build phase.  

The change is additive to be extra safe to not break anything. However, it'd be nice to understand the reasoning behind original decision in favour of "FastlaneRunnerCopySigned" introduction and clean up / adjust code based accordingly. 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Steps to test: 
* initialize `fastlane` Swift in iOS project via `fastlane init swift`
* execute `bundle exec fastlane customLane`
* answer YES to "Should we try to upgrade just your `FastlaneSwiftRunner` project?" question 
* validate if there's no error anymore 
* open `FastlaneSwiftRunner` and check if there's no "FastlaneRunnerCopySigned" phase in Build Phases

<img width="904" alt="Screenshot 2023-11-08 at 13 05 56" src="https://github.com/fastlane/fastlane/assets/10795657/be20b11e-035b-4091-8132-453c5891ef94">

<img width="565" alt="Screenshot 2023-11-08 at 13 06 53" src="https://github.com/fastlane/fastlane/assets/10795657/d1fa8c1e-4d9f-49fe-8a6f-e854b4229d26">

Tested on Xcode 15, macOS Sonoma 14.0. 

Thank you 🙇 