### PR TITLE
MatchfileProtocol - remove templateName

### DIFF
--- a/fastlane/swift/MatchfileProtocol.swift
+++ b/fastlane/swift/MatchfileProtocol.swift
@@ -146,9 +146,6 @@ public protocol MatchfileProtocol: AnyObject {
     /// Enable this if you have the Mac Catalyst capability enabled and your project was created with Xcode 11.3 or earlier. Prepends 'maccatalyst.' to the app identifier for the provisioning profile mapping
     var deriveCatalystAppIdentifier: Bool { get }
 
-    /// The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. "Apple Pay Pass Suppression Development")
-    var templateName: String? { get }
-
     /// A custom name for the provisioning profile. This will replace the default provisioning profile name if specified
     var profileName: String? { get }
 
@@ -220,7 +217,6 @@ public extension MatchfileProtocol {
     var skipDocs: Bool { return false }
     var platform: String { return "ios" }
     var deriveCatalystAppIdentifier: Bool { return false }
-    var templateName: String? { return nil }
     var profileName: String? { return nil }
     var failOnNameTaken: Bool { return false }
     var skipCertificateMatching: Bool { return false }


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Looks like Apple removed templateName from the API call:
- https://developer.apple.com/documentation/appstoreconnectapi/profilecreaterequest/data-data.dictionary/attributes-data.dictionary

Issue: 
- https://github.com/fastlane/fastlane/issues/29498