### PR TITLE
[ci] Fix `Validate Fastlane.swift generation` on CI when attempting to update brew 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,19 +180,6 @@ jobs:
           version: << parameters.ruby_version >>
       - *bundle_install
       - *cache_save_bundler
-      - run:
-          name: debug | brew version
-          command: |
-            brew -v
-      - run:
-          name: brew update if needed # temporary solution for this https://discuss.circleci.com/t/macos-image-users-homebrew-brownout-2021-04-26/39872/2
-          command: |
-            # if the version is not 3.x.x, try brew update
-            ruby -e 'exit(1) if `brew -v` =~ /2\.\d+\.\d+/' ||\
-            brew update || \
-            # if brew update fails due to shallow clone, try unshallowing and then brew update again
-            git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow && \
-            brew update
       - run: bundle exec fastlane generate_swift_api
 
   validate_documentation:


### PR DESCRIPTION
### Motivation and Context

Fix broken Fastlane.swift validation test on CI

### Description

Removed outdated `brew update` for a temp workaround

### Testing Steps

N/A
