### PR TITLE
[ci] build: support updating docs during part 2 release

### DIFF
--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -17,6 +17,11 @@ on:
         required: true
         default: false
         type: boolean
+      skip_docs:
+        description: 'Skip generating docs'
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   create_github_release:
@@ -53,4 +58,7 @@ jobs:
       env:
         FASTLANE_RELEASE_API_BEARER: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        bundle exec fastlane create_github_release skip_github_packages:${{ github.event.inputs.skip_github_packages }} skip_rubygems:${{ github.event.inputs.skip_rubygems }}
+        bundle exec fastlane create_github_release \
+          skip_github_packages:${{ github.event.inputs.skip_github_packages }} \
+          skip_rubygems:${{ github.event.inputs.skip_rubygems }} \
+          skip_docs:${{ github.event.inputs.skip_docs }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -397,6 +397,8 @@ lane :create_github_release do |options|
   sh "gem push --key github --host https://rubygems.pkg.github.com/#{github_username} #{gem_path}" unless options[:skip_github_packages]
 
   sh "gem push #{gem_path}" unless options[:skip_rubygems]
+
+  update_docs(version: version) unless options[:skip_docs]
 end
 
 lane :publish_rubygems_from_github_release do |options|


### PR DESCRIPTION
## Problem

It was noticed in #22167 that doc PRs were no longer being automatically opened. This regressed during the move to GHA for automation. The challenge however is the method in which this action works.

It does the following which challenges automation:

 - It clones another repo (fastlane/docs) which the GITHUB_SECRET does not have access for. It will require a deployment key loaded into the fastlane/docs repo with write permission, then hardened as a secret on deploys on fastlane/fastlane.
 
 - It clones a variety of plugins to build plugin scores, which takes a clone of a repo. GITHUB_TOKEN may not be able to clone random repos without first establishing a key for it. This worked in past on CircleCI with a Personal Access Token for a "bot user"
 
## Solution

TBD

---

fixes: #22167