### PR TITLE
Add ability to use Individual API key in deliver and pilot

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -264,6 +264,7 @@ module Deliver
     private
 
     # If App Store Connect API token, use token.
+    # If api_key is specified and it is an Individual API Key, don't use token but use username.
     # If itc_provider was explicitly specified, use it.
     # If there are multiple teams, infer the provider from the selected team name.
     # If there are fewer than two teams, don't infer the provider.
@@ -279,6 +280,14 @@ module Deliver
                   api_key[:key] = Base64.decode64(api_key[:key]) if api_key[:is_key_content_base64]
                   api_key
                 end
+
+      # Currently no kind of transporters accept an Individual API Key. Use username and app-specific password instead.
+      # See https://github.com/fastlane/fastlane/issues/22115
+      is_individual_key = !api_key.nil? && api_key[:issuer_id].nil?
+      if is_individual_key
+        api_key = nil
+        api_token = nil
+      end
 
       unless api_token.nil?
         api_token.refresh! if api_token.expired?

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -30,7 +30,9 @@ describe Deliver::Runner do
   let(:runner) do
     allow(Spaceship::ConnectAPI).to receive(:login).and_return(true)
     allow(Spaceship::ConnectAPI).to receive(:select_team).and_return(true)
-    allow(Spaceship::Tunes).to receive(:client).and_return(MockSession.new)
+    mock_session = MockSession.new
+    allow(Spaceship::Tunes).to receive(:client).and_return(mock_session)
+    allow(Spaceship::ConnectAPI).to receive_message_chain('client.tunes_client').and_return(mock_session)
     allow_any_instance_of(Deliver::DetectValues).to receive(:run!) { |opt| opt }
     Deliver::Runner.new(options)
   end
@@ -47,6 +49,7 @@ describe Deliver::Runner do
   end
 
   let(:fake_team_api_key_json_path) { File.absolute_path("./spaceship/spec/connect_api/fixtures/asc_key.json") }
+  let(:fake_individual_api_key_json_path) { File.absolute_path("./spaceship/spec/connect_api/fixtures/asc_individual_key.json") }
 
   before do
     allow(Deliver).to receive(:cache).and_return({
@@ -143,6 +146,35 @@ describe Deliver::Runner do
         runner.upload_binary
       end
     end
+
+    describe 'with Individual API Key' do
+      before do
+        options[:api_key] = JSON.load_file(fake_individual_api_key_json_path, symbolize_names: true)
+      end
+
+      it 'initializes transporter with username' do
+        token = instance_double(Spaceship::ConnectAPI::Token, {
+          text: 'API_TOKEN',
+          expired?: false
+        })
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return token
+        expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
+        expect(FastlaneCore::ItunesTransporter).to receive(:new)
+          .with(
+            'bill@acme.com',
+            nil,
+            false,
+            nil,
+            {
+              altool_compatible_command: true,
+              api_key: nil,
+            }
+          )
+          .and_return(transporter)
+        expect(transporter).to receive(:upload).and_return(true)
+        runner.upload_binary
+      end
+    end
   end
 
   describe :verify_binary do
@@ -227,6 +259,35 @@ describe Deliver::Runner do
             {
               altool_compatible_command: true,
               api_key: options[:api_key],
+            }
+          )
+          .and_return(transporter)
+        expect(transporter).to receive(:verify).and_return(true)
+        runner.verify_binary
+      end
+    end
+
+    describe 'with Individual API Key' do
+      before do
+        options[:api_key] = JSON.load_file(fake_individual_api_key_json_path, symbolize_names: true)
+      end
+
+      it 'initializes transporter with username' do
+        token = instance_double(Spaceship::ConnectAPI::Token, {
+          text: 'API_TOKEN',
+          expired?: false
+        })
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return token
+        allow_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
+        expect(FastlaneCore::ItunesTransporter).to receive(:new)
+          .with(
+            'bill@acme.com',
+            nil,
+            false,
+            nil,
+            {
+              altool_compatible_command: true,
+              api_key: nil,
             }
           )
           .and_return(transporter)

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -127,7 +127,7 @@ describe Deliver::Runner do
           text: 'API_TOKEN',
           expired?: false
         })
-        allow(Spaceship::ConnectAPI).to receive(:token).and_return token
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return(token)
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
         expect(FastlaneCore::ItunesTransporter).to receive(:new)
           .with(
@@ -157,7 +157,7 @@ describe Deliver::Runner do
           text: 'API_TOKEN',
           expired?: false
         })
-        allow(Spaceship::ConnectAPI).to receive(:token).and_return token
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return(token)
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
         expect(FastlaneCore::ItunesTransporter).to receive(:new)
           .with(
@@ -247,7 +247,7 @@ describe Deliver::Runner do
           text: 'API_TOKEN',
           expired?: false
         })
-        allow(Spaceship::ConnectAPI).to receive(:token).and_return token
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return(token)
         allow_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
         expect(FastlaneCore::ItunesTransporter).to receive(:new)
           .with(
@@ -277,7 +277,7 @@ describe Deliver::Runner do
           text: 'API_TOKEN',
           expired?: false
         })
-        allow(Spaceship::ConnectAPI).to receive(:token).and_return token
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return(token)
         allow_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
         expect(FastlaneCore::ItunesTransporter).to receive(:new)
           .with(

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -128,6 +128,7 @@ describe Deliver::Runner do
           expired?: false
         })
         allow(Spaceship::ConnectAPI).to receive(:token).and_return(token)
+        allow(Spaceship::ConnectAPI).to receive(:token=)
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
         expect(FastlaneCore::ItunesTransporter).to receive(:new)
           .with(
@@ -158,6 +159,7 @@ describe Deliver::Runner do
           expired?: false
         })
         allow(Spaceship::ConnectAPI).to receive(:token).and_return(token)
+        allow(Spaceship::ConnectAPI).to receive(:token=)
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
         expect(FastlaneCore::ItunesTransporter).to receive(:new)
           .with(
@@ -248,6 +250,7 @@ describe Deliver::Runner do
           expired?: false
         })
         allow(Spaceship::ConnectAPI).to receive(:token).and_return(token)
+        allow(Spaceship::ConnectAPI).to receive(:token=)
         allow_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
         expect(FastlaneCore::ItunesTransporter).to receive(:new)
           .with(
@@ -278,6 +281,7 @@ describe Deliver::Runner do
           expired?: false
         })
         allow(Spaceship::ConnectAPI).to receive(:token).and_return(token)
+        allow(Spaceship::ConnectAPI).to receive(:token=)
         allow_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate).and_return('path')
         expect(FastlaneCore::ItunesTransporter).to receive(:new)
           .with(

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -391,6 +391,7 @@ module Pilot
     end
 
     # If App Store Connect API token, use token.
+    # If api_key is specified and it is an Individual API Key, don't use token but use username.
     # If itc_provider was explicitly specified, use it.
     # If there are multiple teams, infer the provider from the selected team name.
     # If there are fewer than two teams, don't infer the provider.
@@ -406,6 +407,14 @@ module Pilot
                   api_key[:key] = Base64.decode64(api_key[:key]) if api_key[:is_key_content_base64]
                   api_key
                 end
+
+      # Currently no kind of transporters accept an Individual API Key. Use username and app-specific password instead.
+      # See https://github.com/fastlane/fastlane/issues/22115
+      is_individual_key = !api_key.nil? && api_key[:issuer_id].nil?
+      if is_individual_key
+        api_key = nil
+        api_token = nil
+      end
 
       unless api_token.nil?
         api_token.refresh! if api_token.expired?

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -871,8 +871,11 @@ describe "Build Manager" do
 
   describe "#transporter_for_selected_team" do
     let(:fake_manager) { Pilot::BuildManager.new }
-    let(:fake_api_key_json_path) do
+    let(:fake_team_api_key_json_path) do
       "./spaceship/spec/connect_api/fixtures/asc_key.json"
+    end
+    let(:fake_individual_api_key_json_path) do
+      "./spaceship/spec/connect_api/fixtures/asc_individual_key.json"
     end
 
     let(:selected_team_id) { "123" }
@@ -890,15 +893,26 @@ describe "Build Manager" do
       }
     end
 
-    it "with API token" do
+    it "with Team API Key and API token" do
       options = {}
-      allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_api_key_json_path))
+      allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_team_api_key_json_path))
 
       transporter = fake_manager.send(:transporter_for_selected_team, options)
       expect(transporter.instance_variable_get(:@jwt)).not_to(be_nil)
       expect(transporter.instance_variable_get(:@user)).to be_nil
       expect(transporter.instance_variable_get(:@password)).to be_nil
       expect(transporter.instance_variable_get(:@provider_short_name)).to be_nil
+    end
+
+    it "with Individual API Key" do
+      options = { username: "josh" }
+      allow(Spaceship::ConnectAPI).to receive(:token).and_return(Spaceship::ConnectAPI::Token.from(filepath: fake_individual_api_key_json_path))
+
+      transporter = fake_manager.send(:transporter_for_selected_team, options)
+      expect(transporter.instance_variable_get(:@jwt)).to(be_nil)
+      expect(transporter.instance_variable_get(:@user)).to eq("josh")
+      expect(transporter.instance_variable_get(:@password)).to eq("DELIVERPASS")
+      expect(transporter.instance_variable_get(:@provider_short_name)).to(be_nil)
     end
 
     describe "with itc_provider" do

--- a/spaceship/spec/connect_api/fixtures/asc_individual_key.json
+++ b/spaceship/spec/connect_api/fixtures/asc_individual_key.json
@@ -1,0 +1,4 @@
+{
+  "key_id": "D485S484",
+  "key": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIOChdk7KmY4kakEbpQzG6h7/FpsLviYzsG8VIAY8dQNPoAoGCCqGSM49\nAwEHoUQDQgAEYrwrM8lljj4upX7lb4YwjsnrD9CDYrMqKRH34GHPc6mMSLmXPqFr\nTdWWgfn6fee6YcJhvdGZliO08CbpjMPY2Q==\n-----END EC PRIVATE KEY-----\n"
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Resolves #22115

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

`altool` used internally by `deliver` and `pilot` has not support Individual API Keys yet.

With this change, fastlane determines the type of API key when uploading a build, and if the API key is a Team API Key, it will use the API key as is, but if it is an Individual API Key, it will not use the key and will use the the application specific password.

### Testing Steps

#### Prerequisites

- Issue your Individual API Key as described in https://developer.apple.com/help/app-store-connect/get-started/app-store-connect-api/
- Issue your application specific password as described in https://support.apple.com/en-us/102654
- Export environment variables in your shell env
  - `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`
  - `INDIVIDUAL_API_KEY_ID`
  - `INDIVIDUAL_API_KEY_CONTENT_BASE64`
  - `FASTLANE_USER` (necessary if it is not specified in your AppFile)
- Build your application with `Release` configuration

#### Steps

```ruby
# fastlane/Fastfile
lane :deploy do
  app_store_connect_api_key(
    key_id: ENV.fetch("INDIVIDUAL_API_KEY_ID"),
    key_content: ENV.fetch("INDIVIDUAL_API_KEY_CONTENT_BASE64"),
    is_key_content_base64: true,
  )
  pilot(ipa: "/path/to/app.ipa")
  deliver(ipa: "/path/to/app.ipa")
end
```

```sh
fastlane deploy
```

I successfully uploaded my app to TestFlight and AppStore Connect with this branch's fastlane.

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
