### PR TITLE
build: enhance update_docs workflow

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -579,7 +579,7 @@ lane :update_docs do |options|
   version = options[:version]
 
   unless debug
-    verify_env_variables
+    verify_env_variables(skip_ruby_gems: true)
     ensure_actions_config_items_formatting
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -576,7 +576,9 @@ desc "Update the actions.md on https://docs.fastlane.tools"
 desc "This will also automatically submit a pull request to fastlane/docs"
 lane :update_docs do |options|
   debug = options[:debug]
-  version = options[:version]
+  version = options[:version] || current_version
+
+  puts("Starting docs update for version #{version} 🚀")
 
   unless debug
     verify_env_variables(skip_ruby_gems: true)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -602,9 +602,11 @@ lane :update_docs do |options|
       File.expand_path(current_output_path) # to make sure we commit the change
     end
 
+    # We want to align fastlane/docs "fastlane" version with the latest released version.
+    # This ensures documentation tests leverage the latest action parameters and code samples.
     unless options[:skip_bundle_update]
-      Bundler.with_clean_env do
-        sh("bundle update")
+      Bundler.with_unbundled_env do
+        sh("bundle update fastlane")
       end
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -608,7 +608,7 @@ lane :update_docs do |options|
     # This ensures documentation tests leverage the latest action parameters and code samples.
     unless options[:skip_bundle_update]
       Bundler.with_unbundled_env do
-        sh("bundle update fastlane")
+        sh('bundle', 'update', 'fastlane')
       end
     end
 

--- a/fastlane/actions/plugin_scores.rb
+++ b/fastlane/actions/plugin_scores.rb
@@ -12,7 +12,7 @@ module Fastlane
         result += "# Available Plugins\n\n\n"
         result += plugins.collect do |current_plugin|
           @plugin = current_plugin
-          result = ERB.new(File.read(params[:template_path]), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
+          result = ERB.new(File.read(params[:template_path]), trim_mode: '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
         end.join("\n")
 
         File.write(File.join("docs", params[:output_path]), result)

--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -194,7 +194,7 @@ module Fastlane
         def append_git_data
           Dir.mktmpdir("fastlane-plugin") do |tmp|
             clone_folder = File.join(tmp, self.name)
-            `GIT_TERMINAL_PROMPT=0 git clone --filter=blob:none #{self.homepage.shellescape} #{clone_folder.shellescape}`
+            `GIT_TERMINAL_PROMPT=0 git clone #{self.homepage.shellescape} #{clone_folder.shellescape}`
 
             break unless File.directory?(clone_folder)
 

--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -67,7 +67,11 @@ module Fastlane
           }
 
           if File.exist?(cache_path)
-            self.cache = YAML.load_file(cache_path)
+            self.cache = YAML.safe_load(
+              File.read(cache_path),
+              permitted_classes: [Date, Time, Symbol, FastlanePluginAction],
+              aliases: true
+            )
           else
             self.cache = {}
           end
@@ -190,7 +194,7 @@ module Fastlane
         def append_git_data
           Dir.mktmpdir("fastlane-plugin") do |tmp|
             clone_folder = File.join(tmp, self.name)
-            `GIT_TERMINAL_PROMPT=0 git clone #{self.homepage.shellescape} #{clone_folder.shellescape}`
+            `GIT_TERMINAL_PROMPT=0 git clone --filter=blob:none #{self.homepage.shellescape} #{clone_folder.shellescape}`
 
             break unless File.directory?(clone_folder)
 

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -97,7 +97,7 @@ module Fastlane
       if File.exist?(custom_file_location)
         UI.verbose("Using custom md.erb file for action #{action.action_name}")
 
-        result = ERB.new(File.read(custom_file_location), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
+        result = ERB.new(File.read(custom_file_location), trim_mode: '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
 
         return result
       end
@@ -122,7 +122,7 @@ module Fastlane
         end
 
         template = File.join(Fastlane::ROOT, "lib/assets/ActionDetails.md.erb")
-        result = ERB.new(File.read(template), 0, '-').result(binding)
+        result = ERB.new(File.read(template), trim_mode: '-').result(binding)
 
         action_mds[action.action_name] = result
       end
@@ -139,7 +139,7 @@ module Fastlane
 
       # Generate actions.md
       template = File.join(Fastlane::ROOT, "lib/assets/Actions.md.erb")
-      result = ERB.new(File.read(template), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
+      result = ERB.new(File.read(template), trim_mode: '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
       File.write(File.join(docs_dir, "generated", "actions.md"), result)
 
       # Generate actions sub pages (e.g. generated/actions/slather.md, generated/actions/scan.md)
@@ -165,7 +165,7 @@ module Fastlane
         end
 
         template = File.join(Fastlane::ROOT, "lib/assets/ActionDetails.md.erb")
-        result = ERB.new(File.read(template), 0, '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
+        result = ERB.new(File.read(template), trim_mode: '-').result(binding) # https://web.archive.org/web/20160430190141/www.rrn.dk/rubys-erb-templating-system
 
         # Actions get placed in "generated/actions" directory
         file_name = File.join(generated_actions_dir, "#{action.action_name}.md")


### PR DESCRIPTION
These changes generated these v2.229.0 docs - https://github.com/fastlane/docs/pull/1292

---

### Problems

1. Executing this `update_docs` locally on Ruby 3.4 fails bad as `Yaml.load_file` is insecure and we need `safe_load`.
2. It spams a lot of warnings.
3. Version is missing if you execute it bare.
4. `bundle update` was too large when you are only trying to update fastlane to latest.
5. Requires ruby gem creds to update docs?


(warning)
```
/Volumes/Nexus/fastlane/fastlane/fastlane/actions/plugin_scores.rb:15: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
```

(no version)
```
[16:03:51]: ▸ [update-actions-md-1763845262 9d86510] Update docs for latest fastlane release  (actions.md, available-plugins.md) 🚀
```

## Solutions
1. Use safer YAML load.
2. Fix deprecation(s).
3. Fallback to current fastlane version if no explicit one passed.
4. Only update fastlane
5. Removes rubygem cred requirement for doc update.