### PR TITLE
[scan] Remove unnecessary shellescape when generating -resultBundlePath option

### DIFF
--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -54,10 +54,10 @@ module Scan
         options << "-scmProvider system"
       end
       if config[:result_bundle_path]
-        options << "-resultBundlePath '#{config[:result_bundle_path].shellescape}'"
+        options << "-resultBundlePath #{config[:result_bundle_path].shellescape}"
         Scan.cache[:result_bundle_path] = config[:result_bundle_path]
       elsif config[:result_bundle]
-        options << "-resultBundlePath '#{result_bundle_path(true)}'"
+        options << "-resultBundlePath #{result_bundle_path(true).shellescape}"
       end
       if FastlaneCore::Helper.xcode_at_least?(10)
         options << "-parallel-testing-enabled #{config[:parallel_testing] ? 'YES' : 'NO'}" unless config[:parallel_testing].nil?

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -495,7 +495,7 @@ describe Scan do
                                          "-project ./scan/examples/standard/app.xcodeproj",
                                          "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                          "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
-                                         "-resultBundlePath './fastlane/test_output/app.test_result'",
+                                         "-resultBundlePath ./fastlane/test_output/app.test_result",
                                          :build,
                                          :test
                                        ])
@@ -516,7 +516,28 @@ describe Scan do
                                          "-project ./scan/examples/standard/app.xcodeproj",
                                          "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
                                          "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
-                                         "-resultBundlePath './fastlane/test_output/app.xcresult'",
+                                         "-resultBundlePath ./fastlane/test_output/app.xcresult",
+                                         :build,
+                                         :test
+                                       ])
+        end
+
+        it "uses the correct build command with the example project when using Xcode 11 or later and a custom result bundle path", requires_xcodebuild: true do
+          allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('11')
+          log_path = File.expand_path("~/Library/Logs/scan/app-app.log")
+
+          options = { project: "./scan/examples/standard/app.xcodeproj", result_bundle_path: "./my_test_output/Alice's Man$ion backtick` quote\" 2024-09-30 at 5.10.35 PM (1).xcresult", scheme: 'app' }
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+
+          result = @test_command_generator.generate
+          expect(result).to start_with([
+                                         "set -o pipefail &&",
+                                         "env NSUnbufferedIO=YES xcodebuild",
+                                         "-scheme app",
+                                         "-project ./scan/examples/standard/app.xcodeproj",
+                                         "-destination 'platform=iOS Simulator,id=E697990C-3A83-4C01-83D1-C367011B31EE'",
+                                         "-derivedDataPath #{Scan.config[:derived_data_path].shellescape}",
+                                         "-resultBundlePath ./my_test_output/Alice\\'s\\ Man\\$ion\\ backtick\\`\\ quote\\\"\\ 2024-09-30\\ at\\ 5.10.35\\ PM\\ \\(1\\).xcresult",
                                          :build,
                                          :test
                                        ])


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

I was trying to add the date and time to the result bundle name by using the `result_bundle_path` option in the scan action. However, I found that the output result bundle name contains extra `\`, because the path was unnecessarily shell-escaped. It is already wrapped in single quotes when being passed to `xcodebuild`.

Example: 

```
fastlane scan --result_bundle_path "2024-10-06 at 05.32.33 PM.xcresult"
```

The generated `xcodebuild` command will have this option: 

```
-resultBundlePath '2024-10-06\ at\ 05.32.33\ PM.xcresult'
```

Note the single quotes there, so the actual file name also contains `\`.

### Description

Remove the unnecessary `shellescape` when generating `-resultBundlePath` option in `test_command_generator`.

### Testing Steps

- Run the above example again. 
- The `-resultBundlePath` option in the xcodebuild command should no longer contain `\`.

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
