### PR TITLE
[ci] downgrade to 2.4.22 bundler for 2.6.x Ruby support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ workflows:
           ruby_opt: -W:deprecated
       - tests_ubuntu:
           name: 'Execute tests on Ubuntu'
-          image: 'cimg/ruby:3.2-node'
+          image: 'cimg/ruby:3.2.2-node'
       - validate_fastlane_swift_generation:
           name: 'Validate Fastlane.swift generation'
           xcode_version: '15.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,4 +404,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   2.5.23
+   2.4.22


### PR DESCRIPTION
Oops. In #29753 I moved to 2.5 Bundler, which moved Ruby min to 3.0. While that is a goal in future to drop the EOL Ruby 2.x - that was not my intent.

https://bundler.io/compatibility.html

To resolve an issue on the CircleCI Ubuntu runner, I dropped to a specific version of the container as the alias `3.2-node` updated to a backed image with bundler 2.7.1. The bin shims configured didn't play nice as we tried to downgrade 2.7 to 2.4, so just using an older image should work.