### PR TITLE
[sigh][match] fix issue where unknown attribute `template_name` is being sent when creating provisioning profiles

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -406,14 +406,16 @@ If you're not using `Fastfile`, you can also use the `force_for_new_devices` opt
 fastlane match adhoc --force_for_new_devices
 ```
 
-##### Templates (aka: custom entitlements)
+##### Managed capabilities
 
-_match_ can generate profiles that contain custom entitlements by passing in the entitlement's name with the `template_name` parameter.
+> [!IMPORTANT]
+> This feature has been deprecated since May 2025, until Apple provides a new solution. We will update this documentation once we have more information on how to handle managed capabilities in the future.
 
-```
-match(type: "development",
-      template_name: "Apple Pay Pass Suppression Development")
-```
+Managed capabilities — formerly known as "additional entitlements" or "custom entitlements", enabled via "templates" — are additional capabilities that require Apple's review and approval before they can be distributed.
+
+These capabilities used to be enabled by passing a `template_name` parameter to the _match_ action, which would then generate a provisioning profile with the entitlements specified by the given template. However, this feature was never officially supported by Apple's API (undocumented), and they eventually removed it in May 2025 ([see issue #29498](https://github.com/fastlane/fastlane/issues/29498)). Apple still hasn't provided a replacement for this functionality.
+
+As a result, the `template_name` parameter was deprecated in the _match_ action, and it will not generate provisioning profiles with custom entitlements.
 
 ### Setup Xcode project
 

--- a/match/lib/match/options.rb
+++ b/match/lib/match/options.rb
@@ -327,6 +327,7 @@ module Match
                                      env_name: "MATCH_PROVISIONING_PROFILE_TEMPLATE_NAME",
                                      description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. \"Apple Pay Pass Suppression Development\")",
                                      optional: true,
+                                     deprecated: "Removed since May 2025 on App Store Connect API OpenAPI v3.8.0 - Learn more: https://docs.fastlane.tools/actions/match/#managed-capabilities",
                                      default_value: nil),
         FastlaneCore::ConfigItem.new(key: :profile_name,
                                     env_name: "MATCH_PROVISIONING_PROFILE_NAME",

--- a/sigh/lib/sigh/options.rb
+++ b/sigh/lib/sigh/options.rb
@@ -190,6 +190,7 @@ module Sigh
                                      env_name: "SIGH_PROVISIONING_PROFILE_TEMPLATE_NAME",
                                      description: "The name of provisioning profile template. If the developer account has provisioning profile templates (aka: custom entitlements), the template name can be found by inspecting the Entitlements drop-down while creating/editing a provisioning profile (e.g. \"Apple Pay Pass Suppression Development\")",
                                      optional: true,
+                                     deprecated: "Removed since May 2025 on App Store Connect API OpenAPI v3.8.0 - Learn more: https://docs.fastlane.tools/actions/match/#managed-capabilities",
                                      default_value: nil),
         FastlaneCore::ConfigItem.new(key: :fail_on_name_taken,
                                      env_name: "SIGH_FAIL_ON_NAME_TAKEN",

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -179,8 +179,7 @@ module Sigh
         profile_type: profile_type,
         bundle_id_id: bundle_id.id,
         certificate_ids: certificates_to_use.map(&:id),
-        device_ids: devices_to_use.map(&:id),
-        template_name: Sigh.config[:template_name]
+        device_ids: devices_to_use.map(&:id)
       )
 
       profile

--- a/sigh/lib/sigh/runner.rb
+++ b/sigh/lib/sigh/runner.rb
@@ -174,6 +174,10 @@ module Sigh
 
       UI.important("Creating new provisioning profile for '#{Sigh.config[:app_identifier]}' with name '#{name}' for '#{Sigh.config[:platform]}' platform")
 
+      unless Sigh.config[:template_name].nil?
+        UI.important("Template name is set to '#{Sigh.config[:template_name]}', however, this is not supported by the App Store Connect API anymore, since May 2025. The template name will be ignored. For more information: https://docs.fastlane.tools/actions/match/#managed-capabilities")
+      end
+
       profile = Spaceship::ConnectAPI::Profile.create(
         name: name,
         profile_type: profile_type,

--- a/spaceship/lib/spaceship/connect_api/models/profile.rb
+++ b/spaceship/lib/spaceship/connect_api/models/profile.rb
@@ -84,7 +84,7 @@ module Spaceship
         return resps.flat_map(&:to_models)
       end
 
-      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil, template_name: nil)
+      def self.create(client: nil, name: nil, profile_type: nil, bundle_id_id: nil, certificate_ids: nil, device_ids: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.post_profiles(
           bundle_id_id: bundle_id_id,
@@ -92,8 +92,7 @@ module Spaceship
           devices: device_ids,
           attributes: {
             name: name,
-            profileType: profile_type,
-            templateName: template_name
+            profileType: profile_type
           }
         )
         return resp.to_models.first


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Apple Deployment is currently broken because they removed the property `attribtues.templateName` in the profiles call. 
 See documentation: https://developer.apple.com/documentation/appstoreconnectapi/profilecreaterequest/data-data.dictionary/attributes-data.dictionary

### Description

Removed `template_name`, since apple seemed to have dropped support for it in the profiles call.

### Testing Steps

1.	Used the patched fastlane fork in a GitHub Actions CI environment where provisioning profiles are generated dynamically.
2.	Verified that profiles are successfully created using fastlane match, both when templateName is omitted (nil) and when provided explicitly (for internal testing).
3.	Ensured existing behavior and arguments remain unaffected.

### Notes

I am not too familiar with fastlane and `template_name` so not sure if any other changes are needed but tests are passing for now. Not sure if apple supports `templateName` now in a different way - if so some additional changes might still be needed.


----
> Edited by @rogerluan:

- Resolves #29498
- Resolves #29579
- Resolves #29499

Related PRs:

- Closes #29501
- Closes #29580
- Closes #29581
- Closes #29607

> End of edits
----