### PR TITLE
fix: correct initial build number to start sequence properly

### DIFF
--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -6546,7 +6546,7 @@ public func jazzy(config: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                                                            username: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                                                            version: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                                                            platform: String = "ios",
-                                                           initialBuildNumber: Int = 1,
+                                                           initialBuildNumber: Int = 0,
                                                            teamId: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                                                            teamName: OptionalConfigValue<String?> = .fastlaneDefault(nil)) -> Int
 {


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

When using fastlane for continuous deployment, I discovered that new versions always start from build number 2 instead of 1. My current workflow follows the official fastlane documentation:
```ruby
increment_build_number({
  build_number: latest_testflight_build_number + 1
})
```
After investigation, I found that the root cause is that when the build number cannot be retrieved (specifically when uploading the first build of a new version for an existing app), it defaults to 1. Therefore, when incrementing by 1, the first uploaded build becomes build number 2, which creates confusion and inconsistency in version numbering.
This change ensures that the first build of any new version starts from build number 1 as expected, maintaining a clean and predictable build numbering sequence.

### Description

Set initial build number to 0 instead of 1 so that builds start from 1 rather than 2 when no previous builds exist.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
