### PR TITLE
[version_get_podspec] feat: add ability to pull value from podspec based on exact key

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,7 +121,7 @@ lane :bump do |options|
 
   # Verify everything is in a consistent state
   latest_version = current_version
-  local_version = version_get_podspec(path: version_file_path, require_variable_prefix: false)
+  local_version = version_get_podspec(path: version_file_path, require_variable_prefix: false, version_var_name: "VERSION")
   UI.user_error!("Version on RubyGems doesn't match local repo: #{latest_version} != #{local_version}") if latest_version != local_version
 
   changelog_text = show_changelog

--- a/fastlane/lib/fastlane/actions/version_bump_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_bump_podspec.rb
@@ -9,8 +9,7 @@ module Fastlane
         podspec_path = params[:path]
 
         UI.user_error!("Could not find podspec file at path #{podspec_path}") unless File.exist?(podspec_path)
-
-        version_podspec_file = Helper::PodspecHelper.new(podspec_path, params[:require_variable_prefix])
+        version_podspec_file = Helper::PodspecHelper.new(podspec_path, params[:require_variable_prefix], params[:version_var_name])
 
         if params[:version_number]
           new_version = params[:version_number]
@@ -72,7 +71,11 @@ module Fastlane
                                        env_name: "FL_VERSION_BUMP_PODSPEC_VERSION_REQUIRE_VARIABLE_PREFIX",
                                        description: "true by default, this is used for non CocoaPods version bumps only",
                                        type: Boolean,
-                                       default_value: true)
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :version_var_name,
+                                       env_name: "FL_VERSION_BUMP_PODSPEC_VERSION_VAR_NAME",
+                                       description: "The name of the variable that contains the version",
+                                       default_value: "version")
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/version_get_podspec.rb
+++ b/fastlane/lib/fastlane/actions/version_get_podspec.rb
@@ -10,7 +10,7 @@ module Fastlane
 
         UI.user_error!("Could not find podspec file at path '#{podspec_path}'") unless File.exist?(podspec_path)
 
-        version_podspec_file = Helper::PodspecHelper.new(podspec_path, params[:require_variable_prefix])
+        version_podspec_file = Helper::PodspecHelper.new(podspec_path, params[:require_variable_prefix], params[:version_var_name])
 
         Actions.lane_context[SharedValues::PODSPEC_VERSION_NUMBER] = version_podspec_file.version_value
       end
@@ -38,7 +38,11 @@ module Fastlane
                                        env_name: "FL_VERSION_BUMP_PODSPEC_VERSION_REQUIRE_VARIABLE_PREFIX",
                                        description: "true by default, this is used for non CocoaPods version bumps only",
                                        type: Boolean,
-                                       default_value: true)
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :version_var_name,
+                                       env_name: "FL_VERSION_PODSPEC_VERSION_VAR_NAME",
+                                       description: "The name of the variable that contains the version",
+                                       default_value: "version")
         ]
       end
 

--- a/fastlane/lib/fastlane/helper/podspec_helper.rb
+++ b/fastlane/lib/fastlane/helper/podspec_helper.rb
@@ -7,10 +7,10 @@ module Fastlane
       attr_accessor :version_match
       attr_accessor :version_value
 
-      def initialize(path = nil, require_variable_prefix = true)
-        version_var_name = 'version'
+      def initialize(path = nil, require_variable_prefix = true, version_var_name = 'version')
         variable_prefix = require_variable_prefix ? /\w\./ : //
         @version_regex = /^(?<begin>[^#]*#{variable_prefix}#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?(?<appendix>(\.[0-9]+)*)?(-(?<prerelease>(.+)))?)(?<end>['"])/i
+        @version_regex = /^[ \t]*(?<begin>#{variable_prefix}#{version_var_name}\s*=\s*['"])(?<value>(?<major>[0-9]+)(\.(?<minor>[0-9]+))?(\.(?<patch>[0-9]+))?(?<appendix>(\.[0-9]+)*)?(-(?<prerelease>(.+)))?)(?<end>['"])/i unless require_variable_prefix
 
         return unless (path || '').length > 0
         UI.user_error!("Could not find podspec file at path '#{path}'") unless File.exist?(path)
@@ -23,7 +23,7 @@ module Fastlane
 
       def parse(podspec_content)
         @podspec_content = podspec_content
-        @version_match = @version_regex.match(@podspec_content)
+        @version_match = @podspec_content.match(@version_regex)
         UI.user_error!("Could not find version in podspec content '#{@podspec_content}'") if @version_match.nil?
         @version_value = @version_match[:value]
       end

--- a/fastlane/spec/helper/podspec_helper_spec.rb
+++ b/fastlane/spec/helper/podspec_helper_spec.rb
@@ -83,5 +83,38 @@ describe Fastlane::Actions do
         expect(@version_podspec_file.version_match[:prerelease]).to eq('SNAPSHOT')
       end
     end
+    context "with custom version_var_name" do
+      it "returns the current version once parsed with custom version_var_name" do
+        test_content = 'spec.my_version = "1.3.2"'
+        version_podspec_file = Fastlane::Helper::PodspecHelper.new(nil, true, 'my_version')
+        result = version_podspec_file.parse(test_content)
+        expect(result).to eq('1.3.2')
+        expect(version_podspec_file.version_value).to eq('1.3.2')
+      end
+
+      it "returns the current version once parsed with custom version_var_name and no prefix" do
+        test_content = 'MY_VERSION = "1.3.2"'
+        version_podspec_file = Fastlane::Helper::PodspecHelper.new(nil, false, 'MY_VERSION')
+        result = version_podspec_file.parse(test_content)
+        expect(result).to eq('1.3.2')
+        expect(version_podspec_file.version_value).to eq('1.3.2')
+      end
+
+      it "matches the correct version when multiple version-like strings exist" do
+        test_content = <<RUBY
+          module Fastlane
+            VERSION = '2.230.0'.freeze
+            SUGGESTED_RUBY_MIN_VERSION = '3.2.0'.freeze
+          end
+RUBY
+        # Default behavior matches first one if case-insensitive and no prefix
+        version_podspec_file = Fastlane::Helper::PodspecHelper.new(nil, false, 'version')
+        expect(version_podspec_file.parse(test_content)).to eq('2.230.0')
+
+        # Explicitly matching SUGGESTED_RUBY_MIN_VERSION
+        version_podspec_file = Fastlane::Helper::PodspecHelper.new(nil, false, 'SUGGESTED_RUBY_MIN_VERSION')
+        expect(version_podspec_file.parse(test_content)).to eq('3.2.0')
+      end
+    end
   end
 end


### PR DESCRIPTION
### Problem

I tried to release 2.231.0 today and it [failed](https://github.com/fastlane/fastlane/actions/runs/21040996819/job/60502464900) because it pulled the local version from the repo as 3.2.0 which made absolutely no sense.

```
 [17:54:07]: Called from Fastfile at line 125
[17:54:07]: ```
[17:54:07]:     123:	  latest_version = current_version
[17:54:07]:     124:	  local_version = version_get_podspec(path: version_file_path, require_variable_prefix: false)
[17:54:07]:  => 125:	  UI.user_error!("Version on RubyGems doesn't match local repo: #{latest_version} != #{local_version}") if latest_version != local_version
[17:54:07]:     126:	
[17:54:07]:     127:	  changelog_text = show_changelog
[17:54:07]: ```
[17:54:07]: Version on RubyGems doesn't match local repo: 2.230.0 != 3.2.0
```

It turns out it uses an action `version_get_podspec` which gets the first key from the file that meets regular expression of "version", which became defeated as I added a Ruby min in this [PR](https://github.com/fastlane/fastlane/commit/b4413acd7a25399fc5411b130b692ba59cdc04a7) which used the word "version" in the key much like the generic "version" previously there.

### Solution

I expand the `version_get_podspec` action to support the exact key to pull from the file. It falls back to the previous key so we have flexibility to ensure we get the key we expect during usage.
