### PR TITLE
[sigh] add force_profile_device_udids option

### DIFF
--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -197,6 +197,13 @@ module Sigh
                                      optional: true,
                                      is_string: false,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :force_profile_device_udids,
+                                     env_name: "SIGH_FORCE_PROFILE_DEVICE_UDIDS",
+                                     description: "Comma delimited list of specific device udids to include in the provisioning profile. If this option is specified it will override the default behavior of leveraging SIGH_PLATFORM (and optionally SIGH_INCLUDE_MAC_IN_PROFILES) when determining the devices to include in the profile based on deviceClass",
+                                     optional: true,
+                                     is_string: true,
+                                     code_gen_sensitive: true,
+                                     default_value: nil),
 
         # Cache
         FastlaneCore::ConfigItem.new(key: :cached_certificates,

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -108,7 +108,7 @@ module Sigh
           if force_profile_device_udids.length > 0
             filtered_devices = current_profile.devices.select { |device| force_profile_device_udids.include?(device.udid) }
             if force_profile_device_udids.length != filtered_devices.length
-              UI.message("Provisioning Profile '#{current_profile.name}' is valid but does not match force_profile_device_udids skipping this one...")
+              UI.message("Provisioning Profile '#{current_profile.name}' is valid but does not match force_profile_device_udids, skipping this one...")
               profile_qualifies = false
             end
           end

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -88,6 +88,13 @@ module Sigh
         includes += ',certificates'
       end
 
+      # also include devices if specific device udids were specified
+      force_profile_device_udids = []
+      unless Sigh.config[:force_profile_device_udids].nil?
+        includes += ",devices"
+        force_profile_device_udids = Sigh.config[:force_profile_device_udids].split(',').map(&:strip)
+      end
+
       results = Sigh.config[:cached_profiles]
       results ||= Spaceship::ConnectAPI::Profile.all(filter: filter, includes: includes)
       results.select! do |profile|
@@ -95,12 +102,20 @@ module Sigh
       end
 
       results = results.find_all do |current_profile|
+        profile_qualifies = false
         if current_profile.valid? || Sigh.config[:force]
-          true
+          profile_qualifies = true
+          if force_profile_device_udids.length > 0
+            filtered_devices = current_profile.devices.select { |device| force_profile_device_udids.include?(device.udid) }
+            if force_profile_device_udids.length != filtered_devices.length
+              UI.message("Provisioning Profile '#{current_profile.name}' is valid but does not match force_profile_device_udids skipping this one...")
+              profile_qualifies = false
+            end
+          end
         else
           UI.message("Provisioning Profile '#{current_profile.name}' is not valid, skipping this one...")
-          false
         end
+        profile_qualifies
       end
 
       # Take the provisioning profile name into account
@@ -218,10 +233,18 @@ module Sigh
       return [] if !Sigh.config[:development] && !Sigh.config[:adhoc]
 
       devices = Sigh.config[:cached_devices]
-      devices ||= Spaceship::ConnectAPI::Device.devices_for_platform(
-        platform: Sigh.config[:platform],
-        include_mac_in_profiles: Sigh.config[:include_mac_in_profiles]
-      )
+
+      if Sigh.config[:force_profile_device_udids]
+        udids = Sigh.config[:force_profile_device_udids].split(',').map(&:strip)
+        UI.message("Getting profile devices based on udid=#{udids.join(',')}")
+        devices ||= Spaceship::ConnectAPI::Device.devices_for_udids(udids)
+      else
+        UI.message("Getting profile devices based on platform=#{Sigh.config[:platform]} include_mac_in_profiles=#{Sigh.config[:include_mac_in_profiles]}")
+        devices ||= Spaceship::ConnectAPI::Device.devices_for_platform(
+          platform: Sigh.config[:platform],
+          include_mac_in_profiles: Sigh.config[:include_mac_in_profiles]
+        )
+      end
 
       return devices
     end

--- a/sigh/spec/runner_spec.rb
+++ b/sigh/spec/runner_spec.rb
@@ -1,3 +1,5 @@
+require_relative 'spec_helper'
+
 describe Sigh do
   describe Sigh::Runner do
     before do
@@ -169,6 +171,67 @@ describe Sigh do
 
         devices = fake_runner.devices_to_use
         expect(devices.size).to eq(1)
+      end
+
+      it "devices for specific udid" do
+        options = { development: true, force_profile_device_udids: "device2" }
+        Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+        devices = generate_devices_list(5)
+        filter = { udid: "device2" }
+        allow(Spaceship::ConnectAPI::Device).to receive(:all).with(filter: filter).and_return([devices[1]])
+
+        devices = fake_runner.devices_to_use
+        expect(devices.size).to eq(1)
+        expect(devices[0].udid).to eq("device2")
+      end
+
+      it "devices for multiple specific udids" do
+        options = { development: true, force_profile_device_udids: "device2,device3" }
+        Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+        devices = generate_devices_list(5)
+        filter = { udid: "device2,device3" }
+        allow(Spaceship::ConnectAPI::Device).to receive(:all).with(filter: filter).and_return([devices[1], devices[2]])
+
+        devices = fake_runner.devices_to_use
+        expect(devices.size).to eq(2)
+        expect(devices[0].udid).to eq("device2")
+        expect(devices[1].udid).to eq("device3")
+      end
+
+      it "devices for multiple specific udids with spaces" do
+        options = { development: true, force_profile_device_udids: "device2 , device3" }
+        Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+        devices = generate_devices_list(5)
+        filter = { udid: "device2,device3" }
+        allow(Spaceship::ConnectAPI::Device).to receive(:all).with(filter: filter).and_return([devices[1], devices[2]])
+
+        devices = fake_runner.devices_to_use
+        expect(devices.size).to eq(2)
+        expect(devices[0].udid).to eq("device2")
+        expect(devices[1].udid).to eq("device3")
+      end
+
+      it "devices for multiple specific udids (invalid value variant 1)" do
+        options = { development: true, force_profile_device_udids: ", " }
+        Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+        allow(Spaceship::ConnectAPI::Device).to receive(:all).and_return([])
+
+        devices = fake_runner.devices_to_use
+        expect(devices.size).to eq(0)
+      end
+
+      it "devices for multiple specific udids (invalid value variant 2)" do
+        options = { development: true, force_profile_device_udids: " " }
+        Sigh.config = FastlaneCore::Configuration.create(Sigh::Options.available_options, options)
+
+        allow(Spaceship::ConnectAPI::Device).to receive(:all).and_return([])
+
+        devices = fake_runner.devices_to_use
+        expect(devices.size).to eq(0)
       end
     end
 

--- a/sigh/spec/spec_helper.rb
+++ b/sigh/spec/spec_helper.rb
@@ -135,6 +135,18 @@ def stub_request_valid_identities(resign, value)
   expect(resign).to receive(:request_valid_identities).and_return(value)
 end
 
+def generate_devices_list(total)
+  devices = []
+  (0..total).each do |i|
+    device_name = "device#{i + 1}"
+    device = { "id" => device_name, "udid" => device_name }
+    allow(device).to receive(:udid).and_return(device_name)
+    allow(device).to receive(:id).and_return(device_name)
+    devices << device
+  end
+  return devices
+end
+
 # Commander::Command::Options does not define sane equals behavior,
 # so we need this to make testing easier
 RSpec::Matchers.define(:match_commander_options) do |expected|

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -136,6 +136,13 @@ module Spaceship
         devices
       end
 
+      # @param udids [Array<String>] The set of UDIDs to restrict the devices lookup by
+      # @return (Device) List of devices matching the criteria
+      def self.devices_for_udids(udids)
+        filter = { "udid": udids.join(",") }
+        return Spaceship::ConnectAPI::Device.all(filter: filter)
+      end
+
       # @param client [ConnectAPI] ConnectAPI client.
       # @param platform [String] The platform of the device.
       # @param include_disabled [Bool] Whether to include disable devices. false by default.


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

We have a need to generate provisioning profiles that are restricted to specific subsets of udids rather than the default selection of large sets of matching uuids based on platform & `deviceClass` oriented.

### Description

The net change was a new option (optional) `--force_profile_device_udids` `SIGH_FORCE_PROFILE_DEVICE_UDIDS` which lets the user specify a comma delimited list of explicit device udids to restrict the generated/downloaded profile to. 

`Comma delimited list of specific device udids to include in the provisioning profile. If this option is specified it will override the default behavior of leveraging SIGH_PLATFORM (and optionally SIGH_INCLUDE_MAC_IN_PROFILES) when determining the devices to include in the profile based on deviceClass`

```
fastlane sigh   \
  --development true \
  --provisioning_name my_test_004 \
  --output_path /tmp/pprofile \
  --cert_id XXXXX9WS99 \
  --filename my_test_004.mobileprovision \
  --app_identifier my.custom.id.Whatever \
  --force_profile_device_udids xxxx-dddddd,yyyy-bbbbbb
```

Overall this involved adding support for filtering the devices returned via apple connect device API using the uuids the user presents via the new argument. 

### Testing Steps

See unit tests. 
