### PR TITLE
Feature/spaceauth ci support

### DIFF
--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -15,7 +15,6 @@ module Spaceship
     end
 
     def run
-
       non_interactive = false
       # FASTLANE_2FA_SCRIPT is used in CI systems that cannot run interactive scripts together with FASTLANE_SESSION_ENV_FILE
       if !ENV["FASTLANE_2FA_SCRIPT"].nil? && ENV["FASTLANE_2FA_SCRIPT"].length > 0

--- a/spaceship/lib/spaceship/spaceauth_runner.rb
+++ b/spaceship/lib/spaceship/spaceauth_runner.rb
@@ -65,7 +65,7 @@ module Spaceship
         File.open(ENV["FASTLANE_SESSION_ENV_FILE"], "w") do |file|
           file.puts("FASTLANE_SESSION='#{@yaml}'")
         end
-        puts("The variable FASTLANE_SESSION has been written to #{ENV['FASTLANE_2FA_SCRIPT']}")
+        puts("The variable FASTLANE_SESSION has been written to #{ENV['FASTLANE_SESSION_ENV_FILE']}")
         return self
       end
 

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -261,6 +261,8 @@ module Spaceship
 
         if two_factor_code.length != 6
           puts("Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}: Output without spaces is not 6 digits.".red)
+          puts("Original Output: #{stdout_str}")
+          puts("Output without spaces: #{two_factor_code}")
           raise "Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}"
         end
 

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -259,14 +259,6 @@ module Spaceship
 
         two_factor_code = stdout_str.delete(' ')
 
-        if two_factor_code.length != 6
-          puts("Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}: Output without spaces is not 6 digits.".red)
-          puts("Original Output: #{stdout_str}")
-          puts("Output without spaces: #{two_factor_code}")
-          puts("Output length: #{two_factor_code.length}")
-          raise "Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}"
-        end
-
         puts("Using the code from the script #{ENV['FASTLANE_2FA_SCRIPT']}: #{two_factor_code}".yellow)
         two_factor_code
       else

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -233,7 +233,12 @@ module Spaceship
 
     # extracted into its own method for testing
     def ask_for_2fa_code(text)
-      ask(text)
+      if !ENV["FASTLANE_2FA_SCRIPT"].nil? && ENV["FASTLANE_2FA_SCRIPT"].length > 0
+        puts("A Two Factor Script was defined using FASTLANE_2FA_SCRIPT. Running this script now to get the 2-factor-code...".yellow)
+        system(ENV["FASTLANE_2FA_SCRIPT"])
+      else
+        ask(text)
+      end
     end
 
     # extracted into its own method for testing

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -263,6 +263,7 @@ module Spaceship
           puts("Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}: Output without spaces is not 6 digits.".red)
           puts("Original Output: #{stdout_str}")
           puts("Output without spaces: #{two_factor_code}")
+          puts("Output length: #{two_factor_code.length}")
           raise "Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}"
         end
 

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -237,6 +237,7 @@ module Spaceship
       if !ENV["FASTLANE_2FA_SCRIPT"].nil? && ENV["FASTLANE_2FA_SCRIPT"].length > 0
         puts("A Two Factor Script was defined using FASTLANE_2FA_SCRIPT. Running this script now to get the 2-factor-code...".yellow)
         stdout_str, stderr_str, exit_code = Open3.capture3(ENV["FASTLANE_2FA_SCRIPT"])
+
         if exit_code != 0
           puts("Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}.".red)
           puts("STDERR:".red)
@@ -245,8 +246,26 @@ module Spaceship
           puts(stdout_str)
           raise "Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}"
         end
-        puts("Using the code from the script #{ENV['FASTLANE_2FA_SCRIPT']}: #{stdout_str.strip}".yellow)
-        stdout_str.strip
+
+        if stdout_str.nil? || stdout_str.length == 0
+          puts("Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}: No output.".red)
+          raise "Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}"
+        end
+
+        if stdout_str.length < 6
+          puts("Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}: Output is too short.".red)
+          raise "Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}"
+        end
+
+        two_factor_code = stdout_str.delete(' ')
+
+        if two_factor_code.length != 6
+          puts("Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}: Output without spaces is not 6 digits.".red)
+          raise "Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}"
+        end
+
+        puts("Using the code from the script #{ENV['FASTLANE_2FA_SCRIPT']}: #{two_factor_code}".yellow)
+        two_factor_code
       else
         ask(text)
       end

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -1,5 +1,6 @@
 require_relative 'globals'
 require_relative 'tunes/tunes_client'
+require 'open3'
 
 module Spaceship
   class Client
@@ -235,7 +236,19 @@ module Spaceship
     def ask_for_2fa_code(text)
       if !ENV["FASTLANE_2FA_SCRIPT"].nil? && ENV["FASTLANE_2FA_SCRIPT"].length > 0
         puts("A Two Factor Script was defined using FASTLANE_2FA_SCRIPT. Running this script now to get the 2-factor-code...".yellow)
-        system(ENV["FASTLANE_2FA_SCRIPT"])
+        stdout_str, stderr_str, exit_code = Open3.capture3(ENV["FASTLANE_2FA_SCRIPT"])
+        if exit_code != 0
+          puts("Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}.".red)
+          puts("STDERR:".red)
+          puts("")
+          puts(stderr_str)
+          puts("")
+          puts("STDOUT:".red)
+          puts("")
+          puts(stdout_str)
+          raise "Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}"
+        end
+        stdout_str.strip
       else
         ask(text)
       end

--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -240,14 +240,12 @@ module Spaceship
         if exit_code != 0
           puts("Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}.".red)
           puts("STDERR:".red)
-          puts("")
           puts(stderr_str)
-          puts("")
           puts("STDOUT:".red)
-          puts("")
           puts(stdout_str)
           raise "Error while running the script #{ENV['FASTLANE_2FA_SCRIPT']}"
         end
+        puts("Using the code from the script #{ENV['FASTLANE_2FA_SCRIPT']}: #{stdout_str.strip}".yellow)
         stdout_str.strip
       else
         ask(text)


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #17012
-->

### Description

This change makes it possible to fastlane completely on ci machines without the need of manual interactions by providing three environment variables for space auth:
```FASTLANE_SESSION_ENV_FILE```: The file to write the Fastlane Session variable into (can be used by other ci jobs)
```FASTLANE_2FA_SCRIPT```: Path to a script to get the 2-factor-code. This should contain something something like this:
```
#!/usr/bin/env osascript

-- Delay for UI elements to load (optional)
delay 1

tell application "System Events"
  if name of every process contains "FollowUpUI" then
    tell process "FollowUpUI"
      try
        -- Optional: "Erlauben"-Button klicken, falls vorhanden
        if exists (button "Erlauben" of window 1) then
          click button "Erlauben" of window 1
          delay 1
        end if
      end try

      try
        set code to value of static text 1 of group 1 of window 1

        if exists (button "Fertig" of window 1) then
          click button "Fertig" of window 1
          delay 1
        end if

        -- Ausgabe für Ruby
        do shell script "echo " & quoted form of code
      on error
        log "❌ Kein 2FA-Code gefunden."
        do shell script "echo ''"
      end try
    end tell
  else
    log "❌ 'FollowUpUI' nicht gefunden."
    do shell script "echo ''"
  end if
end tell
```

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
I tested this on my ci server (mac mini m4) running the latest MacOS and xCode.
