### PR TITLE
[gym] Add option for generate_app_store_information

### DIFF
--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -207,6 +207,8 @@ module Gym
 
         hash[:teamID] = Gym.config[:export_team_id] if Gym.config[:export_team_id]
 
+        hash[:generateAppStoreInformation] = Gym.config[:generate_app_store_information] if Gym.config[:generate_app_store_information]
+
         UI.important("Generated plist file with the following values:")
         UI.command_output("-----------------------------------------")
         UI.command_output(JSON.pretty_generate(hash))

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -329,7 +329,13 @@ module Gym
                                      verify_block: proc do |value|
                                        av = %w(netrc keychain)
                                        UI.user_error!("Unsupported authorization provider '#{value}', must be: #{av}") unless av.include?(value)
-                                     end)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :generate_app_store_information,
+                                     env_name: "GYM_GENERATE_APP_STORE_INFORMATION",
+                                     description: "Generate App Store information",
+                                     type: Boolean,
+                                     default_value: false,
+                                     optional: true)
       ]
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
https://help.apple.com/xcode/mac/current/en.lproj/deva1f2ab5a2.html

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
