### PR TITLE
Fix multiple simulators

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -229,7 +229,7 @@ module Scan
                   "of deployment target (#{deployment_target_version})")
                 end
               end
-              filter_simulators(simulators, :equal, version).tap(&potential_emptiness_error).select { |sim| sim.name == pieces.first }
+              [filter_simulators(simulators, :equal, version).tap(&potential_emptiness_error).first { |sim| sim.name == pieces.first }].compact
             end
           ).tap do |array|
             if array.empty?


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Description
There is an unexpected behavior when the runner appears to have multiple simulators with the same name and iOS version.  
The `detect_simulator` function works differently depending on whether the device is identified by its name alone or by both name and iOS version.  

In the latter case, it returns all available simulators and executes `xcodebuild` on them, but it should probably select only one simulator, as it does when only the name is provided.  

### Motivation and Context
Resolves #29661

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
- Install several simulators with same name
- try to run scan action

<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
