### PR TITLE
Fastlane sh with log set to false should respect a step name

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -218,7 +218,9 @@ module Fastlane
     end
 
     def self.sh(*command, step_name: nil, log: true, error_callback: nil, &b)
-      command_header = log ? step_name || Actions.shell_command_from_args(*command) : "shell command"
+      command_header = step_name
+      command_header ||= log ? Actions.shell_command_from_args(*command) : "shell command"
+
       Actions.execute_action(command_header) do
         Actions.sh_no_action(*command, log: log, error_callback: error_callback, &b)
       end

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -49,7 +49,7 @@ describe Fastlane do
         end
 
         it "passes command as string, step_name, and log false with default error_callback" do
-          expect(Fastlane::Actions).to receive(:execute_action).with("shell command").and_call_original
+          expect(Fastlane::Actions).to receive(:execute_action).with("some_name").and_call_original
 
           expect(Fastlane::Actions).to receive(:sh_no_action)
             .with("git commit", log: false, error_callback: nil)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #22072
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Fastlane sh with log set to false should respect a step name. 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

The lane: 

```ruby
sh("ls", log: false, step_name: "list files")
```

Before 😭 

<img width="383" alt="Screenshot 2024-07-20 at 12 35 42" src="https://github.com/user-attachments/assets/b7638ad1-95b0-4fd4-9a6f-0d475af5b8fc">

After 🎉 

<img width="391" alt="Screenshot 2024-07-20 at 12 35 31" src="https://github.com/user-attachments/assets/a55f7710-5a82-436b-8b54-bd02b9809594">

