### PR TITLE
[core] build: move to modern plist for Ruby 3.4 frozen strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
-    plist (3.7.1)
+    plist (3.7.2)
     pry (0.14.0)
       coderay (~> 1.1)
       method_source (~> 1.0)


### PR DESCRIPTION
## Problem

The build output on anything Ruby 3.4+ is insanely large due to the new frozen string stuff. We have many things to fix, but this is a big first start.

## Solution

Upgrade 1 minor jump on plist - https://github.com/patsplat/plist/compare/v3.7.1...v3.7.2 (diff) to fix. There is no change to Ruby version support.