### PR TITLE
Trainer::XCResult: Remove ObjC Method Prefix and Suffix when sanitizing

### DIFF
--- a/trainer/lib/trainer/xcresult.rb
+++ b/trainer/lib/trainer/xcresult.rb
@@ -173,7 +173,11 @@ module Trainer
       end
 
       def find_failure(failures)
-        sanitizer = proc { |name| name.gsub(/\W/, "_") }
+        sanitizer = proc { |name|
+          # Remove "-[" at the beginning and "]" at the end if they exist
+          trimmed_name = name.sub(/^\-\[/, '').sub(/\]$/, '')
+          trimmed_name.gsub(/\W/, "_")
+        }
         sanitized_identifier = sanitizer.call(self.identifier)
         if self.test_status == "Failure"
           # Tries to match failure on test case name


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

When matching failures, the identifier from `ActionTestMetadata` is compared against the `testCaseName` in `TestFailureIssueSummary`. Both strings are sanitised prior to comparison, but `-[` and `]` from the `testCaseName` are not removed. The comparison `CrashTestTests_testExample == __CrashTestTests_testExample_` returns false and the failure is not recorded.

Resolves #22087 

### Description

The sanitizer in `ActionTestMetadata.find_failure` was updated to remove the ObjC method prefix and suffix, if present.

### Testing Steps

See original CrashTest.zip in GitHub issue.
