### PR TITLE
[deliver][spaceship][scan] fix build warnings in rspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,6 @@ aliases:
       name: Set Ruby version
       command: | # see https://circleci.com/docs/2.0/testing-ios/#using-ruby
         echo "ruby-${_RUBY_VERSION}" > ~/.ruby-version
-        # https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command
-        echo 'chruby ruby-${_RUBY_VERSION}' >> $BASH_ENV
 
   - &bundle_install
     run:

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -1,7 +1,10 @@
 require 'deliver/app_screenshot'
 require 'deliver/setup'
+require_relative 'deliver_constants'
 
 describe Deliver::AppScreenshot do
+  include DeliverConstants
+
   def screen_size_from(path)
     path.match(/{([0-9]+)x([0-9]+)}/).captures.map(&:to_i)
   end
@@ -11,8 +14,6 @@ describe Deliver::AppScreenshot do
       screen_size_from(path)
     end
   end
-
-  ScreenSize = Deliver::AppScreenshot::ScreenSize
 
   describe "#initialize" do
     context "when filename doesn't contain 'iPad Pro (3rd generation)' or 'iPad Pro (4th generation)'" do

--- a/deliver/spec/deliver_constants.rb
+++ b/deliver/spec/deliver_constants.rb
@@ -1,0 +1,5 @@
+require 'deliver/app_screenshot'
+
+module DeliverConstants
+  ScreenSize = Deliver::AppScreenshot::ScreenSize
+end

--- a/deliver/spec/sync_screenshots_spec.rb
+++ b/deliver/spec/sync_screenshots_spec.rb
@@ -1,12 +1,14 @@
 require 'deliver/sync_screenshots'
 require 'fakefs/spec_helpers'
+require_relative 'deliver_constants'
 
 describe Deliver::SyncScreenshots do
   describe '#do_replace_screeshots' do
+    include DeliverConstants
+
     subject { described_class.new(app: nil, platform: nil) }
 
     DisplayType = Spaceship::ConnectAPI::AppScreenshotSet::DisplayType
-    ScreenSize = Deliver::AppScreenshot::ScreenSize
 
     before do
       # To emulate checksum calculation, return the given path as a checksum

--- a/scan/spec/error_handler_spec.rb
+++ b/scan/spec/error_handler_spec.rb
@@ -21,7 +21,7 @@ describe Scan do
           output = File.open('./scan/spec/fixtures/non_parallel_testing_failure.log', &:read)
           expect do
             Scan::ErrorHandler.handle_build_error(output, log_path)
-          end.to_not raise_error
+          end.to_not(raise_error)
         end
       end
 

--- a/scan/spec/error_handler_spec.rb
+++ b/scan/spec/error_handler_spec.rb
@@ -7,19 +7,21 @@ describe Scan do
     describe "handle_build_error" do
       describe "when parsing parallel test failure output" do
         it "does not report a build failure" do
+          expect(Scan).to receive(:config).and_return({})
           output = File.open('./scan/spec/fixtures/parallel_testing_failure.log', &:read)
           expect do
             Scan::ErrorHandler.handle_build_error(output, log_path)
-          end.to_not(raise_error(FastlaneCore::Interface::FastlaneBuildFailure))
+          end.not_to raise_error
         end
       end
 
       describe "when parsing non-parallel test failure output" do
         it "does not report a build failure" do
+          expect(Scan).to receive(:config).and_return({})
           output = File.open('./scan/spec/fixtures/non_parallel_testing_failure.log', &:read)
           expect do
             Scan::ErrorHandler.handle_build_error(output, log_path)
-          end.to_not(raise_error(FastlaneCore::Interface::FastlaneBuildFailure))
+          end.to_not raise_error
         end
       end
 
@@ -40,23 +42,19 @@ describe Scan do
         end
 
         it "mentions log above when not suppressing output", requires_xcodebuild: true do
-          expect(FastlaneCore::UI).to receive(:build_failure!).with("Error building the application. See the log above.")
-
           output = File.open(output_path, &:read)
           expect do
             Scan::ErrorHandler.handle_build_error(output, log_path)
-          end.to(raise_error)
+          end.to(raise_error(FastlaneCore::Interface::FastlaneBuildFailure, "Error building the application. See the log above."))
         end
 
         it "mentions log file when suppressing output", requires_xcodebuild: true do
           Scan.config[:suppress_xcode_output] = true
 
-          expect(FastlaneCore::UI).to receive(:build_failure!).with("Error building the application. See the log here: '#{log_path}'.")
-
           output = File.open(output_path, &:read)
           expect do
             Scan::ErrorHandler.handle_build_error(output, log_path)
-          end.to(raise_error)
+          end.to(raise_error(FastlaneCore::Interface::FastlaneBuildFailure, "Error building the application. See the log here: '#{log_path}'."))
         end
       end
     end

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -55,14 +55,8 @@ describe Spaceship::ProvisioningProfile do
   end
 
   describe '#all via xcode api' do
-    around(:all) do |example|
-      switch = ENV['SPACESHIP_AVOID_XCODE_API']
-      example.run
-      ENV['SPACESHIP_AVOID_XCODE_API'] = switch
-    end
-
     it 'should use the Xcode api to get provisioning profiles and their appIds' do
-      ENV['SPACESHIP_AVOID_XCODE_API'] = nil
+      stub_const('ENV', { "SPACESHIP_AVOID_XCODE_API" => nil })
       expect(client).to receive(:provisioning_profiles_via_xcode_api).and_call_original
       expect(client).not_to(receive(:provisioning_profiles))
       expect(client).not_to(receive(:provisioning_profile_details))
@@ -70,7 +64,7 @@ describe Spaceship::ProvisioningProfile do
     end
 
     it 'should use the developer portal api to get provisioning profiles and their appIds' do
-      ENV['SPACESHIP_AVOID_XCODE_API'] = 'true'
+      stub_const('ENV', { "SPACESHIP_AVOID_XCODE_API" => 'true' })
       expect(client).not_to(receive(:provisioning_profiles_via_xcode_api))
       expect(client).to receive(:provisioning_profiles).and_call_original
       expect(client).to receive(:provisioning_profile_details).and_call_original.exactly(7).times

--- a/spaceship/spec/tunes/device_type_spec.rb
+++ b/spaceship/spec/tunes/device_type_spec.rb
@@ -1,7 +1,7 @@
 describe Spaceship::Tunes::DeviceType do
   describe "type identifiers" do
     before(:each) do
-      # let's catch those calls to avoid polluting the output
+      # Let's catch those calls to avoid polluting the output
       # Note: warning has a different signature in newer versions of ruby
       allow(Warning).to receive(:warn).with(/Spaceship::Tunes::DeviceType has been deprecated./)
       allow(Warning).to receive(:warn).with(/Spaceship::Tunes::DeviceType has been deprecated./, { category: nil })

--- a/spaceship/spec/tunes/device_type_spec.rb
+++ b/spaceship/spec/tunes/device_type_spec.rb
@@ -4,7 +4,7 @@ describe Spaceship::Tunes::DeviceType do
       # let's catch those calls to avoid polluting the output
       # Note: warning has a different signature in newer versions of ruby
       allow(Warning).to receive(:warn).with(/Spaceship::Tunes::DeviceType has been deprecated./)
-      allow(Warning).to receive(:warn).with(/Spaceship::Tunes::DeviceType has been deprecated./, {:category=>nil})
+      allow(Warning).to receive(:warn).with(/Spaceship::Tunes::DeviceType has been deprecated./, { category: nil })
     end
 
     it "should be checkable using singleton functions" do

--- a/spaceship/spec/tunes/device_type_spec.rb
+++ b/spaceship/spec/tunes/device_type_spec.rb
@@ -2,7 +2,7 @@ describe Spaceship::Tunes::DeviceType do
   describe "type identifiers" do
     before(:each) do
       # Let's catch those calls to avoid polluting the output
-      # Note: warning has a different signature in newer versions of ruby
+      # Note: Warning.warn() has a different signature depending on the Ruby version, hence why we need more than one allow(...)
       allow(Warning).to receive(:warn).with(/Spaceship::Tunes::DeviceType has been deprecated./)
       allow(Warning).to receive(:warn).with(/Spaceship::Tunes::DeviceType has been deprecated./, { category: nil })
     end

--- a/spaceship/spec/tunes/device_type_spec.rb
+++ b/spaceship/spec/tunes/device_type_spec.rb
@@ -1,5 +1,12 @@
 describe Spaceship::Tunes::DeviceType do
   describe "type identifiers" do
+    before(:each) do
+      # let's catch those calls to avoid polluting the output
+      # Note: warning has a different signature in newer versions of ruby
+      allow(Warning).to receive(:warn).with(/Spaceship::Tunes::DeviceType has been deprecated./)
+      allow(Warning).to receive(:warn).with(/Spaceship::Tunes::DeviceType has been deprecated./, {:category=>nil})
+    end
+
     it "should be checkable using singleton functions" do
       expect(Spaceship::Tunes::DeviceType.exists?("iphone6")).to be_truthy
     end
@@ -38,8 +45,9 @@ describe Spaceship::Tunes::DeviceType do
         'desktop'
       ]
 
+      types = Spaceship::Tunes::DeviceType.types
       old_types.each do |identifier|
-        expect(Spaceship::Tunes::DeviceType.types).to include(identifier)
+        expect(types).to include(identifier)
       end
     end
   end


### PR DESCRIPTION
build output is cluttered with unecessary error messages. Removing some of them.

WIP

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
