### PR TITLE
feat: `set_github_release` `make_latest` parameter

### DIFF
--- a/fastlane/lib/fastlane/actions/set_github_release.rb
+++ b/fastlane/lib/fastlane/actions/set_github_release.rb
@@ -21,6 +21,7 @@ module Fastlane
           'tag_name' => params[:tag_name],
           'draft' => !!params[:is_draft],
           'prerelease' => !!params[:is_prerelease],
+          'make_latest' => !!params[:make_latest],
           'generate_release_notes' => !!params[:is_generate_release_notes]
         }
         payload['name'] = params[:name] if params[:name]
@@ -220,6 +221,12 @@ module Fastlane
                                        description: "Whether the release should be marked as prerelease",
                                        optional: true,
                                        default_value: false,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :make_latest,
+                                       env_name: "FL_SET_GITHUB_RELEASE_MKE_LATEST",
+                                       description: "Whether the release should be set as the latest release for the repository",
+                                       optional: true,
+                                       default_value: true,
                                        type: Boolean),
           FastlaneCore::ConfigItem.new(key: :is_generate_release_notes,
                                        env_name: "FL_SET_GITHUB_RELEASE_IS_GENERATE_RELEASE_NOTES",

--- a/fastlane/lib/fastlane/actions/set_github_release.rb
+++ b/fastlane/lib/fastlane/actions/set_github_release.rb
@@ -223,7 +223,7 @@ module Fastlane
                                        default_value: false,
                                        type: Boolean),
           FastlaneCore::ConfigItem.new(key: :make_latest,
-                                       env_name: "FL_SET_GITHUB_RELEASE_MKE_LATEST",
+                                       env_name: "FL_SET_GITHUB_RELEASE_MAKE_LATEST",
                                        description: "Whether the release should be set as the latest release for the repository",
                                        optional: true,
                                        default_value: true,


### PR DESCRIPTION
This adds the missing `make_latest` parameter available in the github API https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
