### PR TITLE
[core] fix duplicate builds being matched in BuildWatcher

### DIFF
--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -119,7 +119,7 @@ module FastlaneCore
 
         # Need to filter out duplicate builds (which could be a result from the double X.Y.0 and X.Y queries)
         # See: https://github.com/fastlane/fastlane/issues/22248
-        matched_builds = matched_builds.uniq { |build| build.id }
+        matched_builds = matched_builds.uniq(&:id)
 
         if matched_builds.size > 1 && !select_latest
           error_builds = matched_builds.map do |build|

--- a/fastlane_core/lib/fastlane_core/build_watcher.rb
+++ b/fastlane_core/lib/fastlane_core/build_watcher.rb
@@ -116,6 +116,11 @@ module FastlaneCore
         # Raise error if more than 1 build is returned
         # This should never happen but need to inform the user if it does
         matched_builds = version_matches.map(&:builds).flatten
+
+        # Need to filter out duplicate builds (which could be a result from the double X.Y.0 and X.Y queries)
+        # See: https://github.com/fastlane/fastlane/issues/22248
+        matched_builds = matched_builds.uniq { |build| build.id }
+
         if matched_builds.size > 1 && !select_latest
           error_builds = matched_builds.map do |build|
             "#{build.app_version}(#{build.version}) for #{build.platform} - #{build.processing_state}"

--- a/fastlane_core/spec/build_watcher_spec.rb
+++ b/fastlane_core/spec/build_watcher_spec.rb
@@ -13,7 +13,18 @@ describe FastlaneCore::BuildWatcher do
     end
     let(:ready_build) do
       double(
+        id: '123',
         app_version: "1.0",
+        version: "1",
+        processed?: true,
+        platform: 'IOS',
+        processing_state: 'VALID'
+      )
+    end
+    let(:ready_build_dup) do
+      double(
+        id: '321',
+        app_version: "1.0.0",
         version: "1",
         processed?: true,
         platform: 'IOS',
@@ -133,7 +144,7 @@ describe FastlaneCore::BuildWatcher do
     describe 'multiple builds found' do
       describe 'select_latest is false' do
         it 'raises error select_latest is false' do
-          builds = [ready_build, ready_build]
+          builds = [ready_build, ready_build_dup]
 
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0).and_return([])
           expect(Spaceship::ConnectAPI::Build).to receive(:all).with(options_1_0_0).and_return([])
@@ -155,6 +166,7 @@ describe FastlaneCore::BuildWatcher do
       describe 'select_latest is true' do
         let(:newest_ready_build) do
           double(
+            id: "853",
             app_version: "1.0",
             version: "2",
             processed?: true,
@@ -479,6 +491,7 @@ describe FastlaneCore::BuildWatcher do
 
         let(:newest_ready_build) do
           double(
+            id: '482',
             app_version: "1.0",
             version: "2",
             processed?: true,


### PR DESCRIPTION
### Motivation and Context

Fixes #22248

### Description

- Filter out duplicate builds caused by querying `X.Y.0` and `X.Y`

ℹ️ There is probably a more efficient solution but this one is has least logic change so most shippable ATM 😊 We can improve more later 🤷‍♂️ 

### Testing Steps

Update `Gemfile` and run `bundle install`, `bundle update fastlane`, or `bundle update`

```rb
gem "fastlane", :git => "https://github.com/fastlane/fastlane.git", :branch => "fix-duplicate-builds-in-build-watcher"
```
