### PR TITLE
Add more information to some of the `supply` messages

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -134,16 +134,12 @@ module Supply
 
       UI.message("Updating #{version_code}'s rollout to '#{Supply.config[:rollout]}' in track '#{track_name}'...")
 
-      if track && release
-        completed = Supply.config[:rollout].to_f == 1
-        release.user_fraction = completed ? nil : Supply.config[:rollout]
-        release.status = Supply::ReleaseStatus::COMPLETED if completed
+      completed = Supply.config[:rollout].to_f == 1
+      release.user_fraction = completed ? nil : Supply.config[:rollout]
+      release.status = Supply::ReleaseStatus::COMPLETED if completed
 
-        # Deleted other version codes if completed because only allowed on completed version in a release
-        track.releases.delete_if { |r| !(r.version_codes || []).map(&:to_s).include?(version_code) } if completed
-      else
-        UI.user_error!("Unable to find version to rollout in track '#{Supply.config[:track]}'")
-      end
+      # Deleted other version codes if completed because only allowed on completed version in a release
+      track.releases.delete_if { |r| !(r.version_codes || []).map(&:to_s).include?(version_code) } if completed
 
       client.update_track(Supply.config[:track], track)
     end

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -89,8 +89,8 @@ module Supply
           UI.user_error!("Could not find folder #{metadata_path}") unless File.directory?(metadata_path)
 
           track, release = fetch_track_and_release!(track_name, version_code)
-          UI.user_error!("Unable to find the requested track - '#{track_name}'") unless track
-          UI.user_error!("Could not find release for version code '#{version_code}' to update changelog") unless release
+          UI.user_error!("Unable to find the requested track '#{track_name}' for version code '#{version_code}'") unless track
+          UI.user_error!("Could not find release for version code '#{version_code}' in track '#{track_name}' to update changelog") unless release
 
           release_notes_queue = Queue.new
           upload_worker = create_meta_upload_worker

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -124,13 +124,14 @@ module Supply
     end
 
     def update_rollout
-      track, release = fetch_track_and_release!(Supply.config[:track], Supply.config[:version_code], Supply::ReleaseStatus::IN_PROGRESS)
-      UI.user_error!("Unable to find the requested track - '#{Supply.config[:track]}'") unless track
-      UI.user_error!("Unable to find the requested release on track - '#{Supply.config[:track]}'") unless release
+      track_name = Supply.config[:track]
+      track, release = fetch_track_and_release!(track_name, Supply.config[:version_code], Supply::ReleaseStatus::IN_PROGRESS)
+      UI.user_error!("Unable to find the requested track - '#{track_name}'") unless track
+      UI.user_error!("Unable to find the requested release on track - '#{track_name}'") unless release
 
       version_code = release.version_codes.max
 
-      UI.message("Updating #{version_code}'s rollout to '#{Supply.config[:rollout]}' on track '#{Supply.config[:track]}'...")
+      UI.message("Updating #{version_code}'s rollout to '#{Supply.config[:rollout]}' on track '#{track_name}'...")
 
       if track && release
         completed = Supply.config[:rollout].to_f == 1

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -125,9 +125,10 @@ module Supply
 
     def update_rollout
       track_name = Supply.config[:track]
-      track, release = fetch_track_and_release!(track_name, Supply.config[:version_code], Supply::ReleaseStatus::IN_PROGRESS)
-      UI.user_error!("Unable to find the requested track - '#{track_name}'") unless track
-      UI.user_error!("Unable to find the requested release in track - '#{track_name}'") unless release
+      in_progress_status = Supply::ReleaseStatus::IN_PROGRESS
+      track, release = fetch_track_and_release!(track_name, Supply.config[:version_code], in_progress_status)
+      UI.user_error!("Unable to find the requested track '#{track_name}' with status in progress (#{in_progress_status})") unless track
+      UI.user_error!("Unable to find the requested release in track '#{track_name}' with status in progress (#{in_progress_status})") unless release
 
       version_code = release.version_codes.max
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -89,7 +89,7 @@ module Supply
           UI.user_error!("Could not find folder #{metadata_path}") unless File.directory?(metadata_path)
 
           track, release = fetch_track_and_release!(track_name, version_code)
-          UI.user_error!("Unable to find the requested track - '#{Supply.config[:track]}'") unless track
+          UI.user_error!("Unable to find the requested track - '#{track_name}'") unless track
           UI.user_error!("Could not find release for version code '#{version_code}' to update changelog") unless release
 
           release_notes_queue = Queue.new

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -127,11 +127,11 @@ module Supply
       track_name = Supply.config[:track]
       track, release = fetch_track_and_release!(track_name, Supply.config[:version_code], Supply::ReleaseStatus::IN_PROGRESS)
       UI.user_error!("Unable to find the requested track - '#{track_name}'") unless track
-      UI.user_error!("Unable to find the requested release on track - '#{track_name}'") unless release
+      UI.user_error!("Unable to find the requested release in track - '#{track_name}'") unless release
 
       version_code = release.version_codes.max
 
-      UI.message("Updating #{version_code}'s rollout to '#{Supply.config[:rollout]}' on track '#{track_name}'...")
+      UI.message("Updating #{version_code}'s rollout to '#{Supply.config[:rollout]}' in track '#{track_name}'...")
 
       if track && release
         completed = Supply.config[:rollout].to_f == 1


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. – N.A.
- [x] I've added or updated relevant unit tests. – N.A.

> I see several green `ci/circleci` builds in the "All checks have passed" section of my PR...

I do not see the individual checks, but I can see 12 checks, matching those [in `.circleci/config.yml`](https://github.com/fastlane/fastlane/blob/2de8c8446bfa33d886536f2c1453955e597bbd7d/.circleci/config.yml#L252-L305) on [CircleCI itself](https://app.circleci.com/pipelines/github/fastlane/fastlane/6705/workflows/85688e20-8633-4006-8930-39caee0d5405) following the "Run Tests & Checks" check.


### Motivation and Context

`supply` failed to upload some data on me in a way that I was not expecting. ~~I haven't gotten to the bottom of it yet (I think the issue is on my end) but~~ I eventually got to the bottom of it and learned it was a permission issue on the service account. While trying to understand what was going on I took some time to add info to some of the `UI` messages I saw.

### Description

- Interpolate a few more values in some of the `UI.user_error!` messages
- Remove an unnecessary `if` check

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I guess you could say I manually tested some of these code paths because I run `supply` and saw the updated error messages in my shell.