### PR TITLE
[snapshot] Fix status bar time format to use HH:MM instead of ISO8601

### DIFF
--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -133,12 +133,14 @@ module Snapshot
       UI.message("Overriding Status Bar")
 
       if arguments.nil? || arguments.empty?
-        # The time needs to be passed as ISO8601 so the simulator formats it correctly
+        # The time must be passed as HH:MM format (e.g., "09:41")
+        # Note: Despite the simctl manual stating ISO date strings are supported, only HH:MM format actually works
         time = Time.new(2007, 1, 9, 9, 41, 0)
+        time_str = time.strftime("%H:%M")
 
         # If you don't override the operator name, you'll get "Carrier" in the status bar on no-notch devices such as iPhone 8. Pass an empty string to blank it out.
 
-        arguments = "--time #{time.iso8601} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --operatorName '' --cellularBars 4 --batteryState charged --batteryLevel 100"
+        arguments = "--time #{time_str} --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --operatorName '' --cellularBars 4 --batteryState charged --batteryLevel 100"
       end
 
       Helper.backticks("xcrun simctl status_bar #{device_udid} override #{arguments} &> /dev/null")

--- a/snapshot/spec/simulator_launcher_base_spec.rb
+++ b/snapshot/spec/simulator_launcher_base_spec.rb
@@ -50,5 +50,46 @@ describe Snapshot do
         launcher.add_media(['phone'], 'photo', paths)
       end
     end
+
+    describe '#override_status_bar' do
+      before(:each) do
+        allow(Snapshot::UI).to receive(:message)
+        allow(Kernel).to receive(:sleep)
+      end
+
+      it "should use HH:MM format for time argument", requires_xcode: true do
+        allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
+        allow(ENV).to receive(:[]).with("SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT").and_return(nil)
+
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl bootstatus #{device_udid} -b &> /dev/null")
+          .and_return("").exactly(1).times
+
+        # Verify the time format is HH:MM (e.g., "09:41") not ISO8601
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with(match(/xcrun simctl status_bar #{device_udid} override --time 09:41/))
+          .and_return("").exactly(1).times
+
+        launcher = Snapshot::SimulatorLauncherBase.new
+        launcher.override_status_bar('phone', nil)
+      end
+
+      it "should use custom arguments when provided", requires_xcode: true do
+        allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)
+        allow(ENV).to receive(:[]).with("SNAPSHOT_SIMULATOR_WAIT_FOR_BOOT_TIMEOUT").and_return(nil)
+
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl bootstatus #{device_udid} -b &> /dev/null")
+          .and_return("").exactly(1).times
+
+        custom_args = "--time 10:30 --dataNetwork lte"
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl status_bar #{device_udid} override #{custom_args} &> /dev/null")
+          .and_return("").exactly(1).times
+
+        launcher = Snapshot::SimulatorLauncherBase.new
+        launcher.override_status_bar('phone', custom_args)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Checklist

- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.
- [X] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #22026
Resolves #21255
Resolves #21464

### Description

This PR fixes a bug in the `override_status_bar` method where the `--time` argument was being passed in ISO8601 format, which causes the `xcrun simctl status_bar override` command to fail with an "Invalid, non-ISO date/time string" error.

**Problem:**
The code was using `time.iso8601` which produces strings like `"2007-01-09T09:41:00+00:00"`, but the simulator's `simctl status_bar override` command only accepts time in `HH:MM` format (e.g., `"09:41"`). Despite the simctl manual stating that ISO date strings are supported, testing shows that only the `HH:MM` format actually works. As we are piping stdout into null, it was failing silently.

**Solution:**
- Changed the time formatting from `time.iso8601` to `time.strftime("%H:%M")` to produce the correct `HH:MM` format
- Updated the comment to clarify the required format and note the discrepancy with the simctl manual
- Added comprehensive test coverage to verify the correct format is used

### Testing Steps

**Manual Testing:**
1. Run the following command to verify the format works:
   ```bash
   xcrun simctl status_bar <DEVICE_UDID> override --time "09:41"
   ```
   This should succeed without errors.

2. Test that ISO8601 format fails (to confirm the issue):
   ```bash
   xcrun simctl status_bar <DEVICE_UDID> override --time "2007-01-09T09:41:00"
   ```
   This should fail with "Invalid, non-ISO date/time string" error.

**Automated Testing:**
Run the test suite for the snapshot module:
```bash
bundle exec rspec snapshot/spec/simulator_launcher_base_spec.rb
```

The new tests verify:
- Default arguments use `HH:MM` format (`09:41`)
- Custom arguments are passed through correctly when provided
- The command is constructed with the correct time format

**Integration Testing:**
To test the full snapshot flow with status bar override:
1. Create a test project with UI tests
2. Configure snapshot with `override_status_bar: true`
3. Run snapshot and verify:
   - No errors occur during status bar override
   - Screenshots are captured successfully
   - Status bar shows the expected time (9:41 AM)