### PR TITLE
build: releases should ignore changes to .bundle/config

### DIFF
--- a/.github/workflows/release_step_1_create_version_bump.yml
+++ b/.github/workflows/release_step_1_create_version_bump.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
 
+    - name: Ignore changes to .bundle/config
+      run: git update-index --skip-worktree .bundle/config
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
 
+    - name: Ignore changes to .bundle/config
+      run: git update-index --skip-worktree .bundle/config
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## Problem

During v2.229.1 release a new failure occurred. 

```
[12:41:00]: $ git status --porcelain
[12:41:01]: ▸ M .bundle/config
----

 [12:41:01]: Called from Fastfile at line 113
[12:41:01]: ```
[12:41:01]:     111:	  verify_env_variables(skip_ruby_gems: is_automated_bump)
[12:41:01]:     112:	  ensure_git_branch(branch: "master")
[12:41:01]:  => 113:	  ensure_git_status_clean
[12:41:01]:     114:	
[12:41:01]:     115:	  github_api_token = ENV["FL_GITHUB_RELEASE_API_TOKEN"]
[12:41:01]: ```
[12:41:01]: Git repository is dirty! Please ensure the repo is in a clean state by committing/stashing/discarding all changes first.
```

This is because I added caching to the Gems to speed up builds. When GHA runs it modifies the `.bundle/config` to add some platform flags.

## Solution

Since we don't ship that [file](https://github.com/fastlane/fastlane/blob/master/fastlane.gemspec#L67C27-L67C115) during build - we can ignore it during the check. This is same fix I did on [xcov repo](https://github.com/fastlane-community/xcov/pull/236).