### PR TITLE
[supply] force a track promotion

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -174,6 +174,12 @@ A common Play publishing scenario might involve uploading an APK version to a te
 
 This can be done using the `--track_promote_to` parameter. The `--track_promote_to` parameter works with the `--track` parameter to command the Play API to promote existing Play track APK version(s) (those active on the track identified by the `--track` param value) to a new track (`--track_promote_to` value).
 
+### Force a Track Promotion
+
+The AndroidPublisherV3 API now returns only the latest version of each track instead of multiple versions as before. This created a difficulty when trying to promote older versions, as they were not being returned by the API. See [fastlane/fastlane#18497](https://github.com/fastlane/fastlane/issues/18497) for more info.
+
+To work around this issue, a solution was implemented to force the submission of the version with `version_code = 1`, requiring the inclusion of the `--version_name` parameter and also the `--track_promote_force` parameter. This ensures that the older version is submitted correctly, even after the change in the API.
+
 ## Retrieve Track Release Names & Version Codes
 
 Before performing a new APK upload you may want to check existing track version codes or release names, or you may simply want to provide an informational lane that displays the currently promoted version codes or release name for the production track. You can use the `google_play_track_version_codes` action to retrieve existing version codes for a package and track. You can use the `google_play_track_release_names` action to retrieve existing release names for a package and track.

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -11058,6 +11058,7 @@ public func ssh(username: String,
    - syncImageUpload: Whether to use sha256 comparison to skip upload of images and screenshots that are already in Play Store
    - trackPromoteTo: The track to promote to. The default available tracks are: production, beta, alpha, internal
    - trackPromoteReleaseStatus: Promoted track release status (used when promoting a track) - valid values are completed, draft, halted, inProgress
+   - trackPromoteForce: Force promote a specific version code (version_name is required)
    - validateOnly: Only validate changes with Google Play rather than actually publish
    - mapping: Path to the mapping file to upload (mapping.txt or native-debug-symbols.zip alike)
    - mappingPaths: An array of paths to mapping files to upload (mapping.txt or native-debug-symbols.zip alike)
@@ -11101,6 +11102,7 @@ public func supply(packageName: String,
                    syncImageUpload: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                    trackPromoteTo: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                    trackPromoteReleaseStatus: String = "completed",
+                   trackPromoteForce: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                    validateOnly: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                    mapping: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                    mappingPaths: OptionalConfigValue<[String]?> = .fastlaneDefault(nil),
@@ -11142,6 +11144,7 @@ public func supply(packageName: String,
     let syncImageUploadArg = syncImageUpload.asRubyArgument(name: "sync_image_upload", type: nil)
     let trackPromoteToArg = trackPromoteTo.asRubyArgument(name: "track_promote_to", type: nil)
     let trackPromoteReleaseStatusArg = RubyCommand.Argument(name: "track_promote_release_status", value: trackPromoteReleaseStatus, type: nil)
+    let trackPromoteForceArg = RubyCommand.Argument(name: "track_promote_force", value: trackPromoteForce, type: nil)
     let validateOnlyArg = validateOnly.asRubyArgument(name: "validate_only", type: nil)
     let mappingArg = mapping.asRubyArgument(name: "mapping", type: nil)
     let mappingPathsArg = mappingPaths.asRubyArgument(name: "mapping_paths", type: nil)
@@ -11182,6 +11185,7 @@ public func supply(packageName: String,
                                           syncImageUploadArg,
                                           trackPromoteToArg,
                                           trackPromoteReleaseStatusArg,
+                                          trackPromoteForceArg,
                                           validateOnlyArg,
                                           mappingArg,
                                           mappingPathsArg,
@@ -12856,6 +12860,7 @@ public func uploadToPlayStore(packageName: String,
                               syncImageUpload: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                               trackPromoteTo: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                               trackPromoteReleaseStatus: String = "completed",
+                              trackPromoteForce: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                               validateOnly: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                               mapping: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                               mappingPaths: OptionalConfigValue<[String]?> = .fastlaneDefault(nil),
@@ -12897,6 +12902,7 @@ public func uploadToPlayStore(packageName: String,
     let syncImageUploadArg = syncImageUpload.asRubyArgument(name: "sync_image_upload", type: nil)
     let trackPromoteToArg = trackPromoteTo.asRubyArgument(name: "track_promote_to", type: nil)
     let trackPromoteReleaseStatusArg = RubyCommand.Argument(name: "track_promote_release_status", value: trackPromoteReleaseStatus, type: nil)
+    let trackPromoteForceArg = RubyCommand.Argument(name: "track_promote_force", value: trackPromoteForce, type: nil)
     let validateOnlyArg = validateOnly.asRubyArgument(name: "validate_only", type: nil)
     let mappingArg = mapping.asRubyArgument(name: "mapping", type: nil)
     let mappingPathsArg = mappingPaths.asRubyArgument(name: "mapping_paths", type: nil)
@@ -12937,6 +12943,7 @@ public func uploadToPlayStore(packageName: String,
                                           syncImageUploadArg,
                                           trackPromoteToArg,
                                           trackPromoteReleaseStatusArg,
+                                          trackPromoteForceArg,
                                           validateOnlyArg,
                                           mappingArg,
                                           mappingPathsArg,

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -230,6 +230,12 @@ module Supply
                                      verify_block: proc do |value|
                                                      UI.user_error!("Value must be one of '#{Supply::RELEASE_STATUS}'") unless Supply::ReleaseStatus::ALL.include?(value)
                                                    end),
+        FastlaneCore::ConfigItem.new(key: :track_promote_force,
+                                     env_name: "SUPPLY_TRACK_PROMOTE_FORCE",
+                                     optional: true,
+                                     description: "Force promote a specific version code (:version_name is required)",
+                                     type: Boolean,
+                                     default_value: false),
         FastlaneCore::ConfigItem.new(key: :validate_only,
                                      env_name: "SUPPLY_VALIDATE_ONLY",
                                      optional: true,

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -180,6 +180,16 @@ module Supply
       end
 
       releases = track_from.releases
+
+      if Supply.config[:track_promote_force]
+        if Supply.config[:version_name].nil?
+          UI.user_error!("To force promote a :version_code, it is mandatory to enter the :version_name")
+        end
+
+        releases.first.name = Supply.config[:version_name]
+        releases.first.version_codes = ["#{Supply.config[:version_code]}"]
+      end
+
       if Supply.config[:version_code].to_s != ""
         releases = releases.select do |release|
           release.version_codes.include?(Supply.config[:version_code].to_s)

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -187,7 +187,7 @@ module Supply
         end
 
         releases.first.name = Supply.config[:version_name]
-        releases.first.version_codes = ["#{Supply.config[:version_code]}"]
+        releases.first.version_codes = [Supply.config[:version_code].to_s]
       end
 
       if Supply.config[:version_code].to_s != ""


### PR DESCRIPTION
🔑

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green GitHub Action builds in the "All checks have passed" section of my PR.
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #18497

The Play Developer API only returns the release that is currently serving each
track. A version that has already been superseded by a newer one is missing from
that response, so `promote_track` filters it out and fails with
`Track 'internal' doesn't have any releases` — even though the Play Console
still offers that same version for promotion.

That blocks a common flow: shipping frequent internal/beta builds and later
promoting an older, already validated one to production.

### Description

Adds a `:track_promote_force` option (`SUPPLY_TRACK_PROMOTE_FORCE`) to _supply_.
When it is set, `promote_track` builds the release to promote out of the
configured values instead of looking it up in the source track:

```ruby
AndroidPublisher::TrackRelease.new(
  name: version_name,
  version_codes: [version_code]
)
```

This is the same pattern `update_track` already uses in the same file. Both
`:version_code` and `:version_name` are required with the option, since neither
can be inferred once the release is no longer read from the API response.
Status and rollout keep flowing through the existing code path, so
`:track_promote_release_status` and `:rollout` behave exactly as before.

`promote_track` now also treats a nil `track.releases` as an empty list, so a
source track without any release fails with the existing user-facing error
instead of a `NoMethodError` — the same class of crash fixed in #30029.

Because the release is no longer looked up, the version code is not validated
against the source track. That is stated in the docs and in a warning printed at
runtime.

> An earlier revision of this PR mutated `name` and `version_codes` on the
> release object returned by the API. That approach silently inherited the
> metadata of whichever release happened to be serving the track and crashed on
> tracks with no release, so it was replaced by the above.

### Testing Steps

Unit tests in `supply/spec/uploader_spec.rb`, under the existing
`describe 'promote_track'`:

- the forced promotion builds the expected release, and leaves the release found
  on the source track untouched
- `:version_code` missing → user error
- `:version_name` missing → user error
- source track with no release → user error instead of a crash

```
bundle exec rspec supply/spec/
# 69 examples, 0 failures

bundle exec rubocop supply/
# no offenses detected
```

Manually, against a real app: promoting a superseded version code from
`internal` to `production`. In the run below, `870871` is an older version, with
`870872`, `870873`… ahead of it.

<details>
<summary>Original reproduction (captured on 2.220.0)</summary>

❌ Before — `[!] Track 'internal' doesn't have any releases`

```
+----------------------------------------------------------------------------------------------------+
|                                     Summary for supply 2.220.0                                      |
+------------------------------------+---------------------------------------------------------------+
| version_name                       | 870871 (11.36.3)                                              |
| version_code                       | 870871                                                        |
| track                              | internal                                                      |
| track_promote_to                   | production                                                    |
| track_promote_release_status       | completed                                                     |
| json_key                           | service_account.json                                          |
| package_name                       | com.kobe.dengo                                                |
| skip_upload_apk                    | true                                                          |
| skip_upload_aab                    | true                                                          |
| skip_upload_metadata               | true                                                          |
| skip_upload_changelogs             | true                                                          |
| skip_upload_images                 | true                                                          |
| skip_upload_screenshots            | true                                                          |
| release_status                     | completed                                                     |
| sync_image_upload                  | false                                                         |
| validate_only                      | false                                                         |
| check_superseded_tracks            | false                                                         |
| timeout                            | 300                                                           |
| deactivate_on_promote              | true                                                          |
| changes_not_sent_for_review        | false                                                         |
| rescue_changes_not_sent_for_review | true                                                          |
| ack_bundle_installation_warning    | false                                                         |
+------------------------------------+---------------------------------------------------------------+
```

✅ After — promotion succeeds

```
+----------------------------------------------------------------------------------------------------+
|                                     Summary for supply 2.220.0                                      |
+------------------------------------+---------------------------------------------------------------+
| version_name                       | 870871 (11.36.3)                                              |
| version_code                       | 870871                                                        |
| track                              | internal                                                      |
| track_promote_to                   | production                                                    |
| track_promote_release_status       | completed                                                     |
| track_promote_force                | true                                                          |
| json_key                           | service_account.json                                          |
| package_name                       | com.kobe.dengo                                                |
| skip_upload_apk                    | true                                                          |
| skip_upload_aab                    | true                                                          |
| skip_upload_metadata               | true                                                          |
| skip_upload_changelogs             | true                                                          |
| skip_upload_images                 | true                                                          |
| skip_upload_screenshots            | true                                                          |
| release_status                     | completed                                                     |
| sync_image_upload                  | false                                                         |
| validate_only                      | false                                                         |
| check_superseded_tracks            | false                                                         |
| timeout                            | 300                                                           |
| deactivate_on_promote              | true                                                          |
| changes_not_sent_for_review        | false                                                         |
| rescue_changes_not_sent_for_review | true                                                          |
| ack_bundle_installation_warning    | false                                                         |
+------------------------------------+---------------------------------------------------------------+
```

</details>
