### PR TITLE
Update export methods with new `xcodebuild` values.

### DIFF
--- a/gym/examples/standard/ExampleExport.plist
+++ b/gym/examples/standard/ExampleExport.plist
@@ -14,6 +14,6 @@
 		<string>https://www.example.com/fullSize.png</string>
 	</dict>
 	<key>method</key>
-	<string>ad-hoc</string>
+	<string>release-testing</string>
 </dict>
 </plist>

--- a/gym/lib/gym/code_signing_mapping.rb
+++ b/gym/lib/gym/code_signing_mapping.rb
@@ -1,6 +1,7 @@
 require 'xcodeproj'
 
 require_relative 'module'
+require_relative 'export_method'
 
 module Gym
   class CodeSigningMapping
@@ -69,6 +70,12 @@ module Gym
     # We do some `gsub`bing, because we can't really know the profile type, so we'll just look at the name and see if it includes
     # the export method (which it usually does, but with different notations)
     def app_identifier_contains?(str, contains)
+      # Account for differences in export method and expected identifier names.
+      case contains
+      when ExportMethod::APP_STORE
+        contains = 'app-store'
+      end
+
       return str.to_s.gsub("-", "").gsub(" ", "").gsub("InHouse", "enterprise").downcase.include?(contains.to_s.gsub("-", "").gsub(" ", "").downcase)
     end
 

--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -2,6 +2,7 @@ require 'fastlane_core/core_ext/cfpropertylist'
 require 'fastlane_core/project'
 require_relative 'module'
 require_relative 'code_signing_mapping'
+require_relative 'export_method'
 
 module Gym
   # This class detects all kinds of default values
@@ -109,7 +110,7 @@ module Gym
       return if team_id.nil?
 
       case Gym.config[:export_method]
-      when "app-store"
+      when ExportMethod::APP_STORE
         prefix = "3rd Party Mac Developer Installer: "
       when "developer-id"
         prefix = "Developer ID Installer: "

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -2,6 +2,7 @@
 
 require 'fastlane_core/print_table'
 require_relative 'module'
+require_relative 'export_method'
 
 module Gym
   # This classes methods are called when something goes wrong in the building process
@@ -249,17 +250,17 @@ module Gym
           # the provisioning profile might be called anything below
           # There is no 100% good way to detect the profile type based on the name
           available_export_types = {
-            "app-store" => "app-store",
-            "app store" => "app-store",
-            "appstore" => "app-store",
-            "enterprise" => "enterprise",
-            "in-house" => "enterprise",
-            "in house" => "enterprise",
-            "inhouse" => "enterprise",
-            "ad-hoc" => "ad-hoc",
-            "adhoc" => "ad-hoc",
-            "ad hoc" => "ad-hoc",
-            "development" => "development"
+            "app-store" => ExportMethod::APP_STORE,
+            "app store" => ExportMethod::APP_STORE,
+            "appstore" => ExportMethod::APP_STORE,
+            "enterprise" => ExportMethod::ENTERPRISE,
+            "in-house" => ExportMethod::ENTERPRISE,
+            "in house" => ExportMethod::ENTERPRISE,
+            "inhouse" => ExportMethod::ENTERPRISE,
+            "ad-hoc" => ExportMethod::RELEASE_TESTING,
+            "adhoc" => ExportMethod::RELEASE_TESTING,
+            "ad hoc" => ExportMethod::RELEASE_TESTING,
+            "development" => ExportMethod::DEBUGGING
           }
 
           selected_provisioning_profiles.each do |current_bundle_identifier, current_profile_name|

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -227,9 +227,10 @@ module Gym
       end
 
       def print_environment_information
-        if Gym.config[:export_method].to_s == "development"
+        export_method = Gym.config[:export_method].to_s
+        if [ExportMethod::DEBUGGING, ExportMethod::DEBUGGING_DEPRECATED].include?(export_method)
           UI.message("")
-          UI.error("Your `export_method` in gym is defined as `development`")
+          UI.error("Your `export_method` in gym is defined as `#{export_method}`")
           UI.error("which might cause problems when signing your application")
           UI.error("Are you sure want to build and export for development?")
           UI.error("Please make sure to define the correct export methods when calling")

--- a/gym/lib/gym/export_method.rb
+++ b/gym/lib/gym/export_method.rb
@@ -1,0 +1,62 @@
+# From `xcodebuild -help`:
+#
+# method : String
+#
+# Describes how Xcode should export the archive.
+# Available options:
+#   app-store-connect,
+#   release-testing,
+#   enterprise,
+#   debugging,
+#   developer-id,
+#   mac-application,
+#   validation,
+#   and package.
+#
+# The list of options varies based on the type of archive.
+#
+# Defaults to debugging.
+#
+# Additional options include:
+#   app-store (deprecated: use app-store-connect),
+#   ad-hoc (deprecated: use release-testing),
+#   and development (deprecated: use debugging).
+module Gym
+  class ExportMethod
+    APP_STORE = 'app-store-connect'
+    RELEASE_TESTING = 'release-testing'
+    ENTERPRISE = 'enterprise'
+    DEBUGGING = 'debugging'
+    DEVELOPER_ID = 'developer-id'
+    MAC_APPLICATION = 'mac-application'
+    VALIDATION = 'validation'
+    PACKAGE = 'package'
+
+    APP_STORE_DEPRECATED = 'app-store'
+    RELEASE_TESTING_DEPRECATED = 'ad-hoc'
+    DEBUGGING_DEPRECATED = 'development'
+
+    def self.available_methods
+      [
+        APP_STORE,
+        RELEASE_TESTING,
+        ENTERPRISE,
+        DEBUGGING,
+        DEVELOPER_ID,
+        MAC_APPLICATION,
+        VALIDATION,
+        PACKAGE
+      ]
+    end
+
+    def self.deprecated_methods_notice
+      deprecation_list = [
+        [APP_STORE_DEPRECATED, APP_STORE],
+        [RELEASE_TESTING_DEPRECATED, RELEASE_TESTING],
+        [DEBUGGING_DEPRECATED, DEBUGGING]
+      ].map { |p| "'#{p[0]} in favor of '#{p[1]}'" }.join(', ')
+
+      "Notice that recent versions of xcodebuild have deprecated #{deprecation_list}. See 'xcodebuild -help' for more info."
+    end
+  end
+end

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -12,12 +12,13 @@ require 'fastlane_core/core_ext/cfpropertylist'
 require_relative '../module'
 require_relative '../error_handler'
 require_relative 'build_command_generator'
+require_relative '../export_method'
 
 module Gym
   # Responsible for building the fully working xcodebuild command
   class PackageCommandGeneratorXcode7
     class << self
-      DEFAULT_EXPORT_METHOD = "app-store"
+      DEFAULT_EXPORT_METHOD = ExportMethod::APP_STORE
 
       def generate
         parts = ["/usr/bin/xcrun #{wrap_xcodebuild.shellescape} -exportArchive"]
@@ -190,7 +191,7 @@ module Gym
 
         # Overrides export options if needed
         hash[:method] = Gym.config[:export_method]
-        if Gym.config[:export_method] == 'app-store'
+        if Gym.config[:export_method] == ExportMethod::APP_STORE
           hash[:uploadSymbols] = (Gym.config[:include_symbols] ? true : false) unless Gym.config[:include_symbols].nil?
           hash[:uploadBitcode] = (Gym.config[:include_bitcode] ? true : false) unless Gym.config[:include_bitcode].nil?
         end

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -2,6 +2,7 @@ require 'fastlane_core/configuration/config_item'
 require 'fastlane/helper/xcodebuild_formatter_helper'
 require 'credentials_manager/appfile_config'
 require_relative 'module'
+require_relative 'export_method'
 
 module Gym
   class Options
@@ -106,12 +107,12 @@ module Gym
         FastlaneCore::ConfigItem.new(key: :export_method,
                                      short_option: "-j",
                                      env_name: "GYM_EXPORT_METHOD",
-                                     description: "Method used to export the archive. Valid values are: app-store, validation, ad-hoc, package, enterprise, development, developer-id and mac-application",
+                                     description: "Method used to export the archive. Valid values are: #{ExportMethod.available_methods.join(', ')}",
                                      type: String,
                                      optional: true,
                                      verify_block: proc do |value|
-                                       av = %w(app-store validation ad-hoc package enterprise development developer-id mac-application)
-                                       UI.user_error!("Unsupported export_method '#{value}', must be: #{av}") unless av.include?(value)
+                                       av = ExportMethod.available_methods
+                                       UI.user_error!("Unsupported export_method '#{value}', must be: #{av}. #{ExportMethod.deprecated_methods_notice}") unless av.include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :export_options,
                                      env_name: "GYM_EXPORT_OPTIONS",

--- a/gym/spec/code_signing_mapping_spec.rb
+++ b/gym/spec/code_signing_mapping_spec.rb
@@ -70,7 +70,7 @@ describe Gym::CodeSigningMapping do
     it "only mapping from Xcode Project is available" do
       result = csm.merge_profile_mapping(primary_mapping: {},
                                        secondary_mapping: { "identifier.1" => "value.1" },
-                                           export_method: "app-store")
+                                           export_method: "app-store-connect")
 
       expect(result).to eq({ "identifier.1": "value.1" })
     end
@@ -78,7 +78,7 @@ describe Gym::CodeSigningMapping do
     it "only mapping from match (user) is available" do
       result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "value.1" },
                                        secondary_mapping: {},
-                                           export_method: "app-store")
+                                           export_method: "app-store-connect")
 
       expect(result).to eq({ "identifier.1": "value.1" })
     end
@@ -86,7 +86,7 @@ describe Gym::CodeSigningMapping do
     it "keeps both profiles if they don't conflict" do
       result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "value.1" },
                                        secondary_mapping: { "identifier.2" => "value.2" },
-                                           export_method: "app-store")
+                                           export_method: "app-store-connect")
 
       expect(result).to eq({ "identifier.1": "value.1", "identifier.2": "value.2" })
     end
@@ -94,13 +94,13 @@ describe Gym::CodeSigningMapping do
     it "doesn't crash if nil is provided" do
       result = csm.merge_profile_mapping(primary_mapping: nil,
                                        secondary_mapping: {},
-                                           export_method: "app-store")
+                                           export_method: "app-store-connect")
       expect(result).to eq({})
     end
 
     it "accesses the Xcode profile mapping, if nothing else is given" do
       expect(csm).to receive(:detect_project_profile_mapping).and_return({ "identifier.1" => "value.1" })
-      result = csm.merge_profile_mapping(primary_mapping: {}, export_method: "app-store")
+      result = csm.merge_profile_mapping(primary_mapping: {}, export_method: "app-store-connect")
 
       expect(result).to eq({ "identifier.1": "value.1" })
     end
@@ -110,7 +110,7 @@ describe Gym::CodeSigningMapping do
         it "should prefer the primary mapping" do
           result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-pStoreValue2" },
                                          secondary_mapping: { "identifier.1" => "Ap-pStoreValue1" },
-                                             export_method: "app-store")
+                                             export_method: "app-store-connect")
 
           expect(result).to eq({ "identifier.1": "Ap-pStoreValue2" })
         end
@@ -120,7 +120,7 @@ describe Gym::CodeSigningMapping do
         it "should prefer the primary mapping" do
           result = csm.merge_profile_mapping(primary_mapping: { "identifier.1" => "Ap-p StoreValue1" },
                                          secondary_mapping: { "identifier.1" => "Ad-HocValue" },
-                                             export_method: "app-store")
+                                             export_method: "app-store-connect")
 
           expect(result).to eq({ "identifier.1": "Ap-p StoreValue1" })
         end

--- a/gym/spec/detect_values_spec.rb
+++ b/gym/spec/detect_values_spec.rb
@@ -122,7 +122,7 @@ eos
       end
 
       describe "using export_team_id" do
-        let(:options) { { project: "./gym/examples/multipleSchemes/Example.xcodeproj", export_team_id: team_id, export_method: "app-store" } }
+        let(:options) { { project: "./gym/examples/multipleSchemes/Example.xcodeproj", export_team_id: team_id, export_method: "app-store-connect" } }
 
         it "finds installer cert from list with 2 matching and 1 non-matching" do
           expect(FastlaneCore::Helper).to receive(:backticks).with("security find-certificate -a -c \"3rd Party Mac Developer Installer: \"", print: false).and_return(output_2_matching_1_nonmatching)
@@ -150,7 +150,7 @@ eos
       end
 
       describe "using DEVELOPMENT_TEAM builds setting" do
-        let(:options) { { project: "./gym/examples/multipleSchemes/Example.xcodeproj", export_method: "app-store" } }
+        let(:options) { { project: "./gym/examples/multipleSchemes/Example.xcodeproj", export_method: "app-store-connect" } }
 
         before do
           allow_any_instance_of(FastlaneCore::Project).to receive(:build_settings).with(anything).and_call_original

--- a/gym/spec/error_handler_spec.rb
+++ b/gym/spec/error_handler_spec.rb
@@ -59,7 +59,7 @@ Code signing is required for product type 'Application' in SDK 'iOS 11.0'
       mock_gym_path(@output)
       expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: @output)
 
-      Gym.config[:export_method] = 'app-store'
+      Gym.config[:export_method] = 'app-store-connect'
       Gym.config[:export_options][:provisioningProfiles] = {
         'com.sample.app' => 'In House Ad Hoc'
       }

--- a/gym/spec/package_command_generator_xcode7_spec.rb
+++ b/gym/spec/package_command_generator_xcode7_spec.rb
@@ -100,7 +100,7 @@ describe Gym do
       config_path = Gym::PackageCommandGeneratorXcode7.config_path
 
       expect(Plist.parse_xml(config_path)).to eq({
-        'method' => "app-store"
+        'method' => 'app-store-connect'
       })
     end
 
@@ -118,9 +118,9 @@ describe Gym do
           'displayImageURL' => 'https://www.example.com/display.png',
           'fullSizeImageURL' => 'https://www.example.com/fullSize.png'
         },
-        'method' => 'ad-hoc'
+        'method' => 'release-testing'
       })
-      expect(Gym.config[:export_method]).to eq("ad-hoc")
+      expect(Gym.config[:export_method]).to eq('release-testing')
       expect(Gym.config[:include_symbols]).to be_nil
       expect(Gym.config[:include_bitcode]).to be_nil
       expect(Gym.config[:export_team_id]).to be_nil
@@ -141,14 +141,14 @@ describe Gym do
 
       content = Plist.parse_xml(config_path)
       expect(content["include_symbols"]).to eq(true)
-      expect(content["method"]).to eq('app-store')
+      expect(content['method']).to eq('app-store-connect')
     end
 
     it "reads user export plist and override some parameters" do
       options = {
         project: "./gym/examples/standard/Example.xcodeproj",
         export_options: "./gym/examples/standard/ExampleExport.plist",
-        export_method: "app-store",
+        export_method: "app-store-connect",
         include_symbols: false,
         include_bitcode: true,
         export_team_id: "1234567890"
@@ -165,7 +165,7 @@ describe Gym do
           'displayImageURL' => 'https://www.example.com/display.png',
           'fullSizeImageURL' => 'https://www.example.com/fullSize.png'
         },
-        'method' => 'app-store',
+        'method' => 'app-store-connect',
         'uploadSymbols' => false,
         'uploadBitcode' => true,
         'teamID' => '1234567890'
@@ -187,7 +187,7 @@ describe Gym do
           uploadBitcode: true,
           teamID: "1234567890"
         },
-        export_method: "app-store",
+        export_method: "app-store-connect",
         include_symbols: true,
         include_bitcode: false,
         export_team_id: "ASDFGHJK"
@@ -204,22 +204,22 @@ describe Gym do
           'displayImageURL' => 'https://www.example.com/display%20image.png',
           'fullSizeImageURL' => 'https://www.example.com/fullSize%20image.png'
         },
-        'method' => 'app-store',
+        'method' => 'app-store-connect',
         'uploadSymbols' => true,
         'uploadBitcode' => false,
         'teamID' => 'ASDFGHJK'
       })
     end
 
-    it "doesn't store bitcode/symbols information for non app-store builds" do
-      options = { project: "./gym/examples/standard/Example.xcodeproj", export_method: 'ad-hoc' }
+    it "doesn't store bitcode/symbols information for non app-store-connect builds" do
+      options = { project: './gym/examples/standard/Example.xcodeproj', export_method: 'release-testing' }
       Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
       result = Gym::PackageCommandGeneratorXcode7.generate
       config_path = Gym::PackageCommandGeneratorXcode7.config_path
 
       expect(Plist.parse_xml(config_path)).to eq({
-        'method' => "ad-hoc"
+        'method' => 'release-testing'
       })
     end
 


### PR DESCRIPTION
_Still WIP, hence the draft and incomplete checklist. Here for visibility and early feedback._

---

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

From `xcodebuild -help`:

```
method : String

  Describes how Xcode should export the archive.
  Available options:
    app-store-connect,
    release-testing,
    enterprise,
    debugging,
    developer-id,
    mac-application,
    validation,
    and package.

  The list of options varies based on the type of archive.

  Defaults to debugging.

  Additional options include app-store (deprecated: use app-store-connect),
  ad-hoc (deprecated: use release-testing),
  and development (deprecated: use debugging).
```

See also #22028.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
