### PR TITLE
[Match][S3] Only download (and decrypt) files in the subfolder of the provided TeamID

### DIFF
--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -101,8 +101,11 @@ module Match
         # No existing working directory, creating a new one now
         self.working_directory = Dir.mktmpdir
 
-        s3_client.find_bucket!(s3_bucket).objects(prefix: s3_object_prefix).each do |object|
+        # If team_id is defined, use `:team/` as a prefix (appending it at the end of the `s3_object_prefix` if one provided by the user),
+        # so that we limit the download to only files that are specific to this team, and avoid downloads + decryption of unnecessary files.
+        key_prefix = team_id.nil? ? s3_object_prefix : File.join(s3_object_prefix, team_id, '').delete_prefix('/')
 
+        s3_client.find_bucket!(s3_bucket).objects(prefix: key_prefix).each do |object|
           # Prevent download if the file path is a directory.
           # We need to check if string ends with "/" instead of using `File.directory?` because
           # the string represent a remote location, not a local file in disk.
@@ -181,7 +184,7 @@ module Match
       end
 
       def strip_s3_object_prefix(object_path)
-        object_path.gsub(/^#{s3_object_prefix}/, "")
+        object_path.delete_prefix(s3_object_prefix.to_s).delete_prefix('/')
       end
 
       def sanitize_file_name(file_name)

--- a/match/spec/storage/s3_storage_spec.rb
+++ b/match/spec/storage/s3_storage_spec.rb
@@ -79,12 +79,13 @@ describe Match do
       let(:bucket) { instance_double('Aws::S3::Bucket') }
       let(:s3_client) { instance_double('Fastlane::Helper::S3ClientHelper', find_bucket!: bucket) }
 
-      before { class_double('FileUtils', mkdir_p: true).as_stubbed_const }
-      def stub_bucket_content(bucket_files: files_to_download)
+      def stub_bucket_content(objects: files_to_download)
         allow(bucket).to receive(:objects) do |options|
-          bucket_files.select { |file_object| file_object.key.start_with?(options[:prefix] || '') }
+          objects.select { |file_object| file_object.key.start_with?(options[:prefix] || '') }
         end
       end
+
+      before { class_double('FileUtils', mkdir_p: true).as_stubbed_const }
 
       it 'downloads to correct working directory' do
         stub_bucket_content
@@ -115,7 +116,7 @@ describe Match do
         prefixed_objects = files_to_download.map do |obj|
           instance_double('Aws::S3::Object', key: "123456/#{obj.key}", download_file: true)
         end
-        stub_bucket_content(bucket_files: prefixed_objects)
+        stub_bucket_content(objects: prefixed_objects)
 
         prefixed_objects.each do |file_object|
           expect(file_object).to receive(:download_file).with("#{working_directory}/#{file_object.key.delete_prefix('123456/')}")

--- a/match/spec/storage/s3_storage_spec.rb
+++ b/match/spec/storage/s3_storage_spec.rb
@@ -70,17 +70,40 @@ describe Match do
     describe '#download' do
       let(:files_to_download) do
         [
-          instance_double('Aws::S3::Object', key: 'ABCDEFG/certs/development/ABCDEFG.cer', download_file: true),
-          instance_double('Aws::S3::Object', key: 'ABCDEFG/certs/development/ABCDEFG.p12', download_file: true)
+          instance_double('Aws::S3::Object', key: 'TEAMID1/certs/development/CERTID1.cer', download_file: true),
+          instance_double('Aws::S3::Object', key: 'TEAMID1/certs/development/CERTID1.p12', download_file: true),
+          instance_double('Aws::S3::Object', key: 'TEAMID2/certs/development/CERTID2.cer', download_file: true),
+          instance_double('Aws::S3::Object', key: 'TEAMID2/certs/development/CERTID2.p12', download_file: true)
         ]
       end
-      let(:s3_client) { instance_double('Fastlane::Helper::S3ClientHelper', find_bucket!: double(objects: files_to_download)) }
+      let(:bucket) { instance_double('Aws::S3::Bucket') }
+      let(:s3_client) { instance_double('Fastlane::Helper::S3ClientHelper', find_bucket!: bucket) }
 
       before { class_double('FileUtils', mkdir_p: true).as_stubbed_const }
+      def stub_bucket_content(bucket_files: files_to_download)
+        allow(bucket).to receive(:objects) do |options|
+          bucket_files.select { |file_object| file_object.key.start_with?(options[:prefix] || '') }
+        end
+      end
 
       it 'downloads to correct working directory' do
+        stub_bucket_content
         files_to_download.each do |file_object|
           expect(file_object).to receive(:download_file).with("#{working_directory}/#{file_object.key}")
+        end
+
+        subject.download
+      end
+
+      it 'only downloads files specific to the provided team' do
+        stub_bucket_content
+        allow(subject).to receive(:team_id).and_return('TEAMID2')
+        files_to_download.each do |file_object|
+          if file_object.key.start_with?('TEAMID2')
+            expect(file_object).to receive(:download_file).with("#{working_directory}/#{file_object.key}")
+          else
+            expect(file_object).not_to receive(:download_file)
+          end
         end
 
         subject.download
@@ -89,8 +112,13 @@ describe Match do
       it 'downloads files and strips the s3_object_prefix for working_directory path' do
         allow(subject).to receive(:s3_object_prefix).and_return('123456/')
 
-        files_to_download.each do |file_object|
-          expect(file_object).to receive(:download_file).with("#{working_directory}/#{file_object.key}")
+        prefixed_objects = files_to_download.map do |obj|
+          instance_double('Aws::S3::Object', key: "123456/#{obj.key}", download_file: true)
+        end
+        stub_bucket_content(bucket_files: prefixed_objects)
+
+        prefixed_objects.each do |file_object|
+          expect(file_object).to receive(:download_file).with("#{working_directory}/#{file_object.key.delete_prefix('123456/')}")
         end
 
         subject.download


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

When one invokes `match` / `sync_code_signing` with `storage_mode:s3` and provides an explicit `team_id`, so far _match_ was still downloading the whole content of the S3 bucket, including certificates and profiles from other teams, while those were not useful for the provided `team_id`.

This can lead to extra download of unnecessary files, which in turn affects S3 costs, bandwidth, and also the time it takes for _match_ to download then decrypt all those files. This can especially have an impact when _match_ is run on CI and thus many times a day, on each CI build.

_This is particularly relevant in our case at my company because we have 4 different teams in ASC. I can totally imagine a similar or even worse case for e.g. development agencies or individual contractors who might be developing apps as contractors for many different clients, and thus having been invited to many different ASC Teams, for example._

### Description

This change makes is so that the `team_id` is used as a S3 key prefix when fetching the list of objects in the S3 bucket.

Note that if a `s3_object_prefix` parameter was also already provided by the caller, that `team_id` is added at the end of that `s3_object_prefix` to for the overall prefix used to fetch the list of objects to download.

Also note that this is **not** the same as the caller manually providing the team ID as a value for `s3_object_prefix` explicitly (believe me, that's the first thing I tried when I discovered this issue and wanted to attempt a quick way to limit the bandwidth and time wasted)
 - This is because the user-provided `s3_object_prefix` is stripped from the start of the key when computing the final path where to put those downloaded files on disk (see `strip_s3_object_prefix` helper method).
 - While we want to keep the `team_id` part at the start of the path of the downloaded location for the rest of the _match_ logic to continue working as expected (if we don't, _match_ will ultimately fail to find the certificates and profiles matching the project code signing requirements, because they would not be in the expected location)

### Testing Steps

1. Have a S3 bucket configured for _match_, and use that same bucket for managing certificates and profiles of multiple TeamIDs.
    - Alternatively, fill this bucket with dummy files matching the folder structure expected by match (`${TEAMID}/certs/distribution/{somename}.cer`, `${TEAMID}/certs/distribution/{somename}.p12`, `${TEAMID}/profiles/appstore/*.mobileprovision`, …)
2. Point your test project's `Gemfile` to this branch of `fastlane`, run `bundle install`
3. Run `bundle exec fastlane run --verbose sync_code_signing storage_mode:s3 s3_bucket:${YOUR_BUCKET} s3_region:${YOUR_S3_REGION} type:{enterprise/appstore} team_id:${YOUR_TEAM_ID_1} app_identifier:${YOUR_BUNDLE_ID} readonly:true`
4. Validate from the verbose logs that it only downloads and decrypt the files of your bucket that are under `${YOUR_TEAM_1}` folder (i.e. have `${YOUR_TEAM_1}/` as a key prefix, in S3 parlance), but not the ones in your other teams' subfolders.
5. Repeat the steps with a S3 bucket for which your _match_ files and its expected directory structure are under a subfolder (aka an additional key prefix), and passing the extra `s3_object_prefix:${SAID_PREFIX}` parameter to the fastlane call, and validate it also works as expected, stripping the `${SAID_PREFIX}` but _not_ the `${TEAM_ID}/` from the objects keys when figuring out the destination in the temp folder where those files are downloaded.
