### PR TITLE
Expose RubyCommand/Runner as public so SwiftPM consumers can call custom Ruby actions

### DIFF
--- a/fastlane/lib/fastlane/swift_fastlane_api_generator.rb
+++ b/fastlane/lib/fastlane/swift_fastlane_api_generator.rb
@@ -241,7 +241,7 @@ module Fastlane
     end
 
     def generate_lanefile_parsing_functions
-      parsing_functions = 'func parseArray(fromString: String, function: String = #function) -> [String] {
+      parsing_functions = 'public func parseArray(fromString: String, function: String = #function) -> [String] {
   verbose(message: "parsing an Array from data: \(fromString), from function: \(function)")
   let potentialArray: String
   if fromString.count < 2 {
@@ -253,11 +253,11 @@ module Fastlane
   return array
 }
 
-func parseDictionary(fromString: String, function: String = #function) -> [String : String] {
+public func parseDictionary(fromString: String, function: String = #function) -> [String : String] {
     return parseDictionaryHelper(fromString: fromString, function: function) as! [String: String]
 }
 
-func parseDictionary(fromString: String, function: String = #function) -> [String : Any] {
+public func parseDictionary(fromString: String, function: String = #function) -> [String : Any] {
     return parseDictionaryHelper(fromString: fromString, function: function)
 }
 

--- a/fastlane/spec/swift_fastlane_api_generator_spec.rb
+++ b/fastlane/spec/swift_fastlane_api_generator_spec.rb
@@ -1,0 +1,22 @@
+describe Fastlane do
+  describe Fastlane::SwiftFastlaneAPIGenerator do
+    describe '#generate_lanefile_parsing_functions' do
+      let(:generator) { Fastlane::SwiftFastlaneAPIGenerator.new(target_output_path: 'swift') }
+
+      it 'declares the parse helpers as public so SwiftPM consumers can read return values from custom Ruby actions' do
+        output = generator.generate_lanefile_parsing_functions
+
+        expect(output).to include('public func parseArray(fromString: String, function: String = #function) -> [String] {')
+        expect(output).to include('public func parseDictionary(fromString: String, function: String = #function) -> [String : String] {')
+        expect(output).to include('public func parseDictionary(fromString: String, function: String = #function) -> [String : Any] {')
+      end
+
+      it 'keeps the internal helper non-public' do
+        output = generator.generate_lanefile_parsing_functions
+
+        expect(output).to include('func parseDictionaryHelper(')
+        expect(output).not_to include('public func parseDictionaryHelper(')
+      end
+    end
+  end
+end

--- a/fastlane/swift/OptionalConfigValue.swift
+++ b/fastlane/swift/OptionalConfigValue.swift
@@ -15,7 +15,7 @@ public enum OptionalConfigValue<T> {
     case userDefined(T)
     case `nil`
 
-    func asRubyArgument(name: String, type: RubyCommand.Argument.ArgType? = nil) -> RubyCommand.Argument? {
+    public func asRubyArgument(name: String, type: RubyCommand.Argument.ArgType? = nil) -> RubyCommand.Argument? {
         if case let .userDefined(value) = self {
             return RubyCommand.Argument(name: name, value: value, type: type)
         }

--- a/fastlane/swift/RubyCommand.swift
+++ b/fastlane/swift/RubyCommand.swift
@@ -10,13 +10,20 @@
 
 import Foundation
 
-struct RubyCommand: RubyCommandable {
-    var type: CommandType {
+public struct RubyCommand: RubyCommandable {
+    public var type: CommandType {
         return .action
     }
 
-    struct Argument {
-        enum ArgType {
+    public init(commandID: String, methodName: String, className: String?, args: [Argument]) {
+        self.commandID = commandID
+        self.methodName = methodName
+        self.className = className
+        self.args = args
+    }
+
+    public struct Argument {
+        public enum ArgType {
             case stringClosure
 
             var typeString: String {
@@ -28,10 +35,10 @@ struct RubyCommand: RubyCommandable {
         }
 
         let name: String
-        let value: Any?
+        public let value: Any?
         let type: ArgType?
 
-        init(name: String, value: Any?, type: ArgType? = nil) {
+        public init(name: String, value: Any?, type: ArgType? = nil) {
             self.name = name
             self.value = value
             self.type = type
@@ -77,7 +84,7 @@ struct RubyCommand: RubyCommandable {
     let methodName: String
     let className: String?
     let args: [Argument]
-    let id: String = UUID().uuidString
+    public let id: String = UUID().uuidString
 
     var closure: ((String) -> Void)? {
         let callbacks = args.filter { ($0.type != nil) && $0.type == .stringClosure }
@@ -122,7 +129,7 @@ struct RubyCommand: RubyCommandable {
         completion()
     }
 
-    var commandJson: String {
+    public var commandJson: String {
         let argsArrayJson = args
             .map { $0.json }
             .filter { $0 != "" }

--- a/fastlane/swift/RubyCommandable.swift
+++ b/fastlane/swift/RubyCommandable.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-enum CommandType {
+public enum CommandType {
     case action
     case control
 
@@ -24,7 +24,7 @@ enum CommandType {
     }
 }
 
-protocol RubyCommandable {
+public protocol RubyCommandable {
     var type: CommandType { get }
     var commandJson: String { get }
     var id: String { get }

--- a/fastlane/swift/Runner.swift
+++ b/fastlane/swift/Runner.swift
@@ -12,13 +12,13 @@ import Foundation
 
 let logger: Logger = .init()
 
-let runner: Runner = .init()
+public let runner: Runner = .init()
 
-func desc(_: String) {
+public func desc(_: String) {
     // no-op, this is handled in fastlane/lane_list.rb
 }
 
-class Runner {
+public class Runner {
     private var thread: Thread!
     private var socketClient: SocketClient!
     private let dispatchGroup = DispatchGroup()
@@ -33,7 +33,7 @@ class Runner {
         }
     }()
 
-    func executeCommand(_ command: RubyCommandable) -> String {
+    public func executeCommand(_ command: RubyCommandable) -> String {
         dispatchGroup.enter()
         currentlyExecutingCommand = command
         socketClient.send(rubyCommand: command)


### PR DESCRIPTION
### Motivation and Context

When fastlane is consumed as a Swift Package, the generated `Fastlane.swift` wrappers cover the built-in actions, but `RubyCommand`, `Runner` / the `runner` singleton, and the `parse*` helpers are `internal`. A SwiftPM **executable** therefore cannot construct a `RubyCommand` to invoke a **custom Ruby action** or a **third-party plugin** from Swift — there is no public entry point to the socket runner.

This is the gap discussed in #18511 and #21277. With the official SPM target these calls are simply unreachable, so anyone with project-specific Ruby actions cannot migrate their Fastfile.swift to SPM.

### Description

Make the minimal surface `public` so a consumer can build and dispatch a command:

- `RubyCommand` (+ a public memberwise `init`), `RubyCommand.Argument` (+ public `init` and `value`)
- `RubyCommandable`, `CommandType`
- `Runner`, the `runner` singleton, the no-op `desc(_:)`
- `OptionalConfigValue.asRubyArgument`
- the `parseArray` / `parseDictionary` helpers

Per the review feedback on the autogenerated note: `Fastlane.swift` is produced by `swift_fastlane_api_generator.rb`, so the `public` modifiers on the parse helpers are applied **in the generator** (`generate_lanefile_parsing_functions`), not only in the emitted file. Running `fastlane generate_swift` now keeps them `public`.

> Note: `runner` and `desc` become public free symbols in the module — an intentional trade-off (namespacing them would be a breaking change). Flagging it explicitly.

### Testing Steps

- Added `fastlane/spec/swift_fastlane_api_generator_spec.rb` asserting the generator emits `public func parseArray` / `parseDictionary` while `parseDictionaryHelper` stays internal → 2 examples, 0 failures.
- Re-ran the generator (`SwiftFastlaneAPIGenerator(...).generate_swift`) and confirmed the regenerated `Fastlane.swift` keeps the public parse helpers — the change round-trips with no loss.
- `bundle exec rspec fastlane/spec` → 4808 of 4810 examples pass. The 2 failures are in `plugin_generator_spec.rb` (it shells out to `rubocop`/`rake` inside a freshly generated plugin) and reproduce identically on a clean tree with this PR's change reverted — i.e. a local rubocop-version artifact, unrelated to this PR. No regressions introduced.
- `bundle exec rubocop` on the changed/added files → no offenses.
- Built a SwiftPM executable depending on this branch that calls a real custom Ruby action via `runner.executeCommand(RubyCommand(...))` + `parseDictionary(...)` — compiles and returns the value end-to-end.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass <!-- 4808/4810; the 2 failures are a pre-existing rubocop-version artifact in plugin_generator_spec, reproduced with this change reverted -->
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop` — no offenses on the changed/added files
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR <!-- pending CI -->
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary <!-- no public docs affected -->
- [x] I've added or updated relevant unit tests
