### PR TITLE
[deliver, pilot] Add provider_public_id option for altool uploads

### DIFF
--- a/credentials_manager/lib/credentials_manager/appfile_config.rb
+++ b/credentials_manager/lib/credentials_manager/appfile_config.rb
@@ -123,6 +123,10 @@ module CredentialsManager
       setter(:itc_provider, *args, &block)
     end
 
+    def provider_public_id(*args, &block)
+      setter(:provider_public_id, *args, &block)
+    end
+
     # Android
     def json_key_file(*args, &block)
       setter(:json_key_file, *args, &block)

--- a/credentials_manager/spec/app_file_config_spec.rb
+++ b/credentials_manager/spec/app_file_config_spec.rb
@@ -196,6 +196,13 @@ describe CredentialsManager do
       end
     end
 
+    describe "Appfile10" do
+      it "supports provider_public_id in Appfile" do
+        config = CredentialsManager::AppfileConfig.new('credentials_manager/spec/fixtures/Appfile10')
+        expect(config.data[:provider_public_id]).to eq('00000000-0000-0000-0000-000000000000')
+      end
+    end
+
     describe "No Appfile" do
       it "prefills information from the environment variable" do
         env_name = "User@#{Time.now.to_i}"

--- a/credentials_manager/spec/fixtures/Appfile10
+++ b/credentials_manager/spec/fixtures/Appfile10
@@ -1,0 +1,2 @@
+app_identifier "com.example.app"
+provider_public_id "00000000-0000-0000-0000-000000000000"

--- a/deliver/lib/deliver/options.rb
+++ b/deliver/lib/deliver/options.rb
@@ -323,6 +323,13 @@ module Deliver
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:itc_provider),
                                      default_value_dynamic: true),
+        FastlaneCore::ConfigItem.new(key: :provider_public_id,
+                                     env_name: "DELIVER_PROVIDER_PUBLIC_ID",
+                                     description: "The provider public ID to be used with altool (--provider-public-id). This value will override the automatically detected provider value for altool uploads. Required after Xcode 26 when your account is associated with multiple providers and using username/app-password authentication",
+                                     optional: true,
+                                     code_gen_sensitive: true,
+                                     default_value: CredentialsManager::AppfileConfig.try_fetch_value(:provider_public_id),
+                                     default_value_dynamic: true),
         # rubocop:enable Layout/LineLength
 
         # precheck

--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -277,7 +277,7 @@ module Deliver
 
     # If App Store Connect API token, use token.
     # If api_key is specified and it is an Individual API Key, don't use token but use username.
-    # If itc_provider was explicitly specified, use it.
+    # If itc_provider or provider_public_id was explicitly specified, use it.
     # If there are multiple teams, infer the provider from the selected team name.
     # If there are fewer than two teams, don't infer the provider.
     def transporter_for_selected_team
@@ -303,13 +303,14 @@ module Deliver
 
       unless api_token.nil?
         api_token.refresh! if api_token.expired?
-        return FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, api_token.text, altool_compatible_command: true, api_key: api_key)
+        return FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, api_token.text, altool_compatible_command: true, api_key: api_key, provider_public_id: nil)
       end
 
       tunes_client = Spaceship::ConnectAPI.client.tunes_client
 
-      generic_transporter = FastlaneCore::ItunesTransporter.new(options[:username], nil, false, options[:itc_provider], altool_compatible_command: true, api_key: api_key)
-      return generic_transporter unless options[:itc_provider].nil? && tunes_client.teams.count > 1
+      generic_transporter = FastlaneCore::ItunesTransporter.new(options[:username], nil, false, options[:itc_provider], altool_compatible_command: true, api_key: api_key, provider_public_id: options[:provider_public_id])
+      return generic_transporter if options[:itc_provider] || options[:provider_public_id] || tunes_client.nil?
+      return generic_transporter unless tunes_client.teams.count > 1
 
       begin
         team = tunes_client.teams.find { |t| t['providerId'].to_s == tunes_client.team_id }

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -140,6 +140,7 @@ describe Deliver::Runner do
             {
               altool_compatible_command: true,
               api_key: options[:api_key],
+              provider_public_id: nil
             }
           )
           .and_return(transporter)
@@ -170,6 +171,7 @@ describe Deliver::Runner do
             {
               altool_compatible_command: true,
               api_key: nil,
+              provider_public_id: nil
             }
           )
           .and_return(transporter)

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -264,6 +264,7 @@ describe Deliver::Runner do
             {
               altool_compatible_command: true,
               api_key: options[:api_key],
+              provider_public_id: nil
             }
           )
           .and_return(transporter)
@@ -294,6 +295,7 @@ describe Deliver::Runner do
             {
               altool_compatible_command: true,
               api_key: nil,
+              provider_public_id: nil
             }
           )
           .and_return(transporter)

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -799,3 +799,6 @@ Change syntax highlighting to *Ruby*.
 
 ## Provider Short Name
 If you are on multiple App Store Connect teams, _deliver_ needs a provider short name to know where to upload your binary. _deliver_ will try to use the long name of the selected team to detect the provider short name. To override the detected value with an explicit one, use the `itc_provider` option.
+
+## Provider Public ID
+The provider public ID to be used with altool (--provider-public-id). This value will override the automatically detected provider value for altool uploads. Required after Xcode 26 when your account is associated with multiple providers and using username/app-password authentication.

--- a/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_testflight.md
@@ -264,6 +264,9 @@ _pilot_ uses the [CredentialsManager](https://github.com/fastlane/fastlane/tree/
 ## Provider Short Name
 If you are on multiple App Store Connect teams, iTunes Transporter may need a provider short name to know where to upload your binary. _pilot_ will try to use the long name of the selected team to detect the provider short name. To override the detected value with an explicit one, use the `itc_provider` option.
 
+## Provider Public ID
+The provider public ID to be used with altool (--provider-public-id). This value will override the automatically detected provider value for altool uploads. Required after Xcode 26 when your account is associated with multiple providers and using username/app-password authentication.
+
 ## Use an Application Specific Password to upload
 
 _pilot_/`upload_to_testflight` can use an [Application Specific Password via the `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` environment variable](https://docs.fastlane.tools/best-practices/continuous-integration/#application-specific-passwords) to upload a binary if both the `skip_waiting_for_build_processing` and `apple_id` options are set. (If any of those are not set, it will use the normal Apple login process that might require 2FA authentication.)

--- a/fastlane/lib/fastlane/actions/upload_to_app_store.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_app_store.rb
@@ -34,7 +34,7 @@ module Fastlane
           "If you don't want to verify an HTML preview for App Store builds, use the `:force` option.",
           "This is useful when running _fastlane_ on your Continuous Integration server:",
           "`_upload_to_app_store_(force: true)`",
-          "If your account is on multiple teams and you need to tell the `iTMSTransporter` which 'provider' to use, you can set the `:itc_provider` option to pass this info."
+          "If your account is on multiple teams and you need to tell the transporter which provider to use, you can set `:itc_provider` or `:provider_public_id`."
         ].join("\n")
       end
 

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -115,7 +115,7 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def altool_upload_command(api_key: nil, platform: "macos", provider_short_name: "")
+    def altool_upload_command(api_key: nil, platform: "macos", provider_short_name: "", provider_public_id: "")
       use_api_key = !api_key.nil?
       upload_part = "-f /tmp/my.app.id.itmsp"
       escaped_password = password.shellescape
@@ -128,6 +128,7 @@ describe FastlaneCore do
         ("--apiKey #{api_key[:key_id]}" if use_api_key),
         ("--apiIssuer #{api_key[:issuer_id]}" if use_api_key),
         ("--asc-provider #{provider_short_name}" unless use_api_key || provider_short_name.to_s.empty?),
+        ("--provider-public-id #{provider_public_id}" unless use_api_key || provider_public_id.to_s.empty?),
         ("-t #{platform}"),
         upload_part,
         "-k 100000"
@@ -1173,6 +1174,12 @@ describe FastlaneCore do
             it 'generates a call to altool' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd123', altool_compatible_command: true)
               expect(transporter.upload('my.app.id', '/tmp', package_path: '/tmp/my.app.id.itmsp', platform: "osx")).to eq(altool_upload_command(provider_short_name: 'abcd123'))
+            end
+
+            it 'generates a call to altool with provider_public_id' do
+              provider_public_id = '00000000-0000-0000-0000-000000000000'
+              transporter = FastlaneCore::ItunesTransporter.new(email, password, false, nil, altool_compatible_command: true, provider_public_id: provider_public_id)
+              expect(transporter.upload('my.app.id', '/tmp', package_path: '/tmp/my.app.id.itmsp', platform: "osx")).to eq(altool_upload_command(provider_short_name: nil, provider_public_id: provider_public_id))
             end
           end
 

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -398,7 +398,7 @@ module Pilot
 
     # If App Store Connect API token, use token.
     # If api_key is specified and it is an Individual API Key, don't use token but use username.
-    # If itc_provider was explicitly specified, use it.
+    # If itc_provider or provider_public_id was explicitly specified, use it.
     # If there are multiple teams, infer the provider from the selected team name.
     # If there are fewer than two teams, don't infer the provider.
     def transporter_for_selected_team(options)
@@ -424,14 +424,14 @@ module Pilot
 
       unless api_token.nil?
         api_token.refresh! if api_token.expired?
-        return FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, api_token.text, altool_compatible_command: true, api_key: api_key)
+        return FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, api_token.text, altool_compatible_command: true, api_key: api_key, provider_public_id: nil)
       end
 
       # Otherwise use username and password
       tunes_client = Spaceship::ConnectAPI.client ? Spaceship::ConnectAPI.client.tunes_client : nil
 
-      generic_transporter = FastlaneCore::ItunesTransporter.new(options[:username], nil, false, options[:itc_provider], altool_compatible_command: true, api_key: api_key)
-      return generic_transporter if options[:itc_provider] || tunes_client.nil?
+      generic_transporter = FastlaneCore::ItunesTransporter.new(options[:username], nil, false, options[:itc_provider], altool_compatible_command: true, api_key: api_key, provider_public_id: options[:provider_public_id])
+      return generic_transporter if options[:itc_provider] || options[:provider_public_id] || tunes_client.nil?
       return generic_transporter unless tunes_client.teams.count > 1
 
       begin

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -293,6 +293,10 @@ module Pilot
                                      env_name: "PILOT_ITC_PROVIDER",
                                      description: "The provider short name to be used with the iTMSTransporter to identify your team. This value will override the automatically detected provider short name. To get provider short name run `pathToXcode.app/Contents/Applications/Application\\ Loader.app/Contents/itms/bin/iTMSTransporter -m provider -u 'USERNAME' -p 'PASSWORD' -account_type itunes_connect -v off`. The short names of providers should be listed in the second column",
                                      optional: true),
+        FastlaneCore::ConfigItem.new(key: :provider_public_id,
+                                     env_name: "PILOT_PROVIDER_PUBLIC_ID",
+                                     description: "The provider public ID to be used with altool (--provider-public-id). This value will override the automatically detected provider value for altool uploads. Required after Xcode 26 when your account is associated with multiple providers and using username/app-password authentication",
+                                     optional: true),
         # rubocop:enable Layout/LineLength
 
         # waiting and uploaded build


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Xcode 26+ altool requires `--provider-public-id` for multi‑provider accounts using username/app‑password auth. We need a dedicated `provider_public_id` option while keeping legacy `--asc-provider` support for older altool and existing `itc_provider` users.  
Reference: https://keith.github.io/xcode-man-pages/altool.1.html

### Description

- Added `provider_public_id` option for altool upload/validate
- Kept legacy `--asc-provider` behavior for backward compatibility
- Switched transporter `build_upload_command`/`build_verify_command` to options hashes to avoid optional‑parameter limits
- Documented `provider_public_id` in Pilot/Deliver options and docs
- Added altool upload spec for `provider_public_id`

### Testing Steps
bundle exec rspec ./fastlane_core/spec/itunes_transporter_spec.rb

fixes: #29820