### PR TITLE
[core] chore: rename key (ruby_min) key to remove "VERSION" from it

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -66,8 +66,8 @@ module Fastlane
         end
 
         # Ruby version warning
-        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(Fastlane::SUGGESTED_RUBY_MIN_VERSION) && !FastlaneCore::Env.truthy?("FASTLANE_SKIP_RUBY_VERSION_WARNING")
-          warn = "WARNING: Support for your Ruby version is going away. fastlane will soon require Ruby #{Fastlane::SUGGESTED_RUBY_MIN_VERSION} or newer."
+        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new(Fastlane::SUGGESTED_MINIMUM_RUBY) && !FastlaneCore::Env.truthy?("FASTLANE_SKIP_RUBY_VERSION_WARNING")
+          warn = "WARNING: Support for your Ruby version (#{RUBY_VERSION}) is going away. fastlane will soon require Ruby #{Fastlane::SUGGESTED_MINIMUM_RUBY} or newer."
           UI.important(warn)
           at_exit do
             UI.important(warn)

--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -4,5 +4,5 @@ module Fastlane
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '1.50.2'.freeze
-  SUGGESTED_RUBY_MIN_VERSION = '3.2.0'.freeze
+  SUGGESTED_MINIMUM_RUBY = '3.2.0'.freeze
 end

--- a/fastlane/spec/ruby_version_warning_spec.rb
+++ b/fastlane/spec/ruby_version_warning_spec.rb
@@ -7,14 +7,14 @@ describe Fastlane::CLIToolsDistributor do
       allow(Fastlane::CLIToolsDistributor).to receive(:at_exit)
     end
 
-    it "displays a warning when Ruby version is older than SUGGESTED_RUBY_MIN_VERSION" do
+    it "displays a warning when Ruby version is older than SUGGESTED_MINIMUM_RUBY" do
       stub_const("RUBY_VERSION", "3.1.0")
-      stub_const("Fastlane::SUGGESTED_RUBY_MIN_VERSION", "3.2.0")
+      stub_const("Fastlane::SUGGESTED_MINIMUM_RUBY", "3.2.0")
 
       # It's called once in take_off, and once in at_exit (which we mock, so we can't easily check if it's called at exit without more complex setup)
       # Wait, at_exit block is executed when the process exits. In tests, we are mocking at_exit.
       # If we mock at_exit to NOT yield, then the block inside it won't be executed immediately.
-      expect(UI).to receive(:important).with(/Support for your Ruby version is going away/).once
+      expect(UI).to receive(:important).with(/Support for your Ruby version \(.*\) is going away/).once
 
       FastlaneSpec::Env.with_env_values('FASTLANE_SKIP_UPDATE_CHECK': 'true', 'FASTLANE_DISABLE_ANIMATION': 'true') do
         # We need to mock the require calls
@@ -40,11 +40,11 @@ describe Fastlane::CLIToolsDistributor do
       end
     end
 
-    it "does NOT display a warning when Ruby version is equal to SUGGESTED_RUBY_MIN_VERSION" do
+    it "does NOT display a warning when Ruby version is equal to SUGGESTED_MINIMUM_RUBY" do
       stub_const("RUBY_VERSION", "3.2.0")
-      stub_const("Fastlane::SUGGESTED_RUBY_MIN_VERSION", "3.2.0")
+      stub_const("Fastlane::SUGGESTED_MINIMUM_RUBY", "3.2.0")
 
-      expect(UI).not_to receive(:important).with(/Support for your Ruby version is going away/)
+      expect(UI).not_to receive(:important).with(/Support for your Ruby version \(.*\) is going away/)
 
       FastlaneSpec::Env.with_env_values('FASTLANE_SKIP_UPDATE_CHECK': 'true', 'FASTLANE_DISABLE_ANIMATION': 'true') do
         allow(Fastlane::CLIToolsDistributor).to receive(:require).with("fastlane")
@@ -68,9 +68,9 @@ describe Fastlane::CLIToolsDistributor do
 
     it "does NOT display a warning when FASTLANE_SKIP_RUBY_VERSION_WARNING is set" do
       stub_const("RUBY_VERSION", "3.1.0")
-      stub_const("Fastlane::SUGGESTED_RUBY_MIN_VERSION", "3.2.0")
+      stub_const("Fastlane::SUGGESTED_MINIMUM_RUBY", "3.2.0")
 
-      expect(UI).not_to receive(:important).with(/Support for your Ruby version is going away/)
+      expect(UI).not_to receive(:important).with(/Support for your Ruby version \(.*\) is going away/)
 
       FastlaneSpec::Env.with_env_values('FASTLANE_SKIP_UPDATE_CHECK': 'true', 'FASTLANE_DISABLE_ANIMATION': 'true', 'FASTLANE_SKIP_RUBY_VERSION_WARNING': 'true') do
         allow(Fastlane::CLIToolsDistributor).to receive(:require).with("fastlane")


### PR DESCRIPTION
### Problem

I tried to release 2.231.0 today and it [failed](https://github.com/fastlane/fastlane/actions/runs/21040996819/job/60502464900) because it pulled the local version from the repo as 3.2.0 which made absolutely no sense.

```
 [17:54:07]: Called from Fastfile at line 125
[17:54:07]: ```
[17:54:07]:     123:	  latest_version = current_version
[17:54:07]:     124:	  local_version = version_get_podspec(path: version_file_path, require_variable_prefix: false)
[17:54:07]:  => 125:	  UI.user_error!("Version on RubyGems doesn't match local repo: #{latest_version} != #{local_version}") if latest_version != local_version
[17:54:07]:     126:	
[17:54:07]:     127:	  changelog_text = show_changelog
[17:54:07]: ```
[17:54:07]: Version on RubyGems doesn't match local repo: 2.230.0 != 3.2.0
```

It turns out it uses an action `version_get_podspec` which gets the first key from the file that meets regular expression of "version", which became defeated as I added a Ruby min in this [PR](https://github.com/fastlane/fastlane/commit/b4413acd7a25399fc5411b130b692ba59cdc04a7) which used the word "version" in the key much like the generic "version" previously there.

### Solution

I renamed the new key to remove "VERSION" from it.
