### PR TITLE
Fix DEVELOPER_ID_APPLICATION_G2 api errors

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -160,7 +160,6 @@ module Cert
           return [Spaceship::ConnectAPI::Certificate::CertificateType::MAC_INSTALLER_DISTRIBUTION]
         when :developer_id_application
           return [
-            Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION_G2,
             Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION
           ]
         when :developer_id_kext

--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -47,8 +47,7 @@ module Match
         ].join(',')
       when :developer_id_application
         certificate_type = [
-          Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION,
-          Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION_G2
+          Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION
         ].join(',')
       when :mac_installer_distribution
         certificate_type = [

--- a/sigh/lib/sigh/module.rb
+++ b/sigh/lib/sigh/module.rb
@@ -113,8 +113,7 @@ module Sigh
           ]
         elsif profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_DIRECT || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_DIRECT
           types = [
-            Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION,
-            Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION_G2
+            Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION
           ]
         elsif profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_APP_INHOUSE || profile_type == Spaceship::ConnectAPI::Profile::ProfileType::MAC_CATALYST_APP_INHOUSE
           # Enterprise accounts don't have access to Apple Distribution certificates


### PR DESCRIPTION
Fixes issue: https://github.com/fastlane/fastlane/issues/29587

Apple appears to have removed DEVELOPER_ID_APPLICATION_G2 as a ``certificateType`` that can be passed to their apis.  The apis respond with:

```
An attribute in the provided entity has the wrong type - 'DEVELOPER_ID_APPLICATION_G2' is not a valid value for the attribute 'certificateType'. Expected one of: 'APPLE_PAY', 'APPLE_PAY_MERCHANT_IDENTITY', 'APPLE_PAY_PSP_IDENTITY', 'APPLE_PAY_RSA', 'DEVELOPER_ID_KEXT', 'DEVELOPER_ID_APPLICATION', 'DEVELOPMENT', 'DISTRIBUTION', 'IDENTITY_ACCESS', 'IOS_DEVELOPMENT', 'IOS_DISTRIBUTION', 'MAC_APP_DISTRIBUTION', 'MAC_INSTALLER_DISTRIBUTION', 'MAC_APP_DEVELOPMENT', 'PASS_TYPE_ID', 'PASS_TYPE_ID_WITH_NFC' - /data/attributes/certificateType
```