### PR TITLE
build: remove dependency ci config

### DIFF
--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -1,4 +1,0 @@
-# don't run unmaintained test on any dependencies in Gemfile
-# We need to add this file to exclude unmaintained errors due to the dependency to the "colored" gem
-tests:
-  unmaintained: skip


### PR DESCRIPTION
DependencyCI was acquired (run?) by Tidelift, then SonarQube and shut down a decade ago. We have things like Dependabot now and more.

ref: https://dependencyci.com


So remove config file.