### PR TITLE
[scan][trainer] hotfix for xcresulttool spec changes >= XC16b3

### DIFF
--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -204,8 +204,7 @@ module Trainer
       # Executes xcresulttool to get JSON format of the result bundle object
       # Hotfix: From Xcode 16 beta 3 'xcresulttool get --format json' has been deprecated; '--legacy' flag required to keep on using the command
       xcresulttool_cmd = "xcrun xcresulttool get --format json --path #{path}"
-      xcode_version_object = JSON.parse(`plutil -convert json -o - #{FastlaneCore::Helper.xcode_path}../version.plist`)
-      xcresulttool_cmd << ' --legacy' if xcode_version_object['CFBundleVersion'].to_i >= 23044 # CFBundleVersion of Xcode 16 beta 3
+      xcresulttool_cmd << ' --legacy' if `xcrun --version`.gsub('xcrun version ', '').to_f >= 70.0 # Version of xcrun bundled in Xcode 16 beta 3
 
       result_bundle_object_raw = execute_cmd(xcresulttool_cmd)
       result_bundle_object = JSON.parse(result_bundle_object_raw)

--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -210,10 +210,11 @@ module Trainer
         #{path}
       )
 
-      # Version of xcresulttool bundled in Xcode 16 beta 3 was 23021
-      xcresulttool_version_string = `xcrun xcresulttool version`.split(',')[0]
-      xcresulttool_version = xcresulttool_version_string.gsub('xcresulttool version ', '').to_f
-      xcresulttool_cmd << '--legacy' if xcresulttool_version >= 23_021.0
+      # e.g. DEVELOPER_DIR=/Applications/Xcode_16_beta_3.app
+      # xcresulttool version 23021, format version 3.53 (current)
+      match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+),/)
+      version = match[:version]&.to_f
+      xcresulttool_cmd << '--legacy' if version >= 23_021.0
 
       xcresulttool_cmd.join(' ')
     end

--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -211,7 +211,9 @@ module Trainer
       )
 
       # Version of xcresulttool bundled in Xcode 16 beta 3 was 23021
-      xcresulttool_cmd << '--legacy' if `xcrun xcresulttool version`.split(',')[0].gsub('xcresulttool version ', '').to_f >= 23_021.0
+      xcresulttool_version_string = `xcrun xcresulttool version`.split(',')[0]
+      xcresulttool_version = xcresulttool_version_string.gsub('xcresulttool version ', '').to_f
+      xcresulttool_cmd << '--legacy' if xcresulttool_version >= 23_021.0
 
       xcresulttool_cmd.join(' ')
     end

--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -27,7 +27,7 @@ describe Trainer do
     end
 
     describe "#generate_cmd_parse_xcresult" do
-      it "appends '--legacy' to command for parse_xcresult on >= Xcode 16 beta 3" do
+      it "appends '--legacy' to command for parse_xcresult on >= Xcode 16 beta 3", requires_xcode: true do
         xcresult_sample_path = "./trainer/spec/fixtures/Test.test_result.xcresult"
         @model = Trainer::TestParser.new(xcresult_sample_path)
         allow_any_instance_of(Trainer::TestParser).to receive(:`).and_return("xcresulttool version 23021, format version 3.53 (current)")
@@ -35,7 +35,7 @@ describe Trainer do
         expect(actual).to eq("xcrun xcresulttool get --format json --path #{xcresult_sample_path} --legacy")
       end
 
-      it "use traditional command for parse_xcresult on < Xcode 16 beta 3" do
+      it "use traditional command for parse_xcresult on < Xcode 16 beta 3", requires_xcode: true do
         xcresult_sample_path = "./trainer/spec/fixtures/Test.test_result.xcresult"
         @model = Trainer::TestParser.new(xcresult_sample_path)
         allow_any_instance_of(Trainer::TestParser).to receive(:`).and_return("xcresulttool version 22608, format version 3.49 (current)")

--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -26,6 +26,24 @@ describe Trainer do
       end
     end
 
+    describe "#generate_cmd_parse_xcresult" do
+      it "appends '--legacy' to command for parse_xcresult on >= Xcode 16 beta 3" do
+        xcresult_sample_path = "./trainer/spec/fixtures/Test.test_result.xcresult"
+        @model = Trainer::TestParser.new(xcresult_sample_path)
+        allow_any_instance_of(Trainer::TestParser).to receive(:`).and_return("xcresulttool version 23021, format version 3.53 (current)")
+        actual = @model.send(:generate_cmd_parse_xcresult, xcresult_sample_path)
+        expect(actual).to eq("xcrun xcresulttool get --format json --path #{xcresult_sample_path} --legacy")
+      end
+
+      it "use traditional command for parse_xcresult on < Xcode 16 beta 3" do
+        xcresult_sample_path = "./trainer/spec/fixtures/Test.test_result.xcresult"
+        @model = Trainer::TestParser.new(xcresult_sample_path)
+        allow_any_instance_of(Trainer::TestParser).to receive(:`).and_return("xcresulttool version 22608, format version 3.49 (current)")
+        actual = @model.send(:generate_cmd_parse_xcresult, xcresult_sample_path)
+        expect(actual).to eq("xcrun xcresulttool get --format json --path #{xcresult_sample_path}")
+      end
+    end
+
     describe "Stores the data in a useful format" do
       describe "#tests_successful?" do
         it "returns false if tests failed" do

--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -40,7 +40,7 @@ describe Trainer do
         let(:version) { 'xcresulttool version 23021, format version 3.53 (current)' }
         let(:expected) { "xcrun xcresulttool get --format json --path #{xcresult_sample_path} --legacy" }
 
-        it 'should pass `--legacy`' do
+        it 'should pass `--legacy`', requires_xcode: true do
           expect(command).to eq(expected)
         end
       end
@@ -49,7 +49,7 @@ describe Trainer do
         let(:version) { 'xcresulttool version 22608, format version 3.49 (current)' }
         let(:expected) { "xcrun xcresulttool get --format json --path #{xcresult_sample_path}" }
 
-        it 'should not pass `--legacy`' do
+        it 'should not pass `--legacy`', requires_xcode: true do
           expect(command).to eq(expected)
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
  - for *trainer* module, all passed
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
  - N/A
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves https://github.com/fastlane/fastlane/issues/22132

From Xcode 16 beta 3, `fastlane ios scan` started to fail after xctest had finished. 
The reason is: There has been a deprecation and stderr in traditional `xcrun xcresulttool` command usage.

<details>
  <summary> Error details of xcresulttool related portion </summary>

```
...
00:07:00 Error: This command is deprecated and will be removed in a future release, --legacy flag is required to use it.
00:07:00 Usage: xcresulttool get object [--legacy] --path <path> [--id <id>] [--version <version>] [--format <format>]
00:07:00   See 'xcresulttool get object --help' for more information.
...
```

</details>

I tried new way when obtaining xcresult object (`xcresulttool get tests` or something) but
- test summary was separated
- the entire format of the object was totally different
- test ID for `--id` option was not showing up in the report

For these reasons, decided to add `--legacy` if using Xcode 16 beta 3. 
It would take quite a time to use the new type of `xcresulttool` like in the deprecation notice.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
used changes of this branch as a *fastlane* gem and tried `run_tests` under XC15 and 16.
specs in *trainer* had nothing to test with this part so I tried *scan* on both Xcode 15.4 and 16 beta 3

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

```
00:00:16 $ gem uninstall -Iax fastlane
00:00:16 git clone --single-branch -b dokimyj-patch-1 https://github.com/dokimyj/fastlane fastlane-dokimyj
00:00:16 bundle install --path=vendor/bundle
```

Both environments are in CI, I cloned this single branch and `bundle install` to use bundle fastlane.


```
00:06:53 ▸ Testing passed on 'iPhone 15 Plus'
00:06:53 ▸ Test Succeeded
00:06:57 Skipping HTML... only available with `xcodebuild_formatter: 'xcpretty'` right now
00:06:57 Your 'xcodebuild_formatter' doesn't support these 'output_types'. Change your 'output_types' to prevent these warnings from showing...
00:06:57 +-------------------------+
00:06:57 |      Test Results       |
00:06:57 +--------------------+----+
00:06:57 | Number of tests    | 12 |
00:06:57 | Number of failures | 0  |
00:06:57 +--------------------+----+
```

*scan* with Xcode 16 beta 3 using this branch

```
00:08:36 ▸ Testing passed on 'iPhone 15 Plus'
00:08:36 ▸ Test Succeeded
00:08:41 Skipping HTML... only available with `xcodebuild_formatter: 'xcpretty'` right now
00:08:41 Your 'xcodebuild_formatter' doesn't support these 'output_types'. Change your 'output_types' to prevent these warnings from showing...
00:08:42 +-------------------------+
00:08:42 |      Test Results       |
00:08:42 +--------------------+----+
00:08:42 | Number of tests    | 12 |
00:08:42 | Number of failures | 0  |
00:08:42 +--------------------+----+
```

*scan* with Xcode 15.4 using this branch

Seems no differences in the result!