### PR TITLE
[core] Fix gemspec bin/console exclusion to subtract "console" not "bin/console"

### DIFF
--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob("*/lib/**/*", File::FNM_DOTMATCH) + Dir["fastlane/swift/**/*"] + Dir["bin/*"] + Dir["*/README.md"] + %w(README.md LICENSE .yardopts) - Dir["fastlane/lib/fastlane/actions/device_grid/assets/*"] - Dir["fastlane/lib/fastlane/actions/docs/assets/*"]
   spec.bindir = "bin"
-  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) } - ["bin/console"]
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) } - ["console"]
   spec.require_paths = Dir["*/lib"]
 
   spec.add_dependency('addressable', '>= 2.8', '< 3.0.0') # Support for URI templates


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #29913

### Description

`spec.executables` uses `File.basename` which strips the `bin/` prefix, producing entries like `"console"`. The subtraction array contained `"bin/console"`, which never matched — so `console` was still shipped as an executable.

This became visible when retriable 3.2.0 started shipping its own `console` executable, causing:

```
ERROR: Error installing fastlane:
    "console" from fastlane conflicts with installed executable from retriable
```

One-line fix: change `- ["bin/console"]` to `- ["console"]`.

### Testing Steps

```ruby
ruby -e 'spec = Gem::Specification.load("fastlane.gemspec"); puts spec.executables.inspect'
# Before: ["bin-proxy", "fastlane", "match_file", "console"]
# After:  ["bin-proxy", "fastlane", "match_file"]
```