### PR TITLE
[action] Add format switch to the import_certificate action

### DIFF
--- a/fastlane/lib/fastlane/actions/import_certificate.rb
+++ b/fastlane/lib/fastlane/actions/import_certificate.rb
@@ -6,7 +6,7 @@ module Fastlane
       def self.run(params)
         keychain_path = params[:keychain_path] || FastlaneCore::Helper.keychain_path(params[:keychain_name])
 
-        FastlaneCore::KeychainImporter.import_file(params[:certificate_path], keychain_path, keychain_password: params[:keychain_password], certificate_password: params[:certificate_password], output: params[:log_output])
+        FastlaneCore::KeychainImporter.import_file(params[:certificate_path], keychain_path, keychain_password: params[:keychain_password], certificate_password: params[:certificate_password], certificate_format: params[:certificate_format], output: params[:log_output])
       end
 
       def self.description
@@ -22,6 +22,9 @@ module Fastlane
                                        description: "Certificate password",
                                        sensitive: true,
                                        default_value: "",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :certificate_format,
+                                       description: "Format of the certificate. Check the '-f' switch from 'security import --help' command",
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :keychain_name,
                                        env_name: "KEYCHAIN_NAME",
@@ -65,6 +68,11 @@ module Fastlane
           )',
           'import_certificate(
             certificate_path: "certs/development.cer"
+          )',
+          'import_certificate(
+            certificate_path: "certs/dist.p12",
+            certificate_password: ENV["CERTIFICATE_PASSWORD"] || "default",
+            certificate_format: "pkcs12"
           )'
         ]
       end

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -4,13 +4,15 @@ require 'security'
 
 module FastlaneCore
   class KeychainImporter
-    def self.import_file(path, keychain_path, keychain_password: nil, certificate_password: "", skip_set_partition_list: false, output: FastlaneCore::Globals.verbose?)
+    def self.import_file(path, keychain_path, keychain_password: nil, certificate_password: "", certificate_format: nil, skip_set_partition_list: false, output: FastlaneCore::Globals.verbose?)
       UI.user_error!("Could not find file '#{path}'") unless File.exist?(path)
 
       password_part = " -P #{certificate_password.shellescape}"
+      certificate_format_part = certificate_format.to_s.strip.empty? ? "" : " -f #{certificate_format.shellescape}"
 
       command = "security import #{path.shellescape} -k '#{keychain_path.shellescape}'"
       command << password_part
+      command << certificate_format_part
       command << " -T /usr/bin/codesign" # to not be asked for permission when running a tool like `gym` (before Sierra)
       command << " -T /usr/bin/security"
       command << " -T /usr/bin/productbuild" # to not be asked for permission when using an installer cert for macOS


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #29867

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
While troubleshooting the linked issue #29867 I found that there is a format switch for the `security import` command:
```
-f  Format = openssl|openssh1|openssh2|bsafe|raw|pkcs7|pkcs8|pkcs12|netscape|pemseq
```

When manually executing the security import command with `-f pkcs12` the import succeeded.

I tested everything with my exactly use case. Now using the new option `certificate_format` resulted into the same behaviour (error) as before. Using the option resulted in a success.

Note: This is my very first time with fastlane **and** with ruby.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Test with the following action call / parameters.
```
import_certificate(
  certificate_path: cert_path,
  certificate_password: ENV['P12_PASSWORD'] || "",
  certificate_format: 'pkcs12',
  keychain_name: options[:keychain_name],
  keychain_password: options[:keychain_password],
  log_output: true
)
```

To generate a certificate like mine yourself you can do the following:
1. Open Apple keychain and export any certificate with a private key
2. Execute to get the private key: `openssl pkcs12 -legacy -in Zertifikate.p12 -out Zertifikate.key -nocerts`
3. Execute to get the certificate: `openssl pkcs12 -legacy -in Zertifikate.p12 -out Zertifikate.pem -nodes`
4. Execute to get the full .p12 file without using the legacy mode (default): `openssl pkcs12 -export -out certificates_no_legacy.p12 -inkey certificates.key -in certificates.pem`
5. Use that certificate in the action