### PR TITLE
Temp

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -12,10 +12,14 @@ module Cert
     def launch
       run
 
-      installed = FastlaneCore::CertChecker.installed?(ENV["CER_FILE_PATH"], in_keychain: ENV["CER_KEYCHAIN_PATH"])
-      UI.message("Verifying the certificate is properly installed locally...")
-      UI.user_error!("Could not find the newly generated certificate installed", show_github_issues: true) unless installed
-      UI.success("Successfully installed certificate #{ENV['CER_CERTIFICATE_ID']}")
+      if Helper.mac?
+        UI.message("Verifying the certificate is properly installed locally...")
+        installed = FastlaneCore::CertChecker.installed?(ENV["CER_FILE_PATH"], in_keychain: ENV["CER_KEYCHAIN_PATH"])
+        UI.user_error!("Could not find the newly generated certificate installed", show_github_issues: true) unless installed
+        UI.success("Successfully installed certificate #{ENV['CER_CERTIFICATE_ID']}")
+      else
+        UI.message("Skipping verifying certificates as it would not work on this operating system.")
+      end
       return ENV["CER_FILE_PATH"]
     end
 
@@ -45,7 +49,7 @@ module Cert
 
       should_create = Cert.config[:force]
       unless should_create
-        cert_path = find_existing_cert
+        cert_path = find_existing_cert if Helper.mac?
         should_create = cert_path.nil?
       end
 
@@ -223,17 +227,21 @@ module Cert
 
       cert_path = store_certificate(certificate, Cert.config[:filename])
 
-      # Import all the things into the Keychain
-      keychain = File.expand_path(Cert.config[:keychain_path])
-      password = Cert.config[:keychain_password]
-      FastlaneCore::KeychainImporter.import_file(private_key_path, keychain, keychain_password: password, skip_set_partition_list: Cert.config[:skip_set_partition_list])
-      FastlaneCore::KeychainImporter.import_file(cert_path, keychain, keychain_password: password, skip_set_partition_list: Cert.config[:skip_set_partition_list])
+      if Helper.mac?
+        # Import all the things into the Keychain
+        keychain = File.expand_path(Cert.config[:keychain_path])
+        password = Cert.config[:keychain_password]
+        FastlaneCore::KeychainImporter.import_file(private_key_path, keychain, keychain_password: password, skip_set_partition_list: Cert.config[:skip_set_partition_list])
+        FastlaneCore::KeychainImporter.import_file(cert_path, keychain, keychain_password: password, skip_set_partition_list: Cert.config[:skip_set_partition_list])
+      else
+        UI.message("Skipping importing certificates as it would not work on this operating system.")
+      end
 
       # Environment variables for the fastlane action
       ENV["CER_CERTIFICATE_ID"] = certificate.id
       ENV["CER_FILE_PATH"] = cert_path
 
-      UI.success("Successfully generated #{certificate.id} which was imported to the local machine.")
+      UI.success("Successfully generated #{certificate.id}" + (Helper.mac? ? " which was imported to the local machine." : ""))
 
       return cert_path
     end

--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -32,8 +32,8 @@ module Match
         username: params[:username],
         team_id: params[:team_id],
         team_name: params[:team_name],
-        keychain_path: FastlaneCore::Helper.keychain_path(params[:keychain_name]),
-        keychain_password: params[:keychain_password],
+        keychain_path: Helper.mac? ? FastlaneCore::Helper.keychain_path(params[:keychain_name]) : "",
+        keychain_password: Helper.mac? ? params[:keychain_password] : "",
         skip_set_partition_list: params[:skip_set_partition_list]
       })
 

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -56,7 +56,7 @@ module Match
 
       unless params[:readonly]
         self.spaceship = SpaceshipEnsure.new(params[:username], params[:team_id], params[:team_name], api_token(params))
-        if params[:type] == "enterprise" && !Spaceship.client.in_house?
+        if params[:type] == "enterprise" && !Spaceship::ConnectAPI.client.in_house?
           UI.user_error!("You defined the profile type 'enterprise', but your Apple account doesn't support In-House profiles")
         end
       end

--- a/match/spec/generator_spec.rb
+++ b/match/spec/generator_spec.rb
@@ -1,6 +1,6 @@
 describe Match::Generator do
   describe 'calling through to other tools' do
-    it 'configures cert correctly for nested execution', requires_keychain: true do
+    it 'configures cert correctly for nested execution' do
       require 'cert'
 
       config = FastlaneCore::Configuration.create(Cert::Options.available_options, {
@@ -9,8 +9,8 @@ describe Match::Generator do
         force: true,
         username: 'username',
         team_id: 'team_id',
-        keychain_path: FastlaneCore::Helper.keychain_path("login.keychain"),
-        keychain_password: 'password',
+        keychain_path: FastlaneCore::Helper.mac? ? FastlaneCore::Helper.keychain_path("login.keychain") : "",
+        keychain_password: FastlaneCore::Helper.mac? ? 'password' : "",
         platform: "ios",
         filename: nil,
         team_name: nil


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Im not sure if whether this will cause regression in other tools & scenarios, dont have a high hope 

### Description

Resolves https://github.com/fastlane/fastlane/issues/22324

After recent [changes to enable enterprise API](https://github.com/fastlane/fastlane/pull/22215), we are noticing regressions in match when using `app_store_connect_api_key` for enterprise.

```
undefined method `in_house?' for nil
```

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

For _enterprise_, match for _enterprise_ with `app_store_connect_api_key`
```
sync_code_signing(
        git_branch: *_my_branch_*,
        team_id: *my_team_id_*,
        template_name: *my_template_name_*,
        type: 'enterprise',
        api_key: app_store_connect_api_key,
        app_identifier: *my_app_identitifers_*,
      )
```

Required Env:
```
APP_STORE_CONNECT_API_KEY_KEY
APP_STORE_CONNECT_API_KEY_KEY_ID
(*) APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64
APP_STORE_CONNECT_API_KEY_ISSUER_ID
APP_STORE_CONNECT_API_KEY_IN_HOUSE
```

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
