### PR TITLE
[deliver] [pilot] Allow `-assetFile` and `-assetDescription` options for Transporter on Linux and Windows

### DIFF
--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -83,6 +83,10 @@ module Deliver
                                      conflict_block: proc do |value|
                                        UI.user_error!("You can't use 'pkg' and '#{value.key}' options in one run.")
                                      end),
+        FastlaneCore::ConfigItem.new(key: :asset_description_path,
+                                     env_name: "DELIVER_ASSET_DESCRIPTION_PATH",
+                                     description: "Path to the asset description file (Apple requires a AppStoreInfo.plist for Linux and Windows)",
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :build_number,
                                      short_option: "-n",
                                      env_name: "DELIVER_BUILD_NUMBER",

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -204,6 +204,7 @@ module Deliver
 
       ipa_path = options[:ipa]
       pkg_path = options[:pkg]
+      asset_description_path = options[:asset_description_path]
 
       platform = options[:platform]
       transporter = transporter_for_selected_team
@@ -216,7 +217,7 @@ module Deliver
           package_path: "/tmp",
           platform: platform
         )
-        result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
+        result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform, asset_description: asset_description_path)
       when "osx"
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
@@ -224,7 +225,7 @@ module Deliver
           package_path: "/tmp",
           platform: platform
         )
-        result = transporter.upload(package_path: package_path, asset_path: pkg_path, platform: platform)
+        result = transporter.upload(package_path: package_path, asset_path: pkg_path, platform: platform, asset_description: asset_description_path)
       else
         UI.user_error!("No suitable file found for upload for platform: #{options[:platform]}")
       end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -450,6 +450,10 @@ module FastlaneCore
       self.windows?
     end
 
+    def self.is_linux?
+      self.linux?
+    end
+
     # <b>DEPRECATED:</b> Use the `ROOT` constant from the appropriate tool module instead
     # e.g. File.join(Sigh::ROOT, 'lib', 'assets', 'resign.sh')
     #

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -13,9 +13,8 @@ describe FastlaneCore do
       allow(SecureRandom).to receive(:uuid).and_return(random_uuid)
     end
 
-    def shell_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, use_asset_description: false, username: email, input_pass: password, api_key: nil)
+    def shell_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, username: email, input_pass: password, api_key: nil)
       upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
-      asset_description_part = use_asset_description ? "-assetDescription /tmp/AppStoreInfo.plist" : nil
 
       username = username if username != email
       escaped_password = input_pass
@@ -45,7 +44,6 @@ describe FastlaneCore do
            "-jwt #{jwt}"
          end),
         upload_part,
-        asset_description_part,
         (transporter.to_s if transporter),
         "-k 100000",
         ("-WONoPause true" if FastlaneCore::Helper.windows?),
@@ -144,9 +142,8 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def java_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, classpath: true, use_asset_path: false, use_asset_description: false)
+    def java_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, classpath: true, use_asset_path: false)
       upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
-      asset_description_part = use_asset_description ? "-assetDescription /tmp/AppStoreInfo.plist" : nil
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -164,7 +161,6 @@ describe FastlaneCore do
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         upload_part,
-        asset_description_part,
         (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
@@ -237,9 +233,8 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def java_upload_command_9(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, use_asset_description: false)
+    def java_upload_command_9(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
       upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
-      asset_description_part = use_asset_description ? "-assetDescription /tmp/AppStoreInfo.plist" : nil
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -255,7 +250,6 @@ describe FastlaneCore do
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         upload_part,
-        asset_description_part,
         (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
@@ -305,9 +299,8 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def xcrun_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, use_asset_description: false)
+    def xcrun_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
       upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
-      asset_description_part = use_asset_description ? "-assetDescription /tmp/AppStoreInfo.plist" : nil
 
       [
         ("ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}" if jwt.nil?),
@@ -317,7 +310,6 @@ describe FastlaneCore do
         ("-p @env:ITMS_TRANSPORTER_PASSWORD" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         upload_part,
-        asset_description_part,
         (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -13,8 +13,9 @@ describe FastlaneCore do
       allow(SecureRandom).to receive(:uuid).and_return(random_uuid)
     end
 
-    def shell_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, username: email, input_pass: password, api_key: nil)
+    def shell_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, use_asset_description: false, username: email, input_pass: password, api_key: nil)
       upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      asset_description_part = use_asset_description ? "-assetDescription /tmp/AppStoreInfo.plist" : nil
 
       username = username if username != email
       escaped_password = input_pass
@@ -44,6 +45,7 @@ describe FastlaneCore do
            "-jwt #{jwt}"
          end),
         upload_part,
+        asset_description_part,
         (transporter.to_s if transporter),
         "-k 100000",
         ("-WONoPause true" if FastlaneCore::Helper.windows?),
@@ -142,8 +144,9 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def java_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, classpath: true, use_asset_path: false)
+    def java_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, classpath: true, use_asset_path: false, use_asset_description: false)
       upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      asset_description_part = use_asset_description ? "-assetDescription /tmp/AppStoreInfo.plist" : nil
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -161,6 +164,7 @@ describe FastlaneCore do
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         upload_part,
+        asset_description_part,
         (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
@@ -233,8 +237,9 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def java_upload_command_9(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
+    def java_upload_command_9(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, use_asset_description: false)
       upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      asset_description_part = use_asset_description ? "-assetDescription /tmp/AppStoreInfo.plist" : nil
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -250,6 +255,7 @@ describe FastlaneCore do
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         upload_part,
+        asset_description_part,
         (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
@@ -299,8 +305,9 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def xcrun_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
+    def xcrun_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, use_asset_description: false)
       upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      asset_description_part = use_asset_description ? "-assetDescription /tmp/AppStoreInfo.plist" : nil
 
       [
         ("ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}" if jwt.nil?),
@@ -310,6 +317,7 @@ describe FastlaneCore do
         ("-p @env:ITMS_TRANSPORTER_PASSWORD" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         upload_part,
+        asset_description_part,
         (transporter.to_s if transporter),
         "-k 100000",
         ("-itc_provider #{provider_short_name}" if provider_short_name),

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -31,6 +31,7 @@ module Pilot
 
       platform = fetch_app_platform
       ipa_path = options[:ipa]
+      asset_description_path = options[:asset_description_path]
       if ipa_path && platform != 'osx'
         asset_path = ipa_path
         app_identifier = config[:app_identifier] || fetch_app_identifier
@@ -45,6 +46,7 @@ module Pilot
                                                                 bundle_version: bundle_version)
       else
         pkg_path = options[:pkg]
+        asset_description_path = options[:asset_description_path]
         asset_path = pkg_path
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(app_id: fetch_app_id,
                                                                         pkg_path: pkg_path,
@@ -53,7 +55,7 @@ module Pilot
       end
 
       transporter = transporter_for_selected_team(options)
-      result = transporter.upload(package_path: package_path, asset_path: asset_path, platform: platform)
+      result = transporter.upload(package_path: package_path, asset_path: asset_path, platform: platform, asset_description: asset_description_path)
 
       unless result
         transporter_errors = transporter.displayable_errors

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -102,6 +102,10 @@ module Pilot
                                      conflict_block: proc do |value|
                                        UI.user_error!("You can't use 'pkg' and '#{value.key}' options in one run.")
                                      end),
+        FastlaneCore::ConfigItem.new(key: :asset_description_path,
+                                     env_name: "PILOT_ASSET_DESCRIPTION_PATH",
+                                     description: "Path to the asset description file (Apple requires a AppStoreInfo.plist for Linux and Windows)",
+                                     optional: true),
 
         # app review info
         FastlaneCore::ConfigItem.new(key: :demo_account_required,


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
  - [ ]  Gym detects the correct platform for a visionOS project
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary. (TODO make sure my pilot/deliver options update gets in docs)
- [ ] I've added or updated relevant unit tests. (Updated ✅; TODO Add)

### Motivation and Context

Resolves #29608 

### Description


#### TODO
- [x] gym update to generate this AppStoreInfo.plist
- [x] test with gym -> pilot -> deliver

### Testing Steps
1. Archive an iOS app, and generate a [AppStoreInfo.plist](https://help.apple.com/xcode/mac/current/en.lproj/deva1f2ab5a2.html)
2. Make the `.ipa` and `AppStoreInfo.plist` available on a Linux and/or Windows machine
3. Have `fastlane deliver` set up on that machine
  a. Secrets set up with either Deliverfile or envs
  b. Have [`/usr/local/itms` installed](https://help.apple.com/itc/transporteruserguide/en.lproj/static.html#apdbb0ee90816044)
4. `bundle exec fastlane deliver --ipa:path/to/App.ipa --asset_description_path:path/to/AppStoreInfo.plist`
