### PR TITLE
[match] git storage: allow simultaneous usage of clone_branch_directly and shallow_clone

### DIFF
--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -92,9 +92,14 @@ module Match
         command << " -c http.extraheader='Authorization: Bearer #{self.git_bearer_authorization}'" unless self.git_bearer_authorization.nil?
 
         if self.shallow_clone
-          command << " --depth 1 --no-single-branch"
-        elsif self.clone_branch_directly
+          command << " --depth 1"
+        end
+
+        if self.clone_branch_directly
           command += " -b #{self.branch.shellescape} --single-branch"
+        elsif self.shallow_clone
+          # shallow clone all branches if not cloning branch directly
+          command += " --no-single-branch"
         end
 
         command = command_from_private_key(command) unless self.git_private_key.nil?

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -1,5 +1,16 @@
+require_relative 'git_storage_spec_helper'
+
 describe Match do
   describe Match::Storage::GitStorage do
+
+    let(:git_url) { "https://github.com/fastlane/fastlane/tree/master/certificates" }
+    let(:git_branch) { "test" }
+
+    before(:each) do
+      @path = Dir.mktmpdir # to have access to the actual path
+      allow(Dir).to receive(:mktmpdir).and_return(@path)
+    end
+
     describe "#generate_commit_message" do
       it "works" do
         storage = Match::Storage::GitStorage.new(
@@ -12,286 +23,226 @@ describe Match do
     end
 
     describe "#download" do
-      it "clones the repo" do
-        path = Dir.mktmpdir # to have access to the actual path
-        expect(Dir).to receive(:mktmpdir).and_return(path)
-        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
-        git_branch = "master"
-        shallow_clone = true
+      describe "when no branch is specified" do
+        it("checkouts the master branch ") do
+          # Override default "test" branch name.
+          git_branch = "master"
 
-        expected_commands = [
-          "git clone #{git_url.shellescape} #{path.shellescape} --depth 1 --no-single-branch",
-          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
-          "git checkout --orphan #{git_branch}",
-          "git reset --hard"
-        ]
-        expected_commands.each do |command|
-          expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
-            command: command,
-            print_all: nil,
-            print_command: nil
-          }).and_return("")
+          storage = Match::Storage::GitStorage.new(
+            git_url: git_url
+          )
+
+          clone_command = "git clone #{git_url.shellescape} #{@path.shellescape}"
+
+          expect_command_execution(clone_command)
+          expect_command_execution(branch_checkout_commands(git_branch))
+
+          storage.download
+
+          expect(File.directory?(storage.working_directory)).to eq(true)
+          expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
         end
-
-        storage = Match::Storage::GitStorage.new(
-          git_url: git_url,
-          shallow_clone: shallow_clone
-        )
-        storage.download
-
-        expect(File.directory?(storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
       end
 
-      it "directly clones a single branch with shallow clone" do
-        # GIVEN
-        path = Dir.mktmpdir # to have access to the actual path
-        allow(Dir).to receive(:mktmpdir).and_return(path)
+      describe "when using shallow_clone" do
+        it("clones the repo with correct clone command") do
+          storage = Match::Storage::GitStorage.new(
+            git_url: git_url,
+            branch: git_branch,
+            # Test case:
+            shallow_clone: true
+          )
 
-        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
-        git_branch = "master"
+          clone_command = "git clone #{git_url.shellescape} #{@path.shellescape} --depth 1 --no-single-branch"
 
-        storage = Match::Storage::GitStorage.new(
-          git_url: git_url,
-          branch: git_branch,
-          # Test case:
-          clone_branch_directly: true,
-          shallow_clone: true
-        )
+          expect_command_execution(clone_command)
+          expect_command_execution(branch_checkout_commands(git_branch))
 
-        # EXPECTATIONS
-        expected_commands = [
-          "git clone #{git_url.shellescape} #{path.shellescape} --depth 1 -b #{git_branch} --single-branch",
-          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
-          "git checkout --orphan #{git_branch}",
-          "git reset --hard"
-        ]
-        expected_commands.each do |command|
-          expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
-            command: command,
-            print_all: nil,
-            print_command: nil
-          }).and_return("")
+          storage.download
+
+          expect(File.directory?(storage.working_directory)).to eq(true)
+          expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
         end
-
-        # WHEN
-        storage.download
-
-        # THEN
-        # expected_commands above are executed
-        expect(File.directory?(storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false)
       end
 
-      it "clones the repo (not shallow)" do
-        path = Dir.mktmpdir # to have access to the actual path
-        expect(Dir).to receive(:mktmpdir).and_return(path)
-        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
-        git_branch = "master"
-        shallow_clone = false
+      describe "when using shallow_clone and clone_branch_directly" do
+        it("clones the repo with correct clone command") do
+          storage = Match::Storage::GitStorage.new(
+            git_url: git_url,
+            branch: git_branch,
+            # Test case:
+            clone_branch_directly: true,
+            shallow_clone: true
+          )
 
-        expected_commands = [
-          "git clone #{git_url.shellescape} #{path.shellescape}",
-          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
-          "git checkout --orphan #{git_branch}",
-          "git reset --hard"
-        ]
-        expected_commands.each do |command|
-          expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
-            command: command,
-            print_all: nil,
-            print_command: nil
-          }).and_return("")
+          clone_command = "git clone #{git_url.shellescape} #{@path.shellescape} --depth 1 -b #{git_branch} --single-branch"
+
+          expect_command_execution(clone_command)
+          expect_command_execution(branch_checkout_commands(git_branch))
+
+          storage.download
+
+          expect(File.directory?(storage.working_directory)).to eq(true)
+          expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
         end
-
-        storage = Match::Storage::GitStorage.new(
-          git_url: git_url,
-          shallow_clone: shallow_clone
-        )
-        storage.download
-
-        expect(File.directory?(storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
       end
 
-      it "checks out a branch" do
-        path = Dir.mktmpdir # to have access to the actual path
-        expect(Dir).to receive(:mktmpdir).and_return(path)
-        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
-        git_branch = "test"
-        shallow_clone = false
+      describe "when using clone_branch_directly" do
+        it("clones the repo with correct clone command") do
+          storage = Match::Storage::GitStorage.new(
+            git_url: git_url,
+            branch: git_branch,
+            # Test case:
+            clone_branch_directly: true
+          )
 
-        expected_commands = [
-          "git clone #{git_url.shellescape} #{path.shellescape}",
-          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
-          "git checkout --orphan #{git_branch}",
-          "git reset --hard"
-        ]
-        expected_commands.each do |command|
-          expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
-            command: command,
-            print_all: nil,
-            print_command: nil
-          }).and_return("")
+          clone_command = "git clone #{git_url.shellescape} #{@path.shellescape} -b #{git_branch} --single-branch"
+
+          expect_command_execution(clone_command)
+          expect_command_execution(branch_checkout_commands(git_branch))
+
+          storage.download
+
+          expect(File.directory?(storage.working_directory)).to eq(true)
+          expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
         end
+      end
 
-        storage = Match::Storage::GitStorage.new(
-          git_url: git_url,
-          shallow_clone: shallow_clone,
-          branch: git_branch
-        )
-        storage.download
+      describe "when not using shallow_clone and clone_branch_directly" do
+        it("clones the repo with correct clone command") do
+          storage = Match::Storage::GitStorage.new(
+            git_url: git_url,
+            branch: git_branch,
+            # Test case:
+            clone_branch_directly: false,
+            shallow_clone: false
+          )
 
-        expect(File.directory?(storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
+          clone_command = "git clone #{git_url.shellescape} #{@path.shellescape}"
+
+          expect_command_execution(clone_command)
+          expect_command_execution(branch_checkout_commands(git_branch))
+
+          storage.download
+
+          expect(File.directory?(storage.working_directory)).to eq(true)
+          expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
+        end
       end
     end
 
     describe "#save_changes" do
-      it "skips README file generation if so requested" do
-        path = Dir.mktmpdir # to have access to the actual path
-        expect(Dir).to receive(:mktmpdir).and_return(path)
-        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
-        git_branch = "master"
-        random_file = "random_file"
+      describe "when skip_docs is true" do
+        it "skips README file generation" do
+          random_file_to_commit = "random_file_to_commit"
 
-        storage = Match::Storage::GitStorage.new(
-          type: "appstore",
-          platform: "ios",
-          git_url: git_url,
-          shallow_clone: false,
-          skip_docs: true
-        )
+          storage = Match::Storage::GitStorage.new(
+            type: "appstore",
+            platform: "ios",
+            git_url: git_url,
+            branch: git_branch,
+            skip_docs: true
+          )
 
-        expected_commands = [
-          "git clone #{git_url.shellescape} #{path.shellescape}",
-          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
-          "git checkout --orphan #{git_branch}",
-          "git reset --hard",
-          "git add #{random_file}",
-          "git add match_version.txt",
-          "git commit -m " + '[fastlane] Updated appstore and platform ios'.shellescape,
-          "git push origin #{git_branch}"
-        ]
+          checkout_command = "git clone #{git_url.shellescape} #{@path.shellescape}"
+          expect_command_execution(checkout_command)
+          expect_command_execution(branch_checkout_commands(git_branch))
 
-        expected_commands.each do |command|
-          expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
-            command: command,
-            print_all: nil,
-            print_command: nil
-          }).and_return("")
+          expected_commit_commands = [
+            # Stage new file for commit.
+            "git add #{random_file_to_commit}",
+            # Stage match_version.txt for commit.
+            "git add match_version.txt",
+            # Commit changes.
+            "git commit -m " + '[fastlane] Updated appstore and platform ios'.shellescape,
+            # Push changes to the remote origin.
+            "git push origin #{git_branch}"
+          ]
+          expect_command_execution(expected_commit_commands)
+
+          expect(storage).to receive(:clear_changes).and_return(nil) # so we can inspect the folder
+
+          storage.download
+          storage.save_changes!(files_to_commit: [random_file_to_commit])
+
+          expect(File.directory?(storage.working_directory)).to eq(true)
+          expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false)
+          expect(File.read(File.join(storage.working_directory, 'match_version.txt'))).to eq(Fastlane::VERSION)
         end
-
-        expect(storage).to receive(:clear_changes).and_return(nil) # so we can inspect the folder
-
-        storage.download
-        storage.save_changes!(files_to_commit: [random_file])
-
-        expect(File.directory?(storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false)
-        expect(File.read(File.join(storage.working_directory, 'match_version.txt'))).to eq(Fastlane::VERSION)
       end
     end
 
-    describe "authentication" do
-      it "wraps the git command in ssh-agent shell when using a private key file" do
-        path = Dir.mktmpdir # to have access to the actual path
-        expect(Dir).to receive(:mktmpdir).and_return(path)
-        expect(File).to receive(:file?).twice.and_return(true)
-        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
-        shallow_clone = false
-        private_key = "#{path}/fastlane.match.id_dsa"
-        clone_command = "ssh-agent bash -c 'ssh-add #{private_key.shellescape}; git clone #{git_url.shellescape} #{path.shellescape}'"
+    describe "#authentication" do
+      describe "when using a private key file" do
+        it "wraps the git command in ssh-agent shell" do
+          expect(File).to receive(:file?).twice.and_return(true)
+          private_key = "#{@path}/fastlane.match.id_dsa"
+          clone_command = "ssh-agent bash -c 'ssh-add #{private_key.shellescape}; git clone #{git_url.shellescape} #{@path.shellescape}'"
 
-        git_branch = "master"
+          expect_command_execution(clone_command)
+          expect_command_execution(branch_checkout_commands(git_branch))
 
-        expected_commands = [
-          clone_command,
-          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
-          "git checkout --orphan #{git_branch}",
-          "git reset --hard"
-        ]
+          storage = Match::Storage::GitStorage.new(
+            git_url: git_url,
+            branch: git_branch,
+            git_private_key: private_key
+          )
+          storage.download
 
-        expected_commands.each do |command|
-          expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
-            command: command,
-            print_all: nil,
-            print_command: nil
-          }).and_return("")
+          expect(File.directory?(storage.working_directory)).to eq(true)
+          expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
         end
-
-        storage = Match::Storage::GitStorage.new(
-          git_url: git_url,
-          shallow_clone: shallow_clone,
-          git_private_key: private_key
-        )
-        storage.download
-
-        expect(File.directory?(storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
       end
 
-      it "wraps the git command in ssh-agent shell when using a raw private key" do
-        path = Dir.mktmpdir # to have access to the actual path
-        expect(Dir).to receive(:mktmpdir).and_return(path)
-        expect(File).to receive(:file?).twice.and_return(false)
-        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
-        shallow_clone = false
-        private_key = "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"
-        clone_command = "ssh-agent bash -c 'ssh-add - <<< \"#{private_key}\"; git clone #{git_url.shellescape} #{path.shellescape}'"
+      describe "when using a raw private key" do
+        it "wraps the git command in ssh-agent shell" do
+          expect(File).to receive(:file?).twice.and_return(false)
+          private_key = "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"
+          clone_command = "ssh-agent bash -c 'ssh-add - <<< \"#{private_key}\"; git clone #{git_url.shellescape} #{@path.shellescape}'"
 
-        git_branch = "master"
+          expect_command_execution(clone_command)
+          expect_command_execution(branch_checkout_commands(git_branch))
 
-        expected_commands = [
-          clone_command,
-          "git --no-pager branch --list origin/#{git_branch} --no-color -r",
-          "git checkout --orphan #{git_branch}",
-          "git reset --hard"
-        ]
+          storage = Match::Storage::GitStorage.new(
+            git_url: git_url,
+            branch: git_branch,
+            git_private_key: private_key
+          )
+          storage.download
 
-        expected_commands.each do |command|
-          expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
-            command: command,
-            print_all: nil,
-            print_command: nil
-          }).and_return("")
+          expect(File.directory?(storage.working_directory)).to eq(true)
+          expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
         end
-
-        storage = Match::Storage::GitStorage.new(
-          git_url: git_url,
-          shallow_clone: shallow_clone,
-          git_private_key: private_key
-        )
-        storage.download
-
-        expect(File.directory?(storage.working_directory)).to eq(true)
-        expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
       end
     end
 
-    describe "ssh-agent utilities" do
-      it "wraps any given command in ssh-agent shell when using a raw private key" do
-        given_command = "any random command"
-        private_key = "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"
+    describe "#ssh-agent utilities" do
+      describe "when using a raw private key" do
+        it "wraps any given command in ssh-agent shell" do
+          given_command = "any random command"
+          private_key = "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"
 
-        storage = Match::Storage::GitStorage.new(
-          git_private_key: private_key
-        )
+          storage = Match::Storage::GitStorage.new(
+            git_private_key: private_key
+          )
 
-        expected_command = "ssh-agent bash -c 'ssh-add - <<< \"#{private_key}\"; #{given_command}'"
-        expect(storage.command_from_private_key(given_command)).to eq(expected_command)
+          expected_command = "ssh-agent bash -c 'ssh-add - <<< \"#{private_key}\"; #{given_command}'"
+          expect(storage.command_from_private_key(given_command)).to eq(expected_command)
+        end
       end
 
-      it "wraps any given command in ssh-agent shell when using a private key file" do
-        given_command = "any random command"
-        private_key = "#{Dir.mktmpdir}/fastlane.match.id_dsa"
+      describe "when using a private key file" do
+        it "wraps any given command in ssh-agent shell" do
+          given_command = "any random command"
+          private_key = "#{Dir.mktmpdir}/fastlane.match.id_dsa"
 
-        storage = Match::Storage::GitStorage.new(
-          git_private_key: private_key
-        )
+          storage = Match::Storage::GitStorage.new(
+            git_private_key: private_key
+          )
 
-        expected_command = "ssh-agent bash -c 'ssh-add - <<< \"#{File.expand_path(private_key).shellescape}\"; #{given_command}'"
-        expect(storage.command_from_private_key(given_command)).to eq(expected_command)
+          expected_command = "ssh-agent bash -c 'ssh-add - <<< \"#{File.expand_path(private_key).shellescape}\"; #{given_command}'"
+          expect(storage.command_from_private_key(given_command)).to eq(expected_command)
+        end
       end
     end
   end

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -24,7 +24,7 @@ describe Match do
 
     describe "#download" do
       describe "when no branch is specified" do
-        it("checkouts the master branch ") do
+        it "checkouts the master branch" do
           # Override default "test" branch name.
           git_branch = "master"
 
@@ -45,7 +45,7 @@ describe Match do
       end
 
       describe "when using shallow_clone" do
-        it("clones the repo with correct clone command") do
+        it "clones the repo with correct clone command" do
           storage = Match::Storage::GitStorage.new(
             git_url: git_url,
             branch: git_branch,
@@ -66,7 +66,7 @@ describe Match do
       end
 
       describe "when using shallow_clone and clone_branch_directly" do
-        it("clones the repo with correct clone command") do
+        it "clones the repo with correct clone command" do
           storage = Match::Storage::GitStorage.new(
             git_url: git_url,
             branch: git_branch,
@@ -88,7 +88,7 @@ describe Match do
       end
 
       describe "when using clone_branch_directly" do
-        it("clones the repo with correct clone command") do
+        it "clones the repo with correct clone command" do
           storage = Match::Storage::GitStorage.new(
             git_url: git_url,
             branch: git_branch,
@@ -109,7 +109,7 @@ describe Match do
       end
 
       describe "when not using shallow_clone and clone_branch_directly" do
-        it("clones the repo with correct clone command") do
+        it "clones the repo with correct clone command" do
           storage = Match::Storage::GitStorage.new(
             git_url: git_url,
             branch: git_branch,

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -43,7 +43,7 @@ describe Match do
         expect(File.exist?(File.join(storage.working_directory, 'README.md'))).to eq(false) # because the README is being added when committing the changes
       end
 
-      it "directly clones a single branch wtih shallow clone" do
+      it "directly clones a single branch with shallow clone" do
         # GIVEN
         path = Dir.mktmpdir # to have access to the actual path
         allow(Dir).to receive(:mktmpdir).and_return(path)

--- a/match/spec/storage/git_storage_spec_helper.rb
+++ b/match/spec/storage/git_storage_spec_helper.rb
@@ -1,0 +1,20 @@
+def branch_checkout_commands(git_branch)
+  [
+    # Check if branch exists.
+    "git --no-pager branch --list origin/#{git_branch} --no-color -r",
+    # Checkout branch.
+    "git checkout --orphan #{git_branch}",
+    # Reset all changes in the working branch copy.
+    "git reset --hard"
+  ]
+end
+
+def expect_command_execution(commands)
+  [commands].flatten.each do |command|
+    expect(FastlaneCore::CommandExecutor).to receive(:execute).once.with({
+      command: command,
+      print_all: nil,
+      print_command: nil
+    }).and_return("")
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

I noticed a slow checkout of our match repo 😅.

#### How it worked before
You have to choose `shallow_clone` or `clone_branch_directly`. The first option clones all branches with depth 1, and another clones branch with full history.
Specifying both options (which I've done) led to the shallow cloning of all branches because shallow_clone option took precedence. 

#### How it works in this PR
1. Specifying options separately has no changes in current behavior.
2. Specifying options together leads to a more obvious result: direct cloning of a single branch without any history. Which is the fastest option available 🚀.

### Description

It was one if/elsif statement. I split it into to independent ones, allowing simultaneous usage of both options.
Tests are provided.

### Testing Steps

Run match specifying both options.
