### PR TITLE
[match] fix devices fetch for tvOS platform

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -70,6 +70,8 @@ module Spaceship
                             Spaceship::ConnectAPI::Platform::MAC_OS
                           when :ios
                             Spaceship::ConnectAPI::Platform::IOS
+                          when :tvos
+                            Spaceship::ConnectAPI::Platform::TV_OS
                           when :catalyst
                             Spaceship::ConnectAPI::Platform::MAC_OS
                           end
@@ -106,9 +108,9 @@ module Spaceship
         end
 
         filter = {
-          status: Spaceship::ConnectAPI::Device::Status::ENABLED,
-          platform: device_platforms.uniq.join(',')
+          status: Spaceship::ConnectAPI::Device::Status::ENABLED
         }
+        filter[:platform] = device_platforms.join(',') unless device_platforms.empty?
 
         devices = Spaceship::ConnectAPI::Device.all(
           client: client,

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -68,10 +68,8 @@ module Spaceship
         device_platform = case platform
                           when :osx, :macos, :mac
                             Spaceship::ConnectAPI::Platform::MAC_OS
-                          when :ios
+                          when :ios, :tvos
                             Spaceship::ConnectAPI::Platform::IOS
-                          when :tvos
-                            Spaceship::ConnectAPI::Platform::TV_OS
                           when :catalyst
                             Spaceship::ConnectAPI::Platform::MAC_OS
                           end
@@ -110,7 +108,7 @@ module Spaceship
         filter = {
           status: Spaceship::ConnectAPI::Device::Status::ENABLED
         }
-        filter[:platform] = device_platforms.join(',') unless device_platforms.empty?
+        filter[:platform] = device_platforms.uniq.join(',') unless device_platforms.empty?
 
         devices = Spaceship::ConnectAPI::Device.all(
           client: client,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #21825.

### Description

1. Add check for :tvos platform.
2. Skip adding filter if device_platforms is empty

### Testing Steps
