### PR TITLE
Add initial support for visionOS simulator in scan

### DIFF
--- a/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
+++ b/fastlane/lib/fastlane/actions/reset_simulator_contents.rb
@@ -25,12 +25,14 @@ module Fastlane
         FastlaneCore::Simulator.reset_all_by_version(os_version: os_version)
         FastlaneCore::SimulatorTV.reset_all_by_version(os_version: os_version)
         FastlaneCore::SimulatorWatch.reset_all_by_version(os_version: os_version)
+        FastlaneCore::SimulatorVision.reset_all_by_version(os_version: os_version)
       end
 
       def self.reset_all
         FastlaneCore::Simulator.reset_all
         FastlaneCore::SimulatorTV.reset_all
         FastlaneCore::SimulatorWatch.reset_all
+        FastlaneCore::SimulatorVision.reset_all
       end
 
       def self.description

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -73,6 +73,8 @@ module FastlaneCore
                          ["AppleTV"]
                        elsif requested_os_type == "iOS"
                          ["iPhone", "iPad", "iPod"]
+                       elsif requested_os_type == "visionOS"
+                         ["Apple Vision"]
                        else
                          []
                        end
@@ -202,7 +204,6 @@ module FastlaneCore
 
       def boot
         return unless is_simulator
-        return unless os_type == "iOS"
         return if self.state == 'Booted'
 
         # Boot the simulator and wait for it to finish booting
@@ -213,7 +214,6 @@ module FastlaneCore
 
       def shutdown
         return unless is_simulator
-        return unless os_type == "iOS"
         return if self.state != 'Booted'
 
         UI.message("Shutting down #{self.udid}")
@@ -374,6 +374,14 @@ module FastlaneCore
     class << self
       def all
         return DeviceManager.simulators('watchOS')
+      end
+    end
+  end
+  
+  class SimulatorVision < Simulator
+    class << self
+      def all
+        return DeviceManager.simulators('visionOS')
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -377,7 +377,7 @@ module FastlaneCore
       end
     end
   end
-  
+
   class SimulatorVision < Simulator
     class << self
       def all

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -203,6 +203,29 @@ describe FastlaneCore do
       )
     end
 
+    it "properly parses the simctl output and generates Device objects for visionOS simulator" do
+      response = "response"
+      simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode15')
+      expect(response).to receive(:read).and_return(simctl_output)
+      expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
+
+      devices = FastlaneCore::SimulatorVision.all
+      expect(devices.count).to eq(2)
+
+      expect(devices[0]).to have_attributes(
+        name: "Apple Vision Pro", os_type: "visionOS", os_version: "1.2",
+        udid: "DEC49069-537B-4766-8D30-3B50E27A9A2C",
+        state: "Shutdown",
+        is_simulator: true
+      )
+      expect(devices[1]).to have_attributes(
+        name: "Apple Vision Pro", os_type: "visionOS", os_version: "1.2",
+        udid: "D006BACD-AC30-47B2-8257-39F20D1502D0",
+        state: "Shutdown",
+        is_simulator: true
+      )
+    end
+
     it "properly parses the simctl output and generates Device objects for all simulators" do
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)

--- a/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode15
+++ b/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode15
@@ -1,0 +1,16 @@
+== Devices ==
+-- iOS 17.5 --
+    iPhone SE (3rd generation) (35F4F862-1AF3-44B6-B6B0-4F9D00CD6428) (Shutdown)
+    iPhone 15 (90052AC6-D47D-4B2A-840D-6B5B081260C6) (Shutdown)
+    iPhone 15 Plus (7EF20DA6-2401-4CEE-AF8B-547FDA1A66CA) (Shutdown)
+    iPhone 15 Pro (034483D5-66C0-4F82-8C12-E1C021E65FF1) (Shutdown)
+    iPhone 15 Pro Max (FF220A2F-E6D2-49BA-A151-15004352EB94) (Shutdown)
+    iPad (10th generation) (B926965B-F696-44D3-85D3-9736D0D60F0A) (Shutdown)
+    iPad mini (6th generation) (0FC4F1C0-9E5E-4961-A61D-3A8AA91C5765) (Shutdown)
+    iPad Air 11-inch (M2) (1DB0B4D1-3C75-4E83-8717-F4E60DE91502) (Shutdown)
+    iPad Air 13-inch (M2) (C6F6D446-FF83-4E78-B362-CC05C8A13945) (Shutdown)
+    iPad Pro 11-inch (M4) (010E17FB-CAC0-4803-A43F-CC0C2E4BCD61) (Shutdown)
+    iPad Pro 13-inch (M4) (6AD13ED6-D3A6-4A82-843E-575E0B82E444) (Shutdown)
+-- visionOS 1.2 --
+    Apple Vision Pro (DEC49069-537B-4766-8D30-3B50E27A9A2C) (Shutdown)
+    Apple Vision Pro (D006BACD-AC30-47B2-8257-39F20D1502D0) (Shutdown)

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -30,13 +30,19 @@ module Scan
       if Scan.devices
         if Scan.config[:reset_simulator]
           Scan.devices.each do |device|
-            FastlaneCore::Simulator.reset(udid: device.udid)
+            if device.os_type == "iOS"
+              FastlaneCore::Simulator.reset(udid: device.udid)
+            elsif device.os_type == "visionOS"
+              FastlaneCore::SimulatorVision.reset(udid: device.udid)
+            end
           end
         end
 
         if Scan.config[:disable_slide_to_type]
           Scan.devices.each do |device|
-            FastlaneCore::Simulator.disable_slide_to_type(udid: device.udid)
+            if device.os_type == "iOS"
+              FastlaneCore::Simulator.disable_slide_to_type(udid: device.udid)
+            end
           end
         end
       end
@@ -48,7 +54,11 @@ module Scan
         app_identifier ||= UI.input("App Identifier: ")
 
         Scan.devices.each do |device|
-          FastlaneCore::Simulator.uninstall_app(app_identifier, device.name, device.udid)
+          if device.os_type == "iOS"
+            FastlaneCore::Simulator.uninstall_app(app_identifier, device.name, device.udid)
+          elsif device.os_type == "visionOS"
+            FastlaneCore::SimulatorVision.uninstall_app(app_identifier, device.name, device.udid)
+          end
         end
       end
 
@@ -416,7 +426,11 @@ module Scan
       UI.header("Collecting system logs")
       Scan.devices.each do |device|
         log_identity = "#{device.name}_#{device.os_type}_#{device.os_version}"
-        FastlaneCore::Simulator.copy_logs(device, log_identity, Scan.config[:output_directory], @device_boot_datetime)
+        if device.os_type == "iOS"
+          FastlaneCore::Simulator.copy_logs(device, log_identity, Scan.config[:output_directory], @device_boot_datetime)
+        elsif device.os_type == "visionOS"
+          FastlaneCore::SimulatorVision.copy_logs(device, log_identity, Scan.config[:output_directory], @device_boot_datetime)
+        end
       end
     end
 

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -87,11 +87,8 @@ module Scan
       ]
       exit_status = 0
 
-      FastlaneCore::CommandExecutor.execute(command: command,
-                                          print_all: true,
-                                      print_command: true,
-                                             prefix: prefix_hash,
-                                            loading: "Loading...",
+      FastlaneCore::CommandExecutor.execute(command: command, print_all: true, print_command: true,
+                                             prefix: prefix_hash, loading: "Loading...",
                                     suppress_output: Scan.config[:suppress_xcode_output],
                                               error: proc do |error_output|
                                                 begin
@@ -134,8 +131,7 @@ module Scan
 
       retryable_tests = []
 
-      failing_tests = input.split("Failing tests:\n").fetch(1, [])
-                           .split("\n\n").first
+      failing_tests = input.split("Failing tests:\n").fetch(1, []).split("\n\n").first
 
       suites = failing_tests.split(/(?=\n\s+[\w\s]+:\n)/)
 

--- a/snapshot/lib/snapshot/reset_simulators.rb
+++ b/snapshot/lib/snapshot/reset_simulators.rb
@@ -28,6 +28,7 @@ module Snapshot
 
       FastlaneCore::SimulatorTV.delete_all
       FastlaneCore::SimulatorWatch.delete_all
+      FastlaneCore::SimulatorVision.delete_all
 
       all_runtime_type = runtimes
       # == Runtimes ==


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Adds initial support for the visionOS simulator.

### Description

- Added SimulatorVision class
- Lifted restriction that only iOS devices could be simulated in the runner.
- Added unit tests for device enumeration

### Testing Steps

Create a new visionOS project and add the following Scanfile:

```
# Scanfile

scheme "visionpro"
device "Apple Vision Pro"
clean true
open_report true
```
