### PR TITLE
[pilot] Fix Large File Upload Issues in Mac pkg Deployment

### DIFF
--- a/fastlane_core/lib/fastlane_core/pkg_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/pkg_upload_package_builder.rb
@@ -22,7 +22,7 @@ module FastlaneCore
         apple_id: app_id,
         file_size: File.size(pkg_path),
         ipa_path: File.basename(pkg_path), # this is only the base name as the ipa is inside the package
-        md5: Digest::MD5.hexdigest(File.read(pkg_path)),
+        md5: calculate_md5(pkg_path),
         archive_type: 'product-archive',
         platform: platform
       }
@@ -41,9 +41,33 @@ module FastlaneCore
     def copy_pkg(pkg_path)
       ipa_file_name = Digest::MD5.hexdigest(pkg_path)
       resulting_path = File.join(self.package_path, "#{ipa_file_name}.pkg")
-      FileUtils.cp(pkg_path, resulting_path)
 
-      resulting_path
+      begin
+        File.open(pkg_path, 'rb') do |src|
+          File.open(resulting_path, 'wb') do |dst|
+            while (buffer = src.read(1024 * 1024)) do
+              dst.write(buffer)
+            end
+          end
+        end
+        return resulting_path
+      rescue StandardError => e
+        UI.user_error!("Error copying file '#{pkg_path}' to '#{resulting_path}': #{e.message}")
+      end
+    end
+
+    def calculate_md5(file_path)
+      begin
+        md5 = Digest::MD5.new
+        File.open(file_path, 'rb') do |file|
+          while (buffer = file.read(1024 * 1024)) do
+            md5.update(buffer)
+          end
+        end
+        return md5.hexdigest
+      rescue StandardError => e
+        UI.user_error!("Error reading file '#{file_path}': #{e.message}")
+      end
     end
   end
 end


### PR DESCRIPTION
### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Description

This Pull Request introduces enhancements to the PkgUploadPackageBuilder class in order to improve efficiency when handling large files. The main modifications include the implementation of chunked reading and writing for file operations.

### Motivation and Context
- Chunked File Copying: Modified the copy_pkg method to utilize chunked reading and writing during the file copy process. This approach helps optimize memory usage and improves the handling of large files.
- Chunked MD5 Calculation: Updated the calculate_md5 method to perform MD5 calculation on file data in chunks. This ensures better efficiency when processing large files without loading the entire content into memory.

### Testing Steps
1. Create a test package with a large payload.
2. Start command:
fastlane pilot upload --skip_waiting_for_build_processing true --api_key_path keys.json
3. Verify that the file copying process completed successfully without memory issues.
