### PR TITLE
build: generate plugin robocop config during rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -115,3 +115,29 @@ task(:update_gem_spec_authors) do
 end
 
 task(default: :test_all)
+
+# Prepare the plugin template RuboCop config before building/installing the gem
+desc "Prepare .rubocop.yml for plugin template"
+task(:prepare_rubocop_config) do
+  require 'yaml'
+  require 'fileutils'
+
+  lib = File.expand_path('fastlane/lib', __dir__)
+  rubocop_config = File.expand_path('.rubocop.yml', __dir__)
+
+  next unless File.exist?(rubocop_config)
+
+  config = YAML.safe_load(File.read(rubocop_config))
+  config['require'] = %w[rubocop/require_tools rubocop-performance]
+  config.delete('inherit_from')
+  config.delete('CrossPlatform/ForkUsage')
+  config.delete('Lint/IsStringUsage')
+
+  target = File.join(lib, 'fastlane/plugins/template/.rubocop.yml')
+  FileUtils.mkdir_p(File.dirname(target))
+  File.write(target, YAML.dump(config))
+end
+
+%w(build install release).each do |t|
+  Rake::Task[t].enhance([:prepare_rubocop_config]) if Rake::Task.task_defined?(t)
+end

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -4,20 +4,6 @@ lib = File.expand_path('../fastlane/lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fastlane/version'
 
-# Copy over the latest .rubocop.yml style guide
-require 'yaml'
-rubocop_config = File.expand_path('../.rubocop.yml', __FILE__)
-config = YAML.safe_load(open(rubocop_config))
-config['require'] = [
-  'rubocop/require_tools',
-  'rubocop-performance'
-]
-config.delete('inherit_from')
-config.delete('CrossPlatform/ForkUsage')
-config.delete('Lint/IsStringUsage')
-
-File.write("#{lib}/fastlane/plugins/template/.rubocop.yml", YAML.dump(config))
-
 Gem::Specification.new do |spec|
   spec.name          = "fastlane"
   spec.version       = Fastlane::VERSION
@@ -118,5 +104,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency('mutex_m', '~> 0.3.0') # 3.4 - workaround for httpclient as can't upgrade to 2.9 yet
   spec.add_dependency('nkf', '~> 0.2.0') # 3.4 - workaround for CFPropertyList as can't upgrade to 4.x yet
   spec.add_dependency('logger', '>= 1.6', '< 2.0') # stdlib gem removed from default set in Ruby 3.5+
-
 end


### PR DESCRIPTION
### Problem

A long time ago in 2016 in #4951 we saw Robocop be added to the plugin template, so plugin authors after running `fastlane new_plugin` would create a plugin including the same Robocop rules that _fastlane_ itself used.

The problem though instead of keeping duplicate files in-place resulted in a change to the Gemspec so any execution of the install would run the logic, which would copy the `.robocop` file into place in the template. It was git-ignored so it was really only apparent during the release process in which the file would be included into the final `.gem` file.

The challenge is Dependabot has no idea what this logic is because it only checks out the needed files thus fails.

```
Handled error whilst updating rexml: dependency_file_not_evaluatable {message: "Bundler::GemspecError with message: [!] There was an error while loading `fastlane.gemspec`: No such file or directory @ rb_sysopen - dependabot_tmp_dir/.rubocop.yml. Bundler cannot continue.\n\n #  from dependabot_tmp_dir/fastlane.gemspec:16\n #  -------------------------------------------\n #  rubocop_config = File.expand_path('../.rubocop.yml', __FILE__)\n >  config = YAML.safe_load(open(rubocop_config))\n #  \"sanitized\"\n #  -------------------------------------------"}
 ```
 
 ### Solution
 
It seems if the end goal is the `gem` archive getting the template folder prepped with a modern Robocop config - then lets just hook the rake process to do that copy so we exclude the general usage (Dependabot, etc) from doing this extra work.

### Testing

```
➜  fastlane git:(master) ✗ file fastlane/lib/fastlane/plugins/template/.rubocop.yml   
fastlane/lib/fastlane/plugins/template/.rubocop.yml: cannot open `fastlane/lib/fastlane/plugins/template/.rubocop.yml' (No such file or directory)
➜  fastlane git:(master) ✗ rake build
fastlane 2.229.1 built to pkg/fastlane-2.229.1.gem.
➜  fastlane git:(master) ✗ file fastlane/lib/fastlane/plugins/template/.rubocop.yml
fastlane/lib/fastlane/plugins/template/.rubocop.yml: ASCII text
```
