### PR TITLE
[supply] Handle case where there are more than one release in a track during `update_rollout`

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -141,8 +141,8 @@ module Supply
           release.status = completed ? Supply::ReleaseStatus::COMPLETED : Supply::ReleaseStatus::IN_PROGRESS
         end
 
-        # Its okay to set releases to an array containing the newest release
-        # Google Play will keep previous releases there this release is a partial rollout
+        # It's okay to set releases to an array containing the newest release
+        # Google Play will keep previous releases there untouched
         track.releases = [release]
       else
         UI.user_error!("Unable to find version to rollout in track '#{Supply.config[:track]}'")
@@ -214,7 +214,7 @@ module Supply
       end
 
       if track_to
-        # Its okay to set releases to an array containing the newest release
+        # It's okay to set releases to an array containing the newest release
         # Google Play will keep previous releases there this release is a partial rollout
         track_to.releases = [release]
       else
@@ -439,7 +439,7 @@ module Supply
       tracks = client.tracks(Supply.config[:track])
       track = tracks.first
       if track
-        # Its okay to set releases to an array containing the newest release
+        # It's okay to set releases to an array containing the newest release
         # Google Play will keep previous releases there this release is a partial rollout
         track.releases = [track_release]
       else

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -141,8 +141,9 @@ module Supply
           release.status = completed ? Supply::ReleaseStatus::COMPLETED : Supply::ReleaseStatus::IN_PROGRESS
         end
 
-        # Deleted other version codes if completed because only allowed on completed version in a release
-        track.releases.delete_if { |r| !(r.version_codes || []).map(&:to_s).include?(version_code) } if completed
+        # Its okay to set releases to an array containing the newest release
+        # Google Play will keep previous releases there this release is a partial rollout
+        track.releases = [release]
       else
         UI.user_error!("Unable to find version to rollout in track '#{Supply.config[:track]}'")
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] ~~I've updated the documentation if necessary.~~ N/A
- [ ] ~~I've added or updated relevant unit tests.~~ N/A

### Motivation and Context

When there are more than one release in a Track in Play Store Console, trying to update the rollout leads to the following error:

```
Google Api Error: Invalid request - Too many staged releases specified. - Retrying...
Google Api Error: Invalid request - Too many staged releases specified. - Retrying...
Google Api Error: Invalid request - Too many staged releases specified. - Retrying...
Google Api Error: Invalid request - Too many staged releases specified. - Retrying...
Google Api Error: Invalid request - Too many staged releases specified. - Retrying...
```

This happened to us today while we had a version `7.79-rc-3` with status "halted rollout" and a `7.79-rc-4` with status "Draft" both in the Open Testing track of Play Store Console.

### Description

We already set the `track.releases = [release_to_update]` before calling the client / API in other methods that are updating tracks, like `def promote_to` and `def update_track`, and it's documented that it's ok to do so (i.e. calling the [`edit.tracks.update` API](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks/update) with a `track` that only contains one release will update that release but will keep other releases present in that track untouched). So I just replicated that approach for `def update_rollout` too.

In the previous implementation we had some code to partially handle this case, but said code was only executed `if completed` was true. This new implementation removes that limitation so it also work when we update the rollout of a release still `inProgress` while there are other unrelated releases in the track.

### Testing Steps

I tested this fix with our app we have in Play Store:
 - I applied this fix on my local working copy of `fastlane` then pointed our repo's `Gemfile` to it (`path: …`)
 - I ensured we had more than one release pending in our Open Testing track (`7.79-rc-2` in completed status, `7.79-rc-3` in "halted" status, `7.79-rc-4` in "Draft" status)
 - I ran [our `fastlane update_rollouts percent:0.2` lane](https://github.com/Automattic/pocket-casts-android/blob/0e09fa746893ae9738632914edc6d184733f4a1a/fastlane/Fastfile#L366-L393) and confirmed that it worked and didn't throw the Google Api Error I saw with the same situation before the fix.

<details><summary>Screenshot</summary>
<img width="646" alt="image" src="https://github.com/user-attachments/assets/b62ec83f-760a-4e4c-8559-afd415d138fb" />
</details>