### PR TITLE
Increasing fetch_edit_app_store_version default timeout

### DIFF
--- a/deliver/lib/deliver/upload_metadata.rb
+++ b/deliver/lib/deliver/upload_metadata.rb
@@ -427,7 +427,7 @@ module Deliver
         .uniq
     end
 
-    def fetch_edit_app_store_version(app, platform, wait_time: 10)
+    def fetch_edit_app_store_version(app, platform, wait_time: 60)
       retry_if_nil("Cannot find edit app store version", wait_time: wait_time) do
         app.get_edit_app_store_version(platform: platform)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves [#21705](https://github.com/fastlane/fastlane/issues/21705)

### Description

App Store Connect is recently facing some performance degradation issues where when creating new app versions it takes a while to propagate those changes on Apple's servers, breaking the deliver lane when uploading new releases to App Store Connect.

This PR increases the default timeout for `fetch_edit_app_store_version` to account for this delay and avoiding the lane to fail to complete.

### Testing Steps

Submit a new app version to App Store connect using Deliver.
