### PR TITLE
Add support for Loot Box age rating declaration

### DIFF
--- a/deliver/assets/example_rating_config.json
+++ b/deliver/assets/example_rating_config.json
@@ -13,5 +13,6 @@
   "violenceRealistic": "INFREQUENT_OR_MILD",
   "gambling": false,  
   "seventeenPlus": false,
-  "unrestrictedWebAccess": true
+  "unrestrictedWebAccess": true,
+  "lootBox": false
 }

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -625,6 +625,7 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 - `gambling`
 - 'seventeenPlus'
 - `unrestrictedWebAccess`
+- `lootBox`
 
 #### Kids Age
 

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -22,6 +22,7 @@ module Spaceship
       attr_accessor :gambling
       attr_accessor :seventeen_plus
       attr_accessor :unrestricted_web_access
+      attr_accessor :loot_box
 
       # KidsAge
       attr_accessor :kids_age_band
@@ -58,6 +59,7 @@ module Spaceship
         "violenceRealisticProlongedGraphicOrSadistic" => "violence_realistic_prolonged_graphic_or_sadistic",
         "violenceRealistic" => "violence_realistic",
         "kidsAgeBand" => "kids_age_band",
+        "lootBox" => "loot_box",
 
         # Deprecated as of App Store Connect API 1.3
         "gamblingAndContests" => "gambling_and_contests",


### PR DESCRIPTION
Providing support for the new / regional age rating declaration of loot boxes: https://developer.apple.com/news/?id=7byvco78

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Providing support for the new loot box age rating category/question.

### Testing Steps
Easiest way to verify is via `irb`:

```
bundle exec irb
require "spaceship"
Spaceship::Tunes.login("username", "p4ssw0rd")
connect_app = Spaceship::ConnectAPI::App.find("com.sample.test")
app_info = connect_app.fetch_edit_app_info
age_rating = app_info.fetch_age_rating_declaration
	    attributes_age = {}
	    attributes_age["alcoholTobaccoOrDrugUseOrReferences"] = "NONE"
	    attributes_age["contests"] = "NONE"
	    attributes_age["gamblingSimulated"] = "NONE"
	    attributes_age["medicalOrTreatmentInformation"] = "NONE"
	    attributes_age["profanityOrCrudeHumor"] = "NONE"
	    attributes_age["sexualContentGraphicAndNudity"] = "NONE"
	    attributes_age["sexualContentOrNudity"] = "NONE"
	    attributes_age["horrorOrFearThemes"] = "NONE"
	    attributes_age["matureOrSuggestiveThemes"] = "NONE"
	    attributes_age["violenceCartoonOrFantasy"] = "NONE"
	    attributes_age["violenceRealisticProlongedGraphicOrSadistic"] = "NONE"
	    attributes_age["violenceRealistic"] = "NONE"
	    attributes_age["unrestrictedWebAccess"] = false
	    attributes_age["gambling"] = false
	    attributes_age["kidsAgeBand"] =  nil
	    attributes_age["lootBox"] = false
age_rating.update(attributes: attributes_age)
```