### PR TITLE
Add a console script, similar to `bundle console`

### DIFF
--- a/ToolsAndDebugging.md
+++ b/ToolsAndDebugging.md
@@ -28,6 +28,10 @@ DEBUG=1 bundle exec rspec
 You will then jump into an interactive debugger that allows you to print out variables, call methods and [much more](https://github.com/pry/pry/wiki).
 To continue running the original script use `control` + `d`
 
+## Running fastlane within a IRB console
+
+You can open an IRB console by running `bin/console`
+
 ## Debugging and patching [_spaceship_](https://github.com/fastlane/fastlane/tree/master/spaceship) problems
 
 ### Introduction to _spaceship_
@@ -93,6 +97,10 @@ To run the newly created script, run
 ```
 SPACESHIP_DEBUG=1 bundle exec rake debug
 ```
+
+### Running the spaceship playground
+
+You can open an interactive spaceship session console by running `fastlane spaceship`
 
 ### Additional Information
 See also the [Debugging _spaceship_](spaceship/docs/Debugging.md) documentation.

--- a/ToolsAndDebugging.md
+++ b/ToolsAndDebugging.md
@@ -100,7 +100,7 @@ SPACESHIP_DEBUG=1 bundle exec rake debug
 
 ### Running the spaceship playground
 
-You can open an interactive spaceship session console by running `fastlane spaceship`
+You can open an interactive _spaceship_ session console by running `fastlane spaceship`
 
 ### Additional Information
 See also the [Debugging _spaceship_](spaceship/docs/Debugging.md) documentation.

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "fastlane"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require "irb"
+IRB.start(__FILE__)


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

I am using the console when developing. It doesn't work reliably.

`bundle console`  is deprecated. On top of that I am constantly having issues to run it.

```
lacostej@JLs ~/Code/OSS/fastlane (feature/console) bundle console
[DEPRECATED] bundle console will be replaced by `bin/console` generated by `bundle gem <name>`
/Users/lacostej/Code/OSS/fastlane/.bundle/ruby/3.1.0/gems/fakefs-1.8.0/lib/fakefs/file.rb:876:in `check_file_existence!': No such file or directory - /Users/lacostej/.rvm/gems/ruby-3.1.2/bin/bundle (Errno::ENOENT)
	from /Users/lacostej/Code/OSS/fastlane/.bundle/ruby/3.1.0/gems/fakefs-1.8.0/lib/fakefs/file.rb:503:in `initialize'
	from /Users/lacostej/Code/OSS/fastlane/.bundle/ruby/3.1.0/gems/fakefs-1.8.0/lib/fakefs/file.rb:190:in `new'
	from /Users/lacostej/Code/OSS/fastlane/.bundle/ruby/3.1.0/gems/fakefs-1.8.0/lib/fakefs/file.rb:190:in `read'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/env.rb:126:in `environment'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/env.rb:17:in `report'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/friendly_errors.rb:74:in `request_issue_report_for'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/friendly_errors.rb:53:in `log_error'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/friendly_errors.rb:126:in `rescue in with_friendly_errors'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/friendly_errors.rb:118:in `with_friendly_errors'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/exe/bundle:36:in `<top (required)>'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/bin/bundle:25:in `load'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/bin/bundle:25:in `<main>'
/Users/lacostej/.rvm/rubies/ruby-3.1.2/lib/ruby/3.1.0/pp.rb:444:in `<top (required)>': superclass mismatch for class File (TypeError)
	from /Users/lacostej/Code/OSS/fastlane/.bundle/ruby/3.1.0/gems/pry-0.14.0/lib/pry/color_printer.rb:3:in `require'
	from /Users/lacostej/Code/OSS/fastlane/.bundle/ruby/3.1.0/gems/pry-0.14.0/lib/pry/color_printer.rb:3:in `<top (required)>'
	from /Users/lacostej/Code/OSS/fastlane/.bundle/ruby/3.1.0/gems/pry-0.14.0/lib/pry.rb:27:in `require'
	from /Users/lacostej/Code/OSS/fastlane/.bundle/ruby/3.1.0/gems/pry-0.14.0/lib/pry.rb:27:in `<top (required)>'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/runtime.rb:60:in `require'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/runtime.rb:60:in `block (2 levels) in require'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/runtime.rb:55:in `each'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/runtime.rb:55:in `block in require'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/runtime.rb:44:in `each'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/runtime.rb:44:in `require'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler.rb:187:in `require'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/cli/console.rb:15:in `run'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/cli.rb:515:in `console'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/cli.rb:31:in `dispatch'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/cli.rb:25:in `start'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/exe/bundle:48:in `block in <top (required)>'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/gems/bundler-2.3.21/exe/bundle:36:in `<top (required)>'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/bin/bundle:25:in `load'
	from /Users/lacostej/.rvm/gems/ruby-3.1.2/bin/bundle:25:in `<main>'

```

### Description

This `bin/console` script works for me. I created it manually after reading https://github.com/rubygems/rubygems/issues/4402