### PR TITLE
Fix pty not fully flushing output and causing flaky tests #21792

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 task(:test_all) do
   formatter = "--format progress"
   formatter += " -r rspec_junit_formatter --format RspecJunitFormatter -o #{ENV['CIRCLE_TEST_REPORTS']}/rspec/fastlane-junit-results.xml" if ENV["CIRCLE_TEST_REPORTS"]
-  command = "rspec --pattern spec/**/*_spec.rb,*/spec/**/*_spec.rb #{formatter} #{ENV['RSPEC_ARGS']}"
+  command = "rspec --pattern fastlane_core/spec/command_executor_spec.rb #{formatter} #{ENV['RSPEC_ARGS']}"
 
   run_rspec(command)
 end

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 task(:test_all) do
   formatter = "--format progress"
   formatter += " -r rspec_junit_formatter --format RspecJunitFormatter -o #{ENV['CIRCLE_TEST_REPORTS']}/rspec/fastlane-junit-results.xml" if ENV["CIRCLE_TEST_REPORTS"]
-  command = "rspec --pattern fastlane_core/spec/command_executor_spec.rb #{formatter} #{ENV['RSPEC_ARGS']}"
+  command = "rspec --pattern spec/**/*_spec.rb,*/spec/**/*_spec.rb #{formatter} #{ENV['RSPEC_ARGS']}"
 
   run_rspec(command)
 end

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -28,7 +28,7 @@ module FastlaneCore
 
     def self.spawn_with_pty(original_command, &block)
       require 'pty'
-      # this forces the PTY flush
+      # this forces the PTY flush - fixes #21792
       command = "#{original_command};"
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
         begin

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -26,8 +26,10 @@ module FastlaneCore
       spawn_with_popen(command, &block)
     end
 
-    def self.spawn_with_pty(command, &block)
+    def self.spawn_with_pty(original_command, &block)
       require 'pty'
+      # this forces the PTY flush
+      command = "#{original_command};"
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
         begin
           yield(command_stdout, command_stdin, pid)

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -29,7 +29,7 @@ module FastlaneCore
     def self.spawn_with_pty(original_command, &block)
       require 'pty'
       # this forces the PTY flush - fixes #21792
-      command = "#{original_command};"
+      command = ENV['FASTLANE_EXEC_FLUSH_PTY_WORKAROUND'] ? "#{original_command};" : original_command
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
         begin
           yield(command_stdout, command_stdin, pid)

--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -39,6 +39,8 @@ module FastlaneCore
           # This is expected on some linux systems, that indicates that the subcommand finished
           # and we kept trying to read, ignore it
         ensure
+          command_stdin.close
+          command_stdout.close
           begin
             Process.wait(pid)
           rescue Errno::ECHILD, PTY::ChildExited

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -22,8 +22,6 @@ describe FastlaneCore do
         fake_std_in = double("stdin")
         expect(fake_std_in).to receive(:each).and_yield(*fake_std_in_lines).and_raise(Errno::EIO)
 
-        #expect(fake_std_in).to receive(:each).and_yield(*fake_std_in).and_raise(Errno::EIO)
-
         fake_std_out = double("stdout")
 
         expect(fake_std_in).to receive(:close)

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -5,17 +5,15 @@ describe FastlaneCore do
       let(:failing_command_output) { FastlaneCore::Helper.windows? ? "log \n" : "log\n" }
       let(:failing_command_error_input) { FastlaneCore::Helper.windows? ? "log " : "log" }
 
-      8_000.times {
-        it 'executes a simple command successfully' do
-          unless FastlaneCore::Helper.windows?
-            expect(Process).to receive(:wait)
-          end
-
-          result = FastlaneCore::CommandExecutor.execute(command: 'echo foo')
-
-          expect(result).to eq('foo')
+      it 'executes a simple command successfully' do
+        unless FastlaneCore::Helper.windows?
+          expect(Process).to receive(:wait)
         end
-      }
+
+        result = FastlaneCore::CommandExecutor.execute(command: 'echo foo')
+
+        expect(result).to eq('foo')
+      end
 
       it 'handles reading which throws a EIO exception', requires_pty: true do
         fake_std_in = [

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -10,7 +10,9 @@ describe FastlaneCore do
           expect(Process).to receive(:wait)
         end
 
-        result = FastlaneCore::CommandExecutor.execute(command: 'echo foo')
+        result = FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => '1') do
+          FastlaneCore::CommandExecutor.execute(command: 'echo foo')
+        end
 
         expect(result).to eq('foo')
       end
@@ -29,7 +31,7 @@ describe FastlaneCore do
 
         # Make a fake child process so we have a valid PID and $? is set correctly
         expect(PTY).to receive(:spawn) do |command, &block|
-          expect(command).to eq('ls;')
+          expect(command).to eq('ls')
 
           # PTY uses "$?" to get exitcode, which is filled in by Process.wait(),
           # so we have to spawn a real process unless we want to mock methods
@@ -61,7 +63,7 @@ describe FastlaneCore do
         expect(fake_std_out).to receive(:close)
 
         expect(PTY).to receive(:spawn) do |command, &block|
-          expect(command).to eq('echo foo;')
+          expect(command).to eq('echo foo')
 
           # PTY uses "$?" to get exitcode, which is filled in by Process.wait(),
           # so we have to spawn a real process unless we want to mock methods

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -111,10 +111,9 @@ Shopping list:
             print_all: false,
             error: nil
           )
-        end.to output(failing_command_output).to_stdout.and(raise_error(FastlaneCore::Interface::FastlaneError) {
-          |error|
+        end.to output(failing_command_output).to_stdout.and(raise_error(FastlaneCore::Interface::FastlaneError) do |error|
           expect(error.to_s).to eq("Exit status: 42")
-        })
+        end)
 
         expect do
           FastlaneCore::CommandExecutor.execute(

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -90,5 +90,25 @@ describe FastlaneCore do
         }
       end
     end
+
+    describe "spawn_with_pty" do
+      it 'passes the command to Pty when FASTLANE_EXEC_FLUSH_PTY_WORKAROUND is not set' do
+        allow(PTY).to receive(:spawn).with("echo foo")
+
+        FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => nil) do
+          FastlaneCore::FastlanePty.spawn_with_pty('echo foo') do |command_stdout, command_stdin, pid|
+          end
+        end
+      end
+
+      it 'wraps the command with a workaround when FASTLANE_EXEC_FLUSH_PTY_WORKAROUND is set' do
+        allow(PTY).to receive(:spawn).with("echo foo;")
+
+        FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => '1') do
+          FastlaneCore::FastlanePty.spawn_with_pty('echo foo') do |command_stdout, command_stdin, pid|
+          end
+        end
+      end
+    end
   end
 end

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -14,13 +14,19 @@ describe FastlaneCore do
       end
 
       it 'doesn t return -1 if an exception was raised in the block in PTY.spawn' do
+        status = double("ProcessStatus")
+        allow(status).to receive(:exitstatus) { 0 }
+
+        expect(FastlaneCore::FastlanePty).to receive(:require).with("pty").and_return(nil)
+        allow(FastlaneCore::FastlanePty).to receive(:process_status).and_return(status)
+
         exception = StandardError.new
         expect {
-          exit_status = FastlaneCore::FastlanePty.spawn('echo foo') do |command_stdout, command_stdin, pid|
+          exit_status = FastlaneCore::FastlanePty.spawn('a path of a working exec') do |command_stdout, command_stdin, pid|
             raise exception
           end
         }.to raise_error(FastlaneCore::FastlanePtyError) { |error|
-          expect(error.exit_status).to eq(-1) # command was success but output handling failed
+          expect(error.exit_status).to eq(0) # command was success but output handling failed
         }
       end
 

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -20,7 +20,7 @@ describe FastlaneCore do
             raise exception
           end
         }.to raise_error(FastlaneCore::FastlanePtyError) { |error|
-          expect(error.exit_status).to eq(0) # command was success but output handling failed
+          expect(error.exit_status).to eq(-1) # command was success but output handling failed
         }
       end
 

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -92,7 +92,7 @@ describe FastlaneCore do
     end
 
     describe "spawn_with_pty" do
-      it 'passes the command to Pty when FASTLANE_EXEC_FLUSH_PTY_WORKAROUND is not set' do
+      it 'passes the command to Pty when FASTLANE_EXEC_FLUSH_PTY_WORKAROUND is not set', requires_pty: true do
         allow(PTY).to receive(:spawn).with("echo foo")
 
         FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => nil) do
@@ -101,7 +101,7 @@ describe FastlaneCore do
         end
       end
 
-      it 'wraps the command with a workaround when FASTLANE_EXEC_FLUSH_PTY_WORKAROUND is set' do
+      it 'wraps the command with a workaround when FASTLANE_EXEC_FLUSH_PTY_WORKAROUND is set', requires_pty: true do
         allow(PTY).to receive(:spawn).with("echo foo;")
 
         FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => '1') do


### PR DESCRIPTION
See #21792 

Does it also fail on CI?

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #21792

command execution randomly fails in CI due to the output being not consistently flushed

### Description

After investigating many solutions, the only type of workaround was to force the PTY to flush the outputs by adding a second empty command to run. In fact, just adding a `;` at the end of the command seems to be enough.

### Testing Steps

Look at #21792 for many experiments and ways to reproduce the issue.