### PR TITLE
[spaceship] add `Spaceship::ConnectAPI::AppPreviewSet::PreviewType::IPHONE_67`

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
@@ -17,6 +17,7 @@ module Spaceship
         IPHONE_55 = "IPHONE_55"
         IPHONE_58 = "IPHONE_58"
         IPHONE_65 = "IPHONE_65"
+        IPHONE_67 = "IPHONE_67"
 
         IPAD_97 = "IPAD_97"
         IPAD_105 = "IPAD_105"
@@ -33,6 +34,7 @@ module Spaceship
           IPHONE_55,
           IPHONE_58,
           IPHONE_65,
+          IPHONE_67,
 
           IPAD_97,
           IPAD_105,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

During the integration I found there is no IPHONE_67 constant in this class so impossible to use constant 

### Description

Added IPHONE_67 support to app_preview_set model

