### PR TITLE
avoid nil release

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -300,7 +300,7 @@ module Supply
     end
 
     def latest_version(track)
-      latest_version = tracks.select { |t| t.track == Supply::Tracks::DEFAULT }.map(&:releases).flatten.reject { |r| r.name.nil? }.max_by(&:name)
+      latest_version = tracks.select { |t| t.track == Supply::Tracks::DEFAULT }.map(&:releases).flatten.reject { |r| r.nil? or r.name.nil? }.max_by(&:name)
 
       # Check if user specified '--track' option if version information from 'production' track is nil
       if latest_version.nil? && track == Supply::Tracks::DEFAULT


### PR DESCRIPTION
### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
`supply init` can fail with a Nil release
```
[✔] 🚀
[16:50:27]: 🕗  Downloading metadata, images, screenshots...
[16:50:28]: 📝  Downloading metadata (en-US)
[16:50:28]: Writing to fastlane/metadata/android/en-US/title.txt...
[16:50:28]: Writing to fastlane/metadata/android/en-US/short_description.txt...
[16:50:28]: Writing to fastlane/metadata/android/en-US/full_description.txt...
[16:50:28]: Writing to fastlane/metadata/android/en-US/video.txt...
[16:50:28]: 🖼️  Downloading images (en-US)
[16:50:28]: Downloading `featureGraphic` for en-US...
[16:50:28]:     Downloaded - fastlane/metadata/android/en-US/images/featureGraphic.png
[16:50:28]: Downloading `icon` for en-US...
[16:50:28]:     Downloaded - fastlane/metadata/android/en-US/images/icon.png
[16:50:28]: Downloading `tvBanner` for en-US...
[16:50:29]: Downloading `phoneScreenshots` for en-US...
[16:50:29]:     Downloaded - fastlane/metadata/android/en-US/images/phoneScreenshots/1_en-US.png
[16:50:29]:     Downloaded - fastlane/metadata/android/en-US/images/phoneScreenshots/2_en-US.png
[16:50:29]: Downloading `sevenInchScreenshots` for en-US...
[16:50:30]: Downloading `tenInchScreenshots` for en-US...
[16:50:30]: Downloading `tvScreenshots` for en-US...
[16:50:30]: Downloading `wearScreenshots` for en-US...

Looking for related GitHub issues on fastlane/fastlane...

/opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/supply/lib/supply/client.rb:303:in `block in latest_version': \e[31m[!] undefined me
thod `name' for nil:NilClass (NoMethodError)

      latest_version = tracks.select { |t| t.track == Supply::Tracks::DEFAULT }.map(&:releases).flatten.reject { |r| r.name.nil? }.max_by(&:name)
                                                                                                                      ^^^^^\e[0m
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/supply/lib/supply/client.rb:303:in `reject'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/supply/lib/supply/client.rb:303:in `latest_version'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/supply/lib/supply/setup.rb:19:in `perform_download'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/supply/lib/supply/commands_generator.rb:55:in `block (2 levels) in run'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in `run!'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/supply/lib/supply/commands_generator.rb:61:in `run'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/supply/lib/supply/commands_generator.rb:13:in `start'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/fastlane/lib/fastlane/cli_tools_distributor.rb:115:in `take_off'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/gems/fastlane-2.216.0/bin/fastlane:23:in `<top (required)>'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/bin/fastlane:25:in `load'
        from /opt/homebrew/Cellar/fastlane/2.216.0/libexec/bin/fastlane:25:in `<main>'
```

### Description

This change fixed things for me locally. TBH, I'm not sure why the release is Nil here and what is actually wrong. Since I am not a ruby dev, it is costly for me to go beyond this report / patch. Feel free to push back.

For added info: I do not have a production track release yet, only an alpha release. This may be why?

### Testing Steps

I was able to run `fastlane supply init --track 'alpha'` locally successfully with this change.