### PR TITLE
Add `path` option to add_git_tag and push_git_tags actions.

### DIFF
--- a/fastlane/lib/fastlane/actions/add_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/add_git_tag.rb
@@ -27,7 +27,11 @@ module Fastlane
         cmd << options[:commit].to_s if options[:commit]
 
         UI.message("Adding git tag '#{tag}' 🎯.")
-        Actions.sh(cmd.join(' '))
+
+        options[:path] = './' unless options[:path]
+        Dir.chdir(options[:path]) do
+          Actions.sh(cmd.join(' '))
+        end
       end
 
       def self.description
@@ -101,7 +105,12 @@ module Fastlane
                                        description: "Make a GPG-signed tag, using the default e-mail address's key",
                                        optional: true,
                                        type: Boolean,
-                                       default_value: false)
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: 'FL_GIT_TAG_PATH',
+                                       description: 'Path of the git repository',
+                                       optional: true,
+                                       default_value: './')
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/push_git_tags.rb
+++ b/fastlane/lib/fastlane/actions/push_git_tags.rb
@@ -17,9 +17,12 @@ module Fastlane
         # optionally add the force component
         command << '--force' if params[:force]
 
-        result = Actions.sh(command.join(' '))
-        UI.success('Tags pushed to remote')
-        result
+        params[:path] = './' unless params[:path]
+        Dir.chdir(params[:path]) do
+          result = Actions.sh(command.join(' '))
+          UI.success('Tags pushed to remote')
+          result
+        end
       end
 
       #####################################################
@@ -46,7 +49,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :tag,
                                        env_name: "FL_GIT_PUSH_TAG",
                                        description: "The tag to push to remote",
-                                       optional: true)
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: 'FL_GIT_PUSH_PATH',
+                                       description: 'Path of the git repository',
+                                       optional: true,
+                                       default_value: './')
         ]
       end
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Adds a capability to tag and push tags to git submodules.

### Description

Added a `path` parameter to both add_git_tag and push_git_tags actions. Tested 

### Testing Steps

Create or clone in git repository in a subfolder then run the **add_git_tag** action with a `path:` parameter. The new tag should be created against the git repository in the subfolder, but not in the root project.