### PR TITLE
[ci] add Xcode 15.2 to the suite of tests and remove duplicate CircleCI test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,11 +295,6 @@ workflows:
           ruby_version: '3.1'
           ruby_opt: -W:deprecated
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'
-          xcode_version: '13.4.1'
-          ruby_version: '3.1'
-          ruby_opt: -W:deprecated
-      - tests_macos:
           name: 'Execute tests on macOS (Xcode 14.3.1, Ruby 3.2)'
           xcode_version: '14.3.1'
           ruby_version: '3.2'
@@ -307,6 +302,11 @@ workflows:
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 15.0.1, Ruby 3.2)'
           xcode_version: '15.0.1'
+          ruby_version: '3.2'
+          ruby_opt: -W:deprecated
+      - tests_macos:
+          name: 'Execute tests on macOS (Xcode 15.2.0, Ruby 3.2)'
+          xcode_version: '15.2.0'
           ruby_version: '3.2'
           ruby_opt: -W:deprecated
       - tests_ubuntu:


### PR DESCRIPTION
The cleanups in #21777 revealed/caused a duplicate environment in circle. So let's add a more modern one and remove the duplicate.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
