### PR TITLE
[ci] Restore a regular 'bunde install' during releases

### DIFF
--- a/.github/workflows/release_step_1_create_version_bump.yml
+++ b/.github/workflows/release_step_1_create_version_bump.yml
@@ -25,9 +25,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
 
-    - name: Ignore changes to .bundle/config
-      run: git update-index --skip-worktree .bundle/config
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/release_step_1_create_version_bump.yml
+++ b/.github/workflows/release_step_1_create_version_bump.yml
@@ -29,7 +29,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2
-        bundler-cache: true
+
+    - name: Install fastlane
+      run: bundle install
 
     - name: Run fastlane bump
       run: |

--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -35,7 +35,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.2'
-        bundler-cache: true
+
+    - name: Install fastlane
+      run: bundle install
 
     - uses: rubygems/configure-rubygems-credentials@v1.0.0
 

--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -31,9 +31,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
 
-    - name: Ignore changes to .bundle/config
-      run: git update-index --skip-worktree .bundle/config
-
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## Problem

<img width="2344" height="898" alt="Screenshot 2025-11-24 at 11 47 35 AM" src="https://github.com/user-attachments/assets/4f39340c-5a10-48b0-bd8f-09c4995341be" />

In #29765 - I packed a change with the `packages:write` fix to cache RubyGem dependencies. It seemed fair since I do it on the other CI pipelines without an issue. However, that process touches the `.bundle/config` and sets `frozen/deployment` mode to true.

So I had to introduce a new PR (#29774) to ignore changes to `.bundle/config`. However, as the pipeline continued it tried to install dependencies itself (swiftlint) and adapt versions with on the fly `bundle updates` etc. 

`setup-ruby` does NOT like this because it figures if you are caching dependencies its solely for deployments. As shown in some of these issues:
- https://github.com/ruby/setup-ruby/issues/153
- https://github.com/ruby/setup-ruby/issues/143

## Solution

At this point since I shouldn't have mixed PRs, I'll revert my last change and undo this. Since it seems a losing battle to leveraging caching when its probably more sane for the rare release to get fresh dependencies.