### PR TITLE
Allow multi-platform visionOS IPAs to be created

### DIFF
--- a/gym/lib/gym/module.rb
+++ b/gym/lib/gym/module.rb
@@ -59,7 +59,7 @@ module Gym
     end
 
     def building_multiplatform_for_ios?
-      Gym.project.multiplatform? && Gym.project.ios? && (Gym.config[:sdk] == "iphoneos" || Gym.config[:sdk] == "iphonesimulator")
+      Gym.project.multiplatform? && Gym.project.ios? && (Gym.config[:sdk] == "iphoneos" || Gym.config[:sdk] == "iphonesimulator" || Gym.config[:sdk] == "xros" || Gym.config[:sdk] == "xrsimulator")
     end
 
     def building_multiplatform_for_mac?


### PR DESCRIPTION
🔑 
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Creating an IPA for visionOS with a multi-platform target fails. 

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
This change allows an IPA to be built by treating a multi-platform target building for the visionOS SDK to be treated like an iOS target for the purposes of creating an IPA. I tested this on a closed source project. 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Testing would require having a multi-platform app target. Then, run the gym command with the following settings:

```ruby
gym(
  archive_path: "Release.xcarchive",
  build_path: ".",
  clean: true,
  configuration: "Release",
  export_options: RELEVANT_EXPORT_OPTIONS_FOR_PROJECT,
  output_name: "Release.ipa",
  scheme: "SCHEME_NAME",
  sdk: "xros",
  workspace: "WORKSPACE",
)
```

If you run that command from trunk you will see that the IPA is not created. If you run it from this branch you will see that it is created.