### PR TITLE
Add `benchmark` and `ostruct` gems for Ruby 4.0+

### DIFF
--- a/.github/workflows/module_test.yml
+++ b/.github/workflows/module_test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ['3.3', '3.4']
+        ruby: ['3.3', '3.4', '4.0']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ require_relative "fastlane/lib/fastlane/version.rb"
 
 # Please keep all gems and their comments together without empty lines, so RuboCop can sort them alphabetically.
 
+# Benchmark was removed from Ruby's standard library in Ruby 4.0+.
+gem "benchmark"
 # Allows fine-grained control of environment variables.
 gem "climate_control", "~> 0.2.0"
 # A tool for integrating Coveralls.io with Ruby apps.
@@ -28,6 +30,8 @@ gem "openssl",
     "!= 3.2.0",
     "!= 3.2.1",
     "!= 3.3.0"
+# OpenStruct was removed from Ruby's standard library in Ruby 4.0+.
+gem "ostruct"
 # Fast XML parser and object marshaller.
 # Version 2.14.15+ requires Ruby >=2.7, while fastlane uses a `required_ruby_version` of `>= 2.6`.
 gem "ox", "2.14.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       aws-sdk-s3 (~> 1.0)
       babosa (>= 1.0.3, < 2.0.0)
       base64 (~> 0.2.0)
+      benchmark (>= 0.1.0)
       bundler (>= 1.12.0, < 3.0.0)
       colored (~> 1.2)
       commander (~> 4.6)
@@ -37,6 +38,7 @@ PATH
       naturally (~> 2.2)
       nkf (~> 0.2.0)
       optparse (>= 0.1.1, < 1.0.0)
+      ostruct (>= 0.1.0)
       plist (>= 3.1.0, < 4.0.0)
       rubyzip (>= 2.0.0, < 3.0.0)
       security (= 0.1.5)
@@ -81,6 +83,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.2.0)
+    benchmark (0.5.0)
     bigdecimal (3.1.8)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -235,6 +238,7 @@ GEM
     openssl (3.1.3)
     optparse (0.4.0)
     os (1.1.4)
+    ostruct (0.6.3)
     ox (2.14.14)
     parallel (1.23.0)
     parser (3.2.2.3)
@@ -385,6 +389,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  benchmark
   climate_control (~> 0.2.0)
   coveralls (~> 0.8.13)
   danger (~> 8.0)
@@ -396,6 +401,7 @@ DEPENDENCIES
   fastlane-plugin-slack_train (>= 0.2.0)
   mime-types (>= 1.16, < 4.0)
   openssl (>= 3.1.2, != 3.3.0, != 3.2.1, != 3.2.0)
+  ostruct
   ox (= 2.14.14)
   pry
   pry-byebug

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -99,10 +99,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency('xcpretty', '~> 0.4.1') # prettify xcodebuild output
 
   # As Ruby evolves, some stdlib modules are no longer bundled with Ruby and instead standard gems.
+  spec.add_dependency('benchmark', '>= 0.1.0') # stdlib gem removed from default set in Ruby 3.5+
   spec.add_dependency('abbrev', '~> 0.1.2') # 3.4 - workaround for highline as can't upgrade to 3.x yet
   spec.add_dependency('base64', '~> 0.2.0') # 3.4 - workaround for CFPropertyList as can't upgrade to 4.x yet
   spec.add_dependency('csv', '~> 3.3') # 3.4 - workaround for sinatra as can't upgrade to 4.x yet
   spec.add_dependency('mutex_m', '~> 0.3.0') # 3.4 - workaround for httpclient as can't upgrade to 2.9 yet
   spec.add_dependency('nkf', '~> 0.2.0') # 3.4 - workaround for CFPropertyList as can't upgrade to 4.x yet
-  spec.add_dependency('logger', '>= 1.6', '< 2.0') # stdlib gem removed from default set in Ruby 3.5+
+  spec.add_dependency('logger', '>= 1.6', '< 2.0') # stdlib gem removed from default set in Ruby 4.0+
+  spec.add_dependency('ostruct', '>= 0.1.0') # stdlib gem removed from default set in Ruby 3.5+
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

These gems were removed from the Ruby's standard library in Ruby 4.0.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
