### PR TITLE
Fix CircleCI PR checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ workflows:
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'
           xcode_version: '13.4.1'
-          ruby_version: '3.1.2'
+          ruby_version: '3.1.4'
           ruby_opt: -W:deprecated
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 14.3.1, Ruby 3.1)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ aliases:
     run:
       name: bundle install
       command: |
-        sudo gem update --system `.ci/compatible_gem_version`
+        gem update --system `.ci/compatible_gem_version`
         gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ")
         bundle config set --local path .bundle
         bundle check || bundle install --jobs=4 --retry=3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ workflows:
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'
           xcode_version: '13.4.1'
-          ruby_version: '3.1.4'
+          ruby_version: '3.1'
           ruby_opt: -W:deprecated
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 14.3.1, Ruby 3.1)'


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves https://github.com/fastlane/fastlane/issues/22141

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

The current CircleCI configuration was trying to use Ruby version 3.1.2 with Xcode 13.4.0, however, that Ruby version is not loaded by default on the Xcode 13.4.0 MacOS executor. If you check the [software manifest](https://circle-macos-docs.s3.amazonaws.com/image-manifest/v11776/manifest.txt) for Xcode 13.4.0 on CircleCI, you can see that the closest available version is 3.1.4. This PR changes the Xcode 13.4.0 test job to use Ruby 3.1, which will use the highest patch version of 3.1 available, instead of linking to a specific version of 3.1.X that could become outdated. 

I also noticed that `sudo` was being used to install the system RubyGems, which resulted in a write permissions error when trying to install additional bundle dependencies without using `sudo`. I removed `sudo` from `gem update --system`, which cleared up the permissions issue. 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Run the CI workflow and confirm that there are no errors when setting Ruby versions. 