### PR TITLE
[ci] create new tag on bump merge

### DIFF
--- a/.github/workflows/create_tag_on_bump_merge.yml
+++ b/.github/workflows/create_tag_on_bump_merge.yml
@@ -1,0 +1,34 @@
+name: Create Tag Version on Bump Merge
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  tag-version:
+    if: startsWith(github.event.head_commit.message, 'Merge pull request #') && contains(github.event.head_commit.message, 'version-bump-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7' # Specify your ruby version
+
+      - name: Read gem version
+        id: read_version
+        run: |
+          gemspec_file=$(ls *.gemspec)
+          version=$(grep -E "spec.version\s*=\s*['\"][0-9]+\.[0-9]+\.[0-9]+['\"]" $gemspec_file | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+")
+          echo "::set-output name=version::$version"
+
+      - name: Create Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag -a v${{ steps.read_version.outputs.version }} -m "Version ${{ steps.read_version.outputs.version }}"
+          git push origin --tags


### PR DESCRIPTION
### Motivation and Context

To create a new tab when a bump PR is merged into `master`. After. A tag is created, there will be another job that will prepare the release.

### Description

Creates a new tag when merged into `master
