### PR TITLE
[ci] always record latest_fl_version during part 2 release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -253,6 +253,7 @@ lane :create_github_release do |options|
 
   # Set the version into an ENV variable for GitHub Actions to read
   ENV['FASTLANE_RELEASE_VERSION'] = version
+  File.write("../latest_fl_version.txt", version)
 
   github_username = ENV["RELEASE_GITHUB_USERNAME"] || "fastlane"
   repo_name = "#{github_username}/fastlane"
@@ -282,7 +283,6 @@ lane :create_github_release do |options|
     release_url = github_release['html_url']
     message = [title, description, release_url].join("\n\n")
     add_fastlane_git_tag(tag: "fastlane/#{version}", message: message)
-    File.write("../latest_fl_version.txt", version)
 
     UI.success("New GitHub release has been created: #{release_url}")
   else


### PR DESCRIPTION
### Problem

The build failed on 1st release, but it already generated the GitHub release. This meant the code to generate the artifact file was not here on try 2, which generated the gem.


### Solution

Move the storing/saving of the version file (used for announcing the release) to always run regardless of the generation of the GitHub release.