### PR TITLE
[spaceship] add visionOS support for Connect API

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -99,7 +99,7 @@ module Deliver
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
-                                       UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)
+                                       UI.user_error!("The platform can only be ios, appletvos, xros or osx") unless %('ios', 'appletvos', 'xros', 'osx').include?(value)
                                      end),
 
         # live version

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -172,7 +172,7 @@ module Deliver
       transporter = transporter_for_selected_team
 
       case platform
-      when "ios", "appletvos"
+      when "ios", "appletvos", "xros"
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           ipa_path: ipa_path,
@@ -209,7 +209,7 @@ module Deliver
       transporter = transporter_for_selected_team
 
       case platform
-      when "ios", "appletvos"
+      when "ios", "appletvos", "xros"
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           ipa_path: ipa_path,

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -82,6 +82,20 @@ describe Deliver::Runner do
       end
     end
 
+    describe 'with an IPA file for visionOS' do
+      before do
+        options[:platform] = 'xros'
+      end
+
+      it 'uploads the IPA for the visionOS platform' do
+        expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'xros')
+          .and_return('path')
+        expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.ipa', platform: 'xros').and_return(true)
+        runner.upload_binary
+      end
+    end
+
     describe 'with a PKG file for macOS' do
       before do
         options[:platform] = 'osx'
@@ -125,6 +139,20 @@ describe Deliver::Runner do
           .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'appletvos')
           .and_return('path')
         expect(transporter).to receive(:verify).with(asset_path: "ACME.ipa", package_path: 'path', platform: "appletvos").and_return(true)
+        runner.verify_binary
+      end
+    end
+
+    describe 'with an IPA file for visionOS' do
+      before do
+        options[:platform] = 'xros'
+      end
+
+      it 'verifies the IPA for the visionOS platform' do
+        expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'xros')
+          .and_return('path')
+        expect(transporter).to receive(:verify).with(asset_path: "ACME.ipa", package_path: 'path', platform: "xros").and_return(true)
         runner.verify_binary
       end
     end

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -186,7 +186,7 @@ module Fastlane
                                        optional: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)
+                                         UI.user_error!("The platform can only be ios, appletvos, xros or osx") unless %('ios', 'appletvos', 'xros', 'osx').include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :team_name,
                                        short_option: "-e",

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -374,6 +374,7 @@ The available options:
 
 - 'ios'
 - 'appletvos'
+- 'xros'
 - 'osx'
 
 

--- a/fastlane/lib/fastlane/actions/download_dsyms.rb
+++ b/fastlane/lib/fastlane/actions/download_dsyms.rb
@@ -290,7 +290,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :platform,
                                        short_option: "-p",
                                        env_name: "DOWNLOAD_DSYMS_PLATFORM",
-                                       description: "The app platform for dSYMs you wish to download (ios, appletvos)",
+                                       description: "The app platform for dSYMs you wish to download (ios, xros, appletvos)",
                                        default_value: :ios),
           FastlaneCore::ConfigItem.new(key: :version,
                                        short_option: "-v",
@@ -351,7 +351,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :appletvos].include?(platform)
+        [:ios, :appletvos, :xros].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -83,7 +83,7 @@ module Fastlane
                                        optional: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, osx, or appletvos") unless %('osx', ios', 'appletvos').include?(value)
+                                         UI.user_error!("The platform can only be ios, osx, xros or appletvos") unless %('osx', ios', 'appletvos', 'xros').include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",

--- a/fastlane/lib/fastlane/actions/set_changelog.rb
+++ b/fastlane/lib/fastlane/actions/set_changelog.rb
@@ -169,10 +169,10 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        env_name: "FL_SET_CHANGELOG_PLATFORM",
-                                       description: "The platform of the app (ios, appletvos, mac)",
+                                       description: "The platform of the app (ios, appletvos, xros, mac)",
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         available = ['ios', 'appletvos', 'mac']
+                                         available = ['ios', 'appletvos', 'xros', 'mac']
                                          UI.user_error!("Invalid platform '#{value}', must be #{available.join(', ')}") unless available.include?(value)
                                        end)
         ]
@@ -183,7 +183,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :appletvos, :mac].include?(platform)
+        [:ios, :appletvos, :xros, :mac].include?(platform)
       end
 
       def self.example_code

--- a/fastlane/spec/actions_specs/set_changelog_spec.rb
+++ b/fastlane/spec/actions_specs/set_changelog_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane do
         it 'raises a Fastlane error' do
           expect { Fastlane::FastFile.new.parse(invalidPlatform_lane).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
-              expect(error.message).to match(/Invalid platform 'whatever', must be ios, appletvos, mac/)
+              expect(error.message).to match(/Invalid platform 'whatever', must be ios, appletvos, xros, mac/)
             end
           )
         end

--- a/spaceship/lib/spaceship/tunes/application.rb
+++ b/spaceship/lib/spaceship/tunes/application.rb
@@ -72,7 +72,7 @@ module Spaceship
         def find(identifier, mac: false)
           all.find do |app|
             ((app.apple_id && app.apple_id.casecmp(identifier.to_s) == 0) || (app.bundle_id && app.bundle_id.casecmp(identifier.to_s) == 0)) &&
-              app.version_sets.any? { |v| (mac ? ["osx"] : ["ios", "appletvos"]).include?(v.platform) }
+              app.version_sets.any? { |v| (mac ? ["osx"] : ["ios", "xros", "appletvos"]).include?(v.platform) }
           end
         end
 

--- a/spaceship/lib/spaceship/tunes/tunes_client.rb
+++ b/spaceship/lib/spaceship/tunes/tunes_client.rb
@@ -297,6 +297,8 @@ module Spaceship
             "appletvos"
           when "MAC_OS"
             "osx"
+          when "VISION_OS"
+            "xros"
           when "IOS"
             "ios"
           else


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

This is a simple rebase of #21929 onto master because the original author has not been able to do so in the past month and it would be great to have this in Fastlane to (I think?) complete visionOS support.

The only difference to the original commit is that the changes in `spaceship/connect_api.rb` were discarded as master already contained the same addition of visionOS.

### Description

See #21929.

All credit goes to @yanniks for implementing the changes.

### Testing Steps

I have used it to upload our visionOS app to App Store Connect using deliver.