### PR TITLE
[spaceship] Fix filtering of Mac devices when trying to create a macOS profile

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -33,6 +33,7 @@ module Spaceship
 
         # As of 2022-11-12, this is not officially supported by App Store Connect API
         APPLE_SILICON_MAC = "APPLE_SILICON_MAC"
+        INTEL_MAC = "INTEL_MAC"
       end
 
       module Status
@@ -94,7 +95,9 @@ module Spaceship
             ]
           when :macos, :catalyst
             [
-              Spaceship::ConnectAPI::Device::DeviceClass::MAC
+              Spaceship::ConnectAPI::Device::DeviceClass::MAC,
+              Spaceship::ConnectAPI::Device::DeviceClass::APPLE_SILICON_MAC,
+              Spaceship::ConnectAPI::Device::DeviceClass::INTEL_MAC
             ]
           else
             []

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -31,7 +31,7 @@ module Spaceship
         APPLE_TV = "APPLE_TV"
         MAC = "MAC"
 
-        # As of 2022-11-12, this is not officially supported by App Store Connect API
+        # As of 2024-03-1082, this is not _officially_ supported by App Store Connect API (according to API docs)—yet still used in the API responses
         APPLE_SILICON_MAC = "APPLE_SILICON_MAC"
         INTEL_MAC = "INTEL_MAC"
       end

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -31,7 +31,7 @@ module Spaceship
         APPLE_TV = "APPLE_TV"
         MAC = "MAC"
 
-        # As of 2024-03-1082, this is not _officially_ supported by App Store Connect API (according to API docs)—yet still used in the API responses
+        # As of 2024-03-08, this is not _officially_ supported by App Store Connect API (according to API docs)—yet still used in the API responses
         APPLE_SILICON_MAC = "APPLE_SILICON_MAC"
         INTEL_MAC = "INTEL_MAC"
       end


### PR DESCRIPTION
Seems like ASC updated the values used in of `deviceClass` attribute to now return `APPLE_SILICON_MAC` and `INTEL_MAC` (instead of just `MAC` like currently still documented in the API)

---

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

When trying to update my provisioning profiles for `macOS Development` using `match` today using this lane:

```ruby
  sync_code_signing(
    platform: 'macos',
    app_identifier: APPLE_BUNDLE_IDENTIFIER,
    team_id: APPLE_TEAM_ID,
    type: 'development',

    storage_mode: 's3',
    s3_region: MATCH_S3_REGION,
    s3_bucket: MATCH_S3_BUCKET,

    readonly: false,
    force: true
  )
```

I kept getting the following error from the API:

```json
 {
  "errors" : [ {
    "id" : "51a80083-42f1-4d82-8524-fc0cecb273fc",
    "status" : "409",
    "code" : "ENTITY_ERROR",
    "title" : "There is a problem with the request entity",
    "resultCode" : 35,
    "detail" : "There are no current MAC_OS devices on this team matching the provided device IDs."
  } ]
}
```

It turns out that when `match` tries to list all Mac devices (internally using `devices_for_platform(platform: 'mac')` and filter the found devices by `device_class`, none of the Mac devices had `device_class = 'MAC'`, and thus the subsequent request done by _spaceship_ to create the macOS profile with an empty list of devices made the API complain.

### Description

When running `fastlane spaceship` in Playground mode to debug what was happening, and calling ` Spaceship::ConnectAPI::Device.all`, I saw that amongst all the devices returned, none of them had `MAC` as `device_class`, and `Spaceship::ConnectAPI::Device.all.map(&:device_class).uniq` returned `"APPLE_SILICON_MAC", "IPHONE", "IPOD", "IPAD", "INTEL_MAC", "APPLE_WATCH", "APPLE_TV", "APPLE_VISION_PRO"`

This to fix the issue, this PR:
 - Adds the new `INTEL_MAC` constant to `DeviceClass`
 - Adds `DeviceClass::APPLE_SILICON_MAC` and `DeviceClass::INTEL_MAC` to the list of `device_classes` to filter on—alongside the `DeviceClass::MAC` that was already there—when `platform` is `:macos`

### Testing Steps

I tested this by doing the same modifications as in this PR directly in the `vendor/bundle/ruby/3.2.0/gems/fastlane-2.219.0/spaceship/lib/spaceship/connect_api/models/device.rb` of my project's working copy (like an animal 😅 ) then re-run our lane that calls `match` without any change, and this time it finally passed and created the profile as expected.