### PR TITLE
Remove some unused method parameters

### DIFF
--- a/fastlane/lib/fastlane/command_line_handler.rb
+++ b/fastlane/lib/fastlane/command_line_handler.rb
@@ -26,14 +26,12 @@ module Fastlane
         lane = platform_lane_info[0]
       end
 
-      dot_env = Helper.test? ? nil : options.env
-
       if FastlaneCore::FastlaneFolder.swift?
         disable_runner_upgrades = options.disable_runner_upgrades || false
         swift_server_port = options.swift_server_port
-        Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, dot_env, disable_runner_upgrades: disable_runner_upgrades, swift_server_port: swift_server_port)
+        Fastlane::SwiftLaneManager.cruise_lane(lane, lane_parameters, disable_runner_upgrades: disable_runner_upgrades, swift_server_port: swift_server_port)
       else
-        Fastlane::LaneManager.cruise_lane(platform, lane, lane_parameters, dot_env)
+        Fastlane::LaneManager.cruise_lane(platform, lane, lane_parameters)
       end
     end
 

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -5,9 +5,8 @@ module Fastlane
     # @param platform The name of the platform to execute
     # @param lane_name The name of the lane to execute
     # @param parameters [Hash] The parameters passed from the command line to the lane
-    # @param env Dot Env Information
     # @param A custom Fastfile path, this is used by fastlane.ci
-    def self.cruise_lane(platform, lane, parameters = nil, env = nil, fastfile_path = nil)
+    def self.cruise_lane(platform, lane, parameters = nil, fastfile_path = nil)
       UI.user_error!("lane must be a string") unless lane.kind_of?(String) || lane.nil?
       UI.user_error!("platform must be a string") unless platform.kind_of?(String) || platform.nil?
       UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) || parameters.nil?

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -105,7 +105,7 @@ module Fastlane
       end
     end
 
-    def self.swap_paths_in_target(target: nil, file_refs_to_swap: nil, expected_path_to_replacement_path_tuples: nil)
+    def self.swap_paths_in_target(file_refs_to_swap: nil, expected_path_to_replacement_path_tuples: nil)
       made_project_updates = false
       file_refs_to_swap.each do |file_ref|
         expected_path_to_replacement_path_tuples.each do |preinstalled_config_relative_path, user_config_relative_path|
@@ -197,14 +197,12 @@ module Fastlane
 
       # Swap in all new user supplied configs into the project
       project_modified = swap_paths_in_target(
-        target: runner_target,
         file_refs_to_swap: target_file_refs,
         expected_path_to_replacement_path_tuples: new_user_tool_file_paths
       )
 
       # Swap out any configs the user has removed, inserting fastlane defaults
       project_modified = swap_paths_in_target(
-        target: runner_target,
         file_refs_to_swap: target_file_refs,
         expected_path_to_replacement_path_tuples: user_tool_files_possibly_removed
       ) || project_modified

--- a/fastlane/lib/fastlane/swift_lane_manager.rb
+++ b/fastlane/lib/fastlane/swift_lane_manager.rb
@@ -5,8 +5,7 @@ module Fastlane
   class SwiftLaneManager < LaneManagerBase
     # @param lane_name The name of the lane to execute
     # @param parameters [Hash] The parameters passed from the command line to the lane
-    # @param env Dot Env Information
-    def self.cruise_lane(lane, parameters = nil, env = nil, disable_runner_upgrades: false, swift_server_port: nil)
+    def self.cruise_lane(lane, parameters = nil, disable_runner_upgrades: false, swift_server_port: nil)
       UI.user_error!("lane must be a string") unless lane.kind_of?(String) || lane.nil?
       UI.user_error!("parameters must be a hash") unless parameters.kind_of?(Hash) || parameters.nil?
 

--- a/fastlane/spec/command_line_handler_spec.rb
+++ b/fastlane/spec/command_line_handler_spec.rb
@@ -1,21 +1,19 @@
 describe Fastlane do
   describe Fastlane::CommandLineHandler do
     it "properly handles default calls" do
-      expect(Fastlane::LaneManager).to receive(:cruise_lane).with("ios", "deploy", {}, nil)
+      expect(Fastlane::LaneManager).to receive(:cruise_lane).with("ios", "deploy", {})
       Fastlane::CommandLineHandler.handle(["ios", "deploy"], {})
     end
 
     it "properly handles calls with custom parameters" do
       expect(Fastlane::LaneManager).to receive(:cruise_lane).with("ios", "deploy",
-                                                                  { key: "value", build_number: '123' },
-                                                                  nil)
+                                                                  { key: "value", build_number: '123' })
       Fastlane::CommandLineHandler.handle(["ios", "deploy", "key:value", "build_number:123"], {})
     end
 
     it "properly converts boolean values to real boolean variables" do
       expect(Fastlane::LaneManager).to receive(:cruise_lane).with("ios", "deploy",
-                                                                  { key: true, key2: false },
-                                                                  nil)
+                                                                  { key: true, key2: false })
       Fastlane::CommandLineHandler.handle(["ios", "deploy", "key:true", "key2:false"], {})
     end
   end

--- a/fastlane/spec/lane_manager_spec.rb
+++ b/fastlane/spec/lane_manager_spec.rb
@@ -46,7 +46,7 @@ describe Fastlane do
         it "Supports running a lane with custom Fastfile path" do
           path = "./fastlane/spec/fixtures/fastfiles/FastfileCruiseLane"
 
-          ff = Fastlane::LaneManager.cruise_lane(nil, 'test', nil, nil, path)
+          ff = Fastlane::LaneManager.cruise_lane(nil, 'test', nil, path)
           lanes = ff.runner.lanes
           expect(lanes[nil][:test].description).to eq(["test description for cruise lanes"])
           expect(lanes[:ios][:apple].description).to eq([])

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -325,7 +325,7 @@ module Frameit
     end
 
     def put_title_into_background(background, stack_title)
-      text_images = build_text_images(image.width - 2 * horizontal_frame_padding, image.height - 2 * vertical_frame_padding, stack_title)
+      text_images = build_text_images(image.width - 2 * horizontal_frame_padding, image.height - 2 * vertical_frame_padding)
 
       keyword = text_images[:keyword]
       title = text_images[:title]
@@ -400,7 +400,7 @@ module Frameit
     end
 
     # This will build up to 2 individual images with the title and optional keyword, which will then be added to the real image
-    def build_text_images(max_width, max_height, stack_title)
+    def build_text_images(max_width, max_height)
       words = [:keyword, :title].keep_if { |a| fetch_text(a) } # optional keyword/title
       results = {}
       trim_boxes = {}

--- a/frameit/lib/frameit/editor.rb
+++ b/frameit/lib/frameit/editor.rb
@@ -439,7 +439,7 @@ module Frameit
 
         results[key] = text_image
 
-        # Natively trimming the image with .trim will result in the loss of the common baseline between the text in all images when side-by-side (e.g. stack_title is false).
+        # Natively trimming the image with .trim will result in the loss of the common baseline between the text in all images when side-by-side.
         # Hence retrieve the calculated trim bounding box without actually trimming:
         calculated_trim_box = text_image.identify do |b|
           b.format("%@") # CALCULATED: trim bounding box (without actually trimming), see: http://www.imagemagick.org/script/escape.php

--- a/snapshot/lib/snapshot/setup.rb
+++ b/snapshot/lib/snapshot/setup.rb
@@ -19,7 +19,7 @@ module Snapshot
 
       if File.exist?(snapfile_path)
         if print_instructions_on_failure
-          print_instructions(snapshot_helper_filename: snapshot_helper_filename, snapfile_path: snapfile_path)
+          print_instructions(snapshot_helper_filename: snapshot_helper_filename)
           return
         else
           UI.user_error!("Snapfile already exists at path '#{snapfile_path}'. Run 'fastlane snapshot' to generate screenshots.")
@@ -37,7 +37,7 @@ module Snapshot
       print_instructions(snapshot_helper_filename: snapshot_helper_filename, snapfile_path: snapfile_path)
     end
 
-    def self.print_instructions(snapshot_helper_filename: nil, snapfile_path: nil)
+    def self.print_instructions(snapshot_helper_filename: nil)
       puts("Open your Xcode project and make sure to do the following:".yellow)
       puts("1) Add a new UI Test target to your project".yellow)
       puts("2) Add the ./fastlane/#{snapshot_helper_filename} to your UI Test target".yellow)


### PR DESCRIPTION
I made a first pass at running rubocop on unused method parameters and found these. Also a little code indentation cleanup.

All changes are in individual commits.

More improvements on the same topic coming later.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
