### PR TITLE
Fix WARNINGs when building fastlane gemspec

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -107,6 +107,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('tty-spinner', '>= 0.8.0', '< 1.0.0') # loading indicators
   spec.add_dependency('word_wrap', '~> 1.0.0') # to add line breaks for tables with long strings
   spec.add_dependency('xcodeproj', '>= 1.13.0', '< 2.0.0') # Modify Xcode projects
-  spec.add_dependency('xcpretty-travis-formatter', '>= 1.0.1', '< 2.0.0')
+  spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3', '< 2.0.0')
   spec.add_dependency('xcpretty', '~> 0.3.0') # prettify xcodebuild output
 end

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
                         "Aaron Brager"]
 
   spec.email         = ["fastlane@krausefx.com"]
-  spec.summary       = Fastlane::DESCRIPTION
+  spec.summary       = Fastlane::SUMMARY
   spec.description   = Fastlane::DESCRIPTION
   spec.homepage      = "https://fastlane.tools"
   spec.license       = "MIT"
@@ -75,7 +75,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('babosa', '>= 1.0.3', '< 2.0.0') # library for creating human-friendly identifiers, aka "slugs"
   spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
   spec.add_dependency('CFPropertyList', '>= 2.3', '< 4.0.0') # Needed to be able to read binary plist format
-  spec.add_dependency('colored') # colored terminal output
+  spec.add_dependency('colored', '~> 1.2') # colored terminal output
   spec.add_dependency('commander', '~> 4.6') # CLI parser
   spec.add_dependency('dotenv', '>= 2.1.1', '< 3.0.0')
   spec.add_dependency('emoji_regex', '>= 0.1', '< 4.0') # Used to scan for Emoji in the changelog
@@ -96,7 +96,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('mini_magick', '>= 4.9.4', '< 5.0.0') # To open, edit and export PSD files
   spec.add_dependency('multipart-post', '>= 2.0.0', '< 3.0.0') # Needed for uploading builds to appetize
   spec.add_dependency('naturally', '~> 2.2') # Used to sort strings with numbers in a human-friendly way
-  spec.add_dependency('optparse', '>= 0.1.1') # Used to parse options with Commander
+  spec.add_dependency('optparse', '>= 0.1.1', '< 1.0.0') # Used to parse options with Commander
   spec.add_dependency('plist', '>= 3.1.0', '< 4.0.0') # Needed for set_build_number_repository and get_info_plist_value actions
   spec.add_dependency('rubyzip', '>= 2.0.0', '< 3.0.0') # fix swift/ipa in gym
   spec.add_dependency('security', '= 0.1.3') # macOS Keychain manager, a dead project, no updates expected
@@ -107,6 +107,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('tty-spinner', '>= 0.8.0', '< 1.0.0') # loading indicators
   spec.add_dependency('word_wrap', '~> 1.0.0') # to add line breaks for tables with long strings
   spec.add_dependency('xcodeproj', '>= 1.13.0', '< 2.0.0') # Modify Xcode projects
-  spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3')
+  spec.add_dependency('xcpretty-travis-formatter', '>= 1.0.1', '< 2.0.0')
   spec.add_dependency('xcpretty', '~> 0.3.0') # prettify xcodebuild output
 end

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,6 @@
 module Fastlane
   VERSION = '2.219.0'.freeze
+  SUMMARY = "The easiest way to build and release mobile apps.".freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '1.50.2'.freeze


### PR DESCRIPTION
Annoying warnings when building the gemspec. Clutters the logs and the mind.

```
$ gem build fastlane.gemspec
WARNING:  description and summary are identical
WARNING:  open-ended dependency on colored (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on optparse (>= 0.1.1) is not recommended
  if optparse is semantically versioned, use:
    add_runtime_dependency 'optparse', '~> 0.1', '>= 0.1.1'
WARNING:  open-ended dependency on xcpretty-travis-formatter (>= 0.0.3) is not recommended
  if xcpretty-travis-formatter is semantically versioned, use:
    add_runtime_dependency 'xcpretty-travis-formatter', '~> 0.0', '>= 0.0.3'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: fastlane
  Version: 2.219.0
  File: fastlane-2.219.0.gem
```

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

### Description

* tightened some dependencies
* added a gem summary

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
