### PR TITLE
[Feature] added fetch teams method

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -764,6 +764,37 @@ module Spaceship
       ENV["FASTLANE_SESSION"] || ENV["SPACESHIP_SESSION"]
     end
 
+    # Fetches Apple Developer Teams
+    #
+    # This method sends a POST request to Apple's Developer Portal API to retrieve the list
+    # of teams associated with the authenticated Apple ID. The response includes details about
+    # each team, such as team ID, team name, and team role. This can be useful for accounts
+    # with access to multiple teams or organizations.
+    #
+    # @return [Faraday::Response] Returns the response object containing the team information,
+    #   which can be accessed via `teams_response.body`.
+    #
+    # @example Fetching and printing team names
+    #   teams_response = fetch_teams
+    #   teams = teams_response.body["teams"]
+    #   team_names = teams.map { |team| team["name"] }
+    #
+    # @raise [Faraday::Error] Raises an error if the request fails or if there's an issue with
+    #   the connection to Apple's servers.
+    #
+    # @note Ensure that you are authenticated with the API before calling this method to avoid
+    #   authentication errors.
+    #
+    def fetch_teams
+      teams_response = request(:post) do |req|
+        req.url("https://developer.apple.com/services-account/QH65B2/account/getTeams")
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['Accept'] = 'application/json, text/javascript'
+      end
+
+      return teams_response
+    end
+
     # Get contract messages from App Store Connect's "olympus" endpoint
     def fetch_program_license_agreement_messages
       all_messages = []

--- a/spaceship/spec/portal/fixtures/fetch_teams.json
+++ b/spaceship/spec/portal/fixtures/fetch_teams.json
@@ -1,0 +1,152 @@
+{
+    "creationTimestamp": "2024-11-06T16:41:47Z",
+    "resultCode": 0,
+    "userLocale": "en_US",
+    "devices": [],
+    "teamAddresses": [],
+    "teams": [
+        {
+            "teamId": "ABC1234",
+            "name": "Team name",
+            "status": "active",
+            "phone": "800-555-5555",
+            "address": {
+                "city": "Tulsa",
+                "state": "Oklahoma",
+                "country": "United States",
+                "countryCode": "US",
+                "postalCode": "74135-2905",
+                "team": {
+                    "extendedTeamAttributes": {},
+                    "xcodeFreeOnly": false,
+                    "id": 12345,
+                    "score": 0
+                },
+                "streetAddress1": "12345 S Mocked Ave"
+            },
+            "entityType": "c",
+            "paymentPlatform": 1,
+            "agent": {
+                "personId": 12345,
+                "firstName": "firstName",
+                "lastName": "lastName",
+                "email": "example@example.com",
+                "developerStatus": "active",
+                "cipsAccess": true,
+                "satoriBypass": false,
+                "eligibleForSatori": false,
+                "enrollmentOnApp": false,
+                "paymentPlatform": null,
+                "fssRecommendation": null,
+                "fssDate": null,
+                "fssNameProcessed": null,
+                "fssConvKitStatus": null,
+                "fssConvKitScore": null,
+                "fssRiskingHonorFlag": false,
+                "fssRiskingOverrideAction": null,
+                "fssRiskingOverrideDate": null,
+                "showFssRiskingOverrideApprove": false,
+                "showFssRiskingOverrideReject": false,
+                "showFssRiskingOverrideReset": false,
+                "fssRiskingErrors": null,
+                "isIDVerificationRequired": false,
+                "isCountryUpdateRequired": false,
+                "hcmStatus": null,
+                "hcmStatusModifiedDate": null,
+                "teamMemberId": "XXXX"
+            },
+            "program": {
+                "type": "ad19",
+                "name": "Apple Developer Program",
+                "autoRenew": true,
+                "dateExpires": 1749513599000,
+                "status": "active",
+                "autoRenewPrice": "US$99"
+            },
+            "userRoles": [
+                "Admin"
+            ],
+            "teamMemberId": "ABCD1234",
+            "adminCount": 1,
+            "memberCount": 0,
+            "serverCount": 0,
+            "nextDeviceResetDate": 1749513599000,
+            "isFeeWaiverApproved": false,
+            "isMDMVendor": false,
+            "acceptedLatestAgreement": false,
+            "appRenewalEligibility": "eligible"
+        },
+        {
+            "teamId": "ABC1234",
+            "name": "Another Team Name",
+            "status": "active",
+            "phone": "800-555-5555",
+            "address": {
+                "city": "Bloomington",
+                "state": "Indiana",
+                "country": "United States",
+                "countryCode": "US",
+                "postalCode": "47404-3947",
+                "team": {
+                    "extendedTeamAttributes": {},
+                    "xcodeFreeOnly": false,
+                    "id": 12345,
+                    "score": 0
+                },
+                "streetAddress1": "12345 S Mocked Ave"
+            },
+            "entityType": "c",
+            "paymentPlatform": 2,
+            "agent": {
+                "personId": 12345,
+                "firstName": "firstName",
+                "lastName": "lastName",
+                "email": "example@example.com",
+                "developerStatus": "active",
+                "cipsAccess": true,
+                "satoriBypass": false,
+                "eligibleForSatori": false,
+                "enrollmentOnApp": false,
+                "paymentPlatform": null,
+                "fssRecommendation": null,
+                "fssDate": null,
+                "fssNameProcessed": null,
+                "fssConvKitStatus": null,
+                "fssConvKitScore": null,
+                "fssRiskingHonorFlag": false,
+                "fssRiskingOverrideAction": null,
+                "fssRiskingOverrideDate": null,
+                "showFssRiskingOverrideApprove": false,
+                "showFssRiskingOverrideReject": false,
+                "showFssRiskingOverrideReset": false,
+                "fssRiskingErrors": null,
+                "isIDVerificationRequired": false,
+                "isCountryUpdateRequired": false,
+                "hcmStatus": null,
+                "hcmStatusModifiedDate": null,
+                "teamMemberId": "XXXX"
+            },
+            "program": {
+                "type": "ad19",
+                "name": "Apple Developer Program",
+                "autoRenew": false,
+                "dateExpires": 1741075199000,
+                "status": "active",
+                "autoRenewPrice": "US$99"
+            },
+            "userRoles": [
+                "Admin"
+            ],
+            "teamMemberId": "ABCD1234",
+            "adminCount": 2,
+            "memberCount": 0,
+            "serverCount": 0,
+            "nextDeviceResetDate": 1741075199000,
+            "isFeeWaiverApproved": false,
+            "isMDMVendor": false,
+            "acceptedLatestAgreement": true,
+            "appRenewalEligibility": "eligible"
+        }
+    ],
+    "developers": []
+}

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -316,6 +316,27 @@ describe Spaceship::Client do
       end
     end
 
+    describe '#fetch_teams' do
+      it 'should make a request to fetch the teams associated with the authenticated Apple ID' do
+        PortalStubbing.adp_stub_fetch_teams
+
+        response = subject.fetch_teams
+
+        expect(
+          a_request(:post, 'https://developer.apple.com/services-account/QH65B2/account/getTeams')
+          .with(
+            headers: {
+              'Content-Type' => 'application/json',
+              'Accept' => 'application/json, text/javascript'
+            }
+          )
+        ).to have_been_made
+
+        expect(response.body["teams"].length).to eq(2)
+
+      end
+    end
+
     describe '#fetch_program_license_agreement_messages' do
       it 'makes a request to fetch all Program License Agreement warnings from Olympus' do
         # Stub the GET request that the method will make

--- a/spaceship/spec/portal/portal_stubbing.rb
+++ b/spaceship/spec/portal/portal_stubbing.rb
@@ -339,6 +339,11 @@ class PortalStubbing
         to_return(status: 404, body: adp_read_fixture_file('download_certificate_failure.html'))
     end
 
+    def adp_stub_fetch_teams
+      stub_request(:post, 'https://developer.apple.com/services-account/QH65B2/account/getTeams').
+        to_return(status: 200, body: adp_read_fixture_file('fetch_teams.json'), headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json, text/javascript' })
+    end
+
     def adp_stub_fetch_program_license_agreement_messages
       stub_request(:get, 'https://appstoreconnect.apple.com/olympus/v1/contractMessages').
         to_return(status: 200, body: adp_read_fixture_file('program_license_agreement_messages.json'), headers: { 'Content-Type' => 'application/json' })


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

I work with a client who develops, manages, and releases countless applications on behalf of their clients. We would like to have a way to check which teams have not renewed the Apple Developer Program membership so we can communicate with each account owner and ask them to sign the pending agreements.

In this case, the information is under the `acceptedLatestAgreement` property inside each team.

### Description

Add a new method named `fetch_teams` in `Spaceship::Portal.client` to retrieve the list of teams associated with the authenticated Apple ID.

### Testing Steps

Unit test: `bundle exec rspec ./spaceship/spec/portal/portal_client_spec.rb`

Code: 
```
require "spaceship"

client = Spaceship::ConnectAPI.login("username", "password")
response = client.portal_client.fetch_teams
teams = response.body["teams"]
team_names = teams.map { |team| team["name"] }

puts team_names
```