### PR TITLE
Add xros as supported platform everywhere appletvos appears

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -99,7 +99,7 @@ module Deliver
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
-                                       UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)
+                                       UI.user_error!("The platform can only be ios, appletvos, osx, or xros") unless %('ios', 'appletvos', 'osx', 'xros').include?(value)
                                      end),
 
         # live version

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -172,7 +172,7 @@ module Deliver
       transporter = transporter_for_selected_team
 
       case platform
-      when "ios", "appletvos"
+      when "ios", "appletvos", "xros"
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           ipa_path: ipa_path,
@@ -209,7 +209,7 @@ module Deliver
       transporter = transporter_for_selected_team
 
       case platform
-      when "ios", "appletvos"
+      when "ios", "appletvos", "xros"
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           ipa_path: ipa_path,

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -186,7 +186,7 @@ module Fastlane
                                        optional: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)
+                                         UI.user_error!("The platform can only be ios, appletvos, osx, or xros") unless %('ios', 'appletvos', 'osx', 'xros').include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :team_name,
                                        short_option: "-e",

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -375,6 +375,7 @@ The available options:
 - 'ios'
 - 'appletvos'
 - 'osx'
+- 'xros'
 
 
 ### Non-Localized

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -290,7 +290,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :platform,
                                        short_option: "-p",
                                        env_name: "DOWNLOAD_DSYMS_PLATFORM",
-                                       description: "The app platform for dSYMs you wish to download (ios, appletvos)",
+                                       description: "The app platform for dSYMs you wish to download (ios, appletvos, xros)",
                                        default_value: :ios),
           FastlaneCore::ConfigItem.new(key: :version,
                                        short_option: "-v",
@@ -351,7 +351,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :appletvos].include?(platform)
+        [:ios, :appletvos, :xros].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -83,7 +83,7 @@ module Fastlane
                                        optional: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, osx, or appletvos") unless %('osx', ios', 'appletvos').include?(value)
+                                         UI.user_error!("The platform can only be ios, osx, xros, or appletvos") unless %('osx', ios', 'appletvos', 'xros').include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",

--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -169,10 +169,10 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        env_name: "FL_SET_CHANGELOG_PLATFORM",
-                                       description: "The platform of the app (ios, appletvos, mac)",
+                                       description: "The platform of the app (ios, appletvos, mac, xros)",
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         available = ['ios', 'appletvos', 'mac']
+                                         available = ['ios', 'appletvos', 'mac', 'xros']
                                          UI.user_error!("Invalid platform '#{value}', must be #{available.join(', ')}") unless available.include?(value)
                                        end)
         ]
@@ -183,7 +183,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :appletvos, :mac].include?(platform)
+        [:ios, :appletvos, :mac, :xros].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -179,10 +179,10 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        env_name: "FL_UPLOAD_SYMBOLS_TO_CRASHLYTICS_PLATFORM",
-                                       description: "The platform of the app (ios, appletvos, mac)",
+                                       description: "The platform of the app (ios, appletvos, mac, xros)",
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         available = ['ios', 'appletvos', 'mac']
+                                         available = ['ios', 'appletvos', 'mac', 'xros']
                                          UI.user_error!("Invalid platform '#{value}', must be #{available.join(', ')}") unless available.include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :dsym_worker_threads,
@@ -216,7 +216,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :appletvos].include?(platform)
+        [:ios, :appletvos, :xros].include?(platform)
       end
 
       def self.example_code


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context
Adds xros to valid platform options to support the new Apple Vision Pro

### Description
I previously added xros to _deliver_ for uploads with https://github.com/fastlane/fastlane/pull/21841 and was able to test that myself, but I do not use the _deliver_ functionality or other _fastlane_ actions I modified so while the specs pass I am hoping to get some assistance with the functional testing.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
