### PR TITLE
[scan] Fix device selection issue fallback scenario

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -217,7 +217,7 @@ module Scan
             if pieces.count == 0
               [] # empty array
             elsif pieces.count == 1
-              [ highest_compatible_simulator(simulators, pieces.first) ]
+              [ highest_compatible_simulator(simulators, pieces.first) ].compact
             else # pieces.count == 2 -- mathematically, because of the 'end of line' part of our regular expression
               version = pieces[1].tr('()', '')
               display_device = "'#{pieces[0]}' with version #{version}"


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/21768 when there is no device match for a given name.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Resolves [21768](https://github.com/fastlane/fastlane/issues/21768)

### Description

This was a regression from 2.218 which introduces nil when the device string did not return a matching item (Steps described in the issue report). It causes the **second lambda to not be used** and hence there was an _error instead of using a default device_.

Previously (v2.217.0) it retuned an empty array in such case. This implementation restores the old behaviour by removing all nil values from the array such as [nil] -> []

<!-- Describe your changes in detail, as well as how you tested them. -->

I have run it locally by installing this gem from source. The rest of the steps are same as per the issue report. 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
