### PR TITLE
Correctly select the default configuration for provisioning profile mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+/.build
 /.config
 coverage/
 /InstalledFiles

--- a/gym/lib/gym/export_method.rb
+++ b/gym/lib/gym/export_method.rb
@@ -1,0 +1,9 @@
+module Gym
+  class ExportMethod
+    APP_STORE = "app-store"
+    AD_HOC = "ad-hoc"
+    DEVELOPMENT = "development"
+
+    DEFAULT = APP_STORE
+  end
+end

--- a/gym/lib/gym/generators/package_command_generator.rb
+++ b/gym/lib/gym/generators/package_command_generator.rb
@@ -12,6 +12,10 @@ require_relative 'package_command_generator_xcode7'
 module Gym
   class PackageCommandGenerator
     class << self
+      def default_export_method
+        generator.default_export_method
+      end
+
       def generate
         generator.generate
       end

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -11,13 +11,16 @@ require 'xcodeproj'
 require 'fastlane_core/core_ext/cfpropertylist'
 require_relative '../module'
 require_relative '../error_handler'
+require_relative '../export_method'
 require_relative 'build_command_generator'
 
 module Gym
   # Responsible for building the fully working xcodebuild command
   class PackageCommandGeneratorXcode7
     class << self
-      DEFAULT_EXPORT_METHOD = "app-store"
+      def default_export_method
+        Gym::ExportMethod::DEFAULT
+      end
 
       def generate
         parts = ["/usr/bin/xcrun #{wrap_xcodebuild.shellescape} -exportArchive"]
@@ -171,14 +174,14 @@ module Gym
           hash = normalize_export_options(Gym.config[:export_options])
 
           # Saves configuration for later use
-          Gym.config[:export_method] ||= hash[:method] || DEFAULT_EXPORT_METHOD
+          Gym.config[:export_method] ||= hash[:method] || default_export_method
           Gym.config[:include_symbols] = hash[:uploadSymbols] if Gym.config[:include_symbols].nil?
           Gym.config[:include_bitcode] = hash[:uploadBitcode] if Gym.config[:include_bitcode].nil?
           Gym.config[:export_team_id] ||= hash[:teamID]
         else
           hash = {}
           # Sets default values
-          Gym.config[:export_method] ||= DEFAULT_EXPORT_METHOD
+          Gym.config[:export_method] ||= default_export_method
           Gym.config[:include_symbols] = true if Gym.config[:include_symbols].nil?
           Gym.config[:include_bitcode] = false if Gym.config[:include_bitcode].nil?
         end

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -67,7 +67,7 @@ module Gym
         FastlaneCore::ConfigItem.new(key: :configuration,
                                      short_option: "-q",
                                      env_name: "GYM_CONFIGURATION",
-                                     description: "The configuration to use when building the app. Defaults to 'Release'",
+                                     description: "The configuration to use when building the app. When archiving it is inferred based on export method. If skip archive is set it fallbacks to 'Debug' or the first available configuraiton",
                                      default_value_dynamic: true,
                                      optional: true),
         FastlaneCore::ConfigItem.new(key: :silent,
@@ -106,7 +106,7 @@ module Gym
         FastlaneCore::ConfigItem.new(key: :export_method,
                                      short_option: "-j",
                                      env_name: "GYM_EXPORT_METHOD",
-                                     description: "Method used to export the archive. Valid values are: app-store, validation, ad-hoc, package, enterprise, development, developer-id and mac-application",
+                                     description: "Method used to export the archive. Overrides the method specified in export options. Valid values are: app-store, validation, ad-hoc, package, enterprise, development, developer-id and mac-application. When archiving it fallbacks to app-store unless export options specify a method",
                                      type: String,
                                      optional: true,
                                      verify_block: proc do |value|

--- a/gym/spec/options_spec.rb
+++ b/gym/spec/options_spec.rb
@@ -27,5 +27,85 @@ describe Gym do
 
       expect(Gym.config[:output_name]).to eq("feature_Example")
     end
+
+    it "fallbacks to the 'Debug' configuration when skip build and archive are set", requires_xcodebuild: true do
+      options = { project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_build_archive: true, skip_archive: true }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      configuration = Gym.config[:configuration]
+      expect(configuration).to eq("Debug")
+    end
+
+    it "fallbacks to the 'Debug' configuration when skip archive is set", requires_xcodebuild: true do
+      options = { project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_archive: true }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      configuration = Gym.config[:configuration]
+      expect(configuration).to eq("Debug")
+    end
+
+    it "fallbacks to the 'Debug' configuration for development export method", requires_xcodebuild: true do
+      options = { export_method: "development", project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_archive: false }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      configuration = Gym.config[:configuration]
+      expect(configuration).to eq("Debug")
+    end
+
+    it "fallbacks to the Release configuration for ad-hoc export method", requires_xcodebuild: true do
+      options = { export_method: "ad-hoc", project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_archive: false }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      configuration = Gym.config[:configuration]
+      expect(configuration).to eq("Release")
+    end
+
+    it "fallbacks to the Release configuration for app-store export method", requires_xcodebuild: true do
+      options = { export_method: "app-store", project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_archive: false }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      configuration = Gym.config[:configuration]
+      expect(configuration).to eq("Release")
+    end
+
+    it "returns the specified configuration", requires_xcodebuild: true do
+      options = { configuration: "Debug", project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_archive: false }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      configuration = Gym.config[:configuration]
+      expect(configuration).to eq("Debug")
+    end
+
+    it "doesn't try to detect the export method when skip archive is set", requires_xcodebuild: true do
+      options = { project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_archive: true }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      export_method = Gym.config[:export_method]
+      expect(export_method).to be(nil)
+    end
+
+    it "fallbacks to the method in export options", requires_xcodebuild: true do
+      options = { export_options: { method: "development" }, project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_archive: false }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      export_method = Gym.config[:export_method]
+      expect(export_method).to eq(Gym::ExportMethod::DEVELOPMENT)
+    end
+
+    it "fallbacks to the default export method", requires_xcodebuild: true do
+      options = { project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_archive: false }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      export_method = Gym.config[:export_method]
+      expect(export_method).to eq(Gym::ExportMethod::APP_STORE)
+    end
+
+    it "returns the specified export method", requires_xcodebuild: true do
+      options = { export_method: "ad-hoc", project: "./gym/examples/multipleSchemes/Example.xcodeproj", skip_archive: false }
+      Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
+
+      export_method = Gym.config[:export_method]
+      expect(export_method).to eq(Gym::ExportMethod::AD_HOC)
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves an annoying issue when one was not specifying the `configuration` option in `gym`, and the automatic provisioning profile mapping was instructed to select an incorrect profile, thus failing the archiving process.

#### Why?

This happens because the provisioning profile that can be used for archiving depends on the selected export method.

Usually, we're archiving for ad-hoc, app-store, or other **non-debug** configurations, and by default, if we don't use a custom configuration in which case we would probably specify it in `gym` anyway and didn't have this issue at all, the project is configured to use the `Release` configuration - the default for the `archive` action.

And because `gym` needs to detect some default values it calls `build_xcodebuild_showbuildsettings_command` from `FastlaneCore::Project` indirectly by the `detect_platform` method in `Gym::DetectValues`.

This is causing the `xcodebuild -showBuildSettings` command to run without the `-configuration` option, because it was not specified in the `gym` options in this case.

This makes the above command to run for **the default configuration for the command-line builds** that is specified in Xcode:
![Zrzut ekranu 2024-10-9 o 13 23 21](https://github.com/user-attachments/assets/bb91ac22-0a7b-4beb-89e3-17b3a2e7185d)
It may be set to something different than `Debug`, but as long as it **does not match** the configuration that should be used for a given export method, the detected project configuration and `gym` options will have incorrect values causing problems like this one with archiving. In this case `Debug` vs. `Release`.

#### Why was the mapping not selecting the correct provisioning profile?

Later on `gym` is calling `detect_selected_provisioning_profiles` which calls `merge_profile_mapping` from `CodeSigningMapping`, like this:
```ruby
Gym.config[:export_options] ||= {}
      hash_to_use = (Gym.config[:export_options][:provisioningProfiles] || {}).dup || {} # dup so we can show the original values in `verbose` mode
mapping_object.merge_profile_mapping(primary_mapping: hash_to_use,
                                                           export_method: Gym.config[:export_method])
```
Since we configured `gym` for automatic detection the `Gym.config[:export_options][:provisioningProfiles]` are not provided.
Because the `secondary_mapping` parameter is not provided, the method internally calls `detect_project_profile_mapping`.
```ruby
secondary_mapping ||= self.detect_project_profile_mapping # default to Xcode project
```
Inside this, it tries to determine the configuration by calling:
https://github.com/fastlane/fastlane/blob/bc36cac7ee7d6beabceeb3e42d1f6f0a936b1d3f/gym/lib/gym/code_signing_mapping.rb#L101-L120

In this case the `configuration` option is not specified, and the project does not have `xcshareddata`, so it fallbacks to:
`self.project.default_build_settings(key: "CONFIGURATION")`
which has values collected by the `xcodebuild -showBuildSettings` command mentioned earlier for a **different** configuration than the one expected by the selected export method, thus the mapping following the comment:
`3.3) If none has the right export_method, we'll use whatever is defined in the Xcode project`
returns the wrong profile, and fails the archive at the end of the process 😢 

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
This PR fixes this issue by detecting the correct configuration and export method the `gym` action will use.

It does that by first determining the `export_method` by falling back to `Gym.config[:export_options][:method]`
or the default `app-store` value.

Then it determines the `configuration` depending on whether the `build` or `archive` action is used and what the `export_method` is set to.

Only after that `gym` calls `detect_platform` that triggers the `xcodebuild -showBuildSettings` command to run with the correct `configuration`.

Consequently, a call to `detect_selected_provisioning_profiles` uses correct values to infer the correct mapping.

### Impact on the existing configurations

This PR doesn't break any behavior because it simply adds logic to infer the correct `configuration` if it's not provided.

If in an existing setup the `configuration` is not specified and things were working up to this point - due to the default configuration for the command-line builds matching the configuration for `archive` and the selected export method - the PR still ensures the same result because it will run the `xcodebuild -showBuildSettings` with the same configuration.

If in an existing setup the `configuration` is specified, the PR still ensures it's used for the `xcodebuild -showBuildSettings` command by not inferring anything.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Verify and run the tests that I've added to cover this functionality.