### PR TITLE
[match] fix: 500 HTTP status code on long URL when fetching multiple bundle IDs

### DIFF
--- a/match/lib/match/portal_fetcher.rb
+++ b/match/lib/match/portal_fetcher.rb
@@ -58,12 +58,58 @@ module Match
         devices
       end
 
-      def self.bundle_ids(bundle_id_identifiers: nil)
-        filter = { identifier: bundle_id_identifiers.join(',') } if bundle_id_identifiers
+      # 4096 is the max URL length in the App Store Connect API request.
+      # If the URL length is too long, the ASC API will return a 500 HTTP response code.
+      #
+      # The MAX_BUNDLE_ID_FILTER_LENGTH constant is calculated as follows:
+      #   - minus 84 is the length of the https://.../bundleIds?limit=200&filter%25Bidentifier%25D= in the URL.
+      #   - minus 12 to round up to the round number of 4000.
+      #   - minus 100 to leave some space for the possible other parameters in the URL and URL changes.
+      MAX_BUNDLE_ID_FILTER_LENGTH = 3900
 
-        bundle_ids = Spaceship::ConnectAPI::BundleId.all(
-          filter: filter
-        )
+      def self.bundle_ids(bundle_id_identifiers: nil, max_bundle_id_filter_length: MAX_BUNDLE_ID_FILTER_LENGTH)
+        # Bundle IDs to fetch.
+        bundle_id_identifiers ||= []
+
+        # Radar: FB21179960: v1/bundleIds?filter returns 500 HTTP status code if the URL is longer than 4096 bytes.
+        #
+        # To avoid the 500 HTTP response code, we need to fetch bundle IDs in multiple requests by splitting the bundle ID identifiers into multiple filters.
+        # The splitting logic is if the current filter length is more than 3900 characters, reset the current filter and start a new one.
+
+        # Splitted bundle IDs array into multiple filters we will fetch separately.
+        identifiers_filters = [[]]
+        current_filter_length = 0
+        current_filter_count = 0
+        current_identifiers_filter = identifiers_filters.last # The current bundle IDs identifiers filter.
+        (0..bundle_id_identifiers.count - 1).each do |index|
+          bundle_id_identifier = bundle_id_identifiers[index]
+
+          if current_filter_length + bundle_id_identifier.length > max_bundle_id_filter_length
+            # if next length will be greater than the max bundle id filter length, reset the current filter and start a new one.
+            current_identifiers_filter = []
+            identifiers_filters.push(current_identifiers_filter)
+            current_filter_length = 0
+            current_filter_count = 0
+          end
+
+          current_identifiers_filter.push(bundle_id_identifier)
+          # Update the filter length and count for the current filter.
+          current_filter_length += bundle_id_identifier.length + 3 # ',' is encoded as '%2C' in the URL
+          current_filter_count += 1
+        end
+
+        # All fetched bundle IDs.
+        bundle_ids = []
+
+        # Fetch bundle IDs separately for each splitted chunk.
+        identifiers_filters.each do |identifiers_filter|
+          filter = { identifier: identifiers_filter.join(',') } unless identifiers_filter.empty?
+
+          bundle_ids += Spaceship::ConnectAPI::BundleId.all(
+            filter: filter
+          )
+
+        end
 
         bundle_ids
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

We run `match` with a large list of bundle IDs (>100).

We added a new bundle ID to the list and encountered a problem:
App Store Connect API `https://api.appstoreconnect.apple.com/v1/bundleIds?filter[identifier]=` returns 500 HTTP status if URL length is more than 4096 bytes 🙃.

✅ 103 bundle IDs: 3953 filter list + 84 = 4037 < 4096 characters in the URL is ok.
❌ 104 bundle IDs: 4037 filter list + 84 = 4121 > 4096 characters in the URL is not ok.
`84` is the length of the `https://api.appstoreconnect.apple.com/v1/bundleIds?limit=200&filter%25Bidentifier%25D=` (with URL-encoded `[` & `]`)

Filed radar: FB21179960.

### Description

The solution is to limit the filter length to 3900 symbols, and split `{ identifier:` filter, and do more requests to fetch Bundle IDs.

fixes: #29639
fixes: #21815

### Testing Steps

Updated specs.

