### PR TITLE
[unlock_keychain] fix crash when not having a default keychain

### DIFF
--- a/fastlane/lib/fastlane/actions/unlock_keychain.rb
+++ b/fastlane/lib/fastlane/actions/unlock_keychain.rb
@@ -46,7 +46,7 @@ module Fastlane
           UI.message("Reading existing default keychain")
           Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN] = Fastlane::Actions.sh("security default-keychain").strip
         rescue => e
-          raise unless e.message.include? "security: SecKeychainCopyDefault: A default keychain could not be found."
+          raise unless e.message.include?("security: SecKeychainCopyDefault: A default keychain could not be found.")
         end
         escaped_path = keychain_path.shellescape
         Fastlane::Actions.sh("security list-keychains -s #{escaped_path}", log: false)

--- a/fastlane/lib/fastlane/actions/unlock_keychain.rb
+++ b/fastlane/lib/fastlane/actions/unlock_keychain.rb
@@ -42,7 +42,11 @@ module Fastlane
       end
 
       def self.replace_keychain_in_search_list(keychain_path)
-        Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN] = Fastlane::Actions.sh("security default-keychain", log: false).strip
+        begin
+          Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN] = Fastlane::Actions.sh("security default-keychain", log: false).strip
+        rescue
+          UI.message("Unable to read existing default keychain - maybe none was set")
+        end
         escaped_path = keychain_path.shellescape
         Fastlane::Actions.sh("security list-keychains -s #{escaped_path}", log: false)
       end

--- a/fastlane/lib/fastlane/actions/unlock_keychain.rb
+++ b/fastlane/lib/fastlane/actions/unlock_keychain.rb
@@ -43,9 +43,10 @@ module Fastlane
 
       def self.replace_keychain_in_search_list(keychain_path)
         begin
-          Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN] = Fastlane::Actions.sh("security default-keychain", log: false).strip
-        rescue
-          UI.message("Unable to read existing default keychain - maybe none was set")
+          UI.message("Reading existing default keychain")
+          Actions.lane_context[Actions::SharedValues::ORIGINAL_DEFAULT_KEYCHAIN] = Fastlane::Actions.sh("security default-keychain").strip
+        rescue => e
+          raise unless e.message.include? "security: SecKeychainCopyDefault: A default keychain could not be found."
         end
         escaped_path = keychain_path.shellescape
         Fastlane::Actions.sh("security list-keychains -s #{escaped_path}", log: false)


### PR DESCRIPTION
This PR makes it possible to run `unlock_keychain` with `add_to_search_list: :replace` without an existing default keychain.

### Checklist

- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.
- [X] I've added or updated relevant unit tests.

### Motivation and Context

It is currently not possible to run `unlock_keychain` with `add_to_search_list: :replace` if you don't have an existing default keychain. Even when also providing `set_default: true`. For us this currently means that we have to first run `create_keychain` with `default_keychain: true` in order to create a temporary default dummy keychain and then unlock the actual keychain that we want to use with `unlock_keychain` and then finally remove the unused dummy keychain with `delete_keychain`. 

### Description

This PR wraps the read of the original/existing default keychain with a `begin-rescue` in order to make sure that it doesn't crash when no default keychain is set. 

I can add that the reading of the original default keychain is stored in `SharedValues::ORIGINAL_DEFAULT_KEYCHAIN` but that it is undocumented for the `unlock_keychain` action (it is however documented for the `create_keychain` task https://docs.fastlane.tools/actions/create_keychain/#create_keychain). 

I tried adding some tests for this (inside `fastlane/spec/actions_specs/unlock_keychain_spec.rb`) but I'm a rookie Ruby developer so I didn't manage to make it work because the test wouldn't fail even though I didn't have a default keychain set.

Finally, I can add that a lot of tests (`bundle exec rspec`) fail if you don't have a default keychain set. Also in master of the fastlane repo without my changes from this PR.

### Testing Steps

This can be tested by removing the default keychain on your machine:
```
# Get default keychain
security default-keychain

# Delete default keychain
security delete keychain <default keychain from previous command>

# Validate that no default keychain is set
security default-keychain
```

 and then run a simple lane that creates and unlocks a keychain:
```
lane :test do
  create_keychain(
    name: "Temporary_keychain",
    password: "abcd1234",
    default_keychain: false
  )

  unlock_keychain( # Unlock an existing keychain and add it to the keychain search list
    path: "Temporary_keychain",
    password: "abcd1234",
    add_to_search_list: :replace,
    set_default: true
  )
end
```
Note: To set your login keychain as the default again, run `security default-keychain -s <default keychain from the first command you ran>`, probably something like `security default-keychain -s /Users/<your-username>/Library/Keychains/login.keychain-db`.

If there is no default keychain, the output will now look like this:

```
...
[13:26:50]: -----------------------------
[13:26:50]: --- Step: unlock_keychain ---
[13:26:50]: -----------------------------
[13:26:50]: Reading existing default keychain 
[13:26:50]: Unlocking keychain at path: /Users/***/Library/Keychains/Temporary_keychain-db
```

Instead of failing with:
```
[13:22:02]: Called from Fastfile at line 383
[13:22:02]: ```
[13:22:02]:     381:	  )
[13:22:02]:     382:
[13:22:02]:  => 383:	  unlock_keychain( # Unlock an existing keychain and add it to the keychain search list
[13:22:02]:     384:	    path: "Temporary_keychain",
[13:22:02]:     385:	    password: "abcd1234",
[13:22:02]: ```
[13:22:02]: Shell command exited with exit status 1 instead of 0.
```