### PR TITLE
[cert, match] fix: omit the developer_id_application_g2 certificate type

### DIFF
--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -159,10 +159,13 @@ module Cert
         when :mac_installer_distribution
           return [Spaceship::ConnectAPI::Certificate::CertificateType::MAC_INSTALLER_DISTRIBUTION]
         when :developer_id_application
-          return [
-            Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION_G2,
-            Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION
-          ]
+          # DEVELOPER_ID_APPLICATION_G2 no longer supported by the App Store Connect API.
+          # https://api.appstoreconnect.apple.com/v1/certificates?filter[certificateType]=DEVELOPER_ID_APPLICATION_G2
+          # Radar: FB21181137.
+          # Related:
+          # - https://github.com/fastlane/fastlane/issues/29587
+          # - https://github.com/fastlane/fastlane/pull/29784
+          return [Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_APPLICATION]
         when :developer_id_kext
           return [Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_KEXT]
         when :developer_id_installer


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

I don't really have a dev environment (I'm not a Ruby dev), so this is mainly a strawman PR to start a conversation with maintainers who are a bit more familiar with the matter.

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

See #29587 about how the `DEVELOPER_ID_APPLICATION_G2` certificate type is no longer being accepted by Apple. The original fix for #29587 fixed `spaceship`, but as I detailed in my comment https://github.com/fastlane/fastlane/issues/29587#issuecomment-3817049139, `cert` also needs to be fixed (which this PR does).

Fixes https://github.com/fastlane/fastlane/issues/29587 (again).

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Again, a full explanation with a stack trace is given in https://github.com/fastlane/fastlane/issues/29587#issuecomment-3817049139, but in brief:

Before this PR, the following command was failing for me:

```rb
match(
  readonly: false,
  type: "developer_id",
  additional_cert_types: ["developer_id_installer"],
  platform: "macos",
  readonly: false,
  verbose: true
)
```

It gave the following error:

<details>
<summary>See error</summary>

```
ERROR [2026-01-29 20:43:01.66]: Error finding relevant GitHub issues: undefined method 'map' for nil
bundler: failed to load command: fastlane (/Users/jamie/.rbenv/versions/3.4.3/bin/fastlane)
/Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/spaceship/lib/spaceship/connect_api/api_client.rb:223:in 'Spaceship::ConnectAPI::APIClient#handle_response': [!] An attribute in the provided entity has the wrong type - 'DEVELOPER_ID_APPLICATION_G2' is not a valid value for the attribute 'certificateType'. Expected one of: 'APPLE_PAY', 'APPLE_PAY_MERCHANT_IDENTITY', 'APPLE_PAY_PSP_IDENTITY', 'APPLE_PAY_RSA', 'DEVELOPER_ID_KEXT', 'DEVELOPER_ID_APPLICATION', 'DEVELOPMENT', 'DISTRIBUTION', 'IDENTITY_ACCESS', 'IOS_DEVELOPMENT', 'IOS_DISTRIBUTION', 'MAC_APP_DISTRIBUTION', 'MAC_INSTALLER_DISTRIBUTION', 'MAC_APP_DEVELOPMENT', 'PASS_TYPE_ID', 'PASS_TYPE_ID_WITH_NFC' - /data/attributes/certificateType (Spaceship::UnexpectedResponse)
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/spaceship/lib/spaceship/connect_api/api_client.rb:125:in 'Spaceship::ConnectAPI::APIClient#post'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/spaceship/lib/spaceship/connect_api/provisioning/client.rb:39:in 'Spaceship::ConnectAPI::Provisioning::Client#post'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb:158:in 'Spaceship::ConnectAPI::Provisioning::API#post_certificate'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/forwardable.rb:240:in 'Spaceship::ConnectAPI.post_certificate'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/spaceship/lib/spaceship/connect_api/models/certificate.rb:128:in 'Spaceship::ConnectAPI::Certificate.create'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/cert/lib/cert/runner.rb:206:in 'Cert::Runner#create_certificate'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/cert/lib/cert/runner.rb:58:in 'Cert::Runner#run'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/cert/lib/cert/runner.rb:13:in 'Cert::Runner#launch'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/match/lib/match/generator.rb:43:in 'Match::Generator.generate_certificate'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/match/lib/match/runner.rb:203:in 'Match::Runner#fetch_certificate'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/match/lib/match/runner.rb:88:in 'Match::Runner#run'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/actions/sync_code_signing.rb:19:in 'Fastlane::Actions::SyncCodeSigningAction.run'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/runner.rb:263:in 'block (2 levels) in Fastlane::Runner#execute_action'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/actions/actions_helper.rb:69:in 'Fastlane::Actions.execute_action'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/runner.rb:255:in 'block in Fastlane::Runner#execute_action'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/runner.rb:229:in 'Dir.chdir'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/runner.rb:229:in 'Fastlane::Runner#execute_action'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/runner.rb:157:in 'Fastlane::Runner#trigger_action_by_name'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/fast_file.rb:159:in 'Fastlane::FastFile#method_missing'
        from Fastfile:55:in 'block (2 levels) in Fastlane::FastFile#parsing_binding'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/lane.rb:41:in 'Fastlane::Lane#call'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/runner.rb:49:in 'block in Fastlane::Runner#execute'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/runner.rb:45:in 'Dir.chdir'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/runner.rb:45:in 'Fastlane::Runner#execute'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/lane_manager.rb:46:in 'Fastlane::LaneManager.cruise_lane'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/command_line_handler.rb:34:in 'Fastlane::CommandLineHandler.handle'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/commands_generator.rb:110:in 'block (2 levels) in Fastlane::CommandsGenerator#run'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/commander-4.6.0/lib/commander/command.rb:187:in 'Commander::Command#call'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/commander-4.6.0/lib/commander/command.rb:157:in 'Commander::Command#run'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/commander-4.6.0/lib/commander/runner.rb:444:in 'Commander::Runner#run_active_command'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in 'Commander::Runner#run!'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/commander-4.6.0/lib/commander/delegates.rb:18:in 'Commander::Delegates#run!'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/commands_generator.rb:363:in 'Fastlane::CommandsGenerator#run'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/commands_generator.rb:43:in 'Fastlane::CommandsGenerator.start'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/fastlane/lib/fastlane/cli_tools_distributor.rb:132:in 'Fastlane::CLIToolsDistributor.take_off'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/fastlane-2.231.1/bin/fastlane:23:in '<top (required)>'
        from /Users/jamie/.rbenv/versions/3.4.3/bin/fastlane:25:in 'Kernel#load'
        from /Users/jamie/.rbenv/versions/3.4.3/bin/fastlane:25:in '<top (required)>'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/cli/exec.rb:59:in 'Kernel.load'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/cli.rb:452:in 'Bundler::CLI#exec'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/cli.rb:29:in 'Bundler::CLI.start'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/exe/bundle:28:in 'block in <top (required)>'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/3.4.0/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
        from /Users/jamie/.rbenv/versions/3.4.3/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/exe/bundle:20:in '<top (required)>'
        from /Users/jamie/.rbenv/versions/3.4.3/bin/bundle:25:in 'Kernel#load'
        from /Users/jamie/.rbenv/versions/3.4.3/bin/bundle:25:in '<main>'
```

</details>

I applied this hard-coded patch to my local copy of Fastlane v2.231.1 and it resolved the error.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

Run the following `match()` command via `fastlane mac deploy` or similar:

```rb
match(
  readonly: false,
  type: "developer_id",
  additional_cert_types: ["developer_id_installer"],
  platform: "macos",
  readonly: false,
  verbose: true
)
```