### PR TITLE
[deliver] update ageRatingDeclaration

### DIFF
--- a/deliver/assets/example_rating_config.json
+++ b/deliver/assets/example_rating_config.json
@@ -3,6 +3,7 @@
   "contests": "NONE",
   "gamblingSimulated": "NONE",
   "horrorOrFearThemes": "NONE",
+  "koreaAgeRatingOverride": "NONE",
   "matureOrSuggestiveThemes": "NONE",
   "medicalOrTreatmentInformation": "NONE",
   "profanityOrCrudeHumor": "NONE",
@@ -12,6 +13,6 @@
   "violenceRealisticProlongedGraphicOrSadistic": "FREQUENT_OR_INTENSE",
   "violenceRealistic": "INFREQUENT_OR_MILD",
   "gambling": false,  
-  "seventeenPlus": false,
+  "lootBox": false,
   "unrestrictedWebAccess": true
 }

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -588,7 +588,7 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 
 ### Available age rating groups
 
-#### Non Boolean
+#### Infrequent/Mild or Frequent/Intense
 
 **Values**
 
@@ -610,13 +610,24 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 
 - `horrorOrFearThemes`
 - `kidsAgeBand`
-- `koreaAgeRatingOverride`
 - `matureOrSuggestiveThemes`
 - `sexualContentGraphicAndNudity`
 - `sexualContentOrNudity`
 - `violenceCartoonOrFantasy`
 - `violenceRealistic`
 - `violenceRealisticProlongedGraphicOrSadistic`
+
+#### Fifteen Plus or Nineteen Plus
+
+**Values**
+
+- `NONE`
+- `FIFTEEN_PLUS`
+- `NINETEEN_PLUS`
+
+**Keys**
+
+- `koreaAgeRatingOverride`
 
 #### Boolean
 

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -608,15 +608,15 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 - `medicalOrTreatmentInformation`
 - `profanityOrCrudeHumor`
 
-- `sexualContentGraphicAndNudity`
-- `sexualContentOrNudity`
 - `horrorOrFearThemes`
+- `kidsAgeBand`
 - `koreaAgeRatingOverride`
 - `matureOrSuggestiveThemes`
+- `sexualContentGraphicAndNudity`
+- `sexualContentOrNudity`
 - `violenceCartoonOrFantasy`
-- `violenceRealisticProlongedGraphicOrSadistic`
 - `violenceRealistic`
-- `kidsAgeBand`
+- `violenceRealisticProlongedGraphicOrSadistic`
 
 #### Boolean
 

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -602,29 +602,29 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 
 **Keys**
 
-- 'alcoholTobaccoOrDrugUseOrReferences'
-- 'contests'
-- 'gamblingSimulated'
-- 'medicalOrTreatmentInformation'
-- 'profanityOrCrudeHumor'
+- `alcoholTobaccoOrDrugUseOrReferences`
+- `contests`
+- `gamblingSimulated`
+- `medicalOrTreatmentInformation`
+- `profanityOrCrudeHumor`
 
-- 'sexualContentGraphicAndNudity'
-- 'sexualContentOrNudity'
-- 'horrorOrFearThemes'
-- 'matureOrSuggestiveThemes'
-- 'unrestrictedWebAccess'
-- 'violenceCartoonOrFantasy'
-- 'violenceRealisticProlongedGraphicOrSadistic'
-- 'violenceRealistic'
-- 'kidsAgeBand'
+- `sexualContentGraphicAndNudity`
+- `sexualContentOrNudity`
+- `horrorOrFearThemes`
+- `koreaAgeRatingOverride`
+- `matureOrSuggestiveThemes`
+- `violenceCartoonOrFantasy`
+- `violenceRealisticProlongedGraphicOrSadistic`
+- `violenceRealistic`
+- `kidsAgeBand`
 
 #### Boolean
 
 **Keys**
 
 - `gambling`
-- 'seventeenPlus'
 - `unrestrictedWebAccess`
+- `lootBox`
 
 #### Kids Age
 

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -8,6 +8,7 @@ module Spaceship
       attr_accessor :alcohol_tobacco_or_drug_use_or_references
       attr_accessor :contests
       attr_accessor :gambling_simulated
+      attr_accessor :korea_age_rating_override
       attr_accessor :medical_or_treatment_information
       attr_accessor :profanity_or_crude_humor
       attr_accessor :sexual_content_graphic_and_nudity
@@ -20,7 +21,7 @@ module Spaceship
 
       # Boolean
       attr_accessor :gambling
-      attr_accessor :seventeen_plus
+      attr_accessor :loot_box
       attr_accessor :unrestricted_web_access
 
       # KidsAge
@@ -46,9 +47,10 @@ module Spaceship
         "contests" => "contests",
         "gambling" => "gambling",
         "gamblingSimulated" => "gambling_simulated",
+        "koreaAgeRatingOverride" => "korea_age_rating_override",
+        "lootBox" => "loot_box",
         "medicalOrTreatmentInformation" => "medical_or_treatment_information",
         "profanityOrCrudeHumor" => "profanity_or_crude_humor",
-        "seventeenPlus" => "seventeen_plus",
         "sexualContentGraphicAndNudity" => "sexual_content_graphic_and_nudity",
         "sexualContentOrNudity" => "sexual_content_or_nudity",
         "horrorOrFearThemes" => "horror_or_fear_themes",


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass

I get one failure that looks unrelated to my change but all the others are succeeding.
```
 1) Gym detects the correct platform for a visionOS project
     Failure/Error: expect(Gym.project.visionos?).to eq(true)

       expected: true
            got: false

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -true
       +false

     # ./gym/spec/platform_detection_spec.rb:33:in `block (2 levels) in <top (required)>'
```

- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

I get the following error when executing Deliver with the [provided template](https://github.com/fastlane/fastlane/blob/master/deliver/assets/example_rating_config.json):
```shell
 \e[31m[!] The provided entity includes an unknown attribute - 'seventeenPlus' is not an attribute on the resource 'ageRatingDeclarations' - /data/attributes/seventeenPlus\e[0m (Spaceship::UnexpectedResponse)
```

### Description

Removed `seventeenPlus` and added `koreaAgeRatingOverride` and `lootBox` to match with the [AgeRatingDeclarations](https://developer.apple.com/documentation/appstoreconnectapi/ageratingdeclaration/attributes-data.dictionary).