### PR TITLE
[spaceship] `create_certificate_signing_request`: update from SHA-1 to SHA-256

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -55,7 +55,7 @@ module Spaceship
         Time.parse(expiration_date) > Time.now
       end
 
-      # Create a new code signing request that can be used to
+      # Create a new cert signing request that can be used to
       # generate a new certificate
       # @example
       #  Create a new certificate signing request
@@ -71,7 +71,7 @@ module Spaceship
                                                 ['CN', 'PEM', OpenSSL::ASN1::UTF8STRING]
                                               ])
         csr.public_key = key.public_key
-        csr.sign(key, OpenSSL::Digest::SHA1.new)
+        csr.sign(key, OpenSSL::Digest::SHA256.new)
         return [csr, key]
       end
 

--- a/spaceship/lib/spaceship/portal/certificate.rb
+++ b/spaceship/lib/spaceship/portal/certificate.rb
@@ -205,7 +205,7 @@ module Spaceship
 
       # Class methods
       class << self
-        # Create a new code signing request that can be used to
+        # Create a new cert signing request that can be used to
         # generate a new certificate
         # @example
         #  Create a new certificate signing request
@@ -221,7 +221,7 @@ module Spaceship
                                                   ['CN', 'PEM', OpenSSL::ASN1::UTF8STRING]
                                                 ])
           csr.public_key = key.public_key
-          csr.sign(key, OpenSSL::Digest::SHA1.new)
+          csr.sign(key, OpenSSL::Digest::SHA256.new)
           return [csr, key]
         end
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Update the two places where Fastlane creates CSRs to use SHA-256 (sha256WithRSAEncryption). This signature algorithm is accepted by Apple and CSRs created using Keychain Access at least since Ventura use SHA-256.

SHA-1 is increasingly deprecated by OS vendors. I noticed fastlane was still using SHA-1 when attempting to use `fastlane pem` under RedHat 9 which disables SHA-1 by default[^1].

[^1]: https://wiki.almalinux.org/release-notes/9.0.html#changelog

I noticed fastlane was still using SHA-1 when attempting to use `fastlane pem` under RedHat 9 which disables SHA-1[^1]. Updating fastlane to SHA-256 allows it to generate CSR under RedHat 9 without having to alter the RedHat 9 default crypto policy[^1]. SHA-256 is also what Keychain Access uses for CSRs at least since Ventura.

### Description

Update the two copies of the `create_certificate_signing_request` function to use `OpenSSL::Digest::SHA256.new` instead of `OpenSSL::Digest::SHA1.new`

### Testing Steps

I tested by running the new code under RedHat 9 and macOS Ventura using `irb`.

I inspected the CSR generated by the new code using `openssl req -noout -text` and verified that the "Signature Algorithm" is now `sha256WithRSAEncryption` which matches the algorithm used in CSRs generated by Keychain Access under macOS Ventura.
