### PR TITLE
[slack] Enable emoji-based icons in Slack action by adding icon_emoji parameter

### DIFF
--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -27,6 +27,7 @@ module Fastlane
           slack_attachment = self.class.generate_slack_attachments(options)
           link_names = options[:link_names]
           icon_url = options[:use_webhook_configured_username_and_icon] ? nil : options[:icon_url]
+          icon_emoji = options[:use_webhook_configured_username_and_icon] ? nil : options[:icon_emoji]
 
           post_message(
             channel: channel,
@@ -34,16 +35,18 @@ module Fastlane
             attachments: [slack_attachment],
             link_names: link_names,
             icon_url: icon_url,
+            icon_emoji: icon_emoji,
             fail_on_error: options[:fail_on_error]
           )
         end
 
-        def post_message(channel:, username:, attachments:, link_names:, icon_url:, fail_on_error:)
+        def post_message(channel:, username:, attachments:, link_names:, icon_url:, icon_emoji:, fail_on_error:)
           @notifier.post_to_legacy_incoming_webhook(
             channel: channel,
             username: username,
             link_names: link_names,
             icon_url: icon_url,
+            icon_emoji: icon_emoji,
             attachments: attachments
           )
           UI.success('Successfully sent Slack notification')
@@ -213,6 +216,10 @@ module Fastlane
                                        env_name: "FL_SLACK_ICON_URL",
                                        description: "Overrides the webhook's image property if use_webhook_configured_username_and_icon is false",
                                        default_value: "https://fastlane.tools/assets/img/fastlane_icon.png",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :icon_emoji,
+                                       env_name: "FL_SLACK_ICON_EMOJI",
+                                       description: "Specifies an emoji (using colon shortcodes, eg. :white_check_mark:) to use as the photo of the message. Overrides the webhook's image property if use_webhook_configured_username_and_icon is false. This parameter takes precedence over icon_url",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :payload,
                                        env_name: "FL_SLACK_PAYLOAD",

--- a/fastlane/lib/fastlane/actions/slack.rb
+++ b/fastlane/lib/fastlane/actions/slack.rb
@@ -214,7 +214,7 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :icon_url,
                                        env_name: "FL_SLACK_ICON_URL",
-                                       description: "Overrides the webhook's image property if use_webhook_configured_username_and_icon is false",
+                                       description: "Specifies a URL of an image to use as the photo of the message. Overrides the webhook's image property if use_webhook_configured_username_and_icon is false",
                                        default_value: "https://fastlane.tools/assets/img/fastlane_icon.png",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :icon_emoji,

--- a/fastlane/lib/fastlane/notification/slack.rb
+++ b/fastlane/lib/fastlane/notification/slack.rb
@@ -8,16 +8,17 @@ module Fastlane
         end
       end
 
-      # Overriding channel, icon_url and username is only supported in legacy incoming webhook.
+      # Overriding channel, icon_url, icon_emoji and username is only supported in legacy incoming webhook.
       # Also note that the use of attachments has been discouraged by Slack, in favor of Block Kit.
       # https://api.slack.com/legacy/custom-integrations/messaging/webhooks
-      def post_to_legacy_incoming_webhook(channel:, username:, attachments:, link_names:, icon_url:)
+      def post_to_legacy_incoming_webhook(channel:, username:, attachments:, link_names:, icon_url:, icon_emoji:)
         @client.post(@webhook_url) do |request|
           request.headers['Content-Type'] = 'application/json'
           request.body = {
             channel: channel,
             username: username,
             icon_url: icon_url,
+            icon_emoji: icon_emoji,
             attachments: attachments,
             link_names: link_names
           }.to_json

--- a/fastlane/spec/actions_specs/slack_spec.rb
+++ b/fastlane/spec/actions_specs/slack_spec.rb
@@ -22,6 +22,7 @@ describe Fastlane::Actions do
           message: message,
           success: false,
           channel: channel,
+          icon_emoji: ':white_check_mark:',
           payload: {
             'Build Date' => Time.new.to_s,
             'Built by' => 'Jenkins'
@@ -46,6 +47,7 @@ describe Fastlane::Actions do
           ],
           link_names: false,
           icon_url: 'https://fastlane.tools/assets/img/fastlane_icon.png',
+          icon_emoji: ':white_check_mark:',
           fail_on_error: true
         }
         expect(subject).to receive(:post_message).with(expected_args)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
This update is needed to make the Slack action in Fastlane more flexible by adding support for using emojis as icons in Slack messages. Right now, you can only use image URLs for the icon, even though [Slack’s API](https://api.slack.com/methods/chat.postMessage) lets you use emojis too. This change allows users to customize their notifications a bit more by adding emoji icons, which can make messages more fun or visually informative 🤖 🏄

### Description
I added a new parameter to the Slack action in Fastlane, allowing users to specify an emoji as the message icon. The new parameter integrates with [Slack’s existing API capabilities](https://api.slack.com/methods/chat.postMessage) for setting an emoji as the avatar/icon of a message, offering more customization.

In addition to the new feature, I ensured that the previous functionality, which supports image URLs for the icon, remains unaffected (no breaking changes).

The changes have been tested locally by running the Fastlane Slack action with both emoji and image-based icons. I’ve validated that the correct message format is sent to Slack in each case (see the next section).

### Testing Steps
I tested this branch locally using the Slack action with these scenarios:
1. Message with no icon URL – should display the default Slack icon.
2. Message with an icon URL – should display the specified image icon.
3. Message with an icon emoji – should display the specified emoji as the icon.
4. Message with both an icon URL and emoji – should display the image icon (the icon URL takes priority over the emoji).

I’ve attached the testing lane I used and a screenshot below to show the results for each scenario:

<details>
  <summary>Code</summary>
  
  ```ruby
lane :send_slack_messges do
  slack(
    message: "Message with no icon URL, should show the default icon",
    username: "User 1",
    default_payloads: []
  )

  slack(
    message: "Message with icon URL, should show the given icon",
    username: "User 2",
    icon_url: "https://picsum.photos/seed/picsum/48",
    default_payloads: []
  )

  slack(
    message: "Message with icon emoji, should show the given icon",
    username: "User 3",
    icon_emoji: ":white_check_mark:",
    default_payloads: []
  )

  slack(
    message: "Message with icon URL and emoji, should show the URL emoji (icon URL is overriden)",
    username: "User 4",
    icon_url: "https://picsum.photos/seed/picsum/48",
    icon_emoji: ":white_check_mark:",
    default_payloads: []
  )
end
  ```

</details>

Result of the previous code:

![image](https://github.com/user-attachments/assets/64ebb10d-1cac-447f-9a7c-cc4af2174b09)
