### PR TITLE
[spaceship] Move endpoint version from hostname to path

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -69,7 +69,7 @@ module Spaceship
       # Forwarding to class level if using web session.
       def hostname
         if @token
-          return "https://api.appstoreconnect.apple.com/v1/"
+          return "https://api.appstoreconnect.apple.com/"
         end
         return self.class.hostname
       end

--- a/spaceship/lib/spaceship/connect_api/provisioning/client.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/client.rb
@@ -16,7 +16,7 @@ module Spaceship
         end
 
         def self.hostname
-          'https://developer.apple.com/services-account/v1/'
+          'https://developer.apple.com/services-account/'
         end
 
         #

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -4,6 +4,10 @@ module Spaceship
   class ConnectAPI
     module Provisioning
       module API
+        module Version
+          V1 = "v1"
+        end
+
         def provisioning_request_client=(provisioning_request_client)
           @provisioning_request_client = provisioning_request_client
         end
@@ -19,12 +23,12 @@ module Spaceship
 
         def get_bundle_ids(filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
           params = provisioning_request_client.build_params(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort)
-          provisioning_request_client.get("bundleIds", params)
+          provisioning_request_client.get("#{Version::V1}/bundleIds", params)
         end
 
         def get_bundle_id(bundle_id_id: {}, includes: nil)
           params = provisioning_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil)
-          provisioning_request_client.get("bundleIds/#{bundle_id_id}", params)
+          provisioning_request_client.get("#{Version::V1}/bundleIds/#{bundle_id_id}", params)
         end
 
         def post_bundle_id(name:, platform:, identifier:, seed_id:)
@@ -42,7 +46,7 @@ module Spaceship
             }
           }
 
-          provisioning_request_client.post("bundleIds", body)
+          provisioning_request_client.post("#{Version::V1}/bundleIds", body)
         end
 
         #
@@ -51,12 +55,12 @@ module Spaceship
 
         def get_bundle_id_capabilities(bundle_id_id:, includes: nil, limit: nil, sort: nil)
           params = provisioning_request_client.build_params(filter: nil, includes: includes, limit: limit, sort: sort)
-          provisioning_request_client.get("bundleIds/#{bundle_id_id}/bundleIdCapabilities", params)
+          provisioning_request_client.get("#{Version::V1}/bundleIds/#{bundle_id_id}/bundleIdCapabilities", params)
         end
 
         def get_available_bundle_id_capabilities(bundle_id_id:)
           params = provisioning_request_client.build_params(filter: { bundleId: bundle_id_id })
-          provisioning_request_client.get("capabilities", params)
+          provisioning_request_client.get("#{Version::V1}/capabilities", params)
         end
 
         def post_bundle_id_capability(bundle_id_id:, capability_type:, settings: [])
@@ -83,7 +87,7 @@ module Spaceship
               }
             }
           }
-          provisioning_request_client.post("bundleIdCapabilities", body)
+          provisioning_request_client.post("#{Version::V1}/bundleIdCapabilities", body)
         end
 
         def patch_bundle_id_capability(bundle_id_id:, seed_id:, enabled: false, capability_type:, settings: [])
@@ -118,11 +122,11 @@ module Spaceship
             }
           }
 
-          provisioning_request_client.patch("bundleIds/#{bundle_id_id}", body)
+          provisioning_request_client.patch("#{Version::V1}/bundleIds/#{bundle_id_id}", body)
         end
 
         def delete_bundle_id_capability(bundle_id_capability_id:)
-          provisioning_request_client.delete("bundleIdCapabilities/#{bundle_id_capability_id}")
+          provisioning_request_client.delete("#{Version::V1}/bundleIdCapabilities/#{bundle_id_capability_id}")
         end
 
         #
@@ -132,15 +136,15 @@ module Spaceship
         def get_certificates(profile_id: nil, filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
           params = provisioning_request_client.build_params(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort)
           if profile_id.nil?
-            provisioning_request_client.get("certificates", params)
+            provisioning_request_client.get("#{Version::V1}/certificates", params)
           else
-            provisioning_request_client.get("profiles/#{profile_id}/certificates", params)
+            provisioning_request_client.get("#{Version::V1}/profiles/#{profile_id}/certificates", params)
           end
         end
 
         def get_certificate(certificate_id: nil, includes: nil)
           params = provisioning_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil)
-          provisioning_request_client.get("certificates/#{certificate_id}", params)
+          provisioning_request_client.get("#{Version::V1}/certificates/#{certificate_id}", params)
         end
 
         def post_certificate(attributes: {})
@@ -151,13 +155,13 @@ module Spaceship
             }
           }
 
-          provisioning_request_client.post("certificates", body)
+          provisioning_request_client.post("#{Version::V1}/certificates", body)
         end
 
         def delete_certificate(certificate_id: nil)
           raise "Certificate id is nil" if certificate_id.nil?
 
-          provisioning_request_client.delete("certificates/#{certificate_id}")
+          provisioning_request_client.delete("#{Version::V1}/certificates/#{certificate_id}")
         end
 
         #
@@ -167,9 +171,9 @@ module Spaceship
         def get_devices(profile_id: nil, filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
           params = provisioning_request_client.build_params(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort)
           if profile_id.nil?
-            provisioning_request_client.get("devices", params)
+            provisioning_request_client.get("#{Version::V1}/devices", params)
           else
-            provisioning_request_client.get("profiles/#{profile_id}/devices", params)
+            provisioning_request_client.get("#{Version::V1}/profiles/#{profile_id}/devices", params)
           end
         end
 
@@ -187,7 +191,7 @@ module Spaceship
             }
           }
 
-          provisioning_request_client.post("devices", body)
+          provisioning_request_client.post("#{Version::V1}/devices", body)
         end
 
         def patch_device(id: nil, status: nil, new_name: nil)
@@ -206,7 +210,7 @@ module Spaceship
             }
           }
 
-          provisioning_request_client.patch("devices/#{id}", body)
+          provisioning_request_client.patch("#{Version::V1}/devices/#{id}", body)
         end
 
         #
@@ -215,7 +219,7 @@ module Spaceship
 
         def get_profiles(filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
           params = provisioning_request_client.build_params(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort)
-          provisioning_request_client.get("profiles", params)
+          provisioning_request_client.get("#{Version::V1}/profiles", params)
         end
 
         def post_profiles(bundle_id_id: nil, certificates: nil, devices: nil, attributes: {})
@@ -250,19 +254,19 @@ module Spaceship
             }
           }
 
-          provisioning_request_client.post("profiles", body)
+          provisioning_request_client.post("#{Version::V1}/profiles", body)
         end
 
         def get_profile_bundle_id(profile_id: nil)
           raise "Profile id is nil" if profile_id.nil?
 
-          provisioning_request_client.get("profiles/#{profile_id}/bundleId")
+          provisioning_request_client.get("#{Version::V1}/profiles/#{profile_id}/bundleId")
         end
 
         def delete_profile(profile_id: nil)
           raise "Profile id is nil" if profile_id.nil?
 
-          provisioning_request_client.delete("profiles/#{profile_id}")
+          provisioning_request_client.delete("#{Version::V1}/profiles/#{profile_id}")
         end
       end
     end

--- a/spaceship/lib/spaceship/connect_api/testflight/client.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/client.rb
@@ -19,7 +19,7 @@ module Spaceship
         end
 
         def self.hostname
-          'https://appstoreconnect.apple.com/iris/v1/'
+          'https://appstoreconnect.apple.com/iris/'
         end
       end
     end

--- a/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
+++ b/spaceship/lib/spaceship/connect_api/testflight/testflight.rb
@@ -4,6 +4,10 @@ module Spaceship
   class ConnectAPI
     module TestFlight
       module API
+        module Version
+          V1 = "v1"
+        end
+
         def test_flight_request_client=(test_flight_request_client)
           @test_flight_request_client = test_flight_request_client
         end
@@ -19,12 +23,12 @@ module Spaceship
 
         def get_apps(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("apps", params)
+          test_flight_request_client.get("#{Version::V1}/apps", params)
         end
 
         def get_app(app_id: nil, includes: nil)
           params = test_flight_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil)
-          test_flight_request_client.get("apps/#{app_id}", params)
+          test_flight_request_client.get("#{Version::V1}/apps/#{app_id}", params)
         end
 
         #
@@ -33,7 +37,7 @@ module Spaceship
 
         def get_beta_app_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("betaAppLocalizations", params)
+          test_flight_request_client.get("#{Version::V1}/betaAppLocalizations", params)
         end
 
         def post_beta_app_localizations(app_id: nil, attributes: {})
@@ -52,7 +56,7 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.post("betaAppLocalizations", body)
+          test_flight_request_client.post("#{Version::V1}/betaAppLocalizations", body)
         end
 
         def patch_beta_app_localizations(localization_id: nil, attributes: {})
@@ -64,7 +68,7 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.patch("betaAppLocalizations/#{localization_id}", body)
+          test_flight_request_client.patch("#{Version::V1}/betaAppLocalizations/#{localization_id}", body)
         end
 
         #
@@ -73,7 +77,7 @@ module Spaceship
 
         def get_beta_app_review_detail(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("betaAppReviewDetails", params)
+          test_flight_request_client.get("#{Version::V1}/betaAppReviewDetails", params)
         end
 
         def patch_beta_app_review_detail(app_id: nil, attributes: {})
@@ -85,7 +89,7 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.patch("betaAppReviewDetails/#{app_id}", body)
+          test_flight_request_client.patch("#{Version::V1}/betaAppReviewDetails/#{app_id}", body)
         end
 
         #
@@ -94,7 +98,7 @@ module Spaceship
 
         def get_beta_app_review_submissions(filter: {}, includes: nil, limit: nil, sort: nil, cursor: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort, cursor: cursor)
-          test_flight_request_client.get("betaAppReviewSubmissions", params)
+          test_flight_request_client.get("#{Version::V1}/betaAppReviewSubmissions", params)
         end
 
         def post_beta_app_review_submissions(build_id: nil)
@@ -112,12 +116,12 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.post("betaAppReviewSubmissions", body)
+          test_flight_request_client.post("#{Version::V1}/betaAppReviewSubmissions", body)
         end
 
         def delete_beta_app_review_submission(beta_app_review_submission_id: nil)
           params = test_flight_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil, cursor: nil)
-          test_flight_request_client.delete("betaAppReviewSubmissions/#{beta_app_review_submission_id}", params)
+          test_flight_request_client.delete("#{Version::V1}/betaAppReviewSubmissions/#{beta_app_review_submission_id}", params)
         end
 
         #
@@ -126,7 +130,7 @@ module Spaceship
 
         def get_beta_build_localizations(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("betaBuildLocalizations", params)
+          test_flight_request_client.get("#{Version::V1}/betaBuildLocalizations", params)
         end
 
         def post_beta_build_localizations(build_id: nil, attributes: {})
@@ -145,7 +149,7 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.post("betaBuildLocalizations", body)
+          test_flight_request_client.post("#{Version::V1}/betaBuildLocalizations", body)
         end
 
         def patch_beta_build_localizations(localization_id: nil, feedbackEmail: nil, attributes: {})
@@ -157,7 +161,7 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.patch("betaBuildLocalizations/#{localization_id}", body)
+          test_flight_request_client.patch("#{Version::V1}/betaBuildLocalizations/#{localization_id}", body)
         end
 
         #
@@ -166,7 +170,7 @@ module Spaceship
 
         def get_beta_build_metrics(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("betaBuildMetrics", params)
+          test_flight_request_client.get("#{Version::V1}/betaBuildMetrics", params)
         end
 
         #
@@ -175,7 +179,7 @@ module Spaceship
 
         def get_beta_groups(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("betaGroups", params)
+          test_flight_request_client.get("#{Version::V1}/betaGroups", params)
         end
 
         def add_beta_groups_to_build(build_id: nil, beta_group_ids: [])
@@ -188,7 +192,7 @@ module Spaceship
             end
           }
 
-          test_flight_request_client.post("builds/#{build_id}/relationships/betaGroups", body)
+          test_flight_request_client.post("#{Version::V1}/builds/#{build_id}/relationships/betaGroups", body)
         end
 
         def delete_beta_groups_from_build(build_id: nil, beta_group_ids: [])
@@ -201,7 +205,7 @@ module Spaceship
             end
           }
 
-          test_flight_request_client.delete("builds/#{build_id}/relationships/betaGroups", nil, body)
+          test_flight_request_client.delete("#{Version::V1}/builds/#{build_id}/relationships/betaGroups", nil, body)
         end
 
         def create_beta_group(app_id: nil, group_name: nil, is_internal_group: false, public_link_enabled: false, public_link_limit: 10_000, public_link_limit_enabled: false, has_access_to_all_builds: nil)
@@ -232,7 +236,7 @@ module Spaceship
               type: "betaGroups",
             },
           }
-          test_flight_request_client.post("betaGroups", body)
+          test_flight_request_client.post("#{Version::V1}/betaGroups", body)
         end
 
         def patch_group(group_id: nil, attributes: {})
@@ -244,19 +248,19 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.patch("betaGroups/#{group_id}", body)
+          test_flight_request_client.patch("#{Version::V1}/betaGroups/#{group_id}", body)
         end
 
         def delete_beta_group(group_id: nil)
           raise "group_id is nil" if group_id.nil?
 
-          test_flight_request_client.delete("betaGroups/#{group_id}")
+          test_flight_request_client.delete("#{Version::V1}/betaGroups/#{group_id}")
         end
 
         def get_builds_for_beta_group(group_id: nil)
           raise "group_id is nil" if group_id.nil?
 
-          test_flight_request_client.get("betaGroups/#{group_id}/builds")
+          test_flight_request_client.get("#{Version::V1}/betaGroups/#{group_id}/builds")
         end
 
         #
@@ -265,7 +269,7 @@ module Spaceship
 
         def get_beta_testers(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("betaTesters", params)
+          test_flight_request_client.get("#{Version::V1}/betaTesters", params)
         end
 
         # beta_testers - [{email: "", firstName: "", lastName: ""}]
@@ -293,7 +297,7 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.post("bulkBetaTesterAssignments", body)
+          test_flight_request_client.post("#{Version::V1}/bulkBetaTesterAssignments", body)
         end
 
         # attributes - {email: "", firstName: "", lastName: ""}
@@ -315,7 +319,7 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.post("betaTesters", body)
+          test_flight_request_client.post("#{Version::V1}/betaTesters", body)
         end
 
         def add_beta_tester_to_group(beta_group_id: nil, beta_tester_ids: nil)
@@ -328,7 +332,7 @@ module Spaceship
               }
             end
           }
-          test_flight_request_client.post("betaGroups/#{beta_group_id}/relationships/betaTesters", body)
+          test_flight_request_client.post("#{Version::V1}/betaGroups/#{beta_group_id}/relationships/betaTesters", body)
         end
 
         def delete_beta_tester_from_apps(beta_tester_id: nil, app_ids: [])
@@ -341,7 +345,7 @@ module Spaceship
             end
           }
 
-          test_flight_request_client.delete("betaTesters/#{beta_tester_id}/relationships/apps", nil, body)
+          test_flight_request_client.delete("#{Version::V1}/betaTesters/#{beta_tester_id}/relationships/apps", nil, body)
         end
 
         def delete_beta_tester_from_beta_groups(beta_tester_id: nil, beta_group_ids: [])
@@ -354,7 +358,7 @@ module Spaceship
             end
           }
 
-          test_flight_request_client.delete("betaTesters/#{beta_tester_id}/relationships/betaGroups", nil, body)
+          test_flight_request_client.delete("#{Version::V1}/betaTesters/#{beta_tester_id}/relationships/betaGroups", nil, body)
         end
 
         def delete_beta_testers_from_app(beta_tester_ids: [], app_id: nil)
@@ -367,7 +371,7 @@ module Spaceship
             end
           }
 
-          test_flight_request_client.delete("apps/#{app_id}/relationships/betaTesters", nil, body)
+          test_flight_request_client.delete("#{Version::V1}/apps/#{app_id}/relationships/betaTesters", nil, body)
         end
 
         def add_beta_tester_to_builds(beta_tester_id: nil, build_ids: [])
@@ -380,7 +384,7 @@ module Spaceship
             end
           }
 
-          test_flight_request_client.post("betaTesters/#{beta_tester_id}/relationships/builds", body)
+          test_flight_request_client.post("#{Version::V1}/betaTesters/#{beta_tester_id}/relationships/builds", body)
         end
 
         def add_beta_testers_to_build(build_id: nil, beta_tester_ids: [])
@@ -393,7 +397,7 @@ module Spaceship
             end
           }
 
-          test_flight_request_client.post("builds/#{build_id}/relationships/individualTesters", body)
+          test_flight_request_client.post("#{Version::V1}/builds/#{build_id}/relationships/individualTesters", body)
         end
 
         def delete_beta_testers_from_build(build_id: nil, beta_tester_ids: [])
@@ -406,7 +410,7 @@ module Spaceship
             end
           }
 
-          test_flight_request_client.delete("builds/#{build_id}/relationships/individualTesters", nil, body)
+          test_flight_request_client.delete("#{Version::V1}/builds/#{build_id}/relationships/individualTesters", nil, body)
         end
 
         #
@@ -415,7 +419,7 @@ module Spaceship
 
         def get_beta_tester_metrics(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("betaTesterMetrics", params)
+          test_flight_request_client.get("#{Version::V1}/betaTesterMetrics", params)
         end
 
         #
@@ -424,7 +428,7 @@ module Spaceship
 
         def get_build_bundles_build_bundle_file_sizes(build_bundle_id:, limit: nil)
           params = test_flight_request_client.build_params(filter: nil, includes: nil, limit: limit, sort: nil, cursor: nil)
-          test_flight_request_client.get("buildBundles/#{build_bundle_id}/buildBundleFileSizes", params)
+          test_flight_request_client.get("#{Version::V1}/buildBundles/#{build_bundle_id}/buildBundleFileSizes", params)
         end
 
         #
@@ -433,16 +437,16 @@ module Spaceship
 
         def get_builds(filter: {}, includes: "buildBetaDetail,betaBuildMetrics", limit: 10, sort: "uploadedDate", cursor: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort, cursor: cursor)
-          test_flight_request_client.get("builds", params)
+          test_flight_request_client.get("#{Version::V1}/builds", params)
         end
 
         def get_build(build_id: nil, app_store_version_id: nil, includes: nil)
           if build_id
             params = test_flight_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil, cursor: nil)
-            return test_flight_request_client.get("builds/#{build_id}", params)
+            return test_flight_request_client.get("#{Version::V1}/builds/#{build_id}", params)
           elsif app_store_version_id
             params = test_flight_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil, cursor: nil)
-            return test_flight_request_client.get("appStoreVersions/#{app_store_version_id}/build", params)
+            return test_flight_request_client.get("#{Version::V1}/appStoreVersions/#{app_store_version_id}/build", params)
           else
             return nil
           end
@@ -457,7 +461,7 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.patch("builds/#{build_id}", body)
+          test_flight_request_client.patch("#{Version::V1}/builds/#{build_id}", body)
         end
 
         #
@@ -466,7 +470,7 @@ module Spaceship
 
         def get_build_beta_details(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("buildBetaDetails", params)
+          test_flight_request_client.get("#{Version::V1}/buildBetaDetails", params)
         end
 
         def patch_build_beta_details(build_beta_details_id: nil, attributes: {})
@@ -478,7 +482,7 @@ module Spaceship
             }
           }
 
-          test_flight_request_client.patch("buildBetaDetails/#{build_beta_details_id}", body)
+          test_flight_request_client.patch("#{Version::V1}/buildBetaDetails/#{build_beta_details_id}", body)
         end
 
         #
@@ -487,7 +491,7 @@ module Spaceship
 
         def get_build_deliveries(app_id:, filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("apps/#{app_id}/buildDeliveries", params)
+          test_flight_request_client.get("#{Version::V1}/apps/#{app_id}/buildDeliveries", params)
         end
 
         #
@@ -496,7 +500,7 @@ module Spaceship
 
         def get_pre_release_versions(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("preReleaseVersions", params)
+          test_flight_request_client.get("#{Version::V1}/preReleaseVersions", params)
         end
 
         #
@@ -505,13 +509,13 @@ module Spaceship
 
         def get_beta_feedback(filter: {}, includes: nil, limit: nil, sort: nil)
           params = test_flight_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          test_flight_request_client.get("betaFeedbacks", params)
+          test_flight_request_client.get("#{Version::V1}/betaFeedbacks", params)
         end
 
         def delete_beta_feedback(feedback_id: nil)
           raise "Feedback id is nil" if feedback_id.nil?
 
-          test_flight_request_client.delete("betaFeedbacks/#{feedback_id}")
+          test_flight_request_client.delete("#{Version::V1}/betaFeedbacks/#{feedback_id}")
         end
       end
     end

--- a/spaceship/lib/spaceship/connect_api/tunes/client.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/client.rb
@@ -19,7 +19,7 @@ module Spaceship
         end
 
         def self.hostname
-          'https://appstoreconnect.apple.com/iris/v1/'
+          'https://appstoreconnect.apple.com/iris/'
         end
       end
     end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -4,6 +4,12 @@ module Spaceship
   class ConnectAPI
     module Tunes
       module API
+        module Version
+          V1 = "v1"
+          V2 = "v2"
+          V3 = "v3"
+        end
+
         def tunes_request_client=(tunes_request_client)
           @tunes_request_client = tunes_request_client
         end
@@ -21,7 +27,7 @@ module Spaceship
           raise "Keyword 'app_store_version_id' is deprecated and 'app_info_id' is required" if app_store_version_id || app_info_id.nil?
 
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("appInfos/#{app_info_id}/ageRatingDeclaration", params)
+          tunes_request_client.get("#{Version::V1}/appInfos/#{app_info_id}/ageRatingDeclaration", params)
         end
 
         def patch_age_rating_declaration(age_rating_declaration_id: nil, attributes: nil)
@@ -33,7 +39,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("ageRatingDeclarations/#{age_rating_declaration_id}", body)
+          tunes_request_client.patch("#{Version::V1}/ageRatingDeclarations/#{age_rating_declaration_id}", body)
         end
 
         #
@@ -131,7 +137,7 @@ module Spaceship
             included: included
           }
 
-          tunes_request_client.post("apps", body)
+          tunes_request_client.post("#{Version::V1}/apps", body)
         end
 
         # Updates app attributes, price tier, visibility in regions or countries.
@@ -206,7 +212,7 @@ module Spaceship
           }
           body[:included] = included unless included.empty?
 
-          tunes_request_client.patch("apps/#{app_id}", body)
+          tunes_request_client.patch("#{Version::V1}/apps/#{app_id}", body)
         end
 
         #
@@ -215,7 +221,7 @@ module Spaceship
 
         def get_app_data_usages(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("apps/#{app_id}/dataUsages", params)
+          tunes_request_client.get("#{Version::V1}/apps/#{app_id}/dataUsages", params)
         end
 
         def post_app_data_usage(app_id:, app_data_usage_category_id: nil, app_data_usage_protection_id: nil, app_data_usage_purpose_id: nil)
@@ -264,11 +270,11 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appDataUsages", body)
+          tunes_request_client.post("#{Version::V1}/appDataUsages", body)
         end
 
         def delete_app_data_usage(app_data_usage_id: nil)
-          tunes_request_client.delete("appDataUsages/#{app_data_usage_id}")
+          tunes_request_client.delete("#{Version::V1}/appDataUsages/#{app_data_usage_id}")
         end
 
         #
@@ -277,7 +283,7 @@ module Spaceship
 
         def get_app_data_usage_categories(filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appDataUsageCategories", params)
+          tunes_request_client.get("#{Version::V1}/appDataUsageCategories", params)
         end
 
         #
@@ -286,7 +292,7 @@ module Spaceship
 
         def get_app_data_usage_purposes(filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appDataUsagePurposes", params)
+          tunes_request_client.get("#{Version::V1}/appDataUsagePurposes", params)
         end
 
         #
@@ -295,7 +301,7 @@ module Spaceship
 
         def get_app_data_usages_publish_state(app_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("apps/#{app_id}/dataUsagePublishState", params)
+          tunes_request_client.get("#{Version::V1}/apps/#{app_id}/dataUsagePublishState", params)
         end
 
         def patch_app_data_usages_publish_state(app_data_usages_publish_state_id: nil, published: nil)
@@ -309,7 +315,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appDataUsagesPublishState/#{app_data_usages_publish_state_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appDataUsagesPublishState/#{app_data_usages_publish_state_id}", body)
         end
 
         #
@@ -318,7 +324,7 @@ module Spaceship
 
         def get_app_preview(app_preview_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("appPreviews/#{app_preview_id}", params)
+          tunes_request_client.get("#{Version::V1}/appPreviews/#{app_preview_id}", params)
         end
 
         def post_app_preview(app_preview_set_id: nil, attributes: {})
@@ -337,7 +343,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appPreviews", body)
+          tunes_request_client.post("#{Version::V1}/appPreviews", body)
         end
 
         def patch_app_preview(app_preview_id: nil, attributes: {})
@@ -349,12 +355,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appPreviews/#{app_preview_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appPreviews/#{app_preview_id}", body)
         end
 
         def delete_app_preview(app_preview_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("appPreviews/#{app_preview_id}", params)
+          tunes_request_client.delete("#{Version::V1}/appPreviews/#{app_preview_id}", params)
         end
 
         #
@@ -363,12 +369,12 @@ module Spaceship
 
         def get_app_preview_sets(filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appPreviewSets", params)
+          tunes_request_client.get("#{Version::V1}/appPreviewSets", params)
         end
 
         def get_app_preview_set(app_preview_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appPreviewSets/#{app_preview_set_id}", params)
+          tunes_request_client.get("#{Version::V1}/appPreviewSets/#{app_preview_set_id}", params)
         end
 
         def post_app_preview_set(app_store_version_localization_id: nil, attributes: {})
@@ -387,12 +393,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appPreviewSets", body)
+          tunes_request_client.post("#{Version::V1}/appPreviewSets", body)
         end
 
         def delete_app_preview_set(app_preview_set_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("appPreviewSets/#{app_preview_set_id}", params)
+          tunes_request_client.delete("#{Version::V1}/appPreviewSets/#{app_preview_set_id}", params)
         end
 
         def patch_app_preview_set_previews(app_preview_set_id: nil, app_preview_ids: nil)
@@ -407,7 +413,7 @@ module Spaceship
             end
           }
 
-          tunes_request_client.patch("appPreviewSets/#{app_preview_set_id}/relationships/appPreviews", body)
+          tunes_request_client.patch("#{Version::V1}/appPreviewSets/#{app_preview_set_id}/relationships/appPreviews", body)
         end
 
         #
@@ -416,7 +422,7 @@ module Spaceship
 
         def get_available_territories(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("apps/#{app_id}/availableTerritories", params)
+          tunes_request_client.get("#{Version::V1}/apps/#{app_id}/availableTerritories", params)
         end
 
         #
@@ -425,12 +431,12 @@ module Spaceship
 
         def get_app_prices(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appPrices", params)
+          tunes_request_client.get("#{Version::V1}/appPrices", params)
         end
 
         def get_app_price(app_price_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appPrices/#{app_price_id}", params)
+          tunes_request_client.get("#{Version::V1}/appPrices/#{app_price_id}", params)
         end
 
         #
@@ -438,7 +444,7 @@ module Spaceship
         #
         def get_app_price_points(filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appPricePoints", params)
+          tunes_request_client.get("#{Version::V1}/appPricePoints", params)
         end
 
         #
@@ -461,7 +467,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appStoreReviewAttachments", body)
+          tunes_request_client.post("#{Version::V1}/appStoreReviewAttachments", body)
         end
 
         def patch_app_store_review_attachment(app_store_review_attachment_id: nil, attributes: {})
@@ -473,12 +479,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appStoreReviewAttachments/#{app_store_review_attachment_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appStoreReviewAttachments/#{app_store_review_attachment_id}", body)
         end
 
         def delete_app_store_review_attachment(app_store_review_attachment_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("appStoreReviewAttachments/#{app_store_review_attachment_id}", params)
+          tunes_request_client.delete("#{Version::V1}/appStoreReviewAttachments/#{app_store_review_attachment_id}", params)
         end
 
         #
@@ -487,12 +493,12 @@ module Spaceship
 
         def get_app_screenshot_sets(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appStoreVersionLocalizations/#{app_store_version_localization_id}/appScreenshotSets", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersionLocalizations/#{app_store_version_localization_id}/appScreenshotSets", params)
         end
 
         def get_app_screenshot_set(app_screenshot_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appScreenshotSets/#{app_screenshot_set_id}", params)
+          tunes_request_client.get("#{Version::V1}/appScreenshotSets/#{app_screenshot_set_id}", params)
         end
 
         def post_app_screenshot_set(app_store_version_localization_id: nil, attributes: {})
@@ -511,7 +517,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appScreenshotSets", body)
+          tunes_request_client.post("#{Version::V1}/appScreenshotSets", body)
         end
 
         def patch_app_screenshot_set_screenshots(app_screenshot_set_id: nil, app_screenshot_ids: nil)
@@ -526,12 +532,12 @@ module Spaceship
             end
           }
 
-          tunes_request_client.patch("appScreenshotSets/#{app_screenshot_set_id}/relationships/appScreenshots", body)
+          tunes_request_client.patch("#{Version::V1}/appScreenshotSets/#{app_screenshot_set_id}/relationships/appScreenshots", body)
         end
 
         def delete_app_screenshot_set(app_screenshot_set_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("appScreenshotSets/#{app_screenshot_set_id}", params)
+          tunes_request_client.delete("#{Version::V1}/appScreenshotSets/#{app_screenshot_set_id}", params)
         end
 
         #
@@ -540,7 +546,7 @@ module Spaceship
 
         def get_app_screenshot(app_screenshot_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("appScreenshots/#{app_screenshot_id}", params)
+          tunes_request_client.get("#{Version::V1}/appScreenshots/#{app_screenshot_id}", params)
         end
 
         def post_app_screenshot(app_screenshot_set_id: nil, attributes: {})
@@ -559,7 +565,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appScreenshots", body, tries: 1)
+          tunes_request_client.post("#{Version::V1}/appScreenshots", body, tries: 1)
         end
 
         def patch_app_screenshot(app_screenshot_id: nil, attributes: {})
@@ -571,12 +577,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appScreenshots/#{app_screenshot_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appScreenshots/#{app_screenshot_id}", body)
         end
 
         def delete_app_screenshot(app_screenshot_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("appScreenshots/#{app_screenshot_id}", params)
+          tunes_request_client.delete("#{Version::V1}/appScreenshots/#{app_screenshot_id}", params)
         end
 
         #
@@ -585,7 +591,7 @@ module Spaceship
 
         def get_app_infos(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("apps/#{app_id}/appInfos", params)
+          tunes_request_client.get("#{Version::V1}/apps/#{app_id}/appInfos", params)
         end
 
         def patch_app_info(app_info_id: nil, attributes: {})
@@ -601,7 +607,7 @@ module Spaceship
             data: data
           }
 
-          tunes_request_client.patch("appInfos/#{app_info_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appInfos/#{app_info_id}", body)
         end
 
         #
@@ -679,12 +685,12 @@ module Spaceship
             data: data
           }
 
-          tunes_request_client.patch("appInfos/#{app_info_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appInfos/#{app_info_id}", body)
         end
 
         def delete_app_info(app_info_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("appInfos/#{app_info_id}", params)
+          tunes_request_client.delete("#{Version::V1}/appInfos/#{app_info_id}", params)
         end
 
         #
@@ -693,7 +699,7 @@ module Spaceship
 
         def get_app_info_localizations(app_info_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appInfos/#{app_info_id}/appInfoLocalizations", params)
+          tunes_request_client.get("#{Version::V1}/appInfos/#{app_info_id}/appInfoLocalizations", params)
         end
 
         def post_app_info_localization(app_info_id: nil, attributes: {})
@@ -712,7 +718,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appInfoLocalizations", body)
+          tunes_request_client.post("#{Version::V1}/appInfoLocalizations", body)
         end
 
         def patch_app_info_localization(app_info_localization_id: nil, attributes: {})
@@ -724,7 +730,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appInfoLocalizations/#{app_info_localization_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appInfoLocalizations/#{app_info_localization_id}", body)
         end
 
         #
@@ -733,7 +739,7 @@ module Spaceship
 
         def get_app_store_review_detail(app_store_version_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appStoreVersions/#{app_store_version_id}/appStoreReviewDetail", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersions/#{app_store_version_id}/appStoreReviewDetail", params)
         end
 
         def post_app_store_review_detail(app_store_version_id: nil, attributes: {})
@@ -752,7 +758,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appStoreReviewDetails", body)
+          tunes_request_client.post("#{Version::V1}/appStoreReviewDetails", body)
         end
 
         def patch_app_store_review_detail(app_store_review_detail_id: nil, attributes: {})
@@ -764,7 +770,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appStoreReviewDetails/#{app_store_review_detail_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appStoreReviewDetails/#{app_store_review_detail_id}", body)
         end
 
         #
@@ -773,12 +779,12 @@ module Spaceship
 
         def get_app_store_version_localizations(app_store_version_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("appStoreVersions/#{app_store_version_id}/appStoreVersionLocalizations", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersions/#{app_store_version_id}/appStoreVersionLocalizations", params)
         end
 
         def get_app_store_version_localization(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("appStoreVersionLocalizations/#{app_store_version_localization_id}", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersionLocalizations/#{app_store_version_localization_id}", params)
         end
 
         def post_app_store_version_localization(app_store_version_id: nil, attributes: {})
@@ -797,7 +803,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appStoreVersionLocalizations", body)
+          tunes_request_client.post("#{Version::V1}/appStoreVersionLocalizations", body)
         end
 
         def patch_app_store_version_localization(app_store_version_localization_id: nil, attributes: {})
@@ -809,12 +815,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appStoreVersionLocalizations/#{app_store_version_localization_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appStoreVersionLocalizations/#{app_store_version_localization_id}", body)
         end
 
         def delete_app_store_version_localization(app_store_version_localization_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("appStoreVersionLocalizations/#{app_store_version_localization_id}", params)
+          tunes_request_client.delete("#{Version::V1}/appStoreVersionLocalizations/#{app_store_version_localization_id}", params)
         end
 
         #
@@ -823,7 +829,7 @@ module Spaceship
 
         def get_app_store_version_phased_release(app_store_version_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("appStoreVersions/#{app_store_version_id}/appStoreVersionPhasedRelease", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersions/#{app_store_version_id}/appStoreVersionPhasedRelease", params)
         end
 
         def post_app_store_version_phased_release(app_store_version_id: nil, attributes: {})
@@ -842,7 +848,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appStoreVersionPhasedReleases", body)
+          tunes_request_client.post("#{Version::V1}/appStoreVersionPhasedReleases", body)
         end
 
         def patch_app_store_version_phased_release(app_store_version_phased_release_id: nil, attributes: {})
@@ -854,12 +860,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appStoreVersionPhasedReleases/#{app_store_version_phased_release_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appStoreVersionPhasedReleases/#{app_store_version_phased_release_id}", body)
         end
 
         def delete_app_store_version_phased_release(app_store_version_phased_release_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("appStoreVersionPhasedReleases/#{app_store_version_phased_release_id}", params)
+          tunes_request_client.delete("#{Version::V1}/appStoreVersionPhasedReleases/#{app_store_version_phased_release_id}", params)
         end
 
         #
@@ -868,12 +874,12 @@ module Spaceship
 
         def get_app_store_versions(app_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("apps/#{app_id}/appStoreVersions", params)
+          tunes_request_client.get("#{Version::V1}/apps/#{app_id}/appStoreVersions", params)
         end
 
         def get_app_store_version(app_store_version_id: nil, includes: nil)
           params = tunes_request_client.build_params(filter: nil, includes: includes, limit: nil, sort: nil)
-          tunes_request_client.get("appStoreVersions/#{app_store_version_id}", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersions/#{app_store_version_id}", params)
         end
 
         def post_app_store_version(app_id: nil, attributes: {})
@@ -892,7 +898,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appStoreVersions", body)
+          tunes_request_client.post("#{Version::V1}/appStoreVersions", body)
         end
 
         def patch_app_store_version(app_store_version_id: nil, attributes: {})
@@ -904,7 +910,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appStoreVersions/#{app_store_version_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appStoreVersions/#{app_store_version_id}", body)
         end
 
         def patch_app_store_version_with_build(app_store_version_id: nil, build_id: nil)
@@ -928,7 +934,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("appStoreVersions/#{app_store_version_id}", body)
+          tunes_request_client.patch("#{Version::V1}/appStoreVersions/#{app_store_version_id}", body)
         end
 
         #
@@ -937,7 +943,7 @@ module Spaceship
 
         def get_reset_ratings_request(app_store_version_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("appStoreVersions/#{app_store_version_id}/resetRatingsRequest", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersions/#{app_store_version_id}/resetRatingsRequest", params)
         end
 
         def post_reset_ratings_request(app_store_version_id: nil)
@@ -955,12 +961,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("resetRatingsRequests", body)
+          tunes_request_client.post("#{Version::V1}/resetRatingsRequests", body)
         end
 
         def delete_reset_ratings_request(reset_ratings_request_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("resetRatingsRequests/#{reset_ratings_request_id}", params)
+          tunes_request_client.delete("#{Version::V1}/resetRatingsRequests/#{reset_ratings_request_id}", params)
         end
 
         #
@@ -969,7 +975,7 @@ module Spaceship
 
         def get_app_store_version_submission(app_store_version_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("appStoreVersions/#{app_store_version_id}/appStoreVersionSubmission", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersions/#{app_store_version_id}/appStoreVersionSubmission", params)
         end
 
         def post_app_store_version_submission(app_store_version_id: nil)
@@ -987,12 +993,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("appStoreVersionSubmissions", body)
+          tunes_request_client.post("#{Version::V1}/appStoreVersionSubmissions", body)
         end
 
         def delete_app_store_version_submission(app_store_version_submission_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("appStoreVersionSubmissions/#{app_store_version_submission_id}", params)
+          tunes_request_client.delete("#{Version::V1}/appStoreVersionSubmissions/#{app_store_version_submission_id}", params)
         end
 
         #
@@ -1014,7 +1020,7 @@ module Spaceship
               }
           }
 
-          tunes_request_client.post("appStoreVersionReleaseRequests", body)
+          tunes_request_client.post("#{Version::V1}/appStoreVersionReleaseRequests", body)
         end
 
         #
@@ -1023,7 +1029,7 @@ module Spaceship
 
         def get_custom_app_users(app_id: nil, filter: nil, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("apps/#{app_id}/customAppUsers", params)
+          tunes_request_client.get("#{Version::V1}/apps/#{app_id}/customAppUsers", params)
         end
 
         def post_custom_app_user(app_id: nil, apple_id: nil)
@@ -1044,12 +1050,12 @@ module Spaceship
               }
           }
 
-          tunes_request_client.post("customAppUsers", body)
+          tunes_request_client.post("#{Version::V1}/customAppUsers", body)
         end
 
         def delete_custom_app_user(custom_app_user_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("customAppUsers/#{custom_app_user_id}", params)
+          tunes_request_client.delete("#{Version::V1}/customAppUsers/#{custom_app_user_id}", params)
         end
 
         #
@@ -1058,7 +1064,7 @@ module Spaceship
 
         def get_custom_app_organization(app_id: nil, filter: nil, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("apps/#{app_id}/customAppOrganizations", params)
+          tunes_request_client.get("#{Version::V1}/apps/#{app_id}/customAppOrganizations", params)
         end
 
         def post_custom_app_organization(app_id: nil, device_enrollment_program_id: nil, name: nil)
@@ -1080,12 +1086,12 @@ module Spaceship
               }
           }
 
-          tunes_request_client.post("customAppOrganizations", body)
+          tunes_request_client.post("#{Version::V1}/customAppOrganizations", body)
         end
 
         def delete_custom_app_organization(custom_app_organization_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("customAppOrganizations/#{custom_app_organization_id}", params)
+          tunes_request_client.delete("#{Version::V1}/customAppOrganizations/#{custom_app_organization_id}", params)
         end
 
         #
@@ -1094,7 +1100,7 @@ module Spaceship
 
         def get_idfa_declaration(app_store_version_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("appStoreVersions/#{app_store_version_id}/idfaDeclaration", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersions/#{app_store_version_id}/idfaDeclaration", params)
         end
 
         def post_idfa_declaration(app_store_version_id: nil, attributes: nil)
@@ -1113,7 +1119,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("idfaDeclarations", body)
+          tunes_request_client.post("#{Version::V1}/idfaDeclarations", body)
         end
 
         def patch_idfa_declaration(idfa_declaration_id: nil, attributes: nil)
@@ -1125,12 +1131,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("idfaDeclarations/#{idfa_declaration_id}", body)
+          tunes_request_client.patch("#{Version::V1}/idfaDeclarations/#{idfa_declaration_id}", body)
         end
 
         def delete_idfa_declaration(idfa_declaration_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("idfaDeclarations/#{idfa_declaration_id}", params)
+          tunes_request_client.delete("#{Version::V1}/idfaDeclarations/#{idfa_declaration_id}", params)
         end
 
         #
@@ -1139,12 +1145,12 @@ module Spaceship
 
         def get_review_submissions(app_id:, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("apps/#{app_id}/reviewSubmissions", params)
+          tunes_request_client.get("#{Version::V1}/apps/#{app_id}/reviewSubmissions", params)
         end
 
         def get_review_submission(review_submission_id:, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("reviewSubmissions/#{review_submission_id}", params)
+          tunes_request_client.get("#{Version::V1}/reviewSubmissions/#{review_submission_id}", params)
         end
 
         def post_review_submission(app_id:, platform:)
@@ -1165,7 +1171,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("reviewSubmissions", body)
+          tunes_request_client.post("#{Version::V1}/reviewSubmissions", body)
         end
 
         def patch_review_submission(review_submission_id:, attributes: nil)
@@ -1177,7 +1183,7 @@ module Spaceship
             }
           }
 
-          tunes_request_client.patch("reviewSubmissions/#{review_submission_id}", body)
+          tunes_request_client.patch("#{Version::V1}/reviewSubmissions/#{review_submission_id}", body)
         end
 
         #
@@ -1186,7 +1192,7 @@ module Spaceship
 
         def get_review_submission_items(review_submission_id:, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("reviewSubmissions/#{review_submission_id}/items", params)
+          tunes_request_client.get("#{Version::V1}/reviewSubmissions/#{review_submission_id}/items", params)
         end
 
         def post_review_submission_item(review_submission_id:, app_store_version_id: nil)
@@ -1213,7 +1219,7 @@ module Spaceship
             }
           end
 
-          tunes_request_client.post("reviewSubmissionItems", body)
+          tunes_request_client.post("#{Version::V1}/reviewSubmissionItems", body)
         end
 
         #
@@ -1222,7 +1228,7 @@ module Spaceship
 
         def get_sandbox_testers(filter: nil, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("sandboxTesters", params)
+          tunes_request_client.get("#{Version::V1}/sandboxTesters", params)
         end
 
         def post_sandbox_tester(attributes: {})
@@ -1233,12 +1239,12 @@ module Spaceship
             }
           }
 
-          tunes_request_client.post("sandboxTesters", body)
+          tunes_request_client.post("#{Version::V1}/sandboxTesters", body)
         end
 
         def delete_sandbox_tester(sandbox_tester_id: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.delete("sandboxTesters/#{sandbox_tester_id}", params)
+          tunes_request_client.delete("#{Version::V1}/sandboxTesters/#{sandbox_tester_id}", params)
         end
 
         #
@@ -1247,7 +1253,7 @@ module Spaceship
 
         def get_territories(filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
-          tunes_request_client.get("territories", params)
+          tunes_request_client.get("#{Version::V1}/territories", params)
         end
 
         #
@@ -1260,17 +1266,17 @@ module Spaceship
 
         def get_resolution_center_threads(filter: {}, includes: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes)
-          tunes_request_client.get('resolutionCenterThreads', params)
+          tunes_request_client.get("#{Version::V1}/resolutionCenterThreads", params)
         end
 
         def get_resolution_center_messages(thread_id:, filter: {}, includes: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes)
-          tunes_request_client.get("resolutionCenterThreads/#{thread_id}/resolutionCenterMessages", params)
+          tunes_request_client.get("#{Version::V1}/resolutionCenterThreads/#{thread_id}/resolutionCenterMessages", params)
         end
 
         def get_review_rejection(filter: {}, includes: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes)
-          tunes_request_client.get("reviewRejections", params)
+          tunes_request_client.get("#{Version::V1}/reviewRejections", params)
         end
       end
     end

--- a/spaceship/lib/spaceship/connect_api/users/client.rb
+++ b/spaceship/lib/spaceship/connect_api/users/client.rb
@@ -19,7 +19,7 @@ module Spaceship
         end
 
         def self.hostname
-          'https://appstoreconnect.apple.com/iris/v1/'
+          'https://appstoreconnect.apple.com/iris/'
         end
       end
     end

--- a/spaceship/lib/spaceship/connect_api/users/users.rb
+++ b/spaceship/lib/spaceship/connect_api/users/users.rb
@@ -4,6 +4,10 @@ module Spaceship
   class ConnectAPI
     module Users
       module API
+        module Version
+          V1 = "v1"
+        end
+
         def users_request_client=(users_request_client)
           @users_request_client = users_request_client
         end
@@ -20,12 +24,12 @@ module Spaceship
         # Get list of users
         def get_users(filter: {}, includes: nil, limit: nil, sort: nil)
           params = users_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          users_request_client.get("users", params)
+          users_request_client.get("#{Version::V1}/users", params)
         end
 
         # Delete existing user
         def delete_user(user_id: nil)
-          users_request_client.delete("users/#{user_id}")
+          users_request_client.delete("#{Version::V1}/users/#{user_id}")
         end
 
         # Update existing user
@@ -55,7 +59,7 @@ module Spaceship
           # Avoid API error: You cannot set visible apps for this user because the user's roles give them access to all apps.
           body[:data].delete(:relationships) if all_apps_visible
 
-          users_request_client.patch("users/#{user_id}", body)
+          users_request_client.patch("#{Version::V1}/users/#{user_id}", body)
         end
 
         # Add app permissions for user
@@ -74,7 +78,7 @@ module Spaceship
             end
           }
 
-          users_request_client.post("users/#{user_id}/relationships/visibleApps", body)
+          users_request_client.post("#{Version::V1}/users/#{user_id}/relationships/visibleApps", body)
         end
 
         # Replace app permissions for user
@@ -88,7 +92,7 @@ module Spaceship
             end
           }
 
-          users_request_client.patch("users/#{user_id}/relationships/visibleApps", body)
+          users_request_client.patch("#{Version::V1}/users/#{user_id}/relationships/visibleApps", body)
         end
 
         # Remove app permissions for user
@@ -102,13 +106,13 @@ module Spaceship
             end
           }
           params = nil
-          users_request_client.delete("users/#{user_id}/relationships/visibleApps", params, body)
+          users_request_client.delete("#{Version::V1}/users/#{user_id}/relationships/visibleApps", params, body)
         end
 
         # Get app permissions for user
         def get_user_visible_apps(user_id: id, limit: nil)
           params = users_request_client.build_params(filter: {}, includes: nil, limit: limit, sort: nil)
-          users_request_client.get("users/#{user_id}/visibleApps", params)
+          users_request_client.get("#{Version::V1}/users/#{user_id}/visibleApps", params)
         end
 
         #
@@ -118,7 +122,7 @@ module Spaceship
         # Get all invited users
         def get_user_invitations(filter: {}, includes: nil, limit: nil, sort: nil)
           params = users_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          users_request_client.get("userInvitations", params)
+          users_request_client.get("#{Version::V1}/userInvitations", params)
         end
 
         # Invite new users to App Store Connect
@@ -150,18 +154,18 @@ module Spaceship
           # Avoid API error: You cannot set visible apps for this user because the user's roles give them access to all apps.
           body[:data].delete(:relationships) if all_apps_visible
 
-          users_request_client.post("userInvitations", body)
+          users_request_client.post("#{Version::V1}/userInvitations", body)
         end
 
         # Remove invited user from team (not yet accepted)
         def delete_user_invitation(user_invitation_id: nil)
-          users_request_client.delete("userInvitations/#{user_invitation_id}")
+          users_request_client.delete("#{Version::V1}/userInvitations/#{user_invitation_id}")
         end
 
         # Get all app permissions for invited user
         def get_user_invitation_visible_apps(user_invitation_id: id, limit: nil)
           params = users_request_client.build_params(filter: {}, includes: nil, limit: limit, sort: nil)
-          users_request_client.get("userInvitations/#{user_invitation_id}/visibleApps", params)
+          users_request_client.get("#{Version::V1}/userInvitations/#{user_invitation_id}/visibleApps", params)
         end
       end
     end

--- a/spaceship/lib/spaceship/stats_middleware.rb
+++ b/spaceship/lib/spaceship/stats_middleware.rb
@@ -18,11 +18,11 @@ module Spaceship
         @services ||= [
           ServiceOption.new("App Store Connect API (official)", "api.appstoreconnect.apple.com", "JWT"),
           ServiceOption.new("App Store Connect API (web session)", Spaceship::ConnectAPI::TestFlight::Client.hostname.gsub("https://", ""), "Web session"),
-          ServiceOption.new("App Store Connect API (web session)", Spaceship::ConnectAPI::Provisioning::Client.hostname.gsub("https://", ""), "Web session"),
           ServiceOption.new("Legacy iTunesConnect Auth", "idmsa.apple.com", "Web session"),
           ServiceOption.new("Legacy iTunesConnect Auth", "appstoreconnect.apple.com/olympus/v1/", "Web session"),
           ServiceOption.new("Legacy iTunesConnect", Spaceship::TunesClient.hostname.gsub("https://", ""), "Web session"),
-          ServiceOption.new("Legacy iTunesConnect Developer Portal", Spaceship::PortalClient.hostname.gsub("https://", ""), "Web session")
+          ServiceOption.new("Legacy iTunesConnect Developer Portal", Spaceship::PortalClient.hostname.gsub("https://", ""), "Web session"),
+          ServiceOption.new("App Store Connect API (web session)", Spaceship::ConnectAPI::Provisioning::Client.hostname.gsub("https://", ""), "Web session"),
         ]
       end
 

--- a/spaceship/lib/spaceship/stats_middleware.rb
+++ b/spaceship/lib/spaceship/stats_middleware.rb
@@ -22,7 +22,7 @@ module Spaceship
           ServiceOption.new("Legacy iTunesConnect Auth", "appstoreconnect.apple.com/olympus/v1/", "Web session"),
           ServiceOption.new("Legacy iTunesConnect", Spaceship::TunesClient.hostname.gsub("https://", ""), "Web session"),
           ServiceOption.new("Legacy iTunesConnect Developer Portal", Spaceship::PortalClient.hostname.gsub("https://", ""), "Web session"),
-          ServiceOption.new("App Store Connect API (web session)", Spaceship::ConnectAPI::Provisioning::Client.hostname.gsub("https://", ""), "Web session"),
+          ServiceOption.new("App Store Connect API (web session)", Spaceship::ConnectAPI::Provisioning::Client.hostname.gsub("https://", ""), "Web session")
         ]
       end
 

--- a/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
@@ -47,7 +47,7 @@ describe Spaceship::ConnectAPI::Provisioning::Client do
 
     describe "bundleIds" do
       context 'get_bundle_ids' do
-        let(:path) { "bundleIds" }
+        let(:path) { "v1/bundleIds" }
 
         it 'succeeds' do
           params = {}
@@ -103,7 +103,7 @@ settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings
 
     describe "certificates" do
       context 'get_certificates' do
-        let(:path) { "certificates" }
+        let(:path) { "v1/certificates" }
 
         it 'succeeds' do
           params = {}
@@ -114,7 +114,7 @@ settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings
       end
 
       context 'get_certificates_for_profile' do
-        let(:path) { "profiles/123456789/certificates" }
+        let(:path) { "v1/profiles/123456789/certificates" }
 
         it 'succeeds' do
           params = {}
@@ -127,7 +127,7 @@ settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings
 
     describe "devices" do
       context 'get_devices' do
-        let(:path) { "devices" }
+        let(:path) { "v1/devices" }
 
         it 'succeeds' do
           params = {}
@@ -140,7 +140,7 @@ settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings
 
     describe "profiles" do
       context 'get_profiles' do
-        let(:path) { "profiles" }
+        let(:path) { "v1/profiles" }
 
         it 'succeeds' do
           params = {}

--- a/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
+++ b/spaceship/spec/connect_api/testflight/testflight_client_spec.rb
@@ -47,7 +47,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "apps" do
       context 'get_apps' do
-        let(:path) { "apps" }
+        let(:path) { "v1/apps" }
         let(:bundle_id) { "com.bundle.id" }
 
         it 'succeeds' do
@@ -67,7 +67,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
       context 'get_app' do
         let(:app_id) { "123456789" }
-        let(:path) { "apps/#{app_id}" }
+        let(:path) { "v1/apps/#{app_id}" }
 
         it 'succeeds' do
           params = {}
@@ -80,7 +80,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "betaAppLocalizations" do
       context 'get_beta_app_localizations' do
-        let(:path) { "betaAppLocalizations" }
+        let(:path) { "v1/betaAppLocalizations" }
         let(:app_id) { "123" }
 
         it 'succeeds' do
@@ -99,7 +99,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'post_beta_app_localizations' do
-        let(:path) { "betaAppLocalizations" }
+        let(:path) { "v1/betaAppLocalizations" }
         let(:app_id) { "123" }
         let(:attributes) { { key: "value" } }
         let(:body) do
@@ -129,7 +129,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'patch_beta_app_localizations' do
-        let(:path) { "betaAppLocalizations" }
+        let(:path) { "v1/betaAppLocalizations" }
         let(:localization_id) { "123" }
         let(:attributes) { { key: "value" } }
         let(:body) do
@@ -154,7 +154,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "betaAppReviewDetails" do
       context 'get_beta_app_review_detail' do
-        let(:path) { "betaAppReviewDetails" }
+        let(:path) { "v1/betaAppReviewDetails" }
         let(:app_id) { "123" }
 
         it 'succeeds' do
@@ -173,7 +173,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'patch_beta_app_review_detail' do
-        let(:path) { "betaAppReviewDetails" }
+        let(:path) { "v1/betaAppReviewDetails" }
         let(:app_id) { "123" }
         let(:attributes) { { key: "value" } }
         let(:body) do
@@ -197,7 +197,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "betaAppReviewSubmissions" do
       context 'get_beta_app_review_submissions' do
-        let(:path) { "betaAppReviewSubmissions" }
+        let(:path) { "v1/betaAppReviewSubmissions" }
         let(:app_id) { "123" }
 
         it 'succeeds' do
@@ -216,7 +216,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'post_beta_app_review_submissions' do
-        let(:path) { "betaAppReviewSubmissions" }
+        let(:path) { "v1/betaAppReviewSubmissions" }
         let(:build_id) { "123" }
         let(:body) do
           {
@@ -245,7 +245,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
       context 'delete_beta_app_review_submission' do
         let(:beta_app_review_submission_id) { "123" }
-        let(:path) { "betaAppReviewSubmissions/#{beta_app_review_submission_id}" }
+        let(:path) { "v1/betaAppReviewSubmissions/#{beta_app_review_submission_id}" }
 
         it 'succeeds' do
           params = {}
@@ -258,7 +258,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "betaBuildLocalizations" do
       context 'get_beta_build_localizations' do
-        let(:path) { "betaBuildLocalizations" }
+        let(:path) { "v1/betaBuildLocalizations" }
         let(:build_id) { "123" }
 
         it 'succeeds' do
@@ -277,7 +277,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'post_beta_build_localizations' do
-        let(:path) { "betaBuildLocalizations" }
+        let(:path) { "v1/betaBuildLocalizations" }
         let(:build_id) { "123" }
         let(:attributes) { { key: "value" } }
         let(:body) do
@@ -307,7 +307,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'patch_beta_build_localizations' do
-        let(:path) { "betaBuildLocalizations" }
+        let(:path) { "v1/betaBuildLocalizations" }
         let(:localization_id) { "123" }
         let(:attributes) { { key: "value" } }
         let(:body) do
@@ -332,7 +332,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "betaFeedbacks" do
       context 'get_beta_feedbacks' do
-        let(:path) { "betaFeedbacks" }
+        let(:path) { "v1/betaFeedbacks" }
         let(:app_id) { "123456789" }
         let(:default_params) { {} }
 
@@ -354,7 +354,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "betaGroups" do
       context 'get_beta_groups' do
-        let(:path) { "betaGroups" }
+        let(:path) { "v1/betaGroups" }
         let(:name) { "sir group a lot" }
         let(:default_params) { {} }
 
@@ -374,7 +374,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'add_beta_groups_to_build' do
-        let(:path) { "builds" }
+        let(:path) { "v1/builds" }
         let(:build_id) { "123" }
         let(:beta_group_ids) { ["123", "456"] }
         let(:body) do
@@ -398,7 +398,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'delete_beta_groups_from_build' do
-        let(:path) { "builds" }
+        let(:path) { "v1/builds" }
         let(:build_id) { "123" }
         let(:beta_group_ids) { ["123", "456"] }
         let(:body) do
@@ -422,7 +422,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'patch_beta_groups' do
-        let(:path) { "betaGroups" }
+        let(:path) { "v1/betaGroups" }
         let(:beta_group_id) { "123" }
         let(:attributes) { { public_link_enabled: false } }
         let(:body) do
@@ -447,7 +447,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "betaTesters" do
       context 'get_beta_testers' do
-        let(:path) { "betaTesters" }
+        let(:path) { "v1/betaTesters" }
         let(:app_id) { "123" }
 
         it 'succeeds' do
@@ -466,7 +466,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'post_bulk_beta_tester_assignments' do
-        let(:path) { "bulkBetaTesterAssignments" }
+        let(:path) { "v1/bulkBetaTesterAssignments" }
         let(:beta_group_id) { "123" }
         let(:beta_testers) do
           [
@@ -503,7 +503,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'post_beta_tester_assignment' do
-        let(:path) { "betaTesters" }
+        let(:path) { "v1/betaTesters" }
         let(:beta_group_ids) { ["123", "456"] }
         let(:attributes) { { email: "email1", firstName: "first1", lastName: "last1" } }
         let(:body) do
@@ -537,7 +537,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       context "add_beta_tester_to_group" do
         let(:beta_group_id) { "123" }
         let(:beta_tester_ids) { ["1234", "5678"] }
-        let(:path) { "betaGroups/#{beta_group_id}/relationships/betaTesters" }
+        let(:path) { "v1/betaGroups/#{beta_group_id}/relationships/betaTesters" }
         let(:body) do
           {
               data: beta_tester_ids.map do |id|
@@ -561,7 +561,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       context 'delete_beta_tester_from_apps' do
         let(:beta_tester_id) { "123" }
         let(:app_ids) { ["1234", "5678"] }
-        let(:path) { "betaTesters/#{beta_tester_id}/relationships/apps" }
+        let(:path) { "v1/betaTesters/#{beta_tester_id}/relationships/apps" }
         let(:body) do
           {
             data: app_ids.map do |id|
@@ -585,7 +585,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       context 'delete_beta_tester_from_beta_groups' do
         let(:beta_tester_id) { "123" }
         let(:beta_group_ids) { ["1234", "5678"] }
-        let(:path) { "betaTesters/#{beta_tester_id}/relationships/betaGroups" }
+        let(:path) { "v1/betaTesters/#{beta_tester_id}/relationships/betaGroups" }
         let(:body) do
           {
             data: beta_group_ids.map do |id|
@@ -609,7 +609,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       context "delete_beta_testers_from_app" do
         let(:app_id) { "123" }
         let(:beta_tester_ids) { ["1234", "5678"] }
-        let(:path) { "apps/#{app_id}/relationships/betaTesters" }
+        let(:path) { "v1/apps/#{app_id}/relationships/betaTesters" }
         let(:body) do
           {
             data: beta_tester_ids.map do |id|
@@ -632,7 +632,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       context 'add_beta_tester_to_builds' do
         let(:beta_tester_id) { "123" }
         let(:build_ids) { ["1234", "5678"] }
-        let(:path) { "betaTesters/#{beta_tester_id}/relationships/builds" }
+        let(:path) { "v1/betaTesters/#{beta_tester_id}/relationships/builds" }
         let(:body) do
           {
             data: build_ids.map do |id|
@@ -654,7 +654,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'add_beta_testers_to_build' do
-        let(:path) { "builds" }
+        let(:path) { "v1/builds" }
         let(:build_id) { "123" }
         let(:beta_tester_ids) { ["123", "456"] }
         let(:body) do
@@ -678,7 +678,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'delete_beta_testers_from_build' do
-        let(:path) { "builds" }
+        let(:path) { "v1/builds" }
         let(:build_id) { "123" }
         let(:beta_tester_ids) { ["123", "456"] }
         let(:body) do
@@ -704,7 +704,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "builds" do
       context 'get_builds' do
-        let(:path) { "builds" }
+        let(:path) { "v1/builds" }
         let(:build_id) { "123" }
         let(:default_params) { { include: "buildBetaDetail,betaBuildMetrics", limit: 10, sort: "uploadedDate" } }
 
@@ -725,7 +725,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
       context 'get_build' do
         let(:build_id) { "123" }
-        let(:path) { "builds/#{build_id}" }
+        let(:path) { "v1/builds/#{build_id}" }
 
         it 'succeeds' do
           params = {}
@@ -736,7 +736,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'patch_builds' do
-        let(:path) { "builds" }
+        let(:path) { "v1/builds" }
         let(:build_id) { "123" }
         let(:attributes) { { name: "some_name" } }
         let(:body) do
@@ -761,7 +761,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "buildBetaDetails" do
       context 'get_build_beta_details' do
-        let(:path) { "buildBetaDetails" }
+        let(:path) { "v1/buildBetaDetails" }
         let(:build_id) { "123" }
 
         it 'succeeds' do
@@ -780,7 +780,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
       end
 
       context 'patch_build_beta_details' do
-        let(:path) { "buildBetaDetails" }
+        let(:path) { "v1/buildBetaDetails" }
         let(:build_beta_details_id) { "123" }
         let(:attributes) { { key: "value" } }
         let(:body) do
@@ -806,7 +806,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
     describe "buildDeliveries" do
       context 'get_build_deliveries' do
         let(:app_id) { "123" }
-        let(:path) { "apps/#{app_id}/buildDeliveries" }
+        let(:path) { "v1/apps/#{app_id}/buildDeliveries" }
         let(:version) { "189" }
         let(:default_params) { {} }
 
@@ -828,7 +828,7 @@ describe Spaceship::ConnectAPI::TestFlight::Client do
 
     describe "preReleaseVersions" do
       context 'get_pre_release_versions' do
-        let(:path) { "preReleaseVersions" }
+        let(:path) { "v1/preReleaseVersions" }
         let(:version) { "186" }
         let(:default_params) { {} }
 

--- a/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
@@ -47,7 +47,7 @@ describe Spaceship::ConnectAPI::Tunes::Client do
 
     describe "appStoreVersionReleaseRequests" do
       context 'post_app_store_version_release_request' do
-        let(:path) { "appStoreVersionReleaseRequests" }
+        let(:path) { "v1/appStoreVersionReleaseRequests" }
         let(:app_store_version_id) { "123" }
         let(:body) do
           {
@@ -78,7 +78,7 @@ describe Spaceship::ConnectAPI::Tunes::Client do
     describe "reviewSubmissions" do
       context 'get_review_submissions' do
         let(:app_id) { "123456789-app" }
-        let(:path) { "apps/#{app_id}/reviewSubmissions" }
+        let(:path) { "v1/apps/#{app_id}/reviewSubmissions" }
 
         it 'succeeds' do
           params = {}
@@ -90,7 +90,7 @@ describe Spaceship::ConnectAPI::Tunes::Client do
 
       context 'get_review_submission' do
         let(:review_submission_id) { "123456789" }
-        let(:path) { "reviewSubmissions/#{review_submission_id}" }
+        let(:path) { "v1/reviewSubmissions/#{review_submission_id}" }
 
         it 'succeeds' do
           params = {}
@@ -103,7 +103,7 @@ describe Spaceship::ConnectAPI::Tunes::Client do
       context 'post_review_submission' do
         let(:app_id) { "123456789-app" }
         let(:platform) { Spaceship::ConnectAPI::Platform::IOS }
-        let(:path) { "reviewSubmissions" }
+        let(:path) { "v1/reviewSubmissions" }
         let(:body) do
           {
             data: {
@@ -135,7 +135,7 @@ describe Spaceship::ConnectAPI::Tunes::Client do
       context 'patch_review_submission' do
         let(:review_submission_id) { "123456789" }
         let(:attributes) { { submitted: true } }
-        let(:path) { "reviewSubmissions/#{review_submission_id}" }
+        let(:path) { "v1/reviewSubmissions/#{review_submission_id}" }
         let(:body) do
           {
             data: {
@@ -159,7 +159,7 @@ describe Spaceship::ConnectAPI::Tunes::Client do
     describe "reviewSubmissionItems" do
       context 'get_review_submission_items' do
         let(:review_submission_id) { "123456789" }
-        let(:path) { "reviewSubmissions/#{review_submission_id}/items" }
+        let(:path) { "v1/reviewSubmissions/#{review_submission_id}/items" }
 
         it 'succeeds' do
           params = {}
@@ -172,7 +172,7 @@ describe Spaceship::ConnectAPI::Tunes::Client do
       context 'post_review_submission_item' do
         let(:review_submission_id) { "123456789" }
         let(:app_store_version_id) { "123456789-app-store-version" }
-        let(:path) { "reviewSubmissionItems" }
+        let(:path) { "v1/reviewSubmissionItems" }
         let(:body) do
           {
             data: {

--- a/spaceship/spec/connect_api/users/user_client_spec.rb
+++ b/spaceship/spec/connect_api/users/user_client_spec.rb
@@ -55,7 +55,7 @@ describe Spaceship::ConnectAPI::Users::Client do
 
     describe "users" do
       context 'get_users' do
-        let(:path) { "users" }
+        let(:path) { "v1/users" }
 
         it 'succeeds' do
           params = {}
@@ -70,7 +70,7 @@ describe Spaceship::ConnectAPI::Users::Client do
         let(:all_apps_visible) { false }
         let(:provisioning_allowed) { true }
         let(:roles) { ["ADMIN"] }
-        let(:path) { "users/#{user_id}" }
+        let(:path) { "v1/users/#{user_id}" }
         let(:app_ids) { ["456", "789"] }
         let(:body) do
           {
@@ -119,7 +119,7 @@ describe Spaceship::ConnectAPI::Users::Client do
 
       context 'delete_user' do
         let(:user_id) { "123" }
-        let(:path) { "users/#{user_id}" }
+        let(:path) { "v1/users/#{user_id}" }
 
         it 'succeeds' do
           req_mock = test_request(path)
@@ -130,7 +130,7 @@ describe Spaceship::ConnectAPI::Users::Client do
 
       context 'post_user_visible_apps' do
         let(:user_id) { "123" }
-        let(:path) { "users/#{user_id}/relationships/visibleApps" }
+        let(:path) { "v1/users/#{user_id}/relationships/visibleApps" }
         let(:app_ids) { ["456", "789"] }
         let(:body) do
           {
@@ -154,7 +154,7 @@ describe Spaceship::ConnectAPI::Users::Client do
 
       context 'patch_user_visible_apps' do
         let(:user_id) { "123" }
-        let(:path) { "users/#{user_id}/relationships/visibleApps" }
+        let(:path) { "v1/users/#{user_id}/relationships/visibleApps" }
         let(:app_ids) { ["456", "789"] }
         let(:body) do
           {
@@ -178,7 +178,7 @@ describe Spaceship::ConnectAPI::Users::Client do
 
       context 'delete_user_visible_apps' do
         let(:user_id) { "123" }
-        let(:path) { "users/#{user_id}/relationships/visibleApps" }
+        let(:path) { "v1/users/#{user_id}/relationships/visibleApps" }
         let(:app_ids) { ["456", "789"] }
         let(:body) do
           {
@@ -202,7 +202,7 @@ describe Spaceship::ConnectAPI::Users::Client do
 
       context 'get_user_visible_apps' do
         let(:user_id) { "42" }
-        let(:path) { "users/#{user_id}/visibleApps" }
+        let(:path) { "v1/users/#{user_id}/visibleApps" }
 
         it 'succeeds' do
           params = {}
@@ -215,7 +215,7 @@ describe Spaceship::ConnectAPI::Users::Client do
 
     describe "user_invitations" do
       context 'get_user_invitations' do
-        let(:path) { "userInvitations" }
+        let(:path) { "v1/userInvitations" }
 
         it 'succeeds' do
           params = {}
@@ -226,7 +226,7 @@ describe Spaceship::ConnectAPI::Users::Client do
       end
 
       context 'post_user_invitation' do
-        let(:path) { "userInvitations" }
+        let(:path) { "v1/userInvitations" }
         let(:attributes) {
           {
             email: "test@example.com",
@@ -276,7 +276,7 @@ describe Spaceship::ConnectAPI::Users::Client do
 
       context 'delete_user_invitation' do
         let(:invitation_id) { "123" }
-        let(:path) { "userInvitations/#{invitation_id}" }
+        let(:path) { "v1/userInvitations/#{invitation_id}" }
 
         it 'succeeds' do
           req_mock = test_request(path)
@@ -287,7 +287,7 @@ describe Spaceship::ConnectAPI::Users::Client do
 
       context 'get_user_invitation_visible_apps' do
         let(:invitation_id) { "42" }
-        let(:path) { "userInvitations/#{invitation_id}/visibleApps" }
+        let(:path) { "v1/userInvitations/#{invitation_id}/visibleApps" }
 
         it 'succeeds' do
           params = {}

--- a/spaceship/spec/stats_middleware_spec.rb
+++ b/spaceship/spec/stats_middleware_spec.rb
@@ -64,8 +64,8 @@ describe Spaceship::StatsMiddleware do
       expect(Spaceship::StatsMiddleware.service_stats.size).to eq(8)
 
       expect(find_count("api.appstoreconnect.apple.com")).to eq(2)
-      expect(find_count("appstoreconnect.apple.com/iris/v1/")).to eq(1)
-      expect(find_count("developer.apple.com/services-account/v1/")).to eq(1)
+      expect(find_count("appstoreconnect.apple.com/iris/")).to eq(1)
+      expect(find_count("developer.apple.com/services-account/")).to eq(1)
       expect(find_count("idmsa.apple.com")).to eq(1)
       expect(find_count("appstoreconnect.apple.com/olympus/v1/")).to eq(1)
       expect(find_count("appstoreconnect.apple.com/WebObjects/iTunesConnect.woa/")).to eq(1)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

There is a need for preparing fastlane for implementation of requests that have `v2` or `v3` version in `path` component as noted in https://github.com/fastlane/fastlane/pull/21890.
There are requests defined in open api spec (https://developer.apple.com/documentation/appstoreconnectapi) that  don't have `v1` in `path`, e.g. https://developer.apple.com/documentation/appstoreconnectapi/read_app_availablity_territories
`GET https://api.appstoreconnect.apple.com/v2/appAvailabilities/{id}/territoryAvailabilities`

From spec:
```
"paths" : {
...
  "/v2/appAvailabilities/{id}/territoryAvailabilities" : {
      "get" : {
...
```

### Description

Endpoint's `hostname`s for `ConnectAPI` had hardcoded endpoint version `v1`, also for `https://api.appstoreconnect.apple.com/v1/` when API token is used.
In this PR `v1` version is moved from `hostname` to paths for 4 `ConnectAPI` clients:
- `tunes_request_client`
- `provisioning_request_client`
- `test_flight_request_client`
- `users_request_client`

Also, this change required change in `stats_middleware` and `stats_middleware_spec` to properly log use of endpoints.

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

Runned unit tests. Not all client methods are tested though, so I checked that all `get`, `post`, `patch` and `delete` requests in code have `v1` in path with simple regular expressions:
```
tunes_request_client\.(get|post|patch|delete)
provisioning_request_client\.(get|post|patch|delete)
test_flight_request_client\.(get|post|patch|delete)
users_request_client\.(get|post|patch|delete)
provisioning_request_client\.(get|post|patch|delete)\("#\{Version::V1\}/
users_request_client\.(get|post|patch|delete)\("#\{Version::V1\}/
test_flight_request_client\.(get|post|patch|delete)\("#\{Version::V1\}/
tunes_request_client\.(get|post|patch|delete)\("#\{Version::V1\}/
```
