### PR TITLE
[fastlane_core] recognize AWS CodeBuild CI service as a CI environment

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_ci.rb
@@ -8,7 +8,7 @@ module Fastlane
         end
 
         case detect_provider(params)
-        when 'circleci'
+        when 'circleci', 'codebuild'
           setup_output_paths
         end
 
@@ -20,7 +20,7 @@ module Fastlane
       end
 
       def self.detect_provider(params)
-        params[:provider] || (Helper.is_circle_ci? ? 'circleci' : nil)
+        params[:provider] || (Helper.is_circle_ci? ? 'circleci' : nil) || (Helper.is_codebuild? ? 'codebuild' : nil)
       end
 
       def self.setup_keychain(params)

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -84,6 +84,7 @@ module FastlaneCore
       return ENV.key?('CIRCLECI')
     end
 
+    # @return [boolean] true if environment variable CODEBUILD_BUILD_ARN is set
     def self.is_codebuild?
       return ENV.key?('CODEBUILD_BUILD_ARN')
     end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -74,7 +74,7 @@ module FastlaneCore
       return true if self.is_circle_ci?
 
       # Check for Jenkins, Travis CI, ... environment variables
-      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CI', 'APPCENTER_BUILD_ID', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS', 'TF_BUILD', 'GITHUB_ACTION', 'GITHUB_ACTIONS', 'BITRISE_IO', 'BUDDY'].each do |current|
+      ['JENKINS_HOME', 'JENKINS_URL', 'TRAVIS', 'CI', 'APPCENTER_BUILD_ID', 'TEAMCITY_VERSION', 'GO_PIPELINE_NAME', 'bamboo_buildKey', 'GITLAB_CI', 'XCS', 'TF_BUILD', 'GITHUB_ACTION', 'GITHUB_ACTIONS', 'BITRISE_IO', 'BUDDY', 'CODEBUILD_BUILD_ARN'].each do |current|
         return true if FastlaneCore::Env.truthy?(current)
       end
       return false

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -84,6 +84,10 @@ module FastlaneCore
       return ENV.key?('CIRCLECI')
     end
 
+    def self.is_codebuild?
+      return ENV.key?('CODEBUILD_BUILD_ARN')
+    end
+
     def self.operating_system
       return "macOS" if RUBY_PLATFORM.downcase.include?("darwin")
       return "Windows" if RUBY_PLATFORM.downcase.include?("mswin")


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary. - Pull Request - https://github.com/fastlane/docs/pull/1270
- [x] I've added or updated relevant unit tests.

### Motivation and Context

This PR helps _fastlane_ recognize AWS CodeBuild as CI service enabling CodeBuild customers to use _fastlane_.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
Added CodeBuild env variable to the list of environment variable to check if the request is coming from CI service.
Tested running the `bundle exec rspec` command locally. Also tested internally on CodeBuild system. 
