### PR TITLE
WIP: Fix for `FastlaneCore::BuildWatcher` duplicate build versions found

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -115,7 +115,9 @@ module FastlaneCore
 
         # Raise error if more than 1 build is returned
         # This should never happen but need to inform the user if it does
-        matched_builds = version_matches.map(&:builds).flatten
+        puts version_matches.map(&:builds).flatten
+        matched_builds = version_matches.map(&:builds).flatten.uniq
+        puts matched_builds
         if matched_builds.size > 1 && !select_latest
           error_builds = matched_builds.map do |build|
             "#{build.app_version}(#{build.version}) for #{build.platform} - #{build.processing_state}"

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -34,7 +34,7 @@ module FastlaneCore
 
         showed_info = false
         loop do
-          matched_build, app_version_queried = matching_build(watched_app_version: app_version, watched_build_version: build_version, app_id: app_id, platform: platform, select_latest: select_latest)
+          matched_build = matching_build(watched_app_version: app_version, watched_build_version: build_version, app_id: app_id, platform: platform, select_latest: select_latest)
           if matched_build.nil? && !showed_info
             UI.important("Read more information on why this build isn't showing up yet - https://github.com/fastlane/fastlane/issues/14997")
             showed_info = true
@@ -47,13 +47,6 @@ module FastlaneCore
           # having a build resource appear in AppStoreConnect (matched_build) may be enough (i.e. setting a changelog)
           # so here we may choose to skip the full processing of the build if return_when_build_appears is true
           if matched_build && (return_when_build_appears || processed?(build: matched_build, wait_for_build_beta_detail_processing: wait_for_build_beta_detail_processing))
-
-            if !app_version.nil? && !app_version_queried.nil? && app_version != app_version_queried
-              UI.important("App version is #{app_version} but build was found while querying #{app_version_queried}")
-              UI.important("This shouldn't be an issue as Apple sees #{app_version} and #{app_version_queried} as equal")
-              UI.important("See docs for more info - https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364")
-            end
-
             if return_spaceship_testflight_build
               return matched_build.to_testflight_build
             else
@@ -124,7 +117,7 @@ module FastlaneCore
           raise BuildWatcherError.new, "Found more than 1 matching build: \n#{error_builds}"
         end
 
-        matched_builds
+        matched_builds.last
       end
 
 

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -80,7 +80,8 @@ module FastlaneCore
       def matching_build(watched_app_version: nil, watched_build_version: nil, app_id: nil, platform: nil, select_latest: false)
         # Normalize the watched app version and build version to ensure consistency
         watched_app_version = normalize_version(version: watched_app_version)
-        watched_build_version = normalize_version(version: watched_build_version)
+        # I do not think we want to do anything to the build number
+        # watched_build_version = normalize_version(version: watched_build_version)
 
         # Only query for the specific version, without generating alternates like X.Y vs X.Y.0
         versions = [watched_app_version].compact
@@ -110,6 +111,7 @@ module FastlaneCore
 
         # Raise an error if more than one build is returned
         matched_builds = version_matches.map(&:builds).flatten
+
         if matched_builds.size > 1 && !select_latest
           error_builds = matched_builds.map do |build|
             "#{build.app_version}(#{build.version}) for #{build.platform} - #{build.processing_state}"
@@ -120,19 +122,6 @@ module FastlaneCore
         matched_builds.last
       end
 
-
-      def alternate_version(version)
-        return nil if version.nil?
-
-        version_info = Gem::Version.new(version)
-        if version_info.segments.size == 3 && version_info.segments[2] == 0
-          return version_info.segments[0..1].join(".")
-        elsif version_info.segments.size == 2
-          return "#{version}.0"
-        end
-
-        return nil
-      end
 
       def processed?(build: nil, wait_for_build_beta_detail_processing: false)
         return false unless build

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -70,9 +70,7 @@ module FastlaneCore
         version_parts = version.split('.').map { |s| s.to_i.to_s }
 
         # Add missing parts to conform to the [Major].[Minor].[Patch] format
-        while version_parts.size < 3
-          version_parts << "0"
-        end
+        version_parts << "0" while version_parts.size < 3
 
         version_parts.join('.')
       end
@@ -80,8 +78,7 @@ module FastlaneCore
       def matching_build(watched_app_version: nil, watched_build_version: nil, app_id: nil, platform: nil, select_latest: false)
         # Normalize the watched app version and build version to ensure consistency
         watched_app_version = normalize_version(version: watched_app_version)
-        # I do not think we want to do anything to the build number
-        # watched_build_version = normalize_version(version: watched_build_version)
+        watched_build_version = normalize_version(version: watched_build_version)
 
         # Only query for the specific version, without generating alternates like X.Y vs X.Y.0
         versions = [watched_app_version].compact
@@ -125,7 +122,6 @@ module FastlaneCore
 
       def processed?(build: nil, wait_for_build_beta_detail_processing: false)
         return false unless build
-
         is_processed = build.processed?
 
         # App Store Connect API has multiple build processing states

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -65,11 +65,9 @@ describe FastlaneCore::BuildWatcher do
 
     context 'waits when a build is still processing' do
       it 'when wait_for_build_beta_detail_processing is false' do
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([processing_build])
         expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
 
         expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
         expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{ready_build.platform}")
@@ -83,18 +81,16 @@ describe FastlaneCore::BuildWatcher do
         build_beta_detail_processing = double(processed?: false)
         build_beta_detail_processed = double(processed?: true)
 
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([processing_build])
         expect(FastlaneCore::BuildWatcher).to receive(:sleep)
 
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
+
         expect(ready_build).to receive(:build_beta_detail).and_return(build_beta_detail_processing).twice
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
         expect(FastlaneCore::BuildWatcher).to receive(:sleep)
 
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
+        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
         expect(ready_build).to receive(:build_beta_detail).and_return(build_beta_detail_processed).twice
-        expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
 
         expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
         expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{ready_build.platform}").twice
@@ -106,11 +102,9 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'waits when the build disappears' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([])
       expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
 
       expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
       expect(UI).to receive(:message).with("Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)")
@@ -121,8 +115,7 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'watches the latest build when no builds are processing' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
 
       expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
       found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false)
@@ -130,16 +123,15 @@ describe FastlaneCore::BuildWatcher do
       expect(found_build).to eq(ready_build)
     end
 
-    describe 'multiple builds found' do
+    # not sure how this even works anymore if we're not querying multiple versions anymore to begin with
+    xdescribe 'multiple builds found' do
       describe 'select_latest is false' do
         it 'raises error select_latest is false' do
           builds = [ready_build, ready_build]
 
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([])
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
           expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return(builds)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return(builds)
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
           expect(UI).to receive(:message).with("Waiting for the build to show up in the build list - this may take a few minutes (check your email for processing issues if this continues)")
@@ -166,8 +158,7 @@ describe FastlaneCore::BuildWatcher do
         it 'returns latest build' do
           builds = [newest_ready_build, ready_build]
 
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return(builds)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return(builds)
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
 
@@ -179,11 +170,9 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'sleeps 10 seconds by default' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([processing_build])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep).with(10)
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
 
       allow(UI).to receive(:message)
       allow(UI).to receive(:success)
@@ -191,11 +180,9 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'sleeps for the amount of time specified in poll_interval' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([processing_build])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep).with(123)
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
 
       allow(UI).to receive(:message)
       allow(UI).to receive(:success)
@@ -203,11 +190,9 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'notifies when a build is still processing with timeout duration' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([processing_build])
       expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
 
       expect(UI).to receive(:message).with(/Will timeout watching build after [4-5]{1} seconds around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2})\.\.\./)
       expect(UI).to receive(:verbose).with(/Will timeout watching build after pending [0-5]{1} seconds around (2[0-9]{3}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [+-][0-9]{2}[0-9]{2})\.\.\./)
@@ -220,153 +205,11 @@ describe FastlaneCore::BuildWatcher do
     end
 
     it 'raises error when a build is still processing and timeout duration exceeded' do
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
-      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
+      expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([processing_build])
 
       expect do
         FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false, timeout_duration: -1)
       end.to raise_error("FastlaneCore::BuildWatcher exceeded the '-1' seconds, Stopping now!")
-    end
-
-    describe 'alternate versions' do
-      describe '1.0 with 1.0.0 alternate' do
-        it 'specific version returns one with alternate returns none' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
-          expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
-
-          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{ready_build.platform}")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
-        end
-
-        it 'specific version returns non but alternate returns one' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([processing_build])
-          expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
-
-          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0 - 1) for #{ready_build.platform}")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0', build_version: '1', return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
-        end
-      end
-
-      describe '1.0.0 with 1.0 alternate' do
-        let(:processing_build) do
-          double(
-            app_version: "1.0.0",
-            version: "1",
-            processed?: false,
-            platform: 'IOS',
-            processing_state: 'PROCESSING'
-          )
-        end
-        let(:ready_build) do
-          double(
-            app_version: "1.0.0",
-            version: "1",
-            processed?: true,
-            platform: 'IOS',
-            processing_state: 'VALID'
-          )
-        end
-
-        it 'specific version returns one with alternate returns none' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([processing_build])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([])
-          expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([ready_build])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([])
-
-          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0.0 - 1) for #{ready_build.platform}")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
-
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0.0', build_version: '1', return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
-        end
-
-        it 'specific version returns non but alternate returns one' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([processing_build])
-          expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([ready_build])
-
-          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0.0 - 1) for #{ready_build.platform}")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
-
-          expect(UI).to receive(:important).with("App version is 1.0.0 but build was found while querying 1.0")
-          expect(UI).to receive(:important).with("This shouldn't be an issue as Apple sees 1.0.0 and 1.0 as equal")
-          expect(UI).to receive(:important).with("See docs for more info - https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364")
-
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0.0', build_version: '1', return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
-        end
-      end
-
-      describe '1.0.1 with no alternate versions' do
-        let(:processing_build) do
-          double(
-            app_version: "1.0.1",
-            version: "1",
-            processed?: false,
-            platform: 'IOS',
-            processing_state: 'PROCESSING'
-          )
-        end
-        let(:ready_build) do
-          double(
-            app_version: "1.0.1",
-            version: "1",
-            processed?: true,
-            platform: 'IOS',
-            processing_state: 'VALID'
-          )
-        end
-        let(:options_1_0_1) do
-          { app_id: 'some-app-id', version: '1.0.1', build_number: '1', platform: 'IOS' }
-        end
-
-        it 'specific version returns one with alternate returns none' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_1).and_return([processing_build])
-          expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_1).and_return([ready_build])
-
-          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0.1 - 1) for #{ready_build.platform}")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0.1', build_version: '1', return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
-        end
-
-        it 'specific version returns non but alternate returns one' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_1).and_return([processing_build])
-          expect(FastlaneCore::BuildWatcher).to receive(:sleep)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_1).and_return([ready_build])
-
-          expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: #{ready_build.app_version}, build_version: #{ready_build.version}, platform: #{ready_build.platform}")
-          expect(UI).to receive(:message).with("Waiting for App Store Connect to finish processing the new build (1.0.1 - 1) for #{ready_build.platform}")
-          expect(UI).to receive(:success).with("Successfully finished processing the build #{ready_build.app_version} - #{ready_build.version} for #{ready_build.platform}")
-          found_build = FastlaneCore::BuildWatcher.wait_for_build_processing_to_be_complete(app_id: 'some-app-id', platform: :ios, train_version: '1.0.1', build_version: '1', return_spaceship_testflight_build: false)
-
-          expect(found_build).to eq(ready_build)
-        end
-      end
     end
 
     describe 'no app version to watch' do
@@ -488,8 +331,7 @@ describe FastlaneCore::BuildWatcher do
         end
 
         it 'returns a ready to submit build when select_latest is true' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_nil).and_return([ready_build])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0_nil).and_return([])
+          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0_nil).and_return([ready_build])
           expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: 1.0, build_version: , platform: #{ready_build.platform}")
@@ -501,8 +343,7 @@ describe FastlaneCore::BuildWatcher do
         end
 
         it 'returns a ready to submit build when one build is ready and select_latest is false' do
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_nil).and_return([ready_build])
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0_nil).and_return([])
+          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0_nil).and_return([ready_build])
           expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: 1.0, build_version: , platform: #{ready_build.platform}")
@@ -515,8 +356,7 @@ describe FastlaneCore::BuildWatcher do
 
         it 'raises error when multiple builds are ready and select_latest is false' do
           builds = [newest_ready_build, ready_build]
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_nil).and_return(builds)
-          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0_nil).and_return([])
+          expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0_nil).and_return([builds])
           expect(FastlaneCore::BuildWatcher).to_not(receive(:sleep))
 
           expect(UI).to receive(:message).with("Waiting for processing on... app_id: some-app-id, app_version: 1.0, build_version: , platform: #{ready_build.platform}")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
Includes changes from https://github.com/fastlane/fastlane/pull/22254, adding some more to explore/test.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
