### PR TITLE
New options for Download action

### DIFF
--- a/fastlane/spec/actions_specs/download_spec.rb
+++ b/fastlane/spec/actions_specs/download_spec.rb
@@ -27,6 +27,28 @@ describe Fastlane do
           end").runner.execute(:test)
         end.to raise_error("Error fetching remote file: execution expired")
       end
+
+      it "file contents is store in the sensitive lane context" do
+        url = "https://google.com/remoteFile.json"
+        result = Fastlane::FastFile.new.parse("lane :test do
+          download(url: '#{url}', sensitive: true)
+        end").runner.execute(:test)
+
+        correct = { 'status' => 'ok' }
+        expect(result).to eq(correct)
+        sensitive_context = Fastlane::Actions.lane_context.instance_variable_get(:@sensitive_context)
+        expect(sensitive_context[Fastlane::Actions::SharedValues::DOWNLOAD_CONTENT]).not_to be_nil
+      end
+
+      it "returns the downloaded JSON as plain text" do
+        url = "https://google.com/remoteFile.json"
+        result = Fastlane::FastFile.new.parse("lane :test do
+          download(url: '#{url}', plain_text: true)
+        end").runner.execute(:test)
+
+        expect(result).to be_kind_of(String)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::DOWNLOAD_CONTENT]).to be_kind_of(String)
+      end
     end
   end
 end


### PR DESCRIPTION
Add options to Download action to not turn JSON into an object, and to place the download contents into the sensitive lane context

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

When working with secret keys, I'd like to be able to download files without having to write them to disk first. In the case of `upload_to_play_store`, it expects a JSON string for the parameter `json_key_data`, but because `download` turns it into an object, I have to then turn it back into a string.

Also when using the `download` action, if any error occurs, the secret can be leaked accidentally when the lane context is logged.

### Description

Added an option to Download action that puts the download file into the sensitive lane context
Added an option to Download action that prevents a JSON payload being turned into an object and just returns it as a string

### Testing Steps

Have added tests covering these new options, and because the defaults match the previous behaviour, the existing tests continue to pass.

Have also verified with a test fastfile that the secret is not logged when an exception is raised

<img width="752" alt="Screenshot 2023-02-08 at 21 39 06" src="https://user-images.githubusercontent.com/168025/217658165-9a3073e6-105d-4ec6-9f42-7e0acc7bdc07.png">
<img width="915" alt="Screenshot 2023-02-08 at 21 30 51" src="https://user-images.githubusercontent.com/168025/217658170-e6ec7d35-ea08-486d-be92-c54ea61c6702.png">