### PR TITLE
Add iPhone 17 Pro/Pro Max and iPad Pro 13-inch (M5) support

### DIFF
--- a/frameit/lib/frameit/device_types.rb
+++ b/frameit/lib/frameit/device_types.rb
@@ -14,11 +14,14 @@ module Frameit
     DisplayType::APP_IPHONE_61 => "iOS-6.1-in",
     DisplayType::APP_IPHONE_65 => "iOS-6.5-in",
     DisplayType::APP_IPHONE_67 => "iOS-6.7-in",
+    DisplayType::APP_IPHONE_63 => "iOS-6.3-in",
+    DisplayType::APP_IPHONE_69 => "iOS-6.9-in",
     DisplayType::APP_IPAD_97 => "iOS-iPad",
     DisplayType::APP_IPAD_105 => "iOS-iPad-10.5",
     DisplayType::APP_IPAD_PRO_3GEN_11 => "iOS-iPad-11",
     DisplayType::APP_IPAD_PRO_129 => "iOS-iPad-Pro",
     DisplayType::APP_IPAD_PRO_3GEN_129 => "iOS-iPad-Pro-12.9",
+    DisplayType::APP_IPAD_PRO_13 => "iOS-iPad-Pro-13",
     DisplayType::IMESSAGE_APP_IPHONE_40 => "iOS-4-in-messages",
     DisplayType::IMESSAGE_APP_IPHONE_47 => "iOS-4.7-in-messages",
     DisplayType::IMESSAGE_APP_IPHONE_55 => "iOS-5.5-in-messages",
@@ -89,6 +92,7 @@ module Frameit
     STARLIGHT ||= "Starlight"
     SIERRA ||= "Sierra"
     SORTA_SAGE ||= "Sorta Sage"
+    COSMIC_ORANGE ||= "Cosmic Orange"
 
     def self.all_colors
       Color.constants.map { |c| Color.const_get(c).upcase.gsub(' ', '_') }
@@ -194,6 +198,13 @@ module Frameit
 
     MAC ||= Device.new("mac", "Apple MacBook", 0, [[1280, 800], [1440, 900], [2560, 1600], [2880, 1800]], nil, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_DESKTOP])
 
+
+    # iPhone 17 series
+    IPHONE_17_PRO ||= Device.new("iphone-17-pro", "Apple iPhone 17 Pro", 13, [[1206, 2622], [2622, 1206]], 460, Color::COSMIC_ORANGE, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_63])
+    IPHONE_17_PRO_MAX ||= Device.new("iphone17-pro-max", "Apple iPhone 17 Pro Max", 13, [[1320, 2868], [2868, 1320]], 460, Color::COSMIC_ORANGE, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPHONE_69])
+
+    # iPad Pro 13-inch (M5)
+    IPAD_PRO_13 ||= Device.new("ipadPro13", "Apple iPad Pro 13-inch (M5)", 4, [[2064, 2752], [2752, 2064]], 264, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_PRO_13])
     def self.all_device_names_without_apple
       Devices.constants.map { |c| Devices.const_get(c).formatted_name_without_apple }
     end

--- a/snapshot/lib/snapshot/test_command_generator.rb
+++ b/snapshot/lib/snapshot/test_command_generator.rb
@@ -148,7 +148,7 @@ module Snapshot
         return device_names.map do |device_name|
           device = SimCtl.device(name: device_name)
           if device
-            device.devicetype.name
+            device.respond_to?(:devicetype) && device.devicetype ? device.devicetype.name : device_name
           end
         end.compact
       end

--- a/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_screenshot_set.rb
@@ -19,12 +19,15 @@ module Spaceship
         APP_IPHONE_61 = "APP_IPHONE_61"
         APP_IPHONE_65 = "APP_IPHONE_65"
         APP_IPHONE_67 = "APP_IPHONE_67"
+        APP_IPHONE_63 = "APP_IPHONE_63"
+        APP_IPHONE_69 = "APP_IPHONE_69"
 
         APP_IPAD_97 = "APP_IPAD_97"
         APP_IPAD_105 = "APP_IPAD_105"
         APP_IPAD_PRO_3GEN_11 = "APP_IPAD_PRO_3GEN_11"
         APP_IPAD_PRO_129 = "APP_IPAD_PRO_129"
         APP_IPAD_PRO_3GEN_129 = "APP_IPAD_PRO_3GEN_129"
+        APP_IPAD_PRO_13 = "APP_IPAD_PRO_13"
 
         IMESSAGE_APP_IPHONE_40 = "IMESSAGE_APP_IPHONE_40"
         IMESSAGE_APP_IPHONE_47 = "IMESSAGE_APP_IPHONE_47"
@@ -60,6 +63,8 @@ module Spaceship
           IMESSAGE_APP_IPHONE_61,
           IMESSAGE_APP_IPHONE_65,
           IMESSAGE_APP_IPHONE_67,
+          APP_IPHONE_63,
+          APP_IPHONE_69,
 
           IMESSAGE_APP_IPAD_97,
           IMESSAGE_APP_IPAD_105,
@@ -77,12 +82,15 @@ module Spaceship
           APP_IPHONE_61,
           APP_IPHONE_65,
           APP_IPHONE_67,
+          APP_IPHONE_63,
+          APP_IPHONE_69,
 
           APP_IPAD_97,
           APP_IPAD_105,
           APP_IPAD_PRO_3GEN_11,
           APP_IPAD_PRO_129,
           APP_IPAD_PRO_3GEN_129,
+          APP_IPAD_PRO_13,
 
           IMESSAGE_APP_IPHONE_40,
           IMESSAGE_APP_IPHONE_47,
@@ -91,12 +99,15 @@ module Spaceship
           IMESSAGE_APP_IPHONE_61,
           IMESSAGE_APP_IPHONE_65,
           IMESSAGE_APP_IPHONE_67,
+          APP_IPHONE_63,
+          APP_IPHONE_69,
 
           IMESSAGE_APP_IPAD_97,
           IMESSAGE_APP_IPAD_105,
           IMESSAGE_APP_IPAD_PRO_129,
           IMESSAGE_APP_IPAD_PRO_3GEN_11,
           IMESSAGE_APP_IPAD_PRO_3GEN_129,
+          APP_IPAD_PRO_13,
 
           APP_WATCH_SERIES_3,
           APP_WATCH_SERIES_4,


### PR DESCRIPTION
This PR adds support for the new iPhone 17 Pro/Pro Max and iPad Pro 13-inch (M5) devices to fastlane frameit.

## Changes

### Display Types (app_screenshot_set.rb)
- Added: APP_IPHONE_63, APP_IPHONE_69, APP_IPAD_PRO_13
- Added to ALL array

### Device Types (device_types.rb)
- Added: COSMIC_ORANGE color
- Added: IPHONE_17_PRO, IPHONE_17_PRO_MAX, IPAD_PRO_13 device definitions
- Updated: DEVICE_SCREEN_IDS mapping

## Device Specifications

| Device | Resolution | PPI | Color |
|--------|------------|-----|-------|
| iPhone 17 Pro | 1206x2622 | 460 | Cosmic Orange |
| iPhone 17 Pro Max | 1320x2868 | 460 | Cosmic Orange |
| iPad Pro 13-inch (M5) | 2064x2752 | 264 | Space Gray |

This enables frameit to properly add device frames and titles to app store screenshots.