### PR TITLE
Fix Crash in Scan Runner.rb

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -43,12 +43,14 @@ module Scan
 
       prelaunch_simulators
 
-      if Scan.config[:reinstall_app]
-        app_identifier = Scan.config[:app_identifier]
-        app_identifier ||= UI.input("App Identifier: ")
+      if Scan.devices
+        if Scan.config[:reinstall_app]
+          app_identifier = Scan.config[:app_identifier]
+          app_identifier ||= UI.input("App Identifier: ")
 
-        Scan.devices.each do |device|
-          FastlaneCore::Simulator.uninstall_app(app_identifier, device.name, device.udid)
+          Scan.devices.each do |device|
+            FastlaneCore::Simulator.uninstall_app(app_identifier, device.name, device.udid)
+          end
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves a crash when `Scan.devices` is `nil`. 

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Similar to the lines above it, check if `Scan.devices` is non-`nil` before iterating over its values. 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
