### PR TITLE
moves note about being overwritten to top of README

### DIFF
--- a/match/lib/assets/READMETemplate.md
+++ b/match/lib/assets/READMETemplate.md
@@ -1,10 +1,10 @@
 ## [fastlane match](https://docs.fastlane.tools/actions/match/)
 
+> Do not modify this file, as it gets overwritten every time you run _match_.
+
 This repository contains all your certificates and provisioning profiles needed to build and sign your applications. They are encrypted using OpenSSL via a passphrase.
 
 **Important:** Make sure this repository is set to private and only your team members have access to this repo.
-
-Do not modify this file, as it gets overwritten every time you run _match_.
 
 ### Installation
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Match generates and overwrites a `README.md` file in each repository in which it's deployed. We've often made the mistake of editing the README with our own information only to have it overwritten. Moving the note about the README being auto-generated to the top of the file will help the warning stand out to potential editors.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

This is a simple text change that doesn't affect the performance of any _fastlane_ tools. 

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Testing was done by viewing the changes in a GitHub markdown renderer:

<img width="989" alt="Screenshot 2024-11-13 at 10 37 45 AM" src="https://github.com/user-attachments/assets/0518c9ca-bd0f-471b-81c8-51da90d982d3">

