### PR TITLE
[import_from_git] Fix crash on first execution with version and cache_path options

### DIFF
--- a/fastlane/lib/fastlane/fast_file.rb
+++ b/fastlane/lib/fastlane/fast_file.rb
@@ -356,13 +356,19 @@ module Fastlane
               end
             else
               begin
+                is_checked_out = Actions.sh("cd #{clone_folder.shellescape} && git diff --name-only #{version}").strip.empty?
+              rescue
+                is_checked_out = false
+              end
+
+              begin
                 # https://stackoverflow.com/a/1593574/865175
                 current_tag = Actions.sh("cd #{clone_folder.shellescape} && git describe --exact-match --tags HEAD").strip
               rescue
                 current_tag = nil
               end
 
-              if current_tag != version
+              if !is_checked_out || current_tag != version
                 Actions.sh("cd #{clone_folder.shellescape} && git checkout #{checkout_param.shellescape} #{checkout_path}")
               end
             end

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -239,6 +239,18 @@ describe Fastlane do
           end").runner.execute(:test)
         end
 
+        it "works with initial checkout where the requested version is the last commit" do
+          allow(UI).to receive(:message)
+          expect(UI).to receive(:message).with(caching_message)
+          expect(UI).to receive(:important).with('Works since v2.1')
+
+          Fastlane::FastFile.new.parse("lane :test_wtf do
+            import_from_git(url: '#{source_directory_path}', version: '2.1', cache_path: '#{cache_directory_path}')
+
+            works
+          end").runner.execute(:test_wtf)
+        end
+
         # Meaning, `git fetch` and `git rebase` are performed when caching is eligible
         # and the version isn't specified.
         it "works with updated branch" do

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -19,8 +19,10 @@ describe Fastlane do
         m['version']
       end
 
+      original_source_directory_path = nil
       source_directory_path = nil
 
+      original_cache_directory_path = nil
       cache_directory_path = nil
       missing_cache_directory_path = nil
 
@@ -28,9 +30,9 @@ describe Fastlane do
         # This is needed for tag searching that `import_from_git` needs.
         ENV["FORCE_SH_DURING_TESTS"] = "1"
 
-        source_directory_path = Dir.mktmpdir("fl_spec_import_from_git_source")
+        original_source_directory_path = Dir.mktmpdir("fl_spec_import_from_git_source")
 
-        Dir.chdir(source_directory_path) do
+        Dir.chdir(original_source_directory_path) do
           if Gem::Version.new(git_version) >= Gem::Version.new("2.28.0")
             `git init -b master`
           else
@@ -96,12 +98,21 @@ describe Fastlane do
           FASTFILE
           `git add .`
           `git commit --message "Version 2.1"`
+          `git tag "2.1" --message "Version 2.1"`
         end
 
-        cache_directory_path = Dir.mktmpdir("fl_spec_import_from_git_cache")
+        original_cache_directory_path = Dir.mktmpdir("fl_spec_import_from_git_cache")
 
         missing_cache_directory_path = Dir.mktmpdir("fl_spec_import_from_git_missing_cache")
         FileUtils.remove_dir(missing_cache_directory_path)
+      end
+
+      before :each do
+        source_directory_path = "#{original_source_directory_path}-#{Time.now.to_i}"
+        FileUtils.copy_entry(original_source_directory_path, source_directory_path)
+
+        cache_directory_path = "#{original_cache_directory_path}-#{Time.now.to_i}"
+        FileUtils.copy_entry(original_cache_directory_path, cache_directory_path)
       end
 
       let(:caching_message) { "Eligible for caching" }
@@ -174,6 +185,9 @@ describe Fastlane do
         # Meaning, a `git pull` is performed when the specified tag is not found
         # in the local clone.
         it "works with new tags" do
+          # Simulating a previous `import_from_git` execution
+          Fastlane::Actions.sh("git clone #{source_directory_path.shellescape} #{File.join(cache_directory_path, source_directory_path.split('/').last).shellescape}")
+
           Dir.chdir(source_directory_path) do
             `git checkout "master" 2>&1`
             File.write('fastlane/Fastfile', <<-FASTFILE)
@@ -209,6 +223,8 @@ describe Fastlane do
               works
             end").runner.execute(:test)
           end.not_to raise_error
+
+          FileUtils.remove_dir(missing_cache_directory_path)
         end
 
         it "works with branch" do
@@ -274,13 +290,16 @@ describe Fastlane do
         end
 
         it "doesn't superfluously execute checkout" do
+          # Simulating a previous `import_from_git` execution
+          Fastlane::Actions.sh("git clone #{source_directory_path.shellescape} #{File.join(cache_directory_path, source_directory_path.split('/').last).shellescape}")
+
           allow(UI).to receive(:message)
           expect(UI).to receive(:message).with(caching_message)
-          expect(UI).to receive(:important).with('Works until v6')
+          expect(UI).to receive(:important).with('Works since v2.1')
           allow(Fastlane::Actions).to receive(:sh).and_call_original
 
           Fastlane::FastFile.new.parse("lane :test do
-            import_from_git(url: '#{source_directory_path}', version: '6', cache_path: '#{cache_directory_path}')
+            import_from_git(url: '#{source_directory_path}', version: '2.1', cache_path: '#{cache_directory_path}')
 
             works
           end").runner.execute(:test)
@@ -294,7 +313,7 @@ describe Fastlane do
         it "works when no cache is provided" do
           allow(UI).to receive(:message)
           expect(UI).not_to receive(:message).with(caching_message)
-          expect(UI).to receive(:important).with('Works until v6')
+          expect(UI).to receive(:important).with('Works since v2.1')
           allow(Fastlane::Actions).to receive(:sh).and_call_original
 
           Fastlane::FastFile.new.parse("lane :test do
@@ -328,12 +347,16 @@ describe Fastlane do
         end").runner.execute(:test)
       end
 
+      after :each do
+        FileUtils.remove_dir(source_directory_path)
+        FileUtils.remove_dir(cache_directory_path)
+      end
+
       after :all do
         ENV.delete("FORCE_SH_DURING_TESTS")
 
-        FileUtils.remove_dir(source_directory_path)
-        FileUtils.remove_dir(missing_cache_directory_path)
-        FileUtils.remove_dir(cache_directory_path)
+        FileUtils.remove_dir(original_source_directory_path)
+        FileUtils.remove_dir(original_cache_directory_path)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Resolves #21079.

Introduced via #20895 in https://github.com/fastlane/fastlane/releases/tag/2.212.0.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

I first decouple import_from_git tests from each other, so I can easier test the fix.

Then, since the initial clone is executed without a checkout, I added a new check to ensure that a checkout gets executed at least once before trying to import the Fastfile.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

