### PR TITLE
[deliver][frameit] support the latest devices and resolutions.

### DIFF
--- a/deliver/lib/assets/summary.html.erb
+++ b/deliver/lib/assets/summary.html.erb
@@ -228,10 +228,10 @@
             </div>
           <% elsif @screenshots.count > 0 %>
             <% sc = @screenshots.find_all { |s| s.language == language } %>
-            <% sc_by_size = sc.group_by { |i| i.screen_size } %>
+            <% sc_by_size = sc.group_by { |i| i.display_type } %>
 
-            <% sc_by_size.keys.sort.each do |screen_size| %>
-              <% screenshots = sc_by_size[screen_size].sort { |a, b| [a.path] <=> [b.path] } %>
+            <% sc_by_size.keys.sort.each do |display_type| %>
+              <% screenshots = sc_by_size[display_type].sort { |a, b| [a.path] <=> [b.path] } %>
               <%# we are guaranteed to have at least one element because of the group_by %>
               <h4><%= screenshots[0].formatted_name %></h4>
               <div class="app-screenshot-row">

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -10,43 +10,6 @@ module Deliver
     # Shorthand for DisplayType constants
     DisplayType = Spaceship::ConnectAPI::AppScreenshotSet::DisplayType
 
-    # Mapping from DisplayType constants to screen size strings (preserved for backward compatibility)
-    DISPLAY_TYPE_TO_SCREEN_SIZE = {
-      DisplayType::APP_IPHONE_35 => "iOS-3.5-in",
-      DisplayType::APP_IPHONE_40 => "iOS-4-in",
-      DisplayType::APP_IPHONE_47 => "iOS-4.7-in",
-      DisplayType::APP_IPHONE_55 => "iOS-5.5-in",
-      DisplayType::APP_IPHONE_58 => "iOS-5.8-in",
-      DisplayType::APP_IPHONE_61 => "iOS-6.1-in",
-      DisplayType::APP_IPHONE_65 => "iOS-6.5-in",
-      DisplayType::APP_IPHONE_67 => "iOS-6.7-in",
-      DisplayType::APP_IPAD_97 => "iOS-iPad",
-      DisplayType::APP_IPAD_105 => "iOS-iPad-10.5",
-      DisplayType::APP_IPAD_PRO_3GEN_11 => "iOS-iPad-11",
-      DisplayType::APP_IPAD_PRO_129 => "iOS-iPad-Pro",
-      DisplayType::APP_IPAD_PRO_3GEN_129 => "iOS-iPad-Pro-12.9",
-      DisplayType::IMESSAGE_APP_IPHONE_40 => "iOS-4-in-messages",
-      DisplayType::IMESSAGE_APP_IPHONE_47 => "iOS-4.7-in-messages",
-      DisplayType::IMESSAGE_APP_IPHONE_55 => "iOS-5.5-in-messages",
-      DisplayType::IMESSAGE_APP_IPHONE_58 => "iOS-5.8-in-messages",
-      DisplayType::IMESSAGE_APP_IPHONE_61 => "iOS-6.1-in-messages",
-      DisplayType::IMESSAGE_APP_IPHONE_65 => "iOS-6.5-in-messages",
-      DisplayType::IMESSAGE_APP_IPHONE_67 => "iOS-6.7-in-messages",
-      DisplayType::IMESSAGE_APP_IPAD_97 => "iOS-iPad-messages",
-      DisplayType::IMESSAGE_APP_IPAD_105 => "iOS-iPad-10.5-messages",
-      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11 => "iOS-iPad-11-messages",
-      DisplayType::IMESSAGE_APP_IPAD_PRO_129 => "iOS-iPad-Pro-messages",
-      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129 => "iOS-iPad-Pro-12.9-messages",
-      DisplayType::APP_WATCH_SERIES_3 => "iOS-Apple-Watch",
-      DisplayType::APP_WATCH_SERIES_4 => "iOS-Apple-Watch-Series4",
-      DisplayType::APP_WATCH_SERIES_7 => "iOS-Apple-Watch-Series7",
-      DisplayType::APP_WATCH_SERIES_10 => "iOS-Apple-Watch-Series10",
-      DisplayType::APP_WATCH_ULTRA => "iOS-Apple-Watch-Ultra",
-      DisplayType::APP_APPLE_TV => "Apple-TV",
-      DisplayType::APP_DESKTOP => "Mac",
-      DisplayType::APP_APPLE_VISION_PRO => "visionOS-Vision-Pro"
-    }.freeze
-
     FORMATTED_NAMES = {
       DisplayType::APP_IPHONE_35 => "iPhone 4",
       DisplayType::APP_IPHONE_40 => "iPhone 5",

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -40,16 +40,18 @@ module Deliver
       DisplayType::APP_WATCH_SERIES_3 => "iOS-Apple-Watch",
       DisplayType::APP_WATCH_SERIES_4 => "iOS-Apple-Watch-Series4",
       DisplayType::APP_WATCH_SERIES_7 => "iOS-Apple-Watch-Series7",
+      DisplayType::APP_WATCH_SERIES_10 => "iOS-Apple-Watch-Series10",
       DisplayType::APP_WATCH_ULTRA => "iOS-Apple-Watch-Ultra",
       DisplayType::APP_APPLE_TV => "Apple-TV",
-      DisplayType::APP_DESKTOP => "Mac"
+      DisplayType::APP_DESKTOP => "Mac",
+      DisplayType::APP_APPLE_VISION_PRO => "visionOS-Vision-Pro"
     }.freeze
 
     FORMATTED_NAMES = {
       DisplayType::APP_IPHONE_35 => "iPhone 4",
       DisplayType::APP_IPHONE_40 => "iPhone 5",
-      DisplayType::APP_IPHONE_47 => "iPhone 6", # also 7 & 8
-      DisplayType::APP_IPHONE_55 => "iPhone 6 Plus", # also 7 Plus & 8 Plus
+      DisplayType::APP_IPHONE_47 => "iPhone 6",
+      DisplayType::APP_IPHONE_55 => "iPhone 6 Plus",
       DisplayType::APP_IPHONE_58 => "iPhone XS",
       DisplayType::APP_IPHONE_61 => "iPhone 14 Pro",
       DisplayType::APP_IPHONE_65 => "iPhone XS Max",
@@ -60,8 +62,8 @@ module Deliver
       DisplayType::APP_IPAD_PRO_129 => "iPad Pro",
       DisplayType::APP_IPAD_PRO_3GEN_129 => "iPad Pro (12.9-inch) (3rd generation)",
       DisplayType::IMESSAGE_APP_IPHONE_40 => "iPhone 5 (iMessage)",
-      DisplayType::IMESSAGE_APP_IPHONE_47 => "iPhone 6 (iMessage)", # also 7 & 8
-      DisplayType::IMESSAGE_APP_IPHONE_55 => "iPhone 6 Plus (iMessage)", # also 7 Plus & 8 Plus
+      DisplayType::IMESSAGE_APP_IPHONE_47 => "iPhone 6 (iMessage)",
+      DisplayType::IMESSAGE_APP_IPHONE_55 => "iPhone 6 Plus (iMessage)",
       DisplayType::IMESSAGE_APP_IPHONE_58 => "iPhone XS (iMessage)",
       DisplayType::IMESSAGE_APP_IPHONE_61 => "iPhone 14 Pro (iMessage)",
       DisplayType::IMESSAGE_APP_IPHONE_65 => "iPhone XS Max (iMessage)",
@@ -75,18 +77,23 @@ module Deliver
       DisplayType::APP_WATCH_SERIES_3 => "Watch",
       DisplayType::APP_WATCH_SERIES_4 => "Watch Series4",
       DisplayType::APP_WATCH_SERIES_7 => "Watch Series7",
+      DisplayType::APP_WATCH_SERIES_10 => "Watch Series10",
       DisplayType::APP_WATCH_ULTRA => "Watch Ultra",
-      DisplayType::APP_APPLE_TV => "Apple TV"
+      DisplayType::APP_APPLE_TV => "Apple TV",
+      DisplayType::APP_APPLE_VISION_PRO => "Vision Pro"
     }.freeze
 
     # reference: https://help.apple.com/app-store-connect/#/devd274dd925
-    # This list does not include iPad Pro 12.9-inch (3rd generation)
-    # because it has same resolution as APP_IPAD_PRO_129 and will clobber.
     # Returns a hash mapping DisplayType constants to their supported resolutions.
     DEVICE_RESOLUTIONS = {
+      # These are actually 6.9" devices
       DisplayType::APP_IPHONE_67 => [
+        [1260, 2736],
+        [2736, 1260],
         [1290, 2796],
-        [2796, 1290]
+        [2796, 1290],
+        [1320, 2868],
+        [2868, 1320]
       ],
       DisplayType::APP_IPHONE_65 => [
         [1242, 2688],
@@ -94,15 +101,21 @@ module Deliver
         [1284, 2778],
         [2778, 1284]
       ],
+      # These are actually 6.3" devices
       DisplayType::APP_IPHONE_61 => [
         [1179, 2556],
-        [2556, 1179]
+        [2556, 1179],
+        [1206, 2622],
+        [2622, 1206]
       ],
+      # These are actually 6.1" devices
       DisplayType::APP_IPHONE_58 => [
+        [1170, 2532],
+        [2532, 1170],
         [1125, 2436],
         [2436, 1125],
-        [1170, 2532],
-        [2532, 1170]
+        [1080, 2340],
+        [2340, 1080]
       ],
       DisplayType::APP_IPHONE_55 => [
         [1242, 2208],
@@ -124,14 +137,14 @@ module Deliver
         [960, 600],
         [960, 640]
       ],
-      DisplayType::APP_IPAD_97 => [ # 9.7 inch
+      DisplayType::APP_IPAD_97 => [
         [1024, 748],
         [1024, 768],
         [2048, 1496],
         [2048, 1536],
-        [768, 1004], # portrait without status bar
+        [768, 1004],
         [768, 1024],
-        [1536, 2008], # portrait without status bar
+        [1536, 2008],
         [1536, 2048]
       ],
       DisplayType::APP_IPAD_105 => [
@@ -139,12 +152,24 @@ module Deliver
         [2224, 1668]
       ],
       DisplayType::APP_IPAD_PRO_3GEN_11 => [
+        [1488, 2266],
+        [2266, 1488],
+        [1668, 2420],
+        [2420, 1668],
         [1668, 2388],
-        [2388, 1668]
+        [2388, 1668],
+        [1640, 2360],
+        [2360, 1640]
       ],
       DisplayType::APP_IPAD_PRO_129 => [
+        [2048, 2732],
+        [2732, 2048]
+      ],
+      DisplayType::APP_IPAD_PRO_3GEN_129 => [
+        [2048, 2732],
         [2732, 2048],
-        [2048, 2732]
+        [2064, 2752],
+        [2752, 2064]
       ],
       DisplayType::APP_DESKTOP => [
         [1280, 800],
@@ -161,11 +186,18 @@ module Deliver
       DisplayType::APP_WATCH_SERIES_7 => [
         [396, 484]
       ],
+      DisplayType::APP_WATCH_SERIES_10 => [
+        [416, 496]
+      ],
       DisplayType::APP_WATCH_ULTRA => [
-        [410, 502]
+        [410, 502],
+        [422, 514]
       ],
       DisplayType::APP_APPLE_TV => [
         [1920, 1080],
+        [3840, 2160]
+      ],
+      DisplayType::APP_APPLE_VISION_PRO => [
         [3840, 2160]
       ]
     }.freeze

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -220,7 +220,9 @@ module Deliver
     end
 
     def is_messages?
+      # rubocop:disable Require/MissingRequireStatement
       return DisplayType::ALL_IMESSAGE.include?(self.display_type)
+      # rubocop:enable Require/MissingRequireStatement
     end
 
     def self.calculate_display_type(path)
@@ -245,6 +247,7 @@ module Deliver
         is_2gen = path_lower.include?("app_ipad_pro_129") ||
                   (path_lower.include?("12.9") && path_lower.include?("2nd generation")) # e.g. iPad Pro (12.9-inch) (2nd generation)
 
+        # rubocop:disable Require/MissingRequireStatement
         if is_2gen
           return is_imessage ? DisplayType::IMESSAGE_APP_IPAD_PRO_129 : DisplayType::APP_IPAD_PRO_129
         else
@@ -253,6 +256,7 @@ module Deliver
       # Apple TV vs Vision Pro conflict
       when [3840, 2160]
         return path_lower.include?("vision") ? DisplayType::APP_APPLE_VISION_PRO : DisplayType::APP_APPLE_TV
+        # rubocop:enable Require/MissingRequireStatement
       else
         matching_display_type
       end

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -7,81 +7,186 @@ module Deliver
   # AppScreenshot represents one screenshots for one specific locale and
   # device type.
   class AppScreenshot
-    #
-    module ScreenSize
-      # iPhone 4
-      IOS_35 = "iOS-3.5-in"
-      # iPhone 5
-      IOS_40 = "iOS-4-in"
-      # iPhone 6, 7, & 8
-      IOS_47 = "iOS-4.7-in"
-      # iPhone 6 Plus, 7 Plus, & 8 Plus
-      IOS_55 = "iOS-5.5-in"
-      # iPhone XS
-      IOS_58 = "iOS-5.8-in"
-      # iPhone 14 Pro
-      IOS_61 = "iOS-6.1-in"
-      # iPhone 14 Plus, iPhone 13 Pro Max, iPhone 12 Pro Max, iPhone 11 Pro Max, iPhone 11, iPhone XS Max, iPhone XR
-      IOS_65 = "iOS-6.5-in"
-      # iPhone 14 Pro Max
-      IOS_67 = "iOS-6.7-in"
+    # Shorthand for DisplayType constants
+    DisplayType = Spaceship::ConnectAPI::AppScreenshotSet::DisplayType
 
-      # iPad
-      IOS_IPAD = "iOS-iPad"
-      # iPad 10.5
-      IOS_IPAD_10_5 = "iOS-iPad-10.5"
-      # iPad 11
-      IOS_IPAD_11 = "iOS-iPad-11"
-      # iPad Pro
-      IOS_IPAD_PRO = "iOS-iPad-Pro"
-      # iPad Pro (12.9-inch) (3rd generation)
-      IOS_IPAD_PRO_12_9 = "iOS-iPad-Pro-12.9"
+    # Mapping from DisplayType constants to screen size strings (preserved for backward compatibility)
+    DISPLAY_TYPE_TO_SCREEN_SIZE = {
+      DisplayType::APP_IPHONE_35 => "iOS-3.5-in",
+      DisplayType::APP_IPHONE_40 => "iOS-4-in",
+      DisplayType::APP_IPHONE_47 => "iOS-4.7-in",
+      DisplayType::APP_IPHONE_55 => "iOS-5.5-in",
+      DisplayType::APP_IPHONE_58 => "iOS-5.8-in",
+      DisplayType::APP_IPHONE_61 => "iOS-6.1-in",
+      DisplayType::APP_IPHONE_65 => "iOS-6.5-in",
+      DisplayType::APP_IPHONE_67 => "iOS-6.7-in",
+      DisplayType::APP_IPAD_97 => "iOS-iPad",
+      DisplayType::APP_IPAD_105 => "iOS-iPad-10.5",
+      DisplayType::APP_IPAD_PRO_3GEN_11 => "iOS-iPad-11",
+      DisplayType::APP_IPAD_PRO_129 => "iOS-iPad-Pro",
+      DisplayType::APP_IPAD_PRO_3GEN_129 => "iOS-iPad-Pro-12.9",
+      DisplayType::IMESSAGE_APP_IPHONE_40 => "iOS-4-in-messages",
+      DisplayType::IMESSAGE_APP_IPHONE_47 => "iOS-4.7-in-messages",
+      DisplayType::IMESSAGE_APP_IPHONE_55 => "iOS-5.5-in-messages",
+      DisplayType::IMESSAGE_APP_IPHONE_58 => "iOS-5.8-in-messages",
+      DisplayType::IMESSAGE_APP_IPHONE_61 => "iOS-6.1-in-messages",
+      DisplayType::IMESSAGE_APP_IPHONE_65 => "iOS-6.5-in-messages",
+      DisplayType::IMESSAGE_APP_IPHONE_67 => "iOS-6.7-in-messages",
+      DisplayType::IMESSAGE_APP_IPAD_97 => "iOS-iPad-messages",
+      DisplayType::IMESSAGE_APP_IPAD_105 => "iOS-iPad-10.5-messages",
+      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11 => "iOS-iPad-11-messages",
+      DisplayType::IMESSAGE_APP_IPAD_PRO_129 => "iOS-iPad-Pro-messages",
+      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129 => "iOS-iPad-Pro-12.9-messages",
+      DisplayType::APP_WATCH_SERIES_3 => "iOS-Apple-Watch",
+      DisplayType::APP_WATCH_SERIES_4 => "iOS-Apple-Watch-Series4",
+      DisplayType::APP_WATCH_SERIES_7 => "iOS-Apple-Watch-Series7",
+      DisplayType::APP_WATCH_ULTRA => "iOS-Apple-Watch-Ultra",
+      DisplayType::APP_APPLE_TV => "Apple-TV",
+      DisplayType::APP_DESKTOP => "Mac"
+    }.freeze
 
-      # iPhone 5 iMessage
-      IOS_40_MESSAGES = "iOS-4-in-messages"
-      # iPhone 6, 7, & 8 iMessage
-      IOS_47_MESSAGES = "iOS-4.7-in-messages"
-      # iPhone 6 Plus, 7 Plus, & 8 Plus iMessage
-      IOS_55_MESSAGES = "iOS-5.5-in-messages"
-      # iPhone XS iMessage
-      IOS_58_MESSAGES = "iOS-5.8-in-messages"
-      # iPhone 14 Pro iMessage
-      IOS_61_MESSAGES = "iOS-6.1-in-messages"
-      # iPhone 14 Plus, iPhone 13 Pro Max, iPhone 12 Pro Max, iPhone 11 Pro Max, iPhone 11, iPhone XS Max, iPhone XR iMessage
-      IOS_65_MESSAGES = "iOS-6.5-in-messages"
-      # iPhone 14 Pro Max iMessage
-      IOS_67_MESSAGES = "iOS-6.7-in-messages"
+    FORMATTED_NAMES = {
+      DisplayType::APP_IPHONE_35 => "iPhone 4",
+      DisplayType::APP_IPHONE_40 => "iPhone 5",
+      DisplayType::APP_IPHONE_47 => "iPhone 6", # also 7 & 8
+      DisplayType::APP_IPHONE_55 => "iPhone 6 Plus", # also 7 Plus & 8 Plus
+      DisplayType::APP_IPHONE_58 => "iPhone XS",
+      DisplayType::APP_IPHONE_61 => "iPhone 14 Pro",
+      DisplayType::APP_IPHONE_65 => "iPhone XS Max",
+      DisplayType::APP_IPHONE_67 => "iPhone 14 Pro Max",
+      DisplayType::APP_IPAD_97 => "iPad",
+      DisplayType::APP_IPAD_105 => "iPad 10.5",
+      DisplayType::APP_IPAD_PRO_3GEN_11 => "iPad 11",
+      DisplayType::APP_IPAD_PRO_129 => "iPad Pro",
+      DisplayType::APP_IPAD_PRO_3GEN_129 => "iPad Pro (12.9-inch) (3rd generation)",
+      DisplayType::IMESSAGE_APP_IPHONE_40 => "iPhone 5 (iMessage)",
+      DisplayType::IMESSAGE_APP_IPHONE_47 => "iPhone 6 (iMessage)", # also 7 & 8
+      DisplayType::IMESSAGE_APP_IPHONE_55 => "iPhone 6 Plus (iMessage)", # also 7 Plus & 8 Plus
+      DisplayType::IMESSAGE_APP_IPHONE_58 => "iPhone XS (iMessage)",
+      DisplayType::IMESSAGE_APP_IPHONE_61 => "iPhone 14 Pro (iMessage)",
+      DisplayType::IMESSAGE_APP_IPHONE_65 => "iPhone XS Max (iMessage)",
+      DisplayType::IMESSAGE_APP_IPHONE_67 => "iPhone 14 Pro Max (iMessage)",
+      DisplayType::IMESSAGE_APP_IPAD_97 => "iPad (iMessage)",
+      DisplayType::IMESSAGE_APP_IPAD_PRO_129 => "iPad Pro (iMessage)",
+      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129 => "iPad Pro (12.9-inch) (3rd generation) (iMessage)",
+      DisplayType::IMESSAGE_APP_IPAD_105 => "iPad 10.5 (iMessage)",
+      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11 => "iPad 11 (iMessage)",
+      DisplayType::APP_DESKTOP => "Mac",
+      DisplayType::APP_WATCH_SERIES_3 => "Watch",
+      DisplayType::APP_WATCH_SERIES_4 => "Watch Series4",
+      DisplayType::APP_WATCH_SERIES_7 => "Watch Series7",
+      DisplayType::APP_WATCH_ULTRA => "Watch Ultra",
+      DisplayType::APP_APPLE_TV => "Apple TV"
+    }.freeze
 
-      # iPad iMessage
-      IOS_IPAD_MESSAGES = "iOS-iPad-messages"
-      # iPad 10.5 iMessage
-      IOS_IPAD_10_5_MESSAGES = "iOS-iPad-10.5-messages"
-      # iPad 11 iMessage
-      IOS_IPAD_11_MESSAGES = "iOS-iPad-11-messages"
-      # iPad Pro iMessage
-      IOS_IPAD_PRO_MESSAGES = "iOS-iPad-Pro-messages"
-      # iPad Pro (12.9-inch) (3rd generation) iMessage
-      IOS_IPAD_PRO_12_9_MESSAGES = "iOS-iPad-Pro-12.9-messages"
+    # reference: https://help.apple.com/app-store-connect/#/devd274dd925
+    # This list does not include iPad Pro 12.9-inch (3rd generation)
+    # because it has same resolution as APP_IPAD_PRO_129 and will clobber.
+    # Returns a hash mapping DisplayType constants to their supported resolutions.
+    DEVICE_RESOLUTIONS = {
+      DisplayType::APP_IPHONE_67 => [
+        [1290, 2796],
+        [2796, 1290]
+      ],
+      DisplayType::APP_IPHONE_65 => [
+        [1242, 2688],
+        [2688, 1242],
+        [1284, 2778],
+        [2778, 1284]
+      ],
+      DisplayType::APP_IPHONE_61 => [
+        [1179, 2556],
+        [2556, 1179]
+      ],
+      DisplayType::APP_IPHONE_58 => [
+        [1125, 2436],
+        [2436, 1125],
+        [1170, 2532],
+        [2532, 1170]
+      ],
+      DisplayType::APP_IPHONE_55 => [
+        [1242, 2208],
+        [2208, 1242]
+      ],
+      DisplayType::APP_IPHONE_47 => [
+        [750, 1334],
+        [1334, 750]
+      ],
+      DisplayType::APP_IPHONE_40 => [
+        [640, 1096],
+        [640, 1136],
+        [1136, 600],
+        [1136, 640]
+      ],
+      DisplayType::APP_IPHONE_35 => [
+        [640, 920],
+        [640, 960],
+        [960, 600],
+        [960, 640]
+      ],
+      DisplayType::APP_IPAD_97 => [ # 9.7 inch
+        [1024, 748],
+        [1024, 768],
+        [2048, 1496],
+        [2048, 1536],
+        [768, 1004], # portrait without status bar
+        [768, 1024],
+        [1536, 2008], # portrait without status bar
+        [1536, 2048]
+      ],
+      DisplayType::APP_IPAD_105 => [
+        [1668, 2224],
+        [2224, 1668]
+      ],
+      DisplayType::APP_IPAD_PRO_3GEN_11 => [
+        [1668, 2388],
+        [2388, 1668]
+      ],
+      DisplayType::APP_IPAD_PRO_129 => [
+        [2732, 2048],
+        [2048, 2732]
+      ],
+      DisplayType::APP_DESKTOP => [
+        [1280, 800],
+        [1440, 900],
+        [2560, 1600],
+        [2880, 1800]
+      ],
+      DisplayType::APP_WATCH_SERIES_3 => [
+        [312, 390]
+      ],
+      DisplayType::APP_WATCH_SERIES_4 => [
+        [368, 448]
+      ],
+      DisplayType::APP_WATCH_SERIES_7 => [
+        [396, 484]
+      ],
+      DisplayType::APP_WATCH_ULTRA => [
+        [410, 502]
+      ],
+      DisplayType::APP_APPLE_TV => [
+        [1920, 1080],
+        [3840, 2160]
+      ]
+    }.freeze
 
-      # Apple Watch
-      IOS_APPLE_WATCH = "iOS-Apple-Watch"
-      # Apple Watch Series 4
-      IOS_APPLE_WATCH_SERIES4 = "iOS-Apple-Watch-Series4"
-      # Apple Watch Series 7
-      IOS_APPLE_WATCH_SERIES7 = "iOS-Apple-Watch-Series7"
-      # Apple Watch Ultra
-      IOS_APPLE_WATCH_ULTRA = "iOS-Apple-Watch-Ultra"
+    DEVICE_RESOLUTIONS_MESSAGES = {
+      DisplayType::IMESSAGE_APP_IPHONE_40 => DEVICE_RESOLUTIONS[DisplayType::APP_IPHONE_40],
+      DisplayType::IMESSAGE_APP_IPHONE_47 => DEVICE_RESOLUTIONS[DisplayType::APP_IPHONE_47],
+      DisplayType::IMESSAGE_APP_IPHONE_55 => DEVICE_RESOLUTIONS[DisplayType::APP_IPHONE_55],
+      DisplayType::IMESSAGE_APP_IPHONE_58 => DEVICE_RESOLUTIONS[DisplayType::APP_IPHONE_58],
+      DisplayType::IMESSAGE_APP_IPHONE_61 => DEVICE_RESOLUTIONS[DisplayType::APP_IPHONE_61],
+      DisplayType::IMESSAGE_APP_IPHONE_65 => DEVICE_RESOLUTIONS[DisplayType::APP_IPHONE_65],
+      DisplayType::IMESSAGE_APP_IPHONE_67 => DEVICE_RESOLUTIONS[DisplayType::APP_IPHONE_67],
+      DisplayType::IMESSAGE_APP_IPAD_97 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_97],
+      DisplayType::IMESSAGE_APP_IPAD_105 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_105],
+      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_PRO_3GEN_11],
+      DisplayType::IMESSAGE_APP_IPAD_PRO_129 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_PRO_129],
+      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_PRO_129]
+    }.freeze
 
-      # Apple TV
-      APPLE_TV = "Apple-TV"
-
-      # Mac
-      MAC = "Mac"
-    end
-
-    # @return [Deliver::ScreenSize] the screen size (device type)
-    #  specified at {Deliver::ScreenSize}
-    attr_accessor :screen_size
+    # @return [Spaceship::ConnectAPI::AppScreenshotSet::DisplayType] the display type
+    attr_accessor :display_type
 
     attr_accessor :path
 
@@ -89,89 +194,15 @@ module Deliver
 
     # @param path (String) path to the screenshot file
     # @param language (String) Language of this screenshot (e.g. English)
-    # @param screen_size (Deliver::AppScreenshot::ScreenSize) the screen size, which
-    #  will automatically be calculated when you don't set it. (Deprecated)
-    def initialize(path, language, screen_size = nil)
-      UI.deprecated('`screen_size` for Deliver::AppScreenshot.new is deprecated in favor of the default behavior to calculate size automatically. Passed value is no longer validated.') if screen_size
+    def initialize(path, language)
       self.path = path
       self.language = language
-      self.screen_size = screen_size || self.class.calculate_screen_size(path)
-    end
-
-    # The iTC API requires a different notation for the device
-    def device_type
-      matching = {
-        ScreenSize::IOS_35 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_35,
-        ScreenSize::IOS_40 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_40,
-        ScreenSize::IOS_47 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_47, # also 7 & 8
-        ScreenSize::IOS_55 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55, # also 7 Plus & 8 Plus
-        ScreenSize::IOS_58 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_58,
-        ScreenSize::IOS_61 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_61,
-        ScreenSize::IOS_65 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_65,
-        ScreenSize::IOS_67 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_67,
-        ScreenSize::IOS_IPAD => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPAD_97,
-        ScreenSize::IOS_IPAD_10_5 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPAD_105,
-        ScreenSize::IOS_IPAD_11 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPAD_PRO_3GEN_11,
-        ScreenSize::IOS_IPAD_PRO => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPAD_PRO_129,
-        ScreenSize::IOS_IPAD_PRO_12_9 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPAD_PRO_3GEN_129,
-        ScreenSize::IOS_40_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPHONE_40,
-        ScreenSize::IOS_47_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPHONE_47, # also 7 & 8
-        ScreenSize::IOS_55_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPHONE_55, # also 7 Plus & 8 Plus
-        ScreenSize::IOS_58_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPHONE_58,
-        ScreenSize::IOS_61_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPHONE_61,
-        ScreenSize::IOS_65_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPHONE_65,
-        ScreenSize::IOS_67_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPHONE_67,
-        ScreenSize::IOS_IPAD_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPAD_97,
-        ScreenSize::IOS_IPAD_PRO_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPAD_PRO_129,
-        ScreenSize::IOS_IPAD_PRO_12_9_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129,
-        ScreenSize::IOS_IPAD_10_5_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPAD_105,
-        ScreenSize::IOS_IPAD_11_MESSAGES => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11,
-        ScreenSize::MAC => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_DESKTOP,
-        ScreenSize::IOS_APPLE_WATCH => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_3,
-        ScreenSize::IOS_APPLE_WATCH_SERIES4 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_4,
-        ScreenSize::IOS_APPLE_WATCH_SERIES7 => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_SERIES_7,
-        ScreenSize::IOS_APPLE_WATCH_ULTRA => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_WATCH_ULTRA,
-        ScreenSize::APPLE_TV => Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_APPLE_TV
-      }
-      return matching[self.screen_size]
+      self.display_type = self.class.calculate_display_type(path)
     end
 
     # Nice name
     def formatted_name
-      matching = {
-        ScreenSize::IOS_35 => "iPhone 4",
-        ScreenSize::IOS_40 => "iPhone 5",
-        ScreenSize::IOS_47 => "iPhone 6", # also 7 & 8
-        ScreenSize::IOS_55 => "iPhone 6 Plus", # also 7 Plus & 8 Plus
-        ScreenSize::IOS_58 => "iPhone XS",
-        ScreenSize::IOS_61 => "iPhone 14 Pro",
-        ScreenSize::IOS_65 => "iPhone XS Max",
-        ScreenSize::IOS_67 => "iPhone 14 Pro Max",
-        ScreenSize::IOS_IPAD => "iPad",
-        ScreenSize::IOS_IPAD_10_5 => "iPad 10.5",
-        ScreenSize::IOS_IPAD_11 => "iPad 11",
-        ScreenSize::IOS_IPAD_PRO => "iPad Pro",
-        ScreenSize::IOS_IPAD_PRO_12_9 => "iPad Pro (12.9-inch) (3rd generation)",
-        ScreenSize::IOS_40_MESSAGES => "iPhone 5 (iMessage)",
-        ScreenSize::IOS_47_MESSAGES => "iPhone 6 (iMessage)", # also 7 & 8
-        ScreenSize::IOS_55_MESSAGES => "iPhone 6 Plus (iMessage)", # also 7 Plus & 8 Plus
-        ScreenSize::IOS_58_MESSAGES => "iPhone XS (iMessage)",
-        ScreenSize::IOS_61_MESSAGES => "iPhone 14 Pro (iMessage)",
-        ScreenSize::IOS_65_MESSAGES => "iPhone XS Max (iMessage)",
-        ScreenSize::IOS_67_MESSAGES => "iPhone 14 Pro Max (iMessage)",
-        ScreenSize::IOS_IPAD_MESSAGES => "iPad (iMessage)",
-        ScreenSize::IOS_IPAD_PRO_MESSAGES => "iPad Pro (iMessage)",
-        ScreenSize::IOS_IPAD_PRO_12_9_MESSAGES => "iPad Pro (12.9-inch) (3rd generation) (iMessage)",
-        ScreenSize::IOS_IPAD_10_5_MESSAGES => "iPad 10.5 (iMessage)",
-        ScreenSize::IOS_IPAD_11_MESSAGES => "iPad 11 (iMessage)",
-        ScreenSize::MAC => "Mac",
-        ScreenSize::IOS_APPLE_WATCH => "Watch",
-        ScreenSize::IOS_APPLE_WATCH_SERIES4 => "Watch Series4",
-        ScreenSize::IOS_APPLE_WATCH_SERIES7 => "Watch Series7",
-        ScreenSize::IOS_APPLE_WATCH_ULTRA => "Watch Ultra",
-        ScreenSize::APPLE_TV => "Apple TV"
-      }
-      return matching[self.screen_size]
+      return FORMATTED_NAMES[self.display_type]
     end
 
     # Validates the given screenshots (size and format)
@@ -179,182 +210,14 @@ module Deliver
       UI.deprecated('Deliver::AppScreenshot#is_valid? is deprecated in favor of Deliver::AppScreenshotValidator')
       return false unless ["png", "PNG", "jpg", "JPG", "jpeg", "JPEG"].include?(self.path.split(".").last)
 
-      return self.screen_size == self.class.calculate_screen_size(self.path)
+      return self.display_type == self.class.calculate_display_type(self.path)
     end
 
     def is_messages?
-      return [
-        ScreenSize::IOS_40_MESSAGES,
-        ScreenSize::IOS_47_MESSAGES,
-        ScreenSize::IOS_55_MESSAGES,
-        ScreenSize::IOS_58_MESSAGES,
-        ScreenSize::IOS_61_MESSAGES,
-        ScreenSize::IOS_65_MESSAGES,
-        ScreenSize::IOS_67_MESSAGES,
-        ScreenSize::IOS_IPAD_MESSAGES,
-        ScreenSize::IOS_IPAD_PRO_MESSAGES,
-        ScreenSize::IOS_IPAD_PRO_12_9_MESSAGES,
-        ScreenSize::IOS_IPAD_10_5_MESSAGES,
-        ScreenSize::IOS_IPAD_11_MESSAGES
-      ].include?(self.screen_size)
+      return DisplayType::ALL_IMESSAGE.include?(self.display_type)
     end
 
-    def self.device_messages
-      # This list does not include iPad Pro 12.9-inch (3rd generation)
-      # because it has same resolution as IOS_IPAD_PRO and will clobber
-      return {
-        ScreenSize::IOS_67_MESSAGES => [
-          [1290, 2796],
-          [2796, 1290]
-        ],
-        ScreenSize::IOS_65_MESSAGES => [
-          [1242, 2688],
-          [2688, 1242],
-          [1284, 2778],
-          [2778, 1284]
-        ],
-        ScreenSize::IOS_61_MESSAGES => [
-          [1179, 2556],
-          [2556, 1179]
-        ],
-        ScreenSize::IOS_58_MESSAGES => [
-          [1125, 2436],
-          [2436, 1125],
-          [1170, 2532],
-          [2532, 1170]
-        ],
-        ScreenSize::IOS_55_MESSAGES => [
-          [1242, 2208],
-          [2208, 1242]
-        ],
-        ScreenSize::IOS_47_MESSAGES => [
-          [750, 1334],
-          [1334, 750]
-        ],
-        ScreenSize::IOS_40_MESSAGES => [
-          [640, 1096],
-          [640, 1136],
-          [1136, 600],
-          [1136, 640]
-        ],
-        ScreenSize::IOS_IPAD_MESSAGES => [
-          [1024, 748],
-          [1024, 768],
-          [2048, 1496],
-          [2048, 1536],
-          [768, 1004],
-          [768, 1024],
-          [1536, 2008],
-          [1536, 2048]
-        ],
-        ScreenSize::IOS_IPAD_10_5_MESSAGES => [
-          [1668, 2224],
-          [2224, 1668]
-        ],
-        ScreenSize::IOS_IPAD_11_MESSAGES => [
-          [1668, 2388],
-          [2388, 1668]
-        ],
-        ScreenSize::IOS_IPAD_PRO_MESSAGES => [
-          [2732, 2048],
-          [2048, 2732]
-        ]
-      }
-    end
-
-    # reference: https://help.apple.com/app-store-connect/#/devd274dd925
-    def self.devices
-      # This list does not include iPad Pro 12.9-inch (3rd generation)
-      # because it has same resolution as IOS_IPAD_PRO and will clobber
-      return {
-        ScreenSize::IOS_67 => [
-          [1290, 2796],
-          [2796, 1290]
-        ],
-        ScreenSize::IOS_65 => [
-          [1242, 2688],
-          [2688, 1242],
-          [1284, 2778],
-          [2778, 1284]
-        ],
-        ScreenSize::IOS_61 => [
-          [1179, 2556],
-          [2556, 1179]
-        ],
-        ScreenSize::IOS_58 => [
-          [1125, 2436],
-          [2436, 1125],
-          [1170, 2532],
-          [2532, 1170]
-        ],
-        ScreenSize::IOS_55 => [
-          [1242, 2208],
-          [2208, 1242]
-        ],
-        ScreenSize::IOS_47 => [
-          [750, 1334],
-          [1334, 750]
-        ],
-        ScreenSize::IOS_40 => [
-          [640, 1096],
-          [640, 1136],
-          [1136, 600],
-          [1136, 640]
-        ],
-        ScreenSize::IOS_35 => [
-          [640, 920],
-          [640, 960],
-          [960, 600],
-          [960, 640]
-        ],
-        ScreenSize::IOS_IPAD => [ # 9.7 inch
-          [1024, 748],
-          [1024, 768],
-          [2048, 1496],
-          [2048, 1536],
-          [768, 1004], # portrait without status bar
-          [768, 1024],
-          [1536, 2008], # portrait without status bar
-          [1536, 2048]
-        ],
-        ScreenSize::IOS_IPAD_10_5 => [
-          [1668, 2224],
-          [2224, 1668]
-        ],
-        ScreenSize::IOS_IPAD_11 => [
-          [1668, 2388],
-          [2388, 1668]
-        ],
-        ScreenSize::IOS_IPAD_PRO => [
-          [2732, 2048],
-          [2048, 2732]
-        ],
-        ScreenSize::MAC => [
-          [1280, 800],
-          [1440, 900],
-          [2560, 1600],
-          [2880, 1800]
-        ],
-        ScreenSize::IOS_APPLE_WATCH => [
-          [312, 390]
-        ],
-        ScreenSize::IOS_APPLE_WATCH_SERIES4 => [
-          [368, 448]
-        ],
-        ScreenSize::IOS_APPLE_WATCH_SERIES7 => [
-          [396, 484]
-        ],
-        ScreenSize::IOS_APPLE_WATCH_ULTRA => [
-          [410, 502]
-        ],
-        ScreenSize::APPLE_TV => [
-          [1920, 1080],
-          [3840, 2160]
-        ]
-      }
-    end
-
-    def self.resolve_ipadpro_conflict_if_needed(screen_size, filename)
+    def self.resolve_ipadpro_conflict_if_needed(display_type, filename)
       is_3rd_gen = [
         "iPad Pro (12.9-inch) (3rd generation)", # Default simulator has this name
         "iPad Pro (12.9-inch) (4th generation)", # Default simulator has this name
@@ -364,34 +227,32 @@ module Deliver
         "ipadPro129" # Legacy: screenshots downloaded from iTunes Connect used to have this name
       ].any? { |key| filename.include?(key) }
       if is_3rd_gen
-        if screen_size == ScreenSize::IOS_IPAD_PRO
-          return ScreenSize::IOS_IPAD_PRO_12_9
-        elsif screen_size == ScreenSize::IOS_IPAD_PRO_MESSAGES
-          return ScreenSize::IOS_IPAD_PRO_12_9_MESSAGES
+        if display_type == DisplayType::APP_IPAD_PRO_129
+          return DisplayType::APP_IPAD_PRO_3GEN_129
+        elsif display_type == DisplayType::IMESSAGE_APP_IPAD_PRO_129
+          return DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129
         end
       end
-      screen_size
+      display_type
     end
 
-    def self.calculate_screen_size(path)
+    def self.calculate_display_type(path)
       size = FastImage.size(path)
 
       UI.user_error!("Could not find or parse file at path '#{path}'") if size.nil? || size.count == 0
 
       # iMessage screenshots have same resolution as app screenshots so we need to distinguish them
       path_component = Pathname.new(path).each_filename.to_a[-3]
-      devices = path_component.eql?("iMessage") ? self.device_messages : self.devices
+      devices = path_component.eql?("iMessage") ? DEVICE_RESOLUTIONS_MESSAGES : DEVICE_RESOLUTIONS
 
-      devices.each do |screen_size, resolutions|
+      devices.each do |display_type, resolutions|
         if resolutions.include?(size)
           filename = Pathname.new(path).basename.to_s
-          return resolve_ipadpro_conflict_if_needed(screen_size, filename)
+          return resolve_ipadpro_conflict_if_needed(display_type, filename)
         end
       end
 
       nil
     end
   end
-
-  ScreenSize = AppScreenshot::ScreenSize
 end

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -179,7 +179,7 @@ module Deliver
       DisplayType::IMESSAGE_APP_IPAD_105 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_105],
       DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_PRO_3GEN_11],
       DisplayType::IMESSAGE_APP_IPAD_PRO_129 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_PRO_129],
-      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_PRO_129]
+      DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129 => DEVICE_RESOLUTIONS[DisplayType::APP_IPAD_PRO_3GEN_129]
     }.freeze
 
     # Resolutions that are shared by multiple device types

--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -77,7 +77,7 @@ module Deliver
       # iterate over screenshots per localization
       screenshots_per_language.each do |language, screenshots_for_language|
         localization = supported_localizations.find { |l| l.locale == language }
-        screenshots_per_display_type = screenshots_for_language.reject { |screenshot| screenshot.device_type.nil? }.group_by(&:device_type)
+        screenshots_per_display_type = screenshots_for_language.reject { |screenshot| screenshot.display_type.nil? }.group_by(&:display_type)
 
         screenshots_per_display_type.each do |display_type, screenshots|
           # create AppScreenshotSet for given display_type if it doesn't exist

--- a/deliver/lib/deliver/app_screenshot_iterator.rb
+++ b/deliver/lib/deliver/app_screenshot_iterator.rb
@@ -1,3 +1,5 @@
+require_relative 'module'
+
 module Deliver
   # This is a convenient class that enumerates app store connect's screenshots in various degrees.
   class AppScreenshotIterator
@@ -81,6 +83,7 @@ module Deliver
 
         screenshots_per_display_type.each do |display_type, screenshots|
           # create AppScreenshotSet for given display_type if it doesn't exist
+          UI.verbose("Setting up screenshot set for #{language}, #{display_type}")
           app_screenshot_set = (app_screenshot_set_per_locale_and_display_type[language] || {})[display_type]
           app_screenshot_set ||= localization.create_app_screenshot_set(attributes: { screenshotDisplayType: display_type })
 

--- a/deliver/lib/deliver/app_screenshot_validator.rb
+++ b/deliver/lib/deliver/app_screenshot_validator.rb
@@ -3,25 +3,22 @@ require 'fastimage'
 module Deliver
   class AppScreenshotValidator
     # A simple structure that holds error information as well as formatted error messages consistently
-    # Set `to_skip` to `true` when just needing to skip uploading rather than causing a crash.
     class ValidationError
       # Constants that can be given to `type` param
       INVALID_SCREEN_SIZE = 'Invalid screen size'.freeze
-      UNACCEPTABLE_DEVICE = 'Not an accepted App Store Connect device'.freeze
       INVALID_FILE_EXTENSION = 'Invalid file extension'.freeze
       FILE_EXTENSION_MISMATCH = 'File extension mismatches its image format'.freeze
 
-      attr_reader :type, :path, :debug_info, :to_skip
+      attr_reader :type, :path, :debug_info
 
-      def initialize(type: nil, path: nil, debug_info: nil, to_skip: false)
+      def initialize(type: nil, path: nil, debug_info: nil)
         @type = type
         @path = path
         @debug_info = debug_info
-        @to_skip = to_skip
       end
 
       def to_s
-        "#{to_skip ? '🏃 Skipping' : '🚫 Error'}: #{path} - #{type} (#{debug_info})"
+        "🚫 Error: #{path} - #{type} (#{debug_info})"
       end
 
       def inspect
@@ -46,7 +43,6 @@ module Deliver
       errors_found = []
 
       validate_screen_size(screenshot, errors_found)
-      validate_device_type(screenshot, errors_found)
       validate_file_extension_and_format(screenshot, errors_found)
 
       # Merge errors found into given errors array
@@ -55,22 +51,10 @@ module Deliver
     end
 
     def self.validate_screen_size(screenshot, errors_found)
-      if screenshot.screen_size.nil?
+      if screenshot.display_type.nil?
         errors_found << ValidationError.new(type: ValidationError::INVALID_SCREEN_SIZE,
                                             path: screenshot.path,
-                                            debug_info: "Actual size is #{get_formatted_size(screenshot)}. See the specifications to fix #{APP_SCREENSHOT_SPEC_URL}")
-      end
-    end
-
-    # Checking if the device type exists in spaceship
-    # Ex: iPhone 6.1 inch isn't supported in App Store Connect but need
-    # to have it in there for frameit support
-    def self.validate_device_type(screenshot, errors_found)
-      if !screenshot.screen_size.nil? && screenshot.device_type.nil?
-        errors_found << ValidationError.new(type: ValidationError::UNACCEPTABLE_DEVICE,
-                                            path: screenshot.path,
-                                            debug_info: "Screen size #{screenshot.screen_size} is not accepted. See the specifications to fix #{APP_SCREENSHOT_SPEC_URL}",
-                                            to_skip: true)
+                                            debug_info: "Screenshot size is not supported. Actual size is #{get_formatted_size(screenshot)}. See the specifications to fix #{APP_SCREENSHOT_SPEC_URL}")
       end
     end
 

--- a/deliver/lib/deliver/loader.rb
+++ b/deliver/lib/deliver/loader.rb
@@ -100,16 +100,9 @@ module Deliver
       errors = []
       valid_screenshots = screenshots.select { |screenshot| Deliver::AppScreenshotValidator.validate(screenshot, errors) }
 
-      errors_to_skip, errors_to_crash = errors.partition(&:to_skip)
-
-      unless errors_to_skip.empty?
-        UI.important("🏃 Screenshots to be skipped are detected!")
-        errors_to_skip.each { |error| UI.message(error) }
-      end
-
-      unless errors_to_crash.empty?
+      unless errors.empty?
         UI.important("🚫 Invalid screenshots were detected! Here are the reasons:")
-        errors_to_crash.each { |error| UI.error(error) }
+        errors.each { |error| UI.error(error) }
         UI.user_error!("Canceled uploading screenshots. Please check the error messages above and fix the screenshots.")
       end
 

--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -134,7 +134,7 @@ module Deliver
         number_of_screenshots_per_set[app_screenshot_set] ||= (app_screenshot_set.app_screenshots || []).count
 
         if number_of_screenshots_per_set[app_screenshot_set] >= 10
-          UI.error("Too many screenshots found for device '#{screenshot.device_type}' in '#{screenshot.language}', skipping this one (#{screenshot.path})")
+          UI.error("Too many screenshots found for device '#{screenshot.display_type}' in '#{screenshot.language}', skipping this one (#{screenshot.path})")
           next
         end
 

--- a/deliver/spec/app_screenshot_iterator_spec.rb
+++ b/deliver/spec/app_screenshot_iterator_spec.rb
@@ -111,12 +111,12 @@ describe Deliver::AppScreenshotIterator do
                               get_app_screenshot_sets: [],
                               locale: 'en-US')
 
-        screenshot = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        screenshot = double('Deliver::AppScreenshot', display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
 
         screenshots_per_language = { 'en-US' => [screenshot] }
 
         expect(localization).to receive(:create_app_screenshot_set)
-          .with(attributes: { screenshotDisplayType: screenshot.device_type })
+          .with(attributes: { screenshotDisplayType: screenshot.display_type })
           .and_return(app_screenshot_set)
         actual = described_class.new([localization]).each_local_screenshot(screenshots_per_language).to_a
         expect(actual).to eq([[localization, app_screenshot_set, screenshot, 0]])
@@ -139,10 +139,10 @@ describe Deliver::AppScreenshotIterator do
                                get_app_screenshot_sets: [app_screenshot_set2],
                                locale: 'fr-FR')
 
-        screenshot1 = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
-        screenshot2 = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
-        screenshot3 = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
-        screenshot4 = double('Deliver::AppScreenshot', device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        screenshot1 = double('Deliver::AppScreenshot', display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        screenshot2 = double('Deliver::AppScreenshot', display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        screenshot3 = double('Deliver::AppScreenshot', display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        screenshot4 = double('Deliver::AppScreenshot', display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
 
         screenshots_per_language = { 'en-US' => [screenshot1, screenshot2], 'fr-FR' => [screenshot3, screenshot4] }
 

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -17,243 +17,243 @@ describe Deliver::AppScreenshot do
     context "when filename doesn't contain 'iPad Pro (3rd generation)' or 'iPad Pro (4th generation)'" do
       it "returns iPad Pro(12.9-inch)" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch){2732x2048}.png", "de-DE")
-        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
+        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_129)
       end
     end
 
     context "when filename contains 'iPad Pro (3rd generation)'" do
       it "returns iPad Pro(12.9-inch) 3rd generation" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (3rd generation){2732x2048}.png", "de-DE")
-        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_12_9)
+        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
       end
     end
 
     context "when filename contains 'iPad Pro (4th generation)'" do
       it "returns iPad Pro(12.9-inch) 3rd generation" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (4th generation){2732x2048}.png", "de-DE")
-        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_12_9)
+        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
       end
     end
 
     context "when filename contains 'iPad Pro (5th generation)'" do
       it "returns iPad Pro(12.9-inch) 3rd generation" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (5th generation){2732x2048}.png", "de-DE")
-        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_12_9)
+        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
       end
     end
 
     context "when filename contains 'IPAD_PRO_3GEN_129'" do
       it "returns iPad Pro(12.9-inch) 3rd generation" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/IPAD_PRO_3GEN_129-AAABBBCCCDDD{2732x2048}.png", "de-DE")
-        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_12_9)
+        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
       end
     end
 
     context "when filename contains 'ipadPro129'" do
       it "returns iPad Pro(12.9-inch) 3rd generation" do
         screenshot = Deliver::AppScreenshot.new("path/to/screenshot/ipadPro129-AAABBBCCCDDD{2732x2048}.png", "de-DE")
-        expect(screenshot.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_12_9)
+        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
       end
     end
   end
 
   # Ensure that screenshots correctly map based on the following:
   # https://help.apple.com/app-store-connect/#/devd274dd925
-  describe "#calculate_screen_size" do
-    def expect_screen_size_from_file(file)
-      expect(Deliver::AppScreenshot.calculate_screen_size(file))
+  describe "#calculate_display_type" do
+    def expect_display_type_from_file(file)
+      expect(Deliver::AppScreenshot.calculate_display_type(file))
     end
 
     describe "valid screen sizes" do
       it "should calculate all 6.7 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhone14ProMax-Portrait{1290x2796}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_67)
-        expect_screen_size_from_file("iPhone14ProMax-Landscape{2796x1290}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_67)
+        expect_display_type_from_file("iPhone14ProMax-Portrait{1290x2796}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
+        expect_display_type_from_file("iPhone14ProMax-Landscape{2796x1290}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
       end
 
       it "should calculate all 6.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65)
-        expect_screen_size_from_file("iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65)
-        expect_screen_size_from_file("iPhone12ProMax-Portrait{1284x2778}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65)
-        expect_screen_size_from_file("iPhone12ProMax-Landscape{2778x1284}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65)
+        expect_display_type_from_file("iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
+        expect_display_type_from_file("iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
+        expect_display_type_from_file("iPhone12ProMax-Portrait{1284x2778}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
+        expect_display_type_from_file("iPhone12ProMax-Landscape{2778x1284}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
       end
 
       it "should calculate all 6.1 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhone14Pro-Portrait{1179x2556}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_61)
-        expect_screen_size_from_file("iPhone14Pro-Landscape{2556x1179}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_61)
+        expect_display_type_from_file("iPhone14Pro-Portrait{1179x2556}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
+        expect_display_type_from_file("iPhone14Pro-Landscape{2556x1179}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
       end
 
       it "should calculate all 5.8 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58)
-        expect_screen_size_from_file("iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58)
+        expect_display_type_from_file("iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
+        expect_display_type_from_file("iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
       end
 
       it "should calculate all 5.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55)
-        expect_screen_size_from_file("iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55)
+        expect_display_type_from_file("iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_55)
+        expect_display_type_from_file("iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_55)
       end
 
       it "should calculate all 4.7 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47)
-        expect_screen_size_from_file("iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47)
+        expect_display_type_from_file("iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_47)
+        expect_display_type_from_file("iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_47)
       end
 
       it "should calculate all 4 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
-        expect_screen_size_from_file("iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
-        expect_screen_size_from_file("iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
-        expect_screen_size_from_file("iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40)
+        expect_display_type_from_file("iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40)
+        expect_display_type_from_file("iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40)
+        expect_display_type_from_file("iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40)
+        expect_display_type_from_file("iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40)
       end
 
       it "should calculate all 3.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iPhone4S-Portrait{640x960}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
-        expect_screen_size_from_file("iPhone4S-Landscape{960x640}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
-        expect_screen_size_from_file("iPhone4S-Portrait-NoStatusBar{640x920}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
-        expect_screen_size_from_file("iPhone4S-Landscape-NoStatusBar{960x600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_35)
+        expect_display_type_from_file("iPhone4S-Portrait{640x960}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35)
+        expect_display_type_from_file("iPhone4S-Landscape{960x640}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35)
+        expect_display_type_from_file("iPhone4S-Portrait-NoStatusBar{640x920}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35)
+        expect_display_type_from_file("iPhone4S-Landscape-NoStatusBar{960x600}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35)
       end
 
       it "should calculate all 12.9 inch iPad resolutions" do
-        expect_screen_size_from_file("iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
-        expect_screen_size_from_file("iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
+        expect_display_type_from_file("iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_129)
+        expect_display_type_from_file("iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_129)
       end
 
       it "should calculate all 11 inch iPad resolutions" do
-        expect_screen_size_from_file("iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11)
-        expect_screen_size_from_file("iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11)
+        expect_display_type_from_file("iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
+        expect_display_type_from_file("iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
       end
 
       it "should calculate all 10.5 inch iPad resolutions" do
-        expect_screen_size_from_file("iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5)
-        expect_screen_size_from_file("iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5)
+        expect_display_type_from_file("iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_105)
+        expect_display_type_from_file("iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_105)
       end
 
       it "should calculate all 9.7 inch iPad resolutions" do
-        expect_screen_size_from_file("iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
-        expect_screen_size_from_file("iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+        expect_display_type_from_file("iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
+        expect_display_type_from_file("iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
+        expect_display_type_from_file("iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
+        expect_display_type_from_file("iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
+        expect_display_type_from_file("iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
+        expect_display_type_from_file("iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
+        expect_display_type_from_file("iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
+        expect_display_type_from_file("iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
       end
 
       it "should calculate all supported Mac resolutions" do
-        expect_screen_size_from_file("Mac{1280x800}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
-        expect_screen_size_from_file("Mac{1440x900}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
-        expect_screen_size_from_file("Mac{2560x1600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
-        expect_screen_size_from_file("Mac{2880x1800}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::MAC)
+        expect_display_type_from_file("Mac{1280x800}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
+        expect_display_type_from_file("Mac{1440x900}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
+        expect_display_type_from_file("Mac{2560x1600}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
+        expect_display_type_from_file("Mac{2880x1800}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
       end
 
       it "should calculate all supported Apple TV resolutions" do
-        expect_screen_size_from_file("AppleTV{1920x1080}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::APPLE_TV)
-        expect_screen_size_from_file("AppleTV-4K{3840x2160}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::APPLE_TV)
+        expect_display_type_from_file("AppleTV{1920x1080}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_APPLE_TV)
+        expect_display_type_from_file("AppleTV-4K{3840x2160}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_APPLE_TV)
       end
 
       it "should calculate all supported Apple Watch resolutions" do
-        expect_screen_size_from_file("AppleWatch-Series3{312x390}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH)
-        expect_screen_size_from_file("AppleWatch-Series4{368x448}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES4)
-        expect_screen_size_from_file("AppleWatch-Series7{396x484}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES7)
-        expect_screen_size_from_file("AppleWatch-Ultra{410x502}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_ULTRA)
+        expect_display_type_from_file("AppleWatch-Series3{312x390}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_3)
+        expect_display_type_from_file("AppleWatch-Series4{368x448}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_4)
+        expect_display_type_from_file("AppleWatch-Series7{396x484}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_7)
+        expect_display_type_from_file("AppleWatch-Ultra{410x502}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_ULTRA)
       end
     end
 
-    describe "valid iMessage app screen sizes" do
+    describe "valid iMessage app display types" do
       it "should calculate all 6.7 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhone14ProMax-Portrait{1290x2796}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_67_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhone14ProMax-Landscape{2796x1290}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_67_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPhone14ProMax-Portrait{1290x2796}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_67)
+        expect_display_type_from_file("iMessage/en-GB/iPhone14ProMax-Landscape{2796x1290}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_67)
       end
 
       it "should calculate all 6.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhone12ProMax-Portrait{1284x2778}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhone12ProMax-Landscape{2778x1284}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_65_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65)
+        expect_display_type_from_file("iMessage/en-GB/iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65)
+        expect_display_type_from_file("iMessage/en-GB/iPhone12ProMax-Portrait{1284x2778}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65)
+        expect_display_type_from_file("iMessage/en-GB/iPhone12ProMax-Landscape{2778x1284}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65)
       end
 
       it "should calculate all 6.1 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhone14Pro-Portrait{1179x2556}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_61_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhone14Pro-Landscape{2556x1179}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_61_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPhone14Pro-Portrait{1179x2556}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_61)
+        expect_display_type_from_file("iMessage/en-GB/iPhone14Pro-Landscape{2556x1179}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_61)
       end
 
       it "should calculate all 5.8 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_58_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_58)
+        expect_display_type_from_file("iMessage/en-GB/iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_58)
       end
 
       it "should calculate all 5.5 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_55_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_55)
+        expect_display_type_from_file("iMessage/en-GB/iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_55)
       end
 
       it "should calculate all 4.7 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_47_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_47)
+        expect_display_type_from_file("iMessage/en-GB/iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_47)
       end
 
       it "should calculate all 4 inch iPhone resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40)
+        expect_display_type_from_file("iMessage/en-GB/iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40)
+        expect_display_type_from_file("iMessage/en-GB/iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40)
+        expect_display_type_from_file("iMessage/en-GB/iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40)
       end
 
       it "should calculate all 12.9 inch iPad resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_129)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_129)
       end
 
       it "should calculate all 11 inch iPad resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11)
       end
 
       it "should calculate all 10.5 inch iPad resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_105)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_105)
       end
 
       it "should calculate all 9.7 inch iPad resolutions" do
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
-        expect_screen_size_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
+        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
       end
     end
 
-    describe "invalid screen sizes" do
-      def expect_invalid_screen_size_from_file(file)
-        expect(Deliver::AppScreenshot.calculate_screen_size(file)).to be_nil
+    describe "invalid display types" do
+      def expect_invalid_display_type_from_file(file)
+        expect(Deliver::AppScreenshot.calculate_display_type(file)).to be_nil
       end
 
       it "shouldn't allow native resolution 5.5 inch iPhone screenshots" do
-        expect_invalid_screen_size_from_file("iPhone8Plus-NativeResolution{1080x1920}.jpg")
-        expect_invalid_screen_size_from_file("iMessage/en-GB/iPhone8Plus-NativeResolution{1080x1920}.jpg")
+        expect_invalid_display_type_from_file("iPhone8Plus-NativeResolution{1080x1920}.jpg")
+        expect_invalid_display_type_from_file("iMessage/en-GB/iPhone8Plus-NativeResolution{1080x1920}.jpg")
       end
 
       it "shouldn't calculate portrait Apple TV resolutions" do
-        expect_invalid_screen_size_from_file("appleTV/en-GB/AppleTV-Portrait{1080x1920}.jpg")
-        expect_invalid_screen_size_from_file("appleTV/en-GB/AppleTV-Portrait{2160x3840}.jpg")
+        expect_invalid_display_type_from_file("appleTV/en-GB/AppleTV-Portrait{1080x1920}.jpg")
+        expect_invalid_display_type_from_file("appleTV/en-GB/AppleTV-Portrait{2160x3840}.jpg")
       end
 
       it "shouldn't calculate modern devices excluding status bars" do
-        expect_invalid_screen_size_from_file("iPhoneXSMax-Portrait-NoStatusBar{1242x2556}.jpg")
-        expect_invalid_screen_size_from_file("iPhoneXS-Portrait-NoStatusBar{1125x2304}.jpg")
-        expect_invalid_screen_size_from_file("iPhone8Plus-Portrait-NoStatusBar{1242x2148}.jpg")
-        expect_invalid_screen_size_from_file("iPhone8-Portrait-NoStatusBar{750x1294}.jpg")
-        expect_invalid_screen_size_from_file("iPad-Portrait-12_9Inch-NoStatusBar{2048x2692}.jpg")
-        expect_invalid_screen_size_from_file("iPad-Portrait-11Inch{1668x2348}.jpg")
-        expect_invalid_screen_size_from_file("iPad-Portrait-10_5Inch{1668x2184}.jpg")
+        expect_invalid_display_type_from_file("iPhoneXSMax-Portrait-NoStatusBar{1242x2556}.jpg")
+        expect_invalid_display_type_from_file("iPhoneXS-Portrait-NoStatusBar{1125x2304}.jpg")
+        expect_invalid_display_type_from_file("iPhone8Plus-Portrait-NoStatusBar{1242x2148}.jpg")
+        expect_invalid_display_type_from_file("iPhone8-Portrait-NoStatusBar{750x1294}.jpg")
+        expect_invalid_display_type_from_file("iPad-Portrait-12_9Inch-NoStatusBar{2048x2692}.jpg")
+        expect_invalid_display_type_from_file("iPad-Portrait-11Inch{1668x2348}.jpg")
+        expect_invalid_display_type_from_file("iPad-Portrait-10_5Inch{1668x2184}.jpg")
       end
 
       it "shouldn't allow non 16:10 resolutions for Mac" do
-        expect_invalid_screen_size_from_file("Mac-Portrait{800x1280}.jpg")
-        expect_invalid_screen_size_from_file("Mac-Portrait{900x1440}.jpg")
-        expect_invalid_screen_size_from_file("Mac-Portrait{1600x2560}.jpg")
-        expect_invalid_screen_size_from_file("Mac-Portrait{1800x2880}.jpg")
+        expect_invalid_display_type_from_file("Mac-Portrait{800x1280}.jpg")
+        expect_invalid_display_type_from_file("Mac-Portrait{900x1440}.jpg")
+        expect_invalid_display_type_from_file("Mac-Portrait{1600x2560}.jpg")
+        expect_invalid_display_type_from_file("Mac-Portrait{1800x2880}.jpg")
       end
     end
   end
@@ -299,88 +299,76 @@ describe Deliver::AppScreenshot do
     end
   end
 
-  describe "#device_type" do
-    def app_screenshot_with(screen_size, path = '', language = 'en-US')
-      allow(Deliver::AppScreenshot).to receive(:calculate_screen_size).and_return(screen_size)
+  describe "#display_type" do
+    def app_screenshot_with(display_type, path = '', language = 'en-US')
+      allow(Deliver::AppScreenshot).to receive(:calculate_display_type).and_return(display_type)
       Deliver::AppScreenshot.new(path, language)
     end
 
-    it "should return iphone35 for 3.5 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_35).device_type).to eq("APP_IPHONE_35")
+    it "should return APP_IPHONE_35 for 3.5 inch displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35)
     end
 
-    it "should return iphone4 for 4 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_40).device_type).to eq("APP_IPHONE_40")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_40_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_40")
+    it "should return appropriate display types for 4 inch displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40)
     end
 
-    it "should return iphone6 for 4.7 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_47).device_type).to eq("APP_IPHONE_47")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_47_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_47")
+    it "should return appropriate display types for 4.7 inch displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPHONE_47).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_47)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_47).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_47)
     end
 
-    it "should return iphone6Plus for 5.5 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_55).device_type).to eq("APP_IPHONE_55")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_55_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_55")
+    it "should return appropriate display types for 5.5 inch displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPHONE_55).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_55)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_55).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_55)
     end
 
-    it "should return iphone14Pro for 6.1 inch displays (iPhone 14)" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_61).device_type).to eq("APP_IPHONE_61")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_61_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_61")
+    it "should return appropriate display types for 6.1 inch displays (iPhone 14)" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_61).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_61)
     end
 
-    it "should return iphone67 for 6.7 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_67).device_type).to eq("APP_IPHONE_67")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_67_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_67")
+    it "should return appropriate display types for 6.7 inch displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_67).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_67)
     end
 
-    it "should return iphone65 for 6.5 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_65).device_type).to eq("APP_IPHONE_65")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_65_MESSAGES).device_type).to eq("IMESSAGE_APP_IPHONE_65")
+    it "should return appropriate display types for 6.5 inch displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65)
     end
 
-    it "should return ipad for 9.7 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_IPAD).device_type).to eq("APP_IPAD_97")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_97")
+    it "should return appropriate display types for 9.7 inch iPad displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPAD_97).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
     end
 
-    it "should return ipad105 for 10.5 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5).device_type).to eq("APP_IPAD_105")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_105")
+    it "should return appropriate display types for 10.5 inch iPad displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPAD_105).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_105)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_105).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_105)
     end
 
-    it "should return ipadPro11 for 11 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11).device_type).to eq("APP_IPAD_PRO_3GEN_11")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_PRO_3GEN_11")
+    it "should return appropriate display types for 11 inch iPad displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11)
     end
 
-    it "should return ipadPro for 12.9 inch displays" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO).device_type).to eq("APP_IPAD_PRO_129")
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_MESSAGES).device_type).to eq("IMESSAGE_APP_IPAD_PRO_129")
+    it "should return appropriate display types for 12.9 inch iPad displays" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_129).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_129)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_129).display_type).to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_129)
     end
 
-    it "should return watch for original Apple Watch" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH).device_type).to eq("APP_WATCH_SERIES_3")
+    it "should return watch display types" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_3).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_3)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_4).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_4)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_7).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_7)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_WATCH_ULTRA).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_ULTRA)
     end
 
-    it "should return watchSeries4 for Apple Watch Series 4" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES4).device_type).to eq("APP_WATCH_SERIES_4")
-    end
-
-    it "should return watchSeries7 for Apple Watch Series 7" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_SERIES7).device_type).to eq("APP_WATCH_SERIES_7")
-    end
-
-    it "should return watchUltra for Apple Watch Ultra" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::IOS_APPLE_WATCH_ULTRA).device_type).to eq("APP_WATCH_ULTRA")
-    end
-
-    it "should return appleTV for Apple TV" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::APPLE_TV).device_type).to eq("APP_APPLE_TV")
-    end
-
-    it "should return desktop for Mac" do
-      expect(app_screenshot_with(Deliver::AppScreenshot::ScreenSize::MAC).device_type).to eq("APP_DESKTOP")
+    it "should return other device display types" do
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_APPLE_TV).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_APPLE_TV)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_DESKTOP).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
     end
   end
 end

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -66,8 +66,12 @@ describe Deliver::AppScreenshot do
 
     describe "valid screen sizes" do
       it "should calculate all 6.7 inch iPhone resolutions" do
+        expect_display_type_from_file("iPhone14ProMax-Portrait{1260x2736}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
+        expect_display_type_from_file("iPhone14ProMax-Landscape{2736x1260}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
         expect_display_type_from_file("iPhone14ProMax-Portrait{1290x2796}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
         expect_display_type_from_file("iPhone14ProMax-Landscape{2796x1290}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
+        expect_display_type_from_file("iPhone16ProMax-Portrait{1320x2868}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
+        expect_display_type_from_file("iPhone16ProMax-Landscape{2868x1320}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
       end
 
       it "should calculate all 6.5 inch iPhone resolutions" do
@@ -80,11 +84,17 @@ describe Deliver::AppScreenshot do
       it "should calculate all 6.1 inch iPhone resolutions" do
         expect_display_type_from_file("iPhone14Pro-Portrait{1179x2556}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
         expect_display_type_from_file("iPhone14Pro-Landscape{2556x1179}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
+        expect_display_type_from_file("iPhone15Pro-Portrait{1206x2622}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
+        expect_display_type_from_file("iPhone15Pro-Landscape{2622x1206}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
       end
 
       it "should calculate all 5.8 inch iPhone resolutions" do
+        expect_display_type_from_file("iPhone12-Portrait{1170x2532}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
+        expect_display_type_from_file("iPhone12-Landscape{2532x1170}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
         expect_display_type_from_file("iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
         expect_display_type_from_file("iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
+        expect_display_type_from_file("iPhoneX-Portrait{1080x2340}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
+        expect_display_type_from_file("iPhoneX-Landscape{2340x1080}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
       end
 
       it "should calculate all 5.5 inch iPhone resolutions" do
@@ -117,8 +127,14 @@ describe Deliver::AppScreenshot do
       end
 
       it "should calculate all 11 inch iPad resolutions" do
+        expect_display_type_from_file("iPad-Portrait-11Inch{1488x2266}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
+        expect_display_type_from_file("iPad-Landscape-11Inch{2266x1488}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
+        expect_display_type_from_file("iPad-Portrait-11Inch{1668x2420}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
+        expect_display_type_from_file("iPad-Landscape-11Inch{2420x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
         expect_display_type_from_file("iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
         expect_display_type_from_file("iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
+        expect_display_type_from_file("iPad-Portrait-11Inch{1640x2360}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
+        expect_display_type_from_file("iPad-Landscape-11Inch{2360x1640}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
       end
 
       it "should calculate all 10.5 inch iPad resolutions" do

--- a/deliver/spec/app_screenshot_spec.rb
+++ b/deliver/spec/app_screenshot_spec.rb
@@ -2,6 +2,7 @@ require 'deliver/app_screenshot'
 require 'deliver/setup'
 
 describe Deliver::AppScreenshot do
+  DisplayType = Deliver::AppScreenshot::DisplayType
 
   def screen_size_from(path)
     path.match(/{([0-9]+)x([0-9]+)}/).captures.map(&:to_i)
@@ -14,45 +15,21 @@ describe Deliver::AppScreenshot do
   end
 
   describe "#initialize" do
-    context "when filename doesn't contain 'iPad Pro (3rd generation)' or 'iPad Pro (4th generation)'" do
-      it "returns iPad Pro(12.9-inch)" do
-        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch){2732x2048}.png", "de-DE")
-        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_129)
-      end
-    end
 
-    context "when filename contains 'iPad Pro (3rd generation)'" do
-      it "returns iPad Pro(12.9-inch) 3rd generation" do
-        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (3rd generation){2732x2048}.png", "de-DE")
-        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
-      end
-    end
-
-    context "when filename contains 'iPad Pro (4th generation)'" do
-      it "returns iPad Pro(12.9-inch) 3rd generation" do
-        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (4th generation){2732x2048}.png", "de-DE")
-        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
-      end
-    end
-
-    context "when filename contains 'iPad Pro (5th generation)'" do
-      it "returns iPad Pro(12.9-inch) 3rd generation" do
-        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/Screen-Name-iPad Pro (12.9-inch) (5th generation){2732x2048}.png", "de-DE")
-        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
-      end
-    end
-
-    context "when filename contains 'IPAD_PRO_3GEN_129'" do
-      it "returns iPad Pro(12.9-inch) 3rd generation" do
-        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/IPAD_PRO_3GEN_129-AAABBBCCCDDD{2732x2048}.png", "de-DE")
-        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
-      end
-    end
-
-    context "when filename contains 'ipadPro129'" do
-      it "returns iPad Pro(12.9-inch) 3rd generation" do
-        screenshot = Deliver::AppScreenshot.new("path/to/screenshot/ipadPro129-AAABBBCCCDDD{2732x2048}.png", "de-DE")
-        expect(screenshot.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_129)
+    {
+      "APP_IPAD_PRO_129" => ["Screen-Name-APP_IPAD_PRO_129{2732x2048}.png", DisplayType::APP_IPAD_PRO_129],
+      "iPad Pro (12.9-inch) (2nd generation)" => ["Screen-Name-iPad Pro (12.9-inch) (2nd generation){2732x2048}.png", DisplayType::APP_IPAD_PRO_129],
+      "IPAD_PRO_3GEN_129" => ["IPAD_PRO_3GEN_129-AAABBBCCCDDD{2732x2048}.png", DisplayType::APP_IPAD_PRO_3GEN_129],
+      "iPad Pro (3rd generation)" => ["Screen-Name-iPad Pro (12.9-inch) (3rd generation){2732x2048}.png", DisplayType::APP_IPAD_PRO_3GEN_129],
+      "iPad Pro (4th generation)" => ["Screen-Name-iPad Pro (12.9-inch) (4th generation){2732x2048}.png", DisplayType::APP_IPAD_PRO_3GEN_129],
+      "iPad Pro (5th generation)" => ["Screen-Name-iPad Pro (12.9-inch) (5th generation){2732x2048}.png", DisplayType::APP_IPAD_PRO_3GEN_129],
+      "no generation info" => ["Screen-Name-iPad Pro{2732x2048}.png", DisplayType::APP_IPAD_PRO_3GEN_129]
+    }.each do |description, (filename, expected_type)|
+      context "when filename contains '#{description}'" do
+        it "returns #{expected_type}" do
+          screenshot = Deliver::AppScreenshot.new("path/to/screenshot/#{filename}", "de-DE")
+          expect(screenshot.display_type).to eq(expected_type)
+        end
       end
     end
   end
@@ -65,178 +42,210 @@ describe Deliver::AppScreenshot do
     end
 
     describe "valid screen sizes" do
-      it "should calculate all 6.7 inch iPhone resolutions" do
-        expect_display_type_from_file("iPhone14ProMax-Portrait{1260x2736}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
-        expect_display_type_from_file("iPhone14ProMax-Landscape{2736x1260}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
-        expect_display_type_from_file("iPhone14ProMax-Portrait{1290x2796}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
-        expect_display_type_from_file("iPhone14ProMax-Landscape{2796x1290}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
-        expect_display_type_from_file("iPhone16ProMax-Portrait{1320x2868}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
-        expect_display_type_from_file("iPhone16ProMax-Landscape{2868x1320}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_67)
-      end
+      device_tests = {
+        "6.7 inch iPhone" => [
+          ["iPhone14ProMax-Portrait{1260x2736}.jpg", DisplayType::APP_IPHONE_67],
+          ["iPhone14ProMax-Landscape{2736x1260}.jpg", DisplayType::APP_IPHONE_67],
+          ["iPhone14ProMax-Portrait{1290x2796}.jpg", DisplayType::APP_IPHONE_67],
+          ["iPhone14ProMax-Landscape{2796x1290}.jpg", DisplayType::APP_IPHONE_67],
+          ["iPhone16ProMax-Portrait{1320x2868}.jpg", DisplayType::APP_IPHONE_67],
+          ["iPhone16ProMax-Landscape{2868x1320}.jpg", DisplayType::APP_IPHONE_67]
+        ],
+        "6.5 inch iPhone" => [
+          ["iPhoneXSMax-Portrait{1242x2688}.jpg", DisplayType::APP_IPHONE_65],
+          ["iPhoneXSMax-Landscape{2688x1242}.jpg", DisplayType::APP_IPHONE_65],
+          ["iPhone12ProMax-Portrait{1284x2778}.jpg", DisplayType::APP_IPHONE_65],
+          ["iPhone12ProMax-Landscape{2778x1284}.jpg", DisplayType::APP_IPHONE_65]
+        ],
+        "6.1 inch iPhone" => [
+          ["iPhone14Pro-Portrait{1179x2556}.jpg", DisplayType::APP_IPHONE_61],
+          ["iPhone14Pro-Landscape{2556x1179}.jpg", DisplayType::APP_IPHONE_61],
+          ["iPhone15Pro-Portrait{1206x2622}.jpg", DisplayType::APP_IPHONE_61],
+          ["iPhone15Pro-Landscape{2622x1206}.jpg", DisplayType::APP_IPHONE_61]
+        ],
+        "5.8 inch iPhone" => [
+          ["iPhone12-Portrait{1170x2532}.jpg", DisplayType::APP_IPHONE_58],
+          ["iPhone12-Landscape{2532x1170}.jpg", DisplayType::APP_IPHONE_58],
+          ["iPhoneXS-Portrait{1125x2436}.jpg", DisplayType::APP_IPHONE_58],
+          ["iPhoneXS-Landscape{2436x1125}.jpg", DisplayType::APP_IPHONE_58],
+          ["iPhoneX-Portrait{1080x2340}.jpg", DisplayType::APP_IPHONE_58],
+          ["iPhoneX-Landscape{2340x1080}.jpg", DisplayType::APP_IPHONE_58]
+        ],
+        "5.5 inch iPhone" => [
+          ["iPhone8Plus-Portrait{1242x2208}.jpg", DisplayType::APP_IPHONE_55],
+          ["iPhone8Plus-Landscape{2208x1242}.jpg", DisplayType::APP_IPHONE_55]
+        ],
+        "4.7 inch iPhone" => [
+          ["iPhone8-Portrait{750x1334}.jpg", DisplayType::APP_IPHONE_47],
+          ["iPhone8-Landscape{1334x750}.jpg", DisplayType::APP_IPHONE_47]
+        ],
+        "4 inch iPhone" => [
+          ["iPhoneSE-Portrait{640x1136}.jpg", DisplayType::APP_IPHONE_40],
+          ["iPhoneSE-Landscape{1136x640}.jpg", DisplayType::APP_IPHONE_40],
+          ["iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg", DisplayType::APP_IPHONE_40],
+          ["iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg", DisplayType::APP_IPHONE_40]
+        ],
+        "3.5 inch iPhone" => [
+          ["iPhone4S-Portrait{640x960}.jpg", DisplayType::APP_IPHONE_35],
+          ["iPhone4S-Landscape{960x640}.jpg", DisplayType::APP_IPHONE_35],
+          ["iPhone4S-Portrait-NoStatusBar{640x920}.jpg", DisplayType::APP_IPHONE_35],
+          ["iPhone4S-Landscape-NoStatusBar{960x600}.jpg", DisplayType::APP_IPHONE_35]
+        ],
+        "12.9 inch iPad (2nd gen)" => [
+          ["iPad-Portrait-12.9-inch-(2nd generation){2048x2732}.jpg", DisplayType::APP_IPAD_PRO_129],
+          ["iPad-Landscape-12.9-inch-(2nd generation){2732x2048}.jpg", DisplayType::APP_IPAD_PRO_129],
+          ["APP_IPAD_PRO_129-portrait{2048x2732}.jpg", DisplayType::APP_IPAD_PRO_129],
+          ["APP_IPAD_PRO_129-landscape{2732x2048}.jpg", DisplayType::APP_IPAD_PRO_129]
+        ],
+        "13 inch iPad (3rd+ gen)" => [
+          ["iPad-Portrait-13Inch{2048x2732}.jpg", DisplayType::APP_IPAD_PRO_3GEN_129],
+          ["iPad-Landscape-13Inch{2732x2048}.jpg", DisplayType::APP_IPAD_PRO_3GEN_129],
+          ["iPad-Portrait-13Inch{2064x2752}.jpg", DisplayType::APP_IPAD_PRO_3GEN_129],
+          ["iPad-Landscape-13Inch{2752x2064}.jpg", DisplayType::APP_IPAD_PRO_3GEN_129]
+        ],
+        "11 inch iPad" => [
+          ["iPad-Portrait-11Inch{1488x2266}.jpg", DisplayType::APP_IPAD_PRO_3GEN_11],
+          ["iPad-Landscape-11Inch{2266x1488}.jpg", DisplayType::APP_IPAD_PRO_3GEN_11],
+          ["iPad-Portrait-11Inch{1668x2420}.jpg", DisplayType::APP_IPAD_PRO_3GEN_11],
+          ["iPad-Landscape-11Inch{2420x1668}.jpg", DisplayType::APP_IPAD_PRO_3GEN_11],
+          ["iPad-Portrait-11Inch{1668x2388}.jpg", DisplayType::APP_IPAD_PRO_3GEN_11],
+          ["iPad-Landscape-11Inch{2388x1668}.jpg", DisplayType::APP_IPAD_PRO_3GEN_11],
+          ["iPad-Portrait-11Inch{1640x2360}.jpg", DisplayType::APP_IPAD_PRO_3GEN_11],
+          ["iPad-Landscape-11Inch{2360x1640}.jpg", DisplayType::APP_IPAD_PRO_3GEN_11]
+        ],
+        "10.5 inch iPad" => [
+          ["iPad-Portrait-10_5Inch{1668x2224}.jpg", DisplayType::APP_IPAD_105],
+          ["iPad-Landscape-10_5Inch{2224x1668}.jpg", DisplayType::APP_IPAD_105]
+        ],
+        "9.7 inch iPad" => [
+          ["iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg", DisplayType::APP_IPAD_97],
+          ["iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg", DisplayType::APP_IPAD_97],
+          ["iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg", DisplayType::APP_IPAD_97],
+          ["iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg", DisplayType::APP_IPAD_97],
+          ["iPad-Portrait-9_7Inch-{768x1024}.jpg", DisplayType::APP_IPAD_97],
+          ["iPad-Landscape-9_7Inch-{1024x768}.jpg", DisplayType::APP_IPAD_97],
+          ["iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg", DisplayType::APP_IPAD_97],
+          ["iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg", DisplayType::APP_IPAD_97]
+        ],
+        "Mac" => [
+          ["Mac{1280x800}.jpg", DisplayType::APP_DESKTOP],
+          ["Mac{1440x900}.jpg", DisplayType::APP_DESKTOP],
+          ["Mac{2560x1600}.jpg", DisplayType::APP_DESKTOP],
+          ["Mac{2880x1800}.jpg", DisplayType::APP_DESKTOP]
+        ],
+        "Apple TV" => [
+          ["AppleTV{1920x1080}.jpg", DisplayType::APP_APPLE_TV],
+          ["AppleTV-4K{3840x2160}.jpg", DisplayType::APP_APPLE_TV]
+        ],
+        "Apple Vision Pro" => [
+          ["VisionPro{3840x2160}.jpg", DisplayType::APP_APPLE_VISION_PRO],
+          ["AppleVisionPro{3840x2160}.jpg", DisplayType::APP_APPLE_VISION_PRO],
+          ["Apple-Vision-Pro{3840x2160}.jpg", DisplayType::APP_APPLE_VISION_PRO]
+        ],
+        "Apple Watch" => [
+          ["AppleWatch-Series3{312x390}.jpg", DisplayType::APP_WATCH_SERIES_3],
+          ["AppleWatch-Series4{368x448}.jpg", DisplayType::APP_WATCH_SERIES_4],
+          ["AppleWatch-Series7{396x484}.jpg", DisplayType::APP_WATCH_SERIES_7],
+          ["AppleWatch-Ultra{410x502}.jpg", DisplayType::APP_WATCH_ULTRA]
+        ]
+      }
 
-      it "should calculate all 6.5 inch iPhone resolutions" do
-        expect_display_type_from_file("iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
-        expect_display_type_from_file("iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
-        expect_display_type_from_file("iPhone12ProMax-Portrait{1284x2778}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
-        expect_display_type_from_file("iPhone12ProMax-Landscape{2778x1284}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
-      end
-
-      it "should calculate all 6.1 inch iPhone resolutions" do
-        expect_display_type_from_file("iPhone14Pro-Portrait{1179x2556}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
-        expect_display_type_from_file("iPhone14Pro-Landscape{2556x1179}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
-        expect_display_type_from_file("iPhone15Pro-Portrait{1206x2622}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
-        expect_display_type_from_file("iPhone15Pro-Landscape{2622x1206}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_61)
-      end
-
-      it "should calculate all 5.8 inch iPhone resolutions" do
-        expect_display_type_from_file("iPhone12-Portrait{1170x2532}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
-        expect_display_type_from_file("iPhone12-Landscape{2532x1170}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
-        expect_display_type_from_file("iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
-        expect_display_type_from_file("iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
-        expect_display_type_from_file("iPhoneX-Portrait{1080x2340}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
-        expect_display_type_from_file("iPhoneX-Landscape{2340x1080}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_58)
-      end
-
-      it "should calculate all 5.5 inch iPhone resolutions" do
-        expect_display_type_from_file("iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_55)
-        expect_display_type_from_file("iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_55)
-      end
-
-      it "should calculate all 4.7 inch iPhone resolutions" do
-        expect_display_type_from_file("iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_47)
-        expect_display_type_from_file("iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_47)
-      end
-
-      it "should calculate all 4 inch iPhone resolutions" do
-        expect_display_type_from_file("iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40)
-        expect_display_type_from_file("iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40)
-        expect_display_type_from_file("iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40)
-        expect_display_type_from_file("iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_40)
-      end
-
-      it "should calculate all 3.5 inch iPhone resolutions" do
-        expect_display_type_from_file("iPhone4S-Portrait{640x960}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35)
-        expect_display_type_from_file("iPhone4S-Landscape{960x640}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35)
-        expect_display_type_from_file("iPhone4S-Portrait-NoStatusBar{640x920}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35)
-        expect_display_type_from_file("iPhone4S-Landscape-NoStatusBar{960x600}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_35)
-      end
-
-      it "should calculate all 12.9 inch iPad resolutions" do
-        expect_display_type_from_file("iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_129)
-        expect_display_type_from_file("iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_129)
-      end
-
-      it "should calculate all 11 inch iPad resolutions" do
-        expect_display_type_from_file("iPad-Portrait-11Inch{1488x2266}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
-        expect_display_type_from_file("iPad-Landscape-11Inch{2266x1488}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
-        expect_display_type_from_file("iPad-Portrait-11Inch{1668x2420}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
-        expect_display_type_from_file("iPad-Landscape-11Inch{2420x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
-        expect_display_type_from_file("iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
-        expect_display_type_from_file("iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
-        expect_display_type_from_file("iPad-Portrait-11Inch{1640x2360}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
-        expect_display_type_from_file("iPad-Landscape-11Inch{2360x1640}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_PRO_3GEN_11)
-      end
-
-      it "should calculate all 10.5 inch iPad resolutions" do
-        expect_display_type_from_file("iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_105)
-        expect_display_type_from_file("iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_105)
-      end
-
-      it "should calculate all 9.7 inch iPad resolutions" do
-        expect_display_type_from_file("iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
-        expect_display_type_from_file("iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
-        expect_display_type_from_file("iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
-        expect_display_type_from_file("iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
-        expect_display_type_from_file("iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
-        expect_display_type_from_file("iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
-        expect_display_type_from_file("iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
-        expect_display_type_from_file("iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_IPAD_97)
-      end
-
-      it "should calculate all supported Mac resolutions" do
-        expect_display_type_from_file("Mac{1280x800}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
-        expect_display_type_from_file("Mac{1440x900}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
-        expect_display_type_from_file("Mac{2560x1600}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
-        expect_display_type_from_file("Mac{2880x1800}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
-      end
-
-      it "should calculate all supported Apple TV resolutions" do
-        expect_display_type_from_file("AppleTV{1920x1080}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_APPLE_TV)
-        expect_display_type_from_file("AppleTV-4K{3840x2160}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_APPLE_TV)
-      end
-
-      it "should calculate all supported Apple Watch resolutions" do
-        expect_display_type_from_file("AppleWatch-Series3{312x390}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_3)
-        expect_display_type_from_file("AppleWatch-Series4{368x448}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_4)
-        expect_display_type_from_file("AppleWatch-Series7{396x484}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_7)
-        expect_display_type_from_file("AppleWatch-Ultra{410x502}.jpg").to eq(Deliver::AppScreenshot::DisplayType::APP_WATCH_ULTRA)
+      device_tests.each do |device_name, test_cases|
+        it "should calculate all #{device_name} resolutions" do
+          test_cases.each do |filename, expected_type|
+            expect_display_type_from_file(filename).to eq(expected_type)
+          end
+        end
       end
     end
 
     describe "valid iMessage app display types" do
-      it "should calculate all 6.7 inch iPhone resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPhone14ProMax-Portrait{1290x2796}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_67)
-        expect_display_type_from_file("iMessage/en-GB/iPhone14ProMax-Landscape{2796x1290}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_67)
+      imessage_tests = {
+        "6.7 inch iPhone" => [
+          ["iMessage/en-GB/iPhone14ProMax-Portrait{1290x2796}.jpg", DisplayType::IMESSAGE_APP_IPHONE_67],
+          ["iMessage/en-GB/iPhone14ProMax-Landscape{2796x1290}.jpg", DisplayType::IMESSAGE_APP_IPHONE_67]
+        ],
+        "6.5 inch iPhone" => [
+          ["iMessage/en-GB/iPhoneXSMax-Portrait{1242x2688}.jpg", DisplayType::IMESSAGE_APP_IPHONE_65],
+          ["iMessage/en-GB/iPhoneXSMax-Landscape{2688x1242}.jpg", DisplayType::IMESSAGE_APP_IPHONE_65],
+          ["iMessage/en-GB/iPhone12ProMax-Portrait{1284x2778}.jpg", DisplayType::IMESSAGE_APP_IPHONE_65],
+          ["iMessage/en-GB/iPhone12ProMax-Landscape{2778x1284}.jpg", DisplayType::IMESSAGE_APP_IPHONE_65]
+        ],
+        "6.1 inch iPhone" => [
+          ["iMessage/en-GB/iPhone14Pro-Portrait{1179x2556}.jpg", DisplayType::IMESSAGE_APP_IPHONE_61],
+          ["iMessage/en-GB/iPhone14Pro-Landscape{2556x1179}.jpg", DisplayType::IMESSAGE_APP_IPHONE_61]
+        ],
+        "5.8 inch iPhone" => [
+          ["iMessage/en-GB/iPhoneXS-Portrait{1125x2436}.jpg", DisplayType::IMESSAGE_APP_IPHONE_58],
+          ["iMessage/en-GB/iPhoneXS-Landscape{2436x1125}.jpg", DisplayType::IMESSAGE_APP_IPHONE_58]
+        ],
+        "5.5 inch iPhone" => [
+          ["iMessage/en-GB/iPhone8Plus-Portrait{1242x2208}.jpg", DisplayType::IMESSAGE_APP_IPHONE_55],
+          ["iMessage/en-GB/iPhone8Plus-Landscape{2208x1242}.jpg", DisplayType::IMESSAGE_APP_IPHONE_55]
+        ],
+        "4.7 inch iPhone" => [
+          ["iMessage/en-GB/iPhone8-Portrait{750x1334}.jpg", DisplayType::IMESSAGE_APP_IPHONE_47],
+          ["iMessage/en-GB/iPhone8-Landscape{1334x750}.jpg", DisplayType::IMESSAGE_APP_IPHONE_47]
+        ],
+        "4 inch iPhone" => [
+          ["iMessage/en-GB/iPhoneSE-Portrait{640x1136}.jpg", DisplayType::IMESSAGE_APP_IPHONE_40],
+          ["iMessage/en-GB/iPhoneSE-Landscape{1136x640}.jpg", DisplayType::IMESSAGE_APP_IPHONE_40],
+          ["iMessage/en-GB/iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg", DisplayType::IMESSAGE_APP_IPHONE_40],
+          ["iMessage/en-GB/iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg", DisplayType::IMESSAGE_APP_IPHONE_40]
+        ],
+        "12.9 inch iPad (2nd gen)" => [
+          ["iMessage/en-GB/iPad-Portrait-12.9-inch-(2nd generation){2048x2732}.jpg", DisplayType::IMESSAGE_APP_IPAD_PRO_129],
+          ["iMessage/en-GB/iPad-Landscape-12.9-inch-(2nd generation){2732x2048}.jpg", DisplayType::IMESSAGE_APP_IPAD_PRO_129]
+        ],
+        "13 inch iPad (3rd+ gen)" => [
+          ["iMessage/en-GB/iPad-Portrait-13Inch{2048x2732}.jpg", DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129],
+          ["iMessage/en-GB/iPad-Landscape-13Inch{2732x2048}.jpg", DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129]
+        ],
+        "11 inch iPad" => [
+          ["iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.jpg", DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11],
+          ["iMessage/en-GB/iPad-Landscape-11Inch{2388x1668}.jpg", DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11]
+        ],
+        "10.5 inch iPad" => [
+          ["iMessage/en-GB/iPad-Portrait-10_5Inch{1668x2224}.jpg", DisplayType::IMESSAGE_APP_IPAD_105],
+          ["iMessage/en-GB/iPad-Landscape-10_5Inch{2224x1668}.jpg", DisplayType::IMESSAGE_APP_IPAD_105]
+        ],
+        "9.7 inch iPad" => [
+          ["iMessage/en-GB/iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg", DisplayType::IMESSAGE_APP_IPAD_97],
+          ["iMessage/en-GB/iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg", DisplayType::IMESSAGE_APP_IPAD_97],
+          ["iMessage/en-GB/iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg", DisplayType::IMESSAGE_APP_IPAD_97],
+          ["iMessage/en-GB/iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg", DisplayType::IMESSAGE_APP_IPAD_97],
+          ["iMessage/en-GB/iPad-Portrait-9_7Inch-{768x1024}.jpg", DisplayType::IMESSAGE_APP_IPAD_97],
+          ["iMessage/en-GB/iPad-Landscape-9_7Inch-{1024x768}.jpg", DisplayType::IMESSAGE_APP_IPAD_97],
+          ["iMessage/en-GB/iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg", DisplayType::IMESSAGE_APP_IPAD_97],
+          ["iMessage/en-GB/iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg", DisplayType::IMESSAGE_APP_IPAD_97]
+        ]
+      }
+
+      imessage_tests.each do |device_name, test_cases|
+        it "should calculate all #{device_name} resolutions" do
+          test_cases.each do |filename, expected_type|
+            expect_display_type_from_file(filename).to eq(expected_type)
+          end
+        end
+      end
+    end
+
+    describe "conflict resolution" do
+      it "should resolve iPad Pro 2nd gen vs 3rd+ gen correctly" do
+        expect_display_type_from_file("iPad-Portrait-APP_IPAD_PRO_129{2048x2732}.jpg").to eq(DisplayType::APP_IPAD_PRO_129)
+        expect_display_type_from_file("iPad-Portrait-app_ipad_pro_129{2048x2732}.jpg").to eq(DisplayType::APP_IPAD_PRO_129)
+        expect_display_type_from_file("iPad-Portrait-12.9-inch-(2ND GENERATION){2048x2732}.jpg").to eq(DisplayType::APP_IPAD_PRO_129)
+        expect_display_type_from_file("iPad-Portrait-12.9-inch{2048x2732}.jpg").to eq(DisplayType::APP_IPAD_PRO_3GEN_129)
+        expect_display_type_from_file("iPad-Portrait-generic{2048x2732}.jpg").to eq(DisplayType::APP_IPAD_PRO_3GEN_129)
       end
 
-      it "should calculate all 6.5 inch iPhone resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPhoneXSMax-Portrait{1242x2688}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65)
-        expect_display_type_from_file("iMessage/en-GB/iPhoneXSMax-Landscape{2688x1242}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65)
-        expect_display_type_from_file("iMessage/en-GB/iPhone12ProMax-Portrait{1284x2778}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65)
-        expect_display_type_from_file("iMessage/en-GB/iPhone12ProMax-Landscape{2778x1284}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_65)
-      end
-
-      it "should calculate all 6.1 inch iPhone resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPhone14Pro-Portrait{1179x2556}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_61)
-        expect_display_type_from_file("iMessage/en-GB/iPhone14Pro-Landscape{2556x1179}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_61)
-      end
-
-      it "should calculate all 5.8 inch iPhone resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPhoneXS-Portrait{1125x2436}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_58)
-        expect_display_type_from_file("iMessage/en-GB/iPhoneXS-Landscape{2436x1125}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_58)
-      end
-
-      it "should calculate all 5.5 inch iPhone resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPhone8Plus-Portrait{1242x2208}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_55)
-        expect_display_type_from_file("iMessage/en-GB/iPhone8Plus-Landscape{2208x1242}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_55)
-      end
-
-      it "should calculate all 4.7 inch iPhone resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPhone8-Portrait{750x1334}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_47)
-        expect_display_type_from_file("iMessage/en-GB/iPhone8-Landscape{1334x750}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_47)
-      end
-
-      it "should calculate all 4 inch iPhone resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPhoneSE-Portrait{640x1136}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40)
-        expect_display_type_from_file("iMessage/en-GB/iPhoneSE-Landscape{1136x640}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40)
-        expect_display_type_from_file("iMessage/en-GB/iPhoneSE-Portrait-NoStatusBar{640x1096}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40)
-        expect_display_type_from_file("iMessage/en-GB/iPhoneSE-Landscape-NoStatusBar{1136x600}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPHONE_40)
-      end
-
-      it "should calculate all 12.9 inch iPad resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-12_9Inch{2048x2732}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_129)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-12_9Inch{2732x2048}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_129)
-      end
-
-      it "should calculate all 11 inch iPad resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-11Inch{1668x2388}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-11Inch{2388x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11)
-      end
-
-      it "should calculate all 10.5 inch iPad resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-10_5Inch{1668x2224}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_105)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-10_5Inch{2224x1668}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_105)
-      end
-
-      it "should calculate all 9.7 inch iPad resolutions" do
-        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina{1536x2048}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina{2048x1536}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-Retina-NoStatusBar{1536x2008}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-Retina-NoStatusBar{2048x1496}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-{768x1024}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-{1024x768}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Portrait-9_7Inch-NoStatusBar{768x1004}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
-        expect_display_type_from_file("iMessage/en-GB/iPad-Landscape-9_7Inch-NoStatusBar{1024x748}.jpg").to eq(Deliver::AppScreenshot::DisplayType::IMESSAGE_APP_IPAD_97)
+      it "should resolve Apple TV vs Vision Pro correctly" do
+        expect_display_type_from_file("VisionPro{3840x2160}.jpg").to eq(DisplayType::APP_APPLE_VISION_PRO)
+        expect_display_type_from_file("vision-pro{3840x2160}.jpg").to eq(DisplayType::APP_APPLE_VISION_PRO)
+        expect_display_type_from_file("VISION-PRO{3840x2160}.jpg").to eq(DisplayType::APP_APPLE_VISION_PRO)
+        expect_display_type_from_file("AppleTV{3840x2160}.jpg").to eq(DisplayType::APP_APPLE_TV)
+        expect_display_type_from_file("tv-4k{3840x2160}.jpg").to eq(DisplayType::APP_APPLE_TV)
+        expect_display_type_from_file("generic-4k{3840x2160}.jpg").to eq(DisplayType::APP_APPLE_TV)
       end
     end
 
@@ -384,6 +393,7 @@ describe Deliver::AppScreenshot do
 
     it "should return other device display types" do
       expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_APPLE_TV).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_APPLE_TV)
+      expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_APPLE_VISION_PRO).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_APPLE_VISION_PRO)
       expect(app_screenshot_with(Deliver::AppScreenshot::DisplayType::APP_DESKTOP).display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_DESKTOP)
     end
   end

--- a/deliver/spec/app_screenshot_validator_spec.rb
+++ b/deliver/spec/app_screenshot_validator_spec.rb
@@ -2,11 +2,11 @@ require 'deliver/app_screenshot'
 require 'deliver/setup'
 
 describe Deliver::AppScreenshotValidator do
-  ScreenSize = Deliver::AppScreenshot::ScreenSize
+  DisplayType = Deliver::AppScreenshot::DisplayType
   Error = Deliver::AppScreenshotValidator::ValidationError
 
-  def app_screenshot_with(screen_size, format = :png, path = 'image.png', language = 'en-US')
-    allow(Deliver::AppScreenshot).to receive(:calculate_screen_size).and_return(screen_size)
+  def app_screenshot_with(display_type, format = :png, path = 'image.png', language = 'en-US')
+    allow(Deliver::AppScreenshot).to receive(:calculate_display_type).and_return(display_type)
     allow(FastImage).to receive(:type).and_return(format)
     Deliver::AppScreenshot.new(path, language)
   end
@@ -28,35 +28,31 @@ describe Deliver::AppScreenshotValidator do
     end
 
     it 'should return true for valid screenshot' do
-      expect_no_error(app_screenshot_with(ScreenSize::IOS_65, :png, 'image.png'))
-      expect_no_error(app_screenshot_with(ScreenSize::IOS_65, :jpeg, 'image.jpeg'))
-      expect_no_error(app_screenshot_with(ScreenSize::IOS_67, :png, 'image.png'))
-      expect_no_error(app_screenshot_with(ScreenSize::IOS_67, :jpeg, 'image.jpeg'))
+      expect_no_error(app_screenshot_with(DisplayType::APP_IPHONE_65, :png, 'image.png'))
+      expect_no_error(app_screenshot_with(DisplayType::APP_IPHONE_65, :jpeg, 'image.jpeg'))
+      expect_no_error(app_screenshot_with(DisplayType::APP_IPHONE_67, :png, 'image.png'))
+      expect_no_error(app_screenshot_with(DisplayType::APP_IPHONE_67, :jpeg, 'image.jpeg'))
     end
 
-    it 'should detect valid size screenshot' do
+    it 'should detect invalid size screenshot' do
       expect_errors_to_include(app_screenshot_with(nil, :png, 'image.png'), Error::INVALID_SCREEN_SIZE)
     end
 
-    it 'should detect unacceptable screen size' do
-      expect_errors_to_include(app_screenshot_with('Unknown device'), Error::UNACCEPTABLE_DEVICE)
-    end
-
     it 'should detect invalid file extension' do
-      expect_errors_to_include(app_screenshot_with(ScreenSize::IOS_65, :gif, 'image.gif'), Error::INVALID_FILE_EXTENSION)
-      expect_errors_to_include(app_screenshot_with(ScreenSize::IOS_65, :png, 'image.gif'), Error::INVALID_FILE_EXTENSION, Error::FILE_EXTENSION_MISMATCH)
+      expect_errors_to_include(app_screenshot_with(DisplayType::APP_IPHONE_65, :gif, 'image.gif'), Error::INVALID_FILE_EXTENSION)
+      expect_errors_to_include(app_screenshot_with(DisplayType::APP_IPHONE_65, :png, 'image.gif'), Error::INVALID_FILE_EXTENSION, Error::FILE_EXTENSION_MISMATCH)
     end
 
     it 'should detect file extension mismatch' do
-      expect_errors_to_include(app_screenshot_with(ScreenSize::IOS_65, :jpeg, 'image.png'), Error::FILE_EXTENSION_MISMATCH)
-      expect_errors_to_include(app_screenshot_with(ScreenSize::IOS_65, :png, 'image.jpeg'), Error::FILE_EXTENSION_MISMATCH)
+      expect_errors_to_include(app_screenshot_with(DisplayType::APP_IPHONE_65, :jpeg, 'image.png'), Error::FILE_EXTENSION_MISMATCH)
+      expect_errors_to_include(app_screenshot_with(DisplayType::APP_IPHONE_65, :png, 'image.jpeg'), Error::FILE_EXTENSION_MISMATCH)
     end
   end
 
   describe '.validate_file_extension_and_format' do
     it 'should provide ideal filename to match content format' do
       errors_found = []
-      described_class.validate(app_screenshot_with(ScreenSize::IOS_65, :png, 'image.jpeg'), errors_found)
+      described_class.validate(app_screenshot_with(DisplayType::APP_IPHONE_65, :png, 'image.jpeg'), errors_found)
       error = errors_found.find { |e| e.type == Error::FILE_EXTENSION_MISMATCH }
       expect(error.debug_info).to match(/image\.png/)
     end

--- a/deliver/spec/loader_spec.rb
+++ b/deliver/spec/loader_spec.rb
@@ -172,7 +172,7 @@ describe Deliver::Loader do
       add_screenshot("/Screenshots/en-GB/iPhone8-01First{750x1334}.jpg")
       screenshots = collect_screenshots_from_dir("/Screenshots/")
       expect(screenshots.count).to eq(1)
-      expect(screenshots.first.screen_size).to eq(Deliver::AppScreenshot::ScreenSize::IOS_47)
+      expect(screenshots.first.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_IPHONE_47)
     end
 
     it "should find different languages" do
@@ -203,14 +203,14 @@ describe Deliver::Loader do
       add_screenshot("/Screenshots/en-GB/iPhone8-01First{750x1334}_framed.jpg")
       screenshots = collect_screenshots_from_dir("/Screenshots/")
       expect(screenshots.count).to eq(2)
-      expect(screenshots.group_by(&:device_type).keys).to include("APP_WATCH_SERIES_4", "APP_IPHONE_47")
+      expect(screenshots.group_by(&:display_type).keys).to include(Deliver::AppScreenshot::DisplayType::APP_WATCH_SERIES_4, Deliver::AppScreenshot::DisplayType::APP_IPHONE_47)
     end
 
     it "should support special appleTV directory" do
       add_screenshot("/Screenshots/appleTV/en-GB/01First{3840x2160}.jpg")
       screenshots = collect_screenshots_from_dir("/Screenshots/")
       expect(screenshots.count).to eq(1)
-      expect(screenshots.first.device_type).to eq("APP_APPLE_TV")
+      expect(screenshots.first.display_type).to eq(Deliver::AppScreenshot::DisplayType::APP_APPLE_TV)
     end
 
     it "should detect iMessage screenshots based on the directory they are contained within" do

--- a/deliver/spec/sync_screenshots_spec.rb
+++ b/deliver/spec/sync_screenshots_spec.rb
@@ -6,8 +6,6 @@ describe Deliver::SyncScreenshots do
 
     subject { described_class.new(app: nil, platform: nil) }
 
-    DisplayType = Spaceship::ConnectAPI::AppScreenshotSet::DisplayType
-
     before do
       # To emulate checksum calculation, return the given path as a checksum
       allow(Deliver::ScreenshotComparable).to receive(:calculate_checksum) { |path| path }
@@ -20,10 +18,10 @@ describe Deliver::SyncScreenshots do
     context 'ASC has nothing and going to add screenshots' do
       let(:screenshots) do
         [
-          mock_screenshot(path: '5.5_1.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_55),
-          mock_screenshot(path: '5.5_2.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_55),
-          mock_screenshot(path: '6.5_1.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_65),
-          mock_screenshot(path: '6.5_2.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_65)
+          mock_screenshot(path: '5.5_1.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_55),
+          mock_screenshot(path: '5.5_2.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_55),
+          mock_screenshot(path: '6.5_1.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_65),
+          mock_screenshot(path: '6.5_2.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
         ]
       end
 
@@ -53,10 +51,10 @@ describe Deliver::SyncScreenshots do
     context 'ASC has a screenshot on each screenshot set and going to add another screenshot' do
       let(:screenshots) do
         [
-          mock_screenshot(path: '5.5_1.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_55),
-          mock_screenshot(path: '5.5_2.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_55),
-          mock_screenshot(path: '6.5_1.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_65),
-          mock_screenshot(path: '6.5_2.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_65)
+          mock_screenshot(path: '5.5_1.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_55),
+          mock_screenshot(path: '5.5_2.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_55),
+          mock_screenshot(path: '6.5_1.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_65),
+          mock_screenshot(path: '6.5_2.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
         ]
       end
 
@@ -126,10 +124,10 @@ describe Deliver::SyncScreenshots do
 
       let(:screenshots) do
         [
-          mock_screenshot(path: '5.5_1.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_55),
-          mock_screenshot(path: '5.5_2_improved.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_55),
-          mock_screenshot(path: '6.5_1.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_65),
-          mock_screenshot(path: '6.5_2_improved.jpg', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_65)
+          mock_screenshot(path: '5.5_1.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_55),
+          mock_screenshot(path: '5.5_2_improved.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_55),
+          mock_screenshot(path: '6.5_1.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_65),
+          mock_screenshot(path: '6.5_2_improved.jpg', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_65)
         ]
       end
 
@@ -194,12 +192,12 @@ describe Deliver::SyncScreenshots do
       screenshot
     end
 
-    def mock_screenshot(path: '/path/to/screenshot', language: 'en-US', screen_size: Deliver::AppScreenshot::ScreenSize::IOS_55)
+    def mock_screenshot(path: '/path/to/screenshot', language: 'en-US', display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_55)
       screenshot = double(
         'Deliver::AppScreenshot',
         path: path,
         language: language,
-        device_type: screen_size
+        display_type: display_type
       )
       allow(screenshot).to receive(:kind_of?).with(Deliver::AppScreenshot).and_return(true)
       screenshot

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -72,7 +72,7 @@ describe Deliver::UploadScreenshots do
           local_screenshot = double('Deliver::AppScreenshot',
                                     path: '/path/to/screenshot',
                                     language: 'en-US',
-                                    device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                    display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
           screenshots_per_language = { 'en-US' => [local_screenshot] }
 
           allow(FastlaneCore::Helper).to receive(:show_loading_indicator).and_return(true)
@@ -94,7 +94,7 @@ describe Deliver::UploadScreenshots do
           local_screenshot = double('Deliver::AppScreenshot',
                                     path: '/path/to/screenshot',
                                     language: 'en-US',
-                                    device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                    display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
           screenshots_per_language = { 'en-US' => [local_screenshot] }
           allow(described_class).to receive(:calculate_checksum).and_return('checksum')
 
@@ -116,7 +116,7 @@ describe Deliver::UploadScreenshots do
         local_screenshot = double('Deliver::AppScreenshot',
                                   path: '/path/to/screenshot',
                                   language: 'en-US',
-                                  device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                  display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
         screenshots_per_language = { 'en-US' => [local_screenshot] }
         allow(described_class).to receive(:calculate_checksum).and_return('checksum')
 
@@ -139,7 +139,7 @@ describe Deliver::UploadScreenshots do
         local_screenshot = double('Deliver::AppScreenshot',
                                   path: '/path/to/screenshot',
                                   language: 'en-US',
-                                  device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                  display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
         screenshots_per_language = { 'en-US' => [local_screenshot] }
         allow(described_class).to receive(:calculate_checksum).with(local_screenshot.path).and_return('checksum')
 
@@ -160,7 +160,7 @@ describe Deliver::UploadScreenshots do
         local_screenshot = double('Deliver::AppScreenshot',
                                   path: '/path/to/screenshot',
                                   language: 'en-US',
-                                  device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                  display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
         screenshots_per_language = { 'en-US' => Array.new(11, local_screenshot) }
         allow(described_class).to receive(:calculate_checksum).with(local_screenshot.path).and_return('checksum')
 
@@ -183,11 +183,11 @@ describe Deliver::UploadScreenshots do
         uploaded_local_screenshot = double('Deliver::AppScreenshot',
                                            path: '/path/to/screenshot',
                                            language: 'en-US',
-                                           device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                           display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
         new_local_screenshot = double('Deliver::AppScreenshot',
                                       path: '/path/to/new_screenshot',
                                       language: 'en-US',
-                                      device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                      display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
         screenshots_per_language = { 'en-US' => [*Array.new(10, uploaded_local_screenshot), new_local_screenshot] }
         allow(described_class).to receive(:calculate_checksum).with(uploaded_local_screenshot.path).and_return('checksum')
         allow(described_class).to receive(:calculate_checksum).with(new_local_screenshot.path).and_return('another_checksum')
@@ -211,11 +211,11 @@ describe Deliver::UploadScreenshots do
         uploaded_local_screenshot = double('Deliver::AppScreenshot',
                                            path: 'screenshot.jpg',
                                            language: 'en-US',
-                                           device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                           display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
         new_local_screenshot = double('Deliver::AppScreenshot',
                                       path: '0_screenshot.jpg',
                                       language: 'en-US',
-                                      device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                      display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
 
         # The new screenshot appears prior to others in the iterator
         screenshots_per_language = { 'en-US' => [new_local_screenshot, *Array.new(10, uploaded_local_screenshot)] }
@@ -421,7 +421,7 @@ describe Deliver::UploadScreenshots do
         local_screenshot = double('Deliver::AppScreenshot',
                                   path: '/path/to/new_screenshot',
                                   language: 'en-US',
-                                  device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                  display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
         screenshots_per_language = { 'en-US' => [local_screenshot] }
 
         expect(described_class).to receive(:calculate_checksum).with(local_screenshot.path).and_return('checksum')
@@ -442,7 +442,7 @@ describe Deliver::UploadScreenshots do
         local_screenshot = double('Deliver::AppScreenshot',
                                   path: '/path/to/new_screenshot',
                                   language: 'en-US',
-                                  device_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+                                  display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
         screenshots_per_language = { 'en-US' => [local_screenshot] }
 
         expect(described_class).to receive(:calculate_checksum).with(local_screenshot.path).and_return('checksum')

--- a/frameit/lib/frameit/device.rb
+++ b/frameit/lib/frameit/device.rb
@@ -73,7 +73,7 @@ module Frameit
 
     # Previously ENV[FRAMEIT_FORCE_DEVICE_TYPE] was matched to Deliver::AppScreenshot::ScreenSize constants. However,
     # options.rb defined a few Apple devices with unspecified IDs, this option was never read from Frameit.config.
-    # Therefore this function matches both ScreenSize constants and formatted names to maintain backward compatibility.
+    # Therefore this function matches both DisplayType constants and formatted names to maintain backward compatibility.
     def self.find_device_by_id_or_name(id)
       return nil if id.nil?
       found_device = nil

--- a/frameit/lib/frameit/device.rb
+++ b/frameit/lib/frameit/device.rb
@@ -71,7 +71,7 @@ module Frameit
       return nil
     end
 
-    # Previously ENV[FRAMEIT_FORCE_DEVICE_TYPE] was matched to Deliver::AppScreenshot::ScreenSize constants. However,
+    # Previously ENV[FRAMEIT_FORCE_DEVICE_TYPE] was matched to Deliver::AppScreenshot display type strings.
     # options.rb defined a few Apple devices with unspecified IDs, this option was never read from Frameit.config.
     # Therefore this function matches both DisplayType constants and formatted names to maintain backward compatibility.
     def self.find_device_by_id_or_name(id)

--- a/frameit/lib/frameit/device_types.rb
+++ b/frameit/lib/frameit/device_types.rb
@@ -142,11 +142,11 @@ module Frameit
     IPAD_AIR_2019 ||= Frameit::Device.new("ipad-air-2019", "Apple iPad Air (2019)", 2, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS)
     IPAD_MINI_4 ||= Frameit::Device.new("ipad-mini-4", "Apple iPad Mini 4", 2, [[1536, 2048], [2048, 1536]], 324, Color::SPACE_GRAY)
     IPAD_MINI_2019 ||= Frameit::Device.new("ipad-mini-2019", "Apple iPad Mini (2019)", 3, [[1536, 2048], [2048, 1536]], 324, Color::SPACE_GRAY)
-    # this is 1st or 2nd gen of iPad Pro 12.9:
+    # iPad Pro 12.9" (2nd gen):
     IPAD_PRO ||= Frameit::Device.new("ipad-pro", "Apple iPad Pro", 3, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-Pro")
-    # 3rd generation:
+    # iPad Pro 13" (3rd gen - rebranded from 12.9"):
     IPAD_PRO_12_9 ||= Frameit::Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (3rd generation)", 4, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-Pro-12.9")
-    # 4th generation:
+    # iPad Pro 13" (4th gen):
     IPAD_PRO_12_9_4 ||= Frameit::Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (4th generation)", 5, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-Pro-12.9")
     # iPad Pro (10.5-inch) is not in frameit-frames repo, but must be included so that we are backward compatible with PR #15373
     # priority must be lower so that users who didn't copy the frame to their frameit frames folder will not get an error

--- a/frameit/lib/frameit/device_types.rb
+++ b/frameit/lib/frameit/device_types.rb
@@ -1,8 +1,46 @@
 require_relative 'module'
 require_relative './device'
-require 'deliver/app_screenshot'
+require 'spaceship/connect_api/models/app_screenshot_set'
 
 module Frameit
+  DisplayType = Spaceship::ConnectAPI::AppScreenshotSet::DisplayType
+
+  DEVICE_SCREEN_IDS = {
+    DisplayType::APP_IPHONE_35 => "iOS-3.5-in",
+    DisplayType::APP_IPHONE_40 => "iOS-4-in",
+    DisplayType::APP_IPHONE_47 => "iOS-4.7-in",
+    DisplayType::APP_IPHONE_55 => "iOS-5.5-in",
+    DisplayType::APP_IPHONE_58 => "iOS-5.8-in",
+    DisplayType::APP_IPHONE_61 => "iOS-6.1-in",
+    DisplayType::APP_IPHONE_65 => "iOS-6.5-in",
+    DisplayType::APP_IPHONE_67 => "iOS-6.7-in",
+    DisplayType::APP_IPAD_97 => "iOS-iPad",
+    DisplayType::APP_IPAD_105 => "iOS-iPad-10.5",
+    DisplayType::APP_IPAD_PRO_3GEN_11 => "iOS-iPad-11",
+    DisplayType::APP_IPAD_PRO_129 => "iOS-iPad-Pro",
+    DisplayType::APP_IPAD_PRO_3GEN_129 => "iOS-iPad-Pro-12.9",
+    DisplayType::IMESSAGE_APP_IPHONE_40 => "iOS-4-in-messages",
+    DisplayType::IMESSAGE_APP_IPHONE_47 => "iOS-4.7-in-messages",
+    DisplayType::IMESSAGE_APP_IPHONE_55 => "iOS-5.5-in-messages",
+    DisplayType::IMESSAGE_APP_IPHONE_58 => "iOS-5.8-in-messages",
+    DisplayType::IMESSAGE_APP_IPHONE_61 => "iOS-6.1-in-messages",
+    DisplayType::IMESSAGE_APP_IPHONE_65 => "iOS-6.5-in-messages",
+    DisplayType::IMESSAGE_APP_IPHONE_67 => "iOS-6.7-in-messages",
+    DisplayType::IMESSAGE_APP_IPAD_97 => "iOS-iPad-messages",
+    DisplayType::IMESSAGE_APP_IPAD_105 => "iOS-iPad-10.5-messages",
+    DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_11 => "iOS-iPad-11-messages",
+    DisplayType::IMESSAGE_APP_IPAD_PRO_129 => "iOS-iPad-Pro-messages",
+    DisplayType::IMESSAGE_APP_IPAD_PRO_3GEN_129 => "iOS-iPad-Pro-12.9-messages",
+    DisplayType::APP_WATCH_SERIES_3 => "iOS-Apple-Watch",
+    DisplayType::APP_WATCH_SERIES_4 => "iOS-Apple-Watch-Series4",
+    DisplayType::APP_WATCH_SERIES_7 => "iOS-Apple-Watch-Series7",
+    DisplayType::APP_WATCH_SERIES_10 => "iOS-Apple-Watch-Series10",
+    DisplayType::APP_WATCH_ULTRA => "iOS-Apple-Watch-Ultra",
+    DisplayType::APP_APPLE_TV => "Apple-TV",
+    DisplayType::APP_DESKTOP => "Mac",
+    DisplayType::APP_APPLE_VISION_PRO => "visionOS-Vision-Pro"
+  }.freeze
+
   module Color
     MATTE_BLACK ||= "Matte Black"
     SPACE_GRAY ||= "Space Gray"
@@ -81,80 +119,80 @@ module Frameit
   end
 
   module Devices
-    GOOGLE_PIXEL_3 ||= Frameit::Device.new("google-pixel-3", "Google Pixel 3", 7, [[1080, 2160], [2160, 1080]], 443, Color::JUST_BLACK, Platform::ANDROID)
-    GOOGLE_PIXEL_3_XL ||= Frameit::Device.new("google-pixel-3-xl", "Google Pixel 3 XL", 7, [[1440, 2960], [2960, 1440]], 523, Color::JUST_BLACK, Platform::ANDROID)
+    GOOGLE_PIXEL_3 ||= Device.new("google-pixel-3", "Google Pixel 3", 7, [[1080, 2160], [2160, 1080]], 443, Color::JUST_BLACK, Platform::ANDROID)
+    GOOGLE_PIXEL_3_XL ||= Device.new("google-pixel-3-xl", "Google Pixel 3 XL", 7, [[1440, 2960], [2960, 1440]], 523, Color::JUST_BLACK, Platform::ANDROID)
     # Google Pixel 4's priority should be higher than Samsung Galaxy S10+ (priority 8):
-    GOOGLE_PIXEL_4 ||= Frameit::Device.new("google-pixel-4", "Google Pixel 4", 9, [[1080, 2280], [2280, 1080]], 444, Color::JUST_BLACK, Platform::ANDROID)
-    GOOGLE_PIXEL_4_XL ||= Frameit::Device.new("google-pixel-4-xl", "Google Pixel 4 XL", 9, [[1440, 3040], [3040, 1440]], 537, Color::JUST_BLACK, Platform::ANDROID)
-    GOOGLE_PIXEL_5 ||= Frameit::Device.new("google-pixel-5", "Google Pixel 5", 10, [[1080, 2340], [2340, 1080]], 432, Color::JUST_BLACK, Platform::ANDROID)
-    HTC_ONE_A9 ||= Frameit::Device.new("htc-one-a9", "HTC One A9", 6, [[1080, 1920], [1920, 1080]], 441, Color::BLACK, Platform::ANDROID)
-    HTC_ONE_M8 ||= Frameit::Device.new("htc-one-m8", "HTC One M8", 3, [[1080, 1920], [1920, 1080]], 441, Color::BLACK, Platform::ANDROID)
-    HUAWEI_P8 ||= Frameit::Device.new("huawei-p8", "Huawei P8", 5, [[1080, 1920], [1920, 1080]], 424, Color::BLACK, Platform::ANDROID)
-    MOTOROLA_MOTO_E ||= Frameit::Device.new("motorola-moto-e", "Motorola Moto E", 3, [[540, 960], [960, 540]], 245, Color::BLACK, Platform::ANDROID)
-    MOTOROLA_MOTO_G ||= Frameit::Device.new("motorola-moto-g", "Motorola Moto G", 4, [[1080, 1920], [1920, 1080]], 401, nil, Platform::ANDROID, nil)
-    NEXUS_4 ||= Frameit::Device.new("nexus-4", "Nexus 4", 7, [[768, 1280], [1820, 768]], 318, nil, Platform::ANDROID)
-    NEXUS_5X ||= Frameit::Device.new("nexus-5x", "Nexus 5X", 7, [[1080, 1920], [1920, 1080]], 423, nil, Platform::ANDROID)
-    NEXUS_6P ||= Frameit::Device.new("nexus-6p", "Nexus 6P", 7, [[1440, 2560], [2560, 1440]], 518, nil, Platform::ANDROID)
-    NEXUS_9 ||= Frameit::Device.new("nexus-9", "Nexus 9", 7, [[1536, 2048], [2048, 1536]], 281, nil, Platform::ANDROID)
-    SAMSUNG_GALAXY_GRAND_PRIME ||= Frameit::Device.new("samsung-galaxy-grand-prime", "Samsung Galaxy Grand Prime", 5, [[540, 960], [960, 540]], 220, Color::BLACK, Platform::ANDROID)
-    SAMSUNG_GALAXY_NOTE_5 ||= Frameit::Device.new("samsung-galaxy-note-5", "Samsung Galaxy Note 5", 5, [[1440, 2560], [2560, 1440]], 518, Color::BLACK, Platform::ANDROID)
-    SAMSUNG_GALAXY_NOTE_10 ||= Frameit::Device.new("samsung-galaxy-note-10", "Samsung Galaxy Note 10", 6, [[1080, 2280], [2280, 1080]], 401, Color::AURA_BLACK, Platform::ANDROID)
-    SAMSUNG_GALAXY_NOTE_10_PLUS ||= Frameit::Device.new("samsung-galaxy-note-10-plus", "Samsung Galaxy Note 10+", 7, [[1440, 3040], [3040, 1440]], 498, Color::AURA_BLACK, Platform::ANDROID)
-    SAMSUNG_GALAXY_S_DUOS ||= Frameit::Device.new("samsung-galaxy-s-duos", "Samsung Galaxy S Duos", 3, [[480, 800], [800, 480]], 233, nil, Platform::ANDROID)
-    SAMSUNG_GALAXY_S3 ||= Frameit::Device.new("samsung-galaxy-s3", "Samsung Galaxy S3", 3, [[720, 1280], [1280, 720]], 306, nil, Platform::ANDROID)
-    SAMSUNG_GALAXY_S5 ||= Frameit::Device.new("samsung-galaxy-s5", "Samsung Galaxy S5", 3, [[1080, 1920], [1920, 1080]], 432, Color::BLACK, Platform::ANDROID)
-    SAMSUNG_GALAXY_S7 ||= Frameit::Device.new("samsung-galaxy-s7", "Samsung Galaxy S7", 4, [[1440, 2560], [2560, 1440]], 577, Color::BLACK, Platform::ANDROID)
-    SAMSUNG_GALAXY_S8 ||= Frameit::Device.new("samsung-galaxy-s8", "Samsung Galaxy S8", 5, [[1440, 2960], [2960, 1440]], 570, Color::MIDNIGHT_BLACK, Platform::ANDROID)
-    SAMSUNG_GALAXY_S9 ||= Frameit::Device.new("samsung-galaxy-s9", "Samsung Galaxy S9", 6, [[1440, 2960], [2960, 1440]], 570, Color::MIDNIGHT_BLACK, Platform::ANDROID)
-    SAMSUNG_GALAXY_S10 ||= Frameit::Device.new("samsung-galaxy-s10", "Samsung Galaxy S10", 7, [[1440, 3040], [3040, 1440]], 550, Color::PRISM_BLACK, Platform::ANDROID)
-    SAMSUNG_GALAXY_S10_PLUS ||= Frameit::Device.new("samsung-galaxy-s10-plus", "Samsung Galaxy S10+", 8, [[1440, 3040], [3040, 1440]], 522, Color::PRISM_BLACK, Platform::ANDROID)
-    XIAOMI_MI_MIX_ALPHA ||= Frameit::Device.new("xiaomi-mi-mix-alpha", "Xiaomi Mi Mix Alpha", 1, [[2088, 2250], [2250, 2088]], 388, nil, Platform::ANDROID)
-    IPHONE_5S ||= Frameit::Device.new("iphone-5s", "Apple iPhone 5s", 2, [[640, 1096], [640, 1136], [1136, 600], [1136, 640]], 326, Color::SPACE_GRAY, Platform::IOS, "iOS-4-in", :use_legacy_iphone5s)
-    IPHONE_5C ||= Frameit::Device.new("iphone-5c", "Apple iPhone 5c", 2, [[640, 1136], [1136, 640]], 326, Color::WHITE)
-    IPHONE_SE ||= Frameit::Device.new("iphone-se", "Apple iPhone SE", 3, [[640, 1096], [640, 1136], [1136, 600], [1136, 640]], 326, Color::SPACE_GRAY, Platform::IOS, "iOS-4-in")
-    IPHONE_6S ||= Frameit::Device.new("iphone-6s", "Apple iPhone 6s", 4, [[750, 1334], [1334, 750]], 326, Color::SPACE_GRAY, Platform::IOS, "iOS-4.7-in", :use_legacy_iphone6s)
-    IPHONE_6S_PLUS ||= Frameit::Device.new("iphone-6s-plus", "Apple iPhone 6s Plus", 4, [[1242, 2208], [2208, 1242]], 401, Color::SPACE_GRAY, Platform::IOS, "iOS-5.5-in", :use_legacy_iphone6s)
-    IPHONE_7 ||= Frameit::Device.new("iphone-7", "Apple iPhone 7", 5, [[750, 1334], [1334, 750]], 326, Color::MATTE_BLACK, Platform::IOS, "iOS-4.7-in", :use_legacy_iphone7)
-    IPHONE_7_PLUS ||= Frameit::Device.new("iphone-7-plus", "Apple iPhone 7 Plus", 5, [[1242, 2208], [2208, 1242]], 401, Color::MATTE_BLACK, Platform::IOS, "iOS-5.5-in", :use_legacy_iphone7)
-    IPHONE_8 ||= Frameit::Device.new("iphone-8", "Apple iPhone 8", 6, [[750, 1334], [1334, 750]], 326, Color::SPACE_GRAY)
-    IPHONE_8_PLUS ||= Frameit::Device.new("iphone-8-plus", "Apple iPhone 8 Plus", 6, [[1242, 2208], [2208, 1242]], 401, Color::SPACE_GRAY)
-    IPHONE_X ||= Frameit::Device.new("iphone-X", "Apple iPhone X", 7, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS, "iOS-5.8-in", :use_legacy_iphonex)
-    IPHONE_XS ||= Frameit::Device.new("iphone-XS", "Apple iPhone XS", 8, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS, "iOS-5.8-in", :use_legacy_iphonexs)
-    IPHONE_XR ||= Frameit::Device.new("iphone-XR", "Apple iPhone XR", 8, [[828, 1792], [1792, 828]], 326, Color::SPACE_GRAY, Platform::IOS, "iOS-6.5-in", :use_legacy_iphonexsmax)
-    IPHONE_XS_MAX ||= Frameit::Device.new("iphone-XS-Max", "Apple iPhone XS Max", 8, [[1242, 2688], [2688, 1242]], 458, Color::SPACE_GRAY, Platform::IOS, "iOS-6.5-in", :use_legacy_iphonexsmax)
-    IPHONE_11 ||= Frameit::Device.new("iphone-11", "Apple iPhone 11", 9, [[828, 1792], [1792, 828]], 326, Color::BLACK, Platform::IOS)
-    IPHONE_11_PRO ||= Frameit::Device.new("iphone-11-pro", "Apple iPhone 11 Pro", 9, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS)
-    IPHONE_11_PRO_MAX ||= Frameit::Device.new("iphone11-pro-max", "Apple iPhone 11 Pro Max", 9, [[1242, 2688], [2688, 1242]], 458, Color::SPACE_GRAY, Platform::IOS)
-    IPHONE_12 ||= Frameit::Device.new("iphone-12", "Apple iPhone 12", 10, [[1170, 2532], [2532, 1170]], 460, Color::BLACK, Platform::IOS)
-    IPHONE_12_PRO ||= Frameit::Device.new("iphone-12-pro", "Apple iPhone 12 Pro", 10, [[1170, 2532], [2532, 1170]], 460, Color::SPACE_GRAY, Platform::IOS)
-    IPHONE_12_PRO_MAX ||= Frameit::Device.new("iphone12-pro-max", "Apple iPhone 12 Pro Max", 10, [[1284, 2778], [2778, 1284]], 458, Color::GRAPHITE, Platform::IOS)
-    IPHONE_12_MINI ||= Frameit::Device.new("iphone-12-mini", "Apple iPhone 12 Mini", 10, [[1125, 2436], [2436, 1125]], 476, Color::BLACK, Platform::IOS)
-    IPHONE_13 ||= Frameit::Device.new("iphone-13", "Apple iPhone 13", 11, [[1170, 2532], [2532, 1170]], 460, Color::MIDNIGHT, Platform::IOS)
-    IPHONE_13_PRO ||= Frameit::Device.new("iphone-13-pro", "Apple iPhone 13 Pro", 11, [[1170, 2532], [2532, 1170]], 460, Color::GRAPHITE, Platform::IOS)
-    IPHONE_13_PRO_MAX ||= Frameit::Device.new("iphone13-pro-max", "Apple iPhone 13 Pro Max", 11, [[1284, 2778], [2778, 1284]], 458, Color::GRAPHITE, Platform::IOS)
-    IPHONE_13_MINI ||= Frameit::Device.new("iphone-13-mini", "Apple iPhone 13 Mini", 11, [[1080, 2340], [2340, 1080]], 476, Color::MIDNIGHT, Platform::IOS)
-    IPHONE_14 ||= Frameit::Device.new("iphone-14", "Apple iPhone 14", 12, [[1170, 2532], [2532, 1170]], 460, Color::MIDNIGHT, Platform::IOS)
-    IPHONE_14_PLUS ||= Frameit::Device.new("iphone-14-plus", "Apple iPhone 14 Plus", 12, [[1284, 2778], [2778, 1284]], 458, Color::MIDNIGHT, Platform::IOS)
-    IPHONE_14_PRO ||= Frameit::Device.new("iphone-14-pro", "Apple iPhone 14 Pro", 12, [[1178, 2556], [2556, 1178]], 460, Color::PURPLE, Platform::IOS)
-    IPHONE_14_PRO_MAX ||= Frameit::Device.new("iphone14-pro-max", "Apple iPhone 14 Pro Max", 12, [[1290, 2796], [2796, 1290]], 458, Color::PURPLE, Platform::IOS)
-    IPAD_10_2 ||= Frameit::Device.new("ipad-10-2", "Apple iPad 10.2", 1, [[1620, 2160], [2160, 1620]], 264, Color::SPACE_GRAY, Platform::IOS)
-    IPAD_AIR_2 ||= Frameit::Device.new("ipad-air-2", "Apple iPad Air 2", 1, [[1536, 2048], [2048, 1536]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad")
-    IPAD_AIR_2019 ||= Frameit::Device.new("ipad-air-2019", "Apple iPad Air (2019)", 2, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS)
-    IPAD_MINI_4 ||= Frameit::Device.new("ipad-mini-4", "Apple iPad Mini 4", 2, [[1536, 2048], [2048, 1536]], 324, Color::SPACE_GRAY)
-    IPAD_MINI_2019 ||= Frameit::Device.new("ipad-mini-2019", "Apple iPad Mini (2019)", 3, [[1536, 2048], [2048, 1536]], 324, Color::SPACE_GRAY)
+    GOOGLE_PIXEL_4 ||= Device.new("google-pixel-4", "Google Pixel 4", 9, [[1080, 2280], [2280, 1080]], 444, Color::JUST_BLACK, Platform::ANDROID)
+    GOOGLE_PIXEL_4_XL ||= Device.new("google-pixel-4-xl", "Google Pixel 4 XL", 9, [[1440, 3040], [3040, 1440]], 537, Color::JUST_BLACK, Platform::ANDROID)
+    GOOGLE_PIXEL_5 ||= Device.new("google-pixel-5", "Google Pixel 5", 10, [[1080, 2340], [2340, 1080]], 432, Color::JUST_BLACK, Platform::ANDROID)
+    HTC_ONE_A9 ||= Device.new("htc-one-a9", "HTC One A9", 6, [[1080, 1920], [1920, 1080]], 441, Color::BLACK, Platform::ANDROID)
+    HTC_ONE_M8 ||= Device.new("htc-one-m8", "HTC One M8", 3, [[1080, 1920], [1920, 1080]], 441, Color::BLACK, Platform::ANDROID)
+    HUAWEI_P8 ||= Device.new("huawei-p8", "Huawei P8", 5, [[1080, 1920], [1920, 1080]], 424, Color::BLACK, Platform::ANDROID)
+    MOTOROLA_MOTO_E ||= Device.new("motorola-moto-e", "Motorola Moto E", 3, [[540, 960], [960, 540]], 245, Color::BLACK, Platform::ANDROID)
+    MOTOROLA_MOTO_G ||= Device.new("motorola-moto-g", "Motorola Moto G", 4, [[1080, 1920], [1920, 1080]], 401, nil, Platform::ANDROID, nil)
+    NEXUS_4 ||= Device.new("nexus-4", "Nexus 4", 7, [[768, 1280], [1820, 768]], 318, nil, Platform::ANDROID)
+    NEXUS_5X ||= Device.new("nexus-5x", "Nexus 5X", 7, [[1080, 1920], [1920, 1080]], 423, nil, Platform::ANDROID)
+    NEXUS_6P ||= Device.new("nexus-6p", "Nexus 6P", 7, [[1440, 2560], [2560, 1440]], 518, nil, Platform::ANDROID)
+    NEXUS_9 ||= Device.new("nexus-9", "Nexus 9", 7, [[1536, 2048], [2048, 1536]], 281, nil, Platform::ANDROID)
+    SAMSUNG_GALAXY_GRAND_PRIME ||= Device.new("samsung-galaxy-grand-prime", "Samsung Galaxy Grand Prime", 5, [[540, 960], [960, 540]], 220, Color::BLACK, Platform::ANDROID)
+    SAMSUNG_GALAXY_NOTE_5 ||= Device.new("samsung-galaxy-note-5", "Samsung Galaxy Note 5", 5, [[1440, 2560], [2560, 1440]], 518, Color::BLACK, Platform::ANDROID)
+    SAMSUNG_GALAXY_NOTE_10 ||= Device.new("samsung-galaxy-note-10", "Samsung Galaxy Note 10", 6, [[1080, 2280], [2280, 1080]], 401, Color::AURA_BLACK, Platform::ANDROID)
+    SAMSUNG_GALAXY_NOTE_10_PLUS ||= Device.new("samsung-galaxy-note-10-plus", "Samsung Galaxy Note 10+", 7, [[1440, 3040], [3040, 1440]], 498, Color::AURA_BLACK, Platform::ANDROID)
+    SAMSUNG_GALAXY_S_DUOS ||= Device.new("samsung-galaxy-s-duos", "Samsung Galaxy S Duos", 3, [[480, 800], [800, 480]], 233, nil, Platform::ANDROID)
+    SAMSUNG_GALAXY_S3 ||= Device.new("samsung-galaxy-s3", "Samsung Galaxy S3", 3, [[720, 1280], [1280, 720]], 306, nil, Platform::ANDROID)
+    SAMSUNG_GALAXY_S5 ||= Device.new("samsung-galaxy-s5", "Samsung Galaxy S5", 3, [[1080, 1920], [1920, 1080]], 432, Color::BLACK, Platform::ANDROID)
+    SAMSUNG_GALAXY_S7 ||= Device.new("samsung-galaxy-s7", "Samsung Galaxy S7", 4, [[1440, 2560], [2560, 1440]], 577, Color::BLACK, Platform::ANDROID)
+    SAMSUNG_GALAXY_S8 ||= Device.new("samsung-galaxy-s8", "Samsung Galaxy S8", 5, [[1440, 2960], [2960, 1440]], 570, Color::MIDNIGHT_BLACK, Platform::ANDROID)
+    SAMSUNG_GALAXY_S9 ||= Device.new("samsung-galaxy-s9", "Samsung Galaxy S9", 6, [[1440, 2960], [2960, 1440]], 570, Color::MIDNIGHT_BLACK, Platform::ANDROID)
+    SAMSUNG_GALAXY_S10 ||= Device.new("samsung-galaxy-s10", "Samsung Galaxy S10", 7, [[1440, 3040], [3040, 1440]], 550, Color::PRISM_BLACK, Platform::ANDROID)
+    SAMSUNG_GALAXY_S10_PLUS ||= Device.new("samsung-galaxy-s10-plus", "Samsung Galaxy S10+", 8, [[1440, 3040], [3040, 1440]], 522, Color::PRISM_BLACK, Platform::ANDROID)
+    XIAOMI_MI_MIX_ALPHA ||= Device.new("xiaomi-mi-mix-alpha", "Xiaomi Mi Mix Alpha", 1, [[2088, 2250], [2250, 2088]], 388, nil, Platform::ANDROID)
+    IPHONE_5S ||= Device.new("iphone-5s", "Apple iPhone 5s", 2, [[640, 1096], [640, 1136], [1136, 600], [1136, 640]], 326, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_40], :use_legacy_iphone5s)
+    IPHONE_5C ||= Device.new("iphone-5c", "Apple iPhone 5c", 2, [[640, 1136], [1136, 640]], 326, Color::WHITE)
+    IPHONE_SE ||= Device.new("iphone-se", "Apple iPhone SE", 3, [[640, 1096], [640, 1136], [1136, 600], [1136, 640]], 326, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_40])
+    IPHONE_6S ||= Device.new("iphone-6s", "Apple iPhone 6s", 4, [[750, 1334], [1334, 750]], 326, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_47], :use_legacy_iphone6s)
+    IPHONE_6S_PLUS ||= Device.new("iphone-6s-plus", "Apple iPhone 6s Plus", 4, [[1242, 2208], [2208, 1242]], 401, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_55], :use_legacy_iphone6s)
+    IPHONE_7 ||= Device.new("iphone-7", "Apple iPhone 7", 5, [[750, 1334], [1334, 750]], 326, Color::MATTE_BLACK, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_47], :use_legacy_iphone7)
+    IPHONE_7_PLUS ||= Device.new("iphone-7-plus", "Apple iPhone 7 Plus", 5, [[1242, 2208], [2208, 1242]], 401, Color::MATTE_BLACK, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_55], :use_legacy_iphone7)
+    IPHONE_8 ||= Device.new("iphone-8", "Apple iPhone 8", 6, [[750, 1334], [1334, 750]], 326, Color::SPACE_GRAY)
+    IPHONE_8_PLUS ||= Device.new("iphone-8-plus", "Apple iPhone 8 Plus", 6, [[1242, 2208], [2208, 1242]], 401, Color::SPACE_GRAY)
+    IPHONE_X ||= Device.new("iphone-X", "Apple iPhone X", 7, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_58], :use_legacy_iphonex)
+    IPHONE_XS ||= Device.new("iphone-XS", "Apple iPhone XS", 8, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_58], :use_legacy_iphonexs)
+    IPHONE_XR ||= Device.new("iphone-XR", "Apple iPhone XR", 8, [[828, 1792], [1792, 828]], 326, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_65], :use_legacy_iphonexsmax)
+    IPHONE_XS_MAX ||= Device.new("iphone-XS-Max", "Apple iPhone XS Max", 8, [[1242, 2688], [2688, 1242]], 458, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_65], :use_legacy_iphonexsmax)
+    IPHONE_11 ||= Device.new("iphone-11", "Apple iPhone 11", 9, [[828, 1792], [1792, 828]], 326, Color::BLACK, Platform::IOS)
+    IPHONE_11_PRO ||= Device.new("iphone-11-pro", "Apple iPhone 11 Pro", 9, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS)
+    IPHONE_11_PRO_MAX ||= Device.new("iphone11-pro-max", "Apple iPhone 11 Pro Max", 9, [[1242, 2688], [2688, 1242]], 458, Color::SPACE_GRAY, Platform::IOS)
+    IPHONE_12 ||= Device.new("iphone-12", "Apple iPhone 12", 10, [[1170, 2532], [2532, 1170]], 460, Color::BLACK, Platform::IOS)
+    IPHONE_12_PRO ||= Device.new("iphone-12-pro", "Apple iPhone 12 Pro", 10, [[1170, 2532], [2532, 1170]], 460, Color::SPACE_GRAY, Platform::IOS)
+    IPHONE_12_PRO_MAX ||= Device.new("iphone12-pro-max", "Apple iPhone 12 Pro Max", 10, [[1284, 2778], [2778, 1284]], 458, Color::GRAPHITE, Platform::IOS)
+    IPHONE_12_MINI ||= Device.new("iphone-12-mini", "Apple iPhone 12 Mini", 10, [[1125, 2436], [2436, 1125]], 476, Color::BLACK, Platform::IOS)
+    IPHONE_13 ||= Device.new("iphone-13", "Apple iPhone 13", 11, [[1170, 2532], [2532, 1170]], 460, Color::MIDNIGHT, Platform::IOS)
+    IPHONE_13_PRO ||= Device.new("iphone-13-pro", "Apple iPhone 13 Pro", 11, [[1170, 2532], [2532, 1170]], 460, Color::GRAPHITE, Platform::IOS)
+    IPHONE_13_PRO_MAX ||= Device.new("iphone13-pro-max", "Apple iPhone 13 Pro Max", 11, [[1284, 2778], [2778, 1284]], 458, Color::GRAPHITE, Platform::IOS)
+    IPHONE_13_MINI ||= Device.new("iphone-13-mini", "Apple iPhone 13 Mini", 11, [[1080, 2340], [2340, 1080]], 476, Color::MIDNIGHT, Platform::IOS)
+    IPHONE_14 ||= Device.new("iphone-14", "Apple iPhone 14", 12, [[1170, 2532], [2532, 1170]], 460, Color::MIDNIGHT, Platform::IOS)
+    IPHONE_14_PLUS ||= Device.new("iphone-14-plus", "Apple iPhone 14 Plus", 12, [[1284, 2778], [2778, 1284]], 458, Color::MIDNIGHT, Platform::IOS)
+    IPHONE_14_PRO ||= Device.new("iphone-14-pro", "Apple iPhone 14 Pro", 12, [[1178, 2556], [2556, 1178]], 460, Color::PURPLE, Platform::IOS)
+    IPHONE_14_PRO_MAX ||= Device.new("iphone14-pro-max", "Apple iPhone 14 Pro Max", 12, [[1290, 2796], [2796, 1290]], 458, Color::PURPLE, Platform::IOS)
+    IPAD_10_2 ||= Device.new("ipad-10-2", "Apple iPad 10.2", 1, [[1620, 2160], [2160, 1620]], 264, Color::SPACE_GRAY, Platform::IOS)
+    IPAD_AIR_2 ||= Device.new("ipad-air-2", "Apple iPad Air 2", 1, [[1536, 2048], [2048, 1536]], 264, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_97])
+    IPAD_AIR_2019 ||= Device.new("ipad-air-2019", "Apple iPad Air (2019)", 2, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS)
+    IPAD_MINI_4 ||= Device.new("ipad-mini-4", "Apple iPad Mini 4", 2, [[1536, 2048], [2048, 1536]], 324, Color::SPACE_GRAY)
+    IPAD_MINI_2019 ||= Device.new("ipad-mini-2019", "Apple iPad Mini (2019)", 3, [[1536, 2048], [2048, 1536]], 324, Color::SPACE_GRAY)
     # iPad Pro 12.9" (2nd gen):
-    IPAD_PRO ||= Frameit::Device.new("ipad-pro", "Apple iPad Pro", 3, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-Pro")
+    IPAD_PRO ||= Device.new("ipad-pro", "Apple iPad Pro", 3, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_PRO_129])
     # iPad Pro 13" (3rd gen - rebranded from 12.9"):
-    IPAD_PRO_12_9 ||= Frameit::Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (3rd generation)", 4, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-Pro-12.9")
+    IPAD_PRO_12_9 ||= Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (3rd generation)", 4, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_PRO_3GEN_129])
     # iPad Pro 13" (4th gen):
-    IPAD_PRO_12_9_4 ||= Frameit::Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (4th generation)", 5, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-Pro-12.9")
+    IPAD_PRO_12_9_4 ||= Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (4th generation)", 5, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_PRO_3GEN_129])
     # iPad Pro (10.5-inch) is not in frameit-frames repo, but must be included so that we are backward compatible with PR #15373
     # priority must be lower so that users who didn't copy the frame to their frameit frames folder will not get an error
     # ID and formatted name must be exactly as specified so that device.detect_device() will select this device if the filename includes them
-    IPAD_PRO_10_5 ||= Frameit::Device.new("ipad105", "Apple iPad Pro (10.5-inch)", 1, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-10.5")
-    IPAD_PRO_11 ||= Frameit::Device.new("ipadPro11", "Apple iPad Pro (11-inch)", 1, [[1668, 2388], [2388, 1668]], 265, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-11")
+    IPAD_PRO_10_5 ||= Device.new("ipad105", "Apple iPad Pro (10.5-inch)", 1, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_105])
+    IPAD_PRO_11 ||= Device.new("ipadPro11", "Apple iPad Pro (11-inch)", 1, [[1668, 2388], [2388, 1668]], 265, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_PRO_3GEN_11])
 
-    MAC ||= Frameit::Device.new("mac", "Apple MacBook", 0, [[1280, 800], [1440, 900], [2560, 1600], [2880, 1800]], nil, Color::SPACE_GRAY, Platform::IOS, "Mac")
+    MAC ||= Device.new("mac", "Apple MacBook", 0, [[1280, 800], [1440, 900], [2560, 1600], [2880, 1800]], nil, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_DESKTOP])
 
     def self.all_device_names_without_apple
       Devices.constants.map { |c| Devices.const_get(c).formatted_name_without_apple }

--- a/frameit/lib/frameit/device_types.rb
+++ b/frameit/lib/frameit/device_types.rb
@@ -109,19 +109,19 @@ module Frameit
     SAMSUNG_GALAXY_S10 ||= Frameit::Device.new("samsung-galaxy-s10", "Samsung Galaxy S10", 7, [[1440, 3040], [3040, 1440]], 550, Color::PRISM_BLACK, Platform::ANDROID)
     SAMSUNG_GALAXY_S10_PLUS ||= Frameit::Device.new("samsung-galaxy-s10-plus", "Samsung Galaxy S10+", 8, [[1440, 3040], [3040, 1440]], 522, Color::PRISM_BLACK, Platform::ANDROID)
     XIAOMI_MI_MIX_ALPHA ||= Frameit::Device.new("xiaomi-mi-mix-alpha", "Xiaomi Mi Mix Alpha", 1, [[2088, 2250], [2250, 2088]], 388, nil, Platform::ANDROID)
-    IPHONE_5S ||= Frameit::Device.new("iphone-5s", "Apple iPhone 5s", 2, [[640, 1096], [640, 1136], [1136, 600], [1136, 640]], 326, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_40, :use_legacy_iphone5s)
+    IPHONE_5S ||= Frameit::Device.new("iphone-5s", "Apple iPhone 5s", 2, [[640, 1096], [640, 1136], [1136, 600], [1136, 640]], 326, Color::SPACE_GRAY, Platform::IOS, "iOS-4-in", :use_legacy_iphone5s)
     IPHONE_5C ||= Frameit::Device.new("iphone-5c", "Apple iPhone 5c", 2, [[640, 1136], [1136, 640]], 326, Color::WHITE)
-    IPHONE_SE ||= Frameit::Device.new("iphone-se", "Apple iPhone SE", 3, [[640, 1096], [640, 1136], [1136, 600], [1136, 640]], 326, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_40)
-    IPHONE_6S ||= Frameit::Device.new("iphone-6s", "Apple iPhone 6s", 4, [[750, 1334], [1334, 750]], 326, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_47, :use_legacy_iphone6s)
-    IPHONE_6S_PLUS ||= Frameit::Device.new("iphone-6s-plus", "Apple iPhone 6s Plus", 4, [[1242, 2208], [2208, 1242]], 401, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_55, :use_legacy_iphone6s)
-    IPHONE_7 ||= Frameit::Device.new("iphone-7", "Apple iPhone 7", 5, [[750, 1334], [1334, 750]], 326, Color::MATTE_BLACK, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_47, :use_legacy_iphone7)
-    IPHONE_7_PLUS ||= Frameit::Device.new("iphone-7-plus", "Apple iPhone 7 Plus", 5, [[1242, 2208], [2208, 1242]], 401, Color::MATTE_BLACK, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_55, :use_legacy_iphone7)
+    IPHONE_SE ||= Frameit::Device.new("iphone-se", "Apple iPhone SE", 3, [[640, 1096], [640, 1136], [1136, 600], [1136, 640]], 326, Color::SPACE_GRAY, Platform::IOS, "iOS-4-in")
+    IPHONE_6S ||= Frameit::Device.new("iphone-6s", "Apple iPhone 6s", 4, [[750, 1334], [1334, 750]], 326, Color::SPACE_GRAY, Platform::IOS, "iOS-4.7-in", :use_legacy_iphone6s)
+    IPHONE_6S_PLUS ||= Frameit::Device.new("iphone-6s-plus", "Apple iPhone 6s Plus", 4, [[1242, 2208], [2208, 1242]], 401, Color::SPACE_GRAY, Platform::IOS, "iOS-5.5-in", :use_legacy_iphone6s)
+    IPHONE_7 ||= Frameit::Device.new("iphone-7", "Apple iPhone 7", 5, [[750, 1334], [1334, 750]], 326, Color::MATTE_BLACK, Platform::IOS, "iOS-4.7-in", :use_legacy_iphone7)
+    IPHONE_7_PLUS ||= Frameit::Device.new("iphone-7-plus", "Apple iPhone 7 Plus", 5, [[1242, 2208], [2208, 1242]], 401, Color::MATTE_BLACK, Platform::IOS, "iOS-5.5-in", :use_legacy_iphone7)
     IPHONE_8 ||= Frameit::Device.new("iphone-8", "Apple iPhone 8", 6, [[750, 1334], [1334, 750]], 326, Color::SPACE_GRAY)
     IPHONE_8_PLUS ||= Frameit::Device.new("iphone-8-plus", "Apple iPhone 8 Plus", 6, [[1242, 2208], [2208, 1242]], 401, Color::SPACE_GRAY)
-    IPHONE_X ||= Frameit::Device.new("iphone-X", "Apple iPhone X", 7, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_58, :use_legacy_iphonex)
-    IPHONE_XS ||= Frameit::Device.new("iphone-XS", "Apple iPhone XS", 8, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_58, :use_legacy_iphonexs)
-    IPHONE_XR ||= Frameit::Device.new("iphone-XR", "Apple iPhone XR", 8, [[828, 1792], [1792, 828]], 326, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_65, :use_legacy_iphonexsmax)
-    IPHONE_XS_MAX ||= Frameit::Device.new("iphone-XS-Max", "Apple iPhone XS Max", 8, [[1242, 2688], [2688, 1242]], 458, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_65, :use_legacy_iphonexsmax)
+    IPHONE_X ||= Frameit::Device.new("iphone-X", "Apple iPhone X", 7, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS, "iOS-5.8-in", :use_legacy_iphonex)
+    IPHONE_XS ||= Frameit::Device.new("iphone-XS", "Apple iPhone XS", 8, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS, "iOS-5.8-in", :use_legacy_iphonexs)
+    IPHONE_XR ||= Frameit::Device.new("iphone-XR", "Apple iPhone XR", 8, [[828, 1792], [1792, 828]], 326, Color::SPACE_GRAY, Platform::IOS, "iOS-6.5-in", :use_legacy_iphonexsmax)
+    IPHONE_XS_MAX ||= Frameit::Device.new("iphone-XS-Max", "Apple iPhone XS Max", 8, [[1242, 2688], [2688, 1242]], 458, Color::SPACE_GRAY, Platform::IOS, "iOS-6.5-in", :use_legacy_iphonexsmax)
     IPHONE_11 ||= Frameit::Device.new("iphone-11", "Apple iPhone 11", 9, [[828, 1792], [1792, 828]], 326, Color::BLACK, Platform::IOS)
     IPHONE_11_PRO ||= Frameit::Device.new("iphone-11-pro", "Apple iPhone 11 Pro", 9, [[1125, 2436], [2436, 1125]], 458, Color::SPACE_GRAY, Platform::IOS)
     IPHONE_11_PRO_MAX ||= Frameit::Device.new("iphone11-pro-max", "Apple iPhone 11 Pro Max", 9, [[1242, 2688], [2688, 1242]], 458, Color::SPACE_GRAY, Platform::IOS)
@@ -138,23 +138,23 @@ module Frameit
     IPHONE_14_PRO ||= Frameit::Device.new("iphone-14-pro", "Apple iPhone 14 Pro", 12, [[1178, 2556], [2556, 1178]], 460, Color::PURPLE, Platform::IOS)
     IPHONE_14_PRO_MAX ||= Frameit::Device.new("iphone14-pro-max", "Apple iPhone 14 Pro Max", 12, [[1290, 2796], [2796, 1290]], 458, Color::PURPLE, Platform::IOS)
     IPAD_10_2 ||= Frameit::Device.new("ipad-10-2", "Apple iPad 10.2", 1, [[1620, 2160], [2160, 1620]], 264, Color::SPACE_GRAY, Platform::IOS)
-    IPAD_AIR_2 ||= Frameit::Device.new("ipad-air-2", "Apple iPad Air 2", 1, [[1536, 2048], [2048, 1536]], 264, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_IPAD)
+    IPAD_AIR_2 ||= Frameit::Device.new("ipad-air-2", "Apple iPad Air 2", 1, [[1536, 2048], [2048, 1536]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad")
     IPAD_AIR_2019 ||= Frameit::Device.new("ipad-air-2019", "Apple iPad Air (2019)", 2, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS)
     IPAD_MINI_4 ||= Frameit::Device.new("ipad-mini-4", "Apple iPad Mini 4", 2, [[1536, 2048], [2048, 1536]], 324, Color::SPACE_GRAY)
     IPAD_MINI_2019 ||= Frameit::Device.new("ipad-mini-2019", "Apple iPad Mini (2019)", 3, [[1536, 2048], [2048, 1536]], 324, Color::SPACE_GRAY)
     # this is 1st or 2nd gen of iPad Pro 12.9:
-    IPAD_PRO ||= Frameit::Device.new("ipad-pro", "Apple iPad Pro", 3, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO)
+    IPAD_PRO ||= Frameit::Device.new("ipad-pro", "Apple iPad Pro", 3, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-Pro")
     # 3rd generation:
-    IPAD_PRO_12_9 ||= Frameit::Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (3rd generation)", 4, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_12_9)
+    IPAD_PRO_12_9 ||= Frameit::Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (3rd generation)", 4, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-Pro-12.9")
     # 4th generation:
-    IPAD_PRO_12_9_4 ||= Frameit::Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (4th generation)", 5, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_IPAD_PRO_12_9)
+    IPAD_PRO_12_9_4 ||= Frameit::Device.new("ipadPro129", "Apple iPad Pro (12.9-inch) (4th generation)", 5, [[2048, 2732], [2732, 2048]], 264, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-Pro-12.9")
     # iPad Pro (10.5-inch) is not in frameit-frames repo, but must be included so that we are backward compatible with PR #15373
     # priority must be lower so that users who didn't copy the frame to their frameit frames folder will not get an error
     # ID and formatted name must be exactly as specified so that device.detect_device() will select this device if the filename includes them
-    IPAD_PRO_10_5 ||= Frameit::Device.new("ipad105", "Apple iPad Pro (10.5-inch)", 1, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_IPAD_10_5)
-    IPAD_PRO_11 ||= Frameit::Device.new("ipadPro11", "Apple iPad Pro (11-inch)", 1, [[1668, 2388], [2388, 1668]], 265, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::IOS_IPAD_11)
+    IPAD_PRO_10_5 ||= Frameit::Device.new("ipad105", "Apple iPad Pro (10.5-inch)", 1, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-10.5")
+    IPAD_PRO_11 ||= Frameit::Device.new("ipadPro11", "Apple iPad Pro (11-inch)", 1, [[1668, 2388], [2388, 1668]], 265, Color::SPACE_GRAY, Platform::IOS, "iOS-iPad-11")
 
-    MAC ||= Frameit::Device.new("mac", "Apple MacBook", 0, [[1280, 800], [1440, 900], [2560, 1600], [2880, 1800]], nil, Color::SPACE_GRAY, Platform::IOS, Deliver::AppScreenshot::ScreenSize::MAC)
+    MAC ||= Frameit::Device.new("mac", "Apple MacBook", 0, [[1280, 800], [1440, 900], [2560, 1600], [2880, 1800]], nil, Color::SPACE_GRAY, Platform::IOS, "Mac")
 
     def self.all_device_names_without_apple
       Devices.constants.map { |c| Devices.const_get(c).formatted_name_without_apple }

--- a/frameit/lib/frameit/template_finder.rb
+++ b/frameit/lib/frameit/template_finder.rb
@@ -24,7 +24,7 @@ module Frameit
       end
 
       if templates.count == 0
-        if screenshot.deliver_screen_id == "iOS-3.5-in"
+        if screenshot.deliver_screen_id == DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_35]
           UI.important("Unfortunately 3.5\" device frames were discontinued. Skipping screen '#{screenshot.path}'")
           UI.error("Looked for: '#{filename}.png'")
         else

--- a/frameit/lib/frameit/template_finder.rb
+++ b/frameit/lib/frameit/template_finder.rb
@@ -24,7 +24,7 @@ module Frameit
       end
 
       if templates.count == 0
-        if screenshot.deliver_screen_id == Deliver::AppScreenshot::ScreenSize::IOS_35
+        if screenshot.deliver_screen_id == "iOS-3.5-in"
           UI.important("Unfortunately 3.5\" device frames were discontinued. Skipping screen '#{screenshot.path}'")
           UI.error("Looked for: '#{filename}.png'")
         else

--- a/frameit/spec/device_spec.rb
+++ b/frameit/spec/device_spec.rb
@@ -87,7 +87,7 @@ describe Frameit::Device do
         expect_forced_screen_size("iPhone X").to eq(Devices::IPHONE_X)
       end
 
-      it "should force iPhone XS despite arbitrary file name and resolution via Deliver::AppScreenshot::ScreenSize" do
+      it "should force iPhone XS despite arbitrary file name and resolution via display type string" do
         expect_forced_screen_size("iOS-5.8-in").to eq(Devices::IPHONE_XS)
       end
     end

--- a/frameit/spec/template_finder_spec.rb
+++ b/frameit/spec/template_finder_spec.rb
@@ -1,6 +1,10 @@
 require 'ostruct'
+
 describe Frameit do
   describe Frameit::TemplateFinder do
+    DEVICE_SCREEN_IDS = Frameit::DEVICE_SCREEN_IDS
+    DisplayType = Frameit::DisplayType
+
     describe 'it can find some screenshots' do
       # Prevent the tests from looking in the real home
       # directory.
@@ -36,7 +40,7 @@ describe Frameit do
                                          device_name: 'Apple iPhone-SE',
                                          color: 'SpaceGray',
                                          orientation_name: 'Vert',
-                                         deliver_screen_id: 'iOS-4-in'
+                                         deliver_screen_id: DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_40]
         })
         expected_result = 'Apple iPhone-SE SpaceGray'
 
@@ -48,7 +52,7 @@ describe Frameit do
                                          device_name: 'Apple iPhone-SE',
                                          color: 'Silver',
                                          orientation_name: 'Horz',
-                                         deliver_screen_id: 'iOS-4-in'
+                                         deliver_screen_id: DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_40]
         })
         expected_result = 'Apple iPhone-SE Silver'
 
@@ -60,7 +64,7 @@ describe Frameit do
                                          device_name: 'Apple iPhone_5s',
                                          color: 'SpaceGray',
                                          orientation_name: 'Horz',
-                                         deliver_screen_id: 'iOS-4-in'
+                                         deliver_screen_id: DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_40]
         })
         expected_result = 'Apple iPhone_5s SpaceGray'
 
@@ -70,7 +74,7 @@ describe Frameit do
       it 'finds an iPhone 6s' do
         screenshot = make_screenshot({
                                          device_name: 'Apple iPhone-6s',
-                                         deliver_screen_id: 'iOS-4.7-in'
+                                         deliver_screen_id: DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_47]
         })
         expected_result = 'Apple iPhone-6s silver'
 
@@ -81,7 +85,7 @@ describe Frameit do
         screenshot = make_screenshot({
                                          device_name: 'Apple iPhone-6s-Plus',
                                          orientation_name: 'Horz',
-                                         deliver_screen_id: 'iOS-4.7-in'
+                                         deliver_screen_id: DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_47]
         })
         expected_result = 'Apple iPhone-6s-Plus silver'
 
@@ -91,7 +95,7 @@ describe Frameit do
       it 'finds an ipad mini' do
         screenshot = make_screenshot({
                                          device_name: 'Apple iPad-mini',
-                                         deliver_screen_id: 'iOS-iPad'
+                                         deliver_screen_id: DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_97]
         })
         expected_result = 'Apple iPad-mini silver'
 
@@ -103,7 +107,7 @@ describe Frameit do
                                          device_name: 'Apple iPad-Pro',
                                          color: 'SpaceGray',
                                          orientation_name: 'Vert',
-                                         deliver_screen_id: 'iOS-iPad-Pro'
+                                         deliver_screen_id: DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_PRO_129]
         })
         expected_result = 'Apple iPad-Pro SpaceGray'
 

--- a/spaceship/lib/spaceship/connect_api/models/app_info_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_info_localization.rb
@@ -33,15 +33,15 @@ module Spaceship
         client ||= Spaceship::ConnectAPI
         attributes = reverse_attr_mapping(attributes)
         client.patch_app_info_localization(app_info_localization_id: id, attributes: attributes)
-      rescue
-        raise Spaceship::AppStoreLocalizationError, @locale
+      rescue => error
+        raise Spaceship::AppStoreLocalizationError.new(@locale, error)
       end
 
       def delete!(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
         client.delete_app_info_localization(app_info_localization_id: id)
-      rescue
-        raise Spaceship::AppStoreLocalizationError, @locale
+      rescue => error
+        raise Spaceship::AppStoreLocalizationError.new(@locale, error)
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
@@ -43,11 +43,14 @@ module Spaceship
         APP_WATCH_SERIES_3 = "APP_WATCH_SERIES_3"
         APP_WATCH_SERIES_4 = "APP_WATCH_SERIES_4"
         APP_WATCH_SERIES_7 = "APP_WATCH_SERIES_7"
+        APP_WATCH_SERIES_10 = "APP_WATCH_SERIES_10"
         APP_WATCH_ULTRA = "APP_WATCH_ULTRA"
 
         APP_APPLE_TV = "APP_APPLE_TV"
 
         APP_DESKTOP = "APP_DESKTOP"
+
+        APP_APPLE_VISION_PRO = "APP_APPLE_VISION_PRO"
 
         ALL_IMESSAGE = [
           IMESSAGE_APP_IPHONE_40,
@@ -98,9 +101,12 @@ module Spaceship
           APP_WATCH_SERIES_3,
           APP_WATCH_SERIES_4,
           APP_WATCH_SERIES_7,
+          APP_WATCH_SERIES_10,
           APP_WATCH_ULTRA,
 
-          APP_DESKTOP
+          APP_DESKTOP,
+
+          APP_APPLE_VISION_PRO
         ]
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
@@ -2,7 +2,6 @@ require_relative '../model'
 require_relative './app_preview_set'
 require_relative './app_screenshot_set'
 require_relative '../../errors'
-require_relative '../../module'
 
 module Spaceship
   class ConnectAPI
@@ -105,7 +104,6 @@ module Spaceship
       end
 
       def create_app_screenshot_set(client: nil, attributes: nil)
-        UI.verbose("Creating screenshot set for localization attributes: #{attributes}")
         client ||= Spaceship::ConnectAPI
         resp = client.post_app_screenshot_set(app_store_version_localization_id: id, attributes: attributes)
         return resp.to_models.first

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
@@ -2,6 +2,7 @@ require_relative '../model'
 require_relative './app_preview_set'
 require_relative './app_screenshot_set'
 require_relative '../../errors'
+require_relative '../../module'
 
 module Spaceship
   class ConnectAPI
@@ -44,31 +45,31 @@ module Spaceship
         client ||= Spaceship::ConnectAPI
         resp = client.get_app_store_version_localization(app_store_version_localization_id: app_store_version_localization_id, filter: filter, includes: includes, limit: limit, sort: sort)
         return resp.to_models
-      rescue
-        raise Spaceship::AppStoreLocalizationError, @locale
+      rescue => error
+        raise Spaceship::AppStoreLocalizationError.new(@locale, error)
       end
 
       def self.all(client: nil, app_store_version_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.get_app_store_version_localizations(app_store_version_id: app_store_version_id, filter: filter, includes: includes, limit: limit, sort: sort)
         return resp.to_models
-      rescue
-        raise Spaceship::AppStoreLocalizationError, @locale
+      rescue => error
+        raise Spaceship::AppStoreLocalizationError.new(@locale, error)
       end
 
       def update(client: nil, attributes: nil)
         client ||= Spaceship::ConnectAPI
         attributes = reverse_attr_mapping(attributes)
         client.patch_app_store_version_localization(app_store_version_localization_id: id, attributes: attributes)
-      rescue
-        raise Spaceship::AppStoreLocalizationError, @locale
+      rescue => error
+        raise Spaceship::AppStoreLocalizationError.new(@locale, error)
       end
 
       def delete!(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
         client.delete_app_store_version_localization(app_store_version_localization_id: id)
-      rescue
-        raise Spaceship::AppStoreLocalizationError, @locale
+      rescue => error
+        raise Spaceship::AppStoreLocalizationError.new(@locale, error)
       end
 
       #
@@ -80,16 +81,16 @@ module Spaceship
         filter ||= {}
         filter["appStoreVersionLocalization"] = id
         return Spaceship::ConnectAPI::AppPreviewSet.all(client: client, filter: filter, includes: includes, limit: limit, sort: sort)
-      rescue
-        raise Spaceship::AppStoreAppPreviewError, @locale
+      rescue => error
+        raise Spaceship::AppStoreAppPreviewError.new(@locale, error)
       end
 
       def create_app_preview_set(client: nil, attributes: nil)
         client ||= Spaceship::ConnectAPI
         resp = client.post_app_preview_set(app_store_version_localization_id: id, attributes: attributes)
         return resp.to_models.first
-      rescue
-        raise Spaceship::AppStoreAppPreviewError, @locale
+      rescue => error
+        raise Spaceship::AppStoreAppPreviewError.new(@locale, error)
       end
 
       #
@@ -99,16 +100,17 @@ module Spaceship
       def get_app_screenshot_sets(client: nil, filter: {}, includes: "appScreenshots", limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
         return Spaceship::ConnectAPI::AppScreenshotSet.all(client: client, app_store_version_localization_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
-      rescue
-        raise Spaceship::AppStoreScreenshotError, @locale
+      rescue => error
+        raise Spaceship::AppStoreScreenshotError.new(@locale, error)
       end
 
       def create_app_screenshot_set(client: nil, attributes: nil)
+        UI.verbose("Creating screenshot set for localization attributes: #{attributes}")
         client ||= Spaceship::ConnectAPI
         resp = client.post_app_screenshot_set(app_store_version_localization_id: id, attributes: attributes)
         return resp.to_models.first
-      rescue
-        raise Spaceship::AppStoreScreenshotError, @locale
+      rescue => error
+        raise Spaceship::AppStoreScreenshotError.new(@locale, error)
       end
     end
   end

--- a/spaceship/lib/spaceship/errors.rb
+++ b/spaceship/lib/spaceship/errors.rb
@@ -116,9 +116,11 @@ module Spaceship
 
   # Base class for errors coming from App Store Connect locale changes
   class AppStoreLocaleError < BasicPreferredInfoError
-    def initialize(msg)
-      @message = (msg ? "An exception occurred for locale: #{msg}." : nil)
-      super
+    def initialize(locale, error)
+      error_message = error.respond_to?(:message) ? error.message : error.to_s
+      locale_str = locale || "unknown"
+      @message = "An exception has occurred for locale: #{locale_str}.\nError: #{error_message}"
+      super(@message)
     end
 
     # no need to search github issues since the error is specific
@@ -130,21 +132,21 @@ module Spaceship
   # Raised for localized text errors from App Store Connect
   class AppStoreLocalizationError < AppStoreLocaleError
     def preferred_error_info
-      "#{@message} Check the localization requirements here: https://developer.apple.com/help/app-store-connect/manage-app-information/localize-app-information"
+      "#{@message}\nCheck the localization requirements here: https://developer.apple.com/help/app-store-connect/manage-app-information/localize-app-information"
     end
   end
 
   # Raised for localized screenshots errors from App Store Connect
   class AppStoreScreenshotError < AppStoreLocaleError
     def preferred_error_info
-      "#{@message} Check the screenshot requirements here: https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications"
+      "#{@message}\nCheck the screenshot requirements here: https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications"
     end
   end
 
   # Raised for localized app preview errors from App Store Connect
   class AppStoreAppPreviewError < AppStoreLocaleError
     def preferred_error_info
-      "#{@message} Check the app preview requirements here: https://developer.apple.com/help/app-store-connect/reference/app-preview-specifications"
+      "#{@message}\nCheck the app preview requirements here: https://developer.apple.com/help/app-store-connect/reference/app-preview-specifications"
     end
   end
 end

--- a/spaceship/lib/spaceship/errors.rb
+++ b/spaceship/lib/spaceship/errors.rb
@@ -130,21 +130,21 @@ module Spaceship
   # Raised for localized text errors from App Store Connect
   class AppStoreLocalizationError < AppStoreLocaleError
     def preferred_error_info
-      "#{@message} Check the localization requirements here: https://help.apple.com/app-store-connect/en.lproj/static.html#dev354659071"
+      "#{@message} Check the localization requirements here: https://developer.apple.com/help/app-store-connect/manage-app-information/localize-app-information"
     end
   end
 
   # Raised for localized screenshots errors from App Store Connect
   class AppStoreScreenshotError < AppStoreLocaleError
     def preferred_error_info
-      "#{@message} Check the screenshot requirements here: https://help.apple.com/app-store-connect/en.lproj/static.html#devd274dd925"
+      "#{@message} Check the screenshot requirements here: https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications"
     end
   end
 
   # Raised for localized app preview errors from App Store Connect
   class AppStoreAppPreviewError < AppStoreLocaleError
     def preferred_error_info
-      "#{@message} Check the app preview requirements here: https://help.apple.com/app-store-connect/en.lproj/static.html#dev4e413fcb8"
+      "#{@message} Check the app preview requirements here: https://developer.apple.com/help/app-store-connect/reference/app-preview-specifications"
     end
   end
 end

--- a/spaceship/lib/spaceship/module.rb
+++ b/spaceship/lib/spaceship/module.rb
@@ -1,11 +1,7 @@
-require 'fastlane_core/ui/ui'
-
 module Spaceship
   # Requiring pathname is required here if not using bundler and requiring spaceship directly
   # https://github.com/fastlane/fastlane/issues/14661
   require 'pathname'
-
-  UI = FastlaneCore::UI
 
   ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
   DESCRIPTION = "Ruby library to access the Apple Dev Center and App Store Connect".freeze

--- a/spaceship/lib/spaceship/module.rb
+++ b/spaceship/lib/spaceship/module.rb
@@ -1,7 +1,11 @@
+require 'fastlane_core/ui/ui'
+
 module Spaceship
   # Requiring pathname is required here if not using bundler and requiring spaceship directly
   # https://github.com/fastlane/fastlane/issues/14661
   require 'pathname'
+
+  UI = FastlaneCore::UI
 
   ROOT = Pathname.new(File.expand_path('../../..', __FILE__))
   DESCRIPTION = "Ruby library to access the Apple Dev Center and App Store Connect".freeze


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
There have been complaints for a long time about missing iPad resolutions for the _deliver_ action. E.g. #22030 and #22267.

### Description

In this PR I've cross checked _deliver_ and _spaceship_ devices and resolutions against current Apple specs:
- https://developer.apple.com/help/app-store-connect/reference/app-information/screenshot-specifications/
- https://developer.apple.com/documentation/appstoreconnectapi/screenshotdisplaytype

and systematically added support for all modern variants.

I've also updated the conflict resolution mechanism so that iPad Pro's and tv vs Vision Pro get disambiguated properly according to their file names. About iPads in particular I've taken the approach to only detect the rare 2nd generation by certain heuristics, otherwise fallback to the more widespread 13" model, which also appear the first inside AppStoreConnect. I did my best to tweak the logic in a way so that existing setups don't break.

Also have removed the old `Deliver::AppScreenshot::ScreenSize` class as it was basically a duplicate of `Spaceship::ConnectAPI::AppScreenshotSet::DisplayType`, and made _deliver_ use the latter throughout. The raw values of the old ScreenSize were only used in _frameit_, so have moved it there as a hash.

### Testing Steps

Updated/added relevant tests. They should continue to pass.

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

---

fixes: #22267 
fixes: #29651
fixes: #22030
fixes: #29632
fixes: #29578

closes: #29742
closes: #29670
closes: #29640
closes: #22066
closes: #22036 
closes: #22288
closes: #29695


