### PR TITLE
Fix - Handle nil expiration_date in valid? method for pending certifi…

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -52,6 +52,7 @@ module Spaceship
       end
 
       def valid?
+        return false if expiration_date.nil? || expiration_date.empty?
         Time.parse(expiration_date) > Time.now
       end
 

--- a/spaceship/spec/connect_api/models/certificate_spec.rb
+++ b/spaceship/spec/connect_api/models/certificate_spec.rb
@@ -46,5 +46,21 @@ describe Spaceship::ConnectAPI::Certificate do
         expect(certificate.valid?).to eq(true)
       end
     end
+
+    context 'when expiration_date is nil' do
+      before { certificate.expiration_date = nil }
+
+      it 'should be invalid' do
+        expect(certificate.valid?).to eq(false)
+      end
+    end
+
+    context 'when expiration_date is an empty string' do
+      before { certificate.expiration_date = "" }
+
+      it 'should be invalid' do
+        expect(certificate.valid?).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
…cates

Handle nil expiration_date in valid? method for pending certificates

Commit Description:
This update improves the valid? method in Spaceship::ConnectAPI::Certificate by handling cases where expiration_date is nil or an empty string. This issue occurs when a certificate is in a "Pending Approval" state in the Apple Developer portal, leading to fastlane match failures.

Changes:
Updated valid? to return false if expiration_date is nil or an empty string. Added test cases to ensure valid? handles:
nil expiration date (pending approval case).
Empty expiration date string.
Expired certificates.
Valid certificates.
This prevents crashes due to Time.parse(nil) and improves stability when fetching certificates.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
