### PR TITLE
Windows adaptation

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -50,6 +50,10 @@ module Deliver
                                      description: "The version that should be edited or created",
                                      optional: true),
 
+        FastlaneCore::ConfigItem.new(key: :app_version_build,
+                                     description: "The build version number (CFBundleVersion)",
+                                     optional: true),
+
         # binary / build
         FastlaneCore::ConfigItem.new(key: :ipa,
                                      short_option: "-i",

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -224,7 +224,6 @@ module Deliver
             app_identifier: app_identifier,
             app_version_build: app_version_build
           )
-          result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
         else
           package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
             app_id: Deliver.cache[:app].id,
@@ -232,8 +231,8 @@ module Deliver
             package_path: "/tmp",
             platform: platform
           )
-          result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
         end
+        result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
       when "osx"
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -204,19 +204,36 @@ module Deliver
 
       ipa_path = options[:ipa]
       pkg_path = options[:pkg]
+      app_version = options[:app_version]
+      app_identifier = options[:app_identifier]
+      app_version_build = options[:app_version_build]
 
       platform = options[:platform]
       transporter = transporter_for_selected_team
 
       case platform
       when "ios", "appletvos", "xros"
-        package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
-          app_id: Deliver.cache[:app].id,
-          ipa_path: ipa_path,
-          package_path: "/tmp",
-          platform: platform
-        )
-        result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
+        case RbConfig::CONFIG['host_os']
+        when /mswin|mingw32|windows/
+          package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
+            app_id: Deliver.cache[:app].id,
+            ipa_path: ipa_path,
+            package_path: "tmp",
+            platform: platform,
+            app_version: app_version,
+            app_identifier: app_identifier,
+            app_version_build: app_version_build
+          )
+          result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
+        else
+          package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
+            app_id: Deliver.cache[:app].id,
+            ipa_path: ipa_path,
+            package_path: "/tmp",
+            platform: platform
+          )
+          result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
+        end
       when "osx"
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
@@ -224,7 +241,7 @@ module Deliver
           package_path: "/tmp",
           platform: platform
         )
-        result = transporter.upload(package_path: package_path, asset_path: pkg_path, platform: platform)
+        result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
       else
         UI.user_error!("No suitable file found for upload for platform: #{options[:platform]}")
       end

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -241,7 +241,7 @@ module Deliver
           package_path: "/tmp",
           platform: platform
         )
-        result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
+        result = transporter.upload(package_path: package_path, asset_path: pkg_path, platform: platform)
       else
         UI.user_error!("No suitable file found for upload for platform: #{options[:platform]}")
       end

--- a/fastlane_core/lib/assets/XMLTemplate.xml.erb
+++ b/fastlane_core/lib/assets/XMLTemplate.xml.erb
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://apple.com/itunes/importer" version="software5.4">
-  <software_assets apple_id="<%= @data[:apple_id] %>" app_platform="<%= @data[:platform] %>">
+<software_assets
+    apple_id="<%= @data[:apple_id] %>"
+    app_platform="<%= @data[:platform] %>"
+    bundle_short_version_string="<%= @data[:bundle_short_version_string] %>"
+    bundle_version="<%= @data[:bundle_version] %>"
+    bundle_identifier="<%= @data[:bundle_identifier] %>">
     <asset type="<%= @data[:archive_type] %>">
       <data_file>
         <size><%= @data[:file_size] %></size>

--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -12,13 +12,16 @@ module FastlaneCore
 
     attr_accessor :package_path
 
-    def generate(app_id: nil, ipa_path: nil, package_path: nil, platform: nil)
+    def generate(app_id: nil, ipa_path: nil, package_path: nil, platform: nil, app_version: nil, app_identifier: nil, app_version_build: nil)
       self.package_path = File.join(package_path, "#{app_id}-#{SecureRandom.uuid}.itmsp")
       FileUtils.rm_rf(self.package_path) if File.directory?(self.package_path)
       FileUtils.mkdir_p(self.package_path)
 
       ipa_path = copy_ipa(ipa_path)
       @data = {
+        bundle_short_version_string: app_version,
+        bundle_version: app_version_build,
+        bundle_identifier: app_identifier,
         apple_id: app_id,
         file_size: File.size(ipa_path),
         ipa_path: File.basename(ipa_path), # this is only the base name as the ipa is inside the package

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -247,7 +247,12 @@ module Spaceship
           @logger = Logger.new(STDOUT)
         else
           # Log to file by default
-          path = "/tmp/spaceship#{Time.now.to_i}_#{Process.pid}_#{Thread.current.object_id}.log"
+          case RbConfig::CONFIG['host_os']
+          when /mswin|mingw32|windows/
+            path = "tmp/spaceship#{Time.now.to_i}_#{Process.pid}_#{Thread.current.object_id}.log"
+          else
+            path = "/tmp/spaceship#{Time.now.to_i}_#{Process.pid}_#{Thread.current.object_id}.log"
+          end
           @logger = Logger.new(path)
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

I'm using a Windows environment and encountered issues while attempting to upload .ipa files to the App Store using the ```upload_to_app_store``` function from Fastlane version 2.222.0.

### Description

- Fastlane creates a "/tmp" folder but on windows, the "/" causes the folder to be created in the wrong path. Solved by removing the "/" before the "tmp" (only do that if we are on a windows os).
- The actual XMLTemplate.xml.erb file seems incomplete leading to an ```An error occurred while trying to call the requested method validateAssets. (1272)``` error message. Solved by adding ```bundle_short_version_string```, ```bundle_version``` and ```bundle_identifier``` in the ```software_assets```.
- No way found to put bundle_version (CFBundleVersion) in the XMLTemplate.xml.erb file. Solved by adding an ```app_version_build parameter``` to ```Deliver``` then pass it in the ```IpaUploadPackageBuilder.generate``` function as well as ```bundle_short_version_string``` and "bundle_identifier```.

### Testing Steps

Example of Fastfile I'm using:

```
default_platform(:ios)

path_to_ipa = 'path/to/file.ipa'

platform :ios do
  desc "Deploy ios app"
  lane :appstore_upload do |options|
    
    api_key = app_store_connect_api_key(
      key_id: "my_key_id",
      issuer_id: "my_issuer_id",
      key_filepath: "my_auth_file.p8",
      duration: 1200, # optional (maximum 1200)
      in_house: false # optional but may be required if using match/sigh
    )

    upload_to_app_store(
      precheck_include_in_app_purchases: false,
      force: "true",
      automatic_release: "true",
      ipa: path_to_ipa,
      api_key: api_key,
      app_identifier: 'com.my.bundle.identifier',
      app_version: "number.number.number",
      app_version_build: "number"
    )
  end
end
```

Command:
```
fastlane appstore_upload --verbose
```
