### PR TITLE
[supply] Fix #28995 and `release_status` vs `rollout` parameters

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -136,7 +136,7 @@ module Supply
         rollout = Supply.config[:rollout]
         status = Supply.config[:release_status]
 
-        # If release_status not provided explicitly (and thus defaults to 'completed'), but rollout is privided with a value < 1.0, then set to 'inProgress' instead
+        # If release_status not provided explicitly (and thus defaults to 'completed'), but rollout is provided with a value < 1.0, then set to 'inProgress' instead
         status = Supply::ReleaseStatus::IN_PROGRESS if status == Supply::ReleaseStatus::COMPLETED && !rollout.nil? && rollout.to_f < 1
         # If release_status is set to 'inProgress' but rollout is provided with a value = 1.0, then set to 'completed' instead
         status = Supply::ReleaseStatus::COMPLETED if status == Supply::ReleaseStatus::IN_PROGRESS && rollout.to_f == 1

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -481,8 +481,8 @@ describe Supply do
         it "sets status to #{expected_status} and user_fraction to #{expected_user_fraction.inspect}" do
           expect(client).to receive(:update_track).with('alpha', track) do |_, track_param|
             expect(track_param.releases).to eq([release])
-            expect(track_param.releases.first.user_fraction).to eq(expected_user_fraction)
             expect(track_param.releases.first.status).to eq(expected_status)
+            expect(track_param.releases.first.user_fraction).to eq(expected_user_fraction)
           end
           subject.update_rollout
         end

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -532,7 +532,7 @@ describe Supply do
             rollout: 0.5,
             release_status: Supply::ReleaseStatus::DRAFT,
             expected_status: Supply::ReleaseStatus::DRAFT,
-            expected_user_fraction: 0.5
+            expected_user_fraction: nil # user_fraction is only valid for IN_PROGRESS or HALTED status
         end
 
         context 'when release_status is IN_PROGRESS' do
@@ -559,7 +559,7 @@ describe Supply do
             rollout: 1.0,
             release_status: Supply::ReleaseStatus::DRAFT,
             expected_status: Supply::ReleaseStatus::DRAFT,
-            expected_user_fraction: 1.0
+            expected_user_fraction: nil # user_fraction is only valid for IN_PROGRESS or HALTED status
         end
 
         context 'when release_status is IN_PROGRESS' do

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -453,5 +453,152 @@ describe Supply do
         end
       end
     end
+
+    describe '#update_rollout' do
+      let(:subject) { Supply::Uploader.new }
+      let(:client) { double('client') }
+      let(:version_code) { 123 }
+      let(:config) { { track: 'alpha' } }
+      let(:release) { AndroidPublisher::TrackRelease.new }
+      let(:track) { AndroidPublisher::Track.new }
+
+      before do
+        Supply.config = config
+        allow(Supply::Client).to receive(:make_from_config).and_return(client)
+        allow(client).to receive(:tracks).with('alpha').and_return([track])
+        allow(release).to receive(:version_codes).and_return([version_code])
+        allow(client).to receive(:update_track)
+      end
+
+      shared_examples 'updates track with correct status and rollout' do |rollout:, release_status:, expected_status:, expected_user_fraction:|
+        before do
+          release.status = Supply::ReleaseStatus::IN_PROGRESS
+          track.releases = [release]
+          config[:rollout] = rollout
+          config[:release_status] = release_status
+        end
+
+        it "sets status to #{expected_status} and user_fraction to #{expected_user_fraction.inspect}" do
+          expect(client).to receive(:update_track).with('alpha', track) do |_, track_param|
+            expect(track_param.releases).to eq([release])
+            expect(track_param.releases.first.user_fraction).to eq(expected_user_fraction)
+            expect(track_param.releases.first.status).to eq(expected_status)
+          end
+          subject.update_rollout
+        end
+      end
+
+      shared_examples 'raises error for invalid rollout' do |rollout:, release_status:, expected_error:|
+        before do
+          release.status = Supply::ReleaseStatus::IN_PROGRESS
+          track.releases = [release]
+          config[:rollout] = rollout
+          config[:release_status] = release_status
+        end
+
+        it 'raises an error' do
+          expect { subject.update_rollout }.to raise_error(expected_error)
+        end
+      end
+
+      context 'when rollout is nil' do
+        context 'when release_status is DRAFT' do
+          include_examples 'updates track with correct status and rollout',
+            rollout: nil,
+            release_status: Supply::ReleaseStatus::DRAFT,
+            expected_status: Supply::ReleaseStatus::DRAFT,
+            expected_user_fraction: nil
+        end
+
+        context 'when release_status is IN_PROGRESS' do
+          include_examples 'raises error for invalid rollout',
+            rollout: nil,
+            release_status: Supply::ReleaseStatus::IN_PROGRESS,
+            expected_error: /You need to provide a rollout value when release_status is set to 'inProgress'/
+        end
+
+        context 'when release_status is COMPLETED' do
+          include_examples 'updates track with correct status and rollout',
+            rollout: nil,
+            release_status: Supply::ReleaseStatus::COMPLETED,
+            expected_status: Supply::ReleaseStatus::COMPLETED,
+            expected_user_fraction: nil
+        end
+      end
+
+      context 'when rollout is 0.5' do
+        context 'when release_status is DRAFT' do
+          include_examples 'updates track with correct status and rollout',
+            rollout: 0.5,
+            release_status: Supply::ReleaseStatus::DRAFT,
+            expected_status: Supply::ReleaseStatus::DRAFT,
+            expected_user_fraction: 0.5
+        end
+
+        context 'when release_status is IN_PROGRESS' do
+          include_examples 'updates track with correct status and rollout',
+            rollout: 0.5,
+            release_status: Supply::ReleaseStatus::IN_PROGRESS,
+            expected_status: Supply::ReleaseStatus::IN_PROGRESS,
+            expected_user_fraction: 0.5
+        end
+
+        context 'when release_status is COMPLETED' do
+          include_examples 'updates track with correct status and rollout',
+            rollout: 0.5,
+            release_status: Supply::ReleaseStatus::COMPLETED,
+            # We want to ensure the implementation forces status of IN_PROGRESS when explicit rollout < 1.0 is provided
+            expected_status: Supply::ReleaseStatus::IN_PROGRESS,
+            expected_user_fraction: 0.5
+        end
+      end
+
+      context 'when rollout is 1.0' do
+        context 'when release_status is DRAFT' do
+          include_examples 'updates track with correct status and rollout',
+            rollout: 1.0,
+            release_status: Supply::ReleaseStatus::DRAFT,
+            expected_status: Supply::ReleaseStatus::DRAFT,
+            expected_user_fraction: 1.0
+        end
+
+        context 'when release_status is IN_PROGRESS' do
+          include_examples 'updates track with correct status and rollout',
+            rollout: 1.0,
+            release_status: Supply::ReleaseStatus::IN_PROGRESS,
+            # We want to ensure the implementation forces status of COMPLETED when explicit rollout = 1.0 is provided
+            expected_status: Supply::ReleaseStatus::COMPLETED,
+            expected_user_fraction: nil
+        end
+
+        context 'when release_status is COMPLETED' do
+          include_examples 'updates track with correct status and rollout',
+            rollout: 1.0,
+            release_status: Supply::ReleaseStatus::COMPLETED,
+            expected_status: Supply::ReleaseStatus::COMPLETED,
+            expected_user_fraction: nil
+        end
+      end
+
+      context 'when track is not found' do
+        before do
+          allow(client).to receive(:tracks).with('alpha').and_return([])
+        end
+
+        it 'raises an error' do
+          expect { subject.update_rollout }.to raise_error(/Unable to find the requested track/)
+        end
+      end
+
+      context 'when release is not found' do
+        before do
+          allow(track).to receive(:releases).and_return([])
+        end
+
+        it 'raises an error' do
+          expect { subject.update_rollout }.to raise_error(/Unable to find the requested release on track/)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] ~~I've updated the documentation if necessary.~~
- [x] I've added or updated relevant unit tests.

### Motivation and Context

After I introduced [this change](https://github.com/fastlane/fastlane/pull/28960/files#diff-97356a4e0e18355c574a489a006bb0caccb0bfe74f62a6fca7fbce037b4f67a2R138-R142) to _supply_ in `2.226.0`, this broke the behavior for some users in https://github.com/fastlane/fastlane/issues/28995.

This is because when they provided a `rollout:` parameter with an <1.0 value, but didn't provide an explicit `release_status:` parameter (and it thus defaulted to `'completed'`), the new implementation made the API call with `release_status: 'completed', user_fraction: rollout` instead of using `inProgress` implicitly for rollout values <1.0

<details><summary>The before/after and history of past implementations</summary>
Before https://github.com/fastlane/fastlane/issues/28995, it was ok to not change the `release.status` of the existing track and status that was fetched by the API to be modified by `#update_rollout`, because before that PR we only fetched releases that were in `inProgress` state, so we were guaranteed that the `status` property of those `release` objects we got back already had the `release.status = 'inProgress'`, and all the old implementation was doing was thus to update that `release.status` to `'completed'` only if a value of `rollout: '1.0'` was provided, leaving the value unchanged to `'inProgress'` otherwise.

But after https://github.com/fastlane/fastlane/issues/28995 landed, the `release` objects we got back from the API could be either `inProgress` or `draft`. This is why that part of the implementation / logic was changed to make sure the provided value for the `release_status` parameter was applied, so that it could be changed from `draft` to `inProgress` and vice-versa too if that's what the caller explicitly asked. But that implementation failed to account for the fact that the `release_status` parameter (`ConfigItem`) of _supply_ had a default value of `'completed'` which means that if the user didn't provide a `release_status` parameter explicitly, the new code would attempt to set it to `'completed'` even if `rollout:` was provided with a <1.0 value.
</details>

### Description

This new implementation was written by writing the Unit Tests (rspecs) first, to write down all the possible use cases that we could encounter with regards to combinations of `release_status`/`rollout` parameter pairs and write down the expectation we have for each of those cases. Then I adjusted the implementation to make sure those tests passed (TDD FTW!)

Here's the various use cases covered by the unit tests and the behavior we implemented:

| `rollout` parameter | `release_status` parameter | `user_fraction` sent to API[^1] | `release.status` sent to API |
|-------------------|---------------------------|-------------------------|-------------------------|
| `nil` | `DRAFT` | `nil` | `DRAFT` |
| `nil` | `IN_PROGRESS` | - | Error: "You need to provide a rollout value when release_status is set to 'inProgress'" |
| `nil` | `COMPLETED` | `nil` | `COMPLETED` |
| `0.5` | `DRAFT` | `nil`[^1] | `DRAFT` |
| `0.5` | `IN_PROGRESS` | `0.5` | `IN_PROGRESS` |
| `0.5` | `COMPLETED` | `0.5` | `IN_PROGRESS`[^2] |
| `1.0` | `DRAFT` | `nil`[^1] | `DRAFT` |
| `1.0` | `IN_PROGRESS` | `nil`[^1] | `COMPLETED`[^3] |
| `1.0` | `COMPLETED` | `nil`[^1] | `COMPLETED` |

[^1]: [The `user_fraction` parameter is only expected by the API if `status` is `inProgress` or `halted`](https://googleapis.dev/ruby/google-api-client/latest/Google/Apis/AndroidpublisherV3/TrackRelease.html#user_fraction-instance_method)
[^2]: We intentionally force the status sent to the API to be `'inProgress'` even if the user called the action with `'completed'`, because the `rollout` parameter was explicitly passed with value `1.0`
[^3]: We intentionally force the status sent to the API to be `'completed'` even if the user called the action with `'inProgress'`, because the `rollout` parameter was explicitly passed but with a value <1.0

### Testing Steps

 - Point your `Gemfile` to the branch of this PR
 - Call `upload_to_play_store` in your `Fastfile` with the usual parameters you'd call it with, but testing the different use cases provided in the table above for `rollout` and `release_status`

In particular, it'd be nice if some of you could test those calls while your tracks in Google Play are in different states, like the track already containing a release but being in draft, or a track containing a release which has started rollout but not at 100% yet, multiple releases in draft in the same track, …

---

cc @Noorrama @sreejithbnaick @lberaldodev @GiebelGobbler @mcfarljw — who chimed in on the original issue #28995