### PR TITLE
Fix changelog generation when no author

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -475,7 +475,7 @@ private_lane :github_changelog do |options|
     # Default to commit message info
     message = commit["commit"]["message"].lines.first.strip
     name = commit["commit"]["author"]["name"]
-    username = commit["author"]["login"]
+    username = commit["author"]&.[]("login")
 
     # Get pull request associate with commit message
     sha = commit["sha"]


### PR DESCRIPTION
### Motivation and Context

Changelog generation was crashing when no author

### Description

Don't know why there would be no author but now looking safely for it

The one with `TomoXD` was the one that was crashing it previously 👇 

<img width="1047" alt="Screenshot 2024-09-26 at 10 24 42 AM" src="https://github.com/user-attachments/assets/c10f6ba6-1b7f-4cb9-8329-12f73abe81f9">

