### PR TITLE
hardcode fallback for updated runtime

### DIFF
--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -147,7 +147,17 @@ module Scan
           end
 
           # Get OS version corresponding to build
-          Gem::Version.new(FastlaneCore::DeviceManager.runtime_build_os_versions[runtime_build])
+          
+          # In August 2025, Apple released an update to the simulator, without updating xcode
+          # this leads to a nil os_version here.
+          os_version = FastlaneCore::DeviceManager.runtime_build_os_versions[runtime_build]
+          
+          if os_version.nil? and runtime_build == "22F76"
+           # retry with the hardcoded runtime build version
+           os_version = FastlaneCore::DeviceManager.runtime_build_os_versions["22G86"]
+          end
+          
+          Gem::Version.new(os_version)
         end
       end
     end


### PR DESCRIPTION

### Checklist

- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- I got  "undefined method 'do_get_block' for class 'WebMockHTTPClient' " but I do not think this has something to do with my code
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
Rubocop did not launch.
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.
- [] I've added or updated relevant unit tests.

### Motivation and Context

Apple has once again updated a simulator runtime, without updating Xcode.

<img width="790" height="47" alt="Screenshot 2025-08-18 at 16 00 45" src="https://github.com/user-attachments/assets/5dd666e1-a358-465c-8b7b-e5b1e9fac0a3" />

For my project, this lead to the problem that the simulator is no longer found:

```
[15:55:10]: $ xcodebuild -showBuildSettings -scheme ClinicApp -project ./ClinicApp.xcodeproj 2>&1
[15:55:13]: Command timed out after 3 seconds on try 1 of 4, trying again with a 6 second timeout...
[15:55:19]: Command timed out after 6 seconds on try 2 of 4, trying again with a 12 second timeout...
nil versions are discouraged and will be deprecated in Rubygems 4
[15:55:27]: Ignoring 'iPhone 16 Pro Max iOS-18-5', couldn't find matching simulator

+------------------------------------------------------------------------------------------------------------------------------------------+
|                                                         Summary for scan 2.228.0                                                         |
+------------------------------------------------+-----------------------------------------------------------------------------------------+
| scheme                                         | ClinicApp                                                                               |
| testplan                                       | Tests                                                                                   |
| skip_detect_devices                            | true                                                                                    |
| reset_simulator                                | false                                                                                   |
| devices                                        | ["iPhone 16 Pro Max iOS-18-5"]                                                          |
| output_types                                   | junit                                                                                   |
| output_files                                   | junit.xml                                                                               |
| output_directory                               | ./fastlane/test_output/scan-ClinicApp                                                   |
| code_coverage                                  | true                                                                                    |
| buildlog_path                                  | .logs/tests                                                                             |
| xcargs                                         | -skipPackagePluginValidation -skipMacroValidation                                       |
| parallel_testing                               | true                                                                                    |
| concurrent_workers                             | 3                                                                                       |
| prelaunch_simulator                            | true                                                                                    |
| project                                        | ./ClinicApp.xcodeproj                                                                   |
| ensure_devices_found                           | false                                                                                   |
| force_quit_simulator                           | false                                                                                   |
| disable_slide_to_type                          | true                                                                                    |
| reinstall_app                                  | false                                                                                   |
| app_identifier                                 | de.number42.HammKliniken                                                                |
| clean                                          | false                                                                                   |
| open_report                                    | false                                                                                   |
| include_simulator_logs                         | false                                                                                   |
| xcodebuild_formatter                           | xcpretty                                                                                |
| output_remove_retry_attempts                   | false                                                                                   |
| derived_data_path                              | /Users/admin/Library/Developer/Xcode/DerivedData/ClinicApp-aisphxldtrzqiraqscjpzjjuettp |
| should_zip_build_products                      | false                                                                                   |
| output_xctestrun                               | false                                                                                   |
| result_bundle                                  | false                                                                                   |
| use_clang_report_name                          | false                                                                                   |
| disable_concurrent_testing                     | false                                                                                   |
| skip_build                                     | false                                                                                   |
| slack_use_webhook_configured_username_and_icon | false                                                                                   |
| slack_username                                 | fastlane                                                                                |
| slack_icon_url                                 | https://fastlane.tools/assets/img/fastlane_icon.png                                     |
| skip_slack                                     | false                                                                                   |
| slack_only_on_failure                          | false                                                                                   |
| run_rosetta_simulator                          | false                                                                                   |
| xcodebuild_command                             | env NSUnbufferedIO=YES xcodebuild                                                       |
| skip_package_dependencies_resolution           | false                                                                                   |
| disable_package_automatic_updates              | false                                                                                   |
| use_system_scm                                 | false                                                                                   |
| number_of_retries                              | 0                                                                                       |
| fail_build                                     | true                                                                                    |
| xcode_path                                     | /Applications/Xcode-16.4.0.app                                                          |
+------------------------------------------------+-----------------------------------------------------------------------------------------+
```

Same happens if I update the iOS Version to 18.6.

The line 

```
nil versions are discouraged and will be deprecated in Rubygems 4
```

made it clear, that some lookup failed.

### Description

I inspected the map of build number to version and found, that a fallback is needed for this case.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
