### PR TITLE
[Sigh] Take 'cert_id' parameter into account while fetching profile.

### DIFF
--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -201,13 +201,13 @@ module Sigh
     def filter_profiles_by_cert_id(profiles)
       results = profiles.find_all do |current_profile|
         validCertId = false
-          current_profile.certificates.map do |cert|
-            if cert.id == Sigh.config[:cert_id].to_s
-              validCertId = true
-            else
-              UI.message("Provisioning Profile CERTID : '#{cert.id}' not match given CERTID : '#{Sigh.config[:cert_id]}', skipping this one...")
-            end
+        current_profile.certificates.each do |cert|
+          if cert.id == Sigh.config[:cert_id].to_s
+            validCertId = true
+          else
+            UI.message("Provisioning Profile cert_id : '#{cert.id}' not match given cert_id : '#{Sigh.config[:cert_id]}', skipping this one...")
           end
+        end
         validCertId
       end
       results

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -203,9 +203,9 @@ module Sigh
         validCertId = false
           current_profile.certificates.map do |cert|
             if cert.id == Sigh.config[:cert_id].to_s
-               validCertId = true
+              validCertId = true
             else
-               UI.message("Provisioning Profile CERTID : '#{cert.id}' not match given CERTID : '#{Sigh.config[:cert_id]}', skipping this one...")
+              UI.message("Provisioning Profile CERTID : '#{cert.id}' not match given CERTID : '#{Sigh.config[:cert_id]}', skipping this one...")
             end
           end
         validCertId

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -199,7 +199,7 @@ module Sigh
     end
 
     def filter_profiles_by_cert_id(profiles)
-      results = profiles.find_all do |current_profile|
+      filtered = profiles.find_all do |current_profile|
         validCertId = false
         current_profile.certificates.each do |cert|
           if cert.id == Sigh.config[:cert_id].to_s
@@ -210,7 +210,7 @@ module Sigh
         end
         validCertId
       end
-      results
+      filtered
     end
 
     def fetch_certificates(certificate_types)

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -106,7 +106,6 @@ module Sigh
       # Take the provisioning profile name into account
       results = filter_profiles_by_name(results) if Sigh.config[:provisioning_name].to_s.length > 0
       # Take the cert_id into account
-      UI.message("Verifying profile certificate ID...")
       results = filter_profiles_by_cert_id(results) if Sigh.config[:cert_id].to_s.length > 0
       return results if Sigh.config[:skip_certificate_verification] || Sigh.config[:include_all_certificates]
 
@@ -206,7 +205,7 @@ module Sigh
             if cert.id == Sigh.config[:cert_id].to_s
                validCertId = true
             else
-               UI.message("Provisioning Profile CERTID : '#{cert.id}' doesn't match given CERTID : '#{Sigh.config[:cert_id]}', skipping this one...")
+               UI.message("Provisioning Profile CERTID : '#{cert.id}' not match given CERTID : '#{Sigh.config[:cert_id]}', skipping this one...")
             end
           end
         validCertId

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -84,7 +84,7 @@ module Sigh
 
       includes = 'bundleId'
 
-      unless Sigh.config[:skip_certificate_verification] || Sigh.config[:include_all_certificates]
+      unless (Sigh.config[:skip_certificate_verification] || Sigh.config[:include_all_certificates]) && Sigh.config[:cert_id].to_s.length == 0
         includes += ',certificates'
       end
 
@@ -105,6 +105,9 @@ module Sigh
 
       # Take the provisioning profile name into account
       results = filter_profiles_by_name(results) if Sigh.config[:provisioning_name].to_s.length > 0
+      # Take the cert_id into account
+      UI.message("Verifying profile certificate ID...")
+      results = filter_profiles_by_cert_id(results) if Sigh.config[:cert_id].to_s.length > 0
       return results if Sigh.config[:skip_certificate_verification] || Sigh.config[:include_all_certificates]
 
       UI.message("Verifying certificates...")
@@ -194,6 +197,21 @@ module Sigh
         profiles = filtered
       end
       profiles
+    end
+
+    def filter_profiles_by_cert_id(profiles)
+      results = profiles.find_all do |current_profile|
+        validCertId = false
+          current_profile.certificates.map do |cert|
+            if cert.id == Sigh.config[:cert_id].to_s
+               validCertId = true
+            else
+               UI.message("Provisioning Profile CERTID : '#{cert.id}' doesn't match given CERTID : '#{Sigh.config[:cert_id]}', skipping this one...")
+            end
+          end
+        validCertId
+      end
+      results
     end
 
     def fetch_certificates(certificate_types)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.
- [X] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
I'm working for the french national railway as an iOS expert. 
This company has 400+ internal apps and one part of my job is to sign those app.
I'm using fastlane for provisioning profiles (PP) renewing.
In house certificates are valid 3 years so every 3 years all PP and the distribution certificate have to be renewed.

The problem is when you renew the certificate and ask 'sigh action' to give me a PP with that certificate using cert_id option :

```
  #################### GET/CREATE PP START ####################
  lane :provision do |options|
        sigh( app_identifier: options[:bundle_identifier], username: options[:user_name], output_path: options[:output_path], provisioning_name: options[:provision_name], cert_id: options[:cert_id])
  end
  #################### GET/CREATE PP END ####################
  
  +--------------------------------------------------------------------------+
|                         Summary for sigh 2.227.1                         |
+-------------------------------------+------------------------------------+
| app_identifier                      | ***.****.**.internal.testapp       |
| username                            | ******@***.***                     |
| provisioning_name                   | testapp PP 2028                    |
| cert_id                             | 9P*******                          |
| adhoc                               | false                              |
| developer_id                        | false                              |
| development                         | false                              |
| skip_install                        | true                               |
| force                               | false                              |
| include_mac_in_profiles             | false                              |
| ignore_profiles_with_different_name | false                              |
| skip_fetch_profiles                 | false                              |
| include_all_certificates            | false                              |
| skip_certificate_verification       | true                               |
| platform                            | ios                                |
| readonly                            | false                              |
| fail_on_name_taken                  | false                              |
+-------------------------------------+------------------------------------+
  
```
First case : In this case if a PP exist with the current app_identifier, it will be returned even if the cert_id to this PP doesn't match the specified one. 

Second case : If PP with app_identifier doesn't exist, it will be created with the specified cert_id as we expect and the next time we try to get again the same app_identifier PP we get the correct PP... because there is only one PP.

But tree years later and after create a new in house distribution certificate we are back to first case ...

This unwanted behavior make me **sign an app with incorrect PP witch lead to an integrity problem and the app can't start from an iOS device.** 

I know this is probably not a issue on macOS using keychain and 'skip_certificate_verification' = false but this solution download certificate from the app_store then check if one of them is installed and finally compare PP's cert_id fetched.

This is not what we try to do, I don't want check if certificate are localy installed ( I'm on alpline linux so no way... ) I just want a provisioning profile with the cert_id I specified.

### Description
Adding a step before returning PPs that filter fetched PPs by the specified cert_id.
This prevent from fetching an old PP generated with incorrect / old certificate.

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

Current fastlane version ( 2.227.1 ) :
1. Delete all PP from apple dev console for the specified app_identifier.
2. Try to generate PP with specified **old** cert_id.  => PP generated with old cert_id 👍 
3. Then try to generate PP with specified **new** cert_id. => PP from step 1 is fetched and returned with old cert_id ⛔ 
4. Try to fetch again PP with specified **old** cert_id => PP fetched ( not re-generated ) with correct old cert_id 👍
5. Try to fetch again PP with specified **new** cert_id => PP from step 1 is fetched and returned with old cert_id ⛔ 


With this fix :
1. Delete all PP from apple dev console for the specified app_identifier.
2. Try with the fix to generate PP with specified **old** cert_id.  => PP generated with old cert_id 👍
3. Then try to generate PP with specified **new** cert_id. => PP generated with new cert_id 👍
4. Try to fetch again PP with specified **old** cert_id => PP fetched ( not re-generated ) with correct old cert_id 👍
5. Try to fetch again PP with specified **new** cert_id => PP fetched ( not re-generated ) with correct new cert_id 👍

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
