### PR TITLE
build: assert bin/* contents in built gem to prevent global pollution.

### DIFF
--- a/.github/workflows/module_test.yml
+++ b/.github/workflows/module_test.yml
@@ -50,6 +50,9 @@ jobs:
           set -euo pipefail
           export PATH="$GEM_HOME/bin:$PATH"
 
+          # Verify executables
+          ruby -e "require 'rubygems/package'; spec = Gem::Package.new('${{ steps.build.outputs.gem_file }}').spec; expected = %w(bin-proxy fastlane match_file); puts \"Gem executables: #{spec.executables}\"; exit(1) unless spec.executables.sort == expected.sort"
+
           # Determine installed fastlane version from the gem
           FASTLANE_VERSION=$(ruby -e "require 'fastlane'; puts Fastlane::VERSION")
           echo "Detected fastlane version: ${FASTLANE_VERSION}"


### PR DESCRIPTION
## Problem

We sometimes emit more bin binaries than intended. Development binaries should not be exposed, especially something as generic as "console".

## Solution

Add CI to test what we emit in /bin. This will prevent the issue in #29914 from re-appearing.