### PR TITLE
Allow .app files in IPA validation

### DIFF
--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -166,7 +166,7 @@ module Sigh
     end
 
     def validate_ipa_file(ipa)
-      UI.user_error!("ipa file could not be found or is not an ipa file (#{ipa})") unless File.exist?(ipa) && ipa.end_with?('.ipa')
+      UI.user_error!("ipa file could not be found or is not an ipa file (#{ipa})") unless File.exist?(ipa) && (ipa.end_with?('.ipa') || ipa.end_with?('.app'))
     end
 
     def validate_provisioning_file(provisioning_profile)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context
The [`resign`](https://docs.fastlane.tools/actions/resign/) function allows to resign an `.ipa` file which is used for an iOS app. Because of the strict extension validation (`ipa.end_with?('.ipa')`), this cannot be used for a MacOS app that is similar other than it uses a `.app` extension.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

Extend the file validation to also accept `.app`.

I didn't change much of the file / documentation that refers to `ipa`. I was unsure about what would be best. Surely not breaking existing APIs. Possibly to add a new parameter `app` that is more generic and deprecate ipa while still supporting it?

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
