### PR TITLE
[match][enterprise] Fix undefined method `in_house?' for nil

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -56,7 +56,7 @@ module Match
 
       unless params[:readonly]
         self.spaceship = SpaceshipEnsure.new(params[:username], params[:team_id], params[:team_name], api_token(params))
-        if params[:type] == "enterprise" && !Spaceship.client.in_house?
+        if params[:type] == "enterprise" && !Spaceship::ConnectAPI.client.in_house?
           UI.user_error!("You defined the profile type 'enterprise', but your Apple account doesn't support In-House profiles")
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

`Spaceship.client.in_house?` doesnt exist anywhere else in the codebase, and causing runtime failure under `enterprise` circumstances

### Description

Resolves https://github.com/fastlane/fastlane/issues/21782 and related to https://github.com/fastlane/fastlane/issues/22324

After recent [changes to enable enterprise API](https://github.com/fastlane/fastlane/pull/22215) and switching `app_store_connect_api_key` for enterprise - noticed errors in match that prevents its from running. 

Error: 
```
undefined method `in_house?' for nil
```

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

For _enterprise_, match for _enterprise_ with `app_store_connect_api_key`
```
sync_code_signing(
   git_branch: *_my_branch_*,
   team_id: *my_team_id_*,
   template_name: *my_template_name_*,
   type: 'enterprise',
   api_key: app_store_connect_api_key,
   app_identifier: *my_app_identitifers_*,
)
```

Required Env:
```
APP_STORE_CONNECT_API_KEY_KEY
APP_STORE_CONNECT_API_KEY_KEY_ID
(*) APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64
APP_STORE_CONNECT_API_KEY_ISSUER_ID
APP_STORE_CONNECT_API_KEY_IN_HOUSE
```

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
