### PR TITLE
[sigh] prevent crashes in `fetch_profiles` when profiles have no `bundle_id`

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -91,7 +91,7 @@ module Sigh
       results = Sigh.config[:cached_profiles]
       results ||= Spaceship::ConnectAPI::Profile.all(filter: filter, includes: includes)
       results.select! do |profile|
-        profile.bundle_id.identifier == Sigh.config[:app_identifier]
+        profile.bundle_id&.identifier == Sigh.config[:app_identifier]
       end
 
       results = results.find_all do |current_profile|


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

This change is required for fastlane sigh, if the provisioning profiles for Apple needs to be recreated or fetched.

Shell command: 
fastlane sigh --app_identifier $APP_ID --username $FASTLANE_USER --provisioning_name $PROVISIONINF_NAME --team_id $TEAM_ID --template_name "$TEMPLATE_NAME" --ignore_profiles_with_different_name --skip_certificate_verification

Error: identifier' for nil:NilClass (NoMethodError)

If a build pipeline is running the same shell / bash command for fastlane sigh multiple times, the error is happening sporadically.

Resolves #21238

### Description

The change is to check if the profile.bundle_id is nil / null.

### Testing Steps

Changes are tested within a forked repository. From this forked repository, the forked version for gem install was created, implemented in the pipeline and many builds are triggered and ran successfully in parallel using the above fastlane sigh command.
