### PR TITLE
[supply] Support external_account type for Workload Identity Federation

### DIFF
--- a/supply/spec/fixtures/sample-external-account.json
+++ b/supply/spec/fixtures/sample-external-account.json
@@ -1,0 +1,10 @@
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/locations/global/workforcePools/WORKFORCE_POOL_ID/providers/PROVIDER_ID",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "workforce_pool_user_project": "WORKFORCE_POOL_USER_PROJECT",
+  "credential_source": {
+    "file": "PATH_TO_OIDC_CREDENTIALS_FILE"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

See: https://github.com/fastlane/fastlane/discussions/19869

Currently, `Google::Auth::ServiceAccountCredentials` is used as Google API authentication, but `Google::Auth::ExternalAccount::Credentials` should be used if [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) is used.
https://github.com/fastlane/fastlane/blob/ec78d7d81a6a66e9e89fd29f6e0616d5ba09840a/supply/lib/supply/client.rb#L49

<details>
<summary> Workload Identity Federation sample JSON </summary>

```json5
{
  "type": "external_account",
  "audience": "//iam.googleapis.com/locations/global/workforcePools/WORKFORCE_POOL_ID/providers/PROVIDER_ID",
  "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
  "token_url": "https://sts.googleapis.com/v1/token",
  "workforce_pool_user_project": "WORKFORCE_POOL_USER_PROJECT",
  "credential_source": {
    "file": "PATH_TO_OIDC_CREDENTIALS_FILE"
  }
}
```
</details>


### Description

Check the value corresponding to the `type` key in the JSON, if it is external_account then use `Google::Auth::ExternalAccount::Credentials`, otherwise use `Google::Auth::ServiceAccountCredentials`

- - - 

googleauth gem has [Google::Auth.get_application_default](https://github.com/googleapis/google-auth-library-ruby/blob/546b06ee0987816ea81bb3834ed01554f3bb0453/lib/googleauth/application_default.rb#L53), which returns valid credentials if authentication file or env is enough (e.g. loads GOOGLE_APPLICATION_CREDENTIALS automatically if exists). 

This means fastlane could allow to call supply action even if both json_key_data and json_key are not found and Google::Auth.get_application_default is valid. Therefore, it's better to call supply action if Google::Auth.get_application_default can be obtained without specifying json_key_data or json_key, but it will be a large code diff, so I will try it if this pull request is merged and update docs if Google::Auth.get_application_default use change has merged.


### Testing Steps

it might be easy to use GitHub Actions

1. Setup Workload Identity integration https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines#github-actions
2. Create a GitHub Actions workflow which uses fastlane and [google-github-actions/auth@v2](https://github.com/google-github-actions/auth)
3. Run workflow

```yaml
# GitHub Actions workflow
- id: auth
   uses: google-github-actions/auth@v2
   with:
     create_credentials_file: true # generates credential path as GOOGLE_APPLICATION_CREDENTIALS, CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, GOOGLE_GHA_CREDS_PATH, default: true.
     workload_identity_provider: 'projects/12345/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
     service_account: 'service-account@my-project.iam.gserviceaccount.com'
 ```

```ruby
# Fastfile
lane :download_metadata do
  download_from_play_store(
    package_name: 'com.app.id',
    json_key: ENV['GOOGLE_APPLICATION_CREDENTIALS'], # specify explicitly. this value holds file path like: /home/runner/work/app/app/gha-creds-1234.json
  )
end
```

I prepared a sample repository: https://github.com/mataku/SunsetScrob/pull/652/files uses forked fastlane gem and 

- confirmed current service account JSON keeps working
  - commit: https://github.com/mataku/SunsetScrob/pull/652/commits/0d5af1da774bfc10d51f1214f78dfa3401ec5df0
  - actions workflow: https://github.com/mataku/SunsetScrob/actions/runs/11773706405/job/32791045336
- confirmed new external_account type JSON works: 
  - commit hash: https://github.com/mataku/SunsetScrob/pull/652/commits/faf1d88800028084e2dc4dad183a9c2c593df6f3
  - actions workflow: https://github.com/mataku/SunsetScrob/actions/runs/11772486928/job/32787971810


<details>
<summary> repo diff details </summary>

- Delete fastlane/metadata dir for metadata download check (this is not essentially relevant for this changes)
- Use mataku/fastlane with branch: https://github.com/mataku/fastlane/tree/feature/google-auth-external-account
- Try `download_from_play_store` action
- Try `upload_to_play_store_internal_app_sharing` action

</details>

### References
https://cloud.google.com/iam/docs/workforce-obtaining-short-lived-credentials#use_configuration_files_for_sign-in
https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines#github-actions
