### PR TITLE
[fastlane_core] fix the display of non-unicode characters when printing lane context

### DIFF
--- a/fastlane/lib/fastlane/lane_manager_base.rb
+++ b/fastlane/lib/fastlane/lane_manager_base.rb
@@ -67,7 +67,7 @@ module Fastlane
 
       # Print a nice table unless in FastlaneCore::Globals.verbose? mode
       rows = Actions.lane_context.collect do |key, content|
-        [key, content.to_s]
+        [key, content.to_s.encode("utf-8", invalid: :replace)]
       end
 
       require 'terminal-table'

--- a/fastlane/lib/fastlane/lane_manager_base.rb
+++ b/fastlane/lib/fastlane/lane_manager_base.rb
@@ -67,7 +67,7 @@ module Fastlane
 
       # Print a nice table unless in FastlaneCore::Globals.verbose? mode
       rows = Actions.lane_context.collect do |key, content|
-        [key, content.to_s.encode("utf-8", invalid: :replace)]
+        [key, content.to_s]
       end
 
       require 'terminal-table'

--- a/fastlane/spec/lane_manager_base_spec.rb
+++ b/fastlane/spec/lane_manager_base_spec.rb
@@ -29,14 +29,6 @@ describe Fastlane do
       it "doesn't crash when lane_context contains non unicode text" do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = "test\xAE"
 
-        cleaned_row_data = [[:LANE_NAME, "test�"]]
-
-        table_data = FastlaneCore::PrintTable.transform_output(cleaned_row_data)
-        expect(FastlaneCore::PrintTable).to receive(:transform_output).with(cleaned_row_data).and_call_original
-        expect(Terminal::Table).to receive(:new).with({
-          title: "Lane Context".yellow,
-          rows: table_data
-        })
         Fastlane::LaneManagerBase.print_lane_context
       end
     end

--- a/fastlane/spec/lane_manager_base_spec.rb
+++ b/fastlane/spec/lane_manager_base_spec.rb
@@ -1,0 +1,33 @@
+describe Fastlane do
+  describe Fastlane::LaneManagerBase do
+    describe "#print_lane_context" do
+      it "prints lane context" do
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = "test"
+
+        cleaned_row_data = [[:LANE_NAME, "test"]]
+
+        table_data = FastlaneCore::PrintTable.transform_output(cleaned_row_data)
+        expect(FastlaneCore::PrintTable).to receive(:transform_output).with(cleaned_row_data).and_call_original
+        expect(Terminal::Table).to receive(:new).with({
+          title: "Lane Context".yellow,
+          rows: table_data
+        })
+        Fastlane::LaneManagerBase.print_lane_context
+      end
+
+      it "doesn't crash when lane_context contains non unicode text" do
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = "test\xAE"
+
+        cleaned_row_data = [[:LANE_NAME, "test�"]]
+
+        table_data = FastlaneCore::PrintTable.transform_output(cleaned_row_data)
+        expect(FastlaneCore::PrintTable).to receive(:transform_output).with(cleaned_row_data).and_call_original
+        expect(Terminal::Table).to receive(:new).with({
+          title: "Lane Context".yellow,
+          rows: table_data
+        })
+        Fastlane::LaneManagerBase.print_lane_context
+      end
+    end
+  end
+end

--- a/fastlane/spec/lane_manager_base_spec.rb
+++ b/fastlane/spec/lane_manager_base_spec.rb
@@ -15,6 +15,17 @@ describe Fastlane do
         Fastlane::LaneManagerBase.print_lane_context
       end
 
+      it "prints lane context" do
+        Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = "test"
+
+        expect(UI).to receive(:important).with('Lane Context:'.yellow)
+        expect(UI).to receive(:message).with(Fastlane::Actions.lane_context)
+
+        FastlaneSpec::Env.with_verbose(true) do
+          Fastlane::LaneManagerBase.print_lane_context
+        end
+      end
+
       it "doesn't crash when lane_context contains non unicode text" do
         Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::LANE_NAME] = "test\xAE"
 

--- a/fastlane_core/lib/fastlane_core/print_table.rb
+++ b/fastlane_core/lib/fastlane_core/print_table.rb
@@ -1,6 +1,22 @@
 require_relative 'configuration/configuration'
 require_relative 'helper'
 
+# Monkey patch Terminal::Table until this is merged
+# https://github.com/tj/terminal-table/pull/131
+# solves https://github.com/fastlane/fastlane/issues/21852
+# loads Terminal::Table first to be able to monkey patch it.
+require 'terminal-table'
+module Terminal
+  class Table
+    class Cell
+      def lines
+        # @value.to_s.split(/\n/)
+        @value.to_s.encode("utf-8", invalid: :replace).split(/\n/)
+      end
+    end
+  end
+end
+
 module FastlaneCore
   class PrintTable
     class << self


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Resolves #21852

Note that I think the real fix should be either in
* Terminal::Table
* FastlaneCore::PrintTable.transform_output

So I'll mark this as WIP for now. 

```
/Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/cell.rb:51:in `split': [!] invalid byte sequence in UTF-8 (ArgumentError)
        @value.to_s.split(/\n/)
                          ^^^^
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/cell.rb:51:in `lines'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/cell.rb:71:in `value_for_column_width_recalc'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:233:in `block (2 levels) in recalc_column_widths'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:232:in `each'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:232:in `block in recalc_column_widths'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:230:in `each'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:230:in `recalc_column_widths'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:368:in `column_widths'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:97:in `column_width'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/separator.rb:33:in `block in render'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/separator.rb:32:in `each'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/separator.rb:32:in `render'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:171:in `block in render'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:171:in `map'
	from /Users/vagrant/git/vendor/bundle/ruby/3.2.0/gems/terminal-table-3.0.2/lib/terminal-table/table.rb:171:in `render'
```

### Description

Implemented a fix in `terminal-table` gem https://github.com/tj/terminal-table/pull/131

But until it is fixed, I suspect we can live with a local monkey patching? 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
