### PR TITLE
[action][spm] add `parallel` option

### DIFF
--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -12,6 +12,7 @@ module Fastlane
         cmd << "--verbose" if params[:verbose]
         cmd << params[:command] if package_commands.include?(params[:command])
         cmd << "--enable-code-coverage" if params[:enable_code_coverage] && (params[:command] == 'generate-xcodeproj' || params[:command] == 'test')
+        cmd << "--parallel" if params[:parallel] && params[:command] == 'test'
         if params[:xcconfig]
           cmd << "--xcconfig-overrides #{params[:xcconfig]}"
         end
@@ -48,6 +49,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :enable_code_coverage,
                                        env_name: "FL_SPM_ENABLE_CODE_COVERAGE",
                                        description: "Enables code coverage for the generated Xcode project when using the 'generate-xcodeproj' and the 'test' command",
+                                       type: Boolean,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :parallel,
+                                       env_name: "FL_SPM_PARALLEL",
+                                       description: "Enables running tests in parallel when using the 'test' command",
                                        type: Boolean,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :build_path,

--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -55,7 +55,7 @@ module Fastlane
                                        env_name: "FL_SPM_PARALLEL",
                                        description: "Enables running tests in parallel when using the 'test' command",
                                        type: Boolean,
-                                       optional: true),
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :build_path,
                                        env_name: "FL_SPM_BUILD_PATH",
                                        description: "Specify build/cache directory [default: ./.build]",

--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -122,6 +122,10 @@ module Fastlane
           'spm(
             command: "generate-xcodeproj",
             xcconfig: "Package.xcconfig"
+          )',
+          'spm(
+            command: "test",
+            parallel: true
           )'
         ]
       end

--- a/fastlane/spec/actions_specs/spm_spec.rb
+++ b/fastlane/spec/actions_specs/spm_spec.rb
@@ -186,6 +186,48 @@ describe Fastlane do
 
           expect(result).to eq("swift test")
         end
+
+        it "sets --parallel to true for test" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            spm(
+              command: 'test',
+              parallel: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swift test --parallel")
+        end
+
+        it "sets --parellel to false for test" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            spm(
+              command: 'test',
+              parallel: false
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swift test")
+        end
+
+        it "does not add --parellel by default" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            spm(
+              command: 'test'
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swift test")
+        end
+
+        it "does not add --parellel for irrelevant commands" do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            spm(
+              parallel: true
+            )
+          end").runner.execute(:test)
+
+          expect(result).to eq("swift build")
+        end
       end
 
       context "when command is package related" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

~~I think something is wrong with my local setup, because if I run `bundle exec rspec` on a clean clone of the fastlane repo on the `master` branch, I still get some failures:~~ This is resolved. I was using ruby 3.2.2 and with that the tests fail. But I noticed the CI uses 3.1 so I tried again locally with 3.1.2 and now they pass.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

`swift test` allows parallel testing by passing the `--parallel` option. This reduces the time it takes to run the tests in a project. (In my case the time drops from 822 seconds to 133 seconds)

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

A `parallel` option has been added to the `SpmAction` action. If this options is set to `true` _and_ the `command` is `"test"`, the `--parallel` flag will be added to the command.

This functionality has been tested by using my [local fastlane setup](https://github.com/fastlane/fastlane/blob/master/Testing.md#test-your-local-fastlane-code-base-with-your-setup) in a real project. 

There is one small issue: when the tests are run in parallel, there seems to be no output to fastlane while the tests are running. When the tests complete (either successfully or as a failure), the output is shown. I don't know how to resolve this, so if anyone has an idea, feel free to let me know! But otherwise I think it's a tradeoff users of the `parallel` flag can make. I suspect the issue is that when running the tests with the `--parallel` option, output is not 'appended', but there's only one line that's constantly being removed and rewritten. You can see this happening when running `swift test --parallel` directly.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Create a lane that uses the `spm(command: 'test', parallel: true)` action.
