### PR TITLE
Add `lootBox` property in the file `age_rating_declaration`

### DIFF
--- a/deliver/assets/example_rating_config.json
+++ b/deliver/assets/example_rating_config.json
@@ -13,5 +13,6 @@
   "violenceRealistic": "INFREQUENT_OR_MILD",
   "gambling": false,  
   "seventeenPlus": false,
-  "unrestrictedWebAccess": true
+  "unrestrictedWebAccess": true,
+  "lootBox": false
 }

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -22,7 +22,7 @@ module Spaceship
       attr_accessor :gambling
       attr_accessor :seventeen_plus
       attr_accessor :unrestricted_web_access
-
+      attr_accessor :loot_box
       # KidsAge
       attr_accessor :kids_age_band
 
@@ -58,7 +58,7 @@ module Spaceship
         "violenceRealisticProlongedGraphicOrSadistic" => "violence_realistic_prolonged_graphic_or_sadistic",
         "violenceRealistic" => "violence_realistic",
         "kidsAgeBand" => "kids_age_band",
-
+        "lootBox" => "loot_box",
         # Deprecated as of App Store Connect API 1.3
         "gamblingAndContests" => "gambling_and_contests",
       })


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context
Apple updated its API, and the `lootBox` property was added to the [list](https://developer.apple.com/documentation/appstoreconnectapi/ageratingdeclarationupdaterequest/data-data.dictionary/attributes-data.dictionary).

Apple release note: 
https://developer.apple.com/documentation/appstoreconnectapi/app-store-connect-api-3-6-release-notes

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
The property `lootBox` was added as a property and in the `example_rating_config.json` 
<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps
- Add the key `lootBox` in the `rating_config.json`, the property is required and it is boolean.

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
