### PR TITLE
[ci] automate fastlane deployments to RubyGems when a new release is published

### DIFF
--- a/.github/workflows/announce_release.yml
+++ b/.github/workflows/announce_release.yml
@@ -1,9 +1,9 @@
 name: Processing release
-on: 
+on:
   release:
     types: [published]
 
-jobs:   
+jobs:
   communicate-on-pull-request-released:
     name: communicate on pull request released
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_to_rubygems.yml
+++ b/.github/workflows/deploy_to_rubygems.yml
@@ -1,7 +1,9 @@
+---
 name: Deploy to RubyGems
 on:
   release:
-    types: [published]
+    types:
+      - published
 
 jobs:
   deploy-to-rubygems:
@@ -11,12 +13,10 @@ jobs:
       contents: write
       id-token: write
     steps:
-      # Set up
       - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "3.2"
-      # Release
+          ruby-version: '3.2'
       - uses: rubygems/release-gem@v1

--- a/.github/workflows/deploy_to_rubygems.yml
+++ b/.github/workflows/deploy_to_rubygems.yml
@@ -1,0 +1,22 @@
+name: Deploy to RubyGems
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy-to-rubygems:
+    name: Deploy to RubyGems
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      # Set up
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "3.2"
+      # Release
+      - uses: rubygems/release-gem@v1


### PR DESCRIPTION
### Motivation and Context

After the exciting news about [RubyGems announcing Trusted Publishing](https://blog.rubygems.org/2023/12/14/trusted-publishing.html), I'm thrilled to implement it in _fastlane_!

This means we won't have to do a manual deployment to RubyGems when there's a new release 🎉 

This takes us one HUGE step closer from implementing automated periodic releases! 🚀

### Description

I simply followed the sample code in https://blog.rubygems.org/2023/12/14/trusted-publishing.html but with the same hook used in `.github/workflows/announce_release.yml` (when there's a new "published release", deploy).

### Testing Steps

Not sure, actually. I guess we'll have to review, merge, enable Trusted Publishing in RubyGems itself, and then see if it works next time we release 😄 