### PR TITLE
[notarize] support notarytool --keychain-profile and --keychain options

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -48,9 +48,25 @@ module Fastlane
       def self.notarytool(params, package_path, bundle_id, skip_stapling, print_log, verbose, api_key, compressed_package_path)
         temp_file = nil
 
+        # Auth methods precedence:
+        # 1. Keychain or User/app specific password.
+        # 2. API Key.
+        #
+        # All three options are conflicting, but even if api_key is not specified
+        # as paramerer, it can be retrieved from the lane context.
+        # We must eliminate situation when user provides username or keychain
+        # aurhentication and api_key auth is used.
+
         # Create authorization part of command with either API Key or Apple ID
         auth_parts = []
-        if api_key
+        if params[:keychain_profile]
+          auth_parts << "--keychain-profile #{params[:keychain_profile].shellescape}"
+          auth_parts << "--keychain #{params[:keychain].shellescape}" if params[:keychain]
+        elsif params[:username]
+          auth_parts << "--apple-id #{params[:username]}"
+          auth_parts << "--password #{ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD']}"
+          auth_parts << "--team-id #{params[:asc_provider]}"
+        elsif api_key
           # Writes key contents to temporary file for command
           require 'tempfile'
           temp_file = Tempfile.new
@@ -59,10 +75,6 @@ module Fastlane
           auth_parts << "--key #{temp_file.path}"
           auth_parts << "--key-id #{api_key.key_id}"
           auth_parts << "--issuer #{api_key.issuer_id}"
-        else
-          auth_parts << "--apple-id #{params[:username]}"
-          auth_parts << "--password #{ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD']}"
-          auth_parts << "--team-id #{params[:asc_provider]}"
         end
 
         # Submits package and waits for processing using `xcrun notarytool submit --wait`
@@ -306,7 +318,7 @@ module Fastlane
                                        description: 'Apple ID username',
                                        default_value: username,
                                        optional: true,
-                                       conflicting_options: [:api_key_path, :api_key],
+                                       conflicting_options: [:api_key_path, :api_key, :keychain_profile],
                                        default_value_dynamic: true),
           FastlaneCore::ConfigItem.new(key: :asc_provider,
                                        env_name: 'FL_NOTARIZE_ASC_PROVIDER',
@@ -329,7 +341,7 @@ module Fastlane
                                        env_names: ['FL_NOTARIZE_API_KEY_PATH', "APP_STORE_CONNECT_API_KEY_PATH"],
                                        description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
                                        optional: true,
-                                       conflicting_options: [:username, :api_key],
+                                       conflicting_options: [:username, :api_key, :keychain_profile],
                                        verify_block: proc do |value|
                                          UI.user_error!("API Key not found at '#{value}'") unless File.exist?(value)
                                        end),
@@ -337,9 +349,21 @@ module Fastlane
                                        env_names: ['FL_NOTARIZE_API_KEY', "APP_STORE_CONNECT_API_KEY"],
                                        description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-hash-option)",
                                        optional: true,
-                                       conflicting_options: [:username, :api_key_path],
+                                       conflicting_options: [:username, :api_key_path, :keychain_profile],
                                        sensitive: true,
-                                       type: Hash)
+                                       type: Hash),
+          FastlaneCore::ConfigItem.new(key: :keychain,
+                                       env_name: 'FL_NOTARIZE_KEYCHAIN',
+                                       description: "The path to a keychain file to use for reading the keychain item. If not specified, the default user keychain is used",
+                                       optional: true,
+                                       conflicting_options: [:username, :api_key_path, :api_key],
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :keychain_profile,
+                                       env_name: 'FL_NOTARIZE_KEYCHAIN_PROFILE',
+                                       description: "Authenticate with credentials stored in the Keychain. Use the profile name you provided in the \"xcrun notarytool store-credentials\" command",
+                                       optional: true,
+                                       conflicting_options: [:username, :api_key_path, :api_key],
+                                       type: String)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -85,6 +85,10 @@ module Fastlane
           "--wait"
         ] + auth_parts
 
+        if verbose
+          submit_parts << "--verbose"
+        end
+
         submit_command = submit_parts.join(' ')
         submit_response = Actions.sh(
           submit_command,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

If an engineer does not have access to the API key in its current state, the `notarize` action will require specifying an app-specific password each time developer notarize, which looks less secure.
There is another way: to store username, team id and app-specific password in the keychain.

The flow is the following:
1. Run `xcrun notarytool store-credentials --team-id "TEAM_ID" --password "APP_SPECIFIC_PASSWORD" --apple-id "APPLE_ID"`
2. There will be prompt for the profile name.
3. Specified profile name can be used at any time w/o the need to specify team ID, username and password:
  `xcrun notarytool submit --keychain-profile KEYCHAIN_PROFILE_NAME`

### Description

1. Reordered auth methods. Now specified auth method is used.
2. Added two new options to the `notarize` action to support `--keychain` and `--keychain-profile` options of the `notarytool`.

### Testing Steps

1. Build macOS app.
2. Generate App Specific password.
3. Use `xcrun notarytool store-credentials` to save user auth info to the Keychain.
4. Specify keychain_profile to the notarize action.