### PR TITLE
[ci] remove houndci config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,0 @@
-ruby:
-  config_file: .rubocop.yml


### PR DESCRIPTION
## Problem

[HoundCI](https://houndci.com) hasn't been used in like a decade. It was abandoned when CircleCI was added.


## Solution

Remove the config file to cleanup the root of the project 