### PR TITLE
[ci] build: automate messages on released prs

### DIFF
--- a/.github/workflows/announce_release.yml
+++ b/.github/workflows/announce_release.yml
@@ -41,7 +41,7 @@ jobs:
         id: release_version
         run: |
           if [ -f "release_tag.txt" ]; then
-            echo "version=$(cat release_tag/release_tag.txt)" >> "$GITHUB_OUTPUT"
+            echo "version=$(cat release_tag.txt)" >> "$GITHUB_OUTPUT"
           else
             echo "release_tag.txt not found in expected locations"
             exit 1

--- a/.github/workflows/announce_release.yml
+++ b/.github/workflows/announce_release.yml
@@ -8,6 +8,8 @@ on:
     types:
       - completed
 permissions:
+  actions: read
+  contents: read
   issues: write
   pull-requests: write
 
@@ -21,7 +23,28 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: master
+
+      - name: Download release tag artifact
+        uses: actions/download-artifact@v7
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: release_tag
+
+      - name: Extract version from artifact
+        id: release_version
+        run: |
+          if [ -f "release_tag/release_tag.txt" ]; then
+            echo "version=$(cat release_tag/release_tag.txt)" >> "$GITHUB_OUTPUT"
+          elif [ -f "release_tag.txt" ]; then
+            # Fallback in case the artifact was extracted directly in the workspace
+            echo "version=$(cat release_tag.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_tag.txt not found in expected locations" >&2
+            exit 1
+          fi
+
       - name: Announce release on released pull requests
         uses: fastlane/github-actions/communicate-on-pull-request-released@latest
         with:
+          version: ${{ steps.release_version.outputs.version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/announce_release.yml
+++ b/.github/workflows/announce_release.yml
@@ -35,12 +35,11 @@ jobs:
       - name: Extract version from artifact
         if: ${{ github.event_name == 'workflow_run' }}
         run: |
-          if [ -f "latest.txt" ]; then
-            echo "FL_VERSION=$(cat latest.txt)" >> "$GITHUB_ENV"
-          else
-            echo "latest.txt not found in expected locations"
+          if [ ! -f "latest_fl_version.txt" ]; then
+            echo "latest_fl_version.txt not found in expected locations"
             exit 1
           fi
+          echo "FL_VERSION=$(cat latest_fl_version.txt)" >> "$GITHUB_ENV"
 
       - name: Set version from workflow_dispatch input
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/announce_release.yml
+++ b/.github/workflows/announce_release.yml
@@ -22,27 +22,23 @@ jobs:
   announce-release-on-released-pull-requests:
     name: Announce release on released pull requests
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          ref: master
-
       - name: Download release tag artifact
         if: ${{ github.event_name == 'workflow_run' }}
         uses: actions/download-artifact@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
           name: release_tag
 
       - name: Extract version from artifact
         if: ${{ github.event_name == 'workflow_run' }}
         run: |
-          if [ -f "release_tag.txt" ]; then
-            echo "FL_VERSION=$(cat release_tag.txt)" >> "$GITHUB_ENV"
+          if [ -f "latest.txt" ]; then
+            echo "FL_VERSION=$(cat latest.txt)" >> "$GITHUB_ENV"
           else
-            echo "release_tag.txt not found in expected locations"
+            echo "latest.txt not found in expected locations"
             exit 1
           fi
 

--- a/.github/workflows/announce_release.yml
+++ b/.github/workflows/announce_release.yml
@@ -38,10 +38,9 @@ jobs:
 
       - name: Extract version from artifact
         if: ${{ github.event_name == 'workflow_run' }}
-        id: release_version
         run: |
           if [ -f "release_tag.txt" ]; then
-            echo "version=$(cat release_tag.txt)" >> "$GITHUB_OUTPUT"
+            echo "FL_VERSION=$(cat release_tag.txt)" >> "$GITHUB_ENV"
           else
             echo "release_tag.txt not found in expected locations"
             exit 1
@@ -49,11 +48,10 @@ jobs:
 
       - name: Set version from workflow_dispatch input
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        id: release_version
-        run: echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+        run: echo "FL_VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
 
       - name: Announce release on released pull requests
         uses: fastlane/github-actions/communicate-on-pull-request-released@latest
         with:
-          version: ${{ steps.release_version.outputs.version }}
+          version: ${{ env.FL_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/announce_release.yml
+++ b/.github/workflows/announce_release.yml
@@ -7,6 +7,11 @@ on:
       - master
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to announce'
+        required: true
 permissions:
   actions: read
   contents: read
@@ -25,23 +30,27 @@ jobs:
           ref: master
 
       - name: Download release tag artifact
+        if: ${{ github.event_name == 'workflow_run' }}
         uses: actions/download-artifact@v7
         with:
           run-id: ${{ github.event.workflow_run.id }}
           name: release_tag
 
       - name: Extract version from artifact
+        if: ${{ github.event_name == 'workflow_run' }}
         id: release_version
         run: |
-          if [ -f "release_tag/release_tag.txt" ]; then
+          if [ -f "release_tag.txt" ]; then
             echo "version=$(cat release_tag/release_tag.txt)" >> "$GITHUB_OUTPUT"
-          elif [ -f "release_tag.txt" ]; then
-            # Fallback in case the artifact was extracted directly in the workspace
-            echo "version=$(cat release_tag.txt)" >> "$GITHUB_OUTPUT"
           else
-            echo "release_tag.txt not found in expected locations" >&2
+            echo "release_tag.txt not found in expected locations"
             exit 1
           fi
+
+      - name: Set version from workflow_dispatch input
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: release_version
+        run: echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Announce release on released pull requests
         uses: fastlane/github-actions/communicate-on-pull-request-released@latest

--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -55,11 +55,8 @@ jobs:
       run: |
         bundle exec fastlane create_github_release skip_github_packages:${{ github.event.inputs.skip_github_packages }} skip_rubygems:${{ github.event.inputs.skip_rubygems }}
 
-    - name: Save tag for release announcement
-      run: echo "$FASTLANE_RELEASE_VERSION" > release_tag.txt
-
     - uses: actions/upload-artifact@v6
       with:
         name: release_tag
-        path: release_tag.txt
+        path: latest.txt
         retention-days: 1

--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -58,5 +58,5 @@ jobs:
     - uses: actions/upload-artifact@v6
       with:
         name: release_tag
-        path: latest.txt
+        path: latest_fl_version.txt
         retention-days: 1

--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -54,3 +54,12 @@ jobs:
         FASTLANE_RELEASE_API_BEARER: ${{ secrets.GITHUB_TOKEN }}
       run: |
         bundle exec fastlane create_github_release skip_github_packages:${{ github.event.inputs.skip_github_packages }} skip_rubygems:${{ github.event.inputs.skip_rubygems }}
+
+    - name: Save tag for release announcement
+      run: echo "$FASTLANE_RELEASE_VERSION" > release_tag.txt
+
+    - uses: actions/upload-artifact@v6
+      with:
+        name: release_tag
+        path: release_tag.txt
+        retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ test_output/
 .DS_Store
 .keys
 *.swp
+latest_fl_version.txt
 
 ## Specific to Android
 .gradle/

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -387,7 +387,7 @@ lane :create_github_release do |options|
     release_url = github_release['html_url']
     message = [title, description, release_url].join("\n\n")
     add_fastlane_git_tag(tag: "fastlane/#{version}", message: message)
-    File.write("../latest.txt", version)
+    File.write("../latest_fl_version.txt", version)
 
     UI.success("New GitHub release has been created: #{release_url}")
   else

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -387,6 +387,7 @@ lane :create_github_release do |options|
     release_url = github_release['html_url']
     message = [title, description, release_url].join("\n\n")
     add_fastlane_git_tag(tag: "fastlane/#{version}", message: message)
+    File.write("../latest.txt", version)
 
     UI.success("New GitHub release has been created: #{release_url}")
   else

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -356,6 +356,9 @@ lane :create_github_release do |options|
     UI.user_error!("Version number #{version} was already deployed")
   end
 
+  # Set the version into an ENV variable for GitHub Actions to read
+  ENV['FASTLANE_RELEASE_VERSION'] = version
+
   github_username = ENV["RELEASE_GITHUB_USERNAME"] || "fastlane"
   repo_name = "#{github_username}/fastlane"
 


### PR DESCRIPTION
# Automation is back!
_The messages on **merged** & **released** prs._

## The Nerdy
When things moved to GitHub Actions `GITHUB_TOKEN` those workflows cannot trigger their own workflows to prevent infinite loops. This meant the job that ran after a deploy never ran. If we want to keep a solution that depends on no PAT keys - we have to make changes.

## Changes
1. During Stage 2 of a Release we write a file to repo called `latest_fl_version.txt` - this is AFTER gem creation so it is not included in gem file.
2. The job exports that file as an attachment to that workflow.
3. A fixed workflow now reacts to that finished job (checks if completed) and downloads that file.
4. It extracts that file, identifys version released and passes onward to `communicate-on-pull-requested-released`.


## Testing

I heavily tested on my fork until it worked. I can confirm both responses to PRs and issues work.

<img width="959" height="223" alt="Screenshot From 2025-12-21 07-35-41" src="https://github.com/user-attachments/assets/e6bd12a5-cecc-4d70-a03a-4f81bd88b638" />
<img width="943" height="201" alt="Screenshot From 2025-12-21 07-35-31" src="https://github.com/user-attachments/assets/26306b78-98e3-4e59-8032-ad3a9af3d6a2" />

https://github.com/iBotPeaches/fastlane/actions/runs/20409818600 - the CI

https://github.com/iBotPeaches/fastlane/pull/14 - test pr

https://github.com/iBotPeaches/fastlane/issues/15 - test issue

## Other

* PR on github/actions - https://github.com/fastlane/github-actions/pull/142
