### PR TITLE
Update AppStoreConnect Documentation to account for language change

### DIFF
--- a/spaceship/docs/AppStoreConnect.md
+++ b/spaceship/docs/AppStoreConnect.md
@@ -67,7 +67,7 @@ end
 app = Spaceship::ConnectAPI::App.create(name: "App Name",
                                         version_string: "1.0", # initial version
                                         sku: "123",
-                                        primary_locale: "English",
+                                        primary_locale: "en-us",
                                         bundle_id: "com.krausefx.app",
                                         platforms: ["IOS"],
                                         company_name: "krause inc")


### PR DESCRIPTION
Primary local of "English" doesn't work anymore now that it's "English (U.S.) on App Store Connect.

Changed to en-us

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
