### PR TITLE
[ci] build: force circleci to previous resource_class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ aliases:
 jobs:
   tests_macos: &tests_macos_base
     description: 'Execute tests on macOS with given Xcode and Ruby version'
+    resource_class: macos-m1-medium-gen1
     macos:
       xcode: << parameters.xcode_version >>
     parameters:
@@ -138,6 +139,7 @@ jobs:
           when: always  # Run this even when tests fail
 
   validate_fastlane_swift_generation:
+    resource_class: macos-m1-medium-gen1
     <<: *tests_macos_base
     steps:
       - *cache_restore_git


### PR DESCRIPTION
# Problem

After merge of https://github.com/fastlane/fastlane/pull/21793 a chunk of the CircleCI jobs failed. It seemed unrelated to the merge as every PR after that was failing with same issues.

They failed because the default runner changed to `macos.m4pro.medium` which is the new [default](https://circleci.com/changelog/free-plan-default-macos-resource-class-changes-to-m4pro-medium-on-november/) for jobs without a `resource_class` specified - we never specified one. The M4 Pro doesn't support all these older Xcode versions, so all failed instantly with crashes like:

```
Job was rejected because resource class macos.m4pro.medium, image xcode:16.4.0 is not a valid resource class
Job was rejected because resource class macos.m4pro.medium, image xcode:13.4.1 is not a valid resource class 
```

# Solution
Since the default resource class changed we have to opt back to our old one `macos-m1-medium-gen1` which will probably die another day, but buys us time now. 
