### PR TITLE
Support Ruby 3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.6)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
@@ -71,6 +73,7 @@ GEM
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
+    base64 (0.2.0)
     bigdecimal (3.1.8)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -213,6 +216,7 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)
+    nkf (0.2.0)
     no_proxy_fix (0.1.2)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -314,7 +318,7 @@ GEM
       rack-protection (= 2.2.4)
       tilt (~> 2.0)
     slack-notifier (2.3.2)
-    strscan (3.1.0)
+    strscan (3.1.2)
     sync (0.5.0)
     sysrandom (1.0.5)
     term-ansicolor (1.7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     fastlane (2.227.2)
       CFPropertyList (>= 2.3, < 4.0.0)
+      abbrev (~> 0.1.2)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
       aws-sdk-s3 (~> 1.0)
@@ -10,6 +11,7 @@ PATH
       bundler (>= 1.12.0, < 3.0.0)
       colored (~> 1.2)
       commander (~> 4.6)
+      csv (~> 3.3)
       dotenv (>= 2.1.1, < 3.0.0)
       emoji_regex (>= 0.1, < 4.0)
       excon (>= 0.71.0, < 1.0.0)
@@ -29,6 +31,7 @@ PATH
       jwt (>= 2.1.0, < 3)
       mini_magick (>= 4.9.4, < 5.0.0)
       multipart-post (>= 2.0.0, < 3.0.0)
+      mutex_m (~> 0.3.0)
       naturally (~> 2.2)
       optparse (>= 0.1.1, < 1.0.0)
       plist (>= 3.1.0, < 4.0.0)
@@ -51,6 +54,7 @@ GEM
       base64
       nkf
       rexml
+    abbrev (0.1.2)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.15)
@@ -100,6 +104,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    csv (3.3.2)
     danger (8.6.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
@@ -213,6 +218,7 @@ GEM
     multipart-post (2.0.0)
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
+    mutex_m (0.3.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -110,4 +110,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('xcodeproj', '>= 1.13.0', '< 2.0.0') # Modify Xcode projects
   spec.add_dependency('xcpretty-travis-formatter', '>= 0.0.3', '< 2.0.0')
   spec.add_dependency('xcpretty', '~> 0.4.1') # prettify xcodebuild output
+  spec.add_dependency('mutex_m', '~> 0.3.0') # workaround for httpclient gem dependency resolution
+  spec.add_dependency('csv', '~> 3.3') # CSV Reading and Writing
+  spec.add_dependency('abbrev', '~> 0.1.2') # commander and highline dependency for Ruby 3.4 or higher. highline (~> 3.0.0) depends on Ruby >= 3.0
 end

--- a/fastlane/spec/fast_file_spec.rb
+++ b/fastlane/spec/fast_file_spec.rb
@@ -395,15 +395,25 @@ describe Fastlane do
         it "use case 4: Passing parameters to another lane" do
           ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/SwitcherFastfile')
           ff.runner.execute(:lane5, :ios)
+          expected_value = if Gem::Version.create('3.4.0') <= Gem::Version.create(RUBY_VERSION)
+                             "{key: :value}"
+                           else
+                             "{:key=>:value}"
+                           end
 
-          expect(File.read("/tmp/deliver_result.txt")).to eq("{:key=>:value}")
+          expect(File.read("/tmp/deliver_result.txt")).to eq(expected_value)
         end
 
         it "use case 5: Calling a method outside of the current platform" do
           ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/SwitcherFastfile')
           ff.runner.execute(:call_general_lane, :ios)
+          expected_value = if Gem::Version.create('3.4.0') <= Gem::Version.create(RUBY_VERSION)
+                             "{random: :value}"
+                           else
+                             "{:random=>:value}"
+                           end
 
-          expect(File.read("/tmp/deliver_result.txt")).to eq("{:random=>:value}")
+          expect(File.read("/tmp/deliver_result.txt")).to eq(expected_value)
         end
 
         it "calling a lane that doesn't exist" do
@@ -471,18 +481,33 @@ lane :beta do
   sigh(app_identifier: "hi"
 end
 RUBY
-        expect(UI).to receive(:user_error!).with(%r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSyntaxError:17: syntax error, unexpected (keyword_end|end|`end'), expecting '\)'})
+        expected_message = if Gem::Version.create('3.4.0') <= Gem::Version.create(RUBY_VERSION)
+                             %r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSyntaxError:17: syntax error found}
+                           else
+                             %r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSyntaxError:17: syntax error, unexpected (keyword_end|end|`end'), expecting '\)'}
+                           end
+        expect(UI).to receive(:user_error!).with(expected_message)
         ff = Fastlane::FastFile.new('./fastlane/spec/fixtures/fastfiles/FastfileSyntaxError')
       end
 
       it "properly shows an error message when there is a syntax error in the Fastfile from string" do
         # ruby error message differs in 2.5 and earlier. We use a matcher
-        expect(UI).to receive(:content_error).with(<<-RUBY.chomp, "3")
+        expected_arg = if Gem::Version.create('3.4.0') <= Gem::Version.create(RUBY_VERSION)
+                         "2"
+                       else
+                         "3"
+                       end
+        expect(UI).to receive(:content_error).with(<<-RUBY.chomp, expected_arg)
         lane :test do
           cases = [:abc,
         end
         RUBY
-        expect(UI).to receive(:user_error!).with(/Syntax error in your Fastfile on line 3: \(eval\):3: syntax error, unexpected (keyword_end|end|`end'), expecting '\]'\n        end\n.*/)
+        expected_message = if Gem::Version.create('3.4.0') <= Gem::Version.create(RUBY_VERSION)
+                             /Syntax error in your Fastfile on line 2: \(eval\):2: syntax errors found.*/
+                           else
+                             /Syntax error in your Fastfile on line 3: \(eval\):3: syntax error, unexpected (keyword_end|end|`end'), expecting '\]'\n        end\n.*/
+                           end
+        expect(UI).to receive(:user_error!).with(expected_message)
 
         ff = Fastlane::FastFile.new.parse(<<-RUBY.chomp)
         lane :test do
@@ -513,7 +538,12 @@ lane :beta do
   sigh(app_identifier: "hi"
 end
 RUBY
-        expect(UI).to receive(:user_error!).with(%r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSyntaxError:17: syntax error, unexpected (keyword_end|end|`end'), expecting '\)'})
+        expected_message = if Gem::Version.create('3.4.0') <= Gem::Version.create(RUBY_VERSION)
+                             %r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSyntaxError:17: syntax error found}
+                           else
+                             %r{Syntax error in your Fastfile on line 17: fastlane/spec/fixtures/fastfiles/FastfileSyntaxError:17: syntax error, unexpected (keyword_end|end|`end'), expecting '\)'}
+                           end
+        expect(UI).to receive(:user_error!).with(expected_message)
         ff.import('./FastfileSyntaxError')
       end
 

--- a/spaceship/spec/portal/portal_permission_spec.rb
+++ b/spaceship/spec/portal/portal_permission_spec.rb
@@ -17,12 +17,14 @@ describe Spaceship::Portal do
           "httpCode": 200
         }', headers: { 'Content-Type' => 'application/json' })
 
-      expected_error_message = "User spaceship@krausefx.com (Team ID XXXXXXXXXX) doesn't have enough permission for the following action: download_certificate (You are not permitted to download this certificate.)"
+      expected_error_message = "User spaceship@krausefx.com (Team ID XXXXXXXXXX) doesn't have enough permission for the following action:"
 
       cert = Spaceship::Certificate.all.first
-      expect do
+      begin
         cert.download
-      end.to raise_exception(Spaceship::Client::InsufficientPermissions, expected_error_message)
+      rescue Spaceship::Client::InsufficientPermissions => ex
+        expect(ex.to_s).to include(expected_error_message)
+      end
     end
   end
 end

--- a/spaceship/spec/tunes/app_version_spec.rb
+++ b/spaceship/spec/tunes/app_version_spec.rb
@@ -250,7 +250,12 @@ describe Spaceship::AppVersion, all: true do
         version.description = "Yes"
         raise "Should raise exception before"
       rescue NoMethodError => ex
-        expect(ex.to_s).to include("undefined method `description='")
+        expected_message = if Gem::Version.create('3.4.0') <= Gem::Version.create(RUBY_VERSION)
+                             "undefined method 'description='"
+                           else
+                             "undefined method `description='"
+                           end
+        expect(ex.to_s).to include(expected_message)
       end
     end
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

closes https://github.com/fastlane/fastlane/issues/29183

Ruby 3.4 has been released. fastlane causes error according to standard gem change
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/

<details>
<summary> error log </summary>

```shell
$ bundle exec fastlane android build_debug
[⠋] 🚀 /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/helper.rb:1: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
/Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/httpclient-2.8.3/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
/Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/highline-2.0.3/lib/highline.rb:17: warning: abbrev was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add abbrev to your Gemfile or gemspec to silence this warning.
bundler: failed to load command: fastlane (/Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/bin/fastlane)
[⠙] 🚀 /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane/lib/fastlane/cli_tools_distributor.rb:126:in 'Fastlane::CLIToolsDistributor.take_off': uninitialized constant FastlaneCore::UpdateChecker (NameError)

        FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)
                    ^^^^^^^^^^^^^^^
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/bin/fastlane:23:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/bin/fastlane:25:in 'Kernel#load'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/bin/fastlane:25:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli/exec.rb:58:in 'Kernel.load'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli/exec.rb:58:in 'Bundler::CLI::Exec#kernel_load'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli.rb:455:in 'Bundler::CLI#exec'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/vendor/thor/lib/thor.rb:527:in 'Bundler::Thor.dispatch'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/exe/bundle:28:in 'block in <top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/exe/bundle:20:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/bin/bundle:25:in 'Kernel#load'
        from /Users/mataku/.rbenv/versions/3.4.0/bin/bundle:25:in '<main>'
/Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- abbrev (LoadError)
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/highline-2.0.3/lib/highline.rb:17:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'Kernel.require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/highline-2.0.3/lib/highline/import.rb:10:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'Kernel.require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/commander-4.6.0/lib/commander.rb:26:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'Kernel.require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/configuration/commander_generator.rb:1:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/configuration/configuration.rb:4:in 'Kernel#require_relative'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/configuration/configuration.rb:4:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/android_package_name_guesser.rb:3:in 'Kernel#require_relative'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/android_package_name_guesser.rb:3:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/analytics/app_identifier_guesser.rb:1:in 'Kernel#require_relative'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/analytics/app_identifier_guesser.rb:1:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/analytics/action_completion_context.rb:1:in 'Kernel#require_relative'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core/analytics/action_completion_context.rb:1:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core.rb:6:in 'Kernel#require_relative'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane_core/lib/fastlane_core.rb:6:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'Kernel.require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane/lib/fastlane.rb:1:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'Kernel.require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/3.4.0+1/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/fastlane/lib/fastlane/cli_tools_distributor.rb:41:in 'Fastlane::CLIToolsDistributor.take_off'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/fastlane-2.226.0/bin/fastlane:23:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/bin/fastlane:25:in 'Kernel#load'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/bin/fastlane:25:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli/exec.rb:58:in 'Kernel.load'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli/exec.rb:58:in 'Bundler::CLI::Exec#kernel_load'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli.rb:455:in 'Bundler::CLI#exec'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/vendor/thor/lib/thor.rb:527:in 'Bundler::Thor.dispatch'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/exe/bundle:28:in 'block in <top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/lib/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
        from /Users/mataku/.rbenv/versions/3.4.0/lib/ruby/gems/3.4.0+1/gems/bundler-2.5.22/exe/bundle:20:in '<top (required)>'
        from /Users/mataku/.rbenv/versions/3.4.0/bin/bundle:25:in 'Kernel#load'
        from /Users/mataku/.rbenv/versions/3.4.0/bin/bundle:25:in '<main>'
```

</details>

### Description

#### Update dependencies
- Update CFPropertyLIst which depends on base64 and nkf

#### Add Ruby 3.4 standard gem dependencies
- Add abbrev gem explicitly for commander and highline
  - highline 3.0 requires Ruby >= 3.0
  - Looks like highline 3.0 stops using abbrev as a result, so we can remove abbrev dependency if updates
- Add `csv` gem explicitly for pilot
- Add `mutex_m` gem explicitly for httpclient gem. We can remove it if there will be httpclient release

#### Fix tests
Fix specs according to error message style change on Ruby 3.4. 

https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/

> - Error messages and backtrace displays have been changed.
>  - Use a single quote instead of a backtick as a opening quote. [[Feature #16495](https://bugs.ruby-lang.org/issues/16495)]
>  - Display a class name before a method name (only when the class has a permanent name). [[Feature #19117](https://bugs.ruby-lang.org/issues/19117)]
>  - Kernel#caller, Thread::Backtrace::Location’s methods, etc. are also changed accordingly.
>
>Old:
>test.rb:1:in `foo': undefined method `time' for an instance of Integer
>        from test.rb:2:in `<main>'
>
>New:
>test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
>        from test.rb:2:in '<main>'


I separated the expected results for Ruby 3.4 and earlier. It may not be a problem if regex is used, but since the assertion of the error message does not seem to be that important, I separated the error messages without preparing a regex to match both.

- - - 

I think it's better to add Ruby 3.4 as the CI matrix, but I didn't know the maintenance policy. Let me know if you need it.
https://github.com/fastlane/fastlane/blob/master/.circleci/config.yml


### Testing Steps

For Ruby 3.3 or lower, please check the CI result. 

For Ruby 3.4:

```shell
rbenv local 3.4.0
bundle exec fastlane validate_repo
```