### PR TITLE
Fix import_from_git when specifying a tag and cache_path

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -346,7 +346,7 @@ module Fastlane
                 Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard")
                 # Check if checked out "branch" is actually a branch or a tag
                 current_branch = Actions.sh("cd #{clone_folder.shellescape} && git branch --show-current")
-                if !current_branch.empty?
+                unless current_branch.empty?
                   Actions.sh("cd #{clone_folder.shellescape} && git rebase")
                 end
               end

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -345,7 +345,7 @@ module Fastlane
               Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
                 Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard")
                 # Check if checked out "branch" is actually a branch or a tag
-                current_branch = Actions.sh("cd #{clone_folder.shellescape} && git branch --show-current")
+                current_branch = Actions.sh("cd #{clone_folder.shellescape} && git rev-parse --abbrev-ref HEAD")
                 unless current_branch.empty?
                   Actions.sh("cd #{clone_folder.shellescape} && git rebase")
                 end

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -343,7 +343,12 @@ module Fastlane
               # Update the repo if it's eligible for caching but the version isn't specified
               UI.message("Fetching remote git branches and updating git repo...")
               Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
-                Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard && git rebase")
+                Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard")
+                # Check if checked out "branch" is actually a branch or a tag
+                current_branch = Actions.sh("cd #{clone_folder.shellescape} && git rev-parse --abbrev-ref HEAD")
+                unless current_branch.empty?
+                  Actions.sh("cd #{clone_folder.shellescape} && git rebase")
+                end
               end
             else
               begin

--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -343,7 +343,12 @@ module Fastlane
               # Update the repo if it's eligible for caching but the version isn't specified
               UI.message("Fetching remote git branches and updating git repo...")
               Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
-                Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard && git rebase")
+                Actions.sh("cd #{clone_folder.shellescape} && git fetch --all --quiet && git checkout #{checkout_param.shellescape} #{checkout_path} && git reset --hard")
+                # Check if checked out "branch" is actually a branch or a tag
+                current_branch = Actions.sh("cd #{clone_folder.shellescape} && git branch --show-current")
+                if !current_branch.empty?
+                  Actions.sh("cd #{clone_folder.shellescape} && git rebase")
+                end
               end
             else
               begin


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

If you run `import_from_git` with a tag and `cache_path` like this:

```
import_from_git(
  url: "https://myprivaterepo",
  branch: "fastlane/1.2.3", # This is a tag, not a branch!
  cache_path: "./cache/fastlane",
)
```

It fails (for full error log see bottom of post):

```
...
bundler: failed to load command: fastlane (/Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/bin/fastlane)
/Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane_core/lib/fastlane_core/ui/interface.rb:153:in `shell_error!': [!] Exit status of command 'cd /Users/johndoe/Documents/repos/myrepo/fastlane/cache/fastlane/myprivaterepo && git fetch --all --quiet && git checkout fastlane/0  && git reset --hard && git rebase' was 1 instead of 0. (FastlaneCore::Interface::FastlaneShellError)
HEAD is now at d81cbd8 revert
HEAD is now at d81cbd8 revert
You are not currently on a branch.
Please specify which branch you want to rebase against.
See git-rebase(1) for details.

    git rebase '<branch>'
...
```

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
This PR avoids running `git rebase` when `cache_path` is provided and `branch` is actually a git tag and not a branch - because you have to be on a branch in order to do a git rebase.

I've tested my PR by both running `import_from_git` with the `branch` parameter being a git tag and a git branch and verified that `git rebase` is still called when `branch` is actually a branch and not called when `branch` is a git tag:

`branch` is a git branch:

```
import_from_git(
  url: "https://myprivaterepo",
  branch: "fastlane/some-branch", # This is a branch, not a tag!
  cache_path: "./cache/fastlane",
)
```

`branch` is a git tag:

```
import_from_git(
  url: "https://myprivaterepo",
  branch: "fastlane/1.2.3", # This is a tag, not a branch!
  cache_path: "./cache/fastlane",
)
```

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
See previous description on how to test this. 

<details>
  <summary>Full error log</summary>

```
[13:31:51]: -----------------------------
[13:31:51]: --- Step: import_from_git ---
[13:31:51]: -----------------------------
[13:31:51]: Eligible for caching
[13:31:51]: Fetching remote git branches and updating git repo...
[13:31:51]: $ cd /Users/johndoe/Documents/repos/myrepo/fastlane/cache/fastlane/myprivaterepo && git fetch --all --quiet && git checkout fastlane/0  && git reset --hard && git rebase
[13:31:52]: ▸ HEAD is now at d81cbd8 revert
[13:31:52]: ▸ HEAD is now at d81cbd8 revert
[13:31:52]: ▸ You are not currently on a branch.
[13:31:52]: ▸ Please specify which branch you want to rebase against.
[13:31:52]: ▸ See git-rebase(1) for details.
[13:31:52]: ▸ git rebase '<branch>'

Looking for related GitHub issues on fastlane/fastlane...

+-------------------------------------------+
|         Plugin updates available          |
+-----------+--------------+----------------+
| Plugin    | Your Version | Latest Version |
+-----------+--------------+----------------+
| appcenter | 2.0.0        | 2.1.2          |
+-----------+--------------+----------------+
[13:31:52]: To update all plugins, just run
[13:31:52]: $ bundle exec fastlane update_plugins

bundler: failed to load command: fastlane (/Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/bin/fastlane)
/Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane_core/lib/fastlane_core/ui/interface.rb:153:in `shell_error!': [!] Exit status of command 'cd /Users/johndoe/Documents/repos/myrepo/fastlane/cache/fastlane/myprivaterepo && git fetch --all --quiet && git checkout fastlane/0  && git reset --hard && git rebase' was 1 instead of 0. (FastlaneCore::Interface::FastlaneShellError)
HEAD is now at d81cbd8 revert
HEAD is now at d81cbd8 revert
You are not currently on a branch.
Please specify which branch you want to rebase against.
See git-rebase(1) for details.

    git rebase '<branch>'


	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in `method_missing'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/helper/sh_helper.rb:80:in `sh_control_output'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/helper/sh_helper.rb:12:in `sh'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/fast_file.rb:346:in `block (3 levels) in import_from_git'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane_core/lib/fastlane_core/helper.rb:342:in `with_env_values'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/fast_file.rb:345:in `block (2 levels) in import_from_git'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/fast_file.rb:393:in `block in import_from_git'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/actions/actions_helper.rb:69:in `execute_action'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/fast_file.rb:282:in `import_from_git'
	from Fastfile:4:in `parsing_binding'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/fast_file.rb:61:in `eval'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/fast_file.rb:61:in `block in parse'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/fast_file.rb:50:in `chdir'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/fast_file.rb:50:in `parse'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/fast_file.rb:40:in `initialize'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/lane_manager.rb:14:in `new'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/lane_manager.rb:14:in `cruise_lane'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/command_line_handler.rb:34:in `handle'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/commands_generator.rb:110:in `block (2 levels) in run'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in `run!'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/commands_generator.rb:363:in `run'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/commands_generator.rb:43:in `start'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/fastlane/lib/fastlane/cli_tools_distributor.rb:123:in `take_off'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/gems/fastlane-2.221.1/bin/fastlane:23:in `<top (required)>'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/bin/fastlane:25:in `load'
	from /Users/johndoe/Documents/repos/myrepo/gems/ruby/3.2.0/bin/fastlane:25:in `<top (required)>'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/cli/exec.rb:58:in `load'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/cli/exec.rb:23:in `run'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/cli.rb:455:in `exec'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/cli.rb:35:in `dispatch'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/cli.rb:29:in `start'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/exe/bundle:28:in `block in <top (required)>'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /Users/johndoe/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/gems/bundler-2.5.13/exe/bundle:20:in `<top (required)>'
	from /Users/johndoe/.rbenv/versions/3.2.3/bin/bundle:25:in `load'
	from /Users/johndoe/.rbenv/versions/3.2.3/bin/bundle:25:in `<main>'
```
</details>