### PR TITLE
Only Download Team ID S3 Objects

### DIFF
--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -1,7 +1,7 @@
 require 'fastlane_core/command_executor'
 require 'fastlane_core/configuration/configuration'
 require 'fastlane/helper/s3_client_helper'
-require 'pry'
+
 require_relative '../options'
 require_relative '../module'
 require_relative '../spaceship_ensure'

--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -1,7 +1,7 @@
 require 'fastlane_core/command_executor'
 require 'fastlane_core/configuration/configuration'
 require 'fastlane/helper/s3_client_helper'
-
+require 'pry'
 require_relative '../options'
 require_relative '../module'
 require_relative '../spaceship_ensure'
@@ -108,7 +108,11 @@ module Match
           # the string represent a remote location, not a local file in disk.
           next if object.key.end_with?("/")
 
-          file_path = strip_s3_object_prefix(object.key) # :s3_object_prefix:team_id/path/to/file
+          file_path = strip_s3_object_prefix(object.key) # :s3_object_prefix/:team_id/path/to/file
+          if !team_id.nil? && !team_id.empty?
+            # Skip the current object as it is not associated with the supplied team
+            next unless file_path.start_with?(team_id.to_s)
+          end
 
           # strip s3_prefix from file_path
           download_path = File.join(self.working_directory, file_path)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
This PR makes it so that S3 buckets that store multiple teams only download the specified team ID.

Resolves #21610

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
#### unit test
  * `bundle exec rspec match/spec/starage/s3_storage_spec.rb`
#### integration test
* Have an S3 bucket that has multiple teams in it
  * The bucket will have files that have paths like: `< s3 prefix >/< team ID >/...`
* In you Matchfile or however you have it setup make sure that the `team_id` is set
* Run `match` make sure only the certificates and profiles for your specified team are downloaded.
