### PR TITLE
Match: Allow using legacy encryption mode when writing to storage

### DIFF
--- a/match/lib/match/change_password.rb
+++ b/match/lib/match/change_password.rb
@@ -26,7 +26,8 @@ module Match
         git_url: params[:git_url],
         s3_bucket: params[:s3_bucket],
         s3_skip_encryption: params[:s3_skip_encryption],
-        working_directory: storage.working_directory
+        working_directory: storage.working_directory,
+        force_legacy_encryption: params[:force_legacy_encryption]
       })
       encryption.decrypt_files
 

--- a/match/lib/match/encryption/encryption.rb
+++ b/match/lib/match/encryption/encryption.rb
@@ -134,11 +134,11 @@ module Match
 
     # The methods of this class will encrypt or decrypt files in place, by default.
     class MatchFileEncryption
-      def encrypt(file_path:, password:, output_path: nil)
+      def encrypt(file_path:, password:, output_path: nil, version: 2)
         output_path = file_path unless output_path
         data_to_encrypt = File.binread(file_path)
         e = MatchDataEncryption.new
-        data = e.encrypt(data: data_to_encrypt, password: password)
+        data = e.encrypt(data: data_to_encrypt, password: password, version: version)
         File.write(output_path, data)
       end
 

--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -23,7 +23,8 @@ module Match
         git_url: params[:git_url],
         s3_bucket: params[:s3_bucket],
         s3_skip_encryption: params[:s3_skip_encryption],
-        working_directory: storage.working_directory
+        working_directory: storage.working_directory,
+        force_legacy_encryption: params[:force_legacy_encryption]
       })
       encryption.decrypt_files if encryption
       UI.success("Repo is at: '#{storage.working_directory}'")

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -42,7 +42,8 @@ module Match
         git_url: params[:git_url],
         s3_bucket: params[:s3_bucket],
         s3_skip_encryption: params[:s3_skip_encryption],
-        working_directory: storage.working_directory
+        working_directory: storage.working_directory,
+        force_legacy_encryption: params[:force_legacy_encryption]
       })
       self.encryption.decrypt_files if self.encryption
 

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -355,6 +355,11 @@ module Match
                                      description: "Skips setting the partition list (which can sometimes take a long time). Setting the partition list is usually needed to prevent Xcode from prompting to allow a cert to be used for signing",
                                      type: Boolean,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :force_legacy_encryption,
+                                     env_name: "MATCH_FORCE_LEGACY_ENCRYPTION",
+                                     description: "Force encryption to use legacy cbc algorithm for backwards compatibility with older match versions",
+                                     type: Boolean,
+                                     default_value: false),
 
         # other
         FastlaneCore::ConfigItem.new(key: :verbose,

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -49,7 +49,8 @@ module Match
         git_url: params[:git_url],
         s3_bucket: params[:s3_bucket],
         s3_skip_encryption: params[:s3_skip_encryption],
-        working_directory: storage.working_directory
+        working_directory: storage.working_directory,
+        force_legacy_encryption: params[:force_legacy_encryption]
       })
       encryption.decrypt_files if encryption
 

--- a/match/spec/encryption/openssl_spec.rb
+++ b/match/spec/encryption/openssl_spec.rb
@@ -59,5 +59,43 @@ describe Match do
       @e.decrypt_files
       expect(File.binread(@full_path)).to eq(@content)
     end
+
+    describe "behavior of force_legacy_encryption parameter" do
+
+      before do
+        @match_encryption_double = instance_double(Match::Encryption::MatchFileEncryption)
+
+        expect(Match::Encryption::MatchFileEncryption)
+          .to(receive(:new))
+          .and_return(@match_encryption_double)
+      end
+
+      it "defaults to false and uses v2 encryption" do
+        expect(@match_encryption_double).to(receive(:encrypt)).with(file_path: anything(), password: anything(), version: 2)
+        @e.encrypt_files
+      end
+
+      it "uses v1 when force_legacy_encryption is true" do
+        enc = Match::Encryption::OpenSSL.new(
+          keychain_name: @git_url,
+          working_directory: @directory,
+          force_legacy_encryption: true
+        )
+
+        expect(@match_encryption_double).to(receive(:encrypt)).with(file_path: anything(), password: anything(), version: 1)
+        enc.encrypt_files
+      end
+
+      it "uses v2 when force_legacy_encryption is false" do
+        enc = Match::Encryption::OpenSSL.new(
+          keychain_name: @git_url,
+          working_directory: @directory,
+          force_legacy_encryption: false
+        )
+
+        expect(@match_encryption_double).to(receive(:encrypt)).with(file_path: anything(), password: anything(), version: 2)
+        enc.encrypt_files
+      end
+    end
   end
 end

--- a/match/spec/encryption/openssl_spec.rb
+++ b/match/spec/encryption/openssl_spec.rb
@@ -71,7 +71,10 @@ describe Match do
       end
 
       it "defaults to false and uses v2 encryption" do
-        expect(@match_encryption_double).to(receive(:encrypt)).with(file_path: anything(), password: anything(), version: 2)
+        expect(@match_encryption_double)
+          .to(receive(:encrypt))
+          .with(file_path: anything, password: anything, version: 2)
+
         @e.encrypt_files
       end
 
@@ -82,7 +85,10 @@ describe Match do
           force_legacy_encryption: true
         )
 
-        expect(@match_encryption_double).to(receive(:encrypt)).with(file_path: anything(), password: anything(), version: 1)
+        expect(@match_encryption_double)
+          .to(receive(:encrypt))
+          .with(file_path: anything, password: anything, version: 1)
+
         enc.encrypt_files
       end
 
@@ -93,7 +99,10 @@ describe Match do
           force_legacy_encryption: false
         )
 
-        expect(@match_encryption_double).to(receive(:encrypt)).with(file_path: anything(), password: anything(), version: 2)
+        expect(@match_encryption_double)
+          .to(receive(:encrypt))
+          .with(file_path: anything, password: anything, version: 2)
+
         enc.encrypt_files
       end
     end

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -143,7 +143,7 @@ describe Match do
           allow(fake_storage).to receive(:prefixed_working_directory).and_return(repo_dir)
 
           fake_encryption = "fake_encryption"
-          expect(Match::Encryption::OpenSSL).to receive(:new).with(keychain_name: fake_storage.git_url, working_directory: fake_storage.working_directory).and_return(fake_encryption)
+          expect(Match::Encryption::OpenSSL).to receive(:new).with(keychain_name: fake_storage.git_url, working_directory: fake_storage.working_directory, force_legacy_encryption: false).and_return(fake_encryption)
           expect(fake_encryption).to receive(:decrypt_files).and_return(nil)
 
           expect(Match::Utils).to receive(:import).with(key_path, keychain, password: nil).and_return(nil)
@@ -199,7 +199,7 @@ describe Match do
           fake_storage = create_fake_storage(match_config: config, repo_dir: repo_dir)
 
           fake_encryption = "fake_encryption"
-          expect(Match::Encryption::OpenSSL).to receive(:new).with(keychain_name: fake_storage.git_url, working_directory: fake_storage.working_directory).and_return(fake_encryption)
+          expect(Match::Encryption::OpenSSL).to receive(:new).with(keychain_name: fake_storage.git_url, working_directory: fake_storage.working_directory, force_legacy_encryption: false).and_return(fake_encryption)
           expect(fake_encryption).to receive(:decrypt_files).and_return(nil)
 
           spaceship = "spaceship"

--- a/match/spec/spec_helper.rb
+++ b/match/spec/spec_helper.rb
@@ -74,7 +74,7 @@ end
 
 def create_fake_encryption(storage:)
   fake_encryption = "fake_encryption"
-  expect(Match::Encryption::OpenSSL).to receive(:new).with(keychain_name: storage.git_url, working_directory: storage.working_directory).and_return(fake_encryption)
+  expect(Match::Encryption::OpenSSL).to receive(:new).with(keychain_name: storage.git_url, working_directory: storage.working_directory, force_legacy_encryption: false).and_return(fake_encryption)
 
   # Ensure files from storage are decrypted.
   expect(fake_encryption).to receive(:decrypt_files).and_return(nil)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
Resolves #21973

Match was significantly refactored in fastlane 2.220.0 with updates to the default encryption algorithm used when encrypting and storing certs and profiles to the designated storage. However, due to the encryption step [always using EncryptionV2](https://github.com/fastlane/fastlane/blob/2de8c8446bfa33d886536f2c1453955e597bbd7d/match/lib/match/encryption/encryption.rb#L94C1-L94C48), any new profiles created by fastlane versions 2.220.0 and above are not compatible with older versions of fastlane.

Although this works in an ideal scenario where the fastlane version is easily updated, for companies that deal with multiple releases in different historical branches and tags it is sometimes not easy to retroactively update fastlane on these branches. 

### Description

Add a new flag `force_legacy_encryption` to match and the related tools that encrypt files, to allow users to override the default behavior of using the v2 encryption.

### Testing Steps

- Run match on this branch with force_legacy_encryption set to true, and confirm it encrypts and uploads correctly.
- Confirm file is encrypted with "Salted_" prefix: `cat file | base64 -d`
- Run match pointing to the same repo using older fastlane version (manually tested with 2.211.0)
