### PR TITLE
[snapshot] fix: keep 'stderr' during simulator configuration/launch

### DIFF
--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -323,7 +323,7 @@ module FastlaneCore
       return result
     end
 
-    def self.backticks_if_verbose(command)
+    def self.backticks_verbose(command)
       UI.command(command) if FastlaneCore::Globals.verbose?
       result = `#{command}`
       UI.command_output(result) if FastlaneCore::Globals.verbose?

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -323,7 +323,7 @@ module FastlaneCore
       return result
     end
 
-    def self.backticks_ng(command)
+    def self.backticks_if_verbose(command)
       UI.command(command) if FastlaneCore::Globals.verbose?
       result = `#{command}`
       UI.command_output(result) if FastlaneCore::Globals.verbose?

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -323,13 +323,6 @@ module FastlaneCore
       return result
     end
 
-    def self.backticks_verbose(command)
-      UI.command(command) if FastlaneCore::Globals.verbose?
-      result = `#{command}`
-      UI.command_output(result) if FastlaneCore::Globals.verbose?
-      return result
-    end
-
     # removes ANSI colors from string
     def self.strip_ansi_colors(str)
       str.gsub(/\e\[([;\d]+)?m/, '')

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -323,6 +323,13 @@ module FastlaneCore
       return result
     end
 
+    def self.backticks_ng(command)
+      UI.command(command) if FastlaneCore::Globals.verbose?
+      result = `#{command}`
+      UI.command_output(result) if FastlaneCore::Globals.verbose?
+      return result
+    end
+
     # removes ANSI colors from string
     def self.strip_ansi_colors(str)
       str.gsub(/\e\[([;\d]+)?m/, '')

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -241,19 +241,19 @@ describe FastlaneCore do
 
     describe "#backticks" do
       it "executes the command and returns the output" do
-        expect(FastlaneCore::Helper.backticks("echo 'hello'")).to eq("hello\n")
+        expect(FastlaneCore::Helper.backticks("echo hello")).to eq("hello\n")
       end
 
       it "prints the command and output if print is true" do
-        expect(FastlaneCore::UI).to receive(:command).with("echo 'hello'")
+        expect(FastlaneCore::UI).to receive(:command).with("echo hello")
         expect(FastlaneCore::UI).to receive(:command_output).with("hello\n")
-        FastlaneCore::Helper.backticks("echo 'hello'", print: true)
+        FastlaneCore::Helper.backticks("echo hello", print: true)
       end
 
       it "does not print the command and output if print is false" do
         expect(FastlaneCore::UI).not_to receive(:command)
         expect(FastlaneCore::UI).not_to receive(:command_output)
-        FastlaneCore::Helper.backticks("echo 'hello'", print: false)
+        FastlaneCore::Helper.backticks("echo hello", print: false)
       end
     end
 

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -239,6 +239,24 @@ describe FastlaneCore do
       end
     end
 
+    describe "#backticks" do
+      it "executes the command and returns the output" do
+        expect(FastlaneCore::Helper.backticks("echo 'hello'")).to eq("hello\n")
+      end
+
+      it "prints the command and output if print is true" do
+        expect(FastlaneCore::UI).to receive(:command).with("echo 'hello'")
+        expect(FastlaneCore::UI).to receive(:command_output).with("hello\n")
+        FastlaneCore::Helper.backticks("echo 'hello'", print: true)
+      end
+
+      it "does not print the command and output if print is false" do
+        expect(FastlaneCore::UI).not_to receive(:command)
+        expect(FastlaneCore::UI).not_to receive(:command_output)
+        FastlaneCore::Helper.backticks("echo 'hello'", print: false)
+      end
+    end
+
     describe "#which" do
       it "delegates to FastlaneCore::CommandExecutor.which" do
         expect(FastlaneCore::CommandExecutor).to receive(:which).with('ruby').and_return('/usr/bin/ruby')

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -52,7 +52,7 @@ module Snapshot
       # Kill and shutdown all currently running simulators so that the following settings
       # changes will be picked up when they are started again.
       Snapshot.kill_simulator # because of https://github.com/fastlane/fastlane/issues/2533
-      Helper.backticks("xcrun simctl shutdown booted", print: FastlaneCore::Globals.verbose?)
+      Helper.backticks_ng("xcrun simctl shutdown booted")
 
       Fixes::SimulatorZoomFix.patch
       Fixes::HardwareKeyboardFix.patch
@@ -81,7 +81,7 @@ module Snapshot
 
       unless launcher_config.headless
         simulator_path = File.join(Helper.xcode_path, 'Applications', 'Simulator.app')
-        Helper.backticks("open -a #{simulator_path} -g", print: FastlaneCore::Globals.verbose?)
+        Helper.backticks_ng("open -a #{simulator_path} -g")
       end
     end
 
@@ -95,22 +95,22 @@ module Snapshot
 
         UI.message("Launch Simulator #{device_type}")
         if FastlaneCore::Helper.xcode_at_least?("13")
-          Helper.backticks("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
+          Helper.backticks_ng("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
         else
-          Helper.backticks("xcrun instruments -w #{device_udid}", print: FastlaneCore::Globals.verbose?)
+          Helper.backticks_ng("xcrun instruments -w #{device_udid}")
         end
 
         paths.each do |path|
           UI.message("Adding '#{path}'")
 
           # Attempting addmedia since addphoto and addvideo are deprecated
-          output = Helper.backticks("xcrun simctl addmedia #{device_udid} #{path.shellescape}", print: FastlaneCore::Globals.verbose?)
+          output = Helper.backticks_ng("xcrun simctl addmedia #{device_udid} #{path.shellescape}")
 
           # Run legacy addphoto and addvideo if addmedia isn't found
           # Output will be empty string if it was a success
           # Output will contain "usage: simctl" if command not found
           if output.include?('usage: simctl')
-            Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape}", print: FastlaneCore::Globals.verbose?)
+            Helper.backticks_ng("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape}")
           end
         end
       end
@@ -121,7 +121,7 @@ module Snapshot
 
       UI.message("Launch Simulator #{device_type}")
       # Boot the simulator and wait for it to finish booting
-      Helper.backticks("xcrun simctl bootstatus #{device_udid} -b", print: FastlaneCore::Globals.verbose?)
+      Helper.backticks_ng("xcrun simctl bootstatus #{device_udid} -b")
 
       # "Booted" status is not enough for to adjust the status bar
       # Simulator could still be booting with Apple logo
@@ -143,14 +143,14 @@ module Snapshot
         arguments = "--time #{time_str} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --operatorName '' --cellularBars 4 --batteryState charged --batteryLevel 100"
       end
 
-      Helper.backticks("xcrun simctl status_bar #{device_udid} override #{arguments}", print: FastlaneCore::Globals.verbose?)
+      Helper.backticks_ng("xcrun simctl status_bar #{device_udid} override #{arguments}")
     end
 
     def clear_status_bar(device_type)
       device_udid = TestCommandGenerator.device_udid(device_type)
 
       UI.message("Clearing Status Bar Override")
-      Helper.backticks("xcrun simctl status_bar #{device_udid} clear", print: FastlaneCore::Globals.verbose?)
+      Helper.backticks_ng("xcrun simctl status_bar #{device_udid} clear")
     end
 
     def uninstall_app(device_type)
@@ -166,7 +166,7 @@ module Snapshot
 
       UI.important("Erasing #{device_type}...")
 
-      Helper.backticks("xcrun simctl erase #{device_udid}", print: FastlaneCore::Globals.verbose?)
+      Helper.backticks_ng("xcrun simctl erase #{device_udid}")
     end
 
     def localize_simulator(device_type, language, locale)

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -52,7 +52,7 @@ module Snapshot
       # Kill and shutdown all currently running simulators so that the following settings
       # changes will be picked up when they are started again.
       Snapshot.kill_simulator # because of https://github.com/fastlane/fastlane/issues/2533
-      Helper.backticks_if_verbose("xcrun simctl shutdown booted")
+      Helper.backticks_verbose("xcrun simctl shutdown booted")
 
       Fixes::SimulatorZoomFix.patch
       Fixes::HardwareKeyboardFix.patch
@@ -81,7 +81,7 @@ module Snapshot
 
       unless launcher_config.headless
         simulator_path = File.join(Helper.xcode_path, 'Applications', 'Simulator.app')
-        Helper.backticks_if_verbose("open -a #{simulator_path} -g")
+        Helper.backticks_verbose("open -a #{simulator_path} -g")
       end
     end
 
@@ -95,22 +95,22 @@ module Snapshot
 
         UI.message("Launch Simulator #{device_type}")
         if FastlaneCore::Helper.xcode_at_least?("13")
-          Helper.backticks_if_verbose("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
+          Helper.backticks_verbose("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
         else
-          Helper.backticks_if_verbose("xcrun instruments -w #{device_udid}")
+          Helper.backticks_verbose("xcrun instruments -w #{device_udid}")
         end
 
         paths.each do |path|
           UI.message("Adding '#{path}'")
 
           # Attempting addmedia since addphoto and addvideo are deprecated
-          output = Helper.backticks_if_verbose("xcrun simctl addmedia #{device_udid} #{path.shellescape}")
+          output = Helper.backticks_verbose("xcrun simctl addmedia #{device_udid} #{path.shellescape}")
 
           # Run legacy addphoto and addvideo if addmedia isn't found
           # Output will be empty string if it was a success
           # Output will contain "usage: simctl" if command not found
           if output.include?('usage: simctl')
-            Helper.backticks_if_verbose("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape}")
+            Helper.backticks_verbose("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape}")
           end
         end
       end
@@ -121,7 +121,7 @@ module Snapshot
 
       UI.message("Launch Simulator #{device_type}")
       # Boot the simulator and wait for it to finish booting
-      Helper.backticks_if_verbose("xcrun simctl bootstatus #{device_udid} -b")
+      Helper.backticks_verbose("xcrun simctl bootstatus #{device_udid} -b")
 
       # "Booted" status is not enough for to adjust the status bar
       # Simulator could still be booting with Apple logo
@@ -143,14 +143,14 @@ module Snapshot
         arguments = "--time #{time_str} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --operatorName '' --cellularBars 4 --batteryState charged --batteryLevel 100"
       end
 
-      Helper.backticks_if_verbose("xcrun simctl status_bar #{device_udid} override #{arguments}")
+      Helper.backticks_verbose("xcrun simctl status_bar #{device_udid} override #{arguments}")
     end
 
     def clear_status_bar(device_type)
       device_udid = TestCommandGenerator.device_udid(device_type)
 
       UI.message("Clearing Status Bar Override")
-      Helper.backticks_if_verbose("xcrun simctl status_bar #{device_udid} clear")
+      Helper.backticks_verbose("xcrun simctl status_bar #{device_udid} clear")
     end
 
     def uninstall_app(device_type)
@@ -166,7 +166,7 @@ module Snapshot
 
       UI.important("Erasing #{device_type}...")
 
-      Helper.backticks_if_verbose("xcrun simctl erase #{device_udid}")
+      Helper.backticks_verbose("xcrun simctl erase #{device_udid}")
     end
 
     def localize_simulator(device_type, language, locale)

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -52,7 +52,7 @@ module Snapshot
       # Kill and shutdown all currently running simulators so that the following settings
       # changes will be picked up when they are started again.
       Snapshot.kill_simulator # because of https://github.com/fastlane/fastlane/issues/2533
-      `xcrun simctl shutdown booted &> /dev/null`
+      Helper.backticks("xcrun simctl shutdown booted &> /dev/null")
 
       Fixes::SimulatorZoomFix.patch
       Fixes::HardwareKeyboardFix.patch
@@ -95,22 +95,22 @@ module Snapshot
 
         UI.message("Launch Simulator #{device_type}")
         if FastlaneCore::Helper.xcode_at_least?("13")
-          Helper.backticks("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid} &> /dev/null")
+          Helper.backticks("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid} 2>&1 > /dev/null")
         else
-          Helper.backticks("xcrun instruments -w #{device_udid} &> /dev/null")
+          Helper.backticks("xcrun instruments -w #{device_udid} 2>&1 > /dev/null")
         end
 
         paths.each do |path|
           UI.message("Adding '#{path}'")
 
           # Attempting addmedia since addphoto and addvideo are deprecated
-          output = Helper.backticks("xcrun simctl addmedia #{device_udid} #{path.shellescape} &> /dev/null")
+          output = Helper.backticks("xcrun simctl addmedia #{device_udid} #{path.shellescape} 2>&1 > /dev/null")
 
           # Run legacy addphoto and addvideo if addmedia isn't found
           # Output will be empty string if it was a success
           # Output will contain "usage: simctl" if command not found
           if output.include?('usage: simctl')
-            Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape} &> /dev/null")
+            Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape} 2>&1 > /dev/null")
           end
         end
       end
@@ -121,7 +121,7 @@ module Snapshot
 
       UI.message("Launch Simulator #{device_type}")
       # Boot the simulator and wait for it to finish booting
-      Helper.backticks("xcrun simctl bootstatus #{device_udid} -b &> /dev/null")
+      Helper.backticks("xcrun simctl bootstatus #{device_udid} -b 2>&1 > /dev/null")
 
       # "Booted" status is not enough for to adjust the status bar
       # Simulator could still be booting with Apple logo
@@ -143,14 +143,14 @@ module Snapshot
         arguments = "--time #{time_str} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --operatorName '' --cellularBars 4 --batteryState charged --batteryLevel 100"
       end
 
-      Helper.backticks("xcrun simctl status_bar #{device_udid} override #{arguments} &> /dev/null")
+      Helper.backticks("xcrun simctl status_bar #{device_udid} override #{arguments} 2>&1 > /dev/null")
     end
 
     def clear_status_bar(device_type)
       device_udid = TestCommandGenerator.device_udid(device_type)
 
       UI.message("Clearing Status Bar Override")
-      Helper.backticks("xcrun simctl status_bar #{device_udid} clear &> /dev/null")
+      Helper.backticks("xcrun simctl status_bar #{device_udid} clear 2>&1 > /dev/null")
     end
 
     def uninstall_app(device_type)
@@ -166,7 +166,7 @@ module Snapshot
 
       UI.important("Erasing #{device_type}...")
 
-      `xcrun simctl erase #{device_udid} &> /dev/null`
+      Helper.backticks("xcrun simctl erase #{device_udid} 2>&1 > /dev/null")
     end
 
     def localize_simulator(device_type, language, locale)

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -52,7 +52,7 @@ module Snapshot
       # Kill and shutdown all currently running simulators so that the following settings
       # changes will be picked up when they are started again.
       Snapshot.kill_simulator # because of https://github.com/fastlane/fastlane/issues/2533
-      Helper.backticks_ng("xcrun simctl shutdown booted")
+      Helper.backticks_if_verbose("xcrun simctl shutdown booted")
 
       Fixes::SimulatorZoomFix.patch
       Fixes::HardwareKeyboardFix.patch
@@ -81,7 +81,7 @@ module Snapshot
 
       unless launcher_config.headless
         simulator_path = File.join(Helper.xcode_path, 'Applications', 'Simulator.app')
-        Helper.backticks_ng("open -a #{simulator_path} -g")
+        Helper.backticks_if_verbose("open -a #{simulator_path} -g")
       end
     end
 
@@ -95,22 +95,22 @@ module Snapshot
 
         UI.message("Launch Simulator #{device_type}")
         if FastlaneCore::Helper.xcode_at_least?("13")
-          Helper.backticks_ng("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
+          Helper.backticks_if_verbose("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
         else
-          Helper.backticks_ng("xcrun instruments -w #{device_udid}")
+          Helper.backticks_if_verbose("xcrun instruments -w #{device_udid}")
         end
 
         paths.each do |path|
           UI.message("Adding '#{path}'")
 
           # Attempting addmedia since addphoto and addvideo are deprecated
-          output = Helper.backticks_ng("xcrun simctl addmedia #{device_udid} #{path.shellescape}")
+          output = Helper.backticks_if_verbose("xcrun simctl addmedia #{device_udid} #{path.shellescape}")
 
           # Run legacy addphoto and addvideo if addmedia isn't found
           # Output will be empty string if it was a success
           # Output will contain "usage: simctl" if command not found
           if output.include?('usage: simctl')
-            Helper.backticks_ng("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape}")
+            Helper.backticks_if_verbose("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape}")
           end
         end
       end
@@ -121,7 +121,7 @@ module Snapshot
 
       UI.message("Launch Simulator #{device_type}")
       # Boot the simulator and wait for it to finish booting
-      Helper.backticks_ng("xcrun simctl bootstatus #{device_udid} -b")
+      Helper.backticks_if_verbose("xcrun simctl bootstatus #{device_udid} -b")
 
       # "Booted" status is not enough for to adjust the status bar
       # Simulator could still be booting with Apple logo
@@ -143,14 +143,14 @@ module Snapshot
         arguments = "--time #{time_str} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --operatorName '' --cellularBars 4 --batteryState charged --batteryLevel 100"
       end
 
-      Helper.backticks_ng("xcrun simctl status_bar #{device_udid} override #{arguments}")
+      Helper.backticks_if_verbose("xcrun simctl status_bar #{device_udid} override #{arguments}")
     end
 
     def clear_status_bar(device_type)
       device_udid = TestCommandGenerator.device_udid(device_type)
 
       UI.message("Clearing Status Bar Override")
-      Helper.backticks_ng("xcrun simctl status_bar #{device_udid} clear")
+      Helper.backticks_if_verbose("xcrun simctl status_bar #{device_udid} clear")
     end
 
     def uninstall_app(device_type)
@@ -166,7 +166,7 @@ module Snapshot
 
       UI.important("Erasing #{device_type}...")
 
-      Helper.backticks_ng("xcrun simctl erase #{device_udid}")
+      Helper.backticks_if_verbose("xcrun simctl erase #{device_udid}")
     end
 
     def localize_simulator(device_type, language, locale)

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -52,7 +52,7 @@ module Snapshot
       # Kill and shutdown all currently running simulators so that the following settings
       # changes will be picked up when they are started again.
       Snapshot.kill_simulator # because of https://github.com/fastlane/fastlane/issues/2533
-      Helper.backticks("xcrun simctl shutdown booted &> /dev/null")
+      Helper.backticks("xcrun simctl shutdown booted", print: FastlaneCore::Globals.verbose?)
 
       Fixes::SimulatorZoomFix.patch
       Fixes::HardwareKeyboardFix.patch
@@ -95,22 +95,22 @@ module Snapshot
 
         UI.message("Launch Simulator #{device_type}")
         if FastlaneCore::Helper.xcode_at_least?("13")
-          Helper.backticks("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid} 2>&1 > /dev/null")
+          Helper.backticks("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
         else
-          Helper.backticks("xcrun instruments -w #{device_udid} 2>&1 > /dev/null")
+          Helper.backticks("xcrun instruments -w #{device_udid}", print: FastlaneCore::Globals.verbose?)
         end
 
         paths.each do |path|
           UI.message("Adding '#{path}'")
 
           # Attempting addmedia since addphoto and addvideo are deprecated
-          output = Helper.backticks("xcrun simctl addmedia #{device_udid} #{path.shellescape} 2>&1 > /dev/null")
+          output = Helper.backticks("xcrun simctl addmedia #{device_udid} #{path.shellescape}", print: FastlaneCore::Globals.verbose?)
 
           # Run legacy addphoto and addvideo if addmedia isn't found
           # Output will be empty string if it was a success
           # Output will contain "usage: simctl" if command not found
           if output.include?('usage: simctl')
-            Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape} 2>&1 > /dev/null")
+            Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape}", print: FastlaneCore::Globals.verbose?)
           end
         end
       end
@@ -121,7 +121,7 @@ module Snapshot
 
       UI.message("Launch Simulator #{device_type}")
       # Boot the simulator and wait for it to finish booting
-      Helper.backticks("xcrun simctl bootstatus #{device_udid} -b 2>&1 > /dev/null")
+      Helper.backticks("xcrun simctl bootstatus #{device_udid} -b", print: FastlaneCore::Globals.verbose?)
 
       # "Booted" status is not enough for to adjust the status bar
       # Simulator could still be booting with Apple logo
@@ -143,14 +143,14 @@ module Snapshot
         arguments = "--time #{time_str} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --operatorName '' --cellularBars 4 --batteryState charged --batteryLevel 100"
       end
 
-      Helper.backticks("xcrun simctl status_bar #{device_udid} override #{arguments} 2>&1 > /dev/null")
+      Helper.backticks("xcrun simctl status_bar #{device_udid} override #{arguments}", print: FastlaneCore::Globals.verbose?)
     end
 
     def clear_status_bar(device_type)
       device_udid = TestCommandGenerator.device_udid(device_type)
 
       UI.message("Clearing Status Bar Override")
-      Helper.backticks("xcrun simctl status_bar #{device_udid} clear 2>&1 > /dev/null")
+      Helper.backticks("xcrun simctl status_bar #{device_udid} clear", print: FastlaneCore::Globals.verbose?)
     end
 
     def uninstall_app(device_type)
@@ -166,7 +166,7 @@ module Snapshot
 
       UI.important("Erasing #{device_type}...")
 
-      Helper.backticks("xcrun simctl erase #{device_udid} 2>&1 > /dev/null")
+      Helper.backticks("xcrun simctl erase #{device_udid}", print: FastlaneCore::Globals.verbose?)
     end
 
     def localize_simulator(device_type, language, locale)

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -52,7 +52,7 @@ module Snapshot
       # Kill and shutdown all currently running simulators so that the following settings
       # changes will be picked up when they are started again.
       Snapshot.kill_simulator # because of https://github.com/fastlane/fastlane/issues/2533
-      Helper.backticks_verbose("xcrun simctl shutdown booted")
+      Helper.backticks("xcrun simctl shutdown booted", print: FastlaneCore::Globals.verbose?)
 
       Fixes::SimulatorZoomFix.patch
       Fixes::HardwareKeyboardFix.patch
@@ -81,7 +81,7 @@ module Snapshot
 
       unless launcher_config.headless
         simulator_path = File.join(Helper.xcode_path, 'Applications', 'Simulator.app')
-        Helper.backticks_verbose("open -a #{simulator_path} -g")
+        Helper.backticks("open -a #{simulator_path} -g", print: FastlaneCore::Globals.verbose?)
       end
     end
 
@@ -95,22 +95,22 @@ module Snapshot
 
         UI.message("Launch Simulator #{device_type}")
         if FastlaneCore::Helper.xcode_at_least?("13")
-          Helper.backticks_verbose("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
+          Helper.backticks("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
         else
-          Helper.backticks_verbose("xcrun instruments -w #{device_udid}")
+          Helper.backticks("xcrun instruments -w #{device_udid}", print: FastlaneCore::Globals.verbose?)
         end
 
         paths.each do |path|
           UI.message("Adding '#{path}'")
 
           # Attempting addmedia since addphoto and addvideo are deprecated
-          output = Helper.backticks_verbose("xcrun simctl addmedia #{device_udid} #{path.shellescape}")
+          output = Helper.backticks("xcrun simctl addmedia #{device_udid} #{path.shellescape}", print: FastlaneCore::Globals.verbose?)
 
           # Run legacy addphoto and addvideo if addmedia isn't found
           # Output will be empty string if it was a success
           # Output will contain "usage: simctl" if command not found
           if output.include?('usage: simctl')
-            Helper.backticks_verbose("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape}")
+            Helper.backticks("xcrun simctl add#{media_type} #{device_udid} #{path.shellescape}", print: FastlaneCore::Globals.verbose?)
           end
         end
       end
@@ -121,7 +121,7 @@ module Snapshot
 
       UI.message("Launch Simulator #{device_type}")
       # Boot the simulator and wait for it to finish booting
-      Helper.backticks_verbose("xcrun simctl bootstatus #{device_udid} -b")
+      Helper.backticks("xcrun simctl bootstatus #{device_udid} -b", print: FastlaneCore::Globals.verbose?)
 
       # "Booted" status is not enough for to adjust the status bar
       # Simulator could still be booting with Apple logo
@@ -143,14 +143,14 @@ module Snapshot
         arguments = "--time #{time_str} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --operatorName '' --cellularBars 4 --batteryState charged --batteryLevel 100"
       end
 
-      Helper.backticks_verbose("xcrun simctl status_bar #{device_udid} override #{arguments}")
+      Helper.backticks("xcrun simctl status_bar #{device_udid} override #{arguments}", print: FastlaneCore::Globals.verbose?)
     end
 
     def clear_status_bar(device_type)
       device_udid = TestCommandGenerator.device_udid(device_type)
 
       UI.message("Clearing Status Bar Override")
-      Helper.backticks_verbose("xcrun simctl status_bar #{device_udid} clear")
+      Helper.backticks("xcrun simctl status_bar #{device_udid} clear", print: FastlaneCore::Globals.verbose?)
     end
 
     def uninstall_app(device_type)
@@ -166,7 +166,7 @@ module Snapshot
 
       UI.important("Erasing #{device_type}...")
 
-      Helper.backticks_verbose("xcrun simctl erase #{device_udid}")
+      Helper.backticks("xcrun simctl erase #{device_udid}", print: FastlaneCore::Globals.verbose?)
     end
 
     def localize_simulator(device_type, language, locale)

--- a/snapshot/spec/simulator_launcher_base_spec.rb
+++ b/snapshot/spec/simulator_launcher_base_spec.rb
@@ -8,20 +8,20 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
 
         if FastlaneCore::Helper.xcode_at_least?("13")
-          expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+          expect(Fastlane::Helper).to receive(:backticks_verbose)
             .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
             .and_return("").exactly(1).times
         else
-          expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+          expect(Fastlane::Helper).to receive(:backticks_verbose)
             .with("xcrun instruments -w #{device_udid}")
             .and_return("").exactly(1).times
         end
-        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+        expect(Fastlane::Helper).to receive(:backticks_verbose)
           .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}")
           .and_return("").exactly(1).times
 
-        # Verify that backticks_if_verbose isn't called for the fallback to addphoto/addvideo
-        expect(Fastlane::Helper).to receive(:backticks_if_verbose).with(any_args).and_return(anything).exactly(0).times
+        # Verify that backticks_verbose isn't called for the fallback to addphoto/addvideo
+        expect(Fastlane::Helper).to receive(:backticks_verbose).with(any_args).and_return(anything).exactly(0).times
 
         launcher = Snapshot::SimulatorLauncherBase.new
         launcher.add_media(['phone'], 'photo', paths)
@@ -31,20 +31,20 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
 
         if FastlaneCore::Helper.xcode_at_least?("13")
-          expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+          expect(Fastlane::Helper).to receive(:backticks_verbose)
             .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
             .and_return("").exactly(1).times
         else
-          expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+          expect(Fastlane::Helper).to receive(:backticks_verbose)
             .with("xcrun instruments -w #{device_udid}")
             .and_return("").exactly(1).times
         end
 
-        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+        expect(Fastlane::Helper).to receive(:backticks_verbose)
           .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}")
           .and_return("usage: simctl [--noxpc] [--set <path>] [--profiles <path>] <subcommand> ...\n").exactly(1).times
 
-        expect(Fastlane::Helper).to receive(:backticks_if_verbose).with(any_args).and_return(anything).exactly(1).times
+        expect(Fastlane::Helper).to receive(:backticks_verbose).with(any_args).and_return(anything).exactly(1).times
 
         launcher = Snapshot::SimulatorLauncherBase.new
         launcher.add_media(['phone'], 'photo', paths)
@@ -61,12 +61,12 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
         allow(ENV).to receive(:[]).with("SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT").and_return(nil)
 
-        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+        expect(Fastlane::Helper).to receive(:backticks_verbose)
           .with("xcrun simctl bootstatus #{device_udid} -b")
           .and_return("").exactly(1).times
 
         # Verify the time format is HH:MM (e.g., "09:41") not ISO8601
-        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+        expect(Fastlane::Helper).to receive(:backticks_verbose)
           .with(match(/xcrun simctl status_bar #{device_udid} override --time 09:41/))
           .and_return("").exactly(1).times
 
@@ -78,12 +78,12 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
         allow(ENV).to receive(:[]).with("SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT").and_return(nil)
 
-        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+        expect(Fastlane::Helper).to receive(:backticks_verbose)
           .with("xcrun simctl bootstatus #{device_udid} -b")
           .and_return("").exactly(1).times
 
         custom_args = "--time 10:30 --dataNetwork lte"
-        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+        expect(Fastlane::Helper).to receive(:backticks_verbose)
           .with("xcrun simctl status_bar #{device_udid} override #{custom_args}")
           .and_return("").exactly(1).times
 

--- a/snapshot/spec/simulator_launcher_base_spec.rb
+++ b/snapshot/spec/simulator_launcher_base_spec.rb
@@ -9,15 +9,15 @@ describe Snapshot do
 
         if FastlaneCore::Helper.xcode_at_least?("13")
           expect(Fastlane::Helper).to receive(:backticks)
-            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid} &> /dev/null")
+            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid} 2>&1 > /dev/null")
             .and_return("").exactly(1).times
         else
           expect(Fastlane::Helper).to receive(:backticks)
-            .with("xcrun instruments -w #{device_udid} &> /dev/null")
+            .with("xcrun instruments -w #{device_udid} 2>&1 > /dev/null")
             .and_return("").exactly(1).times
         end
         expect(Fastlane::Helper).to receive(:backticks)
-          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')} &> /dev/null")
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')} 2>&1 > /dev/null")
           .and_return("").exactly(1).times
 
         # Verify that backticks isn't called for the fallback to addphoto/addvideo
@@ -32,16 +32,16 @@ describe Snapshot do
 
         if FastlaneCore::Helper.xcode_at_least?("13")
           expect(Fastlane::Helper).to receive(:backticks)
-            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid} &> /dev/null")
+            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid} 2>&1 > /dev/null")
             .and_return("").exactly(1).times
         else
           expect(Fastlane::Helper).to receive(:backticks)
-            .with("xcrun instruments -w #{device_udid} &> /dev/null")
+            .with("xcrun instruments -w #{device_udid} 2>&1 > /dev/null")
             .and_return("").exactly(1).times
         end
 
         expect(Fastlane::Helper).to receive(:backticks)
-          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')} &> /dev/null")
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')} 2>&1 > /dev/null")
           .and_return("usage: simctl [--noxpc] [--set <path>] [--profiles <path>] <subcommand> ...\n").exactly(1).times
 
         expect(Fastlane::Helper).to receive(:backticks).with(anything).and_return(anything).exactly(1).times

--- a/snapshot/spec/simulator_launcher_base_spec.rb
+++ b/snapshot/spec/simulator_launcher_base_spec.rb
@@ -9,15 +9,15 @@ describe Snapshot do
 
         if FastlaneCore::Helper.xcode_at_least?("13")
           expect(Fastlane::Helper).to receive(:backticks)
-            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid} 2>&1 > /dev/null")
+            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
             .and_return("").exactly(1).times
         else
           expect(Fastlane::Helper).to receive(:backticks)
-            .with("xcrun instruments -w #{device_udid} 2>&1 > /dev/null")
+            .with("xcrun instruments -w #{device_udid}", print: FastlaneCore::Globals.verbose?)
             .and_return("").exactly(1).times
         end
         expect(Fastlane::Helper).to receive(:backticks)
-          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')} 2>&1 > /dev/null")
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}", print: FastlaneCore::Globals.verbose?)
           .and_return("").exactly(1).times
 
         # Verify that backticks isn't called for the fallback to addphoto/addvideo
@@ -32,16 +32,16 @@ describe Snapshot do
 
         if FastlaneCore::Helper.xcode_at_least?("13")
           expect(Fastlane::Helper).to receive(:backticks)
-            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid} 2>&1 > /dev/null")
+            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
             .and_return("").exactly(1).times
         else
           expect(Fastlane::Helper).to receive(:backticks)
-            .with("xcrun instruments -w #{device_udid} 2>&1 > /dev/null")
+            .with("xcrun instruments -w #{device_udid}", print: FastlaneCore::Globals.verbose?)
             .and_return("").exactly(1).times
         end
 
         expect(Fastlane::Helper).to receive(:backticks)
-          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')} 2>&1 > /dev/null")
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}", print: FastlaneCore::Globals.verbose?)
           .and_return("usage: simctl [--noxpc] [--set <path>] [--profiles <path>] <subcommand> ...\n").exactly(1).times
 
         expect(Fastlane::Helper).to receive(:backticks).with(anything).and_return(anything).exactly(1).times

--- a/snapshot/spec/simulator_launcher_base_spec.rb
+++ b/snapshot/spec/simulator_launcher_base_spec.rb
@@ -21,7 +21,7 @@ describe Snapshot do
           .and_return("").exactly(1).times
 
         # Verify that backticks isn't called for the fallback to addphoto/addvideo
-        expect(Fastlane::Helper).to receive(:backticks).with(anything).and_return(anything).exactly(0).times
+        expect(Fastlane::Helper).to receive(:backticks).with(any_args).and_return(anything).exactly(0).times
 
         launcher = Snapshot::SimulatorLauncherBase.new
         launcher.add_media(['phone'], 'photo', paths)
@@ -44,7 +44,7 @@ describe Snapshot do
           .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}", print: FastlaneCore::Globals.verbose?)
           .and_return("usage: simctl [--noxpc] [--set <path>] [--profiles <path>] <subcommand> ...\n").exactly(1).times
 
-        expect(Fastlane::Helper).to receive(:backticks).with(anything).and_return(anything).exactly(1).times
+        expect(Fastlane::Helper).to receive(:backticks).with(any_args).and_return(anything).exactly(1).times
 
         launcher = Snapshot::SimulatorLauncherBase.new
         launcher.add_media(['phone'], 'photo', paths)

--- a/snapshot/spec/simulator_launcher_base_spec.rb
+++ b/snapshot/spec/simulator_launcher_base_spec.rb
@@ -8,20 +8,20 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
 
         if FastlaneCore::Helper.xcode_at_least?("13")
-          expect(Fastlane::Helper).to receive(:backticks)
-            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
+          expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
             .and_return("").exactly(1).times
         else
-          expect(Fastlane::Helper).to receive(:backticks)
-            .with("xcrun instruments -w #{device_udid}", print: FastlaneCore::Globals.verbose?)
+          expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+            .with("xcrun instruments -w #{device_udid}")
             .and_return("").exactly(1).times
         end
-        expect(Fastlane::Helper).to receive(:backticks)
-          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}", print: FastlaneCore::Globals.verbose?)
+        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}")
           .and_return("").exactly(1).times
 
-        # Verify that backticks isn't called for the fallback to addphoto/addvideo
-        expect(Fastlane::Helper).to receive(:backticks).with(any_args).and_return(anything).exactly(0).times
+        # Verify that backticks_if_verbose isn't called for the fallback to addphoto/addvideo
+        expect(Fastlane::Helper).to receive(:backticks_if_verbose).with(any_args).and_return(anything).exactly(0).times
 
         launcher = Snapshot::SimulatorLauncherBase.new
         launcher.add_media(['phone'], 'photo', paths)
@@ -31,20 +31,20 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
 
         if FastlaneCore::Helper.xcode_at_least?("13")
-          expect(Fastlane::Helper).to receive(:backticks)
-            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
+          expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
             .and_return("").exactly(1).times
         else
-          expect(Fastlane::Helper).to receive(:backticks)
-            .with("xcrun instruments -w #{device_udid}", print: FastlaneCore::Globals.verbose?)
+          expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+            .with("xcrun instruments -w #{device_udid}")
             .and_return("").exactly(1).times
         end
 
-        expect(Fastlane::Helper).to receive(:backticks)
-          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}", print: FastlaneCore::Globals.verbose?)
+        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}")
           .and_return("usage: simctl [--noxpc] [--set <path>] [--profiles <path>] <subcommand> ...\n").exactly(1).times
 
-        expect(Fastlane::Helper).to receive(:backticks).with(any_args).and_return(anything).exactly(1).times
+        expect(Fastlane::Helper).to receive(:backticks_if_verbose).with(any_args).and_return(anything).exactly(1).times
 
         launcher = Snapshot::SimulatorLauncherBase.new
         launcher.add_media(['phone'], 'photo', paths)
@@ -61,12 +61,12 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
         allow(ENV).to receive(:[]).with("SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT").and_return(nil)
 
-        expect(Fastlane::Helper).to receive(:backticks)
-          .with("xcrun simctl bootstatus #{device_udid} -b &> /dev/null")
+        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+          .with("xcrun simctl bootstatus #{device_udid} -b")
           .and_return("").exactly(1).times
 
         # Verify the time format is HH:MM (e.g., "09:41") not ISO8601
-        expect(Fastlane::Helper).to receive(:backticks)
+        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
           .with(match(/xcrun simctl status_bar #{device_udid} override --time 09:41/))
           .and_return("").exactly(1).times
 
@@ -78,13 +78,13 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
         allow(ENV).to receive(:[]).with("SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT").and_return(nil)
 
-        expect(Fastlane::Helper).to receive(:backticks)
-          .with("xcrun simctl bootstatus #{device_udid} -b &> /dev/null")
+        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+          .with("xcrun simctl bootstatus #{device_udid} -b")
           .and_return("").exactly(1).times
 
         custom_args = "--time 10:30 --dataNetwork lte"
-        expect(Fastlane::Helper).to receive(:backticks)
-          .with("xcrun simctl status_bar #{device_udid} override #{custom_args} &> /dev/null")
+        expect(Fastlane::Helper).to receive(:backticks_if_verbose)
+          .with("xcrun simctl status_bar #{device_udid} override #{custom_args}")
           .and_return("").exactly(1).times
 
         launcher = Snapshot::SimulatorLauncherBase.new

--- a/snapshot/spec/simulator_launcher_base_spec.rb
+++ b/snapshot/spec/simulator_launcher_base_spec.rb
@@ -8,20 +8,20 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
 
         if FastlaneCore::Helper.xcode_at_least?("13")
-          expect(Fastlane::Helper).to receive(:backticks_verbose)
-            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
+          expect(Fastlane::Helper).to receive(:backticks)
+            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
             .and_return("").exactly(1).times
         else
-          expect(Fastlane::Helper).to receive(:backticks_verbose)
-            .with("xcrun instruments -w #{device_udid}")
+          expect(Fastlane::Helper).to receive(:backticks)
+            .with("xcrun instruments -w #{device_udid}", print: FastlaneCore::Globals.verbose?)
             .and_return("").exactly(1).times
         end
-        expect(Fastlane::Helper).to receive(:backticks_verbose)
-          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}")
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}", print: FastlaneCore::Globals.verbose?)
           .and_return("").exactly(1).times
 
-        # Verify that backticks_verbose isn't called for the fallback to addphoto/addvideo
-        expect(Fastlane::Helper).to receive(:backticks_verbose).with(any_args).and_return(anything).exactly(0).times
+        # Verify that backticks isn't called for the fallback to addphoto/addvideo
+        expect(Fastlane::Helper).to receive(:backticks).with(any_args).and_return(anything).exactly(0).times
 
         launcher = Snapshot::SimulatorLauncherBase.new
         launcher.add_media(['phone'], 'photo', paths)
@@ -31,20 +31,20 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
 
         if FastlaneCore::Helper.xcode_at_least?("13")
-          expect(Fastlane::Helper).to receive(:backticks_verbose)
-            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}")
+          expect(Fastlane::Helper).to receive(:backticks)
+            .with("open -a Simulator.app --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
             .and_return("").exactly(1).times
         else
-          expect(Fastlane::Helper).to receive(:backticks_verbose)
-            .with("xcrun instruments -w #{device_udid}")
+          expect(Fastlane::Helper).to receive(:backticks)
+            .with("xcrun instruments -w #{device_udid}", print: FastlaneCore::Globals.verbose?)
             .and_return("").exactly(1).times
         end
 
-        expect(Fastlane::Helper).to receive(:backticks_verbose)
-          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}")
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl addmedia #{device_udid} #{paths.join(' ')}", print: FastlaneCore::Globals.verbose?)
           .and_return("usage: simctl [--noxpc] [--set <path>] [--profiles <path>] <subcommand> ...\n").exactly(1).times
 
-        expect(Fastlane::Helper).to receive(:backticks_verbose).with(any_args).and_return(anything).exactly(1).times
+        expect(Fastlane::Helper).to receive(:backticks).with(any_args).and_return(anything).exactly(1).times
 
         launcher = Snapshot::SimulatorLauncherBase.new
         launcher.add_media(['phone'], 'photo', paths)
@@ -61,13 +61,13 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
         allow(ENV).to receive(:[]).with("SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT").and_return(nil)
 
-        expect(Fastlane::Helper).to receive(:backticks_verbose)
-          .with("xcrun simctl bootstatus #{device_udid} -b")
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl bootstatus #{device_udid} -b", print: FastlaneCore::Globals.verbose?)
           .and_return("").exactly(1).times
 
         # Verify the time format is HH:MM (e.g., "09:41") not ISO8601
-        expect(Fastlane::Helper).to receive(:backticks_verbose)
-          .with(match(/xcrun simctl status_bar #{device_udid} override --time 09:41/))
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with(match(/xcrun simctl status_bar #{device_udid} override --time 09:41/), print: FastlaneCore::Globals.verbose?)
           .and_return("").exactly(1).times
 
         launcher = Snapshot::SimulatorLauncherBase.new
@@ -78,13 +78,13 @@ describe Snapshot do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
         allow(ENV).to receive(:[]).with("SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT").and_return(nil)
 
-        expect(Fastlane::Helper).to receive(:backticks_verbose)
-          .with("xcrun simctl bootstatus #{device_udid} -b")
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl bootstatus #{device_udid} -b", print: FastlaneCore::Globals.verbose?)
           .and_return("").exactly(1).times
 
         custom_args = "--time 10:30 --dataNetwork lte"
-        expect(Fastlane::Helper).to receive(:backticks_verbose)
-          .with("xcrun simctl status_bar #{device_udid} override #{custom_args}")
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl status_bar #{device_udid} override #{custom_args}", print: FastlaneCore::Globals.verbose?)
           .and_return("").exactly(1).times
 
         launcher = Snapshot::SimulatorLauncherBase.new


### PR DESCRIPTION
### Motivation and Context

We saw in #21255 that a simple error was hidden for so long since our commands eat up stdout/stderr and ignore them. This required end users to change _fastlane_ code to identify error in order to fix it.

### Description

I redirect stdout to null, but hold on to stderr. My test being that real errors throw from invalid commands are thrown on stderr, but this requires further testing.

### Testing Steps

refs: #21954
