### PR TITLE
Added missing config[:devices].nil? check

### DIFF
--- a/snapshot/lib/snapshot/detect_values.rb
+++ b/snapshot/lib/snapshot/detect_values.rb
@@ -66,7 +66,7 @@ module Snapshot
 
           config[:devices] << sim.name
         end
-      elsif Snapshot.project.mac?
+      elsif config[:devices].nil? && Snapshot.project.mac?
         config[:devices] = ["Mac"]
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves #21752
Resolves #22150 

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
A check was missing that config[:devices] is empty, which resulted in "Mac" always being set as device if the project supported Mac. This is unwanted for projects supporting both iOS and Mac.

After applying this fix the devices parameter is no longer ignored for projects supporting both iOS and Mac. Without the change it was impossible to create iOS snapshots for these projects.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
