### PR TITLE
[snapshot] Fix device configuration being overwritten for iOS+Mac projects

### DIFF
--- a/snapshot/lib/snapshot/detect_values.rb
+++ b/snapshot/lib/snapshot/detect_values.rb
@@ -66,7 +66,7 @@ module Snapshot
 
           config[:devices] << sim.name
         end
-      elsif Snapshot.project.mac?
+      elsif config[:devices].nil? && Snapshot.project.mac?
         config[:devices] = ["Mac"]
       end
     end

--- a/snapshot/spec/detect_values_spec.rb
+++ b/snapshot/spec/detect_values_spec.rb
@@ -35,5 +35,46 @@ describe Snapshot do
         expect(Snapshot.config[:skip_testing]).to eq(["Bundle/SuiteA", "Bundle/SuiteB"])
       end
     end
+
+    describe "device configuration for Mac projects" do
+      before(:each) do
+        allow(Snapshot).to receive(:snapfile_name).and_return("some fake snapfile")
+        fake_out_xcode_project_loading
+        allow(File).to receive(:expand_path).and_call_original
+        allow(File).to receive(:expand_path).with("some fake snapfile").and_return("/fake/path/Snapfile")
+        allow(File).to receive(:expand_path).with("..", "./snapshot/example/Example.xcodeproj").and_return("./snapshot/example")
+        allow(File).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:chdir).and_yield
+      end
+
+      it "sets devices to ['Mac'] when devices is nil and project is Mac", requires_xcodebuild: true do
+        options = {
+            project: "./snapshot/example/Example.xcodeproj",
+            scheme: "ExampleMacOSUITests"
+        }
+        mock_project = instance_double(FastlaneCore::Project, mac?: true, path: "./snapshot/example/Example.xcodeproj", select_scheme: nil)
+        allow(FastlaneCore::Project).to receive(:new).and_return(mock_project)
+        allow(FastlaneCore::Project).to receive(:detect_projects)
+
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+
+        expect(Snapshot.config[:devices]).to eq(["Mac"])
+      end
+
+      it "does not overwrite devices when devices is already set and project is Mac", requires_xcodebuild: true do
+        options = {
+            project: "./snapshot/example/Example.xcodeproj",
+            scheme: "ExampleMacOSUITests",
+            devices: ["iPhone 15 Pro"]
+        }
+        mock_project = instance_double(FastlaneCore::Project, mac?: true, path: "./snapshot/example/Example.xcodeproj", select_scheme: nil)
+        allow(FastlaneCore::Project).to receive(:new).and_return(mock_project)
+        allow(FastlaneCore::Project).to receive(:detect_projects)
+
+        Snapshot.config = FastlaneCore::Configuration.create(Snapshot::Options.available_options, options)
+
+        expect(Snapshot.config[:devices]).to eq(["iPhone 15 Pro"])
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds test coverage for the changes introduced in huven:snapshot-devices branch. The change ensures that when config[:devices] is already set, it doesn't get overwritten for Mac projects.

Related to: #22246 (huven:snapshot-devices branch)
Resolves #21752
Resolves #22150
Closes #22246

### Checklist

- [x] I've run `bundle exec rspec snapshot/spec/detect_values_spec.rb` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've added or updated relevant unit tests.

### Test Results
All tests passing: 5 examples, 0 failures