### PR TITLE
[pilot] add xros as valid option for pilot upload

### DIFF
--- a/pilot/lib/pilot/manager.rb
+++ b/pilot/lib/pilot/manager.rb
@@ -85,8 +85,8 @@ module Pilot
       result ||= FastlaneCore::IpaFileAnalyser.fetch_app_platform(config[:ipa]) if config[:ipa]
       result ||= FastlaneCore::PkgFileAnalyser.fetch_app_platform(config[:pkg]) if config[:pkg]
       if required
-        result ||= UI.input("Please enter the app's platform (appletvos, ios, osx): ")
-        UI.user_error!("App Platform must be ios, appletvos, or osx") unless ['ios', 'appletvos', 'osx'].include?(result)
+        result ||= UI.input("Please enter the app's platform (appletvos, ios, osx, xros): ")
+        UI.user_error!("App Platform must be ios, appletvos, osx, or xros") unless ['ios', 'appletvos', 'osx', 'xros'].include?(result)
         UI.verbose("App Platform (#{result})")
       end
       return result

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -49,7 +49,7 @@ module Pilot
                                      description: "The platform to use (optional)",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       UI.user_error!("The platform can only be ios, appletvos, or osx") unless ['ios', 'appletvos', 'osx'].include?(value)
+                                       UI.user_error!("The platform can only be ios, appletvos, osx, or xros") unless ['ios', 'appletvos', 'osx'].include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :apple_id,
                                      short_option: "-p",

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -49,7 +49,7 @@ module Pilot
                                      description: "The platform to use (optional)",
                                      optional: true,
                                      verify_block: proc do |value|
-                                       UI.user_error!("The platform can only be ios, appletvos, osx, or xros") unless ['ios', 'appletvos', 'osx'].include?(value)
+                                       UI.user_error!("The platform can only be ios, appletvos, osx, or xros") unless ['ios', 'appletvos', 'osx', 'xros'].include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :apple_id,
                                      short_option: "-p",

--- a/pilot/spec/manager_spec.rb
+++ b/pilot/spec/manager_spec.rb
@@ -520,7 +520,7 @@ describe Pilot do
           end
 
           it "asks user to enter the app's platform manually" do
-            expect(UI).to receive(:input).with("Please enter the app's platform (appletvos, ios, osx): ").and_return(fake_app_platform)
+            expect(UI).to receive(:input).with("Please enter the app's platform (appletvos, ios, osx, xros): ").and_return(fake_app_platform)
 
             fetch_app_platform_result = fake_manager.fetch_app_platform
 
@@ -542,7 +542,7 @@ describe Pilot do
           end
 
           it "asks user to enter the app's platform manually" do
-            expect(UI).to receive(:input).with("Please enter the app's platform (appletvos, ios, osx): ").and_return(fake_app_platform)
+            expect(UI).to receive(:input).with("Please enter the app's platform (appletvos, ios, osx, xros): ").and_return(fake_app_platform)
 
             fetch_app_platform_result = fake_manager.fetch_app_platform
 
@@ -566,7 +566,7 @@ describe Pilot do
           end
 
           it "does not ask user to enter the app's platform manually" do
-            expect(UI).not_to receive(:input).with("Please enter the app's platform (appletvos, ios, osx): ")
+            expect(UI).not_to receive(:input).with("Please enter the app's platform (appletvos, ios, osx, xros): ")
 
             fetch_app_platform_result = fake_manager.fetch_app_platform(required: false)
 
@@ -589,12 +589,12 @@ describe Pilot do
 
           allow(UI)
             .to receive(:input)
-            .with("Please enter the app's platform (appletvos, ios, osx): ")
+            .with("Please enter the app's platform (appletvos, ios, osx, xros): ")
             .and_return(invalid_app_platform)
         end
 
         it "raises the 'invalid platform' exception" do
-          expect(UI).to receive(:user_error!).with("App Platform must be ios, appletvos, or osx")
+          expect(UI).to receive(:user_error!).with("App Platform must be ios, appletvos, osx, or xros")
 
           fake_manager.fetch_app_platform
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
The Apple Vision Pro headset officially releases this Friday, and currently the process I use for uploading apps to Apple is blocked because xros is not considered a supported platform by _fastlane pilot_

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
This change adds xros as a valid option everywhere appletvos is mentioned for _pilot_, and also adjusts the specs. Prompted by the discussion https://github.com/fastlane/fastlane/discussions/21802

I updated our resigning service to use my updated local copy of _fastlane_ and was able to `fastlane pilot upload` our vision pro ipa with these changes.

Once this PR is ironed out I'm likely to take a look at adding it to the `deliver` in the hopes of maybe getting a release out ahead of or in line with the vision pro launch if at all possible.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

The command ultimately used to test the upload was `bundle exec fastlane pilot upload --api-key-path <REDACTED> --skip_waiting_for_build_processing --team_id <REDACTED> --ipa <PATH/TO/IPA>`
