### PR TITLE
Fix: fastlane  match issue -template name is not an attribute on the resource profiles

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -84,7 +84,7 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
+      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,
@@ -92,8 +92,7 @@ module Spaceship
           devices: device_ids,
           attributes: {
             name: name,
-            profileType: profile_type,
-            templateName: template_name
+            profileType: profile_type
           }
         )
         return resp.to_models.first

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -84,7 +84,7 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil)
+      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -86,20 +86,20 @@ module Spaceship
 
       def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
         client ||= Spaceship::ConnectAPI
-      
+
         attributes = {
           name: name,
           profileType: profile_type
         }
         attributes[:templateName] = template_name if template_name
-      
+
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,
           certificates: certificate_ids,
           devices: device_ids,
           attributes: attributes
         )
-      
+
         return resp.to_models.first
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -86,15 +86,20 @@ module Spaceship
 
       def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
         client ||= Spaceship::ConnectAPI
+      
+        attributes = {
+          name: name,
+          profileType: profile_type
+        }
+        attributes[:templateName] = template_name if template_name
+      
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,
           certificates: certificate_ids,
           devices: device_ids,
-          attributes: {
-            name: name,
-            profileType: profile_type
-          }
+          attributes: attributes
         )
+      
         return resp.to_models.first
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Motivation and Context
This change resolves a runtime error caused by passing the templateName attribute to Apple’s App Store Connect API, which currently does not recognize this parameter in provisioning profile creation requests.

The error message encountered:
The provided entity includes an unknown attribute - 'templateName' is not an attribute on the resource 'profiles'
Resolves 
#29580
#29499 
#29579


### Description

This PR conditionally excludes the templateName field from the API request payload unless it is explicitly provided and non-nil. This preserves backward compatibility and avoids triggering an error from Apple’s API for standard use cases.

The change was made in Spaceship::ConnectAPI::Profile.create and ensures the attributes hash is built dynamically, only including templateName if present.



### Testing Steps

```
1.	Used the patched fastlane fork in a GitHub Actions CI environment where provisioning profiles are generated dynamically.
2.	Verified that profiles are successfully created using fastlane match, both when templateName is omitted (nil) and when provided explicitly (for internal testing).
3.	Ensured existing behavior and arguments remain unaffected.
```
