### PR TITLE
[tests][ci] clean up tests output on CI

### DIFF
--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -74,6 +74,8 @@ describe Deliver::UploadScreenshots do
                                     language: 'en-US',
                                     device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
           screenshots_per_language = { 'en-US' => [local_screenshot] }
+
+          allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
           allow(described_class).to receive(:calculate_checksum).and_return('checksum')
 
           expect(app_screenshot_set).to receive(:upload_screenshot).with(path: local_screenshot.path, wait_for_processing: false)
@@ -96,6 +98,7 @@ describe Deliver::UploadScreenshots do
           screenshots_per_language = { 'en-US' => [local_screenshot] }
           allow(described_class).to receive(:calculate_checksum).and_return('checksum')
 
+          allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
           expect(app_screenshot_set).to receive(:upload_screenshot).with(path: local_screenshot.path, wait_for_processing: false)
           subject.upload_screenshots([localization], screenshots_per_language)
         end
@@ -117,6 +120,7 @@ describe Deliver::UploadScreenshots do
         screenshots_per_language = { 'en-US' => [local_screenshot] }
         allow(described_class).to receive(:calculate_checksum).and_return('checksum')
 
+        allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
         expect(app_screenshot_set).to receive(:upload_screenshot).with(path: local_screenshot.path, wait_for_processing: false)
         subject.upload_screenshots([localization], screenshots_per_language)
       end
@@ -139,6 +143,7 @@ describe Deliver::UploadScreenshots do
         screenshots_per_language = { 'en-US' => [local_screenshot] }
         allow(described_class).to receive(:calculate_checksum).with(local_screenshot.path).and_return('checksum')
 
+        allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
         expect(app_screenshot_set).to_not(receive(:upload_screenshot))
         subject.upload_screenshots([localization], screenshots_per_language)
       end
@@ -159,6 +164,7 @@ describe Deliver::UploadScreenshots do
         screenshots_per_language = { 'en-US' => Array.new(11, local_screenshot) }
         allow(described_class).to receive(:calculate_checksum).with(local_screenshot.path).and_return('checksum')
 
+        allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
         expect(app_screenshot_set).to receive(:upload_screenshot).exactly(10).times
         subject.upload_screenshots([localization], screenshots_per_language)
       end
@@ -186,6 +192,7 @@ describe Deliver::UploadScreenshots do
         allow(described_class).to receive(:calculate_checksum).with(uploaded_local_screenshot.path).and_return('checksum')
         allow(described_class).to receive(:calculate_checksum).with(new_local_screenshot.path).and_return('another_checksum')
 
+        allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
         expect(app_screenshot_set).to_not(receive(:upload_screenshot))
         subject.upload_screenshots([localization], screenshots_per_language)
       end
@@ -215,6 +222,7 @@ describe Deliver::UploadScreenshots do
         allow(described_class).to receive(:calculate_checksum).with(uploaded_local_screenshot.path).and_return('checksum')
         allow(described_class).to receive(:calculate_checksum).with(new_local_screenshot.path).and_return('another_checksum')
 
+        allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
         expect(app_screenshot_set).to_not(receive(:upload_screenshot))
         subject.upload_screenshots([localization], screenshots_per_language)
       end

--- a/fastlane/lib/fastlane/actions/verify_build.rb
+++ b/fastlane/lib/fastlane/actions/verify_build.rb
@@ -67,7 +67,7 @@ module Fastlane
 
       def self.update_with_profile_info(app_path, values)
         provision_profile_path = "#{app_path}/embedded.mobileprovision"
-        UI.user_error!("Unable to extract profile") unless File.exist?(provision_profile_path)
+        UI.user_error!("Unable to find embedded profile in #{provision_profile_path}") unless File.exist?(provision_profile_path)
 
         profile = `cat #{provision_profile_path.shellescape} | security cms -D`
         UI.user_error!("Unable to extract profile") unless $? == 0

--- a/fastlane/lib/fastlane/actions/verify_build.rb
+++ b/fastlane/lib/fastlane/actions/verify_build.rb
@@ -24,7 +24,7 @@ module Fastlane
 
         case File.extname(build_path)
         when ".ipa", ".zip"
-          `unzip #{build_path.shellescape} -d #{dir.shellescape} -x '__MACOSX/*' '*.DS_Store'`
+          `unzip #{build_path.shellescape} -d #{dir.shellescape} -x '__MACOSX/*' '*.DS_Store' 2>&1`
           UI.user_error!("Unable to unzip ipa") unless $? == 0
           # Adding extra ** for edge-case ipas where Payload directory is nested.
           app_path = Dir["#{dir}/**/Payload/*.app"].first

--- a/fastlane/lib/fastlane/actions/verify_build.rb
+++ b/fastlane/lib/fastlane/actions/verify_build.rb
@@ -66,7 +66,10 @@ module Fastlane
       end
 
       def self.update_with_profile_info(app_path, values)
-        profile = `cat #{app_path.shellescape}/embedded.mobileprovision | security cms -D`
+        provision_profile_path = "#{app_path}/embedded.mobileprovision"
+        UI.user_error!("Unable to extract profile") unless File.exist?(provision_profile_path)
+
+        profile = `cat #{provision_profile_path.shellescape} | security cms -D`
         UI.user_error!("Unable to extract profile") unless $? == 0
 
         plist = Plist.parse_xml(profile)

--- a/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -191,7 +191,15 @@ describe Fastlane do
       end
 
       it "Runs between option from command line" do
-        expect(system("fastlane run changelog_from_git_commits between:123456,HEAD")).to be
+
+        options = FastlaneCore::Configuration.create(Fastlane::Actions::ChangelogFromGitCommitsAction.available_options, {
+          between: '123456,HEAD'
+        })
+
+        result = Fastlane::Actions::ChangelogFromGitCommitsAction.run(options)
+
+        changelog = %w(git log --pretty=%B 123456...HEAD).shelljoin
+        expect(result).to eq(changelog)
       end
 
       it "Accepts string value for :between" do

--- a/fastlane/spec/actions_specs/git_remote_branch_spec.rb
+++ b/fastlane/spec/actions_specs/git_remote_branch_spec.rb
@@ -44,7 +44,7 @@ describe Fastlane do
         test_directory_path = Dir.mktmpdir(directory)
 
         Dir.chdir(test_directory_path) do
-          `git init`
+          `git -c init.defaultBranch=main init`
 
           File.write('test_file', <<-TESTFILE)
               'Hello'

--- a/fastlane/spec/actions_specs/verify_build_spec.rb
+++ b/fastlane/spec/actions_specs/verify_build_spec.rb
@@ -83,14 +83,14 @@ describe Fastlane do
         end
 
         it "raises an error if app is built for iOS simulator" do
-          expect(FastlaneCore::UI).to receive(:user_error!).with("Unable to extract profile").and_call_original
+          expect(FastlaneCore::UI).to receive(:user_error!).with(/Unable to find embedded profile/).and_call_original
           expect do
             Fastlane::FastFile.new.parse("lane :test do
               verify_build(
                 build_path: '#{simulator_app}'
               )
             end").runner.execute(:test)
-          end.to raise_error("Unable to extract profile")
+          end.to raise_error(/Unable to find embedded profile/)
         end
 
         it "uses xcarchive set via build_path" do

--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -33,6 +33,11 @@ describe Fastlane::CLIToolsDistributor do
   end
 
   describe "update checking" do
+    before(:each) do
+      # prevent the update checker to run and clutter the output
+      ENV["FASTLANE_SKIP_UPDATE_CHECK"] = "a_value"
+    end
+
     it "checks for updates when running a lane" do
       FastlaneSpec::Env.with_ARGV(["sigh"]) do
         require 'fastlane/commands_generator'

--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -35,7 +35,8 @@ describe Fastlane::CLIToolsDistributor do
   describe "update checking" do
     before(:each) do
       # prevent the update checker to run and clutter the output
-      ENV["FASTLANE_SKIP_UPDATE_CHECK"] = "a_value"
+      # (FastlaneCore::UpdateChecker.start_looking_for_update() will return)
+      ENV["FASTLANE_SKIP_UPDATE_CHECK"] = "a_truthy_value"
     end
 
     it "checks for updates when running a lane" do

--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -1,6 +1,15 @@
 require 'fastlane/cli_tools_distributor'
 
 describe Fastlane::CLIToolsDistributor do
+  around do |example|
+    # FASTLANE_SKIP_UPDATE_CHECK: prevent the update checker to run and clutter the output
+    # (Fastlane::PluginUpdateManager.start_looking_for_updates() will return)
+    # FASTLANE_DISABLE_ANIMATION: prevent the spinner in Fastlane::CLIToolsDistributor.take_off
+    FastlaneSpec::Env.with_env_values('FASTLANE_SKIP_UPDATE_CHECK': 'a_truthy_value', 'FASTLANE_DISABLE_ANIMATION': 'true') do
+      example.run
+    end
+  end
+
   describe "command handling" do
     it "runs the lane instead of the tool when there is a conflict" do
       FastlaneSpec::Env.with_ARGV(["sigh"]) do
@@ -33,12 +42,6 @@ describe Fastlane::CLIToolsDistributor do
   end
 
   describe "update checking" do
-    before(:each) do
-      # prevent the update checker to run and clutter the output
-      # (FastlaneCore::UpdateChecker.start_looking_for_update() will return)
-      ENV["FASTLANE_SKIP_UPDATE_CHECK"] = "a_truthy_value"
-    end
-
     it "checks for updates when running a lane" do
       FastlaneSpec::Env.with_ARGV(["sigh"]) do
         require 'fastlane/commands_generator'

--- a/fastlane/spec/fixtures/plugins/Pluginfile1
+++ b/fastlane/spec/fixtures/plugins/Pluginfile1
@@ -1,3 +1,5 @@
+source "https://rubygems.org"
+
 gem "fastlane-plugin-xcversion"
 gem "fastlane_core"
 gem "hemal"

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -180,7 +180,7 @@ module FastlaneCore
     # @return Swift version
     def self.swift_version
       if system("which swift > /dev/null 2>&1")
-        output = `swift --version`
+        output = `swift --version 2> /dev/null`
         return output.split("\n").first.match(/version ([0-9.]+)/).captures.first
       end
       return nil

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -364,6 +364,7 @@ module FastlaneCore
       else
         command = "xcodebuild clean -showBuildSettings #{xcodebuild_parameters.join(' ')}"
       end
+      command = "#{command} 2>&1" # xcodebuild produces errors on stderr #21672
       command
     end
 
@@ -417,8 +418,6 @@ module FastlaneCore
         end
 
         command = build_xcodebuild_showbuildsettings_command
-
-        command = "#{command} 2>&1" # xcodebuild produces errors on stderr #21672
 
         # Xcode might hang here and retrying fixes the problem, see fastlane#4059
         begin

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -347,7 +347,7 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("13").and_return(false)
         expect(FastlaneCore::Helper).to receive(:xcode_at_least?).with("8.3").and_return(true)
         command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2>&1"
-        expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 3, retries: 3, print: true }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
+        expect(FastlaneCore::Project).to receive(:run_command).with(command, { timeout: 3, retries: 3, print: true }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
       end
 
@@ -358,7 +358,7 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:xcode_at_least?).with("13").and_return(false)
         expect(FastlaneCore::Helper).to receive(:xcode_at_least?).with("8.3").and_return(false)
         command = "xcodebuild clean -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2>&1"
-        expect(FastlaneCore::Project).to receive(:run_command).with(command.to_s, { timeout: 3, retries: 3, print: true }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
+        expect(FastlaneCore::Project).to receive(:run_command).with(command, { timeout: 3, retries: 3, print: true }).and_return(File.read("./fastlane_core/spec/fixtures/projects/build_settings_with_toolchains"))
         expect(@project.build_settings(key: "SUPPORTED_PLATFORMS")).to eq("iphonesimulator iphoneos")
       end
     end

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -491,7 +491,7 @@ describe FastlaneCore do
           project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
           derived_data_path: "./special/path/DerivedData"
         })
-        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -derivedDataPath ./special/path/DerivedData"
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -derivedDataPath ./special/path/DerivedData 2>&1"
         expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
       end
     end
@@ -503,7 +503,7 @@ describe FastlaneCore do
           project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
           disable_package_automatic_updates: true
         })
-        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -disableAutomaticPackageResolution"
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -disableAutomaticPackageResolution 2>&1"
         expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
       end
     end
@@ -511,7 +511,7 @@ describe FastlaneCore do
     describe 'xcodebuild_xcconfig option', requires_xcode: true do
       it 'generates an xcodebuild -showBuildSettings command without xcconfig by default' do
         project = FastlaneCore::Project.new({ project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj" })
-        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2>&1"
         expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
       end
 
@@ -520,7 +520,7 @@ describe FastlaneCore do
           project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
           xcconfig: "/path/to/some.xcconfig"
         })
-        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -xcconfig /path/to/some.xcconfig"
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -xcconfig /path/to/some.xcconfig 2>&1"
         expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
       end
     end
@@ -531,7 +531,7 @@ describe FastlaneCore do
           project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
           use_system_scm: true
         })
-        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -scmProvider system"
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -scmProvider system 2>&1"
         expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
       end
 
@@ -539,7 +539,7 @@ describe FastlaneCore do
         project = FastlaneCore::Project.new({
           project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
         })
-        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2>&1"
         expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
       end
 
@@ -548,7 +548,7 @@ describe FastlaneCore do
           project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
           use_system_scm: false
         })
-        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2>&1"
         expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
       end
     end
@@ -588,7 +588,7 @@ describe FastlaneCore do
           project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
           cloned_source_packages_path: "./path/to/resolve"
         })
-        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+        command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2>&1"
         expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
       end
 
@@ -621,7 +621,7 @@ describe FastlaneCore do
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
               destination: "FakeDestination"
             })
-            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination FakeDestination"
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination FakeDestination 2>&1"
             expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
           end
 
@@ -640,7 +640,7 @@ describe FastlaneCore do
             project = FastlaneCore::Project.new({
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
             })
-            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2>&1"
             expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
           end
 
@@ -667,7 +667,7 @@ describe FastlaneCore do
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
               destination: "FakeDestination"
             })
-            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2>&1"
             expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
           end
 
@@ -686,7 +686,7 @@ describe FastlaneCore do
             project = FastlaneCore::Project.new({
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
             })
-            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj"
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj 2>&1"
             expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
           end
 

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -21,6 +21,7 @@ describe Match do
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
 
+        allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
         allow(File).to receive(:exist?).and_return(false)
@@ -40,6 +41,7 @@ describe Match do
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{''.shellescape} #{keychain} 1> /dev/null"
 
+        allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with(keychain).and_return(true)
         allow(File).to receive(:exist?).and_return(false)
@@ -65,6 +67,7 @@ describe Match do
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db 1> /dev/null"
 
+        allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
         allow(File).to receive(:file?).and_return(false)
         expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain-db").and_return(true)
         allow(File).to receive(:exist?).and_return(false)
@@ -89,6 +92,7 @@ describe Match do
           expect(FastlaneCore::Helper).to receive(:ask_password).and_return('user_entered')
           expect(Security::InternetPassword).to receive(:add).with('fastlane_keychain_login', anything, 'user_entered')
 
+          allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
           allow(File).to receive(:file?).and_return(false)
           expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
           allow(File).to receive(:exist?).and_return(false)
@@ -110,6 +114,7 @@ describe Match do
           allow(item).to receive(:password).and_return('from_keychain')
           allow(Security::InternetPassword).to receive(:find).and_return(item)
 
+          allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
           allow(File).to receive(:file?).and_return(false)
           expect(File).to receive(:file?).with("#{Dir.home}/Library/Keychains/login.keychain").and_return(true)
           allow(File).to receive(:exist?).and_return(false)


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

Still trying to get the test output to only display . or X in minified mode.

Remains 
* plenty of xcodebuild errors like this one
```
2023-11-24 19:18:08.713 xcodebuild[3270:11980] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
```

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
