### PR TITLE
Switch Onesignal to use the new Organization keys

### DIFF
--- a/fastlane/lib/fastlane/actions/onesignal.rb
+++ b/fastlane/lib/fastlane/actions/onesignal.rb
@@ -53,7 +53,7 @@ module Fastlane
         payload["organization_id"] = organization_id unless organization_id.nil?
 
         # here's the actual lifting - POST or PUT to OneSignal
-        json_headers = { 'Content-Type' => 'application/json', 'Authorization' => "Basic #{auth_token}" }
+        json_headers = { 'Content-Type' => 'application/json', 'Authorization' => "Key #{auth_token}" }
         url = +'https://api.onesignal.com/apps'
         url << '/' + app_id if is_update
         uri = URI.parse(url)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Onesignal killed the old user auth keys, they no longer work and you can't create new ones. Here's a conversation with their support...

Me:
> where can I create a user authorization key for use with the API?

> my key I was using is no longer working

Them:
> Hi there,
> Thank you for reaching out!
​
> On the 14th of November 2024, we announced the new rich API key system described above and started deprecating legacy API keys. The legacy user auth keys will be deprecated on the 1st of March 2025, and legacy app REST API keys will be deprecated in Q1 2026. ​https://documentation.onesignal.com/docs/keys-and-ids#migrating-from-legacy-api-keys
> 1. This is the guide on generating the new rich auth key. https://documentation.onesignal.com/docs/keys-and-ids#api-keys ​Instead of using "Basic { REST API Key}", the new authentication key would be using this format "Key {Rich_Authentication_Key}". This will replace the REST API key. ​
> 2. For APIs using the user auth key, it will be replaced with the Organization API key: ​https://documentation.onesignal.com/docs/keys-and-ids#organization-api-key A sample request via the API can be found here along with other information: https://documentation.onesignal.com/reference/quick-start-api-guide#rest-api-key Let us know if you have any additional questions.
> Thanks.

<img width="921" alt="Screenshot 2025-01-03 at 12 34 44 PM" src="https://github.com/user-attachments/assets/d959f2a6-f590-448d-9807-db0cf3ccafa1" />

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
Changed the auth header as per their instructions

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
