### PR TITLE
[match] Fix `Aws::S3::Object#download_file` deprecation

### DIFF
--- a/fastlane/lib/fastlane/helper/s3_client_helper.rb
+++ b/fastlane/lib/fastlane/helper/s3_client_helper.rb
@@ -39,6 +39,10 @@ module Fastlane
         obj.public_url.to_s
       end
 
+      def download_file(bucket_name, key, destination_path)
+        Aws::S3::TransferManager.new(client: client).download_file(destination_path, bucket: bucket_name, key: key)
+      end
+
       def delete_file(bucket_name, file_name)
         bucket = find_bucket!(bucket_name)
         file = bucket.object(file_name)

--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -105,12 +105,9 @@ module Match
         # so that we limit the download to only files that are specific to this team, and avoid downloads + decryption of unnecessary files.
         key_prefix = team_id.nil? ? s3_object_prefix : File.join(s3_object_prefix, team_id, '').delete_prefix('/')
 
-        s3_client.find_bucket!(s3_bucket).objects(prefix: key_prefix).each do |object|
-          # Prevent download if the file path is a directory.
-          # We need to check if string ends with "/" instead of using `File.directory?` because
-          # the string represent a remote location, not a local file in disk.
-          next if object.key.end_with?("/")
-
+        objects_to_download = s3_client.find_bucket!(s3_bucket).objects(prefix: key_prefix).reject { |object| object.key.end_with?("/") }
+        UI.message("Downloading #{objects_to_download.count} files from S3 bucket...")
+        objects_to_download.each do |object|
           file_path = strip_s3_object_prefix(object.key) # :s3_object_prefix:team_id/path/to/file
 
           # strip s3_prefix from file_path

--- a/match/lib/match/storage/s3_storage.rb
+++ b/match/lib/match/storage/s3_storage.rb
@@ -119,7 +119,7 @@ module Match
           FileUtils.mkdir_p(File.expand_path("..", download_path))
           UI.verbose("Downloading file from S3 '#{file_path}' on bucket #{self.s3_bucket}")
 
-          object.download_file(download_path)
+          s3_client.download_file(s3_bucket, object.key, download_path)
         end
         UI.verbose("Successfully downloaded files from S3 to #{self.working_directory}")
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] ~~I've updated the documentation if necessary.~~
- [x] I've added or updated relevant unit tests.

### Motivation and Context

[As of `aws-sdk-ruby` version `1.197.0` (2025-08-19), the `Aws::S3::Object#download_file` method is deprecated](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-s3/CHANGELOG.md#11970-2025-08-19).

This leads to the following deprecation warning message in the output when running the `sync_code_signing`/`match` action with `storage_mode: 's3'`:

```
#################### DEPRECATION WARNING ####################
Called deprecated method `download_file` of Aws::S3::Object. Use `Aws::S3::TransferManager#download_file` instead.
Method `download_file` will be removed in next major version.
#############################################################
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.199.1/lib/aws-sdk-s3/customizations/object_summary.rb:80:in `download_file'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/match/lib/match/storage/s3_storage.rb:122:in `block in download'
```

<details><summary>Expand for full extract</summary>

```
#################### DEPRECATION WARNING ####################
Called deprecated method `download_file` of Aws::S3::Object. Use `Aws::S3::TransferManager#download_file` instead.
Method `download_file` will be removed in next major version.
#############################################################
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.199.1/lib/aws-sdk-s3/customizations/object_summary.rb:80:in `download_file'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/match/lib/match/storage/s3_storage.rb:122:in `block in download'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:54:in `yield'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:54:in `block (3 levels) in each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:53:in `each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:53:in `block (2 levels) in each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:102:in `yield'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:102:in `block (2 levels) in non_empty_batches'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.199.1/lib/aws-sdk-s3/bucket.rb:1565:in `yield'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.199.1/lib/aws-sdk-s3/bucket.rb:1565:in `block (2 levels) in objects'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/pageable_response.rb:191:in `each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-s3-1.199.1/lib/aws-sdk-s3/bucket.rb:1555:in `block in objects'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:101:in `each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:101:in `each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:101:in `block in non_empty_batches'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:52:in `each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:52:in `each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:52:in `block in each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:58:in `each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:58:in `each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/aws-sdk-core-3.233.0/lib/aws-sdk-core/resources/collection.rb:58:in `each'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/match/lib/match/storage/s3_storage.rb:108:in `download'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/match/lib/match/runner.rb:45:in `run'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/actions/sync_code_signing.rb:19:in `run'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:263:in `block (2 levels) in execute_action'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/actions/actions_helper.rb:69:in `execute_action'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:255:in `block in execute_action'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:229:in `chdir'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:229:in `execute_action'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:157:in `trigger_action_by_name'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/fast_file.rb:159:in `method_missing'
Fastfile:28:in `block in parsing_binding'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/lane.rb:32:in `block in initialize'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/lane.rb:41:in `call'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:49:in `block in execute'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:45:in `chdir'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:45:in `execute'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/lane_manager.rb:46:in `cruise_lane'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/command_line_handler.rb:34:in `handle'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/commands_generator.rb:110:in `block (2 levels) in run'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in `run!'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/commands_generator.rb:363:in `run'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/commands_generator.rb:43:in `start'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/fastlane/lib/fastlane/cli_tools_distributor.rb:123:in `take_off'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/gems/fastlane-2.228.0/bin/fastlane:23:in `<top (required)>'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/bin/fastlane:25:in `load'
/Users/olivierhalligon/Documents/Dev/apps/wordpress-contributor-toolkit/vendor/bundle/ruby/3.2.0/bin/fastlane:25:in `<top (required)>'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/cli/exec.rb:59:in `load'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/cli/exec.rb:59:in `kernel_load'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/cli/exec.rb:23:in `run'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/cli.rb:452:in `exec'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/vendor/thor/lib/thor.rb:538:in `dispatch'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/cli.rb:35:in `dispatch'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/cli.rb:29:in `start'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/exe/bundle:28:in `block in <top (required)>'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/Users/olivierhalligon/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.6.8/exe/bundle:20:in `<top (required)>'
/Users/olivierhalligon/.rbenv/versions/3.2.2/bin/bundle:25:in `load'
/Users/olivierhalligon/.rbenv/versions/3.2.2/bin/bundle:25:in `<main>'
[08:43:56]: 🔓  Successfully decrypted certificates repo
```
</details>

### Description

This PR updates the implementation of `s3_client_helper.rb` to add a `download_file` helper method, then make `s3_storage.rb` use that helper function to download the certificates and profile files from the S3 bucket instead of using `object.download_file(…)` directly.

The new `S3ClientHelper#download_file` helper method then uses `TransferManager.new(client: client).download_file(…)` to perform the download instead of using the deprecated `object.download_file` directly as before.

This also adds a `UI.message("Downloading #{objects_to_download.count} files from S3 bucket...")` to make it less suspicious when you see the fastlane output pausing for a bit while it downloads all the matching files from the bucket (especially if your S3 bucket contains lots of certs and profiles to download)

### Testing Steps

Have a call to `sync_code_signing` (aka `match`) in your `Fastfile` that uses `storage_mode: 's3'`, and have a corresponding S3 bucket configured for your match certs and profiles.
Here's an example of a case I used for sync'ing a Mac DeveloperID:

```ruby
lane :setup_code_signing do
  app_store_connect_api_key

  sync_code_signing(
    platform: 'macos',
    app_identifier: APPLE_BUNDLE_IDENTIFIER,
    team_id: APPLE_TEAM_ID,
    type: 'developer_id',
    storage_mode: 's3',
    s3_bucket: S3_BUCKET_NAME,
    readonly: true
  )
end
```
Also, ensure you `bundle update` to get one of the latest version of `aws-sdk-s3`, at least >= `1.197.0`, in your `Gemfile.lock`

Then run `bundle exec fastlane setup_code_signing`
 - If you run that on a version of `fastlane` before this PR, you should get the lengthy warning from the `aws-sdk` gem
 - If you run the same lane after pointing `fastlane` to this PR / branch, you should not get the warning anymore
 - In both cases you should see a green `🔓  Successfully decrypted certificates repo` after the download has finished