### PR TITLE
[ci] fix homebrew bump url

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -323,7 +323,7 @@ end
 
 lane :release_brew do
   version = local_version
-  sh("cd .. && brew bump-formula-pr fastlane --force --url=https://github.com/fastlane/fastlane/archive/#{version}.tar.gz")
+  sh("cd .. && brew bump-formula-pr fastlane --force --url=https://github.com/fastlane/fastlane/archive/refs/tags/#{version}.tar.gz")
 end
 
 lane :release_github do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -323,7 +323,7 @@ end
 
 lane :release_brew do
   version = local_version
-  sh("cd .. && brew bump-formula-pr fastlane --force --url=https://github.com/fastlane/fastlane/archive/refs/tags/#{version}.tar.gz")
+  sh("cd .. && brew update && brew bump-formula-pr fastlane --force --url=https://github.com/fastlane/fastlane/archive/refs/tags/#{version}.tar.gz")
 end
 
 lane :release_github do


### PR DESCRIPTION
### Motivation and Context

`fastlane release_brew` was failing due to an invalid url format

### Description

Added `refs/tags` to the archive url as brew CLI requested
