### PR TITLE
[sigh][manage] print warning when no profiles for cleanup found

### DIFF
--- a/sigh/lib/sigh/local_manage.rb
+++ b/sigh/lib/sigh/local_manage.rb
@@ -102,8 +102,12 @@ module Sigh
       now = DateTime.now
 
       profiles = load_profiles.select { |profile| (expired && profile["ExpirationDate"] < now) || (!pattern.nil? && profile["Name"] =~ pattern) }
+      if profiles.empty?
+        UI.important("No provisioning profiles that are either expired or match your pattern found")
+        return
+      end
 
-      UI.message("The following provisioning profiles are either expired or matches your pattern:")
+      UI.message("The following provisioning profiles are either expired or match your pattern:")
       profiles.each do |profile|
         UI.message(profile["Name"].red)
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

It makes no sense to ask for confirmation to delete 0 profiles

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Warning for 0 profiles + early return

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

    bundle exec fastlane sigh manage -e -p random_rubbish