### PR TITLE
Issue-22329 fix update_code_signing_settings for projects saved with  Xcode 16

### DIFF
--- a/fastlane/lib/fastlane/actions/automatic_code_signing.rb
+++ b/fastlane/lib/fastlane/actions/automatic_code_signing.rb
@@ -13,7 +13,7 @@ module Fastlane
         UI.user_error!("Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!") unless File.exist?(path)
         UI.message("Updating the Automatic Codesigning flag to #{params[:use_automatic_signing] ? 'enabled' : 'disabled'} for the given project '#{path}'")
 
-        unless project.root_object.attributes["TargetAttributes"]
+        if project.root_object.attributes["TargetAttributes"].nil? && project.object_version.to_i < 55
           UI.user_error!("Seems to be a very old project file format - please open your project file in a more recent version of Xcode")
           return false
         end

--- a/fastlane/lib/fastlane/actions/update_code_signing_settings.rb
+++ b/fastlane/lib/fastlane/actions/update_code_signing_settings.rb
@@ -11,7 +11,7 @@ module Fastlane
         UI.user_error!("Could not find path to project config '#{path}'. Pass the path to your project (not workspace)!") unless File.exist?(path)
         UI.message("Updating the Automatic Codesigning flag to #{params[:use_automatic_signing] ? 'enabled' : 'disabled'} for the given project '#{path}'")
 
-        unless project.root_object.attributes["TargetAttributes"]
+        if project.isTooOldForFastlaneCodesigning?
           UI.user_error!("Seems to be a very old project file format - please open your project file in a more recent version of Xcode")
           return false
         end
@@ -218,6 +218,16 @@ module Fastlane
       def self.is_supported?(platform)
         [:ios, :mac].include?(platform)
       end
+    end
+  end
+end
+
+module Xcodeproj
+  class Project
+    # we have to have the helper function here
+    # otherwise rubocop checking shows too complex function Fastlane.Actions.UpdateCodeSigningSettingsAction.run()
+    def isTooOldForFastlaneCodesigning?
+      return root_object.attributes["TargetAttributes"].nil? && object_version.to_i < 55
     end
   end
 end


### PR DESCRIPTION
==  fix update_code_signing_settings for projects saved with  Xcode 16

If you open any project with Xcode 16 then TargetAttributes key will be removed from pbxproj (if it has empty array)

So this PR solving this issue: https://github.com/fastlane/fastlane/issues/22329

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
NB: one test was failed
 ```
  1) Gym detects the correct platform for a visionOS project
     Failure/Error: expect(Gym.project.visionos?).to eq(true)

       expected: true
            got: false

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -true
       +false

     # ./gym/spec/platform_detection_spec.rb:33:in `block (2 levels) in <top (required)>'
```
But I have checked master branch have the sane issue
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves: #22329

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Now fastlane check about too old project written properly - and Xcode 16 saved project is not handled as too old project

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

1. if pbxproj saved wit hxcode 16 please ensure the update_code_signing_settings command will fail (issue https://github.com/fastlane/fastlane/issues/22329 could be reproduced

2. then checkout the new branch and ensure the issue is gone