### PR TITLE
[fastlane_core] add support to Ruby 3.3

### DIFF
--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -124,9 +124,9 @@ describe Fastlane::PluginGenerator do
         $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
         # rubocop:disable Security/Eval
-        # starting with ruby 3.3 we must pass the __FILE__ of the actual file location for the all_class method implementation to work
-        # also we expand the relative_path within the chdir, as Dir.chdir on Mac will make it so tmp paths will always be under /private,
-        # while expand_path called from outside of the chdir will not prefix by /private
+        # Starting with Ruby 3.3, we must pass the __FILE__ of the actual file location for the all_class method implementation to work.
+        # Also, we expand the relative_path within Dir.chdir, as Dir.chdir on macOS will make it so tmp paths will always be under /private,
+        # while expand_path called from outside of Dir.chdir will not be prefixed by /private
         eval(plugin_rb_contents, binding, File.expand_path(relative_path), __LINE__)
         # rubocop:enable Security/Eval
 

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -111,7 +111,9 @@ describe Fastlane::PluginGenerator do
     end
 
     it "creates a plugin.rb file for the plugin" do
-      plugin_rb_file = File.join(tmp_dir, gem_name, 'lib', 'fastlane', 'plugin', "#{plugin_name}.rb")
+      relative_path = File.join('lib', 'fastlane', 'plugin', "#{plugin_name}.rb")
+      plugin_rb_file = File.join(tmp_dir, gem_name, relative_path)
+
       expect(File.exist?(plugin_rb_file)).to be(true)
 
       plugin_rb_contents = File.read(plugin_rb_file)
@@ -122,7 +124,10 @@ describe Fastlane::PluginGenerator do
         $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
         # rubocop:disable Security/Eval
-        eval(plugin_rb_contents)
+        # starting with ruby 3.3 we must pass the __FILE__ of the actual file location for the all_class method implementation to work
+        # also we expand the relative_path within the chdir, as Dir.chdir on Mac will make it so tmp paths will always be under /private,
+        # while expand_path called from outside of the chdir will not prefix by /private
+        eval(plugin_rb_contents, binding, File.expand_path(relative_path), __LINE__)
         # rubocop:enable Security/Eval
 
         # If we evaluate the contents of the generated plugin.rb file,

--- a/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
+++ b/fastlane_core/lib/fastlane_core/configuration/configuration_file.rb
@@ -48,7 +48,7 @@ module FastlaneCore
 
         print_resulting_config_values unless skip_printing_values # only on success
       rescue SyntaxError => ex
-        line = ex.to_s.match(/\(eval\):(\d+)/)[1]
+        line = ex.to_s.match(/\(eval.*\):(\d+)/)[1]
         UI.error("Error in your #{File.basename(path)} at line #{line}")
         UI.content_error(content, line)
         UI.user_error!("Syntax error in your configuration file '#{path}' on line #{line}: #{ex}")

--- a/frameit/spec/strings_parser_spec.rb
+++ b/frameit/spec/strings_parser_spec.rb
@@ -48,7 +48,7 @@ describe Frameit do
       describe "failure parsing" do
         it "logs a helpful message on a bad file" do
           expect(Frameit::UI).to receive(:error).with(/.*translations.bad.strings line 2:/)
-          expect(Frameit::UI).to receive(:verbose).with(/undefined method .\[\]. for nil:NilClass/)
+          expect(Frameit::UI).to receive(:verbose).with(/undefined method .\[\]. for nil/)
           expect(Frameit::UI).to receive(:error).with(/Empty parsing result for .*translations.bad.strings/)
 
           translations = Frameit::StringsParser.parse("./frameit/spec/fixtures/translations.bad.strings")


### PR DESCRIPTION
3 tests are failing in ruby 3.3.0-preview3
```
./fastlane/spec/plugins_specs/plugin_generator_spec.rb:113 
./fastlane_core/spec/configuration_file_spec.rb:115 
./frameit/spec/strings_parser_spec.rb:49
```
ruby 3.3. isn't yet available on circleci though.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've added or updated relevant unit tests.

### Motivation and Context

### Description


### Testing Steps

rspec