### PR TITLE
[ci] speed up release actions + fix gha publishing

### DIFF
--- a/.github/workflows/release_step_1_create_version_bump.yml
+++ b/.github/workflows/release_step_1_create_version_bump.yml
@@ -29,9 +29,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2
-
-    - name: Install fastlane
-      run: bundle install
+        bundler-cache: true
 
     - name: Run fastlane bump
       run: |
@@ -46,4 +44,3 @@ jobs:
         FL_CHANGELOG_SLEEP: 10
         FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 180
         FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 5
-        

--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -35,9 +35,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.2'
-
-    - name: Install fastlane
-      run: bundle install
+        bundler-cache: true
 
     - uses: rubygems/configure-rubygems-credentials@v1.0.0
 

--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: macos-latest
 
     permissions:
+      packages: write
       contents: write
       id-token: write
 


### PR DESCRIPTION
## Problem

GHA publishing [failed](https://github.com/fastlane/fastlane/actions/runs/19583577849/job/56087194441) with:

```
Your request could not be authenticated by the GitHub Packages service. Please ensure your access token is valid and has the appropriate scopes configured.
```

The token was missing `packages: write` so had no permission to write. Difficult to test this, but I believe that to be the issue.

## Solution

We added bundler cache for `ruby/setup-ruby` for a speed up and added `packages:write` for the release flow.
