### PR TITLE
Validate credential account

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -46,7 +46,10 @@ module Supply
     # Initializes the service and its auth_client using the specified information
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
-      auth_client = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
+      # check if it's an external account or service account
+      json_file = JSON.parse(File.read(service_account_json))
+      auth = json_file["type"] == "external_account" ? Google::Auth::ExternalAccount::Credentials : Google::Auth::ServiceAccountCredentials
+      auth_client = auth.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
 
       UI.verbose("Fetching a new access token from Google...")
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -47,7 +47,7 @@ module Supply
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
       # check if it's an external account or service account
-      json_file = JSON.parse(File.read(service_account_json.string))
+      json_file = JSON.parse(File.read(service_account_json.read))
       auth = json_file["type"] == "external_account" ? Google::Auth::ExternalAccount::Credentials : Google::Auth::ServiceAccountCredentials
       auth_client = auth.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -47,7 +47,7 @@ module Supply
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
       # check if it's an external account or service account
-      json_file = JSON.parse(File.read(service_account_json.read))
+      json_file = JSON.parse(service_account_json)
       auth = json_file["type"] == "external_account" ? Google::Auth::ExternalAccount::Credentials : Google::Auth::ServiceAccountCredentials
       auth_client = auth.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -47,7 +47,7 @@ module Supply
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
       # check if it's an external account or service account
-      json_file = JSON.parse(File.read(service_account_json).string)
+      json_file = JSON.parse(File.read(service_account_json.string))
       auth = json_file["type"] == "external_account" ? Google::Auth::ExternalAccount::Credentials : Google::Auth::ServiceAccountCredentials
       auth_client = auth.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -47,7 +47,7 @@ module Supply
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
       # check if it's an external account or service account
-      json_file = JSON.parse(service_account_json)
+      json_file = JSON.parse(service_account_json.string)
       auth = json_file["type"] == "external_account" ? Google::Auth::ExternalAccount::Credentials : Google::Auth::ServiceAccountCredentials
       auth_client = auth.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -47,7 +47,7 @@ module Supply
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
       # check if it's an external account or service account
-      json_file = JSON.parse(File.read(service_account_json))
+      json_file = JSON.parse(File.read(service_account_json).string)
       auth = json_file["type"] == "external_account" ? Google::Auth::ExternalAccount::Credentials : Google::Auth::ServiceAccountCredentials
       auth_client = auth.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

We use `supply` method to upload our app bundle (Android) to Play Store. Recently we are migrating our service account key usage to [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) (WIF) in order to enhance the security.

### Description

Added validation to check whether it's an `external_account` or `service_account` to fix error `missing client_email` caused by https://github.com/googleapis/google-auth-library-ruby/blob/main/lib/googleauth/json_key_reader.rb#L24 when using Workload Identity Federation
- service_account –> `Google::Auth::ServiceAccountCredentials`
- external_account –> `Google::Auth::ExternalAccount::Credentials`

### Testing Steps

Successfully [validate the credential](https://docs.fastlane.tools/actions/validate_play_store_json_key/) using the credential config from WIF
