### PR TITLE
Change relationship type from appStoreVersions to appInfos

### DIFF
--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -717,9 +717,9 @@ module Spaceship
               type: "appInfoLocalizations",
               attributes: attributes,
               relationships: {
-                appStoreVersion: {
+                appInfo: {
                   data: {
-                    type: "appStoreVersions",
+                    type: "appInfos",
                     id: app_info_id
                   }
                 }


### PR DESCRIPTION
Fix AppStore Connect API usage for POST to appInfoLocalizations. See https://developer.apple.com/documentation/appstoreconnectapi/post-v1-appinfolocalizations#Add-Localized-App-Information-in-US-English

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
 
It fixes AppStore Connect API use error for POST to appInfoLocalizations. 

Resolves #29690


### Description

I tried using spaceship as a library to update / create app info localizations and it failed with the following error.

```
Failed to update app info for language fr: The provided entity includes an unknown relationship - 'appStoreVersion' is not a relationship on the resource 'appInfoLocalizations' - /data/relationships/appStoreVersion
The provided entity is missing a required relationship - You must provide a value for the relationship 'appInfo' with this request - /data/relationships/appInfo
```

### Testing Steps

Run 

```
    attributes = {
      name: localization.name
    }

    app_info.create_app_info_localization(
      client: client,
      attributes: attributes.merge(locale: "it")
    )
```
