### PR TITLE
Fix incomplete options being allowed for some parameters

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -99,7 +99,7 @@ module Deliver
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
-                                       UI.user_error!("The platform can only be ios, appletvos, xros or osx") unless %('ios', 'appletvos', 'xros', 'osx').include?(value)
+                                       UI.user_error!("The platform can only be ios, appletvos, xros or osx") unless %w(ios appletvos xros osx).include?(value)
                                      end),
 
         # live version

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -186,7 +186,7 @@ module Fastlane
                                        optional: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, appletvos, xros or osx") unless %('ios', 'appletvos', 'xros', 'osx').include?(value)
+                                         UI.user_error!("The platform can only be ios, appletvos, xros or osx") unless %w(ios appletvos xros osx).include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :team_name,
                                        short_option: "-e",

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -83,7 +83,7 @@ module Fastlane
                                        optional: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, osx, xros or appletvos") unless %('osx', ios', 'appletvos', 'xros').include?(value)
+                                         UI.user_error!("The platform can only be ios, osx, xros or appletvos") unless %w(osx ios appletvos xros).include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",

--- a/fastlane/lib/fastlane/actions/register_device.rb
+++ b/fastlane/lib/fastlane/actions/register_device.rb
@@ -58,7 +58,7 @@ module Fastlane
                                        optional: true,
                                        default_value: platform.empty? ? "ios" : platform,
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios or mac") unless %('ios', 'mac').include?(value)
+                                         UI.user_error!("The platform can only be ios or mac") unless %w(ios mac).include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :udid,
                                        env_name: "FL_REGISTER_DEVICE_UDID",

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -160,7 +160,7 @@ module Fastlane
                                        optional: true,
                                        default_value: platform.empty? ? "ios" : platform,
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios or mac") unless %('ios', 'mac').include?(value)
+                                         UI.user_error!("The platform can only be ios or mac") unless %w(ios mac).include?(value)
                                        end)
         ]
       end

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -84,7 +84,7 @@ module Precheck
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
-                                       UI.user_error!("The platform can only be ios, appletvos, or osx") unless %('ios', 'appletvos', 'osx').include?(value)
+                                       UI.user_error!("The platform can only be ios, appletvos, or osx") unless %w(ios appletvos osx).include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :default_rule_level,
                                      short_option: "-r",

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -54,7 +54,7 @@ module Produce
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
-                                                     UI.user_error!("The platform can only be ios or osx") unless %('ios', 'osx', 'tvos').include?(value)
+                                                     UI.user_error!("The platform can only be ios or osx") unless %w(ios osx tvos).include?(value)
                                                    end),
         FastlaneCore::ConfigItem.new(key: :platforms,
                                      short_option: "-J",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Some of the parameters were verifying the values using [string literals](https://docs.ruby-lang.org/en/master/syntax/literals_rdoc.html#label-25q-3A+Non-Interpolable+String+Literals) instead of [string-array literals](https://docs.ruby-lang.org/en/master/syntax/literals_rdoc.html#label-25w+and+-25W-3A+String-Array+Literals), which meant that they were actually checking if the string `"option1 option2"` contains the provided value, so a value like `"opt"` was incorrectly allowed.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
