### PR TITLE
[sigh] Add support for Apple Vision Pro Device

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -282,7 +282,8 @@ module Sigh
                            Spaceship::ConnectAPI::Device::DeviceClass::APPLE_WATCH,
                            Spaceship::ConnectAPI::Device::DeviceClass::IPAD,
                            Spaceship::ConnectAPI::Device::DeviceClass::IPHONE,
-                           Spaceship::ConnectAPI::Device::DeviceClass::IPOD
+                           Spaceship::ConnectAPI::Device::DeviceClass::IPOD,
+                           Spaceship::ConnectAPI::Device::DeviceClass::APPLE_VISION_PRO
                          ]
                        when 'tvos'
                          [Spaceship::ConnectAPI::Device::DeviceClass::APPLE_TV]

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -32,6 +32,7 @@ module Spaceship
 
         # As of 2022-11-12, this is not officially supported by App Store Connect API
         APPLE_SILICON_MAC = "APPLE_SILICON_MAC"
+        APPLE_VISION_PRO = "APPLE_VISION_PRO"
       end
 
       module Status

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -30,7 +30,7 @@ module Spaceship
         APPLE_TV = "APPLE_TV"
         MAC = "MAC"
 
-        # As of 2022-11-12, this is not officially supported by App Store Connect API
+        # As of 2023-11-10, these are not officially supported by App Store Connect API
         APPLE_SILICON_MAC = "APPLE_SILICON_MAC"
         APPLE_VISION_PRO = "APPLE_VISION_PRO"
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

This PR supports adding the Apple Vision Pro device when generating dev & adhoc profiles with SIGH.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
- Adds `Spaceship::ConnectAPI::Device::DeviceClass::APPLE_VISION_PRO`
- Adds the new class to sigh runner under iOS platform

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
