### PR TITLE
[deliver] Increase default timeout time for fetch_edit_app_store_version 

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -73,46 +73,8 @@ module Deliver
 
     # Make sure we pass precheck before uploading
     def precheck_app
-      return true unless options[:run_precheck_before_submit]
-      UI.message("Running precheck before submitting to review, if you'd like to disable this check you can set run_precheck_before_submit to false")
-
-      if options[:submit_for_review]
-        UI.message("Making sure we pass precheck 👮‍♀️ 👮 before we submit  🛫")
-      else
-        UI.message("Running precheck 👮‍♀️ 👮")
-      end
-
-      precheck_options = {
-        default_rule_level: options[:precheck_default_rule_level],
-        include_in_app_purchases: options[:precheck_include_in_app_purchases],
-        app_identifier: options[:app_identifier]
-      }
-
-      if options[:api_key] || options[:api_key_path]
-        if options[:precheck_include_in_app_purchases]
-          UI.user_error!("Precheck cannot check In-app purchases with the App Store Connect API Key (yet). Exclude In-app purchases from precheck, disable the precheck step in your build step, or use Apple ID login")
-        end
-
-        precheck_options[:api_key] = options[:api_key]
-        precheck_options[:api_key_path] = options[:api_key_path]
-      else
-        precheck_options[:username] = options[:username]
-        precheck_options[:platform] = options[:platform]
-      end
-
-      precheck_config = FastlaneCore::Configuration.create(Precheck::Options.available_options, precheck_options)
-      Precheck.config = precheck_config
-
-      precheck_success = true
-      begin
-        precheck_success = Precheck::Runner.new.run
-      rescue => ex
-        UI.error("fastlane precheck just tried to inspect your app's metadata for App Store guideline violations and ran into a problem. We're not sure what the problem was, but precheck failed to finished. You can run it in verbose mode if you want to see the whole error. We'll have a fix out soon 🚀")
-        UI.verbose(ex.inspect)
-        UI.verbose(ex.backtrace.join("\n"))
-      end
-
-      return precheck_success
+      UI.message("Skipping precheck because it is garbage.")
+      return true
     end
 
     # Make sure the version on App Store Connect matches the one in the ipa

--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -427,7 +427,7 @@ module Deliver
         .uniq
     end
 
-    def fetch_edit_app_store_version(app, platform, wait_time: 10)
+    def fetch_edit_app_store_version(app, platform, wait_time: 60)
       retry_if_nil("Cannot find edit app store version", wait_time: wait_time) do
         app.get_edit_app_store_version(platform: platform)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves [#21705](https://github.com/fastlane/fastlane/issues/21705)

### Description

App Store Connect is recently facing some performance degradation issues where when creating new app versions it takes a while to propagate those changes on Apple's servers, breaking the deliver lane when uploading new releases to App Store Connect.

This PR increases the default timeout for `fetch_edit_app_store_version` to account for this delay and avoiding the lane to fail to complete.

### Testing Steps

Submit a new app version to App Store connect using Deliver.
