### PR TITLE
Fix developer_id_application erroring in match nuke

### DIFF
--- a/match/lib/match/module.rb
+++ b/match/lib/match/module.rb
@@ -27,7 +27,7 @@ module Match
     type = type.to_s.downcase
     return :mac_installer_distribution if type == "mac_installer_distribution"
     return :developer_id_installer if type == "developer_id_installer"
-    return :developer_id_application if type == "developer_id"
+    return :developer_id_application if type == "developer_id" || type == "developer_id_application"
     return :enterprise if type == "enterprise"
     return :development if type == "development"
     return :distribution if ["adhoc", "appstore", "distribution"].include?(type)

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -381,6 +381,10 @@ module Match
         return [
           Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION
         ]
+      when :developer_id_application
+        return [
+          Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION
+        ]
       else
         raise "Unknown type '#{type}'"
       end


### PR DESCRIPTION
Fixes issue: https://github.com/fastlane/fastlane/issues/21147

It looks like developer_id_application was simply overlooked in regards to the match_nuke lanes.  This adds it in.