### PR TITLE
Fix gemspec warnings (update `Gemfile.lock`)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       aws-sdk-s3 (~> 1.0)
       babosa (>= 1.0.3, < 2.0.0)
       bundler (>= 1.12.0, < 3.0.0)
-      colored
+      colored (~> 1.2)
       commander (~> 4.6)
       dotenv (>= 2.1.1, < 3.0.0)
       emoji_regex (>= 0.1, < 4.0)
@@ -29,7 +29,7 @@ PATH
       mini_magick (>= 4.9.4, < 5.0.0)
       multipart-post (>= 2.0.0, < 3.0.0)
       naturally (~> 2.2)
-      optparse (>= 0.1.1)
+      optparse (>= 0.1.1, < 1.0.0)
       plist (>= 3.1.0, < 4.0.0)
       rubyzip (>= 2.0.0, < 3.0.0)
       security (= 0.1.3)
@@ -41,7 +41,7 @@ PATH
       word_wrap (~> 1.0.0)
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
-      xcpretty-travis-formatter (>= 0.0.3)
+      xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Was missing in #21807
