### PR TITLE
[ci] fix CI by updating validate_documentation workflow docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
 
   tests_ubuntu:
     parameters:
-      ruby_version:
+      image:
         type: string
     environment:
       CIRCLE_TEST_REPORTS: '~/test-reports'
@@ -138,7 +138,7 @@ jobs:
       LANG: 'C.UTF-8'
       FASTLANE_ITUNES_TRANSPORTER_PATH: .bundle
     docker:
-      - image: << parameters.ruby_version >>
+      - image: << parameters.image >>
     steps:
       - *cache_restore_git
       - checkout
@@ -217,10 +217,10 @@ jobs:
 
   lint_source_code:
     parameters:
-      ruby_version:
+      image:
         type: string
     docker:
-      - image: << parameters.ruby_version >>
+      - image: << parameters.image >>
     steps:
       - *cache_restore_git
       - checkout
@@ -233,13 +233,13 @@ jobs:
 
   modules_load_up_tests:
     parameters:
-      ruby_version:
+      image:
         type: string
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
     docker:
-      - image: << parameters.ruby_version >>
+      - image: << parameters.image >>
     shell: /bin/bash --login -eo pipefail
     steps:
       - *cache_restore_git
@@ -307,7 +307,7 @@ workflows:
           ruby_opt: -W:deprecated
       - tests_ubuntu:
           name: 'Execute tests on Ubuntu'
-          ruby_version: 'fastlanetools/ci:0.3.0'
+          image: 'fastlanetools/ci:0.3.0'
       - validate_fastlane_swift_generation:
           name: 'Validate Fastlane.swift generation'
           xcode_version: '12.5.1'
@@ -317,7 +317,7 @@ workflows:
           image: 'cimg/ruby:3.2.2'
       - lint_source_code:
           name: 'Lint source code'
-          ruby_version: 'cimg/ruby:2.6'
+          image: 'cimg/ruby:2.6'
       - modules_load_up_tests:
           name: 'Modules load up tests'
-          ruby_version: 'cimg/ruby:2.6'
+          image: 'cimg/ruby:2.6'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,10 +196,10 @@ jobs:
 
   validate_documentation:
     parameters:
-      ruby_version:
+      image:
         type: string
     docker:
-      - image: << parameters.ruby_version >>
+      - image: << parameters.image >>
     steps:
       - *cache_restore_git
       - checkout
@@ -314,7 +314,7 @@ workflows:
           ruby_version: '2.7'
       - validate_documentation:
           name: 'Validate Documentation'
-          ruby_version: 'fastlanetools/ci:0.3.0'
+          image: 'cimg/ruby:3.2.2'
       - lint_source_code:
           name: 'Lint source code'
           ruby_version: 'cimg/ruby:2.6'


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

CI is broken in master:

<img width="1179" alt="image" src="https://github.com/fastlane/fastlane/assets/8419048/9d5c3614-fb98-4aaf-8b00-0f892fdc54c6">

I think CircleCI pushed some breaking changes on their end because this happened without us making changes.

### Description

We'd need to update the docker image from one that is using Ruby 2.6.x to 3.x, and just 2 weeks ago we updated ours to 2.7. I'm not sure if we really need a custom docker image for this workflow/lane, it's just a validation step. If this passes CI, I think it's better to lean on standard CI-provided images since they require less maintenance, so next time we need to bump we simply update this LOC, instead of having to update a docker image in another repo. Happy to hear dissenting opinions though 🙏 I'm curious to understand why this specific workflow/lane required a custom image.

### Testing Steps

Pass CI.