### PR TITLE
Fix bug detecting configurations from workspace

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -188,7 +188,7 @@ module FastlaneCore
       @configurations ||= if workspace?
                             workspace
                               .file_references
-                              .map(&:path)
+                              .map { |fr| fr.absolute_path(File.expand_path("..", self.path)) }
                               .reject { |p| p.include?("Pods/Pods.xcodeproj") }
                               .map do |p|
                                 # To maintain backwards compatibility, we

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -232,7 +232,7 @@ describe FastlaneCore do
       end
 
       it "#schemes returns all configurations" do
-        expect(@workspace.configurations).to eq([])
+        expect(@workspace.configurations).to eq(["Debug", "Release"])
       end
     end
 
@@ -335,7 +335,7 @@ describe FastlaneCore do
       end
 
       it "#schemes returns all configurations" do
-        expect(@workspace.configurations).to eq([])
+        expect(@workspace.configurations).to eq(["Debug", "Release", "Debug", "Release"])
       end
     end
 


### PR DESCRIPTION
When enumerating the available configurations starting from an xcworkspace, we have to interpret the xcodeproj file references relative to the path of the xcworkspace. The code already handles this properly in the `project_paths` method, but for some reason doesn't qualify the paths correctly in the `configurations` method.

This has likely gone silently undetected because the bug only manifests itself when the xcworkspace is in a different directory from fastlane's CWD.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.
- [X] I've added or updated relevant unit tests.

### Motivation and Context

When enumerating the available configurations starting from an xcworkspace, we have to interpret the xcodeproj file references relative to the path of the xcworkspace. The code already handles this properly in the `project_paths` method, but for some reason doesn't qualify the paths correctly in the `configurations` method.

### Description

Qualify xcodeproj paths relative to xcworkspace in the `configurations` method.

### Testing Steps

Tested locally. We're running this patch in production at $dayjob. Also updated the unit test expectations to test correct behavior. They were testing for the buggy behavior.