### PR TITLE
[spaceship] Fix upload_trailer! method when no preview image is provided

### DIFF
--- a/spaceship/lib/spaceship/tunes/app_version.rb
+++ b/spaceship/lib/spaceship/tunes/app_version.rb
@@ -614,7 +614,7 @@ module Spaceship
               "checksum" => video_preview_data["md5"],
               "pictureAssetToken" => video_preview_data["token"],
               "previewFrameTimeCode" => ts.to_s,
-              "isPortrait" => Utilities.portrait?(video_preview_path)
+              "isPortrait" => Utilities.portrait?(trailer_path)
             }
           }
 


### PR DESCRIPTION
  ### Checklist

  - [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
  - [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
  - [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
  - [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
  - [x] I've updated the documentation if necessary.
  - [x] I've added or updated relevant unit tests.

  ### Motivation and Context

  The `upload_trailer!` method fails when no preview image is provided because it tries to use `video_preview_path` (which can be nil) in the `portrait?` utility check. This causes a runtime error for users who want to upload trailers without custom preview images.

  Resolves #11658

  ### Description

  Changed the `portrait?` check to use `trailer_path` instead of `video_preview_path`. The `trailer_path` is always available when uploading a trailer, while `video_preview_path` is only set when a custom preview image is provided.

  The fix is a one-line change in `spaceship/lib/spaceship/tunes/app_version.rb` at line 617:
  - Before: `"isPortrait" => Utilities.portrait?(video_preview_path)`
  - After: `"isPortrait" => Utilities.portrait?(trailer_path)`

  ### Testing Steps

  1. Ran the full test suite with `bundle exec rspec spaceship/spec/tunes/app_version_spec.rb`
     - Result: 55 examples, 0 failures
  2. Ran rubocop on the modified file with `bundle exec rubocop spaceship/lib/spaceship/tunes/app_version.rb`
     - Result: No offenses detected