### PR TITLE
Resolve master CI error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,20 +251,9 @@ workflows:
   "Run Tests & Checks": # Name of the workflow, which ends up displayed on GitHub's PR Check
     jobs:
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 12.5.1, Ruby 2.6)'
-          xcode_version: '12.5.1'
-          ruby_version: '2.6.6'
-          <<: *important-branches
-      - tests_macos:
-          name: 'Execute tests on macOS (Xcode 12.5.1, Ruby 2.7)'
-          xcode_version: '12.5.1'
-          ruby_version: '2.7.3'
-          ruby_opt: -W:deprecated
-          <<: *important-branches
-      - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.0)'
           xcode_version: '13.4.1'
-          ruby_version: '3.0.4'
+          ruby_version: '3.1'
           ruby_opt: -W:deprecated
           <<: *important-branches
       - tests_macos:


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [xj] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Thanks to https://github.com/fastlane/fastlane/pull/22142, CI seemed to be fixed, but some additional fixes are required.

### Description

- The combination `Xcode 13.4.1, Ruby 3.0` still used Ruby 3.0.4 https://app.circleci.com/pipelines/github/fastlane/fastlane/6609/workflows/13943ff2-cfc5-478c-af59-5d8da5ad9399/jobs/101881
- CircleCI no longer provides Xcode 12 stacks https://app.circleci.com/pipelines/github/fastlane/fastlane/6609/workflows/13943ff2-cfc5-478c-af59-5d8da5ad9399/jobs/101885

I think we don't need to maintain Xcode 12 support still.

This PR fixes this

### Testing Steps

- [x] Pass CI
