### PR TITLE
[ci] lock standard gem openssl to non-affected version(s) to support OpenSSL 3.6.0+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,13 @@ gem "danger-junit", "~> 1.0"
 gem "fakefs", "1.8"
 # for file uploads with Faraday
 gem "mime-types", ['>= 1.16', '< 4.0']
-# standard library for OpenSSL is 3.1.0, but we need a fix for openssl
+# standard library for OpenSSL has affected versions.
 # https://github.com/ruby/openssl/issues/949#issuecomment-3370358680
-gem "openssl", "~> 3.1.1"
+gem "openssl",
+    ">= 3.1.2",
+    "!= 3.2.0",
+    "!= 3.2.1",
+    "!= 3.3.0"
 # Fast XML parser and object marshaller.
 # Version 2.14.15+ requires Ruby >=2.7, while fastlane uses a `required_ruby_version` of `>= 2.6`.
 gem "ox", "2.14.14"

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,9 @@ gem "danger-junit", "~> 1.0"
 gem "fakefs", "1.8"
 # for file uploads with Faraday
 gem "mime-types", ['>= 1.16', '< 4.0']
+# standard library for OpenSSL is 3.3.0, but we need a fix for openssl
+# https://github.com/ruby/openssl/issues/949#issuecomment-3370358680
+gem "openssl", "~> 3.3.1"
 # Fast XML parser and object marshaller.
 # Version 2.14.15+ requires Ruby >=2.7, while fastlane uses a `required_ruby_version` of `>= 2.6`.
 gem "ox", "2.14.14"

--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,9 @@ gem "danger-junit", "~> 1.0"
 gem "fakefs", "1.8"
 # for file uploads with Faraday
 gem "mime-types", ['>= 1.16', '< 4.0']
-# standard library for OpenSSL is 3.3.0, but we need a fix for openssl
+# standard library for OpenSSL is 3.1.0, but we need a fix for openssl
 # https://github.com/ruby/openssl/issues/949#issuecomment-3370358680
-gem "openssl", "~> 3.3.1"
+gem "openssl", "~> 3.1.1"
 # Fast XML parser and object marshaller.
 # Version 2.14.15+ requires Ruby >=2.7, while fastlane uses a `required_ruby_version` of `>= 2.6`.
 gem "ox", "2.14.14"

--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,8 @@ gem "danger-junit", "~> 1.0"
 gem "fakefs", "1.8"
 # for file uploads with Faraday
 gem "mime-types", ['>= 1.16', '< 4.0']
-# standard library for OpenSSL has affected versions.
-# https://github.com/ruby/openssl/issues/949#issuecomment-3370358680
+# standard library for OpenSSL has affected versions (unable to get certificate CRL) - ruby/openssl/issues/949
+# We block affected versions here so a patched gem version will be used regardless of Ruby version.
 gem "openssl",
     ">= 3.1.2",
     "!= 3.2.0",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
-    openssl (3.3.2)
+    openssl (3.1.3)
     optparse (0.4.0)
     os (1.1.4)
     ox (2.14.14)
@@ -386,7 +386,7 @@ DEPENDENCIES
   fastlane-plugin-ruby
   fastlane-plugin-slack_train (>= 0.2.0)
   mime-types (>= 1.16, < 4.0)
-  openssl (~> 3.3.1)
+  openssl (~> 3.1.1)
   ox (= 2.14.14)
   pry
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
+    openssl (3.3.2)
     optparse (0.4.0)
     os (1.1.4)
     ox (2.14.14)
@@ -385,6 +386,7 @@ DEPENDENCIES
   fastlane-plugin-ruby
   fastlane-plugin-slack_train (>= 0.2.0)
   mime-types (>= 1.16, < 4.0)
+  openssl (~> 3.3.1)
   ox (= 2.14.14)
   pry
   pry-byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,7 +386,7 @@ DEPENDENCIES
   fastlane-plugin-ruby
   fastlane-plugin-slack_train (>= 0.2.0)
   mime-types (>= 1.16, < 4.0)
-  openssl (~> 3.1.1)
+  openssl (>= 3.1.2, != 3.3.0, != 3.2.1, != 3.2.0)
   ox (= 2.14.14)
   pry
   pry-byebug

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,6 +73,9 @@ desc "Runs the tests"
 lane :execute_tests do
   version = local_version # has to be outside of the `Dir.chdir`
 
+  # Verify SSL connection is alright.
+  download(url: "https://rubygems.org/api/v1/gems/fastlane.json")
+
   # Verifying the --help command
   Dir.chdir("..") do
     cmd = Helper.windows? ? "cd bin && fastlane --help" : "PAGER=cat bin/fastlane --help"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,7 +73,7 @@ desc "Runs the tests"
 lane :execute_tests do
   version = local_version # has to be outside of the `Dir.chdir`
 
-  # Verify SSL connection is alright.
+  # Verify SSL connection is alright - https://github.com/fastlane/fastlane/issues/29710
   download(url: "https://rubygems.org/api/v1/gems/fastlane.json")
 
   # Verifying the --help command


### PR DESCRIPTION
### The Problem

During v2.229 release - it failed on multiple retries.

```
[16:08:58]: Called from Fastfile at line 703
[16:08:58]: ```
[16:08:58]:     701:	private_lane :current_version do
[16:08:58]:     702:	  puts("Checking the latest version on RubyGems")
[16:08:58]:  => 703:	  download(url: "https://rubygems.org/api/v1/gems/fastlane.json")["version"]
[16:08:58]:     704:	end
[16:08:58]:     705:	
[16:08:58]: ```
[16:08:58]: Error fetching remote file: SSL_connect returned=1 errno=0 peeraddr=151.101.129.227:443 state=error: certificate verify failed (unable to get certificate CRL)
```

This is because Ruby 3.2 has openssl 3.1.0 gem (as part of the standard library). That version had [a flaw](https://github.com/ruby/openssl/issues/949#issuecomment-3370358680) that a recent OpenSSL 3.6.0 version released made apparent. Sure enough `macos-latest` has that version of OpenSSL.

```
brew info openssl                 
==> openssl@3: stable 3.6.0 (bottled)
```

### The Solution

`openssl` is a standard gem, so we need to upgrade to a version past what standard library uses to get to this fix.

<img width="286" height="399" alt="Screenshot 2025-11-21 at 11 43 49 AM" src="https://github.com/user-attachments/assets/b27e101d-0ef1-4330-9c11-8ddc37fd487b" />

Since CI for release runs on Ruby 3.2 - that has version 3.1.0 of [standard gem](https://stdgems.org/openssl/) openssl. We know the fixed version is 3.1.2, so we can set our minimum to 3.1.2. Unfortunately this will require a native compilation of openssl, because it's no longer matching the standard gem for Ruby 3.2.

The challenge we face is supporting Ruby 2.6, which [openssl 3.2](https://github.com/ruby/openssl?tab=readme-ov-file#compatibility-and-maintenance-policy) dropped support for. So we devise a criteria of blocking the affected gem versions to force user-land to upgrade to a constraint that fits them.

<img width="867" height="437" alt="Screenshot 2025-11-21 at 12 10 32 PM" src="https://github.com/user-attachments/assets/30a611fc-2dce-4aee-bc5b-e5e60ded5f14" />

### Testing

A simple HTTPS test was added to confirm the SSL fix.

