### PR TITLE
add Apple Watch Series 10/11 and Ultra 3 sizes

### DIFF
--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -69,8 +69,12 @@ module Deliver
       IOS_APPLE_WATCH_SERIES4 = "iOS-Apple-Watch-Series4"
       # Apple Watch Series 7
       IOS_APPLE_WATCH_SERIES7 = "iOS-Apple-Watch-Series7"
+      # Apple Watch Series 10
+      IOS_APPLE_WATCH_SERIES10 = "iOS-Apple-Watch-Series10"
       # Apple Watch Ultra
       IOS_APPLE_WATCH_ULTRA = "iOS-Apple-Watch-Ultra"
+      # Apple Watch Ultra 3
+      IOS_APPLE_WATCH_ULTRA3 = "iOS-Apple-Watch-Ultra3"
 
       # Apple TV
       APPLE_TV = "Apple-TV"
@@ -130,7 +134,9 @@ module Deliver
         ScreenSize::IOS_APPLE_WATCH => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_3,
         ScreenSize::IOS_APPLE_WATCH_SERIES4 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_4,
         ScreenSize::IOS_APPLE_WATCH_SERIES7 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_7,
+        ScreenSize::IOS_APPLE_WATCH_SERIES10 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_10,
         ScreenSize::IOS_APPLE_WATCH_ULTRA => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_ULTRA,
+        ScreenSize::IOS_APPLE_WATCH_ULTRA3 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_ULTRA3,
         ScreenSize::APPLE_TV => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_APPLE_TV
       }
       return matching[self.screen_size]
@@ -168,7 +174,9 @@ module Deliver
         ScreenSize::IOS_APPLE_WATCH => "Watch",
         ScreenSize::IOS_APPLE_WATCH_SERIES4 => "Watch Series4",
         ScreenSize::IOS_APPLE_WATCH_SERIES7 => "Watch Series7",
+        ScreenSize::IOS_APPLE_WATCH_SERIES10 => "Watch Series10",
         ScreenSize::IOS_APPLE_WATCH_ULTRA => "Watch Ultra",
+        ScreenSize::IOS_APPLE_WATCH_ULTRA3 => "Watch Ultra3",
         ScreenSize::APPLE_TV => "Apple TV"
       }
       return matching[self.screen_size]
@@ -344,8 +352,14 @@ module Deliver
         ScreenSize::IOS_APPLE_WATCH_SERIES7 => [
           [396, 484]
         ],
+        ScreenSize::IOS_APPLE_WATCH_SERIES10 => [
+          [416, 496]
+        ],
         ScreenSize::IOS_APPLE_WATCH_ULTRA => [
           [410, 502]
+        ],
+        ScreenSize::IOS_APPLE_WATCH_ULTRA3 => [
+          [422, 514]
         ],
         ScreenSize::APPLE_TV => [
           [1920, 1080],

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -153,7 +153,9 @@ describe Deliver::AppScreenshot do
         expect_screen_size_from_file("AppleWatch-Series3{312x390}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH)
         expect_screen_size_from_file("AppleWatch-Series4{368x448}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES4)
         expect_screen_size_from_file("AppleWatch-Series7{396x484}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES7)
+        expect_screen_size_from_file("AppleWatch-Series7{416x496}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES10)
         expect_screen_size_from_file("AppleWatch-Ultra{410x502}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_ULTRA)
+        expect_screen_size_from_file("AppleWatch-Ultra3{422x514}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_ULTRA3)
       end
     end
 
@@ -371,8 +373,16 @@ describe Deliver::AppScreenshot do
       expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES7).device_type).to eq("APP_WATCH_SERIES_7")
     end
 
+    it "should return watchSeries10 for Apple Watch Series 10" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES10).device_type).to eq("APP_WATCH_SERIES_10")
+    end
+
     it "should return watchUltra for Apple Watch Ultra" do
       expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_ULTRA).device_type).to eq("APP_WATCH_ULTRA")
+    end
+
+    it "should return watchUltra3 for Apple Watch Ultra 3" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_ULTRA3).device_type).to eq("APP_WATCH_ULTRA_3")
     end
 
     it "should return appleTV for Apple TV" do

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
@@ -43,7 +43,9 @@ module Spaceship
         APP_WATCH_SERIES_3 = "APP_WATCH_SERIES_3"
         APP_WATCH_SERIES_4 = "APP_WATCH_SERIES_4"
         APP_WATCH_SERIES_7 = "APP_WATCH_SERIES_7"
+        APP_WATCH_SERIES_10 = "APP_WATCH_SERIES_10"
         APP_WATCH_ULTRA = "APP_WATCH_ULTRA"
+        APP_WATCH_ULTRA_3 = "APP_WATCH_ULTRA_3"
 
         APP_APPLE_TV = "APP_APPLE_TV"
 
@@ -98,7 +100,9 @@ module Spaceship
           APP_WATCH_SERIES_3,
           APP_WATCH_SERIES_4,
           APP_WATCH_SERIES_7,
+          APP_WATCH_SERIES_10,
           APP_WATCH_ULTRA,
+          APP_WATCH_ULTRA_3,
 
           APP_DESKTOP
         ]


### PR DESCRIPTION
### Motivation and Context

current fastlane deliver fails to allow uploading of the new Apple Watch sizes

### Description

followed format and added new sizes
