### PR TITLE
[ci] review and lint GitHub Actions workflow files

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,14 +1,16 @@
+---
 name: Processing issues
-on: 
+on:
   issues:
-    types: [opened]
+    types:
+      - opened
 
-jobs:   
+jobs:
   fastlane-env:
     name: fastlane env reminder
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: fastlane/github-actions/fastlane-env-reminder@latest
-      with:
-        repo-token: "${{ secrets.BOT_GITHUB_TOKEN }}"
+      - uses: actions/checkout@master
+      - uses: fastlane/github-actions/fastlane-env-reminder@latest
+        with:
+          repo-token: '${{ secrets.BOT_GITHUB_TOKEN }}'

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,5 +1,5 @@
 ---
-name: Processing issues
+name: Process issues
 on:
   issues:
     types:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   fastlane-env:
-    name: fastlane env reminder
+    name: Remind user about posting their fastlane env
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,12 +1,12 @@
 ---
-# Locks closed and inactive issues and pull requests.
-name: Locking issues and pull requests
+name: Lock issues and pull requests
 on:
   schedule:
     - cron: "0 0 * * *" # Every day at midnight
 
 jobs:
   lock:
+    name: Lock closed and inactive issues and pull requests
     runs-on: ubuntu-latest
     steps:
       - uses: fastlane/github-actions/lock@latest

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,14 +1,15 @@
-# Locking closed, inactive issues and pull requests
+---
+# Locks closed and inactive issues and pull requests.
 name: Locking issues and pull requests
 on:
   schedule:
-  - cron: "0 0 * * *"
+    - cron: "0 0 * * *" # Every day at midnight
 
 jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-    - uses: fastlane/github-actions/lock@latest
-      with:
-        repo-token: ${{ secrets.BOT_GITHUB_TOKEN }}
-        days-before-lock: 60
+      - uses: fastlane/github-actions/lock@latest
+        with:
+          repo-token: '${{ secrets.BOT_GITHUB_TOKEN }}'
+          days-before-lock: 60

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,20 @@
 ---
-name: Processing release
+name: Process release
 on:
   release:
     types:
       - published
 
 jobs:
-  communicate-on-pull-request-released:
-    name: communicate on pull request released
+  announce-release-on-released-pull-requests:
+    name: Announce release on released pull requests
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@master
         with:
           ref: refs/heads/master
-      - name: Communicate on PR released
+      - name: Announce release on released pull requests
         uses: fastlane/github-actions/communicate-on-pull-request-released@latest
         with:
           repo-token: '${{ secrets.BOT_GITHUB_TOKEN }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,20 @@
+---
 name: Processing release
-on: 
+on:
   release:
-    types: [published]
+    types:
+      - published
 
-jobs:   
+jobs:
   communicate-on-pull-request-released:
     name: communicate on pull request released
     runs-on: ubuntu-latest
     steps:
-    - name: Git checkout
-      uses: actions/checkout@master
-      with:
-        ref: refs/heads/master
-    - name: Communicate on PR released
-      uses: fastlane/github-actions/communicate-on-pull-request-released@latest
-      with:
-        repo-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+      - name: Git checkout
+        uses: actions/checkout@master
+        with:
+          ref: refs/heads/master
+      - name: Communicate on PR released
+        uses: fastlane/github-actions/communicate-on-pull-request-released@latest
+        with:
+          repo-token: '${{ secrets.BOT_GITHUB_TOKEN }}'

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -1,5 +1,5 @@
 ---
-name: Deploying to Homebrew
+name: Deploy to Homebrew
 on:
   push:
     tags: 'v*' # Push events to tags matching v*
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: mislav/bump-homebrew-formula-action@v3.1
-        if: "!contains(github.ref, '-')" # skip prereleases
+        if: "!contains(github.ref, '-')" # Skip prereleases
         with:
           formula-name: fastlane
         env:

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -1,6 +1,8 @@
+---
+name: Deploying to Homebrew
 on:
   push:
-    tags: 'v*'
+    tags: 'v*' # Push events to tags matching v*
 
 jobs:
   homebrew:
@@ -12,4 +14,4 @@ jobs:
         with:
           formula-name: fastlane
         env:
-          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_COMMITTER_TOKEN }}
+          COMMITTER_TOKEN: '${{ secrets.HOMEBREW_COMMITTER_TOKEN }}'


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've updated the documentation if necessary.

### Motivation and Context

This PR supersedes https://github.com/fastlane/fastlane/pull/16033 — the part where it lints the GitHub Actions yaml files.

Closes https://github.com/fastlane/fastlane/pull/16033

### Description

I saw the PR https://github.com/fastlane/fastlane/pull/16033 whose branch got deleted, and thought that the part where the author was linting the yaml files was still valuable for us to add, so I decided to lint the existing files, review them all, adding comments where it's not clear, review their wording/workflow names/etc, and open this PR.

The part of that PR that adds a GHA to run rake on ubuntu/macOS isn't needed as we're already running tests on CircleCI.

### Testing Steps

No testing steps I think; we just need to make sure that the changes I'm making to the workflow identifiers and names won't affect anything, which I believe they won't. If we had GHA checks that would be run on pull requests, where the repo settings would require some of those check to be successful, then those are identified by name, and would be affected, but since we don't have any GHA running on PRs, then I think we're safe 😃 