### PR TITLE
CONTRIBUTING.md: remove Google CLA section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,19 +20,6 @@ Some people might also use the [_fastlane_ tag on StackOverflow](https://stackov
 - You will need a Google account to sign the CLA when you make your first PR
 - For some more advanced tooling and debugging tips, check out [ToolsAndDebugging.md](ToolsAndDebugging.md)
 
-### Google Contributor License Agreement (CLA)
-Upon your first pull request to _fastlane_, the [googlebot](https://github.com/googlebot) will ask you to sign the Google Contributor License Agreement. Once the CLA has been accepted, the PR will be available to merge and you will not be asked to sign it again unless your GitHub username or email address changes.
-
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution;
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
-
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
-
 ### New Actions
 
 Please be aware that we don’t accept submissions for new actions at the moment. You can find more information about that [here][submit action].


### PR DESCRIPTION
fastlane is no longer under the auspices of Google[^1].

Completing the Google Contributor License Agreement is no longer required.

[^1]: https://github.com/MobileNativeFoundation/discussions/discussions/194

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

fastlane is no longer under the auspices of Google[^1].

Completing the Google Contributor License Agreement is no longer required.

### Description

fastlane is no longer under the auspices of Google[^1].

Completing the Google Contributor License Agreement is no longer required.

### Testing Steps

N/A
