### PR TITLE
docs: remove IMAGE_GUIDELINES as Google remnant

### DIFF
--- a/fastlane/assets/IMAGE_GUIDELINES.md
+++ b/fastlane/assets/IMAGE_GUIDELINES.md
@@ -1,1 +1,0 @@
-Google open source projects may contain logos, trademarks or service names. These are "Brand Features", and if you want to use them, please do so consistent with [google.com/permissions/trademark/rules.html](https://www.google.com/permissions/trademark/rules.html).


### PR DESCRIPTION
In a journey to "de-google". This was found in a code search.