### PR TITLE
Update app_screenshot.rb - Fix for #22267

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -205,7 +205,9 @@ module Deliver
       return {
         ScreenSize::IOS_67_MESSAGES => [
           [1290, 2796],
-          [2796, 1290]
+          [2796, 1290],
+          [1320, 2868],
+          [2868, 1320]
         ],
         ScreenSize::IOS_65_MESSAGES => [
           [1242, 2688],
@@ -269,7 +271,9 @@ module Deliver
       return {
         ScreenSize::IOS_67 => [
           [1290, 2796],
-          [2796, 1290]
+          [2796, 1290],
+          [1320, 2868],
+          [2868, 1320]
         ],
         ScreenSize::IOS_65 => [
           [1242, 2688],


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
Resolves #22267
Trying to upload screenshots for the iPhone 16 Pro Max leads to an error:
"Invalid screen size (Actual size is 2868x1320. See the specifications to fix https://help.apple.com/app-store-connect/#/devd274dd925)"



### Description

Apple has not created a new ScreenshotDisplayType. APP_IPHONE_67 is also used for iPhone 16 ProMax. Therefore just adding th new resolution to APP_IPHONE_67 fixes the issue

### Testing Steps


