### PR TITLE
[deliver] fix regression where changes made to the privacy URL fail to upload

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -468,7 +468,7 @@ module Deliver
       end
       localizations = app_info.get_app_info_localizations
 
-      LOCALISED_APP_VALUES.keys.each do |key|
+      LOCALISED_APP_VALUES.each do |key, localizedKey|
         current = options[key]
         next unless current
 
@@ -485,7 +485,7 @@ module Deliver
           next if app_info_locale.nil?
 
           begin
-            current_value = app_info_locale.public_send(key.to_sym)
+            current_value = app_info_locale.public_send(localizedKey.to_sym)
           rescue NoMethodError
             next
           end

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -468,7 +468,7 @@ module Deliver
       end
       localizations = app_info.get_app_info_localizations
 
-      LOCALISED_APP_VALUES.each do |key, localizedKey|
+      LOCALISED_APP_VALUES.each do |key, localized_key|
         current = options[key]
         next unless current
 
@@ -485,7 +485,7 @@ module Deliver
           next if app_info_locale.nil?
 
           begin
-            current_value = app_info_locale.public_send(localizedKey.to_sym)
+            current_value = app_info_locale.public_send(localized_key.to_sym)
           rescue NoMethodError
             next
           end

--- a/deliver/spec/upload_metadata_spec.rb
+++ b/deliver/spec/upload_metadata_spec.rb
@@ -289,6 +289,31 @@ describe Deliver::UploadMetadata do
         end
       end
 
+      context "with privacy_url" do
+        it 'saves privacy_url' do
+          options = {
+            platform: "ios",
+            metadata_path: metadata_path,
+            privacy_url: { "en-US" => "https://fastlane.tools" },
+            apple_tv_privacy_policy: { "en-US" => "https://fastlane.tools/tv" }
+          }
+
+          # Get number of versions (used for if whats_new should be sent)
+          expect(Spaceship::ConnectAPI).to receive(:get_app_store_versions).and_return(app_store_versions)
+
+          expect(version).to receive(:update).with(attributes: {})
+
+          # Validate symbol names used when comparing privacy urls before upload
+          expect(app_info_localization_en).to receive(:privacy_policy_url).and_return(options[:privacy_url]["en-US"])
+          expect(app_info_localization_en).to receive(:privacy_policy_text).and_return(options[:apple_tv_privacy_policy]["en-US"])
+
+          # Update app info
+          expect(app_info).to receive(:update_categories).with(category_id_map: {})
+
+          uploader.upload(options)
+        end
+      end
+
       context "with auto_release_date" do
         it 'with date' do
           options = {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #21654, fixing a regression introduced in #21472

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Previously, the localized key was not used when checking to see if the app info has changed during the deliver upload step, so it was always failing to upload changes to privacy urls. With this change, we now check the current value of the app info using the localized key so that it can compare the current and previous app info values as expected, allowing changes to the privacy url to upload as expected.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

1. Change the privacy url in a project with fastlane/metadata/en-US/privacy_url.txt
2. Use fastlane deliver to upload the change
