### PR TITLE
DRAFT - [meta] chore: fix circleci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,10 @@ aliases:
       name: bundle install
       command: |
         gem update --system `.ci/compatible_gem_version`
-        gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ")
+        gem install bundler -v `.ci/bundler_version.rb`
         bundle config set --local path .bundle
         bundle check || bundle install --jobs=4 --retry=3
-        bundle env
+        rbenv rehash
 
 jobs:
   tests_macos: &tests_macos_base
@@ -88,13 +88,14 @@ jobs:
           version: << parameters.ruby_version >>
       - run:
           name: debug | ruby version
-          command: |
-            ruby -v
+          command: ruby -v
       - run:
           name: Setup Build
-          command: |
-            mkdir -p ~/test-reports
+          command: mkdir -p ~/test-reports
       - *bundle_install
+      - run:
+          name: debug | bundler version
+          command: bundle env
       - *cache_save_bundler
       - run:
           name: Check PR Metadata
@@ -179,6 +180,9 @@ jobs:
       - macos/switch-ruby:
           version: << parameters.ruby_version >>
       - *bundle_install
+      - run:
+          name: debug | bundler version
+          command: bundle env
       - *cache_save_bundler
       - run: bundle exec fastlane generate_swift_api
 


### PR DESCRIPTION
### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Turns CI pipeline green so we can review other PRs.

### Description

CircleCI updated and we had a mismatch between bundler and Ruby. Now we parse

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
