### PR TITLE
[action] Revert to "-uploadedDate" sort order for app_store_build_num…

### DIFF
--- a/fastlane/spec/actions_specs/app_store_build_number_spec.rb
+++ b/fastlane/spec/actions_specs/app_store_build_number_spec.rb
@@ -217,10 +217,10 @@ describe Fastlane do
           end
 
           it "sets the correct filters and fetches the latest testflight build number with any platform" do
-            expected_filter = {}
+            expected_filter = { state: "PROCESSING,FAILED,COMPLETE" }
             expect(Spaceship::ConnectAPI::Platform).to receive(:map).with(nil).and_return(nil)
             expect(UI).to receive(:message).with("Fetching the latest build number for any version")
-            expect(Spaceship::ConnectAPI).to receive(:get_build_uploads).with(app_id: app_id, filter: expected_filter, sort: "-cfBundleVersion", limit: 1).and_return([build_upload])
+            expect(Spaceship::ConnectAPI).to receive(:get_build_uploads).with(app_id: app_id, filter: expected_filter, sort: "-uploadedDate", limit: 1).and_return([build_upload])
             expect(UI).to receive(:message).with("Latest upload for version #{app_version} on any platform is build: #{build_number}")
 
             result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
@@ -236,9 +236,9 @@ describe Fastlane do
           end
 
           it "sets the correct filters and fetches the latest testflight build number with correct platform" do
-            expected_filter = { "platform" => platform }
+            expected_filter = { :state => "PROCESSING,FAILED,COMPLETE", "platform" => platform }
             expect(UI).to receive(:message).with("Fetching the latest build number for any version")
-            expect(Spaceship::ConnectAPI).to receive(:get_build_uploads).with(app_id: app_id, filter: expected_filter, sort: "-cfBundleVersion", limit: 1).and_return([build_upload])
+            expect(Spaceship::ConnectAPI).to receive(:get_build_uploads).with(app_id: app_id, filter: expected_filter, sort: "-uploadedDate", limit: 1).and_return([build_upload])
             expect(UI).to receive(:message).with("Latest upload for version #{app_version} on #{platform} platform is build: #{build_number}")
 
             result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
@@ -254,10 +254,10 @@ describe Fastlane do
           end
 
           it "sets the correct filters and fetches the latest testflight build number with any platform of given version" do
-            expected_filter = { "cfBundleShortVersionString" => app_version }
+            expected_filter = { :state => "PROCESSING,FAILED,COMPLETE", "cfBundleShortVersionString" => app_version }
             expect(Spaceship::ConnectAPI::Platform).to receive(:map).with(nil).and_return(nil)
             expect(UI).to receive(:message).with("Fetching the latest build number for version #{app_version}")
-            expect(Spaceship::ConnectAPI).to receive(:get_build_uploads).with(app_id: app_id, filter: expected_filter, sort: "-cfBundleVersion", limit: 1).and_return([build_upload])
+            expect(Spaceship::ConnectAPI).to receive(:get_build_uploads).with(app_id: app_id, filter: expected_filter, sort: "-uploadedDate", limit: 1).and_return([build_upload])
             expect(UI).to receive(:message).with("Latest upload for version #{app_version} on any platform is build: #{build_number}")
 
             result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
@@ -273,9 +273,9 @@ describe Fastlane do
           end
 
           it "sets the correct filters and fetches the latest testflight build number with correct platform of given version" do
-            expected_filter = { "platform" => platform, "cfBundleShortVersionString" => app_version }
+            expected_filter = { :state => "PROCESSING,FAILED,COMPLETE", "platform" => platform, "cfBundleShortVersionString" => app_version }
             expect(UI).to receive(:message).with("Fetching the latest build number for version #{app_version}")
-            expect(Spaceship::ConnectAPI).to receive(:get_build_uploads).with(app_id: app_id, filter: expected_filter, sort: "-cfBundleVersion", limit: 1).and_return([build_upload])
+            expect(Spaceship::ConnectAPI).to receive(:get_build_uploads).with(app_id: app_id, filter: expected_filter, sort: "-uploadedDate", limit: 1).and_return([build_upload])
             expect(UI).to receive(:message).with("Latest upload for version #{app_version} on #{platform} platform is build: #{build_number}")
 
             result = Fastlane::Actions::AppStoreBuildNumberAction.get_build_info(options)
@@ -286,10 +286,10 @@ describe Fastlane do
 
         context "when could not find the build and 'initial_build_number' is NOT given in input options" do
           before(:each) do
-            expected_filter = { "platform" => platform, "cfBundleShortVersionString" => app_version }
+            expected_filter = { :state => "PROCESSING,FAILED,COMPLETE", "platform" => platform, "cfBundleShortVersionString" => app_version }
             allow(Spaceship::ConnectAPI)
               .to receive(:get_build_uploads)
-              .with(app_id: app_id, filter: expected_filter, sort: "-cfBundleVersion", limit: 1)
+              .with(app_id: app_id, filter: expected_filter, sort: "-uploadedDate", limit: 1)
               .and_return([nil])
 
             options[:version] = app_version
@@ -308,10 +308,10 @@ describe Fastlane do
 
         context "when could not find the build but 'initial_build_number' is given in input options" do
           before(:each) do
-            expected_filter = { "platform" => platform, "cfBundleShortVersionString" => app_version }
+            expected_filter = { :state => "PROCESSING,FAILED,COMPLETE", "platform" => platform, "cfBundleShortVersionString" => app_version }
             allow(Spaceship::ConnectAPI)
               .to receive(:get_build_uploads)
-              .with(app_id: app_id, filter: expected_filter, sort: "-cfBundleVersion", limit: 1)
+              .with(app_id: app_id, filter: expected_filter, sort: "-uploadedDate", limit: 1)
               .and_return([nil])
 
             options[:version] = app_version


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->
Resolves #29897

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->
Revert the sort order to `-uploadedDate`. However, this change alone is insufficient because builds currently being uploaded don't have an `uploadedDate` yet (it's set to `NULL`), which would cause them to be sorted to the top. To prevent this, build uploads in the `AWAITING_UPLOAD` state are excluded.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
Check #29897 for details.