### PR TITLE
allow --env CLI flag to use relative env file paths  

### DIFF
--- a/fastlane/lib/fastlane/helper/dotenv_helper.rb
+++ b/fastlane/lib/fastlane/helper/dotenv_helper.rb
@@ -40,7 +40,16 @@ module Fastlane
 
         # Loads .env file for the environment(s) passed in through options
         envs.each do |env|
-          env_file = File.join(base_path, ".env.#{env}")
+          # Determine if `env` is a relative path and construct `env_file` accordingly
+          if env.include?('..') || env.start_with?('./') || env.start_with?('.\\')
+            # `env` appears to be a relative path
+            # Expand it from the current working directory
+            env_file = File.expand_path(env)
+          else
+            # `env` does not appear to be a relative path
+            # Use `File.join` to construct `env_file` with `base_path`
+            env_file = File.join(base_path, ".env.#{env}")
+          end
           UI.success("Loading from '#{env_file}'")
           Dotenv.overload(env_file)
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

In multiplatform projects env files could be kept in a root directory especially when multiple platforms share the same envs to stay DRY. For example:
`../env/.env.development` might be for both ios and android in a flutter, react native, or kotlin multiplatform project and same with  `../env/.env.release`. However, the `fastlane foo --env "../../.env.development"` currently doesn't work due to the .env approach being hardcoded to only pass a simple string rather than a potential relative path to the env file.  

I tried alternatives like Dotenv.load(:options[myoption]) but the problem is that these don't work in Matchfile and Appfile which introduces a bunch of unnecessary hurdles and wasted time for engineers. It shouldn't be this hard to load an env file from a different directory if we want.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

I decided that rather than introduce a breaking change I could just check if someone is trying to pass a relative path I could just expand the relative path, and otherwise keep the old approach. 

Personally I think a breaking change would be better because the flexibility of loading an env file from anywhere is much better than the current approach which was presumably intending to save the user from typing only 4 characters `.env.`. 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
To make sure the old way works pass an env with `--env foo` to reach `.env.foo` file in the fastlane directory.
To make sure the new way works pass an env with `--env ../../.env.foo` to reach `.env.foo` file in a different directory.


Please note that the current local testing env has a bunch of flakes.