### PR TITLE
Strengthen some checks that trigger Github's CodeQL security checks

### DIFF
--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -52,7 +52,7 @@ module Fastlane
           self.homepage = hash["homepage_uri"] || hash["documentation_uri"]
           self.raw_hash = hash
 
-          has_github_page = self.homepage.to_s.include?("https://github.com") # Here we can add non GitHub support one day
+          has_github_page = self.homepage.to_s.start_with?("https://github.com") # Here we can add non GitHub support one day
 
           self.data = {
             has_homepage: self.homepage.to_s.length > 5,

--- a/fastlane/spec/actions_specs/flock_spec.rb
+++ b/fastlane/spec/actions_specs/flock_spec.rb
@@ -14,7 +14,7 @@ describe Fastlane do
       context 'options' do
         before do
           ENV['FL_FLOCK_BASE_URL'] = 'https://example.com'
-          stub_request(:any, /example.com/)
+          stub_request(:any, /example\.com/)
         end
 
         it 'requires message' do

--- a/fastlane/spec/env_spec.rb
+++ b/fastlane/spec/env_spec.rb
@@ -4,7 +4,7 @@ require "fastlane/cli_tools_distributor"
 describe Fastlane do
   describe Fastlane::EnvironmentPrinter do
     before do
-      stub_request(:get, %r{https:\/\/rubygems.org\/api\/v1\/gems\/.*}).
+      stub_request(:get, %r{https:\/\/rubygems\.org\/api\/v1\/gems\/.*}).
         to_return(status: 200, body: '{"version": "0.16.2"}', headers: {})
     end
 

--- a/fastlane/spec/env_spec.rb
+++ b/fastlane/spec/env_spec.rb
@@ -4,7 +4,7 @@ require "fastlane/cli_tools_distributor"
 describe Fastlane do
   describe Fastlane::EnvironmentPrinter do
     before do
-      stub_request(:get, %r{https:\/\/rubygems\.org\/api\/v1\/gems\/.*}).
+      stub_request(:get, %r{https://rubygems\.org\/api\/v1\/gems\/.*}).
         to_return(status: 200, body: '{"version": "0.16.2"}', headers: {})
     end
 

--- a/match/spec/storage/gitlab/client_spec.rb
+++ b/match/spec/storage/gitlab/client_spec.rb
@@ -101,7 +101,7 @@ describe Match do
           { id: 2, name: 'file2' }
         ].to_json
 
-        stub_request(:get, /gitlab.example.com/).
+        stub_request(:get, /gitlab\.example\.com/).
           with(headers: { 'PRIVATE-TOKEN' => 'abc123' }).
           to_return(status: 200, body: response)
 
@@ -111,7 +111,7 @@ describe Match do
       end
 
       it 'returns an empty array if there are results' do
-        stub_request(:get, /gitlab.example.com/).
+        stub_request(:get, /gitlab\.example\.com/).
           with(headers: { 'PRIVATE-TOKEN' => 'abc123' }).
           to_return(status: 200, body: [].to_json)
 
@@ -119,7 +119,7 @@ describe Match do
       end
 
       it 'requests 100 files from the API' do
-        stub_request(:get, /gitlab.example.com/).
+        stub_request(:get, /gitlab\.example\.com/).
           to_return(status: 200, body: [].to_json)
 
         files = subject.files
@@ -128,7 +128,7 @@ describe Match do
       end
 
       it 'raises an exception for a non-json response' do
-        stub_request(:get, /gitlab.example.com/).
+        stub_request(:get, /gitlab\.example\.com/).
           with(headers: { 'PRIVATE-TOKEN' => 'abc123' }).
           to_return(status: 200, body: 'foo')
 

--- a/spaceship/spec/mock_servers.rb
+++ b/spaceship/spec/mock_servers.rb
@@ -5,9 +5,9 @@ RSpec.configure do |config|
   config.include(WebMock::API)
 
   config.before do
-    stub_request(:any, %r(appstoreconnect.apple.com/testflight/v2)).to_rack(MockAPI::TestFlightServer)
-    stub_request(:any, %r(developer.apple.com/services-account/QH65B2/account/auth/key)).to_rack(MockAPI::DeveloperPortalServer)
-    stub_request(:any, %r(developer.apple.com/services-account/QH65B2/account/ios/identifiers/.*OMC(s){0,1}\.action)).to_rack(MockAPI::DeveloperPortalServer)
+    stub_request(:any, %r(appstoreconnect\.apple.com/testflight/v2)).to_rack(MockAPI::TestFlightServer)
+    stub_request(:any, %r(developer\.apple\.com/services-account/QH65B2/account/auth/key)).to_rack(MockAPI::DeveloperPortalServer)
+    stub_request(:any, %r(developer\.apple\.com/services-account/QH65B2/account/ios/identifiers/.*OMC(s){0,1}\.action)).to_rack(MockAPI::DeveloperPortalServer)
   end
 
   config.after do

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -259,7 +259,7 @@ describe Spaceship::Client do
                                                 "deviceIds",
                                                 "appId",
                                                 "certificateIds")
-        expect(a_request(:post, /developerservices2.apple.com/)).to have_been_made
+        expect(a_request(:post, /developerservices2\.apple\.com/)).to have_been_made
       end
     end
 


### PR DESCRIPTION
CodeQL generates quite a few security warnings. Some are false positives, some are innocuous issues like the one fixed by this PR.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

### Description

### Testing Steps
