### PR TITLE
Properly close PTY parameters to get rid of leaks that cause Pty to fail with 'Can't get Master/Slave device' error [WIP]

### DIFF
--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -17,6 +17,11 @@ describe FastlaneCore do
         ]
         expect(fake_std_in).to receive(:each).and_yield(*fake_std_in).and_raise(Errno::EIO)
 
+        fake_std_out = 'not_really_std_out'
+
+        expect(fake_std_in).to receive(:close)
+        expect(fake_std_out).to receive(:close)
+
         # Make a fake child process so we have a valid PID and $? is set correctly
         expect(PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('ls')
@@ -27,7 +32,7 @@ describe FastlaneCore do
           child_process_id = Process.spawn('echo foo', out: File::NULL)
           expect(Process).to receive(:wait).with(child_process_id)
 
-          block.yield(fake_std_in, 'not_really_std_out', child_process_id)
+          block.yield(fake_std_in, fake_std_out, child_process_id)
         end
 
         result = FastlaneCore::CommandExecutor.execute(command: 'ls')
@@ -45,6 +50,11 @@ describe FastlaneCore do
           "  - Muffins\n"
         ]
 
+        fake_std_out = 'not_really_std_out'
+
+        expect(fake_std_in).to receive(:close)
+        expect(fake_std_out).to receive(:close)
+
         expect(PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('echo foo')
 
@@ -54,7 +64,7 @@ describe FastlaneCore do
           child_process_id = Process.spawn('echo foo', out: File::NULL)
           expect(Process).to receive(:wait).with(child_process_id)
 
-          block.yield(fake_std_in, 'not_really_std_out', child_process_id)
+          block.yield(fake_std_in, fake_std_out, child_process_id)
         end
 
         result = FastlaneCore::CommandExecutor.execute(command: 'echo foo')


### PR DESCRIPTION
While investigating #21792, I recreated issue #8258. This fixes it.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
