### PR TITLE
[ci] Bye AppVeyor & CircleCI - Hello GitHub Actions 🔥 

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,161 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TEST_REPORTS: ${{ github.workspace }}/test-reports
+  CIRCLE_TEST_REPORTS: ${{ github.workspace }}/test-reports
+
+jobs:
+  macos-tests:
+    name: ${{ matrix.os }}, Xcode ${{ matrix.xcode }}, Ruby ${{ matrix.ruby }} Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - { xcode: '14.3.1', ruby: '3.2', rubyopt: '-W:deprecated', os: 'macos-13' }
+          - { xcode: '15.0.1', ruby: '3.2', rubyopt: '-W:deprecated', os: 'macos-13' }
+          - { xcode: '15.2', ruby: '3.2', rubyopt: '', os: 'macos-13' }
+          - { xcode: '15.3', ruby: '3.3', rubyopt: '', os: 'macos-14' }
+          - { xcode: '16.2', ruby: '3.2', rubyopt: '', os: 'macos-14' }
+          # - { xcode: '26.0.1', ruby: '3.3', rubyopt: '', os: 'macos-15' }
+          - { xcode: '', ruby: '3.3', rubyopt: '', os: 'ubuntu-24.04' }
+          - { xcode: '', ruby: '3.2', rubyopt: '', os: 'windows-2022' }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode ${{ matrix.xcode }}
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+
+      - name: Debug | Xcode version
+        if: runner.os == 'macOS'
+        run: |
+          xcodebuild -version
+          xcode-select -p
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Debug | Ruby version
+        shell: bash
+        run: ruby -v
+
+      - name: Setup Build directories
+        if: runner.os != 'Windows'
+        run: mkdir -p "$TEST_REPORTS"
+
+      - name: Increase Open File Limit
+        if: runner.os != 'Windows'
+        shell: bash
+        run: ulimit -n 65536
+
+      - name: Run tests
+        env:
+          RUBYOPT: ${{ matrix.rubyopt }}
+        shell: bash
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          bundle exec fastlane execute_tests
+
+      - name: Check compatibility with Ruby 3.0
+        shell: bash
+        run: |
+          touch "$TEST_REPORTS/ruby_warnings.txt"
+          ! grep -E "warning:\s.*(deprecated).*$" "$TEST_REPORTS/ruby_warnings.txt" && echo "No deprecation message found."
+          ! grep -E "warning:\s.*(obsolete).*$" "$TEST_REPORTS/ruby_warnings.txt" && echo "No obsolete message found."
+
+      - name: Upload rspec reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rspec-${{ matrix.xcode }}-ruby-${{ matrix.ruby }}
+          path: ${{ env.TEST_REPORTS }}/rspec
+          if-no-files-found: ignore
+
+      - name: Upload ruby warnings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby_warnings-${{ matrix.xcode }}-ruby-${{ matrix.ruby }}.txt
+          path: ${{ env.TEST_REPORTS }}/ruby_warnings.txt
+          if-no-files-found: ignore
+
+  validate_fastlane_swift_generation:
+    name: Validate Fastlane.swift generation
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.0.1'
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Generate Swift API
+        run: bundle exec fastlane generate_swift_api
+
+  validate_documentation:
+    name: Validate Documentation
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Validate docs
+        run: bundle exec fastlane validate_docs
+
+  lint_source_code:
+    name: Lint source code
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Lint
+        run: bundle exec fastlane lint_source
+
+  modules_load_up_tests:
+    name: Modules load up tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Build and install gem locally
+        shell: bash
+        run: |
+          gem install $(echo $(gem build fastlane.gemspec) | sed 's/.*File: //')
+
+      - name: Run module tests
+        run: bash ./test_modules/run_tests.sh

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,36 @@
+name: Danger
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  checks: write
+  statuses: write
+
+jobs:
+  danger:
+    name: Danger
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Run Danger
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bundle exec danger

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ build/
 ## Environment normalisation:
 /.bundle/
 /lib/bundler/man/
+/vendor/bundle/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/.rspec
+++ b/.rspec
@@ -3,6 +3,7 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 --default-path ./
+--exclude-pattern 'vendor/**/*_spec.rb'
 --require ./spec_helper
 --color
 --format d

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "fakefs", "1.8"
 # for file uploads with Faraday
 gem "mime-types", ['>= 1.16', '< 4.0']
 # Fast XML parser and object marshaller.
-gem "ox", "2.13.2"
+gem "ox", "2.14.23"
 # Provides an interactive debugging environment for Ruby.
 gem "pry"
 # A plugin for pry that adds step-by-step debugging and stack navigation.

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,8 @@ gem "fakefs", "1.8"
 # for file uploads with Faraday
 gem "mime-types", ['>= 1.16', '< 4.0']
 # Fast XML parser and object marshaller.
-gem "ox", "2.14.23"
+# Version 2.14.15 requires Ruby >= 2.7, while fastlane uses a `required_ruby_version` of `>= 2.6`.
+gem "ox", "2.14.14"
 # Provides an interactive debugging environment for Ruby.
 gem "pry"
 # A plugin for pry that adds step-by-step debugging and stack navigation.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,8 +220,7 @@ GEM
     open4 (1.3.4)
     optparse (0.4.0)
     os (1.1.4)
-    ox (2.14.23)
-      bigdecimal (>= 3.0)
+    ox (2.14.14)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -376,7 +375,7 @@ DEPENDENCIES
   fastlane-plugin-ruby
   fastlane-plugin-slack_train (>= 0.2.0)
   mime-types (>= 1.16, < 4.0)
-  ox (= 2.14.23)
+  ox (= 2.14.14)
   pry
   pry-byebug
   pry-rescue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,8 @@ GEM
     open4 (1.3.4)
     optparse (0.4.0)
     os (1.1.4)
-    ox (2.13.2)
+    ox (2.14.23)
+      bigdecimal (>= 3.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -375,7 +376,7 @@ DEPENDENCIES
   fastlane-plugin-ruby
   fastlane-plugin-slack_train (>= 0.2.0)
   mime-types (>= 1.16, < 4.0)
-  ox (= 2.13.2)
+  ox (= 2.14.23)
   pry
   pry-byebug
   pry-rescue

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 task(:test_all) do
   formatter = "--format progress"
   formatter += " -r rspec_junit_formatter --format RspecJunitFormatter -o #{ENV['CIRCLE_TEST_REPORTS']}/rspec/fastlane-junit-results.xml" if ENV["CIRCLE_TEST_REPORTS"]
-  command = "rspec --pattern ./**/*_spec.rb #{formatter} #{ENV['RSPEC_ARGS']}"
+  command = "rspec --pattern spec/**/*_spec.rb,*/spec/**/*_spec.rb #{formatter} #{ENV['RSPEC_ARGS']}"
 
   run_rspec(command)
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,8 +25,7 @@ end
 desc "Verifies source code is in a good state"
 lane :lint_source do
   # Verifying that no debug code is in the code base
-  #
-  exclude_dirs = ["\.bundle", "*/vendor/bundle"]
+  exclude_dirs = %w[.bundle vendor]
   ensure_no_debug_code(text: "binding\.(irb|pry)", extension: ".rb", exclude: "playground.rb", exclude_dirs: exclude_dirs) # debugging code
   ensure_no_debug_code(text: "# TODO", extension: ".rb", exclude_dirs: exclude_dirs) # TODOs
   ensure_no_debug_code(text: "now: ", extension: ".rb", exclude_dirs: exclude_dirs) # rspec focus
@@ -41,9 +40,9 @@ lane :lint_source do
   Dir.chdir("..") do
     # Verify shell code style
     if FastlaneCore::Helper.mac?
-      sh('find -E . -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -exec shellcheck {} +')
+      sh('find -E . -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -name "vendor" -exec shellcheck {} +')
     elsif !FastlaneCore::Helper.windows?
-      sh('find . -regextype posix-egrep -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -exec shellcheck {} +')
+      sh('find . -regextype posix-egrep -regex ".*\.(sh|bash)" -not -name "Pods-*" -name ".bundle" -name "vendor" -exec shellcheck {} +')
     end
   end
 end
@@ -561,7 +560,7 @@ end
 desc "Makes sure the tests on https://docs.fastlane.tools still work with the latest version"
 lane :verify_docs do
   clone_docs do
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       puts(`sed -i -e "s/activate_bin_path/bin_path/g" $(which bundle)`) # workaround for bundler https://github.com/bundler/bundler/issues/4602#issuecomment-233619696
       sh("bundle install")
       sh("bundle exec fastlane test skip_building:true") # skip_building since we don't have a proper python environment set up
@@ -712,6 +711,7 @@ private_lane :ensure_tool_name_formatting do
   Dir.chdir("..") do
     Dir["**/*.md"].each do |path|
       next if path == "CHANGELOG.latest.md"
+      next if path.start_with?('vendor/bundle', '.bundle')
       helper = Helper::ToolNameFormattingHelper.new(path: path, is_documenting_invalid_examples: path == 'CONTRIBUTING.md')
       errors += helper.find_tool_name_formatting_errors
     end

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -97,7 +97,7 @@ module Fastlane
       if File.exist?(custom_file_location)
         UI.verbose("Using custom md.erb file for action #{action.action_name}")
 
-        result = ERB.new(File.read(custom_file_location), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
+        result = ERB.new(File.read(custom_file_location), trim_mode: '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
 
         return result
       end
@@ -122,7 +122,7 @@ module Fastlane
         end
 
         template = File.join(Fastlane::ROOT, "lib/assets/ActionDetails.md.erb")
-        result = ERB.new(File.read(template), 0, '-').result(binding)
+        result = ERB.new(File.read(template), trim_mode: '-').result(binding)
 
         action_mds[action.action_name] = result
       end
@@ -139,7 +139,7 @@ module Fastlane
 
       # Generate actions.md
       template = File.join(Fastlane::ROOT, "lib/assets/Actions.md.erb")
-      result = ERB.new(File.read(template), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
+      result = ERB.new(File.read(template), trim_mode: '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
       File.write(File.join(docs_dir, "generated", "actions.md"), result)
 
       # Generate actions sub pages (e.g. generated/actions/slather.md, generated/actions/scan.md)
@@ -165,7 +165,7 @@ module Fastlane
         end
 
         template = File.join(Fastlane::ROOT, "lib/assets/ActionDetails.md.erb")
-        result = ERB.new(File.read(template), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
+        result = ERB.new(File.read(template), trim_mode: '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
 
         # Actions get placed in "generated/actions" directory
         file_name = File.join(generated_actions_dir, "#{action.action_name}.md")

--- a/fastlane_core/spec/fastlane_user_dir_spec.rb
+++ b/fastlane_core/spec/fastlane_user_dir_spec.rb
@@ -1,6 +1,6 @@
 describe FastlaneCore do
   it "returns the path to the user's directory" do
-    expected_path = File.join(ENV["HOME"], ".fastlane")
+    expected_path = File.join(Dir.home, ".fastlane")
 
     expect(File).to receive(:directory?).and_return(false)
     expect(FileUtils).to receive(:mkdir_p).with(expected_path)


### PR DESCRIPTION
Welcome to the GitHub Actions _fastlane_. 🔑

#### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR 
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### tldr;
* GitHub Actions replaces AppVeyor & CircleCI with parity.
* Ruby 3.1 is dropped from testing.
* Ruby 2.6 is still the actual min.
* PRs open to other fastlane repos to fix dependencies
 * [docker](https://github.com/fastlane/docker/pull/10) - fix building of old ruby 2.x image
 * ~~[docs](https://github.com/fastlane/docs/pull/1286) - update to fastlane 2.228 in docs repo~~
 * [github-actions](https://github.com/fastlane/github-actions/pull/117) - fix actions so the bot returns to prs to help out

---
### Motivation and Context

Fastlane is decaying with CI pipelines not green. When they aren't green - maintainers are less likely to merge code and with a red pipeline - stuff decays.

We have 3 types of failures

 - ~~Doc failures ([example 1](https://app.circleci.com/pipelines/github/fastlane/fastlane/7254/workflows/6e11b9f0-5bbc-46b0-bbb3-c5898f2720f7/jobs/109422?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary)) - fix is [doc repo](https://github.com/fastlane/docs/pull/1286).~~
 - Test failures ([example 1](https://app.circleci.com/pipelines/github/fastlane/fastlane/7254/workflows/6e11b9f0-5bbc-46b0-bbb3-c5898f2720f7/jobs/109419?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary))
 - Swift failures ([example 1](https://app.circleci.com/pipelines/github/fastlane/fastlane/7254/workflows/6e11b9f0-5bbc-46b0-bbb3-c5898f2720f7/jobs/109418?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary))
 
A chunk of these failures are due to CircleCI decaying and having a quite complex build process. We have to worry about aligning Ruby, bundler and gem versions. Entire scripts (`.ci/bundler_version.sh` & `.ci/compatible_gem_versions.sh`) were designed to help the CI pipelines install stuff.

We have 3 different CI services in play (GitHub Actions, AppVeyor & CircleCI) and they all are configured slightly differently. Maintainers time is spent on keeping pipelines green instead of having the time & energy to work on the project itself. Additionally, in order to keep all these CI pipelines green more and more tooling was built around it like a [docker image](https://github.com/fastlane/docker) to help CircleCI have a Ubuntu stable image.

However, those docker images were built on Ruby 2.x and decaying versions of Debian - so even those are collapsing. This is why a lot of the automation on PRs and Repo health have decayed.

The doc failure is an odd one - its broken because the doc repo is pulled down during fastlane checks, but the doc repo is still on fastlane 2.220, so it crashes on missing params that have since been added. This is not an issue in fastlane, but instead on the doc repo. This [PR](https://github.com/fastlane/docs/pull/1285) should fix the CI pipeline of docs, then this [PR](https://github.com/fastlane/docs/pull/1286) should fix the fastlane upgrade.

We need to reset ourself and stop building on a complex base and look to the future of GitHub Actions. We can replace nearly 200 lines of code with this.

```yaml
- name: Set up Ruby ${{ matrix.ruby }}
   uses: ruby/setup-ruby@v1
   with:
     ruby-version: ${{ matrix.ruby }}
     bundler-cache: true
```

Which handles everything from Ruby install (quick), bundler and getting gems installed & cached with a few lines of yaml.

### Description

**This brings Ubuntu, Mac and Windows testing by porting the CircleCI & AppVeyor tests to GitHub Actions.** - they work in terms of a matrix of capabilities. You select the Xcode version, Ruby version and host OS and the unified test suite does the rest.

1 CI file for all 3 platforms :)

<img width="1163" height="734" alt="Screenshot 2025-10-16 at 12 04 29 PM" src="https://github.com/user-attachments/assets/2f28e4c1-ac40-4a95-91c5-05ef016617eb" />

---

### What changed & why

#### breaking changes
We never test Ruby 3.1 anymore. Ruby 3.1 went [EOL in March of 2025](https://endoflife.date/ruby). While Ruby 3.4 is not yet supported officially - its increasingly difficult to support a pipeline on EOL versions. This isn't saying Ruby 3.1 is broken, but its saying we aren't officially testing against 3.1 anymore.

#### bundle
It doesn't seem like _fastlane_ ever made a stance on where gems should be installed. It was different between CI and local and a mix between outside of project, `.bundle` or elsewhere. Due to GitHub Action [requiring](https://github.com/ruby/setup-ruby?tab=readme-ov-file#bundle-config) `vendor/bundle` in order to handle native caching of gems - we moved to `vendor/bundle` controlling this via the `.bundle/config` file.

#### additional ignores
Due to storing gem dependencies in a git ignored folder in project `vendor/bundle` - some tasks and projects globbed improperly the whole tree. This meant we tested and brought in code from vendors, which is a no no. So changes were made across the system to refine our patterns to prevent that globbing.

#### deprecations
sometimes stuff spammed the logs for a simple deprecation fix. These become more important as Ruby 3.4 is added.

### danger
This fixes danger and puts it on its own workflow. However, that workflow has `pull_request_target` so will not fire until the code exists on `master`. This is because it cannot be trusted (as it mutates prs) from the context of the pr.

### final
This does not remove anything with CircleCI or AppVeyor, but indeed changes things that may affect those. I imagine folks are alright with that given GitHub Actions works and has parity with what those services did.

---

### Testing Steps

Ran on local (Mac/Ubuntu) & GitHub Actions - Windows, Mac and Linux with a variety of Ruby versions. [Tested on fork many times](https://github.com/iBotPeaches/fastlane/pull/1).
