### PR TITLE
[scan] Handle Xcode26 test failure

### DIFF
--- a/scan/lib/scan/error_handler.rb
+++ b/scan/lib/scan/error_handler.rb
@@ -38,6 +38,11 @@ module Scan
           return
         when /Testing failed/
           UI.build_failure!("Error building the application. #{details}")
+        when /Testing started.*\*\* TEST FAILED \*\*/m, /Testing started.*\*\* TEST EXECUTE FAILED \*\*/m
+          # Xcode 26+: If we see both "Testing started" and "** TEST FAILED **"
+          # or "** TEST EXECUTE FAILED **" (test-without-building), then tests
+          # were executed but failed.
+          return
         when /Executed/, /Failing tests:/
           # this is *really* important:
           # we don't want to raise an exception here

--- a/scan/spec/error_handler_spec.rb
+++ b/scan/spec/error_handler_spec.rb
@@ -25,6 +25,36 @@ describe Scan do
         end
       end
 
+      describe "when parsing Xcode 26 test failure output" do
+        it "does not report a build failure" do
+          expect(Scan).to receive(:config).and_return({})
+          output = File.open('./scan/spec/fixtures/xcode26_testing_failure.log', &:read)
+          expect do
+            Scan::ErrorHandler.handle_build_error(output, log_path)
+          end.not_to raise_error
+        end
+      end
+
+      describe "when parsing Xcode 26 xcbeautify test failure output" do
+        it "does not report a build failure" do
+          expect(Scan).to receive(:config).and_return({})
+          output = File.open('./scan/spec/fixtures/xcode26_xcbeautify_failure.log', &:read)
+          expect do
+            Scan::ErrorHandler.handle_build_error(output, log_path)
+          end.not_to raise_error
+        end
+      end
+
+      describe "when parsing Xcode 26 test-without-building failure output" do
+        it "does not report a build failure" do
+          expect(Scan).to receive(:config).and_return({})
+          output = File.open('./scan/spec/fixtures/xcode26_test_execute_failure.log', &:read)
+          expect do
+            Scan::ErrorHandler.handle_build_error(output, log_path)
+          end.not_to raise_error
+        end
+      end
+
       describe "when parsing early failure output" do
         let(:output_path) { './scan/spec/fixtures/early_testing_failure.log' }
 

--- a/scan/spec/fixtures/xcode26_test_execute_failure.log
+++ b/scan/spec/fixtures/xcode26_test_execute_failure.log
@@ -1,0 +1,11 @@
+Testing started
+Test suite 'ExampleTestTests' started on 'Clone 1 of iPhone 17 Pro - ExampleTest (96789)'
+Test case 'ExampleTestTests.testExample()' failed on 'Clone 1 of iPhone 17 Pro - ExampleTest (96789)' (0.474 seconds)
+Test suite 'ExampleTestUITests' started on 'Clone 2 of iPhone 17 Pro - ExampleTestUITests-Runner (97123)'
+Test case 'ExampleTestUITests.testExample()' failed on 'Clone 2 of iPhone 17 Pro - ExampleTestUITests-Runner (97123)' (6.270 seconds)
+2026-01-09 15:48:35.816 xcodebuild[96200:1553005] [MT] IDETestOperationsObserverDebug: 144.107 elapsed -- Testing started completed.
+
+Test session results, code coverage, and logs:
+        /Users/test/Library/Developer/Xcode/DerivedData/ExampleTest/Logs/Test/Test-ExampleTest-2026.01.09.xcresult
+
+** TEST EXECUTE FAILED **

--- a/scan/spec/fixtures/xcode26_testing_failure.log
+++ b/scan/spec/fixtures/xcode26_testing_failure.log
@@ -1,0 +1,13 @@
+Testing started
+Test suite 'ExampleTestTests' started on 'Clone 1 of iPhone 17 Pro - ExampleTest (96789)'
+Test case 'ExampleTestTests.testExample()' failed on 'Clone 1 of iPhone 17 Pro - ExampleTest (96789)' (0.474 seconds)
+Test suite 'ExampleTestUITests' started on 'Clone 2 of iPhone 17 Pro - ExampleTestUITests-Runner (97123)'
+Test case 'ExampleTestUITests.testExample()' failed on 'Clone 2 of iPhone 17 Pro - ExampleTestUITests-Runner (97123)' (6.270 seconds)
+2026-01-09 15:48:35.816 xcodebuild[96200:1553005] [MT] IDETestOperationsObserverDebug: 144.107 elapsed -- Testing started completed.
+2026-01-09 15:48:35.816 xcodebuild[96200:1553005] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
+2026-01-09 15:48:35.816 xcodebuild[96200:1553005] [MT] IDETestOperationsObserverDebug: 144.107 sec, +144.107 sec -- end
+
+Test session results, code coverage, and logs:
+        /Users/test/Library/Developer/Xcode/DerivedData/ExampleTest/Logs/Test/Test-ExampleTest-2026.01.09.xcresult
+
+** TEST FAILED **

--- a/scan/spec/fixtures/xcode26_xcbeautify_failure.log
+++ b/scan/spec/fixtures/xcode26_xcbeautify_failure.log
@@ -1,0 +1,9 @@
+Testing started
+[15:47:28]: ▸ Test Suite ExampleTestTests started on 'Clone 1 of iPhone 17 Pro - ExampleTest (96789)'
+[15:47:28]: ▸     ✖ [ExampleTestTests] testExample on 'Clone 1 of iPhone 17 Pro - ExampleTest (96789)' (0.474 seconds)
+[15:48:09]: ▸ Test Suite ExampleTestUITests started on 'Clone 2 of iPhone 17 Pro - ExampleTestUITests-Runner (97123)'
+[15:48:15]: ▸     ✖ [ExampleTestUITests] testExample on 'Clone 2 of iPhone 17 Pro - ExampleTestUITests-Runner (97123)' (6.270 seconds)
+[15:48:35]: ▸ 2026-01-09 15:48:35.816 xcodebuild[96200:1553005] [MT] IDETestOperationsObserverDebug: 144.107 elapsed -- Testing started completed.
+[15:48:35]: ▸ 2026-01-09 15:48:35.816 xcodebuild[96200:1553005] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
+[15:48:35]: ▸ 2026-01-09 15:48:35.816 xcodebuild[96200:1553005] [MT] IDETestOperationsObserverDebug: 144.107 sec, +144.107 sec -- end
+[15:48:35]: ▸ ** TEST FAILED **


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
Xcode 26 has some changes in xcodebuild command output. In UI testing, fastlane detects if there are failing tests by simply looking for "Failing tests:", but Xcode 26 doesn't report the failing tests list.

fixes: #29799 

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description
It is also compatible with Xcode 16.4, but I didn't remove the old code because I don't want to break backward compatibility.
<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
