### PR TITLE
fix: add `abbrev`/`mutex_m` gems as no longer in ruby 3.4+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,8 @@ gem "xcov", "~> 1.4.1"
 gem "yard", "~> 0.9.11"
 
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
-  # A module used to abbreviate strings.
   gem "abbrev"
+  gem "mutex_m"
 end
 
 gemspec(path: ".")

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,11 @@ gem "xcov", "~> 1.4.1"
 # A documentation generation tool for Ruby.
 gem "yard", "~> 0.9.11"
 
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.4.0')
+  # A module used to abbreviate strings.
+  gem "abbrev"
+end
+
 gemspec(path: ".")
 
 plugins_path = File.join(File.expand_path("..", __FILE__), "fastlane", "Pluginfile")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
+    abbrev (0.1.2)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.15)
@@ -365,6 +366,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  abbrev
   climate_control (~> 0.2.0)
   coveralls (~> 0.8.13)
   danger (~> 8.0)
@@ -394,4 +396,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   2.3.21
+   2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,7 @@ GEM
     multipart-post (2.0.0)
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
+    mutex_m (0.3.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)
@@ -377,6 +378,7 @@ DEPENDENCIES
   fastlane-plugin-ruby
   fastlane-plugin-slack_train (>= 0.2.0)
   mime-types (>= 1.16, < 4.0)
+  mutex_m
   ox (= 2.13.2)
   pry
   pry-byebug


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

---

seeing this warning and adding abbrev gem explicitly for ruby 3.4+

> [⠙] 🚀 /opt/homebrew/Cellar/ruby/3.4.1/lib/ruby/3.4.0/did_you_mean/core_ext/name_error.rb:11: warning: abbrev is not part of the default gems starting from Ruby 3.4.0. Install abbrev from RubyGems.

- https://github.com/ruby/ruby/pull/9607
- https://github.com/ruby/ruby/pull/9456

---
- https://github.com/Homebrew/homebrew-core/pull/202443