### PR TITLE
[fastlane] Print better errors when exception occurring in Fastfile 

### DIFF
--- a/fastlane/lib/fastlane/lane_manager_base.rb
+++ b/fastlane/lib/fastlane/lane_manager_base.rb
@@ -78,15 +78,23 @@ module Fastlane
     end
 
     def self.print_error_line(ex)
-      error_line = ex.backtrace.first
-      return if error_line.nil?
+      lines = ex.backtrace_locations&.select { |loc| loc.path == 'Fastfile' }&.map(&:lineno)
+      return if lines.nil? || lines.empty?
 
-      error_line = error_line.match("Fastfile:(\\d+):")
-      return unless error_line
+      fastfile_content = File.read(FastlaneCore::FastlaneFolder.fastfile_path, encoding: "utf-8")
+      if ex.backtrace_locations.first&.path == 'Fastfile'
+        # If exception happened directly in the Fastfile itself (e.g. ArgumentError)
+        UI.error("Error in your Fastfile at line #{lines.first}")
+        UI.content_error(fastfile_content, lines.first)
+        lines.shift
+      end
 
-      line = error_line[1]
-      UI.error("Error in your Fastfile at line #{line}")
-      UI.content_error(File.read(FastlaneCore::FastlaneFolder.fastfile_path, encoding: "utf-8"), line)
+      unless lines.empty?
+        # If exception happened directly in the Fastfile, also print the caller (still from the Fastfile).
+        # If exception happened in _fastlane_ internal code, print the line from the Fastfile that called it
+        UI.error("Called from Fastfile at line #{lines.first}")
+        UI.content_error(fastfile_content, lines.first)
+      end
     end
   end
 end

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -40,13 +40,13 @@ module Fastlane
       return_val = nil
 
       path_to_use = FastlaneCore::FastlaneFolder.path || Dir.pwd
-      parameters ||= {}
+      parameters ||= {} # by default no parameters
       begin
         Dir.chdir(path_to_use) do # the file is located in the fastlane folder
           execute_flow_block(before_all_blocks, current_platform, current_lane, parameters)
           execute_flow_block(before_each_blocks, current_platform, current_lane, parameters)
 
-          return_val = lane_obj.call(parameters) # by default no parameters
+          return_val = lane_obj.call(parameters)
 
           # after blocks are only called if no exception was raised before
           # Call the platform specific after block and then the general one

--- a/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
+++ b/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb
@@ -108,12 +108,14 @@ module FastlaneCore
       start_line = error_line - 2 < 1 ? 1 : error_line - 2
       end_line = error_line + 2 < contents.length ? error_line + 2 : contents.length
 
+      error('```')
       Range.new(start_line, end_line).each do |line|
         str = line == error_line ? " => " : "    "
         str << line.to_s.rjust(Math.log10(end_line) + 1)
         str << ":\t#{contents[line - 1]}"
         error(str)
       end
+      error('```')
     end
 
     #####################################################


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

When there is an error in the Fastfile, the error printed out isn't always clear which line from the fastfile the error comes from.
 - This happened to me while I was starting to use the `lane :foo do |readonly: true|` keyword syntax to declare my lanes in my `Fastfile` (see https://github.com/fastlane/fastlane/pull/21587) and noticed that calling that lane with incorrect arguments didn't show me the _call site_ that needed fixing, but instead the line where the method was _declared_.
    <details><summary>🖼️ e.g. <code>Fastfile</code> calling a lane named <code>alpha_code_signing</code> which ends up calling <code>update_code_signing_enterprise(read_only: true, app_identifiers: APP_IDS)</code> with wrong parameters, but logs doesn't show me that the problem is at the call site in the <code>alpha_code_signing</code> lane</summary><img width="996" alt="image" src="https://github.com/fastlane/fastlane/assets/216089/f5fdb03a-d226-4cc2-90c2-07a2535ee96e"></details>
 - This also happen if you have a syntax error when calling a lane or have a string in your code that doesn't correspond to a lane, variable or action
    <details><summary>🖼️ e.g. If I have a <code>boum!</code> in the code of one of my lane, it doesn't show me where in the <code>Fastfile</code> that <code>boum!</code> call is</summary><img width="1022" alt="image" src="https://github.com/fastlane/fastlane/assets/216089/d0260df7-7651-45ae-ab8c-9be23e09b0d9"></details>


### Description

This PR improves the output of errors that happen when evaluating lanes in the `Fastfile`—be it `ArgumentError` for invalid lane parameters, invalid action names, etc—to print more code context, and print that context in more cases (e.g. even if the exception from the Fastfile evaluation is not at the top of the backtrace).

Now the error reporting looks like this:
<details><summary>🖼️ Calling another lane with wrong keyword arguments</summary><img width="1111" alt="image" src="https://github.com/fastlane/fastlane/assets/216089/facea683-7205-4c44-b93d-a91b91ccc207"></details>
<details><summary>🖼️ Calling another Ruby function with wrong arguments</summary><img width="996" alt="image" src="https://github.com/fastlane/fastlane/assets/216089/ab31be3e-e55a-48b6-a172-6a17df250291"></details>
<details><summary>🖼️  Calling a non-existing method from the Fastfile</summary><img width="1112" alt="image" src="https://github.com/fastlane/fastlane/assets/216089/8db564c3-3bea-47b9-ab99-96b1572aecce"></details>


### Testing Steps

 - Write a dummy `Fastfile` in a test folder
```ruby
lane :parent do |arg1: true|
  child(arg1: arg1, arg2: arg2)
end
lane :child do |arg1: true, arg2: 42|
  custom_func(arg1: arg1, arg2: arg2)
end
def custom_func(arg1:, arg2:)
  UI.message("arg1: #{arg1}, arg2: #{arg2}")
end
```
 - Create a `Gemfile` in that test folder pointing to this branch of `fastlane`, run `bundle install`
 - Run `bundle exec fastlane parent` and confirm that it works
 - Run `bundle exec fastlane parent arg_1:oops` and confirm that the error is logged with a nice backtrace pointing to the definition of `lane :parent`, and the full Ruby stacktrace isn't printed
 - Edit the `Fastfile` to introduce an error in the call site of `child` within the `parent` lane
 - Run `bundle exec fastlane parent arg1:false` and confirm that the error is logged with two nice backtraces pointing to the definition of `lane :child` then the erroneous call site of it within `lane :parent`
 - Test other similar cases by moving the syntax errors to other places in the `Fastfile`, like in the call to `custom_func`
