### PR TITLE
[supply] Fix missing_email error when using external account credentials

### DIFF
--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -46,7 +46,7 @@ module Supply
     # Initializes the service and its auth_client using the specified information
     # @param service_account_json: The raw service account Json data
     def initialize(service_account_json: nil, params: nil)
-      auth_client = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
+      auth_client = Google::Auth::DefaultCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
 
       UI.verbose("Fetching a new access token from Google...")
 

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -42,6 +42,12 @@ describe Supply do
         }.to raise_error(FastlaneCore::Interface::FastlaneError, "Google Api Error: Invalid request - Ensure project settings are enabled.")
       end
 
+      it "displays error messages for invalid credentials" do
+        expect {
+          Supply::Client.new(service_account_json: StringIO.new("{}"), params: { timeout: 1 })
+        }.to raise_error(FastlaneCore::Interface::FastlaneError, "Invalid Google Credentials file provided.")
+      end
+
       it "with 5 retries" do
         stub_const("ENV", { 'SUPPLY_UPLOAD_MAX_RETRIES' => 5 })
 

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -20,6 +20,18 @@ describe Supply do
 
         Supply::Client.new(service_account_json: StringIO.new(external_account_file), params: { timeout: 1 })
       end
+
+      it "with external account credentials from file" do
+        stub_request(:get, "https://credential-source.example.com/token").
+          to_return(status: 200, body: '{"value": "access-token"}', headers: { 'Content-Type' => 'application/json' })
+        stub_request(:post, "https://sts.googleapis.com/v1/token").
+          to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+        stub_request(:post, "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/fastlane@fastlane-tools.iam.gserviceaccount.com:generateAccessToken").
+          to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+
+        file_path = fixture_file("sample-external-account.json")
+        Supply::Client.make_from_config(params: { json_key: file_path, timeout: 1 })
+      end
     end
 
     describe "displays error messages from the API" do
@@ -42,10 +54,16 @@ describe Supply do
         }.to raise_error(FastlaneCore::Interface::FastlaneError, "Google Api Error: Invalid request - Ensure project settings are enabled.")
       end
 
-      it "displays error messages for invalid credentials" do
+      it "displays error messages for invalid json" do
+        expect {
+          Supply::Client.new(service_account_json: StringIO.new("{/asdf"), params: { timeout: 1 })
+        }.to raise_error(FastlaneCore::Interface::FastlaneError, "Invalid Google Credentials file provided - unable to parse json.")
+      end
+
+      it "displays error messages for missing credential type" do
         expect {
           Supply::Client.new(service_account_json: StringIO.new("{}"), params: { timeout: 1 })
-        }.to raise_error(FastlaneCore::Interface::FastlaneError, "Invalid Google Credentials file provided.")
+        }.to raise_error(FastlaneCore::Interface::FastlaneError, "Invalid Google Credentials file provided - no credential type found.")
       end
 
       it "with 5 retries" do

--- a/supply/spec/fixtures/sample-external-account.json
+++ b/supply/spec/fixtures/sample-external-account.json
@@ -1,0 +1,11 @@
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/ftl-test-app/locations/global/workloadIdentityPools/identity-pool/providers/token-provider",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "url": "https://credential-source.example.com/token",
+    "format": { "type": "json", "subject_token_field_name": "value" }
+  },
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/fastlane@fastlane-tools.iam.gserviceaccount.com:generateAccessToken"
+}


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary - https://github.com/fastlane/docs/pull/1294/files
- [x] I've added or updated relevant unit tests.

### Motivation and Context

As per https://github.com/fastlane/fastlane/pull/29492, this change adds support for `external_credentials` when authenticating with Google APIs for deployment to Google Play.

Resolves #29491
Closes #29492
Closes: #22122

### Description

The Supply client now supports authentication using external account credentials (including via Workload Identity Federation).

Supply checks the type of credentials that it is provided with: previously this was assumed to always be a Service Account JSON file.  Service Account JSON files are long lived credentials and therefore should only be used when other options are unavailable.

### Testing Steps

Unit test is updated to initialize supply client using a demo external account credentials file. The format of the file can be different depending on how you set up Workload Identity Federation.

To test using GitHub Action:

1. Follow [Workload Identity Federation through a Service Account](https://github.com/google-github-actions/auth?tab=readme-ov-file#indirect-wif) to set up workload identity pool and token provider.
2. In an existing GitHub Action workflow that uses JSON credentials file, replace it with google-github-actions/auth action to obtain credentials.
3. Run Fastlane. Depending on project configuration, Google Auth client should be able to pick up the credentials, or save the generated credentials into a JSON file to be read by supply.
