### PR TITLE
Add explicit error for destination without simulator

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -129,10 +129,13 @@ module FastlaneCore
       end
 
       def latest_simulator_version_for_device(device)
-        simulators.select { |s| s.name == device }
-                  .sort_by { |s| Gem::Version.create(s.os_version) }
-                  .last
-                  .os_version
+        latest_simulator = simulators.select { |s| s.name == device }
+                                     .sort_by { |s| Gem::Version.create(s.os_version) }
+                                     .last
+
+        UI.error("No simulator found for device: #{device}") unless latest_simulator
+
+        latest_simulator.os_version
       end
 
       # The code below works from Xcode 7 on


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

**😭 Before:**
When configuring a new target with UI tests to setup Fastlane Snapshot, it's easy to get fooled and add an unwanted "Mac" destination. 
In this case, when launching `fastlane snapshot`, user receives a cryptic error: 
````Error running screenshots command - latest_simulator_version_for_device: undefined method `os_version' for nil:NilClass ````.

**👍 After:**
With this change, if no simulator is found for a given device, display a pretty error to show for which device, so that users can quickly understand that the destination target is wrong.


<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
