### PR TITLE
[spaceship] add robust handling around sirp api calls

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -476,6 +476,10 @@ module Spaceship
       puts("Received SIRP signin init response: #{response.body}") if Spaceship::Globals.verbose?
 
       body = response.body
+      unless body.kind_of?(Hash)
+        raise UnexpectedResponse, "Expected JSON response, but got #{body.class}: #{body.to_s[0..1000]}"
+      end
+
       iterations = body["iteration"]
       salt = Base64.strict_decode64(body["salt"])
       b = Base64.strict_decode64(body["b"])
@@ -1040,6 +1044,10 @@ module Spaceship
           raise BadGatewayError.new, "Apple 502 detected - this might be temporary server error, try again later"
         end
 
+        if response.body.to_s.include?("<title>503 Service Temporarily Unavailable</title>") || response.body.to_s.include?("<h1>503 Service Temporarily Unavailable</h1>")
+          raise AppleTimeoutError.new, "Apple 503 detected - this might be temporary server error, check https://developer.apple.com/system-status/ to see if there is a known downtime"
+        end
+
         return response
       end
     end
@@ -1056,6 +1064,12 @@ module Spaceship
         raise AccessForbiddenError.new, msg
       when 429
         raise TooManyRequestsError, response.to_hash
+      when 502
+        raise BadGatewayError.new, "Apple 502 detected - this might be temporary server error, try again later"
+      when 503
+        raise AppleTimeoutError.new, "Apple 503 detected - this might be temporary server error, check https://developer.apple.com/system-status/ to see if there is a known downtime"
+      when 504
+        raise GatewayTimeoutError.new, "Apple 504 detected - this might be temporary server error, try again later"
       end
     end
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -480,6 +480,10 @@ module Spaceship
         raise UnexpectedResponse, "Expected JSON response, but got #{body.class}: #{body.to_s[0..1000]}"
       end
 
+      if body["serviceErrors"]
+        raise UnexpectedResponse, body
+      end
+
       iterations = body["iteration"]
       salt = Base64.strict_decode64(body["salt"])
       b = Base64.strict_decode64(body["b"])

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -335,6 +335,27 @@ BODY
         subject.do_sirp("user", "password", nil)
       end.to raise_error(Spaceship::Client::UnexpectedResponse, /Expected JSON response, but got String/)
     end
+
+    it "raises Spaceship::UnexpectedResponse when body contains serviceErrors" do
+      response_body = {
+        "iteration" => 0,
+        "serviceErrors" => [
+          {
+            "code" => "-900007",
+            "suppressDismissal" => false
+          }
+        ]
+      }
+
+      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin/init").
+        to_return(status: 200, body: response_body.to_json, headers: { 'Content-Type' => 'application/json' })
+
+      allow(subject).to receive(:itc_service_key).and_return("fake_service_key")
+
+      expect do
+        subject.do_sirp("user", "password", nil)
+      end.to raise_error(Spaceship::Client::UnexpectedResponse)
+    end
   end
 
   describe "#log_response" do

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -78,12 +78,37 @@ describe Spaceship::Client do
       end.to raise_error(Spaceship::GatewayTimeoutError)
     end
 
-    it "raises Spaceship::GatewayTimeoutError" do
+    it "raises Spaceship::GatewayTimeoutError for 504" do
       stub_client_request(Spaceship::GatewayTimeoutError, 6, 504, "<html>Gateway Timeout - In Read</html>")
 
       expect do
         subject.req_home
       end.to raise_error(Spaceship::GatewayTimeoutError)
+    end
+
+    it "raises Spaceship::BadGatewayError for 502" do
+      stub_client_request(Spaceship::BadGatewayError, 6, 502, "<html>Bad Gateway</html>")
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::BadGatewayError)
+    end
+
+    it "raises Spaceship::AppleTimeoutError for 503" do
+      stub_client_request(Spaceship::AppleTimeoutError, 6, 503, "<html>Service Unavailable</html>")
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::AppleTimeoutError)
+    end
+
+    it "raises Spaceship::AppleTimeoutError for 503 HTML content" do
+      body = "<html><head><title>503 Service Temporarily Unavailable</title></head><body><center><h1>503 Service Temporarily Unavailable</h1></center></body>"
+      stub_client_request(Spaceship::AppleTimeoutError, 6, 200, body)
+
+      expect do
+        subject.req_home
+      end.to raise_error(Spaceship::AppleTimeoutError)
     end
 
     it "raises Spaceship::ProgramLicenseAgreementUpdated" do
@@ -298,6 +323,17 @@ BODY
 
         expect(subject.req_home.body).to eq(default_body)
       end
+    end
+  end
+
+  describe "#do_sirp" do
+    it "raises Spaceship::UnexpectedResponse when body is not valid JSON, but HTTP 200" do
+      stub_request(:post, "https://idmsa.apple.com/appleauth/auth/signin/init").
+        to_return(status: 200, body: "<html>Something went wrong</html>", headers: { 'Content-Type' => 'text/html' })
+
+      expect do
+        subject.do_sirp("user", "password", nil)
+      end.to raise_error(Spaceship::Client::UnexpectedResponse, /Expected JSON response, but got String/)
     end
   end
 


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

There is a generic error that is thrown because `nil` or some invalid JSON is passed to a JSON decoder. It ends up being `nil` and crashes out. A very confusing error because out of 55 comments only one user provided a verbose log with the output. It was:

```
Received SIRP signin init response: <html>
<head><title>503 Service Temporarily Unavailable</title></head>
<body>
<center><h1>503 Service Temporarily Unavailable</h1></center>
<hr><center>Apple</center>
</body>
```

### Description

Enhancements were done in 2 parts - http status code and json parsing. We now check for basic 502, 503 or 504 which you can occasionally get. These are bubbled as helpful exceptions. If we somehow get a HTTP/200 and no JSON we also survive that.

We shouldn't ever get a `undefined method `unpack1' for nil` anymore.

Fixes: #26596 
Fixes: #26368

### Testing Steps

Lots of new tests based on output from real errors.
