### PR TITLE
[supply] Fix missing_email error when using external account credentials

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -46,7 +46,7 @@ module Supply
     # Initializes the service and its auth_client using the specified information
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
-      auth_client = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
+      auth_client = Google::Auth::DefaultCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
 
       UI.verbose("Fetching a new access token from Google...")
 

--- a/supply/spec/fixtures/sample-external-account.json
+++ b/supply/spec/fixtures/sample-external-account.json
@@ -1,0 +1,11 @@
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/ftl-test-app/locations/global/workloadIdentityPools/identity-pool/providers/token-provider",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "url": "https://credential-source.example.com/token",
+    "format": { "type": "json", "subject_token_field_name": "value" }
+  },
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/fastlane@fastlane-tools.iam.gserviceaccount.com:generateAccessToken"
+}


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

This fixes supply client `initialize` error `missing client_email` when using credentials obtained through [Workload Identity Federation](https://github.com/google-github-actions/auth). The credentials file is generated through `google-github-actions/auth` GitHub Action, which Google Auth client uses to impersonate the service account that has access to Google Play API.

Resolves #29491

### Description

In supply client, it assumes the credentials file is always a Service Account JSON file (usually generated through Google Cloud Console). I changed it to use `Google::Auth::DefaultCredentials` which detects the correct credentials class to use to read the credentials.

### Testing Steps

Unit test is updated to initialize supply client using a demo external account credentials file. The format of the file can be different depending on how you set up Workload Identity Federation.

To test using GitHub Action:

* Follow [Workload Identity Federation through a Service Account](https://github.com/google-github-actions/auth?tab=readme-ov-file#indirect-wif) to set up workload identity pool and token provider.
* In an existing GitHub Action workflow that uses JSON credentials file, replace it with `google-github-actions/auth` action to obtain credentials.
* Run Fastlane. Depending on project configuration, Google Auth client should be able to pick up the credentials, or save the generated credentials into a JSON file to be read by supply.

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
