### PR TITLE
[match] Include visionOS devices in provisioning profiles 

### DIFF
--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -89,7 +89,6 @@ module Spaceship
       VISION_OS = "VISION_OS"
       WATCH_OS = "WATCH_OS"
 
-
       ALL = [IOS, MAC_OS, TV_OS, VISION_OS, WATCH_OS]
 
       def self.map(platform)

--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -86,9 +86,11 @@ module Spaceship
       IOS = "IOS"
       MAC_OS = "MAC_OS"
       TV_OS = "TV_OS"
+      VISION_OS = "VISION_OS"
       WATCH_OS = "WATCH_OS"
 
-      ALL = [IOS, MAC_OS, TV_OS, WATCH_OS]
+
+      ALL = [IOS, MAC_OS, TV_OS, VISION_OS, WATCH_OS]
 
       def self.map(platform)
         return platform if ALL.include?(platform)
@@ -101,6 +103,8 @@ module Spaceship
           return Spaceship::ConnectAPI::Platform::MAC_OS
         when :ios
           return Spaceship::ConnectAPI::Platform::IOS
+        when :xros, :visionos
+          return Spaceship::ConnectAPI::Platform::VISION_OS
         else
           raise "Cannot find a matching platform for '#{platform}' - valid values are #{ALL.join(', ')}"
         end
@@ -123,7 +127,7 @@ module Spaceship
         case platform.to_sym
         when :osx, :macos, :mac
           return Spaceship::ConnectAPI::Platform::MAC_OS
-        when :ios
+        when :ios, :xros, :visionos
           return Spaceship::ConnectAPI::Platform::IOS
         else
           raise "Cannot find a matching platform for '#{platform}' - valid values are #{ALL.join(', ')}"

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -30,6 +30,7 @@ module Spaceship
         IPOD = "IPOD"
         APPLE_TV = "APPLE_TV"
         MAC = "MAC"
+        APPLE_VISION_PRO = "APPLE_VISION_PRO"
 
         # As of 2022-11-12, this is not officially supported by App Store Connect API
         APPLE_SILICON_MAC = "APPLE_SILICON_MAC"
@@ -68,7 +69,7 @@ module Spaceship
         device_platform = case platform
                           when :osx, :macos, :mac
                             Spaceship::ConnectAPI::Platform::MAC_OS
-                          when :ios, :tvos
+                          when :ios, :tvos, :xros, :visionos
                             Spaceship::ConnectAPI::Platform::IOS
                           when :catalyst
                             Spaceship::ConnectAPI::Platform::MAC_OS
@@ -86,7 +87,8 @@ module Spaceship
               Spaceship::ConnectAPI::Device::DeviceClass::IPAD,
               Spaceship::ConnectAPI::Device::DeviceClass::IPHONE,
               Spaceship::ConnectAPI::Device::DeviceClass::IPOD,
-              Spaceship::ConnectAPI::Device::DeviceClass::APPLE_WATCH
+              Spaceship::ConnectAPI::Device::DeviceClass::APPLE_WATCH,
+              Spaceship::ConnectAPI::Device::DeviceClass::APPLE_VISION_PRO
             ]
           when :tvos
             [


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
See https://github.com/fastlane/fastlane/issues/21860 for more context.


### Description
Added `APPLE_VISION_PRO` to the `DeviceClass` enum in order to include Vision Pro devices in iOS provisioning profiles.
Also added `VISION_OS` to SpaceShip to support the platform in AppStore connect.


### Testing Steps
Generated new provisioning profiles and validated that the devices are present in the iOS provisioning profiles.

Did it with the following steps:
```
profile=$(security cms -D -i <PATH-TO_PROFILE>)
echo $profile | grep "<DEVICE_UDID>"
```
This should return successfully if the device is present in the profile.