### PR TITLE
Properly handle `package_authorization_provider` when building a Swift Package with scan

### DIFF
--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -53,6 +53,9 @@ module Scan
       if config[:use_system_scm] && !options.include?("-scmProvider system")
         options << "-scmProvider system"
       end
+      if config[:package_authorization_provider] && !options.include?("-packageAuthorizationProvider #{config[:package_authorization_provider].shellescape}")
+        options << "-packageAuthorizationProvider #{options[:package_authorization_provider].shellescape}"
+      end
       if config[:result_bundle_path]
         options << "-resultBundlePath #{config[:result_bundle_path].shellescape}"
         Scan.cache[:result_bundle_path] = config[:result_bundle_path]

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -54,7 +54,7 @@ module Scan
         options << "-scmProvider system"
       end
       if config[:package_authorization_provider] && !options.include?("-packageAuthorizationProvider #{config[:package_authorization_provider].shellescape}")
-        options << "-packageAuthorizationProvider #{options[:package_authorization_provider].shellescape}"
+        options << "-packageAuthorizationProvider #{config[:package_authorization_provider].shellescape}"
       end
       if config[:result_bundle_path]
         options << "-resultBundlePath #{config[:result_bundle_path].shellescape}"

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -297,6 +297,13 @@ describe Scan do
               result = @test_command_generator.project_path_array
               expect(result).to eq(["-scheme package"])
             end
+
+            it "includes packageAuthorizationProvider argument in build command when set", requires_xcodebuild: true do
+              options = { package_path: "./scan/examples/package/", scheme: "package", package_authorization_provider: "netrc" }
+              Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+              result = @test_command_generator.generate
+              expect(result).to include("-packageAuthorizationProvider netrc")
+            end
           end
 
           describe "With workspace" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

This fixes an issue where the value of the `package_authorization_provider` parameter was not being properly set in the build command when using `scan` to test a Swift package.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

This change makes sure that the `-packageAuthorizationProvider` argument is set correctly when the `package_authorization_provider` parameter is passed to `scan`.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

`bundle exec rspec scan/spec/test_command_generator_spec.rb:301`
