### PR TITLE
fix: Add verbosity on download_metadata without a tty and more details to documentation. Fixes: #21075.

### DIFF
--- a/deliver/lib/deliver/commands_generator.rb
+++ b/deliver/lib/deliver/commands_generator.rb
@@ -154,7 +154,7 @@ module Deliver
 
       command :download_metadata do |c|
         c.syntax = 'fastlane deliver download_metadata'
-        c.description = "Downloads existing metadata and stores it locally. This overwrites the local files."
+        c.description = "Downloads existing metadata and stores it locally. Use --force option to overwrite local files without prompt."
 
         FastlaneCore::CommanderGenerator.new.generate(deliverfile_options, command: c)
 
@@ -165,6 +165,7 @@ module Deliver
           containing = FastlaneCore::Helper.fastlane_enabled_folder_path
           path = options[:metadata_path] || File.join(containing, 'metadata')
           res = Deliver::CommandsGenerator.force_overwrite_metadata?(options, path)
+          UI.message("Will not overwrite existing metadata (answered no, or tty not detected). To override: use --force option") unless res
           return 0 unless res
 
           require 'deliver/setup'

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -154,7 +154,7 @@ module Deliver
         FastlaneCore::ConfigItem.new(key: :force,
                                      short_option: "-f",
                                      env_name: "DELIVER_FORCE",
-                                     description: "Skip verification of HTML preview file",
+                                     description: "Skip verification of HTML preview file or overwrite existing metadata without prompt (download_metadata)",
                                      type: Boolean,
                                      default_value: false),
         FastlaneCore::ConfigItem.new(key: :overwrite_screenshots,

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -82,6 +82,13 @@ Download existing metadata from App Store Connect
 fastlane deliver download_metadata
 ```
 
+Download existing metadata from App Store Connect and overwrite local metadata without prompting or when running without a TTY (e.g on CI server).
+
+```no-highlight
+fastlane deliver download_metadata --force
+
+```
+
 To get a list of available options run
 
 ```no-highlight
@@ -100,6 +107,21 @@ deliver(
   force: true,
   metadata_path: "./metadata"
 )
+```
+
+Use download_metadata together with `app_store_connect_api_key`. Note: You must use `--force` option as this will be non-interactive terminal:
+
+```ruby
+app_identifier = "your.app"
+api_key = app_store_connect_api_key(
+  key_id: ENV["ASC_KEY_ID"],
+  issuer_id: ENV["ASC_ISSUER_ID"],
+  key_content: ENV["ASC_KEY_P8"],
+  is_key_content_base64: true,
+  in_house: false # detecting this via ASC private key not currently supported
+)
+  
+sh "bundle exec fastlane deliver download_metadata --force --api_key '#{api_key.to_json}' --app_identifier #{app_identifier}"
 ```
 
 ## More options


### PR DESCRIPTION
…

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
- There's no action available for `deliver download_metadata` that could be called from Fastfile directly
- It has to be executed as CLI command
- When launched from a Fastfile `sh "bundle exec fastlane deliver download_metadata` it's detected as non-interactive. Exits silently and does nothing.
- Documentation doesn't mention about this
- Documentation doesn't mention how to combine this with `app_store_connect_api_key` for passing `api_key` details 

<!-- If it fixes an open issue, please link to the issue following this format:
-->

Fixes: #21075

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
1. Modified description of `--force` option as it's used for skipping HTML preview, but also to force update of metadata
2. Added `--force` to `download_metadata` description too, to point out one can force the metadata update and overwrite local files
3. Added example of using `--force` to docs
4. Added example how to use `download_metadata` in Fastfile, together with `app_store_connect_api_key` and `--force`

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

**NOTE** bundle exec rspec - has failing issues in master, where this PR is branched from, but not related to Deliver.

1. Define a lane in `Fastfile`
```
desc "Download metadata from App Store Connect"
lane :download_app_metadata_and_screenshots do
      app_identifier = "your.app"
      api_key = app_store_connect_api_key(
        key_id: ENV["ASC_KEY_ID"],
        issuer_id: ENV["ASC_ISSUER_ID"],
        key_content: ENV["ASC_KEY_P8"],
        is_key_content_base64: true,
        in_house: false # detecting this via ASC private key not currently supported
      )
      
      sh "bundle exec fastlane deliver download_metadata --force --api_key '#{api_key.to_json}' --app_identifier #{app_identifier}"
end
```
2. Run: `bundle exec fastlane download_app_metadata_and_screenshots`

Run the same without `--force` and see that nothing happens