### PR TITLE
[gym] fix default result bundle path name

### DIFF
--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -184,7 +184,7 @@ module Gym
       def result_bundle_path
         unless Gym.cache[:result_bundle_path]
           path = Gym.config[:result_bundle_path]
-          path ||= File.join(Gym.config[:output_directory], Gym.config[:output_name] + ".result")
+          path ||= File.join(Gym.config[:output_directory], Gym.config[:output_name] + ".xcresult")
           if File.directory?(path)
             FileUtils.remove_dir(path)
           end

--- a/gym/spec/build_command_generator_spec.rb
+++ b/gym/spec/build_command_generator_spec.rb
@@ -279,7 +279,7 @@ describe Gym do
                                "-project ./gym/examples/standard/Example.xcodeproj",
                                "-destination 'generic/platform=iOS'",
                                "-archivePath #{Gym::BuildCommandGenerator.archive_path.shellescape}",
-                               "-resultBundlePath './ExampleProductName.result'",
+                               "-resultBundlePath './ExampleProductName.xcresult'",
                                :archive,
                                "| tee #{log_path.shellescape}",
                                "| xcpretty"


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Gym by default creates a result bundle with an extension that is not recognized by Xcode, thus double-clicking on it does not open what is expected (Xcode result view).

### Description

Use the default correct extension `.xcresult` instead of the current `.result`

### Testing Steps

Use gym and indicate `result_bundle: true` without indicating a `result_bundle_path`.