### PR TITLE
[install_xcode_plugin] hardening sh() to properly handle repo URL

### DIFF
--- a/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
+++ b/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
@@ -26,7 +26,7 @@ module Fastlane
         end
 
         zip_path = File.join(Dir.tmpdir, 'plugin.zip')
-        Actions.sh("curl", "-L", "-s", "-o", zip_path, params[:url])
+        Action.sh("curl", "-L", "-s", "-o", zip_path, params[:url])
         plugins_path = "#{ENV['HOME']}/Library/Application Support/Developer/Shared/Xcode/Plug-ins"
         FileUtils.mkdir_p(plugins_path)
         Action.sh("unzip", "-qo", zip_path, "-d", plugins_path)

--- a/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
+++ b/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
@@ -3,6 +3,7 @@ module Fastlane
     class InstallXcodePluginAction < Action
       def self.run(params)
         require 'fileutils'
+        require 'tmpdir'
 
         if params[:github]
           base_api_url = params[:github].sub('https://github.com', 'https://api.github.com/repos')
@@ -25,7 +26,7 @@ module Fastlane
         end
 
         zip_path = File.join(Dir.tmpdir, 'plugin.zip')
-        sh("curl", "-L", "-s", "-o", zip_path, params[:url])
+        Actions.sh("curl", "-L", "-s", "-o", zip_path, params[:url])
         plugins_path = "#{ENV['HOME']}/Library/Application Support/Developer/Shared/Xcode/Plug-ins"
         FileUtils.mkdir_p(plugins_path)
         Action.sh("unzip", "-qo", zip_path, "-d", plugins_path)

--- a/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
+++ b/fastlane/lib/fastlane/actions/install_xcode_plugin.rb
@@ -25,10 +25,10 @@ module Fastlane
         end
 
         zip_path = File.join(Dir.tmpdir, 'plugin.zip')
-        sh("curl -Lso #{zip_path} #{params[:url]}")
+        sh("curl", "-L", "-s", "-o", zip_path, params[:url])
         plugins_path = "#{ENV['HOME']}/Library/Application Support/Developer/Shared/Xcode/Plug-ins"
         FileUtils.mkdir_p(plugins_path)
-        Action.sh("unzip -qo '#{zip_path}' -d '#{plugins_path}'")
+        Action.sh("unzip", "-qo", zip_path, "-d", plugins_path)
 
         UI.success("Plugin #{File.basename(params[:url], '.zip')} installed successfully")
         UI.message("Please restart Xcode to use the newly installed plugin")

--- a/fastlane/spec/actions_specs/install_xcode_plugin_spec.rb
+++ b/fastlane/spec/actions_specs/install_xcode_plugin_spec.rb
@@ -9,7 +9,7 @@ describe Fastlane do
         url = "https://example.com/plugin.zip; touch /tmp/fastlane_pwned"
 
         expect(FileUtils).to receive(:mkdir_p).with(plugins_path)
-        expect(Fastlane::Actions).to receive(:sh).with("curl", "-L", "-s", "-o", kind_of(String), url)
+        expect(Fastlane::Action).to receive(:sh).with("curl", "-L", "-s", "-o", kind_of(String), url)
         expect(Fastlane::Action).to receive(:sh).with("unzip", "-qo", kind_of(String), "-d", plugins_path)
 
         Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/install_xcode_plugin_spec.rb
+++ b/fastlane/spec/actions_specs/install_xcode_plugin_spec.rb
@@ -1,0 +1,23 @@
+describe Fastlane do
+  describe Fastlane::FastFile do
+    describe "install_xcode_plugin" do
+      it "downloads plugin using argument-safe curl invocation" do
+        tmp_home = Dir.mktmpdir
+        stub_const('ENV', ENV.to_hash.merge('HOME' => tmp_home))
+
+        plugins_path = "#{tmp_home}/Library/Application Support/Developer/Shared/Xcode/Plug-ins"
+        url = "https://example.com/plugin.zip; touch /tmp/fastlane_pwned"
+
+        expect(FileUtils).to receive(:mkdir_p).with(plugins_path)
+        expect(Fastlane::Actions).to receive(:sh).with("curl", "-L", "-s", "-o", kind_of(String), url)
+        expect(Fastlane::Action).to receive(:sh).with("unzip", "-qo", kind_of(String), "-d", plugins_path)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          install_xcode_plugin(url: '#{url}')
+        end").runner.execute(:test)
+      ensure
+        FileUtils.remove_entry(tmp_home) if tmp_home && File.directory?(tmp_home)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

hardening of repo URL in install  x code plugin

fixes: #29809 