### PR TITLE
cli: do not hide the original exception when failing in our ensure block

### DIFF
--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -137,9 +137,11 @@ module Fastlane
         # see https://github.com/fastlane/fastlane/issues/29916
         begin
           FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)
+        # rubocop:disable Lint/RescueException
         rescue Exception => e
           UI.error(e.to_s)
         end
+        # rubocop:enable Lint/RescueException
       end
 
       def map_aliased_tools(tool_name)

--- a/fastlane/lib/fastlane/cli_tools_distributor.rb
+++ b/fastlane/lib/fastlane/cli_tools_distributor.rb
@@ -132,7 +132,14 @@ module Fastlane
           Fastlane::CommandsGenerator.start
         end
       ensure
-        FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)
+        # If the ruby setup if broken, and UpdateChecker fails catastrophically,
+        # we don't want to hide the original exception. We just print it
+        # see https://github.com/fastlane/fastlane/issues/29916
+        begin
+          FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)
+        rescue Exception => e
+          UI.error(e.to_s)
+        end
       end
 
       def map_aliased_tools(tool_name)

--- a/fastlane/spec/cli_tools_distributor_spec.rb
+++ b/fastlane/spec/cli_tools_distributor_spec.rb
@@ -76,6 +76,18 @@ describe Fastlane::CLIToolsDistributor do
         end.to raise_error(SystemExit)
       end
     end
+
+    it "throws the original error if UpdateChecker also fails" do
+      FastlaneSpec::Env.with_ARGV(["beta"]) do
+        expect(FastlaneCore::FastlaneFolder).to receive(:fastfile_path).and_return("./fastlane/spec/fixtures/fastfiles/FastfileErrorInError").at_least(:once)
+        expect(FastlaneCore::UpdateChecker).to receive(:start_looking_for_update).with('fastlane')
+        expect(FastlaneCore::UpdateChecker).to receive(:show_update_status).with('fastlane', Fastlane::VERSION).and_raise(LoadError)
+        expect_any_instance_of(Commander::Runner).to receive(:abort).with("\n[!] Original error".red).and_raise(SystemExit) # mute console output from `abort`
+        expect do
+          Fastlane::CLIToolsDistributor.take_off
+        end.to raise_error(SystemExit)
+      end
+    end
   end
 
   describe "dotenv loading" do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
