### PR TITLE
[action] increment_build_number supports xros

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_build_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_build_number.rb
@@ -8,7 +8,7 @@ module Fastlane
       require 'shellwords'
 
       def self.is_supported?(platform)
-        [:ios, :mac].include?(platform)
+        [:ios, :mac, :xros].include?(platform)
       end
 
       def self.run(params)


### PR DESCRIPTION
### Problem

`increment_build_number` does not support VisionOS, but other tools like deliver do.

### Fix

Add it as a supported type.

fixes: #26602 