### PR TITLE
Fix `fetch_provisioning_profile` when `output_path` is provided as a match option

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -356,7 +356,6 @@ module Match
 
       if params[:output_path]
         FileUtils.cp(stored_profile_path, params[:output_path])
-        installed_profile = FastlaneCore::ProvisioningProfile.install(stored_profile_path, keychain_path)
       end
 
       Utils.fill_environment(Utils.environment_variable_name(app_identifier: app_identifier,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -356,7 +356,7 @@ module Match
 
       if params[:output_path]
         FileUtils.cp(stored_profile_path, params[:output_path])
-        installed_profile = FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
+        installed_profile = FastlaneCore::ProvisioningProfile.install(stored_profile_path, keychain_path)
       end
 
       Utils.fill_environment(Utils.environment_variable_name(app_identifier: app_identifier,

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -224,6 +224,7 @@ describe Match do
 
           # match options
           match_test_options = {
+            output_path: "tmp/match_certs", # to test the expectation that we do a file copy when this option is provided
             readonly: true # Current test suite.
           }
           match_config = create_match_config_with_git_storage(extra_values: match_test_options)
@@ -257,6 +258,12 @@ describe Match do
             expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(stored_valid_profile_path, keychain_path)
             expect(Match::Generator).not_to receive(:generate_provisioning_profile)
           end
+
+          # output_path
+          expect(FileUtils).to receive(:mkdir_p).with(match_test_options[:output_path])
+          expect(FileUtils).to receive(:cp).with(stored_valid_cert_path, match_test_options[:output_path])
+          expect(FileUtils).to receive(:cp).with("#{repo_dir}/certs/distribution/E7P4EE896K.p12", match_test_options[:output_path])
+          expect(FileUtils).to receive(:cp).with(stored_valid_profile_path, match_test_options[:output_path])
 
           # WHEN
           Match::Runner.new.run(match_config)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves https://github.com/fastlane/fastlane/issues/21945

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
Given some investigation and [subsequent conversation](https://github.com/fastlane/fastlane/pull/21946#discussion_r1552393387), this PR proposes that the line of code causing #21945 can simply be removed. It should not be necessary to run `FastlaneCore::ProvisioningProfile.install` a second time when `output_path` is provided as a match option.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

For my own testing, I used this branch of `fastlane` to execute the same CI workflow (from a private project) that was failing on `2.220.0` with the error described in #21945. The `match` actions for all builds, as well as the subsequent `gym` actions, all ran successfully with no observable side effects.

```ruby
match(
    output_path: "/tmp/match_certs", # must include, this creates the condition that this PR fixes
    # everything below is merge suggestion, use whatever you consider to be a standard set of match params
    git_url: YOUR_MATCH_REPO_URL,
    type: "adhoc",
    app_identifier: YOUR_APP_IDENTIFIER,
    force_for_new_devices: true,
    include_all_certificates: true,
    force_for_new_certificates: true,
    shallow_clone: true,
    readonly: true,
)
```
