### PR TITLE
[resign] Adding iOS AppClip support to resign

### DIFF
--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -6,7 +6,7 @@ module Fastlane
         require 'sigh'
 
         # try to resign the ipa
-        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name], params[:short_version], params[:bundle_version], params[:bundle_id], params[:use_app_entitlements], params[:keychain_path])
+        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name], params[:short_version], params[:bundle_version], params[:bundle_id], params[:appclip_bundle_id], params[:use_app_entitlements], params[:keychain_path])
           UI.success('Successfully re-signed .ipa 🔏.')
         else
           UI.user_error!("Failed to re-sign .ipa")
@@ -99,6 +99,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :bundle_id,
                                        env_name: "FL_RESIGN_BUNDLE_ID",
                                        description: "Set new bundle ID during resign (`CFBundleIdentifier`)",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :appclip_bundle_id,
+                                       env_name: "FL_RESIGN_APPCLIP_BUNDLE_ID",
+                                       description: "Set new AppClip bundle ID during resign (`CFBundleIdentifier`)",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :use_app_entitlements,
                                        env_name: "FL_USE_APP_ENTITLEMENTS",

--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -113,6 +113,7 @@ module Sigh
         c.option('--bundle_version STRING', String, 'Bundle version to force binary and all nested binaries to use (CFBundleVersion).')
         c.option('--use_app_entitlements', 'Extract app bundle codesigning entitlements and combine with entitlements from new provisioning profile.')
         c.option('-g', '--new_bundle_id STRING', String, 'New application bundle ID (CFBundleIdentifier)')
+        c.option('-h', '--new_appclip_bundle_id STRING', String, 'New AppClip bundle ID (CFBundleIdentifier of AppClip)')
         c.option('--keychain_path STRING', String, 'Path to the keychain that /usr/bin/codesign should use')
 
         c.action do |args, options|

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -8,18 +8,18 @@ module Sigh
   class Resign
     def run(options, args)
       # get the command line inputs and parse those into the vars we need...
-      ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path = get_inputs(options, args)
+      ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, new_appclip_bundle_id, use_app_entitlements, keychain_path = get_inputs(options, args)
       # ... then invoke our programmatic interface with these vars
-      unless resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
+      unless resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, new_appclip_bundle_id, use_app_entitlements, keychain_path)
         UI.user_error!("Failed to re-sign .ipa")
       end
     end
 
-    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
-      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
+    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, new_appclip_bundle_id, use_app_entitlements, keychain_path)
+      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, new_appclip_bundle_id, use_app_entitlements, keychain_path)
     end
 
-    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
+    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, new_appclip_bundle_id, use_app_entitlements, keychain_path)
       resign_path = find_resign_path
 
       if keychain_path
@@ -51,6 +51,7 @@ module Sigh
       bundle_version = "--bundle-version #{bundle_version}" if bundle_version
       verbose = "-v" if FastlaneCore::Globals.verbose?
       bundle_id = "-b '#{new_bundle_id}'" if new_bundle_id
+      appclip_bundle_id = "--app-clip-bundle-id '#{new_appclip_bundle_id}'" if new_appclip_bundle_id
       use_app_entitlements_flag = "--use-app-entitlements" if use_app_entitlements
       specific_keychain = "--keychain-path #{keychain_path.shellescape}" if keychain_path
 
@@ -67,6 +68,7 @@ module Sigh
         use_app_entitlements_flag,
         verbose,
         bundle_id,
+        appclip_bundle_id,
         specific_keychain,
         ipa.shellescape # Output path must always be last argument
       ].join(' ')
@@ -95,6 +97,7 @@ module Sigh
       short_version = options.short_version || nil
       bundle_version = options.bundle_version || nil
       new_bundle_id = options.new_bundle_id || nil
+      new_appclip_bundle_id = options.new_appclip_bundle_id || nil
       use_app_entitlements = options.use_app_entitlements || nil
       keychain_path = options.keychain_path || nil
 
@@ -102,7 +105,7 @@ module Sigh
         UI.important("The provisioning_name (-n) option is not applicable to resign. You should use provisioning_profile (-p) instead")
       end
 
-      return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path
+      return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, new_appclip_bundle_id, use_app_entitlements, keychain_path
     end
 
     def find_resign_path


### PR DESCRIPTION
Adds iOS AppClip support to resign. Can provide explicit new bundle id with `appclip_bundle_id` or will auto append `.Clip` to existing or specified new `bundle_id`.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Adds support to resign to properly handle embedded iOS AppClips.

### Description

This change adds detection for the presence of AppClips when resigning nested apps.  If an AppClip is detected it will allow setting the AppClip's `bundle_id` with the supplied value via the `appclip_bundle_id `argument or default to Apple's standard naming pattern of appending ".Clip" to the parent `bundle_id`.
<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

Changes were test with a sample project that includes an AppClip and was signed with a different team id.  Resigned .ipa was successfully submitted to TestFlight and pass Apple's automated scan.
