### PR TITLE
[snapshot] fix regression introduced in 2.218.0 caused by extraneous method argument in snapshot setup

### DIFF
--- a/snapshot/lib/snapshot/setup.rb
+++ b/snapshot/lib/snapshot/setup.rb
@@ -34,7 +34,7 @@ module Snapshot
       puts("✅  Successfully created #{snapshot_helper_filename} '#{File.join(path, snapshot_helper_filename)}'".green)
       puts("✅  Successfully created new Snapfile at '#{snapfile_path}'".green)
       puts("-------------------------------------------------------".yellow)
-      print_instructions(snapshot_helper_filename: snapshot_helper_filename, snapfile_path: snapfile_path)
+      print_instructions(snapshot_helper_filename: snapshot_helper_filename)
     end
 
     def self.print_instructions(snapshot_helper_filename: nil)


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #21813 

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
