### PR TITLE
[ci] swap to github action token instead of pat for meta workflows

### DIFF
--- a/.github/workflows/announce_release.yml
+++ b/.github/workflows/announce_release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - published
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   announce-release-on-released-pull-requests:
@@ -17,4 +20,4 @@ jobs:
       - name: Announce release on released pull requests
         uses: fastlane/github-actions/communicate-on-pull-request-released@latest
         with:
-          repo-token: '${{ secrets.BOT_GITHUB_TOKEN }}'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types:
       - opened
+permissions:
+  issues: write
 
 jobs:
   fastlane-env:
@@ -13,4 +15,4 @@ jobs:
       - uses: actions/checkout@master
       - uses: fastlane/github-actions/fastlane-env-reminder@latest
         with:
-          repo-token: '${{ secrets.BOT_GITHUB_TOKEN }}'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,6 +3,9 @@ name: Lock issues and pull requests
 on:
   schedule:
     - cron: "0 0 * * *" # Every day at midnight
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   lock:
@@ -11,5 +14,5 @@ jobs:
     steps:
       - uses: fastlane/github-actions/lock@latest
         with:
-          repo-token: '${{ secrets.BOT_GITHUB_TOKEN }}'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-lock: 60


### PR DESCRIPTION
### Problem

```
Error: Bad credentials
```

The token behind @fastlane-bot looks to be gone/expired/missing with above error. I have no idea who owns that (cc @mollyIV  @KrauseFx ?). When these workflows were introduced in https://github.com/fastlane/fastlane/pull/15424, they used the native GitHub Actions, but folks preferred a more branded solution (Like a CI account) to use instead.

However, the decay of not knowing of who owns that account to check the status of the token means it has broken.

### Solution
Leverage the official `GITHUB_TOKEN` that you can grant permissions to during CI/CD. This moves back to a GitHub Action branded user, but at this point in the lifetime of this project. I believe less things that have to be manually monitored and kept afloat is for the better.