### PR TITLE
[doc] Update instructions to install fastlane

### DIFF
--- a/match/lib/assets/READMETemplate.md
+++ b/match/lib/assets/READMETemplate.md
@@ -14,7 +14,7 @@ Make sure you have the latest version of the Xcode command line tools installed:
 xcode-select --install
 ```
 
-Install _fastlane_ using bundler by following instructions here : https://docs.fastlane.tools
+Install _fastlane_ using bundler by following instructions here on [fastlane docs](https://docs.fastlane.tools).
 
 or alternatively using 
 

--- a/match/lib/assets/READMETemplate.md
+++ b/match/lib/assets/READMETemplate.md
@@ -14,13 +14,11 @@ Make sure you have the latest version of the Xcode command line tools installed:
 xcode-select --install
 ```
 
-Install _fastlane_ using
+Install _fastlane_ using bundler by following instructions here : https://docs.fastlane.tools
 
-```
-[sudo] gem install fastlane -NV
-```
+or alternatively using 
 
-or alternatively using `brew install fastlane`
+`brew install fastlane`
 
 ### Usage
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

- A non recommended way to install fastlane appears first in the instructions. It's nice to have a direct link to installation instructions from fastlane docs instead.

### Description

##### Before
- Instructions mention a non recommended way to install fastlane
##### After
- Instructions link to installation instructions on fastlane docs.

### Testing Steps

Nothing to test, it's just docs.
