### PR TITLE
[spaceship] Add support for Enterprise Program API

### DIFF
--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -69,7 +69,7 @@ module Spaceship
       # Forwarding to class level if using web session.
       def hostname
         if @token
-          return "https://api.appstoreconnect.apple.com/"
+          return @token.in_house ? "https://api.enterprise.developer.apple.com" : "https://api.appstoreconnect.apple.com/"
         end
         return self.class.hostname
       end

--- a/spaceship/lib/spaceship/connect_api/api_client.rb
+++ b/spaceship/lib/spaceship/connect_api/api_client.rb
@@ -69,7 +69,7 @@ module Spaceship
       # Forwarding to class level if using web session.
       def hostname
         if @token
-          return @token.in_house ? "https://api.enterprise.developer.apple.com" : "https://api.appstoreconnect.apple.com/"
+          return @token.in_house ? "https://api.enterprise.developer.apple.com/" : "https://api.appstoreconnect.apple.com/"
         end
         return self.class.hostname
       end

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -29,6 +29,7 @@ module Spaceship
       attr_accessor :in_house
 
       def self.from(hash: nil, filepath: nil)
+        # FIXME: Ensure `in_house` value is a boolean.
         api_token ||= self.create(**hash.transform_keys(&:to_sym)) if hash
         api_token ||= self.from_json_file(filepath) if filepath
         return api_token
@@ -101,7 +102,7 @@ module Spaceship
           # Reduce the issued-at-time in case our time is slighly ahead of Apple's servers, which causes the token to be rejected.
           iat: now.to_i - 60,
           exp: @expiration.to_i,
-          aud: 'appstoreconnect-v1'
+          aud: @in_house ? 'apple-developer-enterprise-v1' : 'appstoreconnect-v1'
         }
         if issuer_id
           payload[:iss] = issuer_id

--- a/spaceship/lib/spaceship/stats_middleware.rb
+++ b/spaceship/lib/spaceship/stats_middleware.rb
@@ -18,6 +18,7 @@ module Spaceship
         @services ||= [
           ServiceOption.new("App Store Connect API (official)", "api.appstoreconnect.apple.com", "JWT"),
           ServiceOption.new("App Store Connect API (web session)", Spaceship::ConnectAPI::TestFlight::Client.hostname.gsub("https://", ""), "Web session"),
+          ServiceOption.new("Enterprise Program API (official)", "api.enterprise.developer.apple.com", "JWT"),
           ServiceOption.new("Legacy iTunesConnect Auth", "idmsa.apple.com", "Web session"),
           ServiceOption.new("Legacy iTunesConnect Auth", "appstoreconnect.apple.com/olympus/v1/", "Web session"),
           ServiceOption.new("Legacy iTunesConnect", Spaceship::TunesClient.hostname.gsub("https://", ""), "Web session"),

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -260,4 +260,24 @@ describe Spaceship::ConnectAPI::APIClient do
       end
     end
   end
+
+  describe "#hostname" do
+    let(:mock_token) { double('token') }
+    let(:client) { Spaceship::ConnectAPI::APIClient.new(token: mock_token) }
+
+    it 'points to App Store Connect API when in_house is not set' do
+      allow(mock_token).to receive(:in_house).and_return(nil)
+      expect(client.hostname).to eq('https://api.appstoreconnect.apple.com/')
+    end
+
+    it 'points to App Store Connect API when in_house is false' do
+      allow(mock_token).to receive(:in_house).and_return(false)
+      expect(client.hostname).to eq('https://api.appstoreconnect.apple.com/')
+    end
+
+    it 'points to Enterprise Program API when in_house is true' do
+      allow(mock_token).to receive(:in_house).and_return(true)
+      expect(client.hostname).to eq('https://api.enterprise.developer.apple.com')
+    end
+  end
 end

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -277,7 +277,7 @@ describe Spaceship::ConnectAPI::APIClient do
 
     it 'points to Enterprise Program API when in_house is true' do
       allow(mock_token).to receive(:in_house).and_return(true)
-      expect(client.hostname).to eq('https://api.enterprise.developer.apple.com')
+      expect(client.hostname).to eq('https://api.enterprise.developer.apple.com/')
     end
   end
 end

--- a/spaceship/spec/connect_api/api_client_spec.rb
+++ b/spaceship/spec/connect_api/api_client_spec.rb
@@ -5,6 +5,7 @@ describe Spaceship::ConnectAPI::APIClient do
 
     before(:each) do
       allow(mock_token).to receive(:text).and_return("ewfawef")
+      allow(mock_token).to receive(:in_house).and_return(nil)
     end
 
     context 'build_params' do
@@ -98,6 +99,7 @@ describe Spaceship::ConnectAPI::APIClient do
     before(:each) do
       allow(mock_token).to receive(:text).and_return("ewfawef")
       allow(mock_token).to receive(:expired?).and_return(false)
+      allow(mock_token).to receive(:in_house).and_return(nil)
     end
 
     it 'not raise on 200' do
@@ -166,6 +168,10 @@ describe Spaceship::ConnectAPI::APIClient do
     let(:mock_token) { double('token') }
     let(:client) { Spaceship::ConnectAPI::APIClient.new(token: mock_token) }
     let(:mock_response) { double('response') }
+
+    before(:each) do
+      allow(mock_token).to receive(:in_house).and_return(nil)
+    end
 
     describe "status of 200" do
       before(:each) do

--- a/spaceship/spec/connect_api/client_spec.rb
+++ b/spaceship/spec/connect_api/client_spec.rb
@@ -188,7 +188,7 @@ describe Spaceship::ConnectAPI::Client do
         end
 
         it "raise error without in_house set" do
-          expect(mock_token).to receive(:in_house).and_return(nil)
+          allow(mock_token).to receive(:in_house).and_return(nil)
 
           expect do
             client.in_house?
@@ -196,7 +196,7 @@ describe Spaceship::ConnectAPI::Client do
         end
 
         it "with in_house set" do
-          expect(mock_token).to receive(:in_house).and_return(true).twice
+          allow(mock_token).to receive(:in_house).and_return(true)
 
           in_house = client.in_house?
           expect(in_house).to be(true)

--- a/spaceship/spec/connect_api/token_spec.rb
+++ b/spaceship/spec/connect_api/token_spec.rb
@@ -252,16 +252,16 @@ describe Spaceship::ConnectAPI::Token do
 
     describe 'audience field for JWT payload' do
       key = OpenSSL::PKey::EC.generate('prime256v1')
-      
+
       it 'uses appstoreconnect when in_house is false' do
         token = Spaceship::ConnectAPI::Token.new(key_id: key_id, key: key, in_house: false)
-        payload, _ = JWT.decode(token.text, key, true, { algorithm: 'ES256' })
+        payload, = JWT.decode(token.text, key, true, { algorithm: 'ES256' })
         expect(payload['aud']).to eq('appstoreconnect-v1')
       end
 
       it 'uses enterprise when in_house is true' do
         token = Spaceship::ConnectAPI::Token.new(key_id: key_id, key: key, in_house: true)
-        payload, _ = JWT.decode(token.text, key, true, { algorithm: 'ES256' })
+        payload, = JWT.decode(token.text, key, true, { algorithm: 'ES256' })
         expect(payload['aud']).to eq('apple-developer-enterprise-v1')
       end
     end

--- a/spaceship/spec/connect_api/token_spec.rb
+++ b/spaceship/spec/connect_api/token_spec.rb
@@ -249,5 +249,21 @@ describe Spaceship::ConnectAPI::Token do
       expect(header['kid']).to eq(key_id)
       expect(header['typ']).to eq('JWT')
     end
+
+    describe 'audience field for JWT payload' do
+      key = OpenSSL::PKey::EC.generate('prime256v1')
+      
+      it 'uses appstoreconnect when in_house is false' do
+        token = Spaceship::ConnectAPI::Token.new(key_id: key_id, key: key, in_house: false)
+        payload, _ = JWT.decode(token.text, key, true, { algorithm: 'ES256' })
+        expect(payload['aud']).to eq('appstoreconnect-v1')
+      end
+
+      it 'uses enterprise when in_house is true' do
+        token = Spaceship::ConnectAPI::Token.new(key_id: key_id, key: key, in_house: true)
+        payload, _ = JWT.decode(token.text, key, true, { algorithm: 'ES256' })
+        expect(payload['aud']).to eq('apple-developer-enterprise-v1')
+      end
+    end
   end
 end

--- a/spaceship/spec/stats_middleware_spec.rb
+++ b/spaceship/spec/stats_middleware_spec.rb
@@ -37,11 +37,14 @@ describe Spaceship::StatsMiddleware do
         mock_stats
       end
 
+      # Note: This does not test if all these services were actually added.
+
       urls = [
         # Supported
         "https://api.appstoreconnect.apple.com/stuff",
         "https://api.appstoreconnect.apple.com/stuff2",
         "https://appstoreconnect.apple.com/iris/v1/stuff",
+        "https://api.enterprise.developer.apple.com/stuff",
         "https://developer.apple.com/services-account/v1/stuff",
         "https://idmsa.apple.com/stuff",
         "https://appstoreconnect.apple.com/olympus/v1/stuff",
@@ -61,10 +64,11 @@ describe Spaceship::StatsMiddleware do
         expect(success).to be(true)
       end
 
-      expect(Spaceship::StatsMiddleware.service_stats.size).to eq(8)
+      expect(Spaceship::StatsMiddleware.service_stats.size).to eq(9)
 
       expect(find_count("api.appstoreconnect.apple.com")).to eq(2)
       expect(find_count("appstoreconnect.apple.com/iris/")).to eq(1)
+      expect(find_count("api.enterprise.developer.apple.com")).to eq(1)
       expect(find_count("developer.apple.com/services-account/")).to eq(1)
       expect(find_count("idmsa.apple.com")).to eq(1)
       expect(find_count("appstoreconnect.apple.com/olympus/v1/")).to eq(1)


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves #22205 & #18049

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

* Since the new [Enterprise Program API](https://developer.apple.com/documentation/enterpriseprogramapi) closely matches that of the [App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi), it seems we can just change the API endpoint and token header, depending on the `in_house` optional parameter within the api key.
* Fixed some existing unit tests that failed because `in_house` is now being accessed more times.
* Added tests for the changed APIClient hostname and JWT audience field.

#### Notes
* I'm checking regarding adding more unit tests for the new API itself.
* Found an existing bug if adding the `in_house` value to the api key hash as a String instead of a Bool. Can be fixed in this PR or another.
* Worth considering if to declare some portions of the client API that is not available yet on Enterprise, or to just let it naturally error out until Apple adds more matching APIs. Alternative approach could also be to add a new Client.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

- Successfully tested so far:
  - Spaceship:
    - Retrieving Enterprise data (certificates, profiles, bundle IDs).
  - Cert:
    -  Creating a new dev certificate
    - I tried also creating a dist certificate and as expected, got "You already have a current" error and couldn't revoke it as it is currently being used by our org.
  - Sigh:
    - Create, download and install provisioning profiles (dev & adhoc & dist).
  - Match:
    - Create dev cert & profile and upload to git.