### PR TITLE
fix: store generated available-actions in /generated on docs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -610,7 +610,7 @@ lane :update_docs do |options|
     else
       # Create a new branch
       sh("git checkout -b 'update-actions-md-#{Time.now.to_i}'") unless debug
-      plugins_path = "docs/plugins/available-plugins.md"
+      plugins_path = "docs/generated/available-plugins.md"
       unless options[:skip_plugin_scores]
         plugin_scores(template_path: template_path,
                         output_path: plugins_path,


### PR DESCRIPTION
:key:  - See https://github.com/fastlane/docs/pull/1287 or https://github.com/fastlane/docs/issues/1278 for more details.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

This build script is placing the file in the non-generated area. So the fastlane/docs build script is wiping out a new file with a 4 year old generated file.

### Description

This fixes the build pipeline kicked off via fastlane releases to put the automated generated available-plugins file alongside the generated available-actions file.

### Testing Steps

See: https://github.com/fastlane/docs/pull/1287

