### PR TITLE
Fix incorrect scan results with retry feature and -test-repetition-relaunch-enabled

### DIFF
--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -337,7 +337,16 @@ module Trainer
         row
       end
 
-      self.data = rows
+      self.data = remove_repetition_retries(rows, output_remove_retry_attempts)
+    end
+
+    def remove_repetition_retries(rows, output_remove_retry_attempts)
+      if output_remove_retry_attempts
+        rows.group_by { |row| row[:test_name] }
+            .map { |_, group| group.min_by { |row| row[:number_of_failures_excluding_retries] } }
+      else
+        rows
+      end
     end
 
     def test_summaries_to_configuration_names(test_summaries)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

When the 'test-repetition-relaunch-enabled' option is enabled, the scan output includes results from all test retries. The following is an example of a scan run with this option enabled.

```
    scan(
      package_path: '.',
      workspace: '.', 
      device: 'iPhone 14',
      output_directory: test_output_path,
      code_coverage: true,
      result_bundle: true,
      xcargs: "-test-repetition-relaunch-enabled YES",
      number_of_retries: 3
    )
```

From the log, tests run twice and succeeded at the end.

```
Executed 1724 tests, with 2 failures (0 unexpected) in 9.243 (9.687) seconds
Executed 1724 tests, with 0 failures (0 unexpected) in 12.912 (13.143) seconds
```

But the scan results combined them together.

```
 +--------------------+------+
 |       Test Results        |
 +--------------------+------+
 | Number of tests    | 3448 |
 | Number of failures | 2    |
 +--------------------+------+
```
As scan results showed 2 failures, fastlane returned with failure
```
 fastlane finished with errors
```

### Description

This change removes retry attempts and selects the best result from all retries with the minimum test failures as the final scan result, ensuring accurate scan output.

Executed 1724 tests, with 1 failures (0 unexpected) in 10.121 (10.674) seconds
Executed 1724 tests, with 0 failures (0 unexpected) in 13.318 (14.871) seconds

```
 +--------------------+------+
 |       Test Results        |
 +--------------------+------+
 | Number of tests    | 1724 |
 | Number of failures | 0    |
 +--------------------+------+
```

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
