### PR TITLE
Fix --copy_to_clipboard flag for spaceauth command

### DIFF
--- a/spaceship/lib/spaceship/commands_generator.rb
+++ b/spaceship/lib/spaceship/commands_generator.rb
@@ -40,10 +40,19 @@ module Spaceship
       command :spaceauth do |c|
         c.syntax = 'fastlane spaceship spaceauth'
         c.description = 'Authentication helper for spaceship/fastlane to work with Apple 2-Step/2FA'
-        c.option('--copy_to_clipboard', 'Whether the session string should be copied to clipboard. For more info see https://docs.fastlane.tools/best-practices/continuous-integration/#storing-a-manually-verified-session-using-spaceauth`')
+        c.option('--copy_to_clipboard VALUE', 'Whether the session string should be copied to clipboard (true/false). For more info see https://docs.fastlane.tools/best-practices/continuous-integration/#storing-a-manually-verified-session-using-spaceauth`')
         c.option('--check_session', 'Check to see if there is a valid session (either in the cache or via FASTLANE_SESSION). Sets the exit code to 0 if the session is valid or 1 if not.') { Spaceship::Globals.check_session = true }
         c.action do |args, options|
-          Spaceship::SpaceauthRunner.new(username: options.user, copy_to_clipboard: options.copy_to_clipboard).run
+          copy_to_clipboard = if options.copy_to_clipboard.nil?
+                                nil
+                              elsif %w(yes YES true TRUE on ON).include?(options.copy_to_clipboard.to_s)
+                                true
+                              elsif %w(no NO false FALSE off OFF).include?(options.copy_to_clipboard.to_s)
+                                false
+                              else
+                                nil
+                              end
+          Spaceship::SpaceauthRunner.new(username: options.user, copy_to_clipboard: copy_to_clipboard).run
         end
       end
 

--- a/spaceship/lib/spaceship/commands_generator.rb
+++ b/spaceship/lib/spaceship/commands_generator.rb
@@ -49,8 +49,6 @@ module Spaceship
                                 true
                               elsif %w(no NO false FALSE off OFF).include?(options.copy_to_clipboard.to_s)
                                 false
-                              else
-                                nil
                               end
           Spaceship::SpaceauthRunner.new(username: options.user, copy_to_clipboard: copy_to_clipboard).run
         end


### PR DESCRIPTION
## Summary

The `--copy_to_clipboard` flag for `fastlane spaceauth` was not working correctly. Running `fastlane spaceauth --copy_to_clipboard false` would still prompt and copy to clipboard.

## Problem

The option was defined as a boolean flag without a value placeholder:
```ruby
c.option('--copy_to_clipboard', '...')
```

In Commander, this means `--copy_to_clipboard false` parses `false` as a positional argument rather than the option value. The option itself would be set to `true` (flag present) regardless of what followed.

## Solution

Changed the option to accept a VALUE and properly parse boolean strings using the same pattern as `ConfigItem.auto_convert_value`:
- `yes`, `YES`, `true`, `TRUE`, `on`, `ON` → `true`
- `no`, `NO`, `false`, `FALSE`, `off`, `OFF` → `false`

This allows users to run `fastlane spaceauth --copy_to_clipboard false` to skip the clipboard prompt entirely, which is useful for scripted/automated workflows.

## Test Plan

Tested locally:
- `fastlane spaceauth --copy_to_clipboard false` → skips clipboard, prints "Skipped asking to copy..."
- `fastlane spaceauth --copy_to_clipboard true` → copies to clipboard without prompting
- `fastlane spaceauth` (no flag) → prompts interactively as before