### PR TITLE
[pilot] Fix ASC API error when `reject_build_waiting_for_review: true`

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -368,12 +368,17 @@ module Pilot
     end
 
     def reject_build_waiting_for_review(build)
-      waiting_for_review_build = build.app.get_builds(filter: { "betaAppReviewSubmission.betaReviewState" => "WAITING_FOR_REVIEW" }, includes: "betaAppReviewSubmission,preReleaseVersion").first
+      waiting_for_review_build = build.app.get_builds(
+        filter: { "betaAppReviewSubmission.betaReviewState" => "WAITING_FOR_REVIEW,IN_REVIEW",
+                  "expired" => false,
+                  "preReleaseVersion.version" => build.pre_release_version.version },
+        includes: "betaAppReviewSubmission,preReleaseVersion"
+      ).first
       unless waiting_for_review_build.nil?
         UI.important("Another build is already in review. Going to remove that build and submit the new one.")
-        UI.important("Deleting beta app review submission for build: #{waiting_for_review_build.app_version} - #{waiting_for_review_build.version}")
-        waiting_for_review_build.beta_app_review_submission.delete!
-        UI.success("Deleted beta app review submission for previous build: #{waiting_for_review_build.app_version} - #{waiting_for_review_build.version}")
+        UI.important("Canceling beta app review submission for build: #{waiting_for_review_build.app_version} - #{waiting_for_review_build.version}")
+        waiting_for_review_build.expire!
+        UI.success("Canceled beta app review submission for previous build: #{waiting_for_review_build.app_version} - #{waiting_for_review_build.version}")
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/fastlane/fastlane/issues/18408

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

The ASC API to delete TestFlight pending builds doesn't exist, so when _fastlane_'s _pilot_ is trying to `reject_build_waiting_for_review`, we get this error:
```
The resource 'betaAppReviewSubmissions' does not allow 'DELETE'. Allowed operations are: GET_COLLECTION, GET_INSTANCE, CREATE
```

### Description

Applying the fix from https://github.com/fastlane/fastlane/issues/18408#issuecomment-1640343154 to delete pending submissions properly — kudos to @nid90 for the code of the fix.

### Testing Steps

I've just tested the fix with one of our apps which has a TestFlight build still in "Waiting for Review" state.
 - When we tried to submit a new build earlier today, the lane failed with the above error about `DELETE` not being allowed.
 - After trying to submit another new build while pointing my `Gemfile` to this branch of the `fastlane` repo, this time it passed with the following logs in our CI:
```
[09:37:53 -0700]: Another build is already in review. Going to remove that build and submit the new one.
[09:37:53 -0700]: Canceling beta app review submission for build: 34.5 - 345001
[09:37:55 -0700]: Canceled beta app review submission for previous build: 34.5 - 345001
[09:37:55 -0700]: Distributing new build to testers: 34.5 - 345003
```
and the previous build `345001` was properly marked as "Expired" in TestFlight after that:
![image](https://github.com/fastlane/fastlane/assets/216089/ad0664d0-f355-4c07-a770-104c5127784e)
