### PR TITLE
[scan][trainer] hotfix for float-type version acquisition of `xcresulttool version` fails

### DIFF
--- a/trainer/lib/trainer/test_parser.rb
+++ b/trainer/lib/trainer/test_parser.rb
@@ -212,9 +212,9 @@ module Trainer
 
       # e.g. DEVELOPER_DIR=/Applications/Xcode_16_beta_3.app
       # xcresulttool version 23021, format version 3.53 (current)
-      match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>\d+),/)
-      version = match[:version]&.to_f
-      xcresulttool_cmd << '--legacy' if version >= 23_021.0
+      match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>[\d.]+)/)
+      version = match[:version]
+      xcresulttool_cmd << '--legacy' if Gem::Version.new(version) >= Gem::Version.new(23_021)
 
       xcresulttool_cmd.join(' ')
     end

--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -46,7 +46,7 @@ describe Trainer do
       end
 
       context 'with < Xcode 16 beta 3' do
-        let(:version) { 'xcresulttool version 22608, format version 3.49 (current)' }
+        let(:version) { 'xcresulttool version 22608.2, format version 3.49 (current)' }
         let(:expected) { "xcrun xcresulttool get --format json --path #{xcresult_sample_path}" }
 
         it 'should not pass `--legacy`', requires_xcode: true do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
  - N/A
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Fixes error from https://github.com/fastlane/fastlane/pull/22147

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

While trying `run_tests` with https://github.com/fastlane/fastlane/pull/22147 commit source, 
some Xcode versions (e.g. Xcode 16 beta 2) failed due to nil-referring `[]` search.

`trainer/lib/trainer/test_parser.rb:216:in generate_cmd_parse_xcresult': [!] undefined method []' for nil:NilClass (NoMethodError)`

This PR solves the problem below:

<details>
  <summary> Error details and `xcrun xcresulttool version` example of Xcode 16 beta </summary>

```
00:09:43 Called from Fastfile at line 58
00:09:43 ```
00:09:43     56:	  desc "Run test!"
00:09:43     57:	  lane :test do
00:09:43  => 58:	    run_tests(
00:09:43     59:	      scheme: scheme,
00:09:43     60:	      devices: [
00:09:43 ```

...

source_path/vendor/bundle/ruby/3.2.0/bundler/gems/fastlane-26104a51d25a/trainer/lib/trainer/test_parser.rb:216:in `generate_cmd_parse_xcresult': [!] undefined method `[]' for nil:NilClass (NoMethodError)
00:09:47 
00:09:47       version = match[:version]&.to_f
00:09:47                      ^^^^^^^^^^
```

After I have found this error, tried `xcrun xcresulttool version` with all Xcode 16 beta versions and here's the result:

```
$ DEVELOPER_DIR=/Applications/Xcode_16_beta.app xcrun xcresulttool version
xcresulttool version 23019.2, format version 3.53 (current)

$ DEVELOPER_DIR=/Applications/Xcode_16_beta_2.app xcrun xcresulttool version
xcresulttool version 23019.2, format version 3.53 (current)

$ DEVELOPER_DIR=/Applications/Xcode_16_beta_3.app xcrun xcresulttool version
xcresulttool version 23021, format version 3.53 (current)

$ DEVELOPER_DIR=/Applications/Xcode/Xcode_16_beta_4.app xcrun xcresulttool version
xcresulttool version 23024, format version 3.53 (current)
```

</details>

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Installed fastlane gem with the source of this branch, executed `run_tests` with Xcode 15.4, Xcode 16 beta 2, and beta 4.

- Xcode 15.4

```
20:22:39 +-------------------------------------------------------------------------------------------------------------------------------+
20:22:39 |                                                   Summary for scan 2.221.1                                                    |
20:22:39 +------------------------------------------------+------------------------------------------------------------------------------+
...
20:22:39 | xcode_path                                     | /Applications/Xcode/Xcode_15.4.app                                           |
20:22:39 +------------------------------------------------+------------------------------------------------------------------------------+

...

20:25:58 ▸ Test Succeeded
20:26:01 Skipping HTML... only available with `xcodebuild_formatter: 'xcpretty'` right now
20:26:01 Your 'xcodebuild_formatter' doesn't support these 'output_types'. Change your 'output_types' to prevent these warnings from showing...
20:26:02 +------------------------+
20:26:02 |      Test Results      |
20:26:02 +--------------------+---+
20:26:02 | Number of tests    | 6 |
20:26:02 | Number of failures | 0 |
20:26:02 +--------------------+---+
```

- Xcode 16 beta 4

```
20:13:29 +-------------------------------------------------------------------------------------------------------------------------------+
20:13:29 |                                                   Summary for scan 2.221.1                                                    |
20:13:29 +------------------------------------------------+------------------------------------------------------------------------------+
...
20:13:29 | xcode_path                                     | /Applications/Xcode/Xcode_16_beta_4.app                                      |
20:13:29 +------------------------------------------------+------------------------------------------------------------------------------+

...

20:15:15 ▸ Test Succeeded
20:15:19 Skipping HTML... only available with `xcodebuild_formatter: 'xcpretty'` right now
20:15:19 Your 'xcodebuild_formatter' doesn't support these 'output_types'. Change your 'output_types' to prevent these warnings from showing...
20:15:19 +------------------------+
20:15:19 |      Test Results      |
20:15:19 +--------------------+---+
20:15:19 | Number of tests    | 6 |
20:15:19 | Number of failures | 0 |
20:15:19 +--------------------+---+

```

- Xcode 16 beta 2 (Problematic on master branch)

```
20:07:18 +-------------------------------------------------------------------------------------------------------------------------------+
20:07:18 |                                                   Summary for scan 2.221.1                                                    |
20:07:18 +------------------------------------------------+------------------------------------------------------------------------------+
...
20:07:18 | xcode_path                                     | /Applications/Xcode/Xcode_16_beta_2.app                                      |
20:07:18 +------------------------------------------------+------------------------------------------------------------------------------+

...

20:10:00 ▸ Test Succeeded
20:10:04 Skipping HTML... only available with `xcodebuild_formatter: 'xcpretty'` right now
20:10:04 Your 'xcodebuild_formatter' doesn't support these 'output_types'. Change your 'output_types' to prevent these warnings from showing...
20:10:05 +------------------------+
20:10:05 |      Test Results      |
20:10:05 +--------------------+---+
20:10:05 | Number of tests    | 6 |
20:10:05 | Number of failures | 0 |
20:10:05 +--------------------+---+

```