### PR TITLE
Add keychain_name param to setup_ci action

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_ci.rb
@@ -34,7 +34,7 @@ module Fastlane
           return
         end
 
-        keychain_name = "fastlane_tmp_keychain"
+        keychain_name = params[:keychain_name]
         ENV["MATCH_KEYCHAIN_NAME"] = keychain_name
         ENV["MATCH_KEYCHAIN_PASSWORD"] = ""
 
@@ -108,7 +108,12 @@ module Fastlane
                                        env_name: "FL_SETUP_CI_TIMEOUT",
                                        description: "Set a custom timeout in seconds for keychain.  Set `0` if you want to specify 'no time-out'",
                                        type: Integer,
-                                       default_value: 3600)
+                                       default_value: 3600),
+          FastlaneCore::ConfigItem.new(key: :keychain_name,
+                                       env_name: "FL_SETUP_CI_KEYCHAIN_NAME",
+                                       description: "Set a custom keychain name",
+                                       type: String,
+                                       default_value: "fastlane_tmp_keychain")
         ]
       end
 
@@ -128,6 +133,11 @@ module Fastlane
           'setup_ci(
             provider: "circleci",
             timeout: 0
+          )',
+          'setup_ci(
+            provider: "circleci",
+            timeout: 0,
+            keychain_name: "custom_keychain_name"
           )'
         ]
       end

--- a/fastlane/spec/actions_specs/setup_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_ci_spec.rb
@@ -72,21 +72,17 @@ describe Fastlane do
             described_class.run(force: true)
           end
         end
-      end
 
-      describe "keychain_name option" do
-        before do
-          allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
-        end
-
-        it "accepts a custom keychain_name" do
-          allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
-
-          expect(Fastlane::UI).to receive(:message).with("Enabling match readonly mode.")
-          expect(Fastlane::UI).to receive(:message).with("Creating temporary keychain: \"example_keychain_name\".")
-
-          described_class.run(force: true, keychain_name: "example_keychain_name")
-        end
+        describe "keychain_name option" do
+          it "accepts a custom keychain_name" do
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+  
+            expect(Fastlane::UI).to receive(:message).with("Enabling match readonly mode.")
+            expect(Fastlane::UI).to receive(:message).with("Creating temporary keychain: \"example_keychain_name\".")
+  
+            described_class.run(force: true, keychain_name: "example_keychain_name")
+          end
+        end  
       end
     end
 

--- a/fastlane/spec/actions_specs/setup_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_ci_spec.rb
@@ -16,7 +16,7 @@ describe Fastlane do
             expect(Fastlane::UI).to receive(:message).with("Creating temporary keychain: \"fastlane_tmp_keychain\".")
             expect(Fastlane::UI).to receive(:message).with("Skipping Log Path setup as FL_OUTPUT_DIR is unset")
 
-            described_class.run(provider: "circleci")
+            described_class.run(provider: "circleci", keychain_name: "fastlane_tmp_keychain")
           end
 
           it "skips on linux" do
@@ -41,7 +41,7 @@ describe Fastlane do
             expect(Fastlane::UI).to receive(:message).with("Creating temporary keychain: \"fastlane_tmp_keychain\".")
             expect(Fastlane::UI).to receive(:message).with("Skipping Log Path setup as FL_OUTPUT_DIR is unset")
 
-            described_class.run(force: true)
+            described_class.run(force: true, keychain_name: "fastlane_tmp_keychain")
           end
 
           it "skips on linux" do
@@ -61,7 +61,7 @@ describe Fastlane do
             expect(Fastlane::UI).to receive(:message).with("Enabling match readonly mode.")
             expect(Fastlane::UI).to receive(:message).with("Creating temporary keychain: \"fastlane_tmp_keychain\".")
 
-            described_class.run(force: true)
+            described_class.run(force: true, keychain_name: "fastlane_tmp_keychain")
           end
 
           it "skips on linux" do
@@ -71,6 +71,21 @@ describe Fastlane do
 
             described_class.run(force: true)
           end
+        end
+      end
+
+      describe "keychain_name option" do
+        before do
+          allow(Fastlane::Actions::CreateKeychainAction).to receive(:run).and_return(nil)
+        end
+
+        it "accepts a custom keychain_name" do
+          allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+
+          expect(Fastlane::UI).to receive(:message).with("Enabling match readonly mode.")
+          expect(Fastlane::UI).to receive(:message).with("Creating temporary keychain: \"example_keychain_name\".")
+
+          described_class.run(force: true, keychain_name: "example_keychain_name")
         end
       end
     end
@@ -164,8 +179,8 @@ describe Fastlane do
         end
 
         it "sets the MATCH_KEYCHAIN_NAME env var" do
-          described_class.setup_keychain(timeout: 3600)
-          expect(ENV["MATCH_KEYCHAIN_NAME"]).to eql("fastlane_tmp_keychain")
+          described_class.setup_keychain(timeout: 3600, keychain_name: "example_keychain_name")
+          expect(ENV["MATCH_KEYCHAIN_NAME"]).to eql("example_keychain_name")
         end
 
         it "sets the MATCH_KEYCHAIN_PASSWORD env var" do

--- a/fastlane/spec/actions_specs/setup_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_ci_spec.rb
@@ -76,13 +76,13 @@ describe Fastlane do
         describe "keychain_name option" do
           it "accepts a custom keychain_name" do
             allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
-  
+
             expect(Fastlane::UI).to receive(:message).with("Enabling match readonly mode.")
             expect(Fastlane::UI).to receive(:message).with("Creating temporary keychain: \"example_keychain_name\".")
-  
+
             described_class.run(force: true, keychain_name: "example_keychain_name")
           end
-        end  
+        end
       end
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Before this change it was impossible to provide a `name` param to the `create_keychain` action which is called by the `setup_ci` action. This change adds a `keychain_name` param to the `setup_ci` action which will be passed as `name` to the `create_keychain` action.

We use a self hosted MacOS GitHub Actions runner which can run multiple jobs in parallel. When the setup is started twice (or more) exactly at the same time, the creation of the keychain sometimes fails in one of the jobs with the following error:

```
/Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane_core/lib/fastlane_core/ui/interface.rb:153:in `shell_error!': [!] Shell command exited with exit status 48 instead of 0. (FastlaneCore::Interface::FastlaneShellError)
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in `method_missing'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/helper/sh_helper.rb:80:in `sh_control_output'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/helper/sh_helper.rb:12:in `sh'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/actions/create_keychain.rb:28:in `run'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/actions/setup_ci.rb:42:in `setup_keychain'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/actions/setup_ci.rb:15:in `run'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/runner.rb:263:in `block (2 levels) in execute_action'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/actions/actions_helper.rb:69:in `execute_action'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/runner.rb:255:in `block in execute_action'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/runner.rb:229:in `chdir'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/runner.rb:229:in `execute_action'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/runner.rb:157:in `trigger_action_by_name'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/fast_file.rb:159:in `method_missing'
	from Fastfile:29:in `block (2 levels) in parsing_binding'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/runner.rb:291:in `execute_flow_block'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/runner.rb:46:in `block in execute'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/runner.rb:45:in `chdir'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/runner.rb:45:in `execute'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/lane_manager.rb:46:in `cruise_lane'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/command_line_handler.rb:34:in `handle'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/commands_generator.rb:110:in `block (2 levels) in run'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in `run!'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/commands_generator.rb:363:in `run'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/commands_generator.rb:43:in `start'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/fastlane/lib/fastlane/cli_tools_distributor.rb:123:in `take_off'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/gems/fastlane-2.225.0/bin/fastlane:23:in `<top (required)>'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/bin/fastlane:25:in `load'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/bin/fastlane:25:in `<main>'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/bin/ruby_executable_hooks:22:in `eval'
	from /Users/githubrunner/.rvm/gems/ruby-3.2.3/bin/ruby_executable_hooks:22:in `<main>'
```

This happens because of a timing issue where the first job creates the keychain before the second job is able to tell this happened and subsequently also tries to create the keychain.

To mitigate this issue, we would like to give each job its own keychain (which is actually preferred for other reason too). But currently the `setup_ci` action does not allow us to do this.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

The `setup_ci` action has a new `keychain_name` param which is used as the `name` param of the `create_keychain` action.