### PR TITLE
[Supply] Allow promoting draft release to inProgress with initial rollout

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -113,7 +113,7 @@ module Supply
       track = tracks.first
       releases = track.releases
 
-      releases = releases.select { |r| only_statuses.include?(r.status) } unless only_statuses.empty? || only_statuses.nil?
+      releases = releases.select { |r| only_statuses.include?(r.status) } unless only_statuses.nil? || only_statuses.empty?
       releases = releases.select { |r| (r.version_codes || []).map(&:to_s).include?(version_code.to_s) } if version_code
 
       if releases.size > 1

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -135,7 +135,11 @@ module Supply
       if track && release
         completed = Supply.config[:rollout].to_f == 1
         release.user_fraction = completed ? nil : Supply.config[:rollout]
-        release.status = Supply::ReleaseStatus::COMPLETED if completed
+        if Supply.config[:release_status]
+          release.status = Supply.config[:release_status]
+        else
+          release.status = completed ? Supply::ReleaseStatus::COMPLETED : Supply::ReleaseStatus::IN_PROGRESS
+        end
 
         # Deleted other version codes if completed because only allowed on completed version in a release
         track.releases.delete_if { |r| !(r.version_codes || []).map(&:to_s).include?(version_code) } if completed

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -106,14 +106,14 @@ module Supply
       end
     end
 
-    def fetch_track_and_release!(track, version_code, status = nil)
+    def fetch_track_and_release!(track, version_code, only_statuses = nil)
       tracks = client.tracks(track)
       return nil, nil if tracks.empty?
 
       track = tracks.first
       releases = track.releases
 
-      releases = releases.select { |r| r.status == status } if status
+      releases = releases.select { |r| only_statuses.include?(r.status) } unless only_statuses.empty? || only_statuses.nil?
       releases = releases.select { |r| (r.version_codes || []).map(&:to_s).include?(version_code.to_s) } if version_code
 
       if releases.size > 1
@@ -124,7 +124,7 @@ module Supply
     end
 
     def update_rollout
-      track, release = fetch_track_and_release!(Supply.config[:track], Supply.config[:version_code], Supply::ReleaseStatus::IN_PROGRESS)
+      track, release = fetch_track_and_release!(Supply.config[:track], Supply.config[:version_code], [Supply::ReleaseStatus::IN_PROGRESS, Supply::ReleaseStatus::DRAFT])
       UI.user_error!("Unable to find the requested track - '#{Supply.config[:track]}'") unless track
       UI.user_error!("Unable to find the requested release on track - '#{Supply.config[:track]}'") unless release
 

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -106,14 +106,14 @@ module Supply
       end
     end
 
-    def fetch_track_and_release!(track, version_code, only_statuses = nil)
+    def fetch_track_and_release!(track, version_code, statuses = nil)
       tracks = client.tracks(track)
       return nil, nil if tracks.empty?
 
       track = tracks.first
       releases = track.releases
 
-      releases = releases.select { |r| only_statuses.include?(r.status) } unless only_statuses.nil? || only_statuses.empty?
+      releases = releases.select { |r| statuses.include?(r.status) } unless statuses.nil? || statuses.empty?
       releases = releases.select { |r| (r.version_codes || []).map(&:to_s).include?(version_code.to_s) } if version_code
 
       if releases.size > 1


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] ~~I've updated the documentation if necessary.~~
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

If you already called `upload_to_play_store` with a `release_status: 'draft'` to initially create a draft release in Google Play, there was so far no option to submit that existing draft to review via `supply`—aka turn its `release_status: 'inProgress'` with a given initial `rollout`).

This is because when you call `upload_to_play_store(track: …, version_code: …, release_status: 'inProgress', rollout: '0.2')`, the `update_rollout` internal method of _fastlane_ called `fetch_track_and_release` with a filter to only have the Google API return releases with a current status of `IN_PROGRESS`, thus failing to find the existing release if it was in "Draft" state instead of already "In Progress".

We ran into this issue while running [our `bundle exec fastlane update_rollouts percent:0.2` lane](https://github.com/Automattic/pocket-casts-android/blob/0d8d505897a26c486815c45d9c2971b147db01ad/fastlane/Fastfile#L362-L387) while we had a Release for the provided `version_code` in Draft status in the Play Store Console, but _fastlane_ was erroring and complaining it was unable to find the release.

### Description

I've updated the code of `fetch_track_and_release` to allow filtering on more than one status, and updated the call in `update_rollout` to filter on both `IN_PROGRESS` and `DRAFT` instead of only `IN_PROGRESS`.

I've then made sure that the rest of the implementation of `update_rollout` updated the `release.status` to the value of `Supply.config[:release_status]` if provided—instead of keeping it untouched unless `rollout.to_f == 1`, in order to allow the release in draft status to be turned into `inProgress` status

### Testing Steps

I've [updated the `Gemfile` of our app repo to point to these changes](https://github.com/Automattic/pocket-casts-android/pull/3341) then ran [our `bundle exec fastlane update_rollouts percent:0.2` lane](https://github.com/Automattic/pocket-casts-android/blob/tooling/fix-update-rollouts/fastlane/Fastfile#L362-L387) while we had a Release for the provided `version_code` in Draft status in the Play Store Console, and confirmed that it successfully submitted the draft release for review with the provided rollout.