### PR TITLE
[notarize] Remove legacy altool flow

### DIFF
--- a/fastlane/lib/fastlane/actions/notarize.rb
+++ b/fastlane/lib/fastlane/actions/notarize.rb
@@ -6,7 +6,6 @@ module Fastlane
         package_path = params[:package]
         bundle_id = params[:bundle_id]
         skip_stapling = params[:skip_stapling]
-        try_early_stapling = params[:try_early_stapling]
         print_log = params[:print_log]
         verbose = params[:verbose]
 
@@ -15,8 +14,6 @@ module Fastlane
           params[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
         end
         api_key = Spaceship::ConnectAPI::Token.from(hash: params[:api_key], filepath: params[:api_key_path])
-
-        use_notarytool = params[:use_notarytool]
 
         # Compress and read bundle identifier only for .app bundle.
         compressed_package_path = nil
@@ -38,11 +35,7 @@ module Fastlane
 
         UI.user_error!('Could not read bundle identifier, provide as a parameter') unless bundle_id
 
-        if use_notarytool
-          notarytool(params, package_path, bundle_id, skip_stapling, print_log, verbose, api_key, compressed_package_path)
-        else
-          altool(params, package_path, bundle_id, try_early_stapling, skip_stapling, print_log, verbose, api_key, compressed_package_path)
-        end
+        notarytool(params, package_path, bundle_id, skip_stapling, print_log, verbose, api_key, compressed_package_path)
       end
 
       def self.notarytool(params, package_path, bundle_id, skip_stapling, print_log, verbose, api_key, compressed_package_path)
@@ -127,137 +120,11 @@ module Fastlane
         temp_file.delete if temp_file
       end
 
-      def self.altool(params, package_path, bundle_id, try_early_stapling, skip_stapling, print_log, verbose, api_key, compressed_package_path)
-        UI.message('Uploading package to notarization service, might take a while')
-
-        notarization_upload_command = "xcrun altool --notarize-app -t osx -f \"#{compressed_package_path || package_path}\" --primary-bundle-id #{bundle_id} --output-format xml"
-
-        notarization_info = {}
-        with_notarize_authenticator(params, api_key) do |notarize_authenticator|
-          notarization_upload_command << " --asc-provider \"#{params[:asc_provider]}\"" if params[:asc_provider] && api_key.nil?
-
-          notarization_upload_response = Actions.sh(
-            notarize_authenticator.call(notarization_upload_command),
-            log: verbose
-          )
-
-          FileUtils.rm_rf(compressed_package_path) if compressed_package_path
-
-          notarization_upload_plist = Plist.parse_xml(notarization_upload_response)
-
-          if notarization_upload_plist.key?('product-errors') && notarization_upload_plist['product-errors'].any?
-            UI.important("🚫 Could not upload package to notarization service! Here are the reasons:")
-            notarization_upload_plist['product-errors'].each { |product_error| UI.error("#{product_error['message']} (#{product_error['code']})") }
-            UI.user_error!("Package upload to notarization service cancelled. Please check the error messages above.")
-          end
-
-          notarization_request_id = notarization_upload_plist['notarization-upload']['RequestUUID']
-
-          UI.success("Successfully uploaded package to notarization service with request identifier #{notarization_request_id}")
-
-          while notarization_info.empty? || (notarization_info['Status'] == 'in progress')
-            if notarization_info.empty?
-              UI.message('Waiting to query request status')
-            elsif try_early_stapling && !skip_stapling
-              UI.message('Request in progress, trying early staple')
-
-              begin
-                self.staple(package_path, verbose)
-                UI.message('Successfully notarized and early stapled package.')
-
-                return
-              rescue
-                UI.message('Early staple failed, waiting to query again')
-              end
-            end
-
-            sleep(30)
-
-            UI.message('Querying request status')
-
-            # As of July 2020, the request UUID might not be available for polling yet which returns an error code
-            # This is now handled with the error_callback (which prevents an error from being raised)
-            # Catching this error allows for polling to continue until the notarization is complete
-            error = false
-            notarization_info_response = Actions.sh(
-              notarize_authenticator.call("xcrun altool --notarization-info #{notarization_request_id} --output-format xml"),
-              log: verbose,
-              error_callback: lambda { |msg|
-                error = true
-                UI.error("Error polling for notarization info: #{msg}")
-              }
-            )
-
-            unless error
-              notarization_info_plist = Plist.parse_xml(notarization_info_response)
-              notarization_info = notarization_info_plist['notarization-info']
-            end
-          end
-        end
-        # rubocop:enable Metrics/PerceivedComplexity
-
-        log_url = notarization_info['LogFileURL']
-        ENV['FL_NOTARIZE_LOG_FILE_URL'] = log_url
-        log_suffix = ''
-        if log_url && print_log
-          log_response = Net::HTTP.get(URI(log_url))
-          log_json_object = JSON.parse(log_response)
-          log_suffix = ", with log:\n#{JSON.pretty_generate(log_json_object)}"
-        end
-
-        case notarization_info['Status']
-        when 'success'
-          if skip_stapling
-            UI.success("Successfully notarized artifact#{log_suffix}")
-          else
-            UI.message('Stapling package')
-
-            self.staple(package_path, verbose)
-
-            UI.success("Successfully notarized and stapled package#{log_suffix}")
-          end
-        when 'invalid'
-          UI.user_error!("Could not notarize package with message '#{notarization_info['Status Message']}'#{log_suffix}")
-        else
-          UI.crash!("Could not notarize package with status '#{notarization_info['Status']}'#{log_suffix}")
-        end
-      ensure
-        ENV.delete('FL_NOTARIZE_PASSWORD')
-      end
-
       def self.staple(package_path, verbose)
         Actions.sh(
           "xcrun stapler staple #{package_path.shellescape}",
           log: verbose
         )
-      end
-
-      def self.with_notarize_authenticator(params, api_key)
-        if api_key
-          # From xcrun altool for --apiKey:
-          # This option will search the following directories in sequence for a private key file with the name of 'AuthKey_<api_key>.p8':  './private_keys', '~/private_keys', '~/.private_keys', and '~/.appstoreconnect/private_keys'.
-          api_key_folder_path = File.expand_path('~/.appstoreconnect/private_keys')
-          api_key_file_path = File.join(api_key_folder_path, "AuthKey_#{api_key.key_id}.p8")
-          directory_exists = File.directory?(api_key_folder_path)
-          file_exists = File.exist?(api_key_file_path)
-          begin
-            FileUtils.mkdir_p(api_key_folder_path) unless directory_exists
-            api_key.write_key_to_file(api_key_file_path) unless file_exists
-
-            yield(proc { |command| "#{command} --apiKey #{api_key.key_id} --apiIssuer #{api_key.issuer_id}" })
-          ensure
-            FileUtils.rm(api_key_file_path) unless file_exists
-            FileUtils.rm_r(api_key_folder_path) unless directory_exists
-          end
-        else
-          apple_id_account = CredentialsManager::AccountManager.new(user: params[:username])
-
-          # Add password as a temporary environment variable for altool.
-          # Use app specific password if specified.
-          ENV['FL_NOTARIZE_PASSWORD'] = ENV['FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD'] || apple_id_account.password
-
-          yield(proc { |command| "#{command} -u #{apple_id_account.user} -p @env:FL_NOTARIZE_PASSWORD" })
-        end
       end
 
       def self.description
@@ -281,24 +148,10 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Could not find package at '#{value}'") unless File.exist?(value)
                                        end),
-          FastlaneCore::ConfigItem.new(key: :use_notarytool,
-                                       env_name: 'FL_NOTARIZE_USE_NOTARYTOOL',
-                                       description: 'Whether to `xcrun notarytool` or `xcrun altool`',
-                                       default_value: Helper.mac? && Helper.xcode_at_least?("13.0"), # Notary tool added in Xcode 13
-                                       default_value_dynamic: true,
-                                       type: Boolean),
-          FastlaneCore::ConfigItem.new(key: :try_early_stapling,
-                                       env_name: 'FL_NOTARIZE_TRY_EARLY_STAPLING',
-                                       description: 'Whether to try early stapling while the notarization request is in progress',
-                                       optional: true,
-                                       conflicting_options: [:skip_stapling],
-                                       default_value: false,
-                                       type: Boolean),
           FastlaneCore::ConfigItem.new(key: :skip_stapling,
                                        env_name: 'FL_NOTARIZE_SKIP_STAPLING',
                                        description: 'Do not staple the notarization ticket to the artifact; useful for single file executables and ZIP archives',
                                        optional: true,
-                                       conflicting_options: [:try_early_stapling],
                                        default_value: false,
                                        type: Boolean),
           FastlaneCore::ConfigItem.new(key: :bundle_id,

--- a/fastlane/spec/actions_specs/notarize_spec.rb
+++ b/fastlane/spec/actions_specs/notarize_spec.rb
@@ -36,17 +36,6 @@ describe Fastlane do
         end.to raise_error("Unresolved conflict between options: 'username' and 'api_key'")
       end
 
-      it "forbids to provide both :skip_stapling and :try_early_stapling" do
-        expect do
-          Fastlane::FastFile.new.parse("lane :test do
-            notarize(
-              skip_stapling: true,
-              try_early_stapling: true
-            )
-          end").runner.execute(:test)
-        end.to raise_error("Unresolved conflict between options: 'skip_stapling' and 'try_early_stapling'")
-      end
-
       context "with notary tool" do
         let(:package) { Tempfile.new('app.ipa.zip') }
         let(:bundle_id) { 'com.some.app' }
@@ -65,7 +54,6 @@ describe Fastlane do
 
             result = Fastlane::FastFile.new.parse("lane :test do
               notarize(
-                use_notarytool: true,
                 package: '#{package.path}',
                 bundle_id: '#{bundle_id}',
                 username: '#{username}',
@@ -83,7 +71,6 @@ describe Fastlane do
 
             result = Fastlane::FastFile.new.parse("lane :test do
               notarize(
-                use_notarytool: true,
                 package: '#{package.path}',
                 bundle_id: '#{bundle_id}',
                 username: '#{username}',
@@ -102,7 +89,6 @@ describe Fastlane do
 
             result = Fastlane::FastFile.new.parse("lane :test do
               notarize(
-                use_notarytool: true,
                 package: '#{package.path}',
                 bundle_id: '#{bundle_id}',
                 username: '#{username}',
@@ -120,7 +106,6 @@ describe Fastlane do
             expect do
               result = Fastlane::FastFile.new.parse("lane :test do
                 notarize(
-                  use_notarytool: true,
                   package: '#{package.path}',
                   bundle_id: '#{bundle_id}',
                   username: '#{username}',

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -7380,8 +7380,6 @@ public func nexusUpload(file: String,
 
  - parameters:
    - package: Path to package to notarize, e.g. .app bundle or disk image
-   - useNotarytool: Whether to `xcrun notarytool` or `xcrun altool`
-   - tryEarlyStapling: Whether to try early stapling while the notarization request is in progress
    - skipStapling: Do not staple the notarization ticket to the artifact; useful for single file executables and ZIP archives
    - bundleId: Bundle identifier to uniquely identify the package
    - username: Apple ID username
@@ -7392,8 +7390,6 @@ public func nexusUpload(file: String,
    - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-hash-option)
  */
 public func notarize(package: String,
-                     useNotarytool: OptionalConfigValue<Bool> = .fastlaneDefault(true),
-                     tryEarlyStapling: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                      skipStapling: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                      bundleId: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                      username: OptionalConfigValue<String?> = .fastlaneDefault(nil),
@@ -7404,8 +7400,6 @@ public func notarize(package: String,
                      apiKey: OptionalConfigValue<[String: Any]?> = .fastlaneDefault(nil))
 {
     let packageArg = RubyCommand.Argument(name: "package", value: package, type: nil)
-    let useNotarytoolArg = useNotarytool.asRubyArgument(name: "use_notarytool", type: nil)
-    let tryEarlyStaplingArg = tryEarlyStapling.asRubyArgument(name: "try_early_stapling", type: nil)
     let skipStaplingArg = skipStapling.asRubyArgument(name: "skip_stapling", type: nil)
     let bundleIdArg = bundleId.asRubyArgument(name: "bundle_id", type: nil)
     let usernameArg = username.asRubyArgument(name: "username", type: nil)
@@ -7415,8 +7409,6 @@ public func notarize(package: String,
     let apiKeyPathArg = apiKeyPath.asRubyArgument(name: "api_key_path", type: nil)
     let apiKeyArg = apiKey.asRubyArgument(name: "api_key", type: nil)
     let array: [RubyCommand.Argument?] = [packageArg,
-                                          useNotarytoolArg,
-                                          tryEarlyStaplingArg,
                                           skipStaplingArg,
                                           bundleIdArg,
                                           usernameArg,

--- a/fastlane/swift/Fastlane.swift
+++ b/fastlane/swift/Fastlane.swift
@@ -7380,6 +7380,8 @@ public func nexusUpload(file: String,
 
  - parameters:
    - package: Path to package to notarize, e.g. .app bundle or disk image
+   - useNotarytool: Whether to `xcrun notarytool` or `xcrun altool`
+   - tryEarlyStapling: Whether to try early stapling while the notarization request is in progress
    - skipStapling: Do not staple the notarization ticket to the artifact; useful for single file executables and ZIP archives
    - bundleId: Bundle identifier to uniquely identify the package
    - username: Apple ID username
@@ -7390,6 +7392,8 @@ public func nexusUpload(file: String,
    - apiKey: Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-hash-option)
  */
 public func notarize(package: String,
+                     useNotarytool: OptionalConfigValue<Bool> = .fastlaneDefault(true),
+                     tryEarlyStapling: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                      skipStapling: OptionalConfigValue<Bool> = .fastlaneDefault(false),
                      bundleId: OptionalConfigValue<String?> = .fastlaneDefault(nil),
                      username: OptionalConfigValue<String?> = .fastlaneDefault(nil),
@@ -7400,6 +7404,8 @@ public func notarize(package: String,
                      apiKey: OptionalConfigValue<[String: Any]?> = .fastlaneDefault(nil))
 {
     let packageArg = RubyCommand.Argument(name: "package", value: package, type: nil)
+    let useNotarytoolArg = useNotarytool.asRubyArgument(name: "use_notarytool", type: nil)
+    let tryEarlyStaplingArg = tryEarlyStapling.asRubyArgument(name: "try_early_stapling", type: nil)
     let skipStaplingArg = skipStapling.asRubyArgument(name: "skip_stapling", type: nil)
     let bundleIdArg = bundleId.asRubyArgument(name: "bundle_id", type: nil)
     let usernameArg = username.asRubyArgument(name: "username", type: nil)
@@ -7409,6 +7415,8 @@ public func notarize(package: String,
     let apiKeyPathArg = apiKeyPath.asRubyArgument(name: "api_key_path", type: nil)
     let apiKeyArg = apiKey.asRubyArgument(name: "api_key", type: nil)
     let array: [RubyCommand.Argument?] = [packageArg,
+                                          useNotarytoolArg,
+                                          tryEarlyStaplingArg,
                                           skipStaplingArg,
                                           bundleIdArg,
                                           usernameArg,


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Apple’s notary service stopped accepting `altool` notarization uploads on November 1, 2023 (Apple notary service update). This removes a non‑functional path and reduces user confusion.  
[Apple notary service update](https://developer.apple.com/news/upcoming-requirements/?id=11012023a)

### Description

- Removed the legacy `altool` notarization flow from the `notarize` action.
- Removed `use_notarytool` and `try_early_stapling` options and related references.
- Updated notarize specs and Swift API to reflect the single supported flow.

### Testing Steps

- `bundle exec rspec fastlane/spec/actions_specs/notarize_spec.rb`
