### PR TITLE
Fix: Avoid invalid ‘templateName’ attribute when creating provisioning profiles via ConnectAPI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,8 @@ GEM
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.3.5)
-    domain_name (0.6.20240107)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.109.0)
@@ -238,7 +239,7 @@ GEM
     pry-stack_explorer (0.4.12)
       binding_of_caller (~> 0.7)
       pry (~> 0.13)
-    public_suffix (6.0.1)
+    public_suffix (5.1.1)
     racc (1.7.1)
     rack (2.2.8)
     rack-protection (2.2.4)
@@ -332,6 +333,7 @@ GEM
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
     uber (0.1.0)
+    unf (0.2.0)
     unicode-display_width (2.4.2)
     webmock (3.24.0)
       addressable (>= 2.8.0)
@@ -362,7 +364,7 @@ GEM
     yard (0.9.26)
 
 PLATFORMS
-  ruby
+  universal-darwin-24
 
 DEPENDENCIES
   climate_control (~> 0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,8 +119,7 @@ GEM
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.3.5)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
+    domain_name (0.6.20240107)
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.109.0)
@@ -239,7 +238,7 @@ GEM
     pry-stack_explorer (0.4.12)
       binding_of_caller (~> 0.7)
       pry (~> 0.13)
-    public_suffix (5.1.1)
+    public_suffix (6.0.1)
     racc (1.7.1)
     rack (2.2.8)
     rack-protection (2.2.4)
@@ -333,7 +332,6 @@ GEM
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
     uber (0.1.0)
-    unf (0.2.0)
     unicode-display_width (2.4.2)
     webmock (3.24.0)
       addressable (>= 2.8.0)
@@ -364,7 +362,7 @@ GEM
     yard (0.9.26)
 
 PLATFORMS
-  universal-darwin-24
+  ruby
 
 DEPENDENCIES
   climate_control (~> 0.2.0)

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -84,7 +84,7 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
+      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,
@@ -92,8 +92,7 @@ module Spaceship
           devices: device_ids,
           attributes: {
             name: name,
-            profileType: profile_type,
-            templateName: template_name
+            profileType: profile_type
           }
         )
         return resp.to_models.first

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -84,7 +84,7 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil)
+      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -86,15 +86,20 @@ module Spaceship
 
       def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
         client ||= Spaceship::ConnectAPI
+      
+        attributes = {
+          name: name,
+          profileType: profile_type
+        }
+        attributes[:templateName] = template_name if template_name
+      
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,
           certificates: certificate_ids,
           devices: device_ids,
-          attributes: {
-            name: name,
-            profileType: profile_type
-          }
+          attributes: attributes
         )
+      
         return resp.to_models.first
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -86,17 +86,20 @@ module Spaceship
 
       def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
         client ||= Spaceship::ConnectAPI
+      
         attributes = {
           name: name,
           profileType: profile_type
         }
         attributes[:templateName] = template_name if template_name
+      
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,
           certificates: certificate_ids,
           devices: device_ids,
           attributes: attributes
         )
+      
         return resp.to_models.first
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -86,20 +86,17 @@ module Spaceship
 
       def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
         client ||= Spaceship::ConnectAPI
-      
         attributes = {
           name: name,
           profileType: profile_type
         }
         attributes[:templateName] = template_name if template_name
-      
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,
           certificates: certificate_ids,
           devices: device_ids,
           attributes: attributes
         )
-      
         return resp.to_models.first
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

This change resolves a runtime error caused by passing the templateName attribute to Apple’s App Store Connect API, which currently does not recognize this parameter in provisioning profile creation requests.

The error message encountered:

 `The provided entity includes an unknown attribute - 'templateName' is not an attribute on the resource 'profiles'`

This can break CI/CD pipelines that rely on fastlane match or provisioning profile creation through Spaceship::ConnectAPI::Profile.create.

### Description

This PR conditionally excludes the templateName field from the API request payload unless it is explicitly provided and non-nil. This preserves backward compatibility and avoids triggering an error from Apple’s API for standard use cases.

The change was made in Spaceship::ConnectAPI::Profile.create and ensures the attributes hash is built dynamically, only including templateName if present.

### Testing Steps

	1.	Used the patched fastlane fork in a GitHub Actions CI environment where provisioning profiles are generated dynamically.
	2.	Verified that profiles are successfully created using fastlane match, both when templateName is omitted (nil) and when provided explicitly (for internal testing).
	3.	Ensured existing behavior and arguments remain unaffected.
