### PR TITLE
[notarize] Fix erroring out with `bundle_id` parameter being absent

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -4,7 +4,6 @@ module Fastlane
       # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         package_path = params[:package]
-        bundle_id = params[:bundle_id]
         skip_stapling = params[:skip_stapling]
         print_log = params[:print_log]
         verbose = params[:verbose]
@@ -15,7 +14,7 @@ module Fastlane
         end
         api_key = Spaceship::ConnectAPI::Token.from(hash: params[:api_key], filepath: params[:api_key_path])
 
-        # Compress and read bundle identifier only for .app bundle.
+        # Compress only if .app bundle
         compressed_package_path = nil
         if File.extname(package_path) == '.app'
           compressed_package_path = "#{package_path}.zip"
@@ -23,22 +22,12 @@ module Fastlane
             "ditto -c -k --rsrc --keepParent \"#{package_path}\" \"#{compressed_package_path}\"",
             log: verbose
           )
-
-          unless bundle_id
-            info_plist_path = File.join(package_path, 'Contents', 'Info.plist')
-            bundle_id = Actions.sh(
-              "/usr/libexec/PlistBuddy -c \"Print :CFBundleIdentifier\" \"#{info_plist_path}\"",
-              log: verbose
-            ).strip
-          end
         end
 
-        UI.user_error!('Could not read bundle identifier, provide as a parameter') unless bundle_id
-
-        notarytool(params, package_path, bundle_id, skip_stapling, print_log, verbose, api_key, compressed_package_path)
+        notarytool(params, package_path, skip_stapling, print_log, verbose, api_key, compressed_package_path)
       end
 
-      def self.notarytool(params, package_path, bundle_id, skip_stapling, print_log, verbose, api_key, compressed_package_path)
+      def self.notarytool(params, package_path, skip_stapling, print_log, verbose, api_key, compressed_package_path)
         temp_file = nil
 
         # Create authorization part of command with either API Key or Apple ID
@@ -154,10 +143,6 @@ module Fastlane
                                        optional: true,
                                        default_value: false,
                                        type: Boolean),
-          FastlaneCore::ConfigItem.new(key: :bundle_id,
-                                       env_name: 'FL_NOTARIZE_BUNDLE_ID',
-                                       description: 'Bundle identifier to uniquely identify the package',
-                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :username,
                                        env_name: 'FL_NOTARIZE_USERNAME',
                                        description: 'Apple ID username',

--- a/fastlane/spec/actions_specs/notarize_spec.rb
+++ b/fastlane/spec/actions_specs/notarize_spec.rb
@@ -38,7 +38,6 @@ describe Fastlane do
 
       context "with notary tool" do
         let(:package) { Tempfile.new('app.ipa.zip') }
-        let(:bundle_id) { 'com.some.app' }
 
         context "with Apple ID" do
           let(:username) { 'myusername@example.com' }
@@ -55,7 +54,6 @@ describe Fastlane do
             result = Fastlane::FastFile.new.parse("lane :test do
               notarize(
                 package: '#{package.path}',
-                bundle_id: '#{bundle_id}',
                 username: '#{username}',
                 asc_provider: '#{asc_provider}',
               )
@@ -72,7 +70,6 @@ describe Fastlane do
             result = Fastlane::FastFile.new.parse("lane :test do
               notarize(
                 package: '#{package.path}',
-                bundle_id: '#{bundle_id}',
                 username: '#{username}',
                 asc_provider: '#{asc_provider}',
                 verbose: true
@@ -90,7 +87,6 @@ describe Fastlane do
             result = Fastlane::FastFile.new.parse("lane :test do
               notarize(
                 package: '#{package.path}',
-                bundle_id: '#{bundle_id}',
                 username: '#{username}',
                 asc_provider: '#{asc_provider}',
                 skip_stapling: true
@@ -107,7 +103,6 @@ describe Fastlane do
               result = Fastlane::FastFile.new.parse("lane :test do
                 notarize(
                   package: '#{package.path}',
-                  bundle_id: '#{bundle_id}',
                   username: '#{username}',
                   asc_provider: '#{asc_provider}',
                 )


### PR DESCRIPTION
Removed bundle_id parameter from notarytool method (was unused) and updated error handling for altool usage.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
<details>
<summary>Failures</summary>

```
Failures:

  1) Fastlane::PluginGenerator#generate All tests and style validation of the new plugin are passing rubocop validations are passing
     Failure/Error: expect($?.exitstatus).to eq(0)
     
       expected: 0
            got: 1
     
       (compared using ==)
     # ./fastlane/spec/plugins_specs/plugin_generator_spec.rb:300:in `block (4 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.3.0/gems/webmock-3.24.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'

  2) Fastlane::PluginGenerator#generate All tests and style validation of the new plugin are passing `rake` runs both rspec and rubocop
     Failure/Error: expect($?.exitstatus).to eq(0)
     
       expected: 0
            got: 1
     
       (compared using ==)
     # ./fastlane/spec/plugins_specs/plugin_generator_spec.rb:306:in `block (4 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.3.0/gems/webmock-3.24.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'

  3) Trainer Trainer::XCResult::Parser Xcode 26 (xcresulttool 24) xcresult bundle generates correct JUnit XML including retries
     Failure/Error: expect(junit_xml.chomp).to eq(expected_xml.chomp)
     
       expected: "<?xml version='1.0' encoding='UTF-8'?>\n<testsuites tests='192' failures='20' skipped='7' time='275.... name='device' value='iPhone 17 Pro Max (26.1)'/>\n    </properties>\n  </testsuite>\n</testsuites>"
            got: "<?xml version='1.0' encoding='UTF-8'?>\n<testsuites tests='192' failures='20' skipped='7' time='275.... name='device' value='iPhone 17 Pro Max (26.1)'/>\n    </properties>\n  </testsuite>\n</testsuites>"
     
       (compared using ==)
     
       Diff:
       
       
       
       @@ -47,25 +47,25 @@
                </properties>
              </testcase>
              <testcase name='Skipped test with condition' classname='FastlaneTrainerTests' time='0.0'>
       -        <skipped message='Test &apos;Skipped test with condition&apos; skipped: Feature not yet implemented'/>
       +        <skipped/>
                <properties>
                  <property name='repetition' value='First Run'/>
                </properties>
              </testcase>
              <testcase name='Skipped test with condition' classname='FastlaneTrainerTests' time='1.0'>
       -        <skipped message='Test &apos;Skipped test with condition&apos; skipped: Feature not yet implemented'/>
       +        <skipped/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='Conditionally skipped test' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:122: Caught error: TestError(message: &quot;Experimental features not enabled&quot;)'/>
       +        <failure message='Caught error: TestError(message: &quot;Experimental features not enabled&quot;)'/>
                <properties>
                  <property name='repetition' value='First Run'/>
                </properties>
              </testcase>
              <testcase name='Conditionally skipped test' classname='FastlaneTrainerTests' time='3.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:122: Caught error: TestError(message: &quot;Experimental features not enabled&quot;)'/>
       +        <failure message='Caught error: TestError(message: &quot;Experimental features not enabled&quot;)'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
       @@ -113,7 +113,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters()' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 0) &gt; 6: Character '/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 0) &gt; 6: Character '/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value=''/>
       @@ -121,7 +121,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters()' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 0) &gt; 6: Character '/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 0) &gt; 6: Character '/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value=''/>
       @@ -129,7 +129,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0001)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 1) &gt; 6: Character \u0001 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 1) &gt; 6: Character \u0001 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0001'/>
       @@ -137,7 +137,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0001)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 1) &gt; 6: Character \u0001 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 1) &gt; 6: Character \u0001 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0001'/>
       @@ -145,7 +145,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0002)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 2) &gt; 6: Character \u0002 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 2) &gt; 6: Character \u0002 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0002'/>
       @@ -153,7 +153,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0002)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 2) &gt; 6: Character \u0002 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 2) &gt; 6: Character \u0002 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0002'/>
       @@ -161,7 +161,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0003)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 3) &gt; 6: Character \u0003 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 3) &gt; 6: Character \u0003 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0003'/>
       @@ -169,7 +169,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0003)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 3) &gt; 6: Character \u0003 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 3) &gt; 6: Character \u0003 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0003'/>
       @@ -177,7 +177,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0004)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 4) &gt; 6: Character \u0004 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 4) &gt; 6: Character \u0004 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0004'/>
       @@ -185,7 +185,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0004)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 4) &gt; 6: Character \u0004 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 4) &gt; 6: Character \u0004 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0004'/>
       @@ -193,7 +193,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0005)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 5) &gt; 6: Character \u0005 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 5) &gt; 6: Character \u0005 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0005'/>
       @@ -201,7 +201,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0005)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 5) &gt; 6: Character \u0005 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 5) &gt; 6: Character \u0005 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0005'/>
       @@ -209,7 +209,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0006)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 6) &gt; 6: Character \u0006 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 6) &gt; 6: Character \u0006 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0006'/>
       @@ -217,7 +217,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0006)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 6) &gt; 6: Character \u0006 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 6) &gt; 6: Character \u0006 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0006'/>
       @@ -1973,7 +1973,7 @@
                </properties>
              </testcase>
              <testcase name='Validate multiple strings (&quot;FastlaneTrainer&quot;)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:50: Expectation failed: (input.count → 15) &lt; 8'/>
       +        <failure message='Expectation failed: (input.count → 15) &lt; 8'/>
                <properties>
                  <property name='testname' value='Validate multiple strings'/>
                  <property name='argument' value='&quot;FastlaneTrainer&quot;'/>
       @@ -1981,7 +1981,7 @@
                </properties>
              </testcase>
              <testcase name='Validate multiple strings (&quot;FastlaneTrainer&quot;)' classname='FastlaneTrainerTests' time='1.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:50: Expectation failed: (input.count → 15) &lt; 8'/>
       +        <failure message='Expectation failed: (input.count → 15) &lt; 8'/>
                <properties>
                  <property name='testname' value='Validate multiple strings'/>
                  <property name='argument' value='&quot;FastlaneTrainer&quot;'/>
       
       @@ -2030,13 +2030,13 @@
              </testsuite>
              <testsuite name='Test Skipping Demonstrations' time='10.0' tests='11' failures='4' skipped='5'>
                <testcase name='Platform-specific test' classname='FastlaneTrainerTests.SkipTests' time='0.0'>
       -          <skipped message='Test &apos;Platform-specific test&apos; skipped: Test only runs in Catalyst'/>
       +          <skipped/>
                  <properties>
                    <property name='repetition' value='First Run'/>
                  </properties>
                </testcase>
                <testcase name='Platform-specific test' classname='FastlaneTrainerTests.SkipTests' time='0.0'>
       -          <skipped message='Test &apos;Platform-specific test&apos; skipped: Test only runs in Catalyst'/>
       +          <skipped/>
                  <properties>
                    <property name='repetition' value='Retry 1'/>
                  </properties>
       
       
       
       
       
       @@ -2052,41 +2052,41 @@
                  </properties>
                </testcase>
                <testcase name='Unconditionally skipped test' classname='FastlaneTrainerTests.SkipTests' time='0.0'>
       -          <skipped message='Test &apos;Unconditionally skipped test&apos; skipped: Feature pending implementation'/>
       +          <skipped/>
                  <properties>
                    <property name='repetition' value='First Run'/>
                  </properties>
                </testcase>
                <testcase name='Unconditionally skipped test' classname='FastlaneTrainerTests.SkipTests' time='0.0'>
       -          <skipped message='Test &apos;Unconditionally skipped test&apos; skipped: Feature pending implementation'/>
       +          <skipped/>
                  <properties>
                    <property name='repetition' value='Retry 1'/>
                  </properties>
                </testcase>
                <testsuite name='Resource-Dependent Tests' time='4.0' tests='2' failures='2' skipped='0'>
                  <testcase name='Database test with cleanup' classname='FastlaneTrainerTests.SkipTests.ResourceTests' time='0.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:307: Caught error: TestError(message: &quot;Database not available&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Database not available&quot;)'/>
                    <properties>
                      <property name='repetition' value='First Run'/>
                      <property name='tag1' value='database'/>
                    </properties>
                  </testcase>
                  <testcase name='Database test with cleanup' classname='FastlaneTrainerTests.SkipTests.ResourceTests' time='2.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:307: Caught error: TestError(message: &quot;Database not available&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Database not available&quot;)'/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                      <property name='tag1' value='database'/>
                    </properties>
                  </testcase>
                  <testcase name='Network-dependent test' classname='FastlaneTrainerTests.SkipTests.ResourceTests' time='0.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:297: Caught error: TestError(message: &quot;Test requires network access&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Test requires network access&quot;)'/>
                    <properties>
                      <property name='repetition' value='First Run'/>
                      <property name='tag1' value='network'/>
                    </properties>
                  </testcase>
                  <testcase name='Network-dependent test' classname='FastlaneTrainerTests.SkipTests.ResourceTests' time='2.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:297: Caught error: TestError(message: &quot;Test requires network access&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Test requires network access&quot;)'/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                      <property name='tag1' value='network'/>
       
       
       
       @@ -2095,25 +2095,25 @@
                </testsuite>
                <testsuite name='Environment-Dependent Tests' time='2.0' tests='2' failures='0' skipped='2'>
                  <testcase name='Production config test' classname='FastlaneTrainerTests.SkipTests.EnvironmentTests' time='0.0'>
       -            <skipped message='Test &apos;Production config test&apos; skipped: Test only runs in production'/>
       +            <skipped/>
                    <properties>
                      <property name='repetition' value='First Run'/>
                    </properties>
                  </testcase>
                  <testcase name='Production config test' classname='FastlaneTrainerTests.SkipTests.EnvironmentTests' time='1.0'>
       -            <skipped message='Test &apos;Production config test&apos; skipped: Test only runs in production'/>
       +            <skipped/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                    </properties>
                  </testcase>
                  <testcase name='CI environment test' classname='FastlaneTrainerTests.SkipTests.EnvironmentTests' time='0.0'>
       -            <skipped message='Test &apos;CI environment test&apos; skipped: Test only runs in CI environment'/>
       +            <skipped/>
                    <properties>
                      <property name='repetition' value='First Run'/>
                    </properties>
                  </testcase>
                  <testcase name='CI environment test' classname='FastlaneTrainerTests.SkipTests.EnvironmentTests' time='1.0'>
       -            <skipped message='Test &apos;CI environment test&apos; skipped: Test only runs in CI environment'/>
       +            <skipped/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                    </properties>
       
       @@ -2121,14 +2121,14 @@
                </testsuite>
                <testsuite name='Feature Flag Tests' time='3.0' tests='4' failures='2' skipped='1'>
                  <testcase name='Premium feature test' classname='FastlaneTrainerTests.SkipTests.FeatureFlagTests' time='0.0'>
       -            <skipped message='Test &apos;Premium feature test&apos; skipped: Premium features not available'/>
       +            <skipped/>
                    <properties>
                      <property name='repetition' value='First Run'/>
                      <property name='tag1' value='validation'/>
                    </properties>
                  </testcase>
                  <testcase name='Premium feature test' classname='FastlaneTrainerTests.SkipTests.FeatureFlagTests' time='0.0'>
       -            <skipped message='Test &apos;Premium feature test&apos; skipped: Premium features not available'/>
       +            <skipped/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                      <property name='tag1' value='validation'/>
       @@ -2149,7 +2149,7 @@
                    </properties>
                  </testcase>
                  <testcase name='Feature flag dependent tests (&quot;experimental_feature&quot;)' classname='FastlaneTrainerTests.SkipTests.FeatureFlagTests' time='0.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:340: Caught error: TestError(message: &quot;Feature \&apos;experimental_feature\&apos; is not enabled&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Feature \&apos;experimental_feature\&apos; is not enabled&quot;)'/>
                    <properties>
                      <property name='testname' value='Feature flag dependent tests'/>
                      <property name='argument' value='&quot;experimental_feature&quot;'/>
       @@ -2157,7 +2157,7 @@
                    </properties>
                  </testcase>
                  <testcase name='Feature flag dependent tests (&quot;experimental_feature&quot;)' classname='FastlaneTrainerTests.SkipTests.FeatureFlagTests' time='1.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:340: Caught error: TestError(message: &quot;Feature \&apos;experimental_feature\&apos; is not enabled&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Feature \&apos;experimental_feature\&apos; is not enabled&quot;)'/>
                    <properties>
                      <property name='testname' value='Feature flag dependent tests'/>
                      <property name='argument' value='&quot;experimental_feature&quot;'/>
       @@ -2165,7 +2165,7 @@
                    </properties>
                  </testcase>
                  <testcase name='Feature flag dependent tests (&quot;premium_feature&quot;)' classname='FastlaneTrainerTests.SkipTests.FeatureFlagTests' time='0.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:340: Caught error: TestError(message: &quot;Feature \&apos;premium_feature\&apos; is not enabled&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Feature \&apos;premium_feature\&apos; is not enabled&quot;)'/>
                    <properties>
                      <property name='testname' value='Feature flag dependent tests'/>
                      <property name='argument' value='&quot;premium_feature&quot;'/>
       @@ -2173,7 +2173,7 @@
                    </properties>
                  </testcase>
                  <testcase name='Feature flag dependent tests (&quot;premium_feature&quot;)' classname='FastlaneTrainerTests.SkipTests.FeatureFlagTests' time='1.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:340: Caught error: TestError(message: &quot;Feature \&apos;premium_feature\&apos; is not enabled&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Feature \&apos;premium_feature\&apos; is not enabled&quot;)'/>
                    <properties>
                      <property name='testname' value='Feature flag dependent tests'/>
                      <property name='argument' value='&quot;premium_feature&quot;'/>
       
       @@ -2218,15 +2218,15 @@
                      </properties>
                    </testcase>
                    <testcase name='Password length requirements' classname='FastlaneTrainerTests.UserTests.RegistrationTests.PasswordTests' time='0.004'>
       -              <failure message='FastlaneTrainerExampleTests.swift:162: Expectation failed: (password.count → 11) &lt; 8: Password &apos;justbarely8&apos; is too short'/>
       -              <failure message='FastlaneTrainerExampleTests.swift:162: Expectation failed: (password.count → 16) &lt; 8: Password &apos;thisislongenough&apos; is too short'/>
       +              <failure message='Expectation failed: (password.count → 11) &lt; 8: Password &apos;justbarely8&apos; is too short'/>
       +              <failure message='Expectation failed: (password.count → 16) &lt; 8: Password &apos;thisislongenough&apos; is too short'/>
                      <properties>
                        <property name='repetition' value='First Run'/>
                      </properties>
                    </testcase>
                    <testcase name='Password length requirements' classname='FastlaneTrainerTests.UserTests.RegistrationTests.PasswordTests' time='1.0'>
       -              <failure message='FastlaneTrainerExampleTests.swift:162: Expectation failed: (password.count → 11) &lt; 8: Password &apos;justbarely8&apos; is too short'/>
       -              <failure message='FastlaneTrainerExampleTests.swift:162: Expectation failed: (password.count → 16) &lt; 8: Password &apos;thisislongenough&apos; is too short'/>
       +              <failure message='Expectation failed: (password.count → 11) &lt; 8: Password &apos;justbarely8&apos; is too short'/>
       +              <failure message='Expectation failed: (password.count → 16) &lt; 8: Password &apos;thisislongenough&apos; is too short'/>
                      <properties>
                        <property name='repetition' value='Retry 1'/>
                      </properties>
       
       @@ -2338,13 +2338,13 @@
                <testsuite name='Posts' time='4.0' tests='4' failures='1' skipped='0'>
                  <testsuite name='Creation' time='1.0' tests='1' failures='1' skipped='0'>
                    <testcase name='Post length validation' classname='FastlaneTrainerTests.ContentTests.PostTests.CreationTests' time='0.0'>
       -              <failure message='FastlaneTrainerExampleTests.swift:232: Expectation failed: (longPost.count → 1000) &lt;= 500'/>
       +              <failure message='Expectation failed: (longPost.count → 1000) &lt;= 500'/>
                      <properties>
                        <property name='repetition' value='First Run'/>
                      </properties>
                    </testcase>
                    <testcase name='Post length validation' classname='FastlaneTrainerTests.ContentTests.PostTests.CreationTests' time='1.0'>
       -              <failure message='FastlaneTrainerExampleTests.swift:232: Expectation failed: (longPost.count → 1000) &lt;= 500'/>
       +              <failure message='Expectation failed: (longPost.count → 1000) &lt;= 500'/>
                      <properties>
                        <property name='repetition' value='Retry 1'/>
                      </properties>
       
       
       
       
       
       
       
       @@ -2427,51 +2427,51 @@
          <testsuite name='FastlaneTrainerExampleUITests' time='98.0' tests='10' failures='4' skipped='0'>
            <testsuite name='FastlaneTrainerExampleUITests' time='70.0' tests='6' failures='4' skipped='0'>
              <testcase name='testAccessibilityAndScreenshots()' classname='FastlaneTrainerExampleUITests' time='4.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:129: XCTAssertTrue failed'/>
       +        <failure message='XCTAssertTrue failed'/>
                <properties>
                  <property name='repetition' value='First Run'/>
                </properties>
              </testcase>
              <testcase name='testAccessibilityAndScreenshots()' classname='FastlaneTrainerExampleUITests' time='5.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:129: XCTAssertTrue failed'/>
       +        <failure message='XCTAssertTrue failed'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='testAlertHandling()' classname='FastlaneTrainerExampleUITests' time='8.0'/>
              <testcase name='testBasicNavigation()' classname='FastlaneTrainerExampleUITests' time='12.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:43: Failed to tap &quot;Details&quot; Button: No matches found for first query match sequence: `Descendants matching type Button` -&gt; `Elements matching predicate &apos;&quot;Details&quot; IN identifiers&apos;`, given input App element pid: 20176'/>
       +        <failure message='Failed to tap &quot;Details&quot; Button: No matches found for first query match sequence: `Descendants matching type Button` -&gt; `Elements matching predicate &apos;&quot;Details&quot; IN identifiers&apos;`, given input App element pid: 20176'/>
                <properties>
                  <property name='repetition' value='First Run'/>
                </properties>
              </testcase>
              <testcase name='testBasicNavigation()' classname='FastlaneTrainerExampleUITests' time='11.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:43: Failed to tap &quot;Details&quot; Button: No matches found for first query match sequence: `Descendants matching type Button` -&gt; `Elements matching predicate &apos;&quot;Details&quot; IN identifiers&apos;`, given input App element pid: 20180'/>
       +        <failure message='Failed to tap &quot;Details&quot; Button: No matches found for first query match sequence: `Descendants matching type Button` -&gt; `Elements matching predicate &apos;&quot;Details&quot; IN identifiers&apos;`, given input App element pid: 20180'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='testGesturesAndInteractions()' classname='FastlaneTrainerExampleUITests' time='6.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:108: XCTAssertTrue failed'/>
       +        <failure message='XCTAssertTrue failed'/>
                <properties>
                  <property name='repetition' value='First Run'/>
                </properties>
              </testcase>
              <testcase name='testGesturesAndInteractions()' classname='FastlaneTrainerExampleUITests' time='6.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:108: XCTAssertTrue failed'/>
       +        <failure message='XCTAssertTrue failed'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='testLaunchPerformance()' classname='FastlaneTrainerExampleUITests' time='32.0'/>
              <testcase name='testTextInputAndValidation()' classname='FastlaneTrainerExampleUITests' time='8.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:68: XCTAssertEqual failed: (&quot;Optional(&quot;Search&quot;)&quot;) is not equal to (&quot;Optional(&quot;&quot;)&quot;)'/>
       +        <failure message='XCTAssertEqual failed: (&quot;Optional(&quot;Search&quot;)&quot;) is not equal to (&quot;Optional(&quot;&quot;)&quot;)'/>
                <properties>
                  <property name='repetition' value='First Run'/>
                </properties>
              </testcase>
              <testcase name='testTextInputAndValidation()' classname='FastlaneTrainerExampleUITests' time='8.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:68: XCTAssertEqual failed: (&quot;Optional(&quot;Search&quot;)&quot;) is not equal to (&quot;Optional(&quot;&quot;)&quot;)'/>
       +        <failure message='XCTAssertEqual failed: (&quot;Optional(&quot;Search&quot;)&quot;) is not equal to (&quot;Optional(&quot;&quot;)&quot;)'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
       
       
       @@ -2515,19 +2515,19 @@
              <testcase name='testAsyncOperationWithExpectation()' classname='FastlaneTrainerExampleXCTests' time='0.1'/>
              <testcase name='testB_SecondTest()' classname='FastlaneTrainerExampleXCTests' time='0.0011'/>
              <testcase name='testBasicAssertions()' classname='FastlaneTrainerExampleXCTests' time='0.16'>
       -        <failure message='FastlaneTrainerExampleXCTests.swift:53: XCTAssertFalse failed - False should be false'/>
       +        <failure message='XCTAssertFalse failed - False should be false'/>
                <properties>
                  <property name='repetition' value='First Run'/>
                </properties>
              </testcase>
              <testcase name='testBasicAssertions()' classname='FastlaneTrainerExampleXCTests' time='0.00088'>
       -        <failure message='FastlaneTrainerExampleXCTests.swift:53: XCTAssertFalse failed - False should be false'/>
       +        <failure message='XCTAssertFalse failed - False should be false'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='testConditionalExecution()' classname='FastlaneTrainerExampleXCTests' time='0.0041'>
       -        <skipped message='Test skipped - Skipping slow tests'/>
       +        <skipped/>
              </testcase>
              <testcase name='testMultipleExpectations()' classname='FastlaneTrainerExampleXCTests' time='0.21'/>
              <testcase name='testPerformance()' classname='FastlaneTrainerExampleXCTests' time='0.27'/>
       
     # ./trainer/spec/test_parser_spec.rb:423:in `block (4 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.3.0/gems/webmock-3.24.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'

  4) Trainer Trainer::XCResult::Parser Xcode 26 (xcresulttool 24) xcresult bundle generates correct JUnit XML excluding retries
     Failure/Error: expect(junit_xml.chomp).to eq(expected_xml.chomp)
     
       expected: "<?xml version='1.0' encoding='UTF-8'?>\n<testsuites tests='192' failures='20' skipped='7' time='275.... name='device' value='iPhone 17 Pro Max (26.1)'/>\n    </properties>\n  </testsuite>\n</testsuites>"
            got: "<?xml version='1.0' encoding='UTF-8'?>\n<testsuites tests='192' failures='20' skipped='7' time='275.... name='device' value='iPhone 17 Pro Max (26.1)'/>\n    </properties>\n  </testsuite>\n</testsuites>"
     
       (compared using ==)
     
       Diff:
       
       @@ -25,13 +25,13 @@
                </properties>
              </testcase>
              <testcase name='Skipped test with condition' classname='FastlaneTrainerTests' time='1.0'>
       -        <skipped message='Test &apos;Skipped test with condition&apos; skipped: Feature not yet implemented'/>
       +        <skipped/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='Conditionally skipped test' classname='FastlaneTrainerTests' time='3.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:122: Caught error: TestError(message: &quot;Experimental features not enabled&quot;)'/>
       +        <failure message='Caught error: TestError(message: &quot;Experimental features not enabled&quot;)'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
       @@ -58,7 +58,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters()' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 0) &gt; 6: Character '/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 0) &gt; 6: Character '/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value=''/>
       @@ -66,7 +66,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0001)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 1) &gt; 6: Character \u0001 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 1) &gt; 6: Character \u0001 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0001'/>
       @@ -74,7 +74,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0002)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 2) &gt; 6: Character \u0002 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 2) &gt; 6: Character \u0002 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0002'/>
       @@ -82,7 +82,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0003)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 3) &gt; 6: Character \u0003 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 3) &gt; 6: Character \u0003 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0003'/>
       @@ -90,7 +90,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0004)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 4) &gt; 6: Character \u0004 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 4) &gt; 6: Character \u0004 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0004'/>
       @@ -98,7 +98,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0005)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 5) &gt; 6: Character \u0005 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 5) &gt; 6: Character \u0005 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0005'/>
       @@ -106,7 +106,7 @@
                </properties>
              </testcase>
              <testcase name='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(\u0006)' classname='FastlaneTrainerTests' time='0.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:67: Expectation failed: (asciiCharacter.asciiValue ?? 0 → 6) &gt; 6: Character \u0006 has ASCII value &lt;= 6'/>
       +        <failure message='Expectation failed: (asciiCharacter.asciiValue ?? 0 → 6) &gt; 6: Character \u0006 has ASCII value &lt;= 6'/>
                <properties>
                  <property name='testname' value='testName🏷️And📋ParamsUsingSome😱Unusual🤪Characters(asciiCharacter:)'/>
                  <property name='argument' value='\u0006'/>
       @@ -988,7 +988,7 @@
                </properties>
              </testcase>
              <testcase name='Validate multiple strings (&quot;FastlaneTrainer&quot;)' classname='FastlaneTrainerTests' time='1.0'>
       -        <failure message='FastlaneTrainerExampleTests.swift:50: Expectation failed: (input.count → 15) &lt; 8'/>
       +        <failure message='Expectation failed: (input.count → 15) &lt; 8'/>
                <properties>
                  <property name='testname' value='Validate multiple strings'/>
                  <property name='argument' value='&quot;FastlaneTrainer&quot;'/>
       @@ -1018,7 +1018,7 @@
              </testsuite>
              <testsuite name='Test Skipping Demonstrations' time='10.0' tests='11' failures='4' skipped='5'>
                <testcase name='Platform-specific test' classname='FastlaneTrainerTests.SkipTests' time='0.0'>
       -          <skipped message='Test &apos;Platform-specific test&apos; skipped: Test only runs in Catalyst'/>
       +          <skipped/>
                  <properties>
                    <property name='repetition' value='Retry 1'/>
                  </properties>
       
       
       @@ -1029,21 +1029,21 @@
                  </properties>
                </testcase>
                <testcase name='Unconditionally skipped test' classname='FastlaneTrainerTests.SkipTests' time='0.0'>
       -          <skipped message='Test &apos;Unconditionally skipped test&apos; skipped: Feature pending implementation'/>
       +          <skipped/>
                  <properties>
                    <property name='repetition' value='Retry 1'/>
                  </properties>
                </testcase>
                <testsuite name='Resource-Dependent Tests' time='4.0' tests='2' failures='2' skipped='0'>
                  <testcase name='Database test with cleanup' classname='FastlaneTrainerTests.SkipTests.ResourceTests' time='2.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:307: Caught error: TestError(message: &quot;Database not available&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Database not available&quot;)'/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                      <property name='tag1' value='database'/>
                    </properties>
                  </testcase>
                  <testcase name='Network-dependent test' classname='FastlaneTrainerTests.SkipTests.ResourceTests' time='2.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:297: Caught error: TestError(message: &quot;Test requires network access&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Test requires network access&quot;)'/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                      <property name='tag1' value='network'/>
       
       @@ -1052,13 +1052,13 @@
                </testsuite>
                <testsuite name='Environment-Dependent Tests' time='2.0' tests='2' failures='0' skipped='2'>
                  <testcase name='Production config test' classname='FastlaneTrainerTests.SkipTests.EnvironmentTests' time='1.0'>
       -            <skipped message='Test &apos;Production config test&apos; skipped: Test only runs in production'/>
       +            <skipped/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                    </properties>
                  </testcase>
                  <testcase name='CI environment test' classname='FastlaneTrainerTests.SkipTests.EnvironmentTests' time='1.0'>
       -            <skipped message='Test &apos;CI environment test&apos; skipped: Test only runs in CI environment'/>
       +            <skipped/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                    </properties>
       @@ -1066,7 +1066,7 @@
                </testsuite>
                <testsuite name='Feature Flag Tests' time='3.0' tests='4' failures='2' skipped='1'>
                  <testcase name='Premium feature test' classname='FastlaneTrainerTests.SkipTests.FeatureFlagTests' time='0.0'>
       -            <skipped message='Test &apos;Premium feature test&apos; skipped: Premium features not available'/>
       +            <skipped/>
                    <properties>
                      <property name='repetition' value='Retry 1'/>
                      <property name='tag1' value='validation'/>
       @@ -1080,7 +1080,7 @@
                    </properties>
                  </testcase>
                  <testcase name='Feature flag dependent tests (&quot;experimental_feature&quot;)' classname='FastlaneTrainerTests.SkipTests.FeatureFlagTests' time='1.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:340: Caught error: TestError(message: &quot;Feature \&apos;experimental_feature\&apos; is not enabled&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Feature \&apos;experimental_feature\&apos; is not enabled&quot;)'/>
                    <properties>
                      <property name='testname' value='Feature flag dependent tests'/>
                      <property name='argument' value='&quot;experimental_feature&quot;'/>
       @@ -1088,7 +1088,7 @@
                    </properties>
                  </testcase>
                  <testcase name='Feature flag dependent tests (&quot;premium_feature&quot;)' classname='FastlaneTrainerTests.SkipTests.FeatureFlagTests' time='1.0'>
       -            <failure message='FastlaneTrainerExampleTests.swift:340: Caught error: TestError(message: &quot;Feature \&apos;premium_feature\&apos; is not enabled&quot;)'/>
       +            <failure message='Caught error: TestError(message: &quot;Feature \&apos;premium_feature\&apos; is not enabled&quot;)'/>
                    <properties>
                      <property name='testname' value='Feature flag dependent tests'/>
                      <property name='argument' value='&quot;premium_feature&quot;'/>
       @@ -1118,8 +1118,8 @@
                      </properties>
                    </testcase>
                    <testcase name='Password length requirements' classname='FastlaneTrainerTests.UserTests.RegistrationTests.PasswordTests' time='1.0'>
       -              <failure message='FastlaneTrainerExampleTests.swift:162: Expectation failed: (password.count → 11) &lt; 8: Password &apos;justbarely8&apos; is too short'/>
       -              <failure message='FastlaneTrainerExampleTests.swift:162: Expectation failed: (password.count → 16) &lt; 8: Password &apos;thisislongenough&apos; is too short'/>
       +              <failure message='Expectation failed: (password.count → 11) &lt; 8: Password &apos;justbarely8&apos; is too short'/>
       +              <failure message='Expectation failed: (password.count → 16) &lt; 8: Password &apos;thisislongenough&apos; is too short'/>
                      <properties>
                        <property name='repetition' value='Retry 1'/>
                      </properties>
       @@ -1184,7 +1184,7 @@
                <testsuite name='Posts' time='4.0' tests='4' failures='1' skipped='0'>
                  <testsuite name='Creation' time='1.0' tests='1' failures='1' skipped='0'>
                    <testcase name='Post length validation' classname='FastlaneTrainerTests.ContentTests.PostTests.CreationTests' time='1.0'>
       -              <failure message='FastlaneTrainerExampleTests.swift:232: Expectation failed: (longPost.count → 1000) &lt;= 500'/>
       +              <failure message='Expectation failed: (longPost.count → 1000) &lt;= 500'/>
                      <properties>
                        <property name='repetition' value='Retry 1'/>
                      </properties>
       
       
       
       @@ -1236,27 +1236,27 @@
          <testsuite name='FastlaneTrainerExampleUITests' time='98.0' tests='10' failures='4' skipped='0'>
            <testsuite name='FastlaneTrainerExampleUITests' time='70.0' tests='6' failures='4' skipped='0'>
              <testcase name='testAccessibilityAndScreenshots()' classname='FastlaneTrainerExampleUITests' time='5.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:129: XCTAssertTrue failed'/>
       +        <failure message='XCTAssertTrue failed'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='testAlertHandling()' classname='FastlaneTrainerExampleUITests' time='8.0'/>
              <testcase name='testBasicNavigation()' classname='FastlaneTrainerExampleUITests' time='11.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:43: Failed to tap &quot;Details&quot; Button: No matches found for first query match sequence: `Descendants matching type Button` -&gt; `Elements matching predicate &apos;&quot;Details&quot; IN identifiers&apos;`, given input App element pid: 20180'/>
       +        <failure message='Failed to tap &quot;Details&quot; Button: No matches found for first query match sequence: `Descendants matching type Button` -&gt; `Elements matching predicate &apos;&quot;Details&quot; IN identifiers&apos;`, given input App element pid: 20180'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='testGesturesAndInteractions()' classname='FastlaneTrainerExampleUITests' time='6.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:108: XCTAssertTrue failed'/>
       +        <failure message='XCTAssertTrue failed'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='testLaunchPerformance()' classname='FastlaneTrainerExampleUITests' time='32.0'/>
              <testcase name='testTextInputAndValidation()' classname='FastlaneTrainerExampleUITests' time='8.0'>
       -        <failure message='FastlaneTrainerExampleUITests.swift:68: XCTAssertEqual failed: (&quot;Optional(&quot;Search&quot;)&quot;) is not equal to (&quot;Optional(&quot;&quot;)&quot;)'/>
       +        <failure message='XCTAssertEqual failed: (&quot;Optional(&quot;Search&quot;)&quot;) is not equal to (&quot;Optional(&quot;&quot;)&quot;)'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
       
       @@ -1300,13 +1300,13 @@
              <testcase name='testAsyncOperationWithExpectation()' classname='FastlaneTrainerExampleXCTests' time='0.1'/>
              <testcase name='testB_SecondTest()' classname='FastlaneTrainerExampleXCTests' time='0.0011'/>
              <testcase name='testBasicAssertions()' classname='FastlaneTrainerExampleXCTests' time='0.00088'>
       -        <failure message='FastlaneTrainerExampleXCTests.swift:53: XCTAssertFalse failed - False should be false'/>
       +        <failure message='XCTAssertFalse failed - False should be false'/>
                <properties>
                  <property name='repetition' value='Retry 1'/>
                </properties>
              </testcase>
              <testcase name='testConditionalExecution()' classname='FastlaneTrainerExampleXCTests' time='0.0041'>
       -        <skipped message='Test skipped - Skipping slow tests'/>
       +        <skipped/>
              </testcase>
              <testcase name='testMultipleExpectations()' classname='FastlaneTrainerExampleXCTests' time='0.21'/>
              <testcase name='testPerformance()' classname='FastlaneTrainerExampleXCTests' time='0.27'/>
       
     # ./trainer/spec/test_parser_spec.rb:436:in `block (4 levels) in <top (required)>'
     # ./vendor/bundle/ruby/3.3.0/gems/webmock-3.24.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'

Finished in 4 minutes 51.5 seconds (files took 4.06 seconds to load)
7727 examples, 4 failures, 2 pending

Failed examples:

rspec ./fastlane/spec/plugins_specs/plugin_generator_spec.rb:297 # Fastlane::PluginGenerator#generate All tests and style validation of the new plugin are passing rubocop validations are passing
rspec ./fastlane/spec/plugins_specs/plugin_generator_spec.rb:303 # Fastlane::PluginGenerator#generate All tests and style validation of the new plugin are passing `rake` runs both rspec and rubocop
rspec ./trainer/spec/test_parser_spec.rb:413 # Trainer Trainer::XCResult::Parser Xcode 26 (xcresulttool 24) xcresult bundle generates correct JUnit XML including retries
rspec ./trainer/spec/test_parser_spec.rb:426 # Trainer Trainer::XCResult::Parser Xcode 26 (xcresulttool 24) xcresult bundle generates correct JUnit XML excluding retries

```
</details>

- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
I've tried to use the notarize action without bundle_id (stated as optional in docs), but got an error.

### Description
I've moved the error to altool section, the only place where it is used.
<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
