### PR TITLE
[core] build: move to xcodeproj 1.27.0 (from 1.22.0)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,10 +53,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.7)
-      base64
-      nkf
-      rexml
+    CFPropertyList (3.0.8)
     abbrev (0.1.2)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
@@ -223,7 +220,7 @@ GEM
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.3.0)
-    nanaimo (0.3.0)
+    nanaimo (0.4.0)
     nap (1.1.0)
     naturally (2.2.1)
     nkf (0.2.0)
@@ -268,8 +265,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.9)
-      strscan
+    rexml (3.4.4)
     rouge (3.28.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -329,7 +325,6 @@ GEM
       rack-protection (= 2.2.4)
       tilt (~> 2.0)
     slack-notifier (2.4.0)
-    strscan (3.1.2)
     sync (0.5.0)
     sysrandom (1.0.5)
     term-ansicolor (1.7.1)
@@ -358,13 +353,13 @@ GEM
     xcode-install (2.6.8)
       claide (>= 0.9.1, < 1.1.0)
       fastlane (>= 2.1.0, < 3.0.0)
-    xcodeproj (1.22.0)
+    xcodeproj (1.27.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      nanaimo (~> 0.4.0)
+      rexml (>= 3.3.6, < 4.0)
     xcov (1.9.0)
       abbrev
       fastlane (>= 2.141.0, < 3.0.0)


### PR DESCRIPTION
## Problem

We have a vulnerability in rexml, which is handled by a modern xcodeproj.

## Solution

Upgrade from 1.22.0 to 1.27.0 for xcodeproj

fixes: #29727