### PR TITLE
[pilot] Add Support of the BuildAudienceType Field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ xcuserdata/
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint
+.build/
 
 # Dotenv
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,6 @@ xcuserdata/
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint
-.build/
 
 # Dotenv
 .env

--- a/fastlane/lib/fastlane/actions/upload_to_testflight.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_testflight.rb
@@ -75,6 +75,9 @@ module Fastlane
             changelog: "This is my changelog of things that have changed in a log"
           )',
           'upload_to_testflight(
+            app_store_eligible: false # Set build to internal only (default is true for App Store eligible)
+          )',
+          'upload_to_testflight(
             beta_app_review_info: {
               contact_email: "email@email.com",
               contact_first_name: "Connect",

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -7830,7 +7830,8 @@ public func pilot(apiKeyPath: OptionalConfigValue<String?> = .fastlaneDefault(ni
                   waitProcessingTimeoutDuration: OptionalConfigValue<Int?> = .fastlaneDefault(nil),
                   waitForUploadedBuild: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                   rejectBuildWaitingForReview: OptionalConfigValue<Bool> = .fastlaneDefault(false),
-                  submitBetaReview: OptionalConfigValue<Bool> = .fastlaneDefault(true))
+                  submitBetaReview: OptionalConfigValue<Bool> = .fastlaneDefault(true),
+                  appStoreEligible: OptionalConfigValue<Bool> = .fastlaneDefault(true))
 {
     let apiKeyPathArg = apiKeyPath.asRubyArgument(name: "api_key_path", type: nil)
     let apiKeyArg = apiKey.asRubyArgument(name: "api_key", type: nil)
@@ -7871,6 +7872,7 @@ public func pilot(apiKeyPath: OptionalConfigValue<String?> = .fastlaneDefault(ni
     let waitForUploadedBuildArg = waitForUploadedBuild.asRubyArgument(name: "wait_for_uploaded_build", type: nil)
     let rejectBuildWaitingForReviewArg = rejectBuildWaitingForReview.asRubyArgument(name: "reject_build_waiting_for_review", type: nil)
     let submitBetaReviewArg = submitBetaReview.asRubyArgument(name: "submit_beta_review", type: nil)
+    let appStoreEligibleArg = appStoreEligible.asRubyArgument(name: "app_store_eligible", type: nil)
     let array: [RubyCommand.Argument?] = [apiKeyPathArg,
                                           apiKeyArg,
                                           usernameArg,
@@ -7909,7 +7911,8 @@ public func pilot(apiKeyPath: OptionalConfigValue<String?> = .fastlaneDefault(ni
                                           waitProcessingTimeoutDurationArg,
                                           waitForUploadedBuildArg,
                                           rejectBuildWaitingForReviewArg,
-                                          submitBetaReviewArg]
+                                          submitBetaReviewArg,
+                                          appStoreEligibleArg]
     let args: [RubyCommand.Argument] = array
         .filter { $0?.value != nil }
         .compactMap { $0 }
@@ -11758,7 +11761,8 @@ public func testflight(apiKeyPath: OptionalConfigValue<String?> = .fastlaneDefau
                        waitProcessingTimeoutDuration: OptionalConfigValue<Int?> = .fastlaneDefault(nil),
                        waitForUploadedBuild: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                        rejectBuildWaitingForReview: OptionalConfigValue<Bool> = .fastlaneDefault(false),
-                       submitBetaReview: OptionalConfigValue<Bool> = .fastlaneDefault(true))
+                       submitBetaReview: OptionalConfigValue<Bool> = .fastlaneDefault(true),
+                       appStoreEligible: OptionalConfigValue<Bool> = .fastlaneDefault(true))
 {
     let apiKeyPathArg = apiKeyPath.asRubyArgument(name: "api_key_path", type: nil)
     let apiKeyArg = apiKey.asRubyArgument(name: "api_key", type: nil)
@@ -11799,6 +11803,7 @@ public func testflight(apiKeyPath: OptionalConfigValue<String?> = .fastlaneDefau
     let waitForUploadedBuildArg = waitForUploadedBuild.asRubyArgument(name: "wait_for_uploaded_build", type: nil)
     let rejectBuildWaitingForReviewArg = rejectBuildWaitingForReview.asRubyArgument(name: "reject_build_waiting_for_review", type: nil)
     let submitBetaReviewArg = submitBetaReview.asRubyArgument(name: "submit_beta_review", type: nil)
+    let appStoreEligibleArg = appStoreEligible.asRubyArgument(name: "app_store_eligible", type: nil)
     let array: [RubyCommand.Argument?] = [apiKeyPathArg,
                                           apiKeyArg,
                                           usernameArg,
@@ -11837,7 +11842,8 @@ public func testflight(apiKeyPath: OptionalConfigValue<String?> = .fastlaneDefau
                                           waitProcessingTimeoutDurationArg,
                                           waitForUploadedBuildArg,
                                           rejectBuildWaitingForReviewArg,
-                                          submitBetaReviewArg]
+                                          submitBetaReviewArg,
+                                          appStoreEligibleArg]
     let args: [RubyCommand.Argument] = array
         .filter { $0?.value != nil }
         .compactMap { $0 }
@@ -13181,7 +13187,8 @@ public func uploadToTestflight(apiKeyPath: OptionalConfigValue<String?> = .fastl
                                waitProcessingTimeoutDuration: OptionalConfigValue<Int?> = .fastlaneDefault(nil),
                                waitForUploadedBuild: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                                rejectBuildWaitingForReview: OptionalConfigValue<Bool> = .fastlaneDefault(false),
-                               submitBetaReview: OptionalConfigValue<Bool> = .fastlaneDefault(true))
+                               submitBetaReview: OptionalConfigValue<Bool> = .fastlaneDefault(true),
+                               appStoreEligible: OptionalConfigValue<Bool> = .fastlaneDefault(true))
 {
     let apiKeyPathArg = apiKeyPath.asRubyArgument(name: "api_key_path", type: nil)
     let apiKeyArg = apiKey.asRubyArgument(name: "api_key", type: nil)
@@ -13222,6 +13229,7 @@ public func uploadToTestflight(apiKeyPath: OptionalConfigValue<String?> = .fastl
     let waitForUploadedBuildArg = waitForUploadedBuild.asRubyArgument(name: "wait_for_uploaded_build", type: nil)
     let rejectBuildWaitingForReviewArg = rejectBuildWaitingForReview.asRubyArgument(name: "reject_build_waiting_for_review", type: nil)
     let submitBetaReviewArg = submitBetaReview.asRubyArgument(name: "submit_beta_review", type: nil)
+    let appStoreEligibleArg = appStoreEligible.asRubyArgument(name: "app_store_eligible", type: nil)
     let array: [RubyCommand.Argument?] = [apiKeyPathArg,
                                           apiKeyArg,
                                           usernameArg,
@@ -13260,7 +13268,8 @@ public func uploadToTestflight(apiKeyPath: OptionalConfigValue<String?> = .fastl
                                           waitProcessingTimeoutDurationArg,
                                           waitForUploadedBuildArg,
                                           rejectBuildWaitingForReviewArg,
-                                          submitBetaReviewArg]
+                                          submitBetaReviewArg,
+                                          appStoreEligibleArg]
     let args: [RubyCommand.Argument] = array
         .filter { $0?.value != nil }
         .compactMap { $0 }

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -453,6 +453,9 @@ module Pilot
       # This is where we could add a check to see if encryption is required and has been updated
       uploaded_build = set_export_compliance_if_needed(uploaded_build, options)
 
+      # Set build audience type if specified
+      uploaded_build = set_build_audience_type_if_needed(uploaded_build, options)
+
       if options[:submit_beta_review] && (options[:groups] || options[:distribute_external])
         if uploaded_build.ready_for_beta_submission?
           uploaded_build.post_beta_app_review_submission
@@ -501,6 +504,22 @@ module Pilot
       else
         return uploaded_build
       end
+    end
+
+    def set_build_audience_type_if_needed(uploaded_build, options)
+      unless options[:app_store_eligible].nil?
+        build_audience_type = options[:app_store_eligible] ? "APP_STORE_ELIGIBLE" : "INTERNAL_ONLY"
+        attributes = { buildAudienceType: build_audience_type }
+
+        Spaceship::ConnectAPI.patch_builds(build_id: uploaded_build.id, attributes: attributes)
+
+        UI.success("Build audience type has been set to '#{build_audience_type}'")
+
+        # Reload the build to get the updated attributes
+        uploaded_build = Spaceship::ConnectAPI::Build.get(build_id: uploaded_build.id)
+      end
+
+      return uploaded_build
     end
 
     def update_review_detail(build, info)

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -332,7 +332,7 @@ module Pilot
                                      default_value: true),
         FastlaneCore::ConfigItem.new(key: :app_store_eligible,
                                      env_name: "PILOT_APP_STORE_ELIGIBLE",
-                                     description: "Should the build be considered App Store eligible? If set to false, the build of your app is only available to members of your development team. Maps to the BuildAudienceType field of AppStoreConnect API.",
+                                     description: "Should the build be considered App Store eligible? If set to false, the build of your app is only available to members of your development team. Maps to the BuildAudienceType field of AppStoreConnect API",
                                      type: Boolean,
                                      optional: true,
                                      default_value: true)

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -329,6 +329,12 @@ module Pilot
                                      env_name: "PILOT_DISTRIBUTE_EXTERNAL",
                                      description: "Send the build for a beta review",
                                      type: Boolean,
+                                     default_value: true),
+        FastlaneCore::ConfigItem.new(key: :app_store_eligible,
+                                     env_name: "PILOT_APP_STORE_ELIGIBLE",
+                                     description: "Should the build be considered App Store eligible? If set to false, the build of your app is only available to members of your development team. Maps to the BuildAudienceType field of AppStoreConnect API.",
+                                     type: Boolean,
+                                     optional: true,
                                      default_value: true)
       ]
     end

--- a/pilot/spec/options_spec.rb
+++ b/pilot/spec/options_spec.rb
@@ -135,4 +135,21 @@ describe Pilot::Options do
       end.to raise_error(FastlaneCore::Interface::FastlaneError, "Invalid key 'buffalo_chicken'")
     end
   end
+
+  context "app_store_eligible" do
+    it "accepts boolean values" do
+      expect do
+        FastlaneCore::Configuration.create(Pilot::Options.available_options, { app_store_eligible: true })
+      end.not_to(raise_error)
+
+      expect do
+        FastlaneCore::Configuration.create(Pilot::Options.available_options, { app_store_eligible: false })
+      end.not_to(raise_error)
+    end
+
+    it "defaults to true" do
+      config = FastlaneCore::Configuration.create(Pilot::Options.available_options, {})
+      expect(config[:app_store_eligible]).to eq(true)
+    end
+  end
 end

--- a/spaceship/lib/spaceship/connect_api/models/build.rb
+++ b/spaceship/lib/spaceship/connect_api/models/build.rb
@@ -13,6 +13,7 @@ module Spaceship
       attr_accessor :icon_asset_token
       attr_accessor :processing_state
       attr_accessor :uses_non_exempt_encryption
+      attr_accessor :build_audience_type
 
       attr_accessor :app
       attr_accessor :beta_app_review_submission
@@ -32,6 +33,7 @@ module Spaceship
         "iconAssetToken" => "icon_asset_token",
         "processingState" => "processing_state",
         "usesNonExemptEncryption" => "uses_non_exempt_encryption",
+        "buildAudienceType" => "build_audience_type",
 
         "app" => "app",
         "betaAppReviewSubmission" => "beta_app_review_submission",


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
AppStoreConnect API introduced the BuildAudienceType in [WWDC23](https://developer.apple.com/videos/play/wwdc2023/10117/), https://developer.apple.com/documentation/appstoreconnectapi/buildaudiencetype.
Our team is looking to use this option from Fastlane.

<!-- If it fixes an open issue, please link to the issue following this format:
Resolves Discussion https://github.com/fastlane/fastlane/discussions/21543
-->

### Description

Creating a Fastlane option to support the BuildAudienceType. https://developer.apple.com/documentation/appstoreconnectapi/buildaudiencetype
