### PR TITLE
ci: add Ruby 2.6/7 test jobs to CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,6 @@ jobs:
       ruby_opt:
         type: string
         default: ''
-      bundler_version:
-        type: string
-        default: ''
     environment:
       CIRCLE_TEST_REPORTS: '~/test-reports'
       LC_ALL: 'en_US.UTF-8'
@@ -70,25 +67,6 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
-      - run:
-          name: Ensure required Bundler version
-          command: |
-            set -eo pipefail
-            bundler_version="<< parameters.bundler_version >>"
-            if [ -z "$bundler_version" ]; then
-              echo "BUNDLER_VERSION not set, skipping install."
-              exit 0
-            fi
-            if ! gem list -i bundler -v "$bundler_version" > /dev/null 2>&1; then
-              gem install --user-install bundler -v "$bundler_version"
-            fi
-            ruby_version=$(ruby -e 'require "rbconfig"; print RbConfig::CONFIG["ruby_version"]')
-            {
-              echo "export PATH=\"$HOME/.gem/ruby/${ruby_version}/bin:$PATH\""
-              echo "export GEM_HOME=\"$HOME/.gem\""
-              echo "export GEM_PATH=\"$HOME/.gem\""
-            } >> "$BASH_ENV"
-            source "$BASH_ENV"
       - ruby/install-deps
       - run:
           name: Check PR Metadata
@@ -225,11 +203,10 @@ workflows:
   "Run Tests & Checks": # Name of the workflow, which ends up displayed on GitHub's PR Check
     jobs:
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 13.4.1, System Ruby (2.6))'
+          name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 2.7)'
           xcode_version: '13.4.1'
-          ruby_version: 'system'
+          ruby_version: '2.7'
           ruby_opt: -W:deprecated
-          bundler_version: '2.4.22'
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'
           xcode_version: '13.4.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,24 @@ jobs:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
+      - run:
+          name: Ensure required Bundler version
+          command: |
+            set -eo pipefail
+            if [ -z "${BUNDLER_VERSION:-}" ]; then
+              echo "BUNDLER_VERSION not set, skipping install."
+              exit 0
+            fi
+            if ! gem list -i bundler -v "${BUNDLER_VERSION}" > /dev/null 2>&1; then
+              gem install --user-install bundler -v "${BUNDLER_VERSION}"
+            fi
+            ruby_version=$(ruby -e 'require "rbconfig"; print RbConfig::CONFIG["ruby_version"]')
+            {
+              echo "export PATH=\"$HOME/.gem/ruby/${ruby_version}/bin:$PATH\""
+              echo "export GEM_HOME=\"$HOME/.gem\""
+              echo "export GEM_PATH=\"$HOME/.gem\""
+            } >> "$BASH_ENV"
+            source "$BASH_ENV"
       - ruby/install-deps
       - run:
           name: Check PR Metadata
@@ -207,6 +225,8 @@ workflows:
           xcode_version: '13.4.1'
           ruby_version: 'system'
           ruby_opt: -W:deprecated
+          environment:
+            BUNDLER_VERSION: '2.4.22'
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'
           xcode_version: '13.4.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ workflows:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 2.6)'
           xcode_version: '13.4.1'
           ruby_version: '2.6'
-          ruby_opt: ''
+          ruby_opt: -W:deprecated
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'
           xcode_version: '13.4.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,11 @@ workflows:
   "Run Tests & Checks": # Name of the workflow, which ends up displayed on GitHub's PR Check
     jobs:
       - tests_macos:
+          name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 2.6)'
+          xcode_version: '13.4.1'
+          ruby_version: '2.6'
+          ruby_opt: ''
+      - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'
           xcode_version: '13.4.1'
           ruby_version: '3.1'
@@ -241,6 +246,9 @@ workflows:
           xcode_version: '16.4.0'
           ruby_version: '3.4'
           ruby_opt: -W:deprecated
+        - tests_ubuntu:
+          name: 'Execute tests on Ubuntu (Ruby 2.6)'
+          image: 'cimg/ruby:2.6'
       - tests_ubuntu:
           name: 'Execute tests on Ubuntu'
           image: 'cimg/ruby:3.2.2-node'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ workflows:
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 2.6)'
           xcode_version: '13.4.1'
-          ruby_version: '2.6'
+          ruby_version: '2.7'
           ruby_opt: -W:deprecated
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ workflows:
           ruby_opt: -W:deprecated
       - tests_ubuntu:
           name: 'Execute tests on Ubuntu (Ruby 2.6)'
-          image: 'cimg/ruby:2.6'
+          image: 'cimg/ruby:2.6-node'
       - tests_ubuntu:
           name: 'Execute tests on Ubuntu'
           image: 'cimg/ruby:3.2.2-node'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,9 +203,9 @@ workflows:
   "Run Tests & Checks": # Name of the workflow, which ends up displayed on GitHub's PR Check
     jobs:
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 2.6)'
+          name: 'Execute tests on macOS (Xcode 13.4.1, System Ruby (2.6))'
           xcode_version: '13.4.1'
-          ruby_version: '2.7'
+          ruby_version: 'system'
           ruby_opt: -W:deprecated
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ workflows:
           xcode_version: '16.4.0'
           ruby_version: '3.4'
           ruby_opt: -W:deprecated
-        - tests_ubuntu:
+      - tests_ubuntu:
           name: 'Execute tests on Ubuntu (Ruby 2.6)'
           image: 'cimg/ruby:2.6'
       - tests_ubuntu:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,9 @@ jobs:
       ruby_opt:
         type: string
         default: ''
+      bundler_version:
+        type: string
+        default: ''
     environment:
       CIRCLE_TEST_REPORTS: '~/test-reports'
       LC_ALL: 'en_US.UTF-8'
@@ -71,12 +74,13 @@ jobs:
           name: Ensure required Bundler version
           command: |
             set -eo pipefail
-            if [ -z "${BUNDLER_VERSION:-}" ]; then
+            bundler_version="<< parameters.bundler_version >>"
+            if [ -z "$bundler_version" ]; then
               echo "BUNDLER_VERSION not set, skipping install."
               exit 0
             fi
-            if ! gem list -i bundler -v "${BUNDLER_VERSION}" > /dev/null 2>&1; then
-              gem install --user-install bundler -v "${BUNDLER_VERSION}"
+            if ! gem list -i bundler -v "$bundler_version" > /dev/null 2>&1; then
+              gem install --user-install bundler -v "$bundler_version"
             fi
             ruby_version=$(ruby -e 'require "rbconfig"; print RbConfig::CONFIG["ruby_version"]')
             {
@@ -225,8 +229,7 @@ workflows:
           xcode_version: '13.4.1'
           ruby_version: 'system'
           ruby_opt: -W:deprecated
-          environment:
-            BUNDLER_VERSION: '2.4.22'
+          bundler_version: '2.4.22'
       - tests_macos:
           name: 'Execute tests on macOS (Xcode 13.4.1, Ruby 3.1)'
           xcode_version: '13.4.1'

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,10 @@ gem "xcov", "~> 1.4.1"
 # A documentation generation tool for Ruby.
 gem "yard", "~> 0.9.11"
 
+# public_suffix >= 6.0 requires Ruby >= 3.0, while fastlane uses a
+# `required_ruby_version` of `>= 2.6`.
+gem "public_suffix", "< 6.0"
+
 gemspec(path: ".")
 
 plugins_path = File.join(File.expand_path("..", __FILE__), "fastlane", "Pluginfile")

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,10 @@ gem "yard", "~> 0.9.11"
 # `required_ruby_version` of `>= 2.6`.
 gem "public_suffix", "< 6.0"
 
+# domain_name >= 0.6.20240107 requires Ruby >= 2.7.0, while fastlane uses a
+# `required_ruby_version` of `>= 2.6`.
+gem "domain_name", "< 0.6.20240107"
+
 gemspec(path: ".")
 
 plugins_path = File.join(File.expand_path("..", __FILE__), "fastlane", "Pluginfile")

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source("https://rubygems.org")
 # Needed for the Fastlane::RUBOCOP_REQUIREMENT below
 require_relative "fastlane/lib/fastlane/version.rb"
 
-# Please don't add line breaks between the gems and their comments, as RuboCop won't be able to sort these alphabetically.
+# Please keep all gems and their comments together without empty lines, so RuboCop can sort them alphabetically.
 
 # Allows fine-grained control of environment variables.
 gem "climate_control", "~> 0.2.0"
@@ -13,6 +13,9 @@ gem "coveralls", "~> 0.8.13"
 gem "danger", "~> 8.0"
 # Plugin for Danger that reports JUnit test results.
 gem "danger-junit", "~> 1.0"
+# domain_name 0.6.x requires Ruby >= 2.7.0, while fastlane uses a
+# `required_ruby_version` of `>= 2.6`.
+gem "domain_name", "< 0.6"
 # A fake filesystem.
 # Version 1.9+ requires Ruby >=2.7, while fastlane uses a `required_ruby_version` of `>= 2.6`.
 gem "fakefs", "1.8"
@@ -36,6 +39,9 @@ gem "pry-byebug"
 gem "pry-rescue"
 # A plugin for pry that enables exploring the call stack.
 gem "pry-stack_explorer"
+# public_suffix >= 6.0 requires Ruby >= 3.0, while fastlane uses a
+# `required_ruby_version` of `>= 2.6`.
+gem "public_suffix", "< 6.0"
 # A simple task automation tool.
 gem "rake"
 # A readline implementation in Ruby
@@ -61,14 +67,6 @@ gem "xcode-install", ">= 2.6.7"
 gem "xcov", "~> 1.4.1"
 # A documentation generation tool for Ruby.
 gem "yard", "~> 0.9.11"
-
-# public_suffix >= 6.0 requires Ruby >= 3.0, while fastlane uses a
-# `required_ruby_version` of `>= 2.6`.
-gem "public_suffix", "< 6.0"
-
-# domain_name 0.6.x requires Ruby >= 2.7.0, while fastlane uses a
-# `required_ruby_version` of `>= 2.6`.
-gem "domain_name", "< 0.6"
 
 gemspec(path: ".")
 

--- a/Gemfile
+++ b/Gemfile
@@ -66,9 +66,9 @@ gem "yard", "~> 0.9.11"
 # `required_ruby_version` of `>= 2.6`.
 gem "public_suffix", "< 6.0"
 
-# domain_name >= 0.6.20240107 requires Ruby >= 2.7.0, while fastlane uses a
+# domain_name 0.6.x requires Ruby >= 2.7.0, while fastlane uses a
 # `required_ruby_version` of `>= 2.6`.
-gem "domain_name", "< 0.6.20240107"
+gem "domain_name", "< 0.6"
 
 gemspec(path: ".")
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.3.5)
-    domain_name (0.6.20240107)
+    domain_name (0.6.20231109)
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.109.0)
@@ -382,6 +382,7 @@ DEPENDENCIES
   coveralls (~> 0.8.13)
   danger (~> 8.0)
   danger-junit (~> 1.0)
+  domain_name (< 0.6.20240107)
   fakefs (= 1.8)
   fastlane!
   fastlane-plugin-clubmate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,8 @@ GEM
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     docile (1.3.5)
-    domain_name (0.6.20231109)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.109.0)
@@ -345,6 +346,7 @@ GEM
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
     uber (0.1.0)
+    unf (0.2.0)
     unicode-display_width (2.4.2)
     webmock (3.24.0)
       addressable (>= 2.8.0)
@@ -382,7 +384,7 @@ DEPENDENCIES
   coveralls (~> 0.8.13)
   danger (~> 8.0)
   danger-junit (~> 1.0)
-  domain_name (< 0.6.20240107)
+  domain_name (< 0.6)
   fakefs (= 1.8)
   fastlane!
   fastlane-plugin-clubmate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,4 +409,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   2.6.2
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ PATH
       http-cookie (~> 1.0.5)
       json (< 3.0.0)
       jwt (>= 2.1.0, < 3)
+      logger (>= 1.6, < 2.0)
       mini_magick (>= 4.9.4, < 5.0.0)
       multipart-post (>= 2.0.0, < 3.0.0)
       mutex_m (~> 0.3.0)
@@ -211,6 +212,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    logger (1.7.0)
     method_source (1.0.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
     pry-stack_explorer (0.4.12)
       binding_of_caller (~> 0.7)
       pry (~> 0.13)
-    public_suffix (6.0.1)
+    public_suffix (5.1.1)
     racc (1.7.1)
     rack (2.2.8)
     rack-protection (2.2.4)
@@ -394,6 +394,7 @@ DEPENDENCIES
   pry-byebug
   pry-rescue
   pry-stack_explorer
+  public_suffix (< 6.0)
   rake
   rb-readline
   rspec (~> 3.10)
@@ -408,4 +409,4 @@ DEPENDENCIES
   yard (~> 0.9.11)
 
 BUNDLED WITH
-   2.4.22
+   2.6.2

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -117,4 +117,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('csv', '~> 3.3') # 3.4 - workaround for sinatra as can't upgrade to 4.x yet
   spec.add_dependency('mutex_m', '~> 0.3.0') # 3.4 - workaround for httpclient as can't upgrade to 2.9 yet
   spec.add_dependency('nkf', '~> 0.2.0') # 3.4 - workaround for CFPropertyList as can't upgrade to 4.x yet
+  spec.add_dependency('logger', '>= 1.6', '< 2.0') # stdlib gem removed from default set in Ruby 3.5+
+
 end


### PR DESCRIPTION
As fastlane currently still supports older Ruby versions down to 2.6, it makes sense to have tests for these.

- Downgrade dependencies for Ruby 2.6 compatibility (no negative effect in tests)
- Adds Ruby 2.6 test job for Ubuntu
- Adds Ruby 2.7 test job for macOS with Xcode 13.4.1 (as 2.6 is not available to install, and system [which is 2.6] then has trouble installing bundler etc)

