### PR TITLE
[testfairy] Added support for folder_name and other parameters

### DIFF
--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -267,7 +267,10 @@ module Fastlane
                                        optional: true,
                                        env_name: "FL_TESTFAIRY_LANDING_PAGE_MODE",
                                        description: "Visibility of build landing after upload. Can be 'open' or 'closed'",
-                                       default_value: 'open'),
+                                       default_value: 'open',
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The landing page mode can only be open or closed") unless %('open', 'closed').include?(value)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :upload_to_saucelabs,
                                        optional: true,
                                        env_name: "FL_TESTFAIRY_UPLOAD_TO_SAUCELABS",

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -269,7 +269,7 @@ module Fastlane
                                        description: "Visibility of build landing after upload. Can be 'open' or 'closed'",
                                        default_value: 'open',
                                        verify_block: proc do |value|
-                                         UI.user_error!("The landing page mode can only be open or closed") unless %('open', 'closed').include?(value)
+                                         UI.user_error!("The landing page mode can only be open or closed") unless %w(open closed).include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :upload_to_saucelabs,
                                        optional: true,
@@ -277,7 +277,7 @@ module Fastlane
                                        description: "Upload file directly to Sauce Labs. It can be 'on' or 'off'",
                                        default_value: 'off',
                                        verify_block: proc do |value|
-                                         UI.user_error!("The upload to Sauce Labs can only be on or off") unless %('on', 'off').include?(value)
+                                         UI.user_error!("The upload to Sauce Labs can only be on or off") unless %w(on off).include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        optional: true,

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -275,7 +275,10 @@ module Fastlane
                                        optional: true,
                                        env_name: "FL_TESTFAIRY_UPLOAD_TO_SAUCELABS",
                                        description: "Upload file directly to Sauce Labs. It can be 'on' or 'off'",
-                                       default_value: 'off'),
+                                       default_value: 'off',
+                                       verify_block: proc do |value|
+                                         UI.user_error!("The upload to Sauce Labs can only be on or off") unless %('on', 'off').include?(value)
+                                       end),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        optional: true,
                                        env_name: "FL_TESTFAIRY_PLATFORM",

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -257,7 +257,7 @@ module Fastlane
                                        env_name: "FL_TESTFAIRY_TAGS",
                                        description: "Custom tags that can be used to organize your builds",
                                        type: Array,
-                                       default_value: [])
+                                       default_value: []),
           FastlaneCore::ConfigItem.new(key: :folder_name,
                                        optional: true,
                                        env_name: "FL_TESTFAIRY_FOLDER_NAME",
@@ -277,7 +277,7 @@ module Fastlane
                                        optional: true,
                                        env_name: "FL_TESTFAIRY_PLATFORM",
                                        description: "Use if upload build is not iOS or Android. Contact support@testfairy.com for more information",
-                                       default_value: ''),
+                                       default_value: '')
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -98,6 +98,14 @@ module Fastlane
             [key, value]
           when :tags
             [key, value.join(',')]
+          when :folder_name
+            [key, value]
+          when :landing_page_mode
+            [key, value]
+          when :upload_to_saucelabs
+            [key, value]
+          when :platform
+            [key, value]
           else
             UI.user_error!("Unknown parameter: #{key}")
           end
@@ -250,6 +258,26 @@ module Fastlane
                                        description: "Custom tags that can be used to organize your builds",
                                        type: Array,
                                        default_value: [])
+          FastlaneCore::ConfigItem.new(key: :folder_name,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_FOLDER_NAME",
+                                       description: "Name of the dashboard folder that contains this app",
+                                       default_value: ''),
+          FastlaneCore::ConfigItem.new(key: :landing_page_mode,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_LANDING_PAGE_MODE",
+                                       description: "Visibility of build landing after upload. Can be 'open' or 'closed'",
+                                       default_value: 'open'),
+          FastlaneCore::ConfigItem.new(key: :upload_to_saucelabs,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_UPLOAD_TO_SAUCELABS",
+                                       description: "Upload file directly to Sauce Labs. It can be 'on' or 'off'",
+                                       default_value: 'off'),
+          FastlaneCore::ConfigItem.new(key: :platform,
+                                       optional: true,
+                                       env_name: "FL_TESTFAIRY_PLATFORM",
+                                       description: "Use if upload build is not iOS or Android. Contact support@testfairy.com for more information",
+                                       default_value: ''),
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/testfairy.rb
+++ b/fastlane/lib/fastlane/actions/testfairy.rb
@@ -245,7 +245,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :custom,
                                        optional: true,
                                        env_name: "FL_TESTFAIRY_CUSTOM",
-                                       description: "Array of custom options. Contact support@testfairy.com for more information",
+                                       description: "Array of custom options. Contact support for more information",
                                        default_value: ''),
           FastlaneCore::ConfigItem.new(key: :timeout,
                                        env_name: "FL_TESTFAIRY_TIMEOUT",
@@ -276,7 +276,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :platform,
                                        optional: true,
                                        env_name: "FL_TESTFAIRY_PLATFORM",
-                                       description: "Use if upload build is not iOS or Android. Contact support@testfairy.com for more information",
+                                       description: "Use if upload build is not iOS or Android. Contact support for more information",
                                        default_value: '')
         ]
       end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Customers of TestFairy and SauceLabs that use this plugin require passing in parameters to manage their builds. 

They need to define folder names to help with uploaded app organization. Also, apps uploaded through fastlane have open landing/download pages by default. Customers need to ability to define a closed landing page.

### Description

When uploading to TestFairy, according to it's documentation, you can upload builds using the folder_name, landing_page_mode, upload_to_saucelabs and platform parameters.

This was tested by adding these parameters to an uploading using fastlane as follows:

```
publish_to_testfairy(
    api_key: ENV["FL_TESTFAIRY_API_KEY"],
    apk: apk_file,
    folder_name: "nested/folder",
    landing_page_mode: "closed",
    upload_to_saucelabs: "on"
)
```

This yielded a successful upload with the following response:

```
{"status":"ok","build_id":"XXXX","app_name":"XXXX","app_version":"XXXX","file_size":2402770,"build_url":"XXXXX","instrumented_url":"XXXXXX","download_page_url":"https://tsfr.io/XXXX","app_url":"XXXX","invite_testers_url":"XXXX","icon_url":"https://s3.amazonaws.com/XXXX","options":"video-quality=medium,screenshot-interval=1,session-length=60m,video,logcat,shake,cpu,memory,phone-signal,battery,wifi","platform":"Android","tags":["tag1", "tag2"],"metadata":[],"has_testfairy_sdk":false,"landing_page_url":"https://tsfr.io/XXXX","saucelabs":{"app_id":"XXXX","group_id":XXXXX}}
```

### Testing Steps

You can use the code snippet above, just need a valid FL_TESTFAIRY_API_KEY and a valid .apk file.
(PS, all tests on circle-ci shows green, besides "Validate Fastlane.swift generation" which repeatedly times out after 15 minutes or so). 
