### PR TITLE
Activate ruby 3.3 on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,10 @@ workflows:
           name: 'Execute tests on macOS (Xcode 15.2.0, Ruby 3.2)'
           xcode_version: '15.2.0'
           ruby_version: '3.2'
+      - tests_macos:
+          name: 'Execute tests on macOS (Xcode 15.3, Ruby 3.3)'
+          xcode_version: '15.3'
+          ruby_version: '3.3'
           ruby_opt: -W:deprecated
       - tests_ubuntu:
           name: 'Execute tests on Ubuntu'


### PR DESCRIPTION
Well I noticed that ruby 3.3.0 was available in the ruby image, but it's not in the macos one.

We'll have to wait a bit more. Let's monitor https://circleci.com/docs/using-macos/

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
