### PR TITLE
[action][appetize] Raise error when the API returns an unsuccessful response

### DIFF
--- a/fastlane/lib/fastlane/actions/appetize.rb
+++ b/fastlane/lib/fastlane/actions/appetize.rb
@@ -50,6 +50,10 @@ module Fastlane
 
         response = http.request(req)
 
+        unless response.code.to_i.between?(200, 299)
+          UI.user_error!("Error uploading to Appetize.io: received HTTP #{response.code} with body #{response.body}")
+        end
+
         parse_response(response) # this will raise an exception if something goes wrong
 
         UI.message("App URL: #{Actions.lane_context[SharedValues::APPETIZE_APP_URL]}")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves #21786 

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
Adds a check for the response status code. Tested via unit test as well as with the Appetize API by running the action using an invalid token as described in #21786 
