### PR TITLE
Generate Apple Pay Certificate From CSR

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -600,6 +600,18 @@ module Spaceship
       parse_response(r, 'certRequest')
     end
 
+    def create_apple_pay_certificate!(csr, merchant_id = nil, mac = false)
+      ensure_csrf(Spaceship::Portal::Certificate)
+
+      r = request(:post, "account/#{platform_slug(mac)}/certificate/submitCertificateRequest.action", {
+        teamId: team_id,
+        type: Spaceship::Portal::Certificate::CERTIFICATE_TYPE_IDS.key(Spaceship::Portal::Certificate::ApplePay),
+        csrContent: csr,
+        specialIdentifierDisplayId: merchant_id
+      })
+      parse_response(r, 'certRequest')
+    end
+
     def download_certificate(certificate_id, type, mac: false)
       { type: type, certificate_id: certificate_id }.each { |k, v| raise "#{k} must not be nil" if v.nil? }
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

When setting up Apple Pay in an iOS application, you need to generate a certificate from a provider (Usually stripe or Braintree etc.) 

For developers managing large portfolios of applications, this is currently un-scriptable 

This is a simple addition to allow anyone to generate an Apple Pay Certificate

In the below script the only change required in this PR is `certificate = Spaceship::Portal.client.create_apple_pay_certificate!(csr, merchant_id)`, fastlane already did all the other steps

```
require 'spaceship'
require 'openssl'

csr_path = '/PATH/TO/stripe.certSigningRequest'
csr_content = File.read(csr_path)
csr = OpenSSL::X509::Request.new(csr_content)

# Login to Apple Developer account
Spaceship::Portal.login('your_apple_id', 'your_password')

# Select the team if you're part of multiple teams
team_id = 'your_team_id'  # Replace with your actual team ID
Spaceship::Portal.client.team_id = team_id

`fastlane produce merchant -o merchant.com.example.production -r "Example Merchant Production"`

`fastlane produce associate_merchant -a com.krausefx.app merchant.com.example.production`

# Verify that the merchant ID exists
merchant_id = Spaceship.merchant.find("merchant.com.example.production")
if merchant_id?
  puts "Merchant not found"
  exit
else
  puts "Merchant ID found: #{app.app_id}"
end

# Attempt to create the Apple Pay certificate
begin
  certificate = Spaceship::Portal.client.create_apple_pay_certificate!(csr, merchant_id)
  puts "Certificate created: #{certificate.id}"

rescue Spaceship::UnexpectedResponse => e
  puts "Failed to create certificate: #{e.message}"
end

cert_content = Spaceship::Portal.client.download_certificate(certificate['certificateId'], certificate['certificateTypeDisplayId'])
  cert_file_path = '/PATH/TO//Downloads/apple_pay_certificate.cer'   File.write(cert_file_path, cert_content)   
puts "Certificate saved to #{cert_file_path}"
```


Resolves #12466
#15925
#11809
#22054 
-->

### Description

- Used proxyman to monitor Apple Developer traffic when generating the new certificate
- Ran the above script several times on different appIds and merchant accounts
- The change to fastlane is minimal but it allows us to move forward without being blocked

### Testing Steps

Run the above script
