### PR TITLE
[fastlane][ci] Lock google-cloud-env < 2.0.0 for Ruby 2.6 and fix CI to use specified ruby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ workflows:
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 14.3.1, Ruby 3.1)'
           xcode_version: '14.3.1'
-          ruby_version: '3.1
+          ruby_version: '3.1'
           ruby_opt: -W:deprecated
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 15.0.1, Ruby 3.1)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,27 +285,27 @@ workflows:
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 14.3.1, Ruby 3.1)'
           xcode_version: '14.3.1'
-          ruby_version: '3.1.4'
+          ruby_version: '3.1
           ruby_opt: -W:deprecated
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 15.0.1, Ruby 3.1)'
           xcode_version: '15.0.1'
-          ruby_version: '3.1.4'
+          ruby_version: '3.1'
           ruby_opt: -W:deprecated
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.2)'
+          name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'
           xcode_version: '13.4.1'
-          ruby_version: '3.2.2'
+          ruby_version: '3.1'
           ruby_opt: -W:deprecated
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 14.3.1, Ruby 3.2)'
           xcode_version: '14.3.1'
-          ruby_version: '3.2.2'
+          ruby_version: '3.2'
           ruby_opt: -W:deprecated
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 15.0.1, Ruby 3.2)'
           xcode_version: '15.0.1'
-          ruby_version: '3.2.2'
+          ruby_version: '3.2'
           ruby_opt: -W:deprecated
       - tests_ubuntu:
           name: 'Execute tests on Ubuntu'
@@ -318,7 +318,7 @@ workflows:
       - validate_documentation:
           name: 'Validate Documentation'
           image: 'cimg/ruby:3.2.2'
-          ruby_version: '3.2.2'
+          ruby_version: '3.2'
       - lint_source_code:
           name: 'Lint source code'
           image: 'cimg/ruby:2.6'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@
 
 version: 2.1
 orbs:
-    shellcheck: circleci/shellcheck@2.2.2 # brew install shellcheck stopped working so using this
+  shellcheck: circleci/shellcheck@2.2.2 # brew install shellcheck stopped working so using this
+  macos: circleci/macos@2
 
 aliases:
   - &important-branches
@@ -50,12 +51,6 @@ aliases:
       paths:
         - "~/.cache/rubocop_cache"
 
-  - &set_ruby
-    run:
-      name: Set Ruby version
-      command: | # see https://circleci.com/docs/2.0/testing-ios/#using-ruby
-        echo "ruby-${_RUBY_VERSION}" > ~/.ruby-version
-
   - &bundle_install
     run:
       name: bundle install
@@ -81,14 +76,14 @@ jobs:
       CIRCLE_TEST_REPORTS: '~/test-reports'
       LC_ALL: 'en_US.UTF-8'
       LANG: 'en_US.UTF-8'
-      _RUBY_VERSION: << parameters.ruby_version >>
     shell: '/bin/bash --login -eo pipefail'
     steps:
       - *cache_restore_git
       - checkout
       - *cache_save_git
       - *cache_restore_bundler
-      - *set_ruby
+      - macos/switch-ruby:
+          version: << parameters.ruby_version >>
       - run:
           name: debug | ruby version
           command: |
@@ -178,7 +173,8 @@ jobs:
       - checkout
       - *cache_save_git
       - *cache_restore_bundler
-      - *set_ruby
+      - macos/switch-ruby:
+          version: << parameters.ruby_version >>
       - *bundle_install
       - *cache_save_bundler
       - run:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ PATH
       gh_inspector (>= 1.1.2, < 2.0.0)
       google-apis-androidpublisher_v3 (~> 0.3)
       google-apis-playcustomapp_v1 (~> 0.1)
+      google-cloud-env (>= 1.6.0, < 2.0.0)
       google-cloud-storage (~> 1.31)
       highline (~> 2.0)
       http-cookie (~> 1.0.5)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -87,6 +87,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('gh_inspector', '>= 1.1.2', '< 2.0.0') # search for issues on GitHub when something goes wrong
   spec.add_dependency('google-apis-androidpublisher_v3', '~> 0.3') # Google API Client to access Play Publishing API
   spec.add_dependency('google-apis-playcustomapp_v1', '~> 0.1') # Google API Client to access Custom app Publishing API
+  spec.add_dependency('google-cloud-env', '>= 1.7.0', '< 2.0.0') # Must be < 2.0.0 to support Ruby 2.6
   spec.add_dependency('google-cloud-storage', '~> 1.31') # Access Google Cloud Storage for match
   spec.add_dependency('highline', '~> 2.0') # user inputs (e.g. passwords)
   spec.add_dependency('http-cookie', '~> 1.0.5') # Must be 1.0.5+ for Ruby 3 compatibility: https://github.com/sparklemotion/http-cookie/commit/d12449a983d3dd660c5fe1f2b135c35e83755cc3

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -87,7 +87,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('gh_inspector', '>= 1.1.2', '< 2.0.0') # search for issues on GitHub when something goes wrong
   spec.add_dependency('google-apis-androidpublisher_v3', '~> 0.3') # Google API Client to access Play Publishing API
   spec.add_dependency('google-apis-playcustomapp_v1', '~> 0.1') # Google API Client to access Custom app Publishing API
-  spec.add_dependency('google-cloud-env', '>= 1.7.0', '< 2.0.0') # Must be < 2.0.0 to support Ruby 2.6
+  spec.add_dependency('google-cloud-env', '>= 1.6.0', '< 2.0.0') # Must be < 2.0.0 to support Ruby 2.6
   spec.add_dependency('google-cloud-storage', '~> 1.31') # Access Google Cloud Storage for match
   spec.add_dependency('highline', '~> 2.0') # user inputs (e.g. passwords)
   spec.add_dependency('http-cookie', '~> 1.0.5') # Must be 1.0.5+ for Ruby 3 compatibility: https://github.com/sparklemotion/http-cookie/commit/d12449a983d3dd660c5fe1f2b135c35e83755cc3


### PR DESCRIPTION
### Motivation and Context

- CI wasn't using the specified version of Ruby (always using system)
- `google-cloud-env` dropped Ruby 2.6 support in version `2.0.0` so locking us into `< 2.0.0` until we drop Ruby 2.6 (which will be soon-ish but not doing it because its default on some macOS versions still)

### Description

- Lock `fastlane.gemspec` to use `< 2.0.0` for `google-cloud-env`
- Using macOS orb on CircleCI to switch Ruby versions
