### PR TITLE
Fix spelling: "set up" as verb

### DIFF
--- a/cert/lib/cert/module.rb
+++ b/cert/lib/cert/module.rb
@@ -2,7 +2,7 @@ require 'fastlane_core/helper'
 require 'fastlane/boolean'
 
 module Cert
-  # Use this to just setup the configuration attribute and set it later somewhere else
+  # Use this to just set up the configuration attribute and set it later somewhere else
   class << self
     attr_accessor :config
   end

--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -425,7 +425,7 @@ As a result, the `template_name` parameter was deprecated in the _match_ action,
 
 _match_ automatically pre-fills environment variables with the UUIDs of the correct provisioning profiles, ready to be used in your Xcode project.
 
-More information about how to setup your Xcode project can be found [here](/codesigning/xcode-project/)
+More information about how to set up your Xcode project can be found [here](/codesigning/xcode-project/)
 
 #### To build from Xcode manually
 

--- a/fastlane/lib/fastlane/actions/get_build_number.rb
+++ b/fastlane/lib/fastlane/actions/get_build_number.rb
@@ -37,7 +37,7 @@ module Fastlane
         return build_number
       rescue => ex
         return false if params[:hide_error_when_versioning_disabled]
-        UI.error('Before being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html')
+        UI.error('Before being able to increment and read the version number from your Xcode project, you first need to set up your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html')
         raise ex
       end
 

--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -53,7 +53,7 @@ module Fastlane
 
         return Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
       rescue
-        UI.user_error!("Apple Generic Versioning is not enabled in this project.\nBefore being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html")
+        UI.user_error!("Apple Generic Versioning is not enabled in this project.\nBefore being able to increment and read the version number from your Xcode project, you first need to set up your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html")
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -80,7 +80,7 @@ module Fastlane
 
         return Actions.lane_context[SharedValues::VERSION_NUMBER]
       rescue => ex
-        UI.error('Before being able to increment and read the version number from your Xcode project, you first need to setup your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html')
+        UI.error('Before being able to increment and read the version number from your Xcode project, you first need to set up your project properly. Please follow the guide at https://developer.apple.com/library/content/qa/qa1827/_index.html')
         raise ex
       end
 

--- a/fastlane/lib/fastlane/actions/setup_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_ci.rb
@@ -71,7 +71,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Setup the keychain and match to work with CI"
+        "Set up the keychain and match to work with CI"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/setup_circle_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_circle_ci.rb
@@ -10,7 +10,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Setup the keychain and match to work with CircleCI"
+        "Set up the keychain and match to work with CircleCI"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/actions/setup_travis.rb
+++ b/fastlane/lib/fastlane/actions/setup_travis.rb
@@ -10,7 +10,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Setup the keychain and match to work with Travis CI"
+        "Set up the keychain and match to work with Travis CI"
       end
 
       def self.details

--- a/fastlane/lib/fastlane/runner.rb
+++ b/fastlane/lib/fastlane/runner.rb
@@ -304,7 +304,7 @@ module Fastlane
       end
     end
 
-    # Called internally to setup the runner object
+    # Called internally to set up the runner object
     #
 
     # @param lane [Lane] A lane object

--- a/fastlane/lib/fastlane/setup/setup.rb
+++ b/fastlane/lib/fastlane/setup/setup.rb
@@ -116,7 +116,7 @@ module Fastlane
       else
         UI.error("No iOS or Android projects were found in directory '#{Dir.pwd}'")
         UI.error("Make sure to `cd` into the directory containing your iOS or Android app")
-        if UI.confirm("Alternatively, would you like to manually setup a fastlane config in the current directory instead?")
+        if UI.confirm("Alternatively, would you like to manually set up a fastlane config in the current directory instead?")
           SetupIos.new(
             is_swift_fastfile: is_swift_fastfile,
             user: user,

--- a/fastlane/lib/fastlane/setup/setup_ios.rb
+++ b/fastlane/lib/fastlane/setup/setup_ios.rb
@@ -38,7 +38,7 @@ module Fastlane
         "📸  Automate screenshots" => :ios_screenshots,
         "👩‍✈️  Automate beta distribution to TestFlight" => :ios_testflight,
         "🚀  Automate App Store distribution" => :ios_app_store,
-        "🛠  Manual setup - manually setup your project to automate your tasks" => :ios_manual
+        "🛠  Manual setup - manually set up your project to automate your tasks" => :ios_manual
       }
 
       selected = UI.select("What would you like to use fastlane for?", options.keys)

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -9866,7 +9866,7 @@ public func setPodKey(useBundleExec: OptionalConfigValue<Bool> = .fastlaneDefaul
 }
 
 /**
- Setup the keychain and match to work with CI
+ Set up the keychain and match to work with CI
 
  - parameters:
    - force: Force setup, even if not executed by CI
@@ -9901,7 +9901,7 @@ public func setupCi(force: OptionalConfigValue<Bool> = .fastlaneDefault(false),
 }
 
 /**
- Setup the keychain and match to work with CircleCI
+ Set up the keychain and match to work with CircleCI
 
  - parameter force: Force setup, even if not executed by CircleCI
 
@@ -9991,7 +9991,7 @@ public func setupJenkins(force: OptionalConfigValue<Bool> = .fastlaneDefault(fal
 }
 
 /**
- Setup the keychain and match to work with Travis CI
+ Set up the keychain and match to work with Travis CI
 
  - parameter force: Force setup, even if not executed by travis
 

--- a/pem/lib/pem/module.rb
+++ b/pem/lib/pem/module.rb
@@ -1,7 +1,7 @@
 require 'fastlane_core/helper'
 
 module PEM
-  # Use this to just setup the configuration attribute and set it later somewhere else
+  # Use this to just set up the configuration attribute and set it later somewhere else
   class << self
     attr_accessor :config
   end

--- a/precheck/lib/precheck/module.rb
+++ b/precheck/lib/precheck/module.rb
@@ -3,7 +3,7 @@ require 'fastlane_core/ui/ui'
 require 'fastlane/boolean'
 
 module Precheck
-  # Use this to just setup the configuration attribute and set it later somewhere else
+  # Use this to just set up the configuration attribute and set it later somewhere else
   class << self
     attr_accessor :config
 

--- a/screengrab/example/gradlew.bat
+++ b/screengrab/example/gradlew.bat
@@ -67,7 +67,7 @@ goto execute
 set CMD_LINE_ARGS=%$
 
 :execute
-@rem Setup the command line
+@rem Set up the command line
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 

--- a/screengrab/gradlew.bat
+++ b/screengrab/gradlew.bat
@@ -61,7 +61,7 @@ if "x%~1" == "x" goto execute
 set CMD_LINE_ARGS=%*
 
 :execute
-@rem Setup the command line
+@rem Set up the command line
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 

--- a/screengrab/lib/screengrab/module.rb
+++ b/screengrab/lib/screengrab/module.rb
@@ -3,7 +3,7 @@ require 'fastlane/boolean'
 require_relative 'detect_values'
 
 module Screengrab
-  # Use this to just setup the configuration attribute and set it later somewhere else
+  # Use this to just set up the configuration attribute and set it later somewhere else
   class << self
     attr_accessor :config
     attr_accessor :android_environment

--- a/sigh/lib/sigh/module.rb
+++ b/sigh/lib/sigh/module.rb
@@ -2,7 +2,7 @@ require 'fastlane_core/ui/ui'
 require 'fastlane_core/helper'
 
 module Sigh
-  # Use this to just setup the configuration attribute and set it later somewhere else
+  # Use this to just set up the configuration attribute and set it later somewhere else
   class << self
     attr_accessor :config
 

--- a/snapshot/lib/snapshot/module.rb
+++ b/snapshot/lib/snapshot/module.rb
@@ -4,7 +4,7 @@ require_relative 'detect_values'
 require_relative 'dependency_checker'
 
 module Snapshot
-  # Use this to just setup the configuration attribute and set it later somewhere else
+  # Use this to just set up the configuration attribute and set it later somewhere else
   class << self
     attr_accessor :config
 

--- a/supply/lib/supply.rb
+++ b/supply/lib/supply.rb
@@ -12,7 +12,7 @@ require 'supply/languages'
 require 'fastlane_core'
 
 module Supply
-  # Use this to just setup the configuration attribute and set it later somewhere else
+  # Use this to just set up the configuration attribute and set it later somewhere else
   class << self
     attr_accessor :config
   end


### PR DESCRIPTION
"setup" is a noun, and "set up" is a verb. This mistake appears at the beginning of the init process in the CLI and in other places throughout the codebase. I corrected the instances that were easiest to find.