### PR TITLE
[GitHub Actions] Enable pull-requests.yml workflow

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -7,6 +7,9 @@ jobs:
   communicate-on-pull-request-merged:
     name: communicate on pull request merged
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Communicate on PR merged
         if: github.event.pull_request.merged

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,31 @@
+name: Processing pull requests
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  communicate-on-pull-request-merged:
+    name: communicate on pull request merged
+    runs-on: ubuntu-latest
+    steps:
+      - name: Communicate on PR merged
+        if: github.event.pull_request.merged
+        uses: fastlane/github-actions/communicate-on-pull-request-merged@latest
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-comment: >
+            Hey @${{ github.event.pull_request.user.login }} :wave:
+
+            
+            Thank you for your contribution to _fastlane_ and congrats on getting this pull request merged :tada:
+            
+            The code change now lives in the `master` branch, however it wasn't released to [RubyGems](https://rubygems.org/gems/fastlane) yet.
+            
+            We usually ship about once a month, and your PR will be included in the next one.
+            
+            
+            Please let us know if this change requires an immediate release by adding a comment here :+1:
+            
+            We'll notify you once we shipped a new release with your changes :rocket:"
+          pr-label-to-add: 'status: included-in-next-release'
+          pr-label-to-remove: 'status: needs-attention'


### PR DESCRIPTION
closes: https://github.com/fastlane/github-actions/pull/29

Way back in the day this action would respond to PRs when closed. Problem was secrets were not exposed to fork's. Now in modern times we have `pull_request_target` and `GITHUB_TOKEN`.

This works by running workflows against the mainline branch (not the code in the PR). Since this action just responds to a PR based on logic from another workflow - this is safe.

> Running untrusted code on the pull_request_target trigger may lead to security vulnerabilities. These vulnerabilities include cache poisoning and granting unintended access to write privileges or secrets. For more information, see [Secure use reference](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#mitigating-the-risks-of-untrusted-code-checkout) in the GitHub Enterprise Cloud documentation, and [Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests) on the GitHub Security Lab website.


Tested on my fork.

<img width="1233" height="524" alt="Screenshot From 2025-12-20 15-50-51" src="https://github.com/user-attachments/assets/a681a435-6f41-4da1-8afc-2828669d6da9" />


