### PR TITLE
[fix] drop old code made for ruby < 2.6

### DIFF
--- a/deliver/lib/deliver/download_screenshots.rb
+++ b/deliver/lib/deliver/download_screenshots.rb
@@ -1,5 +1,6 @@
 require_relative 'module'
 require 'spaceship'
+require 'open-uri'
 
 module Deliver
   class DownloadScreenshots
@@ -67,7 +68,7 @@ module Deliver
           end
 
           path = File.join(containing_folder, file_name)
-          File.binwrite(path, FastlaneCore::Helper.open_uri(url).read)
+          File.binwrite(path, URI.open(url).read)
         end
       end
     end

--- a/fastlane/actions/plugin_scores.rb
+++ b/fastlane/actions/plugin_scores.rb
@@ -19,12 +19,13 @@ module Fastlane
       end
 
       def self.fetch_plugins(cache_path)
+        require 'open-uri'
         page = 1
         plugins = []
         loop do
           url = "https://rubygems.org/api/v1/search.json?query=fastlane-plugin-&page=#{page}"
           puts("RubyGems API Request: #{url}")
-          results = JSON.parse(FastlaneCore::Helper.open_uri(url).read)
+          results = JSON.parse(URI.open(url).read)
           break if results.count == 0
 
           plugins += results.collect do |current|

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -21,8 +21,9 @@ module Fastlane
         # download certificate
         unless File.exist?(params[:certificate]) && File.size(params[:certificate]) > 0
           UI.message("Downloading root certificate from (#{ROOT_CERTIFICATE_URL}) to path '#{params[:certificate]}'")
+          require 'open-uri'
           File.open(params[:certificate], "w:ASCII-8BIT") do |file|
-            file.write(FastlaneCore::Helper.open_uri(ROOT_CERTIFICATE_URL, "rb").read)
+            file.write(URI.open(ROOT_CERTIFICATE_URL, "rb").read)
           end
         end
 

--- a/fastlane/lib/fastlane/plugins/plugin_fetcher.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_fetcher.rb
@@ -7,13 +7,14 @@ module Fastlane
     # Returns an array of FastlanePlugin objects
     def self.fetch_gems(search_query: nil)
       require 'json'
+      require 'open-uri'
 
       page = 1
       plugins = []
       loop do
         url = "https://rubygems.org/api/v1/search.json?query=#{PluginManager.plugin_prefix}&page=#{page}"
         FastlaneCore::UI.verbose("RubyGems API Request: #{url}")
-        results = JSON.parse(FastlaneCore::Helper.open_uri(url).read)
+        results = JSON.parse(URI.open(url).read)
         break if results.count == 0
 
         plugins += results.collect do |current|

--- a/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_info_collector.rb
@@ -66,8 +66,9 @@ module Fastlane
     # Checks if the gem name is still free on RubyGems
     def gem_name_taken?(name)
       require 'json'
+      require 'open-uri'
       url = "https://rubygems.org/api/v1/gems/#{name}.json"
-      response = JSON.parse(FastlaneCore::Helper.open_uri(url).read)
+      response = JSON.parse(URI.open(url).read)
       return !!response['version']
     rescue
       false

--- a/fastlane/lib/fastlane/plugins/plugin_manager.rb
+++ b/fastlane/lib/fastlane/plugins/plugin_manager.rb
@@ -156,9 +156,10 @@ module Fastlane
 
     def self.fetch_gem_info_from_rubygems(gem_name)
       require 'json'
+      require 'open-uri'
       url = "https://rubygems.org/api/v1/gems/#{gem_name}.json"
       begin
-        JSON.parse(FastlaneCore::Helper.open_uri(url).read)
+        JSON.parse(URI.open(url).read)
       rescue
         nil
       end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -482,20 +482,5 @@ module FastlaneCore
         UI.error("Your entries do not match. Please try again")
       end
     end
-
-    # URI.open added by `require 'open-uri'` is not available in Ruby 2.4. This helper lets you open a URI
-    # by choosing appropriate interface to do so depending on Ruby version. This helper is subject to be removed
-    # when fastlane drops Ruby 2.4 support.
-    def self.open_uri(*rest, &block)
-      require 'open-uri'
-
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.5')
-        dup = rest.dup
-        uri = dup.shift
-        URI.parse(uri).open(*dup, &block)
-      else
-        URI.open(*rest, &block)
-      end
-    end
   end
 end

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -243,10 +243,6 @@ module Commander
       ui.error(e.to_s)
       ui.error("")
       ui.error("SSL errors can be caused by various components on your local machine.")
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1')
-        ui.error("Apple has recently changed their servers to require TLS 1.2, which may")
-        ui.error("not be available to your system installed Ruby (#{RUBY_VERSION})")
-      end
       ui.error("")
       ui.error("The best solution is to use the self-contained fastlane version.")
       ui.error("Which ships with a bundled OpenSSL,ruby and all gems - so you don't depend on system libraries")

--- a/fastlane_core/lib/fastlane_core/ui/help_formatter.rb
+++ b/fastlane_core/lib/fastlane_core/ui/help_formatter.rb
@@ -6,11 +6,7 @@ module FastlaneCore
       # fastlane only customizes the global command help
       return super unless name == :help
 
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.6')
-        ERB.new(File.read(File.join(File.dirname(__FILE__), "help.erb")), nil, '-')
-      else
-        ERB.new(File.read(File.join(File.dirname(__FILE__), "help.erb")), trim_mode: '-')
-      end
+      ERB.new(File.read(File.join(File.dirname(__FILE__), "help.erb")), trim_mode: '-')
     end
   end
 end

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -230,37 +230,5 @@ describe FastlaneCore do
         expect(FastlaneCore::Helper.fastlane_enabled?).to be(true)
       end
     end
-
-    describe '#open_uri' do
-      before do
-        stub_request(:get, 'https://fastlane.tools').to_return(body: 'SOME_TEXT', status: 200)
-      end
-
-      it 'performs URI.open and return IO like object that can be read' do
-        expect(FastlaneCore::Helper.open_uri('https://fastlane.tools')).to respond_to(:read)
-      end
-
-      it 'performs URI.open with block' do
-        is_block_called = false
-        FastlaneCore::Helper.open_uri('https://fastlane.tools') do |content|
-          expect(content).to respond_to(:read)
-          is_block_called = true
-        end
-        expect(is_block_called).to be(true)
-      end
-
-      it 'performs URI.open with options' do
-        expect(FastlaneCore::Helper.open_uri('https://fastlane.tools', 'rb')).to respond_to(:read)
-      end
-
-      it 'performs URI.open with options and block' do
-        is_block_called = false
-        FastlaneCore::Helper.open_uri('https://fastlane.tools', 'rb') do |content|
-          expect(content).to respond_to(:read)
-          is_block_called = true
-        end
-        expect(is_block_called).to be(true)
-      end
-    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Please review #21880 first as this PR also contains it.

### Description

We have some old code, and some of it causes issues with CodeQL. So let's get rid of it.

### Testing Steps

Hopefully I didn't break anything :) 