### PR TITLE
Add app_path parameter to changelog_from_git_commits

### DIFF
--- a/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
+++ b/fastlane/lib/fastlane/actions/changelog_from_git_commits.rb
@@ -37,9 +37,9 @@ module Fastlane
 
         Dir.chdir(params[:path]) do
           if params[:commits_count]
-            changelog = Actions.git_log_last_commits(params[:pretty], params[:commits_count], merge_commit_filtering, params[:date_format], params[:ancestry_path])
+            changelog = Actions.git_log_last_commits(params[:pretty], params[:commits_count], merge_commit_filtering, params[:date_format], params[:ancestry_path], params[:app_path])
           else
-            changelog = Actions.git_log_between(params[:pretty], from, to, merge_commit_filtering, params[:date_format], params[:ancestry_path])
+            changelog = Actions.git_log_between(params[:pretty], from, to, merge_commit_filtering, params[:date_format], params[:ancestry_path], params[:app_path])
           end
 
           changelog = changelog.gsub("\n\n", "\n") if changelog # as there are duplicate newlines
@@ -147,7 +147,11 @@ module Fastlane
                                        verify_block: proc do |value|
                                          matches_option = GIT_MERGE_COMMIT_FILTERING_OPTIONS.any? { |opt| opt.to_s == value }
                                          UI.user_error!("Valid values for :merge_commit_filtering are #{GIT_MERGE_COMMIT_FILTERING_OPTIONS.map { |o| "'#{o}'" }.join(', ')}") unless matches_option
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :app_path,
+                                       env_name: 'FL_CHANGELOG_FROM_GIT_COMMITS_APP_PATH',
+                                       description: "Scopes the changelog to a specific subdirectory of the repository",
+                                       optional: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/helper/git_helper.rb
+++ b/fastlane/lib/fastlane/helper/git_helper.rb
@@ -9,13 +9,14 @@ module Fastlane
       end.freeze
     end
 
-    def self.git_log_between(pretty_format, from, to, merge_commit_filtering, date_format = nil, ancestry_path)
+    def self.git_log_between(pretty_format, from, to, merge_commit_filtering, date_format = nil, ancestry_path, app_path)
       command = %w(git log)
       command << "--pretty=#{pretty_format}"
       command << "--date=#{date_format}" if date_format
       command << '--ancestry-path' if ancestry_path
       command << "#{from}...#{to}"
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
+      command << app_path if app_path
       # "*command" syntax expands "command" array into variable arguments, which
       # will then be individually shell-escaped by Actions.sh.
       Actions.sh(*command.compact, log: false).chomp
@@ -23,13 +24,14 @@ module Fastlane
       nil
     end
 
-    def self.git_log_last_commits(pretty_format, commit_count, merge_commit_filtering, date_format = nil, ancestry_path)
+    def self.git_log_last_commits(pretty_format, commit_count, merge_commit_filtering, date_format = nil, ancestry_path, app_path)
       command = %w(git log)
       command << "--pretty=#{pretty_format}"
       command << "--date=#{date_format}" if date_format
       command << '--ancestry-path' if ancestry_path
       command << '-n' << commit_count.to_s
       command << git_log_merge_commit_filtering_option(merge_commit_filtering)
+      command << app_path if app_path
       Actions.sh(*command.compact, log: false).chomp
     rescue
       nil

--- a/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
+++ b/fastlane/spec/actions_specs/changelog_from_git_commits_spec.rb
@@ -190,6 +190,17 @@ describe Fastlane do
         expect(result).to eq(changelog)
       end
 
+      it "Returns a scoped log from the app's path if so requested" do
+        result = Fastlane::FastFile.new.parse("lane :test do
+          changelog_from_git_commits(app_path: './apps/ios')
+        end").runner.execute(:test)
+
+        tag_name = %w(git rev-list --tags --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        changelog = %W(git log --pretty=%B #{describe}...HEAD ./apps/ios).shelljoin
+        expect(result).to eq(changelog)
+      end
+
       it "Runs between option from command line" do
 
         options = FastlaneCore::Configuration.create(Fastlane::Actions::ChangelogFromGitCommitsAction.available_options, {


### PR DESCRIPTION
Adds a parameter to allow users to specify a subpath for a specific application to scope the changelog to changes to files just in that directory. This is useful in environments where several apps share the same repository.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [No] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary.
- [X] I've added or updated relevant unit tests.

### Motivation and Context

In our environment we have several applications sharing a single repository and want to scope the changelog to a single sub-directory of our monorepo.

### Description

This change adds an `app_path` parameter to `changelog_from_git_commits` allowing one to specify a subdirectory a call to generate a changelog.

### Testing Steps

- Added unit test
- Ensured generated git command returned the expected output