### PR TITLE
[scan] Fix build_for_testing failure to fail

### DIFF
--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -263,7 +263,13 @@ module Scan
       zip_build_products
       copy_xctestrun
 
-      return nil if Scan.config[:build_for_testing]
+      # Ensure we still fail the step on any non-zero exit status from xcodebuild.
+      if Scan.config[:build_for_testing]
+        unless tests_exit_status == 0
+          UI.build_failure!("Build for testing failed. Exit status: #{tests_exit_status}")
+        end
+        return nil
+      end
 
       results = trainer_test_results
 

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -264,7 +264,13 @@ module Scan
       zip_build_products
       copy_xctestrun
 
-      return nil if Scan.config[:build_for_testing]
+      # Ensure we still fail the step on any non-zero exit status from xcodebuild.
+      if Scan.config[:build_for_testing]
+        unless tests_exit_status == 0
+          UI.build_failure!("Build for testing failed. Exit status: #{tests_exit_status}")
+        end
+        return nil
+      end
 
       results = trainer_test_results
 

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -173,6 +173,37 @@ describe Scan do
           end.to raise_error(FastlaneCore::Interface::FastlaneTestFailure, "Test execution failed. Exit status: 1")
         end
       end
+
+      describe "when :build_for_testing is true" do
+        it "fails the run if xcodebuild exits with a non-zero status even when error output contains 'Executed'", requires_xcodebuild: true do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            output_directory: '/tmp/scan_results',
+            project: './scan/examples/standard/app.xcodeproj',
+            build_for_testing: true,
+            fail_build: true
+          })
+
+          test_command_generator = @scan.instance_variable_get(:@test_command_generator)
+          allow(test_command_generator).to receive(:generate).and_return("xcodebuild build-for-testing")
+
+          error_output = <<~ERROR
+            Some random xcodebuild failure output
+            /tmp/MyAppTestsFileThatContainsWordExecuted.swift:12: error: Something broke
+          ERROR
+
+          expect(Scan::ErrorHandler).to receive(:handle_build_error).with(error_output, anything).and_call_original
+
+          allow(FastlaneCore::CommandExecutor).to receive(:execute) do |command:, print_all:, print_command:, prefix:, loading:, suppress_output:, error:|
+            system("ruby -e 'exit 65'")
+            error.call(error_output)
+            ""
+          end
+
+          expect do
+            @scan.run
+          end.to raise_error(FastlaneCore::Interface::FastlaneBuildFailure, "Build for testing failed. Exit status: 65")
+        end
+      end
     end
 
     describe "retry_execute" do


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #20685

### Description

_scan_'s `ErrorHandler.handle_build_error` has explicit logic that checks for `/Executed/` pattern in logs. It seems to be meant for case where tests will be run with same command and so we would want to wait for test results parsing instead. But this is causing _scan_ to not to fail under `build_for_testing` configuration when there is such pattern in logs (eg. some file name contains it).

In order to fix this, I propose to explicitly check for exit status code in `build_for_testing` mode and produce an error if status is not ok.

### Testing Steps

- Have file in the project with a name that contains "Executed".
- Have compile error in the test building.
- Run _scan_ with `build_for_testing: true`
- _fastlane_ succeeds

Example project https://github.com/alvar-bolt/fastlane-scan-failure-poc
