### PR TITLE
[ci] build: reduce confusion in compilation by renaming things

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -690,7 +690,7 @@ end
 
 desc "Confirm RubyGem credentials are set up correctly"
 private_lane :verify_ruby_gem_credentials do
-  UI.user_error!("You're not logged in RubyGems. Log in using `gem push` if using RubyGems < 2.7.0 or `gem signin` if using RubyGems >=2.7.0") unless File.file?(File.expand_path("~/.gem/credentials"))
+  UI.user_error!("You're not logged into RubyGems. Log in using `gem push` if using RubyGems < 2.7.0 or `gem signin` if using RubyGems >=2.7.0") unless File.file?(File.expand_path("~/.gem/credentials"))
 end
 
 desc "Build fastlane gem"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -690,10 +690,10 @@ end
 
 desc "Confirm RubyGem credentials are set up correctly"
 private_lane :verify_ruby_gem_credentials do
-  UI.user_error!("You're not logged into RubyGems. Log in using `gem push` if using RubyGems < 2.7.0 or `gem signin` if using RubyGems >=2.7.0") unless File.file?(File.expand_path("~/.gem/credentials"))
+  UI.user_error!("You're not logged in to RubyGems. Log in using `gem push` if using RubyGems < 2.7.0 or `gem signin` if using RubyGems >=2.7.0") unless File.file?(File.expand_path("~/.gem/credentials"))
 end
 
-desc "Build fastlane gem"
+desc "Builds the fastlane gem"
 private_lane :build_fastlane_gem do |options|
   version = options[:version]
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,8 +90,8 @@ lane :execute_tests do
   benchmark_help_command
 
   # Run the tests
+  build_fastlane_gem(version: version) unless File.file?("pkg/fastlane-#{version}.gem")
   Dir.chdir("..") do
-    build_fastlane_gem(version: version) unless File.file?("pkg/fastlane-#{version}.gem")
     sh("bundle", "exec", "rake", "test_all")
   end
 end
@@ -697,12 +697,20 @@ desc "Build fastlane gem"
 private_lane :build_fastlane_gem do |options|
   version = options[:version]
 
-  sh("bundle check || bundle install")
-  sh("rake install")
+  Dir.chdir("..") do
+    begin
+      sh("bundle check")
+    rescue => e
+      UI.message("bundle check failed (#{e.message.strip}), running bundle install")
+      sh("bundle install")
+    end
 
-  # Ensure the file size of the fastlane gem is below 1.5 MB
-  size_in_mb = File.size("pkg/fastlane-#{version}.gem").to_f / (1024 * 1024 * 1.5)
-  UI.user_error!("fastlane gem is above 1.5 MB, make sure no additional resources are included by mistake") if size_in_mb > 1
+    sh("rake install")
+
+    # Ensure the file size of the fastlane gem is below 1.5 MB
+    size_in_mb = File.size("pkg/fastlane-#{version}.gem").to_f / (1024 * 1024 * 1.5)
+    UI.user_error!("fastlane gem is above 1.5 MB, make sure no additional resources are included by mistake") if size_in_mb > 1
+  end
 end
 
 desc "Get the local version number per version.rb"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,7 +12,9 @@ end
 
 desc "Verifies all tests pass and the current state of the repo is valid"
 lane :validate_repo do
+  version = local_version
   lint_source
+  build_fastlane_gem(version: version)
   execute_tests
   validate_docs
   ensure_tool_name_formatting
@@ -87,17 +89,10 @@ lane :execute_tests do
 
   benchmark_help_command
 
+  # Run the tests
   Dir.chdir("..") do
-    # Install the bundle and the actual gem
-    sh("bundle check || bundle install")
-    sh("rake install")
-
-    # Ensure the file size of the fastlane gem is below 1.5 MB
-    size_in_mb = File.size("pkg/fastlane-#{version}.gem").to_f / (1024 * 1024 * 1.5)
-    UI.user_error!("fastlane gem is above 1.5 MB, make sure no additional resources are included by mistake") if size_in_mb > 1
-
-    # Run the tests
-    sh("bundle exec rake test_all")
+    build_fastlane_gem(version: version) unless File.file?("pkg/fastlane-#{version}.gem")
+    sh("bundle", "exec", "rake", "test_all")
   end
 end
 
@@ -108,7 +103,8 @@ lane :bump do |options|
   bump_type = options[:bump_type]
   is_automated_bump = !bump_type.nil?
 
-  verify_env_variables(skip_ruby_gems: is_automated_bump)
+  verify_env_variables
+  verify_ruby_gem_credentials unless is_automated_bump
   ensure_git_branch(branch: "master")
   ensure_git_status_clean
 
@@ -580,7 +576,7 @@ lane :update_docs do |options|
   puts("Starting docs update for version #{version} 🚀")
 
   unless debug
-    verify_env_variables(skip_ruby_gems: true)
+    verify_env_variables
     ensure_actions_config_items_formatting
   end
 
@@ -688,12 +684,25 @@ end
 
 desc "Ensure all the requirement environment variables are provided"
 desc "this way the deployment script will fail early (and often)"
-private_lane :verify_env_variables do |options|
+private_lane :verify_env_variables do
   ensure_env_vars(env_vars: ['GITHUB_USER_NAME', 'GITHUB_API_TOKEN'])
+end
 
-  unless options[:skip_ruby_gems]
-    UI.user_error!("You're not logged in RubyGems. Log in using `gem push` if using RubyGems < 2.7.0 or `gem signin` if using RubyGems >=2.7.0") unless File.file?(File.expand_path("~/.gem/credentials"))
-  end
+desc "Confirm RubyGem credentials are set up correctly"
+private_lane :verify_ruby_gem_credentials do
+  UI.user_error!("You're not logged in RubyGems. Log in using `gem push` if using RubyGems < 2.7.0 or `gem signin` if using RubyGems >=2.7.0") unless File.file?(File.expand_path("~/.gem/credentials"))
+end
+
+desc "Build fastlane gem"
+private_lane :build_fastlane_gem do |options|
+  version = options[:version]
+
+  sh("bundle check || bundle install")
+  sh("rake install")
+
+  # Ensure the file size of the fastlane gem is below 1.5 MB
+  size_in_mb = File.size("pkg/fastlane-#{version}.gem").to_f / (1024 * 1024 * 1.5)
+  UI.user_error!("fastlane gem is above 1.5 MB, make sure no additional resources are included by mistake") if size_in_mb > 1
 end
 
 desc "Get the local version number per version.rb"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -705,7 +705,7 @@ private_lane :build_fastlane_gem do |options|
       sh("bundle install")
     end
 
-    sh("rake install")
+    sh("rake", "install")
 
     # Ensure the file size of the fastlane gem is below 1.5 MB
     size_in_mb = File.size("pkg/fastlane-#{version}.gem").to_f / (1024 * 1024 * 1.5)


### PR DESCRIPTION
## Reduce Confusion

1. `verify_env_variables` checks for RubyGem creds which isn't needed anymore in GHA flow. I split this out into its own lane called `verify_ruby_gem_credentials`
2. `validate_repo` calls `execute_tests` which builds the gem. This is so confusing. We need a dedicated private lane for building the actual gem file.
3. Another `sh()` hardening.