### PR TITLE
[core] build: support bundler v4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       aws-sdk-s3 (~> 1.0)
       babosa (>= 1.0.3, < 2.0.0)
       base64 (~> 0.2.0)
-      bundler (>= 1.12.0, < 5.0.0)
+      bundler (>= 1.17.3, < 5.0.0)
       colored (~> 1.2)
       commander (~> 4.6)
       csv (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       aws-sdk-s3 (~> 1.0)
       babosa (>= 1.0.3, < 2.0.0)
       base64 (~> 0.2.0)
-      bundler (>= 1.12.0, < 3.0.0)
+      bundler (>= 1.12.0, < 5.0.0)
       colored (~> 1.2)
       commander (~> 4.6)
       csv (~> 3.3)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('artifactory', '~> 3.0') # Used to export to an artifactory server
   spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used for S3 storage in fastlane match
   spec.add_dependency('babosa', '>= 1.0.3', '< 2.0.0') # library for creating human-friendly identifiers, aka "slugs"
-  spec.add_dependency('bundler', '>= 1.12.0', '< 5.0.0') # Used for fastlane plugins
+  spec.add_dependency('bundler', '>= 1.17.3', '< 5.0.0') # Used for fastlane plugins
   spec.add_dependency('CFPropertyList', '>= 2.3', '< 4.0.0') # Needed to be able to read binary plist format
   spec.add_dependency('colored', '~> 1.2') # colored terminal output
   spec.add_dependency('commander', '~> 4.6') # CLI parser

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('artifactory', '~> 3.0') # Used to export to an artifactory server
   spec.add_dependency('aws-sdk-s3', '~> 1.0') # Used for S3 storage in fastlane match
   spec.add_dependency('babosa', '>= 1.0.3', '< 2.0.0') # library for creating human-friendly identifiers, aka "slugs"
-  spec.add_dependency('bundler', '>= 1.12.0', '< 3.0.0') # Used for fastlane plugins
+  spec.add_dependency('bundler', '>= 1.12.0', '< 5.0.0') # Used for fastlane plugins
   spec.add_dependency('CFPropertyList', '>= 2.3', '< 4.0.0') # Needed to be able to read binary plist format
   spec.add_dependency('colored', '~> 1.2') # colored terminal output
   spec.add_dependency('commander', '~> 4.6') # CLI parser


### PR DESCRIPTION
If users want to run a more modern bundler - we shouldn't block it. Due to us supporting Ruby 2.6, we cannot change our own pipeline as Bundler 4 require Ruby 3.2 as min.

I don't think any downside to targeting a more modern bundler.

fixes: #29817 