### PR TITLE
[action] Fix target selection in `get_version_number`

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -69,7 +69,7 @@ module Fastlane
 
           # Returns if only one non-test target
           if non_test_targets.count == 1
-            return targets.first
+            return non_test_targets.first
           end
 
           options = targets.map(&:name)

--- a/fastlane/spec/actions_specs/get_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/get_version_number_action_spec.rb
@@ -110,9 +110,12 @@ describe Fastlane do
         expect(result).to eq("1.0")
       end
 
-      it "gets the correct version number with no target specified (and one target)", requires_xcodeproj: true do
+      it "gets the correct version number with no target specified (and one target that isn't test)", requires_xcodeproj: true do
         allow_any_instance_of(Xcodeproj::Project).to receive(:targets).and_wrap_original do |m, *args|
-          [m.call(*args).first]
+          targets = m.call(*args)
+          targets.select do |target|
+            target.name == "TargetA"
+          end
         end
 
         result = Fastlane::FastFile.new.parse("lane :test do
@@ -121,18 +124,18 @@ describe Fastlane do
         expect(result).to eq("4.3.2")
       end
 
-      it "gets the correct version number with no target specified (and one target and multiple test targets)", requires_xcodeproj: true do
+      it "gets the correct version number with no target specified (and one target that isn't test and multiple test targets)", requires_xcodeproj: true do
         allow_any_instance_of(Xcodeproj::Project).to receive(:targets).and_wrap_original do |m, *args|
           targets = m.call(*args)
           targets.select do |target|
-            target.name == "TargetA" || target.name == "TargetATests" || target.name == "TargetBTests"
+            target.name == "TargetATests" || target.name == "TargetB" || target.name == "TargetBTests"
           end
         end
 
         result = Fastlane::FastFile.new.parse("lane :test do
           get_version_number(xcodeproj: '#{xcodeproj_dir}')
         end").runner.execute(:test)
-        expect(result).to eq("4.3.2")
+        expect(result).to eq("5.4.3")
       end
 
       it "gets the correct version with $(SRCROOT)", requires_xcodeproj: true do


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

`get_version_number()` tries to automatically select a target if non is specified. This automatic selection was changed in https://github.com/fastlane/fastlane/pull/12138 to only consider non-test targets, but failed to return the right non-test target and instead just returned the first of all targets. Depending on the order of targets in the Xcode project a test target might be returned.

### Description

This PR changes the automatic target selection to return the first non-test target in case it is the only such target. It also adjusts the respective unit tests to use test targets that expose the fixed bug (i.e. position of non-test target in all targets).

### Testing Steps

n/a