### PR TITLE
[match] fix error with universal provisioning filter ("'UNIVERSAL' is not a valid filter value")

### DIFF
--- a/match/spec/portal_fetcher_spec.rb
+++ b/match/spec/portal_fetcher_spec.rb
@@ -18,7 +18,7 @@ describe Match do
 
     let(:default_device_all_params) do
       {
-        filter: { platform: 'IOS,UNIVERSAL', status: 'ENABLED' },
+        filter: { platform: 'IOS', status: 'ENABLED' },
         client: anything
       }
     end

--- a/match/spec/portal_fetcher_spec.rb
+++ b/match/spec/portal_fetcher_spec.rb
@@ -19,7 +19,7 @@ describe Match do
     let(:default_device_all_params) do
       {
         filter: { platform: 'IOS', status: 'ENABLED' },
-        client: anything
+        client: nil
       }
     end
 

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -78,7 +78,6 @@ module Spaceship
 
         device_platforms = [
           device_platform,
-          'UNIVERSAL' # Universal Bundle ID platform is undocumented as of Oct 4, 2023.
         ]
 
         device_classes =

--- a/spaceship/lib/spaceship/connect_api/models/device.rb
+++ b/spaceship/lib/spaceship/connect_api/models/device.rb
@@ -77,7 +77,7 @@ module Spaceship
                           end
 
         device_platforms = [
-          device_platform,
+          device_platform
         ]
 
         device_classes =


### PR DESCRIPTION


<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Closes #29497

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Removes `UNIVERSAL` device filter

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
