### PR TITLE
detect binding.irb in `ensure_no_debug_code` during build.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,7 +27,7 @@ lane :lint_source do
   # Verifying that no debug code is in the code base
   #
   exclude_dirs = ["\.bundle", "*/vendor/bundle"]
-  ensure_no_debug_code(text: "binding.pry", extension: ".rb", exclude: "playground.rb", exclude_dirs: exclude_dirs) # debugging code
+  ensure_no_debug_code(text: "binding\.(irb|pry)", extension: ".rb", exclude: "playground.rb", exclude_dirs: exclude_dirs) # debugging code
   ensure_no_debug_code(text: "# TODO", extension: ".rb", exclude_dirs: exclude_dirs) # TODOs
   ensure_no_debug_code(text: "now: ", extension: ".rb", exclude_dirs: exclude_dirs) # rspec focus
   ensure_no_debug_code(text: "<<<<<<<", extension: ".rb", exclude_dirs: exclude_dirs) # Merge conflict


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Since binding.irb is a debugging tool available by default in Ruby supported by the current fastlane, we can use the REPL environment easily by writing `binding.irb` without the need for `gem 'irb'` etc.

Therefore, how about adding binding.irb as a target for debugging code checks if you want to ensure that no debugging codes?


### Description
Add binding.irb by ensure_no_debug_code action

### Testing Steps

bundle exec fastlane test