### PR TITLE
[ci] fix CircleCI builds by adding back `ruby_version` parameter to the workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,7 @@ jobs:
 
 workflows:
   version: 2
-  run_tests_and_checks:
+  "Run Tests & Checks": # Name of the workflow, which ends up displayed on GitHub's PR Check
     jobs:
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 12.5.1, Ruby 2.6)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,7 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  run_tests_and_checks:
     jobs:
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 12.5.1, Ruby 2.6)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,8 @@ jobs:
     parameters:
       image:
         type: string
+      ruby_version: # Used when restoring/saving bundler cache
+        type: string
     environment:
       CIRCLE_TEST_REPORTS: '~/test-reports'
       LC_ALL: 'C.UTF-8'
@@ -198,6 +200,8 @@ jobs:
     parameters:
       image:
         type: string
+      ruby_version: # Used when restoring/saving bundler cache
+        type: string
     docker:
       - image: << parameters.image >>
     steps:
@@ -218,6 +222,8 @@ jobs:
   lint_source_code:
     parameters:
       image:
+        type: string
+      ruby_version: # Used when restoring/saving bundler cache
         type: string
     docker:
       - image: << parameters.image >>
@@ -308,6 +314,7 @@ workflows:
       - tests_ubuntu:
           name: 'Execute tests on Ubuntu'
           image: 'fastlanetools/ci:0.3.0'
+          ruby_version: '2.6'
       - validate_fastlane_swift_generation:
           name: 'Validate Fastlane.swift generation'
           xcode_version: '12.5.1'
@@ -315,9 +322,11 @@ workflows:
       - validate_documentation:
           name: 'Validate Documentation'
           image: 'cimg/ruby:3.2.2'
+          ruby_version: '3.2.2'
       - lint_source_code:
           name: 'Lint source code'
           image: 'cimg/ruby:2.6'
+          ruby_version: '2.6'
       - modules_load_up_tests:
           name: 'Modules load up tests'
           image: 'cimg/ruby:2.6'


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)

### Motivation and Context

CircleCI hasn't been running in PRs or master, or it's intermittent at its best. E.g.:

<img width="727" alt="image" src="https://github.com/fastlane/fastlane/assets/8419048/8cf52102-559b-4efc-b8b3-e20e43af2e07">

This regressed when we merged this PR of mine: https://github.com/fastlane/fastlane/pull/21735

### Description

What is weird is that it was sometimes running and sometimes not running anymore, in master, see `4/4` (CircleCI didn't run) vs `5/5` (CircleCI ran):

![image](https://github.com/fastlane/fastlane/assets/8419048/0c9c233c-ed1f-47cf-a9df-568017ab6495)

Moving forward we really need to add CircleCI to the list of **required** checks in this repo.

I also took the opportunity to change the super vague name of the workflow from `build` to `Run Tests & Checks`:

<img width="834" alt="image" src="https://github.com/fastlane/fastlane/assets/8419048/85f48b7b-53a3-4a39-b294-6585e1bab9d2">

### Testing Steps

Pass CI and check that CircleCI ran in this PR.