### PR TITLE
Add new provisioning profile path for Xcode 16

### DIFF
--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -73,7 +73,16 @@ module FastlaneCore
       end
 
       def profiles_path
-        path = File.expand_path("~") + "/Library/MobileDevice/Provisioning Profiles/"
+        xcode_version = Helper.xcode_version
+
+        # Provisioning profile location changed for XCode 16
+        if xcode_version >= "16"
+          provisioning_path = "/Library/Developer/Xcode/UserData/Provisioning Profiles"
+        else
+          provisioning_path = "/Library/MobileDevice/Provisioning Profiles/"
+        end
+
+        path = File.expand_path("~") + provisioning_path
         # If the directory doesn't exist, create it first
         unless File.directory?(path)
           FileUtils.mkdir_p(path)

--- a/fastlane_core/lib/fastlane_core/provisioning_profile.rb
+++ b/fastlane_core/lib/fastlane_core/provisioning_profile.rb
@@ -77,7 +77,7 @@ module FastlaneCore
 
         # Provisioning profile location changed for XCode 16
         if xcode_version >= "16"
-          provisioning_path = "/Library/Developer/Xcode/UserData/Provisioning Profiles"
+          provisioning_path = "/Library/Developer/Xcode/UserData/Provisioning Profiles/"
         else
           provisioning_path = "/Library/MobileDevice/Provisioning Profiles/"
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
With Xcode 16 provisioning profiles location is changed. Commands that depend on the path, like `sigh` won't work.
This fix checks the Xcode version and if it's greater than or equal to 16 applies the new path.

The change can be found in the release notes:
https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes

### Description
This change adds a check for Xcode version and updates the provisioning profile path inside the `provisioning_profile.rb`.


### Testing Steps

Test on Xcode 16 if commands that make use of the depend on the path work as expected.
