### PR TITLE
[fix] Update simctl command in device_manager.rb [21893]

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -13,7 +13,7 @@ module FastlaneCore
 
       def runtime_build_os_versions
         @runtime_build_os_versions ||= begin
-          output, status = Open3.capture2('xcrun simctl list runtimes -j')
+          output, status = Open3.capture2('xcrun simctl list -j runtimes')
           raise status unless status.success?
           json = JSON.parse(output)
           json['runtimes'].map { |h| [h['buildversion'], h['version']] }.to_h

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -23,7 +23,7 @@ describe FastlaneCore do
 
     it 'raises an error if broken xcrun simctl list runtimes' do
       status = double('status', "success?": true)
-      expect(Open3).to receive(:capture2).with("xcrun simctl list runtimes -j").and_return(['garbage', status])
+      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return(['garbage', status])
 
       expect do
         FastlaneCore::DeviceManager.runtime_build_os_versions
@@ -439,7 +439,7 @@ describe FastlaneCore do
     it 'properly parses `xcrun simctl list runtimes` to associate runtime builds with their exact OS version' do
       status = double('status', "success?": true)
       runtime_output = File.read('./fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutput')
-      expect(Open3).to receive(:capture2).with("xcrun simctl list runtimes -j").and_return([runtime_output, status])
+      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([runtime_output, status])
 
       expect(FastlaneCore::DeviceManager.runtime_build_os_versions['21A328']).to eq('17.0')
       expect(FastlaneCore::DeviceManager.runtime_build_os_versions['21A342']).to eq('17.0.1')


### PR DESCRIPTION
Resolves [21893](https://github.com/fastlane/fastlane/issues/21893)

When run_tests executes, it attempts to get a list of installed runtimes in json format. This fails with Xcode 14.n and 15.n. The reason is that the following command is used to get the list of runtimes: `xcrun simctl list runtimes -j`.

I'm unsure if this worked in older versions of Xcode, but it no longer does. The output modifier must come BEFORE `runtimes` in the command, e.g. `xcrun simctl list -j runtimes`

Running rspec via `bundle exec` just gives the following Output:
   ```
No examples found.


Finished in 0.00026 seconds (files took 0.04599 seconds to load)
0 examples, 0 failures
```

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass. 
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

`run_tests` was failing do to bad simctl command.

### Description

Simply moved the `-j` (JSON) option to immediately after the `list` directive. 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
