### PR TITLE
[action] New `dotenv` action for overloading and loading dotenv files from default or custom directory

### DIFF
--- a/fastlane/lib/fastlane/actions/dotenv.rb
+++ b/fastlane/lib/fastlane/actions/dotenv.rb
@@ -9,15 +9,10 @@ module Fastlane
         overload = params[:overload]
         fail_if_missing = params[:fail_if_missing]
 
-        if path
-          env_file = File.join(path, env_file)
-        else
-          base_path = Fastlane::Helper::DotenvHelper.find_dotenv_directory
-          env_file = File.join(base_path, env_file)
-        end
+        env_path = File.join(path, env_file)
 
         if !File.exist?(env_file)
-          error = "Cannot find request dotenv file at '#{env_file}'"
+          error = "Cannot find dotenv file at '#{env_path}'"
 
           if fail_if_missing
             UI.user_error!(error)
@@ -25,11 +20,11 @@ module Fastlane
 
           UI.error(error)
         elsif overload
-          UI.success("Overloading environment variables from '#{env_file}'")
-          Dotenv.overload(env_file)
+          UI.success("Overloading environment variables from '#{env_path}'")
+          Dotenv.overload(env_path)
         else
-          UI.success("Loading environment variables from '#{env_file}'")
-          Dotenv.load(env_file)
+          UI.success("Loading environment variables from '#{env_path}'")
+          Dotenv.load(env_path)
         end
       end
 
@@ -41,11 +36,12 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :name,
                                        env_name: 'FL_DOTENV_NAME',
-                                       description: 'Load an dotenv file by name. Ex: ios, android, secret'),
+                                       description: 'Load an dotenv file by name. E.g.: ios, android, secret'),
           FastlaneCore::ConfigItem.new(key: :path,
                                        env_name: 'FL_DOTENV_PATH',
                                        description: 'Directory where the dotenv file is located. Defaults to working directory',
-                                       optional: true),
+                                       default_value: Fastlane::Helper::DotenvHelper.find_dotenv_directory,
+                                       default_value_dynamic: true),
           FastlaneCore::ConfigItem.new(key: :overload,
                                        env_name: 'FL_DOTENV_OVERLOAD',
                                        description: 'Whether environment variables should be overloaded',
@@ -74,7 +70,7 @@ module Fastlane
       def self.example_code
         [
           'dotenv(
-            name: "secret" # looking for .env.secret
+            name: "secret" # Looks for .env.secret
           )',
           'dotenv(
             name: "release",

--- a/fastlane/lib/fastlane/actions/dotenv.rb
+++ b/fastlane/lib/fastlane/actions/dotenv.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         env_path = File.join(path, env_file)
 
-        if !File.exist?(env_file)
+        if !File.exist?(env_path)
           error = "Cannot find dotenv file at '#{env_path}'"
 
           if fail_if_missing

--- a/fastlane/lib/fastlane/actions/dotenv.rb
+++ b/fastlane/lib/fastlane/actions/dotenv.rb
@@ -1,0 +1,75 @@
+require 'dotenv'
+
+module Fastlane
+  module Actions
+    class DotenvAction < Action
+      def self.run(params)
+        env_file = ".env.#{params[:name]}"
+        path = params[:path]
+        overload = params[:overload]
+        fail_if_missing = params[:fail_if_missing]
+
+        if path
+          env_file = File.join(path, env_file)
+        else
+          base_path = Fastlane::Helper::DotenvHelper.find_dotenv_directory
+          env_file = File.join(base_path, env_file)
+        end
+
+        if !File.exist?(env_file)
+          error = "Cannot find request dotenv file at '#{env_file}'"
+
+          if fail_if_missing
+            UI.user_error!(error)
+          end
+
+          UI.error(error)
+        elsif overload
+          UI.success("Overloading environment variables from '#{env_file}'")
+          Dotenv.overload(env_file)
+        else
+          UI.success("Loading environment variables from '#{env_file}'")
+          Dotenv.load(env_file)
+        end
+      end
+
+      def self.author
+        "joshdholtz"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :name,
+                                       env_name: 'FL_DOTENV_NAME',
+                                       description: 'Load an dotenv file by name. Ex: ios, android, secret'),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: 'FL_DOTENV_PATH',
+                                       description: 'Directory where the dotenv file is located. Defaults to working directory',
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :overload,
+                                       env_name: 'FL_DOTENV_OVERLOAD',
+                                       description: 'Whether environment variables should be overloaded',
+                                       default_value: true,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :fail_if_missing,
+                                       env_name: 'FL_DOTENV_FAIL_IF_MISSING',
+                                       description: 'Raises an error if the dotenv file cannot be found',
+                                       default_value: false,
+                                       type: Boolean)
+        ]
+      end
+
+      def self.description
+        "Loads a dotenv file by name and optionally in a non-standard path"
+      end
+
+      def self.category
+        :misc
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/dotenv.rb
+++ b/fastlane/lib/fastlane/actions/dotenv.rb
@@ -70,6 +70,22 @@ module Fastlane
       def self.is_supported?(platform)
         true
       end
+
+      def self.example_code
+        [
+          'dotenv(
+            name: "secret" # looking for .env.secret
+          )',
+          'dotenv(
+            name: "release",
+            path: "platforms/ios"
+          )',
+          'dotenv(
+            name: "secret",
+            fail_if_missing: true
+          )'
+        ]
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/dotenv_spec.rb
+++ b/fastlane/spec/actions_specs/dotenv_spec.rb
@@ -1,0 +1,82 @@
+describe Fastlane do
+
+  describe Fastlane::Actions::DotenvAction do
+    describe "dotenv" do
+      describe "when dotenv exists" do
+        describe "overloads" do
+          it "dotenv from default directory" do
+            expect(Fastlane::Helper::DotenvHelper).to receive(:find_dotenv_directory).and_return('/base/path/')
+            expect(Dotenv).to receive(:overload).with('/base/path/.env.secret')
+
+            allow(File).to receive(:exist?).with(anything).and_call_original
+            expect(File).to receive(:exist?).with('/base/path/.env.secret').and_return(true)
+
+            Fastlane::FastFile.new.parse("lane :test do
+              dotenv(name: 'secret')
+            end").runner.execute(:test)
+          end
+
+          it "dotenv from custom directory" do
+            expect(Dotenv).to receive(:overload).with('platforms/ios/.env.release')
+
+            allow(File).to receive(:exist?).with(anything).and_call_original
+            expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(true).times.once
+
+            Fastlane::FastFile.new.parse("lane :test do
+              dotenv(name: 'release', path: 'platforms/ios')
+            end").runner.execute(:test)
+          end
+        end
+
+        describe "loads" do
+          it "dotenv from default directory" do
+            expect(Fastlane::Helper::DotenvHelper).to receive(:find_dotenv_directory).and_return('/base/path/')
+            expect(Dotenv).to receive(:load).with('/base/path/.env.secret')
+
+            allow(File).to receive(:exist?).with(anything).and_call_original
+            expect(File).to receive(:exist?).with('/base/path/.env.secret').and_return(true)
+
+            Fastlane::FastFile.new.parse("lane :test do
+              dotenv(name: 'secret', overload: false)
+            end").runner.execute(:test)
+          end
+
+          it "dotenv from custom directory" do
+            expect(Dotenv).to receive(:load).with('platforms/ios/.env.release')
+
+            allow(File).to receive(:exist?).with(anything).and_call_original
+            expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(true).times.once
+
+            Fastlane::FastFile.new.parse("lane :test do
+              dotenv(name: 'release', path: 'platforms/ios', overload: false)
+            end").runner.execute(:test)
+          end
+        end
+      end
+
+      describe "when dotenv doesn't exist" do
+        it "fails silently with custom directory" do
+          allow(File).to receive(:exist?).with(anything).and_call_original
+          expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(false).times.once
+
+          expect(UI).to receive(:error).with("Cannot find request dotenv file at 'platforms/ios/.env.release'")
+
+          Fastlane::FastFile.new.parse("lane :test do
+            dotenv(name: 'release', path: 'platforms/ios')
+          end").runner.execute(:test)
+        end
+
+        it "fails silently with custom directory" do
+          allow(File).to receive(:exist?).with(anything).and_call_original
+          expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(false).times.once
+
+          expect do
+            Fastlane::FastFile.new.parse("lane :test do
+                dotenv(name: 'release', path: 'platforms/ios', fail_if_missing: true)
+              end").runner.execute(:test)
+          end.to raise_error("Cannot find request dotenv file at 'platforms/ios/.env.release'")
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/dotenv_spec.rb
+++ b/fastlane/spec/actions_specs/dotenv_spec.rb
@@ -5,7 +5,7 @@ describe Fastlane do
       describe "when dotenv exists" do
         describe "overloads" do
           it "dotenv from default directory" do
-            expect(Fastlane::Helper::DotenvHelper).to receive(:find_dotenv_directory).and_return('/base/path/')
+            expect(Fastlane::Helper::DotenvHelper).to receive(:find_dotenv_directory).and_return('/base/path/').times.twice
             expect(Dotenv).to receive(:overload).with('/base/path/.env.secret')
 
             allow(File).to receive(:exist?).with(anything).and_call_original
@@ -20,7 +20,7 @@ describe Fastlane do
             expect(Dotenv).to receive(:overload).with('platforms/ios/.env.release')
 
             allow(File).to receive(:exist?).with(anything).and_call_original
-            expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(true).times.once
+            expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(true)
 
             Fastlane::FastFile.new.parse("lane :test do
               dotenv(name: 'release', path: 'platforms/ios')
@@ -30,7 +30,7 @@ describe Fastlane do
 
         describe "loads" do
           it "dotenv from default directory" do
-            expect(Fastlane::Helper::DotenvHelper).to receive(:find_dotenv_directory).and_return('/base/path/')
+            expect(Fastlane::Helper::DotenvHelper).to receive(:find_dotenv_directory).and_return('/base/path/').times.twice
             expect(Dotenv).to receive(:load).with('/base/path/.env.secret')
 
             allow(File).to receive(:exist?).with(anything).and_call_original
@@ -45,7 +45,7 @@ describe Fastlane do
             expect(Dotenv).to receive(:load).with('platforms/ios/.env.release')
 
             allow(File).to receive(:exist?).with(anything).and_call_original
-            expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(true).times.once
+            expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(true)
 
             Fastlane::FastFile.new.parse("lane :test do
               dotenv(name: 'release', path: 'platforms/ios', overload: false)
@@ -57,7 +57,7 @@ describe Fastlane do
       describe "when dotenv doesn't exist" do
         it "fails silently with custom directory" do
           allow(File).to receive(:exist?).with(anything).and_call_original
-          expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(false).times.once
+          expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(false)
 
           expect(UI).to receive(:error).with("Cannot find dotenv file at 'platforms/ios/.env.release'")
 
@@ -68,7 +68,7 @@ describe Fastlane do
 
         it "fails silently with custom directory" do
           allow(File).to receive(:exist?).with(anything).and_call_original
-          expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(false).times.once
+          expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(false)
 
           expect do
             Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/dotenv_spec.rb
+++ b/fastlane/spec/actions_specs/dotenv_spec.rb
@@ -59,7 +59,7 @@ describe Fastlane do
           allow(File).to receive(:exist?).with(anything).and_call_original
           expect(File).to receive(:exist?).with('platforms/ios/.env.release').and_return(false).times.once
 
-          expect(UI).to receive(:error).with("Cannot find request dotenv file at 'platforms/ios/.env.release'")
+          expect(UI).to receive(:error).with("Cannot find dotenv file at 'platforms/ios/.env.release'")
 
           Fastlane::FastFile.new.parse("lane :test do
             dotenv(name: 'release', path: 'platforms/ios')
@@ -74,7 +74,7 @@ describe Fastlane do
             Fastlane::FastFile.new.parse("lane :test do
                 dotenv(name: 'release', path: 'platforms/ios', fail_if_missing: true)
               end").runner.execute(:test)
-          end.to raise_error("Cannot find request dotenv file at 'platforms/ios/.env.release'")
+          end.to raise_error("Cannot find dotenv file at 'platforms/ios/.env.release'")
         end
       end
     end


### PR DESCRIPTION
### Motivation and Context

I've been manually loading dotenv files for years and this should really be easier and built into _fastlane_

### Description

New `dotenv` action with:
- `name`
- `path`
- `overload`
- `fail_if_missing`

#### Example

```rb
before_all do
  dotenv(name: 'secret')
  # or
  dotenv(name: 'secret', fail_if_missing: true)
  # or
  dotenv(name: 'release', path: './platforms/ios')
end

lane :release do 
  # Stuff
end
```

### Testing Steps

N/A
