### PR TITLE
[supply] return android rollout percentages

### DIFF
--- a/fastlane/lib/fastlane/actions/google_play_track_rollout_percentages.rb
+++ b/fastlane/lib/fastlane/actions/google_play_track_rollout_percentages.rb
@@ -1,0 +1,84 @@
+module Fastlane
+  module Actions
+    class GooglePlayTrackRolloutPercentagesAction < Action
+      # Define options that are applicable for this action.
+      OPTIONS = [
+        :package_name,
+        :track,
+        :key,
+        :issuer,
+        :json_key,
+        :json_key_data,
+        :root_url,
+        :timeout
+      ]
+
+      def self.run(params)
+        require 'supply'
+        require 'supply/options'
+        require 'supply/reader'
+
+        # Configure Supply with parameters
+        Supply.config = params
+
+        # Retrieve rollout percentages using the new method in the Reader class
+        rollout_percentages = Supply::Reader.new.track_rollout_percentages
+        unless rollout_percentages.empty?
+          UI.success("Successfully retrieved rollout percentages for track: #{params[:track]}")
+        end
+        rollout_percentages
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Retrieves rollout percentages for each release in a Google Play track"
+      end
+
+      def self.details
+        "Use this action to fetch the rollout percentages of all active releases in a specified Google Play track."
+      end
+
+      def self.available_options
+        require 'supply'
+        require 'supply/options'
+
+        # Select only the options needed for this action from Supply options
+        Supply::Options.available_options.select do |option|
+          OPTIONS.include?(option.key)
+        end
+      end
+
+      def self.output
+        # Define the kind of data that this action returns
+        [
+          ['GOOGLE_PLAY_TRACK_ROLLOUT_PERCENTAGES', 'A hash containing the rollout percentages of releases']
+        ]
+      end
+
+      def self.return_value
+        "Hash with release names as keys and rollout percentages as values"
+      end
+
+      def self.authors
+        ["your_username"] # Replace with your Fastlane portal username or handle
+      end
+
+      def self.is_supported?(platform)
+        platform == :android # Ensure this runs only for Android platform
+      end
+
+      def self.example_code
+        [
+          'google_play_track_rollout_percentages(track: "beta")'
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/google_play_track_rollout_percentages.rb
+++ b/fastlane/lib/fastlane/actions/google_play_track_rollout_percentages.rb
@@ -18,14 +18,9 @@ module Fastlane
         require 'supply/options'
         require 'supply/reader'
 
-        # Configure Supply with parameters
         Supply.config = params
 
-        # Retrieve rollout percentages using the new method in the Reader class
-        rollout_percentages = Supply::Reader.new.track_rollout_percentages
-        unless rollout_percentages.empty?
-          UI.success("Successfully retrieved rollout percentages for track: #{params[:track]}")
-        end
+        rollout_percentages = Supply::Reader.new.track_rollout_percentages || {}
         rollout_percentages
       end
 
@@ -38,21 +33,19 @@ module Fastlane
       end
 
       def self.details
-        "Use this action to fetch the rollout percentages of all active releases in a specified Google Play track."
+        "More information: [https://docs.fastlane.tools/actions/supply/](https://docs.fastlane.tools/actions/supply/)"
       end
 
       def self.available_options
         require 'supply'
         require 'supply/options'
 
-        # Select only the options needed for this action from Supply options
         Supply::Options.available_options.select do |option|
           OPTIONS.include?(option.key)
         end
       end
 
       def self.output
-        # Define the kind of data that this action returns
         [
           ['GOOGLE_PLAY_TRACK_ROLLOUT_PERCENTAGES', 'A hash containing the rollout percentages of releases']
         ]
@@ -63,11 +56,11 @@ module Fastlane
       end
 
       def self.authors
-        ["your_username"] # Replace with your Fastlane portal username or handle
+        ["brainbicycle"]
       end
 
       def self.is_supported?(platform)
-        platform == :android # Ensure this runs only for Android platform
+        platform == :android
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/google_play_track_rollout_percentages.rb
+++ b/fastlane/lib/fastlane/actions/google_play_track_rollout_percentages.rb
@@ -20,7 +20,7 @@ module Fastlane
 
         Supply.config = params
 
-        rollout_percentages = Supply::Reader.new.track_rollout_percentages || {}
+        rollout_percentages = Supply::Reader.new.track_rollout_percentages || []
         rollout_percentages
       end
 

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -41,6 +41,7 @@ describe Fastlane do
           plugin_scores
           google_play_track_version_codes
           google_play_track_release_names
+          google_play_track_rollout_percentages
           modify_services
           build_app
           build_android_app

--- a/supply/lib/supply/reader.rb
+++ b/supply/lib/supply/reader.rb
@@ -32,6 +32,24 @@ module Supply
       release_names
     end
 
+    def track_rollout_percentages
+      track = Supply.config[:track]
+
+      client.begin_edit(package_name: Supply.config[:package_name])
+      releases = client.track_releases(track)
+      rollout_percentages = releases.map { |release| [release.name, release.user_fraction] }.to_h
+
+      client.abort_current_edit
+
+      if rollout_percentages.empty?
+        UI.important("No rollout percentages found in track '#{track}'")
+      else
+        UI.success("Found rollout percentages for track '#{track}'")
+      end
+
+      rollout_percentages
+    end
+
     private
 
     def client

--- a/supply/lib/supply/reader.rb
+++ b/supply/lib/supply/reader.rb
@@ -37,8 +37,13 @@ module Supply
 
       client.begin_edit(package_name: Supply.config[:package_name])
       releases = client.track_releases(track)
-      rollout_percentages = releases.map { |release| [release.name, release.user_fraction] }.to_h
-
+      rollout_percentages = releases.map do |release|
+        {
+          name: release.name,
+          version_codes: release.version_codes.join(', '),
+          user_fraction: release.user_fraction
+        }
+      end
       client.abort_current_edit
 
       if rollout_percentages.empty?


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves this discussion: https://github.com/fastlane/fastlane/discussions/19432

Android rollouts can be updated via the supply command but as far as I can tell there is no way to retrieve current rollout information for a given track or release. This makes it difficult to automate a rollout strategy, for example we would like to have a release initially rollout to 10% of users the next day 20% the next day 50% and finally 100%. Since app reviews are unpredictable it is difficult or impossible to do this on a set timeline unless we can fetch the current rollout percentage. 

If I missed a way to retrieve this information already please let me know!

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Adds a new command `google_play_track_rollout_percentages(track: 'production')` that returns a list of rollout percentages for the given track. Heavily inspired / copied from existing commands `google_play_track_version_codes` and `google_play_track_release_names` 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I tested this locally:
1.  Installed my updated fastlane as a gem in our repo 
2. Created a build in a test track in google play initiallly rolled out to 10% of users
3. Created a lane that called the new command and updated this track based on roll out strategy: https://github.com/artsy/eigen/pull/10244/files
