### PR TITLE
[ci] fix: allow Dependabot to manage Ruby deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,5 +57,4 @@ gem "yard", "~> 0.9.11"
 
 gemspec(path: ".")
 
-plugins_path = File.join(File.expand_path("..", __FILE__), "fastlane", "Pluginfile")
-eval_gemfile(plugins_path)
+eval_gemfile("fastlane/Pluginfile")


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

_fastlane_ has currently 38 vulnerable reports. It causes strife in companies with strict compliance. Managing all vulnerable dependencies and keeping things up to date is painful. Especially when some upgrades are not compatible. Managing this as humans is tough - robots do it well, but robots can't read this project.

```
Dependabot only supports uninterpolated string arguments to eval_gemfile. Got plugins_path
```

### Description

This path appears to be a logical build up of `fastlane/Pluginfile`. We just hardcode it. This is what Sentry/Clang did to re-enable theirs.

fixes: #22260 

### Testing Steps

Looking at CI output.
