### PR TITLE
[plugin_generator] move development dependencies from `*.gemspec.erb` to `Gemfile.erb`

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -15,10 +15,6 @@ config['require'] = [
 config.delete('inherit_from')
 config.delete('CrossPlatform/ForkUsage')
 config.delete('Lint/IsStringUsage')
-# We declare development dependencies in the Gemspec file because we use dynamic values in its template
-config['Gemspec/DevelopmentDependencies'] = {
-  'Enabled' => false
-}
 
 File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
 

--- a/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
+++ b/fastlane/lib/fastlane/plugins/template/%gem_name%.gemspec.erb
@@ -21,15 +21,4 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
-
-  spec.add_development_dependency('bundler')
-  spec.add_development_dependency('fastlane', '>= <%= Fastlane::VERSION %>')
-  spec.add_development_dependency('pry')
-  spec.add_development_dependency('rake')
-  spec.add_development_dependency('rspec')
-  spec.add_development_dependency('rspec_junit_formatter')
-  spec.add_development_dependency('rubocop', '<%= Fastlane::RUBOCOP_REQUIREMENT %>')
-  spec.add_development_dependency('rubocop-performance')
-  spec.add_development_dependency('rubocop-require_tools')
-  spec.add_development_dependency('simplecov')
 end

--- a/fastlane/lib/fastlane/plugins/template/Gemfile
+++ b/fastlane/lib/fastlane/plugins/template/Gemfile
@@ -1,6 +1,0 @@
-source('https://rubygems.org')
-
-gemspec
-
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/fastlane/lib/fastlane/plugins/template/Gemfile.erb
+++ b/fastlane/lib/fastlane/plugins/template/Gemfile.erb
@@ -1,0 +1,27 @@
+source('https://rubygems.org')
+
+# Bundler provides a consistent environment for Ruby projects by tracking and installing exact gem versions
+gem 'bundler'
+# Fastlane is an automation tool for mobile developers to automate tedious tasks
+gem 'fastlane', '>= <%= Fastlane::VERSION %>'
+# Pry is an interactive shell for debugging and exploring Ruby code
+gem 'pry'
+# Rake is a simple task automation tool in Ruby
+gem 'rake'
+# RSpec is a behavior-driven development (BDD) framework for Ruby
+gem 'rspec'
+# Formatter for RSpec to generate JUnit compatible reports
+gem 'rspec_junit_formatter'
+# A Ruby static code analyzer and formatter
+gem 'rubocop', '<%= Fastlane::RUBOCOP_REQUIREMENT %>'
+# A collection of RuboCop cops for performance optimizations
+gem 'rubocop-performance'
+# A RuboCop extension focused on enforcing tools
+gem 'rubocop-require_tools'
+# SimpleCov is a code coverage analysis tool for Ruby
+gem 'simplecov'
+
+gemspec
+
+plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
+eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/fastlane/lib/fastlane/plugins/template/Gemfile.erb
+++ b/fastlane/lib/fastlane/plugins/template/Gemfile.erb
@@ -1,24 +1,24 @@
 source('https://rubygems.org')
 
-# Bundler provides a consistent environment for Ruby projects by tracking and installing exact gem versions
+# Provides a consistent environment for Ruby projects by tracking and installing exact gem versions.
 gem 'bundler'
-# Fastlane is an automation tool for mobile developers to automate tedious tasks
+# Automation tool for mobile developers.
 gem 'fastlane', '>= <%= Fastlane::VERSION %>'
-# Pry is an interactive shell for debugging and exploring Ruby code
+# Provides an interactive debugging environment for Ruby.
 gem 'pry'
-# Rake is a simple task automation tool in Ruby
+# A simple task automation tool.
 gem 'rake'
-# RSpec is a behavior-driven development (BDD) framework for Ruby
+# Behavior-driven testing tool for Ruby.
 gem 'rspec'
-# Formatter for RSpec to generate JUnit compatible reports
+# Formatter for RSpec to generate JUnit compatible reports.
 gem 'rspec_junit_formatter'
-# A Ruby static code analyzer and formatter
+# A Ruby static code analyzer and formatter.
 gem 'rubocop', '<%= Fastlane::RUBOCOP_REQUIREMENT %>'
-# A collection of RuboCop cops for performance optimizations
+# A collection of RuboCop cops for performance optimizations.
 gem 'rubocop-performance'
-# A RuboCop extension focused on enforcing tools
+# A RuboCop extension focused on enforcing tools.
 gem 'rubocop-require_tools'
-# SimpleCov is a code coverage analysis tool for Ruby
+# SimpleCov is a code coverage analysis tool for Ruby.
 gem 'simplecov'
 
 gemspec

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -103,10 +103,21 @@ describe Fastlane::PluginGenerator do
       gemfile_lines = File.read(gemfile).lines
 
       [
-        "source('https://rubygems.org')\n",
-        "gemspec\n"
+        "source('https://rubygems.org')",
+        "gem 'bundler'",
+        "gem 'fastlane', '>= #{Fastlane::VERSION}'",
+        "gem 'pry'",
+        "gem 'rake'",
+        "gem 'rspec'",
+        "gem 'rspec_junit_formatter'",
+        "gem 'rubocop', '#{Fastlane::RUBOCOP_REQUIREMENT}'",
+        "gem 'rubocop-performance'",
+        "gem 'rubocop-require_tools'",
+        "gem 'simplecov'",
+        "gemspec"
       ].each do |line|
-        expect(gemfile_lines).to include(line)
+        # Expect them to match approximately, e.g. using regex
+        expect(gemfile_lines).to include("#{line}\n")
       end
     end
 
@@ -224,18 +235,7 @@ describe Fastlane::PluginGenerator do
         expect(gemspec.version).to eq(Gem::Version.new('0.1.0'))
         expect(gemspec.email).to eq(email)
         expect(gemspec.summary).to eq(summary)
-        expect(gemspec.development_dependencies).to contain_exactly(
-          Gem::Dependency.new("pry", Gem::Requirement.new([">= 0"]), :development),
-          Gem::Dependency.new("bundler", Gem::Requirement.new([">= 0"]), :development),
-          Gem::Dependency.new("rspec", Gem::Requirement.new([">= 0"]), :development),
-          Gem::Dependency.new("rspec_junit_formatter", Gem::Requirement.new([">= 0"]), :development),
-          Gem::Dependency.new("rake", Gem::Requirement.new([">= 0"]), :development),
-          Gem::Dependency.new("rubocop", Gem::Requirement.new([Fastlane::RUBOCOP_REQUIREMENT]), :development),
-          Gem::Dependency.new("rubocop-require_tools", Gem::Requirement.new([">= 0"]), :development),
-          Gem::Dependency.new("rubocop-performance", Gem::Requirement.new([">= 0"]), :development),
-          Gem::Dependency.new("simplecov", Gem::Requirement.new([">= 0"]), :development),
-          Gem::Dependency.new("fastlane", Gem::Requirement.new([">= #{Fastlane::VERSION}"]), :development)
-        )
+        expect(gemspec.development_dependencies).to eq([])
       end
     end
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

This is a follow up PR similar to https://github.com/fastlane/fastlane/pull/21725

This is the recommended best practice as per RuboCop https://docs.rubocop.org/rubocop/cops_gemspec.html and there was an exception disabling this rule previously.

### Description

The only thing I couldn't enable was ensuring that the `Gemfile.erb` gems are sorted alphabetically, because apparently even if I add `- Include` statement for `Gemfile.erb` in the rubocop config file, it will ignore it and will only look for `Gemfile`, `.gemspec` and `.gems` files in custom directories 😞 The gems are already sorted alphabetically, though, and since this file pretty much never receives updates, this is good enough.

I also added a brief comment about what each dependency does. I think this is great for newcomers and helps lower the contribution barrier 😊 which is especially helpful when users are developing new plugins.

### Testing Steps

To test this branch, modify your Gemfile as:

```ruby
gem 'fastlane', git: 'https://github.com/fastlane/fastlane.git', branch: 'rogerluan/move-dev-dependencies-to-gemfile-in-plugin-generator'
```

And run `bundle install` to apply the changes.

Then run: 

```sh
bundle exec fastlane new_plugin this-is-my-test
```

Screenshot demo'ing this working (notice the Gemfile was generated correctly, including the version placeholders):

![image](https://github.com/fastlane/fastlane/assets/8419048/760ac366-1d95-46d4-9763-d6f190d273a1)