### PR TITLE
Add tags parameter to TestFairy upload action

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -96,6 +96,8 @@ module Fastlane
             [key, options_to_client.call(value).join(',')]
           when :custom
             [key, value]
+          when :tags
+            [key, value]
           else
             UI.user_error!("Unknown parameter: #{key}")
           end
@@ -241,7 +243,13 @@ module Fastlane
                                        env_name: "FL_TESTFAIRY_TIMEOUT",
                                        description: "Request timeout in seconds",
                                        type: Integer,
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :tags,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_TAGS",
+                                       description: "Custom tags that can be used to organize your builds",
+                                       type: Array,
+                                       default_value: [])
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -97,7 +97,7 @@ module Fastlane
           when :custom
             [key, value]
           when :tags
-            [key, value]
+            [key, value.join(',')]
           else
             UI.user_error!("Unknown parameter: #{key}")
           end

--- a/fastlane/spec/actions_specs/testfairy_spec.rb
+++ b/fastlane/spec/actions_specs/testfairy_spec.rb
@@ -111,7 +111,8 @@ describe Fastlane do
               upload_url: 'https://your-subdomain.testfairy.com',
               comment: 'Test Comment!',
               testers_groups: ['group1', 'group2'],
-              custom: 'custom argument'
+              custom: 'custom argument',
+              tags: ['tag1', 'tag2', 'tag3']
             })
           end").runner.execute(:test)
         end.not_to(raise_error)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

We use the `testfairy` action to upload builds for QA testing, however, the QA team has recently been asking if we can add tags to our builds to make them easier to organize. Unfortunately, the current implementation of TestFairy uploads within fastlane does not support adding tags to builds. Since tags are set via an additional parameter during upload, it seemed like a simple addition to modify the `testfairy` action to add support. Support for tags was first brought up in discussion #22062.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

This PR adds an optional `tags` parameter when calling the `testfairy` action to upload a new build. Tags in TestFairy are string labels that aid organization and support categorization of app builds. The `tags` parameter accepts an array of strings, with a default value of an empty array. The array is joined into a comma separated string, which is required for the [TestFairy upload API](https://docs.saucelabs.com/testfairy/api-reference/upload-api/). 

[TestFairy documentation on tags](https://docs.saucelabs.com/testfairy/app-distribution/tags/)

Tested uploading a build in the following scenarios:
* Uploaded a build with no tags
* Uploaded a build with a single tag
* Uploaded a build with multiple tags

All test builds are visible within TestFairy with their respective tags.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

The best way to test these changes is to upload a build to TestFairy containing zero, one, or multiple tags.