### PR TITLE
[deliver] Fix altool not logging errors

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -249,21 +249,7 @@ module FastlaneCore
       @errors << "-1 indicates altool exited abnormally; try retrying (see https://github.com/fastlane/fastlane/issues/21535)" if exit_status == -1
 
       unless @errors.empty? || @all_lines.empty?
-        # Print the last lines that appear after the last error from the logs
-        # If error text is not detected, it will be 20 lines
-        # This is key for non-verbose mode
-
-        # The format of altool's result with error is like below
-        # > *** Error: Error uploading '...'.
-        # > *** Error: ...
-        # > {
-        # >     NSLocalizedDescription = "...",
-        # >     ...
-        # > }
-        # So this line tries to find the line which has "*** Error:" prefix from bottom of log
-        error_line_index = @all_lines.rindex { |line| ERROR_REGEX.match?(line) }
-
-        @all_lines[(error_line_index || -20)..-1].each do |line|
+        @all_lines.each do |line|
           UI.important("[altool] #{line}")
         end
         UI.message("Application Loader output above ^")


### PR DESCRIPTION
I have not run all the tests as the comment suggested.  To be entirely honest, I'm not sure how.  I have only done enough ruby to be dangerous but not enough familiarity to know how to run all the tools fastlane leverages.  Anywho, other devs were prompting me that they were encountering this same issue so hopefully this PR resolves it.  Besides, I suspect the GitHub pipeline will run any necessary tests.  Without further ado:

Altool appears to have changed the format of their cli output.  As a result the error regex is no longer matching.  This PR simply removes that regex expression.  I don't think we should be filtering out errors anyways and should instead log errors verbosely so that the developer can get as much information as possible to debug.  This resolves this issue:

https://github.com/fastlane/fastlane/issues/29368

Note the error itself won't be resolved, but it will now properly log the errors so developers can resolve whatever is wrong on their end.  In my case I needed to bump my minimum supported OS version and I needed to auth credentials.