### PR TITLE
allow excluding expired builds

### DIFF
--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -84,8 +84,6 @@ module Fastlane
 
           UI.message("Fetching the latest build number for #{version_number_message}")
 
-          UI.message("with filter: #{filter}")
-
           # Get latest build for optional version number and return build number if found
           build = Spaceship::ConnectAPI.get_builds(filter: filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1).first
           if build

--- a/fastlane/lib/fastlane/actions/app_store_build_number.rb
+++ b/fastlane/lib/fastlane/actions/app_store_build_number.rb
@@ -67,7 +67,7 @@ module Fastlane
           platform = params[:platform]
 
           # Create filter for get_builds with optional version number
-          filter = { app: app.id }
+          filter = (params[:filter] || {}).merge(app: app.id)
           if version_number
             filter["preReleaseVersion.version"] = version_number
             version_number_message = "version #{version_number}"
@@ -83,6 +83,8 @@ module Fastlane
           end
 
           UI.message("Fetching the latest build number for #{version_number_message}")
+
+          UI.message("with filter: #{filter}")
 
           # Get latest build for optional version number and return build number if found
           build = Spaceship::ConnectAPI.get_builds(filter: filter, sort: "-uploadedDate", includes: "preReleaseVersion", limit: 1).first

--- a/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
+++ b/fastlane/lib/fastlane/actions/latest_testflight_build_number.rb
@@ -106,7 +106,13 @@ module Fastlane
                                        optional: true,
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:itc_team_name),
-                                       default_value_dynamic: true)
+                                       default_value_dynamic: true),
+          FastlaneCore::ConfigItem.new(key: :filter,
+                                       short_option: "-f",
+                                       description: "A map containing additional filters for querying builds. E.g. to filter expired builds, use `{expired: false}`",
+                                       optional: true,
+                                       type: Hash,
+                                       default_value: {})
         ]
       end
 


### PR DESCRIPTION
allow extra filtering when querying an app's build info. This allows for excluding expired builds, e.g. when querying for the latest test flight build.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [?] I've added or updated relevant unit tests.

### Motivation and Context

#### Why?
when querying test flight for the latest build for a specific version using `latest_testflight_build_number`, an expired build can be returned if that build happens to be the latest. It would be handy to exclude expired builds in this case.

#### What problem does it solve?
When our app gets promoted from test to acceptance track (for example), we query test flight using `latest_testflight_build_number` to know the correct build to promote for a specific version. Sometimes, we need to make an ad hoc build on a branch to test something before it gets merged into main/master. However, this ad hoc build can have been built for the same version that the promote job is running for. If that ad hoc build happens to be the most recent build, this ad hoc build gets returned instead of the expected release build meant to go to production. We thought to solve this problem by expiring the build as soon as it is installed by the tester. However, it seems expired builds are not excluded when using `latest_testflight_build_number`. 

In general, we believe it's useful to have the option to exclude expired builds. This PR addresses this.

Maybe it would be useful to have this filter applied by default when using `latest_testflight_build_number`. For now, I left it 100% backwards compatible by not adding any filter by default, although I do believe it could make sense to filter out expired builds by default (when querying for the latest build in test flight).

I will update the documentation when default behavior has been decided.

Resolves #29529

### Description

`get_build_info` in `fastlane/lib/fastlane/actions/app_store_build_number.rb` has been modified to take filters into account passed on through `params`.

in `fastlane/lib/fastlane/actions/latest_testflight_build_number.rb` , I added a new option for the filters. 

### Testing Steps

I don't know how to test this :/ help appreciated.
I also didn't find any existing tests for `latest_testflight_build_number` which i could extend with this new option..