### PR TITLE
Fix duplicate output in CommandExecutor.execute() when command fails

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -77,9 +77,10 @@ module FastlaneCore
 
         # Exit status for build command, should be 0 if build succeeded
         if status != 0
-          o = String.new
           is_output_already_printed = print_all && !suppress_output
-          if !is_output_already_printed || !error.nil?
+          if is_output_already_printed && error.nil?
+            o = ""
+          else
             o = output.join("\n")
           end
           puts(o) unless is_output_already_printed

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -77,8 +77,13 @@ module FastlaneCore
 
         # Exit status for build command, should be 0 if build succeeded
         if status != 0
-          o = output.join("\n")
-          puts(o) unless suppress_output # the user has the right to see the raw output
+          o = String.new
+          is_output_already_printed = print_all && !suppress_output
+          if !is_output_already_printed || !error.nil?
+            o = output.join("\n")
+          end
+          puts(o) unless is_output_already_printed
+
           UI.error("Exit status: #{status}")
           if error
             error.call(o, status)

--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -34,7 +34,7 @@ module FastlaneCore
         print_all = true if FastlaneCore::Globals.verbose?
         prefix ||= {}
 
-        output = ''
+        output = []
         command = command.join(" ") if command.kind_of?(Array)
         UI.command(command) if print_command
 
@@ -47,7 +47,7 @@ module FastlaneCore
             command_stdout.each do |l|
               line = l.chomp
               line = line[1..-1] if line[0] == "\r"
-              output.concat(line, "\n")
+              output << line
 
               next unless print_all
 
@@ -62,35 +62,34 @@ module FastlaneCore
         rescue => ex
           # FastlanePty adds exit_status on to StandardError so every error will have a status code
           status = ex.exit_status
-          output.delete_suffix!("\n") unless output.empty?
 
           # This could happen when the environment is wrong:
           # > invalid byte sequence in US-ASCII (ArgumentError)
-          output.concat(ex.to_s)
-          puts(output)
+          output << ex.to_s
+          o = output.join("\n")
+          puts(o)
           if error
-            error.call(output, nil)
+            error.call(o, nil)
           else
             raise ex
           end
         end
-        output.delete_suffix!("\n") unless output.empty?
 
         # Exit status for build command, should be 0 if build succeeded
         if status != 0
           is_output_already_printed = print_all && !suppress_output
-
-          puts(output) unless is_output_already_printed
+          o = output.join("\n")
+          puts(o) unless is_output_already_printed
 
           UI.error("Exit status: #{status}")
           if error
-            error.call(output, status)
+            error.call(o, status)
           else
             UI.user_error!("Exit status: #{status}")
           end
         end
 
-        return output
+        return output.join("\n")
       end
     end
   end

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -1,6 +1,10 @@
 describe FastlaneCore do
   describe FastlaneCore::CommandExecutor do
     describe "execute" do
+      let(:failing_command) { FastlaneCore::Helper.windows? ? 'echo log && exit 42' : 'echo log; exit 42' }
+      let(:failing_command_output) { FastlaneCore::Helper.windows? ? "log \n" : "log\n" }
+      let(:failing_command_error_input) { FastlaneCore::Helper.windows? ? "log " : "log" }
+
       it 'executes a simple command successfully' do
         unless FastlaneCore::Helper.windows?
           expect(Process).to receive(:wait)
@@ -67,6 +71,77 @@ Shopping list:
   - Bread
   - Muffins
         LIST
+      end
+
+      it "does not print output to stdout when status != 0 and output was already printed" do
+        unless FastlaneCore::Helper.windows?
+          expect(Process).to receive(:wait)
+        end
+
+        expect do
+          FastlaneCore::CommandExecutor.execute(
+            command: failing_command,
+            print_all: true,
+            error: proc do |_error_output| end
+          )
+        end.not_to output(failing_command_output).to_stdout
+      end
+
+      it "prints output to stdout ony ones when status != 0 and output was not already printed" do
+        unless FastlaneCore::Helper.windows?
+          expect(Process).to receive(:wait).exactly(3)
+        end
+
+        expect do
+          FastlaneCore::CommandExecutor.execute(
+            command: failing_command,
+            print_all: false,
+            error: nil
+          )
+        end.to output(failing_command_output).to_stdout.and(raise_error)
+
+        expect do
+          FastlaneCore::CommandExecutor.execute(
+            command: failing_command,
+            print_all: false,
+            error: proc do |_error_output| end
+          )
+        end.to output(failing_command_output).to_stdout
+
+        expect do
+          FastlaneCore::CommandExecutor.execute(
+            command: failing_command,
+            print_all: true,
+            suppress_output: true,
+            error: proc do |_error_output| end
+          )
+        end.to output(failing_command_output).to_stdout
+      end
+
+      it "calls error block with output argument" do
+        unless FastlaneCore::Helper.windows?
+          expect(Process).to receive(:wait).twice
+        end
+
+        error_block_input = nil
+        result = FastlaneCore::CommandExecutor.execute(
+          command: failing_command,
+          print_all: true,
+          error: proc do |error_output|
+            error_block_input = error_output
+          end
+        )
+        expect(error_block_input).to eq(failing_command_error_input)
+
+        error_block_input = nil
+        result = FastlaneCore::CommandExecutor.execute(
+          command: failing_command,
+          print_all: false,
+          error: proc do |error_output|
+            error_block_input = error_output
+          end
+        )
+        expect(error_block_input).to eq(failing_command_error_input)
       end
     end
 

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -87,7 +87,7 @@ Shopping list:
         end.not_to output(failing_command_output).to_stdout
       end
 
-      it "prints output to stdout ony ones when status != 0 and output was not already printed" do
+      it "prints output to stdout only once when status != 0 and output was not already printed" do
         unless FastlaneCore::Helper.windows?
           expect(Process).to receive(:wait).exactly(3)
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves [29550](https://github.com/fastlane/fastlane/issues/29550)

The `run_tests` action calls `execute(print_all: true, ...)`. And `execute()` is always printing full command output if status code is unsuccessful.
It adds large amount of unnecessary duplicated rows into logs, xcodebuild output is huge.

De-duplication logic seems to be common for all commands. We don't have to print output twice on error in general.

### Description

Wrapped output print in simple unless condition at `FastlaneCore::CommandExecutor.execute()`.
Checks if output was printed from code above.

### Testing Steps

Run commands like:
```ruby
FastlaneCore::CommandExecutor.execute(command: 'echo "potentially large output"; exit 42', print_all: true)
FastlaneCore::CommandExecutor.execute(command: 'echo "potentially large output"; exit 42', print_all: false)

FastlaneCore::CommandExecutor.execute(command: 'echo "potentially large output"; exit 0', print_all: true)
FastlaneCore::CommandExecutor.execute(command: 'echo "potentially large output"; exit 0', print_all: false)
```