### PR TITLE
Add an interactive console for users as well

### DIFF
--- a/fastlane/lib/fastlane/commands_generator.rb
+++ b/fastlane/lib/fastlane/commands_generator.rb
@@ -249,6 +249,15 @@ module Fastlane
         end
       end
 
+      command :console do |c|
+        c.syntax = 'fastlane console'
+        c.description = 'Opens an interactive developer console'
+        c.action do |args, options|
+          require 'fastlane/console'
+          Fastlane::Console.execute(args, options)
+        end
+      end
+
       command :enable_auto_complete do |c|
         c.syntax = 'fastlane enable_auto_complete'
         c.description = 'Enable tab auto completion'

--- a/fastlane/lib/fastlane/console.rb
+++ b/fastlane/lib/fastlane/console.rb
@@ -1,0 +1,24 @@
+require 'irb'
+
+module Fastlane
+  # Opens an interactive developer console
+  class Console
+    def self.execute(args, options)
+      ARGV.clear
+      IRB.setup(nil)
+      @irb = IRB::Irb.new(nil)
+      IRB.conf[:MAIN_CONTEXT] = @irb.context
+      IRB.conf[:PROMPT][:FASTLANE] = IRB.conf[:PROMPT][:SIMPLE].dup
+      IRB.conf[:PROMPT][:FASTLANE][:RETURN] = "%s\n"
+      @irb.context.prompt_mode = :FASTLANE
+      @irb.context.workspace = IRB::WorkSpace.new(binding)
+      trap('INT') do
+        @irb.signal_handle
+      end
+
+      UI.message('Welcome to fastlane interactive!')
+
+      catch(:IRB_EXIT) { @irb.eval_input }
+    end
+  end
+end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Sometimes I wish to send code for users to test directly into their setup. This would allow to do it.

### Description

I've used the similar code in our u3d project here for years https://github.com/DragonBox/u3d/blob/8c156f401f2b8443936e3873b8566a965c783165/lib/u3d/commands.rb#L68-L80

### Testing Steps

