### PR TITLE
Fix `notarize` action with `verbose` option

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -74,7 +74,7 @@ module Fastlane
         ] + auth_parts
 
         if verbose
-          submit_command << "--verbose"
+          submit_parts << "--verbose"
         end
 
         submit_command = submit_parts.join(' ')

--- a/fastlane/spec/actions_specs/notarize_spec.rb
+++ b/fastlane/spec/actions_specs/notarize_spec.rb
@@ -74,6 +74,25 @@ describe Fastlane do
             end").runner.execute(:test)
           end
 
+          it "successful with verbose option" do
+            stub_const('ENV', { "FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD" => app_specific_password })
+
+            expect(Fastlane::Actions).to receive(:sh).with("xcrun notarytool submit #{package.path} --output-format json --wait --apple-id #{username} --password #{app_specific_password} --team-id #{asc_provider} --verbose", { error_callback: anything, log: true }).and_return(success_submit_response)
+
+            expect(Fastlane::Actions).to receive(:sh).with("xcrun stapler staple #{package.path}", { log: true })
+
+            result = Fastlane::FastFile.new.parse("lane :test do
+              notarize(
+                use_notarytool: true,
+                package: '#{package.path}',
+                bundle_id: '#{bundle_id}',
+                username: '#{username}',
+                asc_provider: '#{asc_provider}',
+                verbose: true
+              )
+            end").runner.execute(:test)
+          end
+
           it "successful with skip_stapling" do
             stub_const('ENV', { "FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD" => app_specific_password })
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] ~~I've updated the documentation if necessary.~~ N/A
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

This fixes a bug introduced in 2.227.0 via https://github.com/fastlane/fastlane/pull/27546

See https://github.com/fastlane/fastlane/pull/27546/files#r2001002887 cc @PaulTaykalo h/t @al-skobelev

### Testing Steps

CI should pass, including the new tests I added for this.