### PR TITLE
[ci] feat: part 3 release process for docs

### DIFF
--- a/.github/workflows/release_step_1_create_version_bump.yml
+++ b/.github/workflows/release_step_1_create_version_bump.yml
@@ -39,9 +39,6 @@ jobs:
         git config --global user.name "github-actions[bot]"
         bundle exec fastlane bump bump_type:${{ github.event.inputs.bump_type }}
       env:
-        GITHUB_USER_NAME: fastlane # Todo: This is needed for docs - remove somehow
-        GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Todo: This is needed for docs - remove somehow
-        GITHUB_API_BEARER: ${{ secrets.GITHUB_TOKEN }}
         FL_GITHUB_RELEASE_API_BEARER: ${{ secrets.GITHUB_TOKEN }}
         FL_CHANGELOG_SLEEP: 10
         FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 180

--- a/.github/workflows/release_step_3_create_docs_pr.yml
+++ b/.github/workflows/release_step_3_create_docs_pr.yml
@@ -1,0 +1,39 @@
+---
+name: Release Step 3 - Create Docs PR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create_github_release:
+    runs-on: macos-latest
+
+    permissions:
+      packages: write
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install fastlane
+        run: bundle install
+
+      # TODO 1: We need a deployment key for permission to push to fastlane/docs
+      # TODO 2: We need to figure out how to open a PR in another repo from fastlane/fastlane
+      # TODO 3: We need update_docs to support using a pre-cloned repo instead of cloning itself to control auth
+      # TODO 4: Cleanup Part 1 and 2 to remove dependency on fastlane/docs key names and/or standarize them
+      - name: Run fastlane
+        env:
+          GITHUB_USER_NAME: fastlane
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_API_BEARER: ${{ secrets.GITHUB_TOKEN }}
+          FASTLANE_RELEASE_API_BEARER: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bundle exec fastlane update_docs


### PR DESCRIPTION
## Problem

It was noticed in #22167 that doc PRs were no longer being automatically opened. This regressed during the move to GHA for automation. The challenge however is the method in which this action works.

It does the following which challenges automation:

 - It clones another repo (fastlane/docs) which the GITHUB_SECRET does not have access for. It will require a deployment key loaded into the fastlane/docs repo with write permission, then hardened as a secret on deploys on fastlane/fastlane.
 
 - It clones a variety of plugins to build plugin scores, which takes a clone of a repo. GITHUB_TOKEN may not be able to clone random repos without first establishing a key for it. This worked in past on CircleCI with a Personal Access Token for a "bot user"
 
- It opens a PR on another repo (fastlane/docs) based on the branch it pushed, which a `GITHUB_SECRET` on fastlane/fastlane cannot be used for that.
 
## Solution

TBD

---

fixes: #22167