### PR TITLE
[ci] fix linter issues that slipped to master due to CI issue

### DIFF
--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -161,8 +161,8 @@ module Fastlane
           'spm(
             command: "test",
             parallel: true
-          ),
-          spm(
+          )',
+          'spm(
             simulator: "iphonesimulator"
           )',
           'spm(

--- a/fastlane/lib/fastlane/actions/spm.rb
+++ b/fastlane/lib/fastlane/actions/spm.rb
@@ -201,7 +201,7 @@ module Fastlane
       end
 
       def self.simulator_platform(params)
-        platform_suffix = "#{params[:simulator] == "iphonesimulator" ? "ios" : "macosx"}"
+        platform_suffix = params[:simulator] == "iphonesimulator" ? "ios" : "macosx"
         "#{params[:simulator_arch]}-apple-#{platform_suffix}"
       end
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] ~~I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)~~

### Motivation and Context

This PR fixes these issues:

<img width="735" alt="image" src="https://github.com/fastlane/fastlane/assets/8419048/b4259b13-0c9e-414d-adb0-5d5f65691bcf">

<img width="1170" alt="image" src="https://github.com/fastlane/fastlane/assets/8419048/8c3f2081-7f88-4483-9a47-f5df61911704">

Which got introduced when we merged https://github.com/fastlane/fastlane/pull/21707 after CircleCI was broken in https://github.com/fastlane/fastlane/pull/21735

### Description

Simple lint fix with an added improvement to avoid unnecessary string interpolation.

### Testing Steps

This PR won't have the CircleCI checks (e.g. linter) until https://github.com/fastlane/fastlane/pull/21746 is merged, and https://github.com/fastlane/fastlane/pull/21746 won't be mergeable until this PR gets merged because it will fail lint. Cyclic dependency :P let's just get this one merged, which's quite safe, so we can evaluate https://github.com/fastlane/fastlane/pull/21746 after.

#### Here's proof I tested this:

##### `bundle exec rubocop`

<img width="736" alt="image" src="https://github.com/fastlane/fastlane/assets/8419048/12e5370f-84c1-4505-afd4-245847e4520b">

##### `bundle exec fastlane validate_docs`

<img width="574" alt="image" src="https://github.com/fastlane/fastlane/assets/8419048/5469e9a0-d2cd-4f5c-b87b-da4c97aa6c50">

##### `bundle exec rspec`

<img width="596" alt="image" src="https://github.com/fastlane/fastlane/assets/8419048/636a6683-91a0-4046-b519-b43d07a25e75">

