### PR TITLE
[pilot] do not advertise the `skip_waiting_for_build_processing` option when it is already set

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -65,7 +65,7 @@ module Pilot
           UI.important("`skip_waiting_for_build_processing` used and no `changelog` supplied - skipping waiting for build processing")
           return
         else
-          UI.important("`skip_waiting_for_build_processing` used and `changelog` supplied - will wait until build appears on AppStoreConnect, update the changelog and then skip the rest of the remaining of the processing steps.")
+          UI.important("`skip_waiting_for_build_processing` used and `changelog` supplied - will wait until build appears on App Store Connect, update the changelog and then skip the rest of the remaining of the processing steps.")
           return_when_build_appears = true
         end
       end
@@ -75,7 +75,7 @@ module Pilot
 
       if config[:skip_waiting_for_build_processing].nil?
         UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-        UI.message("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+        UI.message("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on App Store Connect, update the changelog and then skip the remaining of the processing steps.")
       end
 
       latest_build = wait_for_build_processing_to_be_complete(return_when_build_appears)

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -72,8 +72,10 @@ module Pilot
       # Calling login again here is needed if login was not called during 'start'
       login unless should_login_in_start
 
-      UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-      UI.message("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+      if config[:skip_waiting_for_build_processing].nil?
+        UI.message("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
+        UI.message("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+      end
 
       latest_build = wait_for_build_processing_to_be_complete(return_when_build_appears)
       distribute(options, build: latest_build)

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -65,6 +65,7 @@ module Pilot
           UI.important("`skip_waiting_for_build_processing` used and no `changelog` supplied - skipping waiting for build processing")
           return
         else
+          UI.important("`skip_waiting_for_build_processing` used and `changelog` supplied - will wait until build appears on AppStoreConnect, update the changelog and then skip the rest of the remaining of the processing steps.")
           return_when_build_appears = true
         end
       end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -707,7 +707,7 @@ describe "Build Manager" do
         expect(fake_build).to receive(:app_version)
         expect(fake_build).to receive(:version)
         expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on App Store Connect, update the changelog and then skip the remaining of the processing steps.")
         expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
 
         expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
@@ -745,7 +745,7 @@ describe "Build Manager" do
         expect(fake_build).to receive(:app_version)
         expect(fake_build).to receive(:version)
         expect(UI).to receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option")
-        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps.")
+        expect(UI).to receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on App Store Connect, update the changelog and then skip the remaining of the processing steps.")
         expect(FastlaneCore::BuildWatcher).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
 
         expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -634,13 +634,13 @@ describe "Build Manager" do
 
       it "does not advertise `skip_waiting_for_build_processing` if the option is set" do
         expect(FastlaneCore::UI).to_not(receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option"))
-        expect(FastlaneCore::UI).to_not(receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps."))
+        expect(FastlaneCore::UI).to_not(receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on App Store Connect, update the changelog and then skip the remaining of the processing steps."))
 
         fake_build_manager.upload(upload_options)
       end
 
       it "shows notice when using `skip_waiting_for_build_processing` and changelog together" do
-        expect(FastlaneCore::UI).to(receive(:important).with("`skip_waiting_for_build_processing` used and `changelog` supplied - will wait until build appears on AppStoreConnect, update the changelog and then skip the rest of the remaining of the processing steps."))
+        expect(FastlaneCore::UI).to(receive(:important).with("`skip_waiting_for_build_processing` used and `changelog` supplied - will wait until build appears on App Store Connect, update the changelog and then skip the rest of the remaining of the processing steps."))
 
         fake_build_manager.upload(upload_options)
       end

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -305,6 +305,10 @@ describe "Build Manager" do
         expect(FastlaneCore::UI).to_not(receive(:message).with(/Distributing new build to testers/))
         expect(FastlaneCore::UI).to_not(receive(:success).with(/Successfully distributed build to/))
 
+        # Don't expect skip_waiting_for_build_processing messages if it is set
+        expect(FastlaneCore::UI).to_not(receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option"))
+        expect(FastlaneCore::UI).to_not(receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps."))
+
         fake_build_manager.distribute(options, build: ready_to_submit_mock_build)
       end
 

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -305,10 +305,6 @@ describe "Build Manager" do
         expect(FastlaneCore::UI).to_not(receive(:message).with(/Distributing new build to testers/))
         expect(FastlaneCore::UI).to_not(receive(:success).with(/Successfully distributed build to/))
 
-        # Don't expect skip_waiting_for_build_processing messages if it is set
-        expect(FastlaneCore::UI).to_not(receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option"))
-        expect(FastlaneCore::UI).to_not(receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps."))
-
         fake_build_manager.distribute(options, build: ready_to_submit_mock_build)
       end
 
@@ -603,6 +599,53 @@ describe "Build Manager" do
   end
 
   describe "#upload" do
+    describe "shows the correct notices" do
+      let(:fake_build_manager) { Pilot::BuildManager.new }
+      let(:fake_app_id) { 123 }
+      let(:fake_dir) { "fake dir" }
+      let(:fake_app_platform) { "ios" }
+      let(:upload_options) do
+        {
+          apple_id: fake_app_id,
+          skip_waiting_for_build_processing: true,
+          changelog: "changelog contents",
+          ipa: 'foo'
+        }
+      end
+
+      before(:each) do
+        allow(fake_build_manager).to receive(:login)
+        allow(fake_build_manager).to receive(:fetch_app_platform).and_return(fake_app_platform)
+        allow(Dir).to receive(:mktmpdir).and_return(fake_dir)
+
+        fake_ipauploadpackagebuilder = double
+        allow(fake_ipauploadpackagebuilder).to receive(:generate).with(app_id: fake_app_id, ipa_path: upload_options[:ipa], package_path: fake_dir, platform: fake_app_platform).and_return(true)
+        allow(FastlaneCore::IpaUploadPackageBuilder).to receive(:new).and_return(fake_ipauploadpackagebuilder)
+
+        fake_itunestransporter = double
+        allow(fake_itunestransporter).to receive(:upload).and_return(true)
+        allow(FastlaneCore::ItunesTransporter).to receive(:new).and_return(fake_itunestransporter)
+
+        fake_build = double
+        expect(fake_build_manager).to receive(:wait_for_build_processing_to_be_complete).and_return(fake_build)
+
+        expect(fake_build_manager).to receive(:distribute).with(upload_options, build: fake_build)
+      end
+
+      it "does not advertise `skip_waiting_for_build_processing` if the option is set" do
+        expect(FastlaneCore::UI).to_not(receive(:message).with("If you want to skip waiting for the processing to be finished, use the `skip_waiting_for_build_processing` option"))
+        expect(FastlaneCore::UI).to_not(receive(:message).with("Note that if `skip_waiting_for_build_processing` is used but a `changelog` is supplied, this process will wait for the build to appear on AppStoreConnect, update the changelog and then skip the remaining of the processing steps."))
+
+        fake_build_manager.upload(upload_options)
+      end
+
+      it "shows notice when using `skip_waiting_for_build_processing` and changelog together" do
+        expect(FastlaneCore::UI).to(receive(:important).with("`skip_waiting_for_build_processing` used and `changelog` supplied - will wait until build appears on AppStoreConnect, update the changelog and then skip the rest of the remaining of the processing steps."))
+
+        fake_build_manager.upload(upload_options)
+      end
+    end
+
     describe "uses Manager.login (which does spaceship login) for ipa" do
       let(:fake_build_manager) { Pilot::BuildManager.new }
       let(:fake_app_id) { 123 }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Reduces superfluous output when uploading builds

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
