### PR TITLE
Add ability to add beta testers to BetaGroup resource

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/beta_group.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_group.rb
@@ -42,6 +42,12 @@ module Spaceship
         return client.post_bulk_beta_tester_assignments(beta_group_id: id, beta_testers: beta_testers)
       end
 
+      # beta_testers - {email: "", firstName: "", lastName: ""}
+      def add_beta_tester(client: nil, attributes: nil)
+        client ||= Spaceship::ConnectAPI
+        return client.post_beta_tester_assignment(beta_group_ids: [id], attributes: attributes)
+      end
+
       def add_beta_testers(client: nil, beta_tester_ids:)
         client ||= Spaceship::ConnectAPI
         return client.add_beta_tester_to_group(beta_group_id: id, beta_tester_ids: beta_tester_ids)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
This issue came up for our organization when we tried adding a GHA workflow that would allows devs to add TestFlight testers to beta groups. Originally we wanted to leverage the `pilot add` functionality outlined [here](https://docs.fastlane.tools/actions/pilot/), however running that currently throws this error:
> The URL path is not valid - The resource 'bulkBetaTesterAssignments' does not exist

This error lead me to [this issue](https://github.com/fastlane/fastlane/issues/18004) from way back in 2021, which was closed, re-opened, and subsequently left without further solutions.[I posted a comment](https://github.com/fastlane/fastlane/issues/18004#issuecomment-2731049910) on that issue recently when our team first started seeing the issue explaining that App Store Connect doesn't have that `bulkBetaTesterAssignments` endpoint any more, but there is a "Create Beta Tester" [endpoint](https://developer.apple.com/documentation/appstoreconnectapi/post-v1-betatesters) that could be leveraged.

Interesting, it appears that the `Spaceship::ConnectAPI::TestFlight` already had that functionality, it just wasn't exposed to the `BetaGroup` resource.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
This change adds a new `add_beta_tester` method to the BetaGroup resource that allows dev teams to add beta testers to groups. Since underlying API request, there are already unit tests in place for the request, so no more tests seemed needed here. 

Resolves: https://github.com/fastlane/fastlane/issues/16087

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I tested this on my own local machine, within our own project by swapping out fastlane implementations as described [here](https://github.com/fastlane/fastlane/blob/master/Testing.md#test-your-local-fastlane-code-base-with-your-setup).

Here is an example lane I added to our project's Fastfile which you should be able to add yourself to further help test:

```ruby
lane :add_beta_tester do |options|
    appIdentifier = options[:app_identifier]

    group = options[:group]

    firstName = options[:first_name]
    UI.user_error!("A valid employee first name is required") unless firstName

    lastName = options[:last_name]
    UI.user_error!("A valid employee last name is required") unless lastName

    email = options[:email]
    UI.user_error!("A valid employee email is required") unless email

    # Reusable function that creates/assigns a token like
    # Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(....)
    login_to_app_store_connect
    
    # Find the Strava Alpha App
    app = Spaceship::ConnectAPI::App.find(appIdentifier)

    # Find the Beta group 
    beta_group = app.get_beta_groups.find { |g| g.name == group }

    # Add the testers to group, which should also send an invite
    tester = beta_group.add_beta_tester(
      attributes: {
        email: email,
        firstName: firstName,
        lastName: lastName
      }
    )
end
```
With this change, running this command will succeed as so and invite the tester:
```
bundle exec fastlane add_beta_tester first_name:"Marcos" last_name:"Ortiz" email:"marcosortiz13@gmail.com"
```
<img width="646" alt="Screenshot 2025-03-31 at 5 15 23 PM" src="https://github.com/user-attachments/assets/61735b94-eeea-4f9d-9b5d-8d113a6d167e" />

<img width="1074" alt="Screenshot 2025-03-31 at 5 16 05 PM" src="https://github.com/user-attachments/assets/f3e1fe59-8a11-4d45-a2d0-5ffc0cd86110" />
