### PR TITLE
Fix simulator runtime OS version mapping for mismatched version strings

### DIFF
--- a/fastlane_core/lib/fastlane_core/device_manager.rb
+++ b/fastlane_core/lib/fastlane_core/device_manager.rb
@@ -157,6 +157,12 @@ module FastlaneCore
                   .os_version
       end
 
+      def clear_cache
+        @devices = nil
+        @runtime_build_os_versions = nil
+        @runtime_name_to_version = nil
+      end
+
       # The code below works from Xcode 7 on
       # def all
       #   UI.verbose("Fetching available devices")
@@ -311,8 +317,7 @@ module FastlaneCore
       end
 
       def clear_cache
-        @devices = nil
-        @runtime_build_os_versions = nil
+        DeviceManager.clear_cache
       end
 
       def launch(device)

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -4,11 +4,14 @@ describe FastlaneCore do
   describe FastlaneCore::DeviceManager do
     before(:all) do
       @simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode7')
+      @simctl_runtime_output = File.read('./fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutput')
       @system_profiler_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSystem_profilerOutput')
       @instruments_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerInstrumentsOutput')
       @system_profiler_output_items_without_items = File.read('./fastlane_core/spec/fixtures/DeviceManagerSystem_profilerOutputItemsWithoutItems')
       @system_profiler_output_usb_hub = File.read('./fastlane_core/spec/fixtures/DeviceManagerSystem_profilerOutputUsbHub')
+    end
 
+    before(:each) do
       FastlaneCore::Simulator.clear_cache
     end
 
@@ -166,6 +169,9 @@ describe FastlaneCore do
     end
 
     it "properly parses the simctl output and generates Device objects for tvOS simulator" do
+      status = double('status', "success?": true)
+      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
+
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
@@ -182,6 +188,9 @@ describe FastlaneCore do
     end
 
     it "properly parses the simctl output and generates Device objects for watchOS simulator" do
+      status = double('status', "success?": true)
+      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
+
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
@@ -204,6 +213,9 @@ describe FastlaneCore do
     end
 
     it "properly parses the simctl output and generates Device objects for all simulators" do
+      status = double('status', "success?": true)
+      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
+
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
@@ -256,6 +268,9 @@ describe FastlaneCore do
     end
 
     it "properly parses the simctl output with unavailable devices and generates Device objects for all simulators" do
+      status = double('status', "success?": true)
+      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
+
       response = "response"
       simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode10BootedUnavailable')
       expect(response).to receive(:read).and_return(simctl_output)
@@ -357,6 +372,9 @@ describe FastlaneCore do
     end
 
     it "properly parses output for all iOS devices" do
+      status = double('status', "success?": true)
+      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
+
       response = "response"
       expect(response).to receive(:read).and_return(@system_profiler_output)
       expect(Open3).to receive(:popen3).with("system_profiler SPUSBDataType -xml").and_yield(nil, response, nil, nil)
@@ -409,6 +427,9 @@ describe FastlaneCore do
     end
 
     it "properly parses output for all tvOS devices" do
+      status = double('status', "success?": true)
+      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
+
       response = "response"
       expect(response).to receive(:read).and_return(@system_profiler_output)
       expect(Open3).to receive(:popen3).with("system_profiler SPUSBDataType -xml").and_yield(nil, response, nil, nil)

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -9,11 +9,11 @@ describe FastlaneCore do
       @instruments_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerInstrumentsOutput')
       @system_profiler_output_items_without_items = File.read('./fastlane_core/spec/fixtures/DeviceManagerSystem_profilerOutputItemsWithoutItems')
       @system_profiler_output_usb_hub = File.read('./fastlane_core/spec/fixtures/DeviceManagerSystem_profilerOutputUsbHub')
+
+      FastlaneCore::Simulator.clear_cache
     end
 
     before(:each) do
-      FastlaneCore::Simulator.clear_cache
-
       status = double('status', "success?": true)
       allow(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
     end

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -13,6 +13,9 @@ describe FastlaneCore do
 
     before(:each) do
       FastlaneCore::Simulator.clear_cache
+
+      status = double('status', "success?": true)
+      allow(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
     end
 
     it 'raises an error if broken xcrun simctl list devices' do
@@ -169,9 +172,6 @@ describe FastlaneCore do
     end
 
     it "properly parses the simctl output and generates Device objects for tvOS simulator" do
-      status = double('status', "success?": true)
-      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
-
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
@@ -188,9 +188,6 @@ describe FastlaneCore do
     end
 
     it "properly parses the simctl output and generates Device objects for watchOS simulator" do
-      status = double('status', "success?": true)
-      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
-
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
@@ -213,9 +210,6 @@ describe FastlaneCore do
     end
 
     it "properly parses the simctl output and generates Device objects for all simulators" do
-      status = double('status', "success?": true)
-      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
-
       response = "response"
       expect(response).to receive(:read).and_return(@simctl_output)
       expect(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
@@ -268,9 +262,6 @@ describe FastlaneCore do
     end
 
     it "properly parses the simctl output with unavailable devices and generates Device objects for all simulators" do
-      status = double('status', "success?": true)
-      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
-
       response = "response"
       simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode10BootedUnavailable')
       expect(response).to receive(:read).and_return(simctl_output)
@@ -372,9 +363,6 @@ describe FastlaneCore do
     end
 
     it "properly parses output for all iOS devices" do
-      status = double('status', "success?": true)
-      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
-
       response = "response"
       expect(response).to receive(:read).and_return(@system_profiler_output)
       expect(Open3).to receive(:popen3).with("system_profiler SPUSBDataType -xml").and_yield(nil, response, nil, nil)
@@ -427,9 +415,6 @@ describe FastlaneCore do
     end
 
     it "properly parses output for all tvOS devices" do
-      status = double('status', "success?": true)
-      expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
-
       response = "response"
       expect(response).to receive(:read).and_return(@system_profiler_output)
       expect(Open3).to receive(:popen3).with("system_profiler SPUSBDataType -xml").and_yield(nil, response, nil, nil)

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -460,8 +460,9 @@ describe FastlaneCore do
       runtime_output = File.read('./fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutputWithVersionMismatch')
       expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([runtime_output, status])
 
-      expect(FastlaneCore::DeviceManager.runtime_name_to_version['iOS 17.0']).to eq('17.0')
-      expect(FastlaneCore::DeviceManager.runtime_name_to_version['iOS 26.0']).to eq('26.0.1')
+      expect(FastlaneCore::DeviceManager.runtime_name_to_version['iOS 17.0']).to eq(['17.0'])
+      expect(FastlaneCore::DeviceManager.runtime_name_to_version['iOS 18.0']).to eq(['18.0', '18.0.1'])
+      expect(FastlaneCore::DeviceManager.runtime_name_to_version['iOS 26.0']).to eq(['26.0.1'])
     end
 
     it 'fixes iOS version mismatch by using actual runtime versions instead of section header versions' do

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -449,7 +449,7 @@ describe FastlaneCore do
     it 'properly maps runtime names to actual versions for version mismatch fix' do
       # Clear cache to ensure our mock is called
       FastlaneCore::DeviceManager.instance_variable_set(:@runtime_name_to_version, nil)
-      
+
       status = double('status', "success?": true)
       runtime_output = File.read('./fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutputWithVersionMismatch')
       expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([runtime_output, status])
@@ -461,13 +461,13 @@ describe FastlaneCore do
     it 'fixes iOS version mismatch by using actual runtime versions instead of section header versions' do
       # Clear cache to ensure our mock is called
       FastlaneCore::DeviceManager.instance_variable_set(:@runtime_name_to_version, nil)
-      
+
       # Mock the runtime JSON response
       status = double('status', "success?": true)
       runtime_output = File.read('./fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutputWithVersionMismatch')
       expect(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([runtime_output, status])
 
-      # Mock the simctl devices output  
+      # Mock the simctl devices output
       response = "response"
       simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputWithVersionMismatch')
       expect(response).to receive(:read).and_return(simctl_output)
@@ -489,12 +489,12 @@ describe FastlaneCore do
       expect(devices[1]).to have_attributes(
         name: "iPhone 15 Pro Max", os_type: "iOS", os_version: "26.0.1",
         udid: "6D8B8DC9-F2BD-41C6-BC9A-C8BCEB521675",
-        state: "Shutdown", 
+        state: "Shutdown",
         is_simulator: true
       )
       expect(devices[2]).to have_attributes(
         name: "iPad Pro (12.9-inch) (6th generation)", os_type: "iOS", os_version: "26.0.1",
-        udid: "F5106A29-D2BF-49DA-81C7-BEB94D9BDCED", 
+        udid: "F5106A29-D2BF-49DA-81C7-BEB94D9BDCED",
         state: "Shutdown",
         is_simulator: true
       )

--- a/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputWithVersionMismatch
+++ b/fastlane_core/spec/fixtures/DeviceManagerSimctlOutputWithVersionMismatch
@@ -1,0 +1,9 @@
+== Runtimes ==
+iOS 17.0 (17.0 - 21A328) - com.apple.CoreSimulator.SimRuntime.iOS-17-0
+iOS 26.0 (26.0.1 - 23A8464) - com.apple.CoreSimulator.SimRuntime.iOS-26-0
+== Devices ==
+-- iOS 17.0 --
+    iPhone 15 Pro Max (752335B5-96D2-460D-89A9-3D5D768BDEAC) (Shutdown)
+-- iOS 26.0 --
+    iPhone 15 Pro Max (6D8B8DC9-F2BD-41C6-BC9A-C8BCEB521675) (Shutdown)
+    iPad Pro (12.9-inch) (6th generation) (F5106A29-D2BF-49DA-81C7-BEB94D9BDCED) (Shutdown)

--- a/fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutputWithVersionMismatch
+++ b/fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutputWithVersionMismatch
@@ -23,6 +23,50 @@
       }
     },
     {
+      "bundlePath" : "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime",
+      "buildversion" : "22A3351",
+      "platform" : "iOS",
+      "runtimeRoot" : "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime/Contents/Resources/RuntimeRoot",
+      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-18-0",
+      "version" : "18.0",
+      "isInternal" : false,
+      "isAvailable" : true,
+      "name" : "iOS 18.0",
+      "supportedDeviceTypes" : [
+        {
+          "bundlePath" : "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 15 Pro Max.simdevicetype",
+          "name" : "iPhone 15 Pro Max",
+          "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro-Max",
+          "productFamily" : "iPhone"
+        }
+      ],
+      "lastUsage" : {
+        "arm64" : "2025-10-31T03:40:19Z"
+      }
+    },
+    {
+      "bundlePath" : "/Library/Developer/CoreSimulator/Volumes/iOS_22A3362/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime",
+      "buildversion" : "22A3362",
+      "platform" : "iOS",
+      "runtimeRoot" : "/Library/Developer/CoreSimulator/Volumes/iOS_22A3362/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime/Contents/Resources/RuntimeRoot",
+      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-18-0",
+      "version" : "18.0.1",
+      "isInternal" : false,
+      "isAvailable" : true,
+      "name" : "iOS 18.0",
+      "supportedDeviceTypes" : [
+        {
+          "bundlePath" : "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 15 Pro Max.simdevicetype",
+          "name" : "iPhone 15 Pro Max",
+          "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro-Max",
+          "productFamily" : "iPhone"
+        }
+      ],
+      "lastUsage" : {
+        "arm64" : "2025-10-31T03:40:19Z"
+      }
+    },
+    {
       "bundlePath" : "/Library/Developer/CoreSimulator/Volumes/iOS_23A8464/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 26.0.simruntime",
       "buildversion" : "23A8464",
       "platform" : "iOS",

--- a/fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutputWithVersionMismatch
+++ b/fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutputWithVersionMismatch
@@ -1,0 +1,54 @@
+{
+  "runtimes" : [
+    {
+      "bundlePath" : "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.0.simruntime",
+      "buildversion" : "21A328",
+      "platform" : "iOS",
+      "runtimeRoot" : "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 17.0.simruntime/Contents/Resources/RuntimeRoot",
+      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-17-0",
+      "version" : "17.0",
+      "isInternal" : false,
+      "isAvailable" : true,
+      "name" : "iOS 17.0",
+      "supportedDeviceTypes" : [
+        {
+          "bundlePath" : "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 15 Pro Max.simdevicetype",
+          "name" : "iPhone 15 Pro Max",
+          "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro-Max",
+          "productFamily" : "iPhone"
+        }
+      ],
+      "lastUsage" : {
+        "arm64" : "2025-10-31T03:40:19Z"
+      }
+    },
+    {
+      "bundlePath" : "/Library/Developer/CoreSimulator/Volumes/iOS_23A8464/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 26.0.simruntime",
+      "buildversion" : "23A8464",
+      "platform" : "iOS",
+      "runtimeRoot" : "/Library/Developer/CoreSimulator/Volumes/iOS_23A8464/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 26.0.simruntime/Contents/Resources/RuntimeRoot",
+      "identifier" : "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+      "version" : "26.0.1",
+      "isInternal" : false,
+      "isAvailable" : true,
+      "name" : "iOS 26.0",
+      "supportedDeviceTypes" : [
+        {
+          "bundlePath" : "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 15 Pro Max.simdevicetype",
+          "name" : "iPhone 15 Pro Max",
+          "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro-Max",
+          "productFamily" : "iPhone"
+        },
+        {
+          "bundlePath" : "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPad Pro (12.9-inch) (6th generation).simdevicetype",
+          "name" : "iPad Pro (12.9-inch) (6th generation)",
+          "identifier" : "com.apple.CoreSimulator.SimDeviceType.iPad-Pro-12-9-inch-6th-generation-8GB",
+          "productFamily" : "iPad"
+        }
+      ],
+      "lastUsage" : {
+        "arm64" : "2025-10-31T03:40:19Z"
+      }
+    }
+  ]
+}

--- a/fastlane_core/spec/simulator_spec.rb
+++ b/fastlane_core/spec/simulator_spec.rb
@@ -20,7 +20,13 @@ describe FastlaneCore do
     Apple Watch - 38mm (FE0C82A5-CDD2-4062-A62C-21278EEE32BB) (Shutdown)
     Apple Watch - 38mm (66D1BF17-3003-465F-A165-E6E3A565E5EB) (Booted)
 "
+      @simctl_runtime_output = File.read('./fastlane_core/spec/fixtures/XcrunSimctlListRuntimesOutput')
       FastlaneCore::Simulator.clear_cache
+    end
+
+    before(:each) do
+      status = double('status', "success?": true)
+      allow(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([@simctl_runtime_output, status])
     end
 
     it "can launch Simulator.app for a simulator device" do

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -153,6 +153,12 @@ describe Scan do
 
     describe "#detect_simulator" do
       it 'returns simulators for requested devices', requires_xcodebuild: true do
+        # Stub Scan.config and Scan.project to avoid full initialization
+        config_stub = double('config')
+        allow(config_stub).to receive(:[]).and_return(nil)
+        allow(Scan).to receive(:config).and_return(config_stub)
+        allow(Scan).to receive(:project).and_return(nil)
+
         simctl_list_devices_output = double('xcrun simctl list devices', read: File.read("./scan/spec/fixtures/XcrunSimctlListDevicesOutput15"))
         allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, simctl_list_devices_output, nil, nil)
 
@@ -180,6 +186,12 @@ describe Scan do
       end
 
       it 'filters out simulators newer than what the current Xcode SDK supports', requires_xcodebuild: true do
+        # Stub Scan.config and Scan.project to avoid full initialization
+        config_stub = double('config')
+        allow(config_stub).to receive(:[]).and_return(nil)
+        allow(Scan).to receive(:config).and_return(config_stub)
+        allow(Scan).to receive(:project).and_return(nil)
+
         simctl_list_devices_output = double('xcrun simctl list devices', read: File.read("./scan/spec/fixtures/XcrunSimctlListDevicesOutput14"))
         allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, simctl_list_devices_output, nil, nil)
 

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -156,6 +156,10 @@ describe Scan do
         simctl_list_devices_output = double('xcrun simctl list devices', read: File.read("./scan/spec/fixtures/XcrunSimctlListDevicesOutput15"))
         allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, simctl_list_devices_output, nil, nil)
 
+        simctl_runtime_output = File.read('./scan/spec/fixtures/XcrunSimctlListRuntimesOutput')
+        runtime_status = double('status', "success?": true)
+        allow(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([simctl_runtime_output, runtime_status])
+
         allow(Scan::DetectValues).to receive(:default_os_version).with('iOS').and_return(Gem::Version.new('17.0'))
         allow(Scan::DetectValues).to receive(:default_os_version).with('tvOS').and_return(Gem::Version.new('17.0'))
         allow(Scan::DetectValues).to receive(:default_os_version).with('watchOS').and_return(Gem::Version.new('10.0'))
@@ -178,6 +182,10 @@ describe Scan do
       it 'filters out simulators newer than what the current Xcode SDK supports', requires_xcodebuild: true do
         simctl_list_devices_output = double('xcrun simctl list devices', read: File.read("./scan/spec/fixtures/XcrunSimctlListDevicesOutput14"))
         allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, simctl_list_devices_output, nil, nil)
+
+        simctl_runtime_output = File.read('./scan/spec/fixtures/XcrunSimctlListRuntimesOutput')
+        runtime_status = double('status', "success?": true)
+        allow(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([simctl_runtime_output, runtime_status])
 
         allow(Scan::DetectValues).to receive(:default_os_version).with('iOS').and_return(Gem::Version.new('16.4'))
         allow(Scan::DetectValues).to receive(:default_os_version).with('tvOS').and_return(Gem::Version.new('16.4'))

--- a/scan/spec/test_command_generator_spec.rb
+++ b/scan/spec/test_command_generator_spec.rb
@@ -63,6 +63,10 @@ describe Scan do
     allow(response).to receive(:read).and_return(@valid_simulators)
     allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, response, nil, nil)
 
+    simctl_runtime_output = File.read('./scan/spec/fixtures/XcrunSimctlListRuntimesOutput')
+    runtime_status = double('status', "success?": true)
+    allow(Open3).to receive(:capture2).with("xcrun simctl list -j runtimes").and_return([simctl_runtime_output, runtime_status])
+
     allow(Open3).to receive(:capture3).with("xcrun simctl runtime -h").and_return([nil, 'Usage: simctl runtime <operation> <arguments>', nil])
 
     allow(FastlaneCore::Helper).to receive(:xcode_at_least?).and_return(false)


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
Fixes an issue where simulator runtime versions reported by `xcrun simctl list devices` section headers don't match the actual runtime versions, causing incorrect OS version detection.

This also likely fixes #29481 which seems similar if not identical to the issue I was having.

### Description
When running `xcrun simctl list devices`, the section headers may show versions like "iOS 26.0", but the actual runtime version (as reported by `xcrun simctl list -j runtimes`) is "26.0.1". This mismatch causes fastlane to incorrectly identify simulator OS versions, which causes snapshot to fail.

- Modified `DeviceManager.simulators` to query `xcrun simctl list -j runtimes` for accurate runtime version mapping
- Added `runtime_name_to_version` method that creates a mapping from runtime names (e.g., "iOS 26.0") to actual versions (e.g., "26.0.1")
- Updated device creation to use the actual runtime version instead of the section header version

### Testing Steps

- Added new test fixtures:
  - `DeviceManagerSimctlOutputWithVersionMismatch` - simulated device list output with version mismatch
  - `XcrunSimctlListRuntimesOutputWithVersionMismatch` - JSON runtime output showing actual versions
- Added test case `properly maps runtime names to actual versions for version mismatch fix` that validates the mapping as a unit test
- Added test case `fixes iOS version mismatch by using actual runtime versions instead of section header versions` that verifies devices get the correct OS version (26.0.1) instead of the section header version (26.0)
- Existing tests continue to pass
- My snapshot failure no longer fails (end-to-end verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)