### PR TITLE
[action][git_add] Add `force` option

### DIFF
--- a/fastlane/lib/fastlane/actions/git_add.rb
+++ b/fastlane/lib/fastlane/actions/git_add.rb
@@ -17,7 +17,16 @@ module Fastlane
           success_message = "Successfully added all files 💾."
         end
 
-        result = Actions.sh("git add #{paths}", log: FastlaneCore::Globals.verbose?).chomp
+        force = params[:force] ? "--force" : nil
+
+        command = [
+          "git",
+          "add",
+          force,
+          paths
+        ].compact
+
+        result = Actions.sh(command.join(" "), log: FastlaneCore::Globals.verbose?).chomp
         UI.success(success_message)
         return result
       end
@@ -46,6 +55,11 @@ module Fastlane
                                        description: "Shell escapes paths (set to false if using wildcards or manually escaping spaces in :path)",
                                        type: Boolean,
                                        default_value: true,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :force,
+                                       description: "Allow adding otherwise ignored files",
+                                       type: Boolean,
+                                       default_value: false,
                                        optional: true),
           # Deprecated
           FastlaneCore::ConfigItem.new(key: :pathspec,
@@ -76,7 +90,8 @@ module Fastlane
           'git_add(path: "./Frameworks/*", shell_escape: false)',
           'git_add(path: ["*.h", "*.m"], shell_escape: false)',
           'git_add(path: "./Frameworks/*", shell_escape: false)',
-          'git_add(path: "*.txt", shell_escape: false)'
+          'git_add(path: "*.txt", shell_escape: false)',
+          'git_add(path: "./tmp/.keep", force: true)'
         ]
       end
 

--- a/fastlane/spec/actions_specs/git_add_spec.rb
+++ b/fastlane/spec/actions_specs/git_add_spec.rb
@@ -69,6 +69,17 @@ describe Fastlane do
         end
       end
 
+      context "as string with force option" do
+        let(:path) { "myfile.txt" }
+
+        it "executes the correct git command" do
+          allow(Fastlane::Actions).to receive(:sh).with("git add --force #{path}", anything).and_return("")
+          result = Fastlane::FastFile.new.parse("lane :test do
+            git_add(path: '#{path}', force: true)
+          end").runner.execute(:test)
+        end
+      end
+
       context "without parameters" do
         it "executes the correct git command" do
           allow(Fastlane::Actions).to receive(:sh).with("git add .", anything).and_return("")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

I want to commit a ignored file in CI.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Add force option to git_add action.
The default value of the action is `false`.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
