### PR TITLE
[screengrab] Allow setting of clean status bar after app reinstall

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -254,6 +254,7 @@ module Screengrab
           uninstall_apks(device_serial, @config[:app_package_name], @config[:tests_package_name])
           install_apks(device_serial, app_apk_path, tests_apk_path)
           grant_permissions(device_serial)
+          enable_clean_status_bar(device_serial, sdk_version)
         else
           kill_app(device_serial, @config[:app_package_name])
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.
- [X] I've added or updated relevant unit tests.

### Motivation and Context

After reinstall of app `android.permission.DUMP` permission has to be granted so clean status bar can be configured.

It was like this in the past but was broken in 2021 (see changes in `screengrab/lib/screengrab/runner.rb` around line 255 in https://github.com/fastlane/fastlane/commit/ba8be11dc53ae94693341c3e1b182e6603ca6cd9 )

### Description

Just put one line back in code.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

I tried running code in my own project and 
```
    capture_android_screenshots(
	  # ...	
      reinstall_app: true,
	  # ...
    )
```
starts to generate screenshots with custom time on status bar set in tests.