### PR TITLE
[scan] fix misleading error message when no devices are found

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -146,6 +146,8 @@ module Scan
 
           selector = ->(sim) { pieces.count > 0 && sim.name == pieces.first }
 
+          display_device = "'#{device_string}'"
+
           set + (
             if pieces.count == 0
               [] # empty array
@@ -157,6 +159,8 @@ module Scan
                 .pop(1)
             else # pieces.count == 2 -- mathematically, because of the 'end of line' part of our regular expression
               version = pieces[1].tr('()', '')
+              display_device = "'#{pieces[0]}' with version #{version}"
+
               potential_emptiness_error = lambda do |sims|
                 if sims.empty?
                   UI.error("No simulators found that are equal to the version " \
@@ -168,8 +172,8 @@ module Scan
             end
           ).tap do |array|
             if array.empty?
-              UI.test_failure!("No device found with name '#{device_string}'") if Scan.config[:ensure_devices_found]
-              UI.error("Ignoring '#{device_string}', couldn’t find matching simulator")
+              UI.test_failure!("No device found with name #{display_device}") if Scan.config[:ensure_devices_found]
+              UI.error("Ignoring '#{device_string}', couldn't find matching simulator")
             end
           end
         end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #21598

When using `scan` with `ensure_devices_found: true`, the error message doesn't actually display the behavior of `scan` is using to find the simulator.

```rb
scan(
  devices: ["iPhone 14 (16.0)"],
  ensure_devices_found: true,
)
```

With the above example, the error previously said...

```
No device found with name 'iPhone 14 (16.4)'
```

However, `scan` is actually trying to find a device with a name of "iPhone 14" but using iOS 16.0.

### Description

Updated error message when using `ensure_devices_found` to be more clear on what `scan` is actually looking for

The above example in the "Motivation and Context" section will now about the following error...

```
No device found with name 'iPhone 14' with version 16.0
```

### Testing Steps

N/A
