### PR TITLE
[deliver] Check only locales that have screenshots to upload when deleting from ASC

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -93,7 +93,9 @@ module Deliver
 
       # Verify all screenshots have been deleted
       # Sometimes API requests will fail but screenshots will still be deleted
-      count = iterator.each_app_screenshot_set.map { |_, app_screenshot_set| app_screenshot_set }
+      count = iterator.each_app_screenshot_set
+                      .select { |localization, _| screenshots_per_language.keys.include?(localization.locale) }
+                      .map { |_, app_screenshot_set| app_screenshot_set }
                       .reduce(0) { |sum, app_screenshot_set| sum + app_screenshot_set.app_screenshots.size }
 
       UI.important("Number of screenshots not deleted: #{count}")

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -76,7 +76,7 @@ describe Deliver::UploadScreenshots do
 
         # en-US set should be deleted, fr-FR should NOT be deleted
         expect(en_screenshot_set).to receive(:delete!)
-        expect(fr_screenshot_set).not_to(receive(:delete!))
+        expect(fr_screenshot_set).to_not(receive(:delete!))
         # Should succeed since en-US count is 0 (fr-FR's screenshot is not counted)
         expect(UI).to_not(receive(:user_error!))
         described_class.new.delete_screenshots([en_localization, fr_localization], screenshots_per_language)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

It can happen that you want to upload screenshots for just a subset of the localizations your app supports. In this scenario _fastlane_ fails saying that it didn't delete all screenshots from App Store Connect.

### Description

Deleting screenshots before the upload is a 2-step process: the deletion itself and the check on how much to delete is left. When enqueing for deletion there is a filter on `screenshots_per_language.keys.include?(localization.locale)`, but that filter is missing during the check. This PR fixes that.

### Testing Steps

1. You have 5 screenshots under the `en-US` locale and 7 screenshots under the `fr-FR` one in ASC
2. You want to just update the  _en-US_ one
3. You put your new screenshots in the _fastlane/screenshots/en-US/_ folder
4. You run _deliver_

**Expected:**
All good

**Actual:**
You get an error saying "7 screenshots not deleted". Then it retries 5 times and eventually fails with the same error.