### PR TITLE
[scan] fix issue where Scan.get_deployment_target_version calls Scan.project.build_settings with an empty key #29623

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -301,7 +301,7 @@ module Scan
     # get deployment target version
     def self.get_deployment_target_version(deployment_target_key)
       version = Scan.config[:deployment_target_version]
-      version ||= Scan.project.build_settings(key: deployment_target_key) if Scan.project
+      version ||= Scan.project.build_settings(key: deployment_target_key) if Scan.project && !deployment_target_key.empty?
       version ||= 0
       return version
     end


### PR DESCRIPTION

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #29623 

### Description



### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
