### PR TITLE
[action][sonar] replace deprecated sonar.login parameter with sonar.token

### DIFF
--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -20,6 +20,7 @@ module Fastlane
         sonar_scanner_args << "-Dsonar.language=\"#{params[:project_language]}\"" if params[:project_language]
         sonar_scanner_args << "-Dsonar.sourceEncoding=\"#{params[:source_encoding]}\"" if params[:source_encoding]
         sonar_scanner_args << "-Dsonar.login=\"#{params[:sonar_login]}\"" if params[:sonar_login]
+        sonar_scanner_args << "-Dsonar.token=\"#{params[:sonar_token]}\"" if params[:sonar_token]
         sonar_scanner_args << "-Dsonar.host.url=\"#{params[:sonar_url]}\"" if params[:sonar_url]
         sonar_scanner_args << "-Dsonar.organization=\"#{params[:sonar_organization]}\"" if params[:sonar_organization]
         sonar_scanner_args << "-Dsonar.branch.name=\"#{params[:branch_name]}\"" if params[:branch_name]
@@ -100,9 +101,17 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :sonar_login,
                                        env_name: "FL_SONAR_LOGIN",
-                                       description: "Pass the Sonar Login token (e.g: xxxxxxprivate_token_XXXXbXX7e)",
+                                       description: "Pass the Sonar Login Token (e.g: xxxxxxprivate_token_XXXXbXX7e)",
+                                       deprecated: "Login and password were deprecated in favor of login token. See https://community.sonarsource.com/t/deprecating-sonar-login-and-sonar-password-in-favor-of-sonar-token/95829 for more details",
                                        optional: true,
-                                       sensitive: true),
+                                       sensitive: true,
+                                       conflicting_options: [:sonar_token]),
+          FastlaneCore::ConfigItem.new(key: :sonar_token,
+                                       env_name: "FL_SONAR_TOKEN",
+                                       description: "Pass the Sonar Token (e.g: xxxxxxprivate_token_XXXXbXX7e)",
+                                       optional: true,
+                                       sensitive: true,
+                                       conflicting_options: [:sonar_login]),
           FastlaneCore::ConfigItem.new(key: :sonar_url,
                                        env_name: "FL_SONAR_URL",
                                        description: "Pass the url of the Sonar server",
@@ -156,7 +165,7 @@ module Fastlane
             project_name: "iOS - AwesomeApp",
             sources_path: File.expand_path("../AwesomeApp"),
             sonar_organization: "myOrg",
-            sonar_login: "123456abcdef",
+            sonar_token: "123456abcdef",
             sonar_url: "https://sonarcloud.io"
           )'
         ]

--- a/fastlane/spec/actions_specs/sonar_spec.rb
+++ b/fastlane/spec/actions_specs/sonar_spec.rb
@@ -16,11 +16,11 @@ describe Fastlane do
 
       it "Should not print sonar command" do
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
-        expected_command = "cd #{File.expand_path('.').shellescape} && sonar-scanner -Dsonar.login=\"asdf\""
+        expected_command = "cd #{File.expand_path('.').shellescape} && sonar-scanner -Dsonar.token=\"asdf\""
         expect(Fastlane::Actions::SonarAction).to receive(:verify_sonar_scanner_binary).and_return(true)
         expect(Fastlane::Actions).to receive(:sh_control_output).with(expected_command, print_command: false, print_command_output: true).and_call_original
         Fastlane::FastFile.new.parse("lane :sonar_test do
-          sonar(sonar_login: 'asdf')
+          sonar(sonar_token: 'asdf')
         end").runner.execute(:sonar_test)
       end
 
@@ -38,7 +38,7 @@ describe Fastlane do
             exclusions: '/Sources/Excluded',
             project_language: 'ruby',
             source_encoding: 'utf-8',
-            sonar_login: 'sonar-login',
+            sonar_token: 'sonar-token',
             sonar_url: 'http://www.sonarqube.com',
             sonar_organization: 'org-key',
             branch_name: 'branch-name',
@@ -57,7 +57,7 @@ describe Fastlane do
                     -Dsonar.exclusions=\"/Sources/Excluded\"
                     -Dsonar.language=\"ruby\"
                     -Dsonar.sourceEncoding=\"utf-8\"
-                    -Dsonar.login=\"sonar-login\"
+                    -Dsonar.token=\"sonar-token\"
                     -Dsonar.host.url=\"http://www.sonarqube.com\"
                     -Dsonar.organization=\"org-key\"
                     -Dsonar.branch.name=\"branch-name\"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Addresses https://github.com/fastlane/fastlane/issues/21436, for more information see SonarQube deprecation notice of the login property here: https://community.sonarsource.com/t/deprecating-sonar-login-and-sonar-password-in-favor-of-sonar-token/95829

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

SonarQube has deprecated the login parameters and requires the token passed as -Dsonar.token. Warnings appear in fastlane

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Test changes when submitting data to sonarqube using a recent (5.0.x+) version of the sonar-scanner CLI too.