### PR TITLE
[spaceship] feat: support webhook integration API

### DIFF
--- a/spaceship/docs/AppStoreConnect.md
+++ b/spaceship/docs/AppStoreConnect.md
@@ -15,6 +15,7 @@
   * [App Analytics](#app-analytics)
   * [Bundle Id](#bundle-id-auth-key)
   * [Bundle Id Capability](#bundle-id-capability-auth-key)
+  * [Webhooks](#webhooks-auth-key)
 - [License](#license)
 
 ## Usage
@@ -450,6 +451,30 @@ capabilities.each do |capability|
     capability.delete!
   end
 end
+```
+
+### Webhooks (Auth Key)
+
+```ruby
+app = Spaceship::ConnectAPI::App.find("com.krausefx.app")
+
+# Fetch all webhooks
+webhooks = Spaceship::ConnectAPI::Webhook.all(app_id: app.id)
+
+# Create a new webhook
+new_webhook = Spaceship::ConnectAPI::Webhook.create(
+  app_id:      app.id,
+  event_types: [
+    Spaceship::ConnectAPI::Webhook::EventType::APP_STORE_VERSION_APP_VERSION_STATE_UPDATED,
+  ],
+  name:         'Webhook Name',
+  secret:       'secret1234',
+  url:          'https://webhook.example.com'
+)
+
+# Delete a webhook
+webhooks.first.delete!
+new_webhook.delete!
 ```
 
 ## License

--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -74,6 +74,7 @@ require 'spaceship/connect_api/models/resolution_center_message'
 require 'spaceship/connect_api/models/resolution_center_thread'
 require 'spaceship/connect_api/models/review_rejection'
 require 'spaceship/connect_api/models/actor'
+require 'spaceship/connect_api/models/webhook'
 
 module Spaceship
   class ConnectAPI

--- a/spaceship/lib/spaceship/connect_api/models/webhook.rb
+++ b/spaceship/lib/spaceship/connect_api/models/webhook.rb
@@ -1,0 +1,62 @@
+require_relative '../model'
+
+module Spaceship
+  class ConnectAPI
+    class Webhook
+      include Spaceship::ConnectAPI::Model
+
+      attr_accessor :enabled
+      attr_accessor :event_types
+      attr_accessor :name
+      attr_accessor :url
+
+      attr_mapping({
+        "enabled" => "enabled",
+        "eventTypes" => "event_types",
+        "name" => "name",
+        "url" => "url"
+      })
+
+      # Found at https://developer.apple.com/documentation/appstoreconnectapi/webhookeventtype
+      module EventType
+        ALTERNATIVE_DISTRIBUTION_PACKAGE_AVAILABLE_UPDATED = "ALTERNATIVE_DISTRIBUTION_PACKAGE_AVAILABLE_UPDATED"
+        ALTERNATIVE_DISTRIBUTION_PACKAGE_VERSION_CREATED = "ALTERNATIVE_DISTRIBUTION_PACKAGE_VERSION_CREATED"
+        ALTERNATIVE_DISTRIBUTION_TERRITORY_AVAILABILITY_UPDATED = "ALTERNATIVE_DISTRIBUTION_TERRITORY_AVAILABILITY_UPDATED"
+        APP_STORE_VERSION_APP_VERSION_STATE_UPDATED = "APP_STORE_VERSION_APP_VERSION_STATE_UPDATED"
+        BACKGROUND_ASSET_VERSION_APP_STORE_RELEASE_STATE_UPDATED = "BACKGROUND_ASSET_VERSION_APP_STORE_RELEASE_STATE_UPDATED"
+        BACKGROUND_ASSET_VERSION_EXTERNAL_BETA_RELEASE_STATE_UPDATED = "BACKGROUND_ASSET_VERSION_EXTERNAL_BETA_RELEASE_STATE_UPDATED"
+        BACKGROUND_ASSET_VERSION_INTERNAL_BETA_RELEASE_CREATED = "BACKGROUND_ASSET_VERSION_INTERNAL_BETA_RELEASE_CREATED"
+        BACKGROUND_ASSET_VERSION_STATE_UPDATED = "BACKGROUND_ASSET_VERSION_STATE_UPDATED"
+        BETA_FEEDBACK_CRASH_SUBMISSION_CREATED = "BETA_FEEDBACK_CRASH_SUBMISSION_CREATED"
+        BETA_FEEDBACK_SCREENSHOT_SUBMISSION_CREATED = "BETA_FEEDBACK_SCREENSHOT_SUBMISSION_CREATED"
+        BUILD_BETA_DETAIL_EXTERNAL_BUILD_STATE_UPDATED = "BUILD_BETA_DETAIL_EXTERNAL_BUILD_STATE_UPDATED"
+        BUILD_UPLOAD_STATE_UPDATED = "BUILD_UPLOAD_STATE_UPDATED"
+      end
+
+      def self.type
+        return "webhooks"
+      end
+
+      #
+      # API
+      #
+
+      def self.all(client: nil, app_id:, filter: {}, includes: nil, limit: nil, sort: nil)
+        client ||= Spaceship::ConnectAPI
+        resps = client.get_webhooks(app_id: app_id, filter: filter, includes: includes, limit: limit, sort: sort).all_pages
+        return resps.flat_map(&:to_models)
+      end
+
+      def self.create(client: nil, app_id:, enabled: true, event_types:, name:, secret:, url:)
+        client ||= Spaceship::ConnectAPI
+        resp = client.post_webhook(app_id: app_id, enabled: enabled, event_types: event_types, name: name, secret: secret, url: url)
+        return resp.to_models.first
+      end
+
+      def delete!(client: nil)
+        client ||= Spaceship::ConnectAPI
+        return client.delete_webhook(webhook_id: id)
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -1242,6 +1242,44 @@ module Spaceship
           params = tunes_request_client.build_params(filter: filter, includes: includes)
           tunes_request_client.get("#{Version::V1}/reviewRejections", params)
         end
+
+        #
+        # webhooks
+        #
+
+        def get_webhooks(app_id:, filter: {}, includes: nil, limit: nil, sort: nil)
+          params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
+          tunes_request_client.get("#{Version::V1}/apps/#{app_id}/webhooks", params)
+        end
+
+        def post_webhook(app_id:, enabled:, event_types:, name:, secret:, url:)
+          body = {
+            data: {
+              type: "webhooks",
+              attributes: {
+                enabled: enabled,
+                eventTypes: event_types,
+                name: name,
+                secret: secret,
+                url: url
+              },
+              relationships: {
+                app: {
+                  data: {
+                    id: app_id,
+                    type: "apps"
+                  }
+                }
+              }
+            }
+          }
+
+          tunes_request_client.post("#{Version::V1}/webhooks", body)
+        end
+
+        def delete_webhook(webhook_id:)
+          tunes_request_client.delete("#{Version::V1}/webhooks/#{webhook_id}")
+        end
       end
     end
   end

--- a/spaceship/spec/connect_api/fixtures/tunes/webhook.json
+++ b/spaceship/spec/connect_api/fixtures/tunes/webhook.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "type": "webhooks",
+    "id": "webhook-789",
+    "attributes": {
+      "enabled": true,
+      "eventTypes": ["BUILD_UPLOAD_STATE_UPDATED"],
+      "name": "New Webhook",
+      "url": "https://new.example.com/webhook"
+    },
+    "relationships": {
+      "deliveries": {
+        "links": {
+          "self": "https://api.appstoreconnect.apple.com/v1/webhooks/webhook-789/relationships/deliveries",
+          "related": "https://api.appstoreconnect.apple.com/v1/webhooks/webhook-789/deliveries"
+        }
+      }
+    },
+    "links": {
+      "self": "https://api.appstoreconnect.apple.com/v1/webhooks/webhook-789"
+    }
+  },
+  "links": {
+    "self": "https://api.appstoreconnect.apple.com/v1/webhooks/webhook-789"
+  }
+}

--- a/spaceship/spec/connect_api/fixtures/tunes/webhooks.json
+++ b/spaceship/spec/connect_api/fixtures/tunes/webhooks.json
@@ -1,0 +1,40 @@
+{
+  "data": [
+    {
+      "type": "webhooks",
+      "id": "webhook-123",
+      "attributes": {
+        "name": "Production Webhook",
+        "url": "https://example.com/webhook",
+        "enabled": true,
+        "eventTypes": ["APP_STORE_VERSION_APP_VERSION_STATE_UPDATED"]
+      },
+      "links": {
+        "self": "https://api.appstoreconnect.apple.com/v1/webhooks/webhook-123"
+      }
+    },
+    {
+      "type": "webhooks",
+      "id": "webhook-456",
+      "attributes": {
+        "name": "Staging Webhook",
+        "url": "https://staging.example.com/webhook",
+        "enabled": true,
+        "eventTypes": ["APP_STORE_VERSION_APP_VERSION_STATE_UPDATED"]
+      },
+      "links": {
+        "self": "https://api.appstoreconnect.apple.com/v1/webhooks/webhook-456"
+      }
+    }
+  ],
+  "links": {
+    "self": "https://api.appstoreconnect.apple.com/v1/apps/1234567890/webhooks"
+  },
+  "meta": {
+    "paging": {
+      "total": 2,
+      "limit": 200
+    }
+  }
+}
+

--- a/spaceship/spec/connect_api/models/webhook_spec.rb
+++ b/spaceship/spec/connect_api/models/webhook_spec.rb
@@ -1,0 +1,86 @@
+describe Spaceship::ConnectAPI::Webhook do
+  before do
+    token = Spaceship::ConnectAPI::Token.from_json_file(File.expand_path("../fixtures/asc_key.json", __dir__))
+    Spaceship::ConnectAPI.token = token
+  end
+
+  after do
+    Spaceship::ConnectAPI.token = nil
+  end
+
+  describe '#client' do
+    describe '#get_webhooks' do
+      it 'returns all webhooks for an app' do
+        response = Spaceship::ConnectAPI.get_webhooks(app_id: "123456789")
+        expect(response).to be_an_instance_of(Spaceship::ConnectAPI::Response)
+
+        expect(response.count).to eq(2)
+        response.each do |model|
+          expect(model).to be_an_instance_of(Spaceship::ConnectAPI::Webhook)
+        end
+
+        model = response.first
+        expect(model.id).to eq("webhook-123")
+        expect(model.name).to eq("Production Webhook")
+        expect(model.url).to eq("https://example.com/webhook")
+        expect(model.enabled).to eq(true)
+        expect(model.event_types).to eq(["APP_STORE_VERSION_APP_VERSION_STATE_UPDATED"])
+      end
+
+      it 'deserializes second webhook correctly' do
+        response = Spaceship::ConnectAPI.get_webhooks(app_id: "123456789")
+        model = response.to_a[1]
+        expect(model.id).to eq("webhook-456")
+        expect(model.name).to eq("Staging Webhook")
+        expect(model.url).to eq("https://staging.example.com/webhook")
+        expect(model.enabled).to eq(true)
+      end
+    end
+
+    it '#post_webhook' do
+      response = Spaceship::ConnectAPI.post_webhook(
+        app_id: "123456789",
+        enabled: true,
+        event_types: ["BUILD_UPLOAD_STATE_UPDATED"],
+        name: "New Webhook",
+        secret: "my-secret",
+        url: "https://new.example.com/webhook"
+      )
+      expect(response).to be_an_instance_of(Spaceship::ConnectAPI::Response)
+
+      model = response.first
+      expect(model).to be_an_instance_of(Spaceship::ConnectAPI::Webhook)
+      expect(model.id).to eq("webhook-789")
+      expect(model.name).to eq("New Webhook")
+      expect(model.url).to eq("https://new.example.com/webhook")
+      expect(model.enabled).to eq(true)
+    end
+
+    it '#delete_webhook' do
+      response = Spaceship::ConnectAPI.delete_webhook(webhook_id: "webhook-123")
+      expect(response).to be_nil.or(be_an_instance_of(Spaceship::ConnectAPI::Response))
+    end
+  end
+
+  it '.all' do
+    webhooks = Spaceship::ConnectAPI::Webhook.all(app_id: "123456789")
+    expect(webhooks).to be_an_instance_of(Array)
+    expect(webhooks.length).to eq(2)
+    webhooks.each do |webhook|
+      expect(webhook).to be_an_instance_of(Spaceship::ConnectAPI::Webhook)
+    end
+  end
+
+  it '.create' do
+    webhook = Spaceship::ConnectAPI::Webhook.create(
+      app_id: "123456789",
+      event_types: ["BUILD_UPLOAD_STATE_UPDATED"],
+      name: "New Webhook",
+      secret: "my-secret",
+      url: "https://new.example.com/webhook"
+    )
+    expect(webhook).to be_an_instance_of(Spaceship::ConnectAPI::Webhook)
+    expect(webhook.name).to eq("New Webhook")
+    expect(webhook.url).to eq("https://new.example.com/webhook")
+  end
+end

--- a/spaceship/spec/connect_api/tunes/tunes_stubbing.rb
+++ b/spaceship/spec/connect_api/tunes/tunes_stubbing.rb
@@ -70,6 +70,17 @@ class ConnectAPIStubbing
         stub_request(:get, "https://appstoreconnect.apple.com/iris/v1/reviewSubmissions/123456789/items").
           to_return(status: 200, body: read_fixture_file('review_submission_items.json'), headers: { 'Content-Type' => 'application/json' })
       end
+
+      def stub_webhooks
+        stub_request(:get, "https://api.appstoreconnect.apple.com/v1/apps/123456789/webhooks").
+          to_return(status: 200, body: read_fixture_file('webhooks.json'), headers: { 'Content-Type' => 'application/json' })
+
+        stub_request(:post, "https://api.appstoreconnect.apple.com/v1/webhooks").
+          to_return(status: 200, body: read_fixture_file('webhook.json'), headers: { 'Content-Type' => 'application/json' })
+
+        stub_request(:delete, "https://api.appstoreconnect.apple.com/v1/webhooks/webhook-123").
+          to_return(status: 200, body: "", headers: {})
+      end
     end
   end
 end

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -93,6 +93,7 @@ def before_each_spaceship
   ConnectAPIStubbing::TestFlight.stub_pre_release_versions
 
   ConnectAPIStubbing::Tunes.stub_app_store_version_release_request
+  ConnectAPIStubbing::Tunes.stub_webhooks
 
   ConnectAPIStubbing::Users.stub_users
 end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

This adds programmatic support for Webhook integration CRUD in Users and Access within App Store Connect. 

### Description

* A new model for webhooks
* A simple interface for listing, creating, and deleting webhooks of a specific app with documentation
* Appropriate specs

### Testing Steps

Note that this API is accessible only via auth key

```ruby
app = Spaceship::ConnectAPI::App.find("com.krausefx.app")

# Fetch all webhooks
webhooks = Spaceship::ConnectAPI::Webhook.all(app_id: app.id)

# Create a new webhook
new_webhook = Spaceship::ConnectAPI::Webhook.create(
  app_id:      app.id,
  event_types: [
    Spaceship::ConnectAPI::Webhook::EventType::APP_STORE_VERSION_APP_VERSION_STATE_UPDATED,
  ],
  name:         'Webhook Name',
  secret:       'secret1234',
  url:          'https://webhook.example.com'
)

# Delete a webhook
webhooks.first.delete!
new_webhook.delete!
```