### PR TITLE
Fix: Randomize birthDate for sandbox tester creation

### DIFF
--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -1196,6 +1196,13 @@ module Spaceship
         end
 
         def post_sandbox_tester(attributes: {})
+          if attributes[:birthDate].nil?
+            year = rand(1970..2000)
+            month = rand(1..12)
+            day = rand(1..28)
+            attributes[:birthDate] = format('%04d-%02d-%02d', year, month, day)
+          end
+
           body = {
             data: {
               type: "sandboxTesters",


### PR DESCRIPTION
This change addresses an issue where creating sandbox testers via Spaceship would fail with an "email already in use" error, even for new email addresses.

The `post_sandbox_tester` method in
`spaceship/lib/spaceship/connect_api/tunes/tunes.rb` has been modified to randomize the `birthDate` attribute if it's not already provided. This ensures that each sandbox tester has a unique birth date, which appears to be a new requirement from Apple's API.

Additionally, new test cases have been added to
`spaceship/spec/connect_api/tunes/tunes_client_spec.rb` to cover the creation and deletion of sandbox testers, including the `birthDate` randomization logic.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
