### PR TITLE
Add missing require 'ostruct' in erb_template_helper.rb to solve uninitialized constant Fastlane::OpenStruct (NameError) 

### DIFF
--- a/fastlane/lib/fastlane/erb_template_helper.rb
+++ b/fastlane/lib/fastlane/erb_template_helper.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 module Fastlane
   class ErbTemplateHelper
     require "erb"

--- a/fastlane/lib/fastlane/erb_template_helper.rb
+++ b/fastlane/lib/fastlane/erb_template_helper.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+
 module Fastlane
   class ErbTemplateHelper
     require "erb"


### PR DESCRIPTION
### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #21944

### Description

Added missing require 'ostruct' on erb_template_helper.rb to solve error:

> /usr/local/lib/ruby/gems/2.7.0/gems/fastlane-2.220.0/fastlane/lib/fastlane/erb_template_helper.rb:20:in <module:Fastlane>': uninitialized constant Fastlane::OpenStruct (NameError)

### Testing Steps
