### PR TITLE
Fix "tvos" platform option not being allowed anymore for some actions

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -99,7 +99,7 @@ module Deliver
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
-                                       UI.user_error!("The platform can only be ios, appletvos, xros or osx") unless %w(ios appletvos xros osx).include?(value)
+                                       UI.user_error!("The platform can only be ios, appletvos/tvos, xros or osx") unless %w(ios appletvos tvos xros osx).include?(value)
                                      end),
 
         # live version

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -186,7 +186,7 @@ module Fastlane
                                        optional: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, appletvos, xros or osx") unless %w(ios appletvos xros osx).include?(value)
+                                         UI.user_error!("The platform can only be ios, appletvos/tvos, xros or osx") unless %w(ios appletvos tvos xros osx).include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :team_name,
                                        short_option: "-e",

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -83,7 +83,7 @@ module Fastlane
                                        optional: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, osx, xros or appletvos") unless %w(osx ios appletvos xros).include?(value)
+                                         UI.user_error!("The platform can only be ios, osx, xros or appletvos/tvos") unless %w(osx ios appletvos tvos xros).include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -83,7 +83,7 @@ module Fastlane
                                        optional: true,
                                        default_value: "ios",
                                        verify_block: proc do |value|
-                                         UI.user_error!("The platform can only be ios, osx, xros or appletvos/tvos") unless %w(osx ios appletvos tvos xros).include?(value)
+                                         UI.user_error!("The platform can only be ios, osx, xros or appletvos/tvos") unless %w(ios osx xros appletvos tvos).include?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :initial_build_number,
                                        env_name: "INITIAL_BUILD_NUMBER",

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -84,7 +84,7 @@ module Precheck
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
-                                       UI.user_error!("The platform can only be ios, appletvos, or osx") unless %w(ios appletvos osx).include?(value)
+                                       UI.user_error!("The platform can only be ios, appletvos/tvos, or osx") unless %w(ios appletvos tvos osx).include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :default_rule_level,
                                      short_option: "-r",

--- a/precheck/lib/precheck/options.rb
+++ b/precheck/lib/precheck/options.rb
@@ -84,7 +84,7 @@ module Precheck
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
-                                       UI.user_error!("The platform can only be ios, appletvos/tvos, or osx") unless %w(ios appletvos tvos osx).include?(value)
+                                       UI.user_error!("The platform can only be ios, appletvos/tvos or osx") unless %w(ios appletvos tvos osx).include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :default_rule_level,
                                      short_option: "-r",

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -54,7 +54,7 @@ module Produce
                                      optional: true,
                                      default_value: "ios",
                                      verify_block: proc do |value|
-                                                     UI.user_error!("The platform can only be ios or osx") unless %w(ios osx tvos).include?(value)
+                                                     UI.user_error!("The platform can only be ios, osx or tvos") unless %w(ios osx tvos).include?(value)
                                                    end),
         FastlaneCore::ConfigItem.new(key: :platforms,
                                      short_option: "-J",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

@changete reported that the `tvos` platform option is not being allowed anymore for some actions:

https://github.com/fastlane/fastlane/pull/28804#issuecomment-2532169428

1. Since it was (unintentionally) allowed before, and
2. since it looks like they're treated as synonyms:
  https://github.com/fastlane/fastlane/blob/d4fc527a51fb3c99c55c0ef1b8145cdbdd0467eb/spaceship/lib/spaceship/connect_api.rb#L100-L101

it makes sense to explicitly allow it again.

Introduced by #28804.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Before the changes:

```sh
bundle exec fastlane run deliver platform:tvos
<...>
[19:44:12]: Error setting value 'tvos' for option 'platform'
[19:44:12]: You passed invalid parameters to 'deliver'.
[19:44:12]: Check out the error below and available options by running `fastlane action deliver`

[!] The platform can only be ios, appletvos/tvos, xros or osx
```

After the changes:

```sh
bundle exec fastlane run deliver platform:tvos
<...>
[19:44:31]: ---------------------
[19:44:31]: --- Step: deliver ---
[19:44:31]: ---------------------
[19:44:31]: To not be asked about this value, you can specify it using 'username'
[19:44:31]: Your Apple ID Username:
```

```sh
bundle exec fastlane run deliver platform:appletvos
<...>
[19:59:30]: ---------------------
[19:59:30]: --- Step: deliver ---
[19:59:30]: ---------------------
[19:59:30]: To not be asked about this value, you can specify it using 'username'
[19:59:30]: Your Apple ID Username:
```

```sh
bundle exec fastlane run deliver platform:some_invalid_platform
<...>
[20:00:05]: Error setting value 'some_invalid_platform' for option 'platform'
[20:00:05]: You passed invalid parameters to 'deliver'.
[20:00:05]: Check out the error below and available options by running `fastlane action deliver`

[!] The platform can only be ios, appletvos/tvos, xros or osx
```

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
