### PR TITLE
fix: migrate to standard which() helper to prevent ci spam

### DIFF
--- a/fastlane/lib/fastlane/actions/appium.rb
+++ b/fastlane/lib/fastlane/actions/appium.rb
@@ -41,7 +41,7 @@ module Fastlane
       end
 
       def self.detect_appium(params)
-        appium_path = params[:appium_path] || `which appium`.to_s.strip
+        appium_path = params[:appium_path] || Helper.which('appium').to_s
 
         if appium_path.empty?
           if File.exist?(APPIUM_PATH_HOMEBREW)

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -56,7 +56,7 @@ module Fastlane
       def self.run(params)
         unless Helper.test?
           UI.message("Install using `brew install appledoc`")
-          UI.user_error!("appledoc not installed") if Helper.which('appledoc').nil?
+          UI.user_error!("appledoc not installed") unless Helper.which('appledoc')
         end
 
         params_hash = params.values

--- a/fastlane/lib/fastlane/actions/appledoc.rb
+++ b/fastlane/lib/fastlane/actions/appledoc.rb
@@ -56,7 +56,7 @@ module Fastlane
       def self.run(params)
         unless Helper.test?
           UI.message("Install using `brew install appledoc`")
-          UI.user_error!("appledoc not installed") if `which appledoc`.length == 0
+          UI.user_error!("appledoc not installed") if Helper.which('appledoc').nil?
         end
 
         params_hash = params.values

--- a/fastlane/lib/fastlane/actions/gcovr.rb
+++ b/fastlane/lib/fastlane/actions/gcovr.rb
@@ -53,7 +53,7 @@ module Fastlane
 
       def self.run(params)
         unless Helper.test?
-          UI.user_error!("gcovr not installed") if Helper.which('gcovr').nil?
+          UI.user_error!("gcovr not installed") unless Helper.which('gcovr')
         end
 
         # The args we will build with

--- a/fastlane/lib/fastlane/actions/gcovr.rb
+++ b/fastlane/lib/fastlane/actions/gcovr.rb
@@ -53,7 +53,7 @@ module Fastlane
 
       def self.run(params)
         unless Helper.test?
-          UI.user_error!("gcovr not installed") if `which gcovr`.length == 0
+          UI.user_error!("gcovr not installed") if Helper.which('gcovr').nil?
         end
 
         # The args we will build with

--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -5,7 +5,7 @@ module Fastlane
     class InstallOnDeviceAction < Action
       def self.run(params)
         unless Helper.test?
-          UI.user_error!("ios-deploy not installed, see https://github.com/ios-control/ios-deploy for instructions") if Helper.which('ios-deploy').nil?
+          UI.user_error!("ios-deploy not installed, see https://github.com/ios-control/ios-deploy for instructions") unless Helper.which('ios-deploy')
         end
         taxi_cmd = [
           "ios-deploy",

--- a/fastlane/lib/fastlane/actions/install_on_device.rb
+++ b/fastlane/lib/fastlane/actions/install_on_device.rb
@@ -5,7 +5,7 @@ module Fastlane
     class InstallOnDeviceAction < Action
       def self.run(params)
         unless Helper.test?
-          UI.user_error!("ios-deploy not installed, see https://github.com/ios-control/ios-deploy for instructions") if `which ios-deploy`.length == 0
+          UI.user_error!("ios-deploy not installed, see https://github.com/ios-control/ios-deploy for instructions") if Helper.which('ios-deploy').nil?
         end
         taxi_cmd = [
           "ios-deploy",

--- a/fastlane/lib/fastlane/actions/lcov.rb
+++ b/fastlane/lib/fastlane/actions/lcov.rb
@@ -7,7 +7,7 @@ module Fastlane
 
       def self.run(options)
         unless Helper.test?
-          UI.user_error!("lcov not installed, please install using `brew install lcov`") if `which lcov`.length == 0
+          UI.user_error!("lcov not installed, please install using `brew install lcov`") if Helper.which('lcov').nil?
         end
         gen_cov(options)
       end

--- a/fastlane/lib/fastlane/actions/lcov.rb
+++ b/fastlane/lib/fastlane/actions/lcov.rb
@@ -7,7 +7,7 @@ module Fastlane
 
       def self.run(options)
         unless Helper.test?
-          UI.user_error!("lcov not installed, please install using `brew install lcov`") if Helper.which('lcov').nil?
+          UI.user_error!("lcov not installed, please install using `brew install lcov`") unless Helper.which('lcov')
         end
         gen_cov(options)
       end

--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -8,7 +8,7 @@ module Fastlane
       # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         oclint_path = params[:oclint_path]
-        if `which #{oclint_path}`.to_s.empty? && !Helper.test?
+        if Helper.which(oclint_path).nil? && !Helper.test?
           UI.user_error!("You have to install oclint or provide path to oclint binary. Fore more details: ") + "http://docs.oclint.org/en/stable/intro/installation.html".yellow
         end
 

--- a/fastlane/lib/fastlane/actions/oclint.rb
+++ b/fastlane/lib/fastlane/actions/oclint.rb
@@ -8,7 +8,7 @@ module Fastlane
       # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         oclint_path = params[:oclint_path]
-        if Helper.which(oclint_path).nil? && !Helper.test?
+        unless Helper.which(oclint_path) || Helper.test?
           UI.user_error!("You have to install oclint or provide path to oclint binary. Fore more details: ") + "http://docs.oclint.org/en/stable/intro/installation.html".yellow
         end
 

--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -40,7 +40,7 @@ module Fastlane
       end
 
       def self.verify_sonar_scanner_binary
-        UI.user_error!("You have to install sonar-scanner using `brew install sonar-scanner`") unless `which sonar-scanner`.to_s.length > 0
+        UI.user_error!("You have to install sonar-scanner using `brew install sonar-scanner`") if Helper.which('sonar-scanner').nil?
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/sonar.rb
+++ b/fastlane/lib/fastlane/actions/sonar.rb
@@ -40,7 +40,7 @@ module Fastlane
       end
 
       def self.verify_sonar_scanner_binary
-        UI.user_error!("You have to install sonar-scanner using `brew install sonar-scanner`") if Helper.which('sonar-scanner').nil?
+        UI.user_error!("You have to install sonar-scanner using `brew install sonar-scanner`") unless Helper.which('sonar-scanner')
       end
 
       #####################################################

--- a/fastlane/lib/fastlane/actions/sourcedocs.rb
+++ b/fastlane/lib/fastlane/actions/sourcedocs.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class SourcedocsAction < Action
       def self.run(params)
-        UI.user_error!("You have to install sourcedocs using `brew install sourcedocs`") if `which sourcedocs`.to_s.length == 0 && !Helper.test?
+        UI.user_error!("You have to install sourcedocs using `brew install sourcedocs`") if Helper.which('sourcedocs').nil? && !Helper.test?
 
         command =  "sourcedocs generate"
         command << " --all-modules" if params[:all_modules]

--- a/fastlane/lib/fastlane/actions/sourcedocs.rb
+++ b/fastlane/lib/fastlane/actions/sourcedocs.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class SourcedocsAction < Action
       def self.run(params)
-        UI.user_error!("You have to install sourcedocs using `brew install sourcedocs`") if Helper.which('sourcedocs').nil? && !Helper.test?
+        UI.user_error!("You have to install sourcedocs using `brew install sourcedocs`") unless Helper.which('sourcedocs') || Helper.test?
 
         command =  "sourcedocs generate"
         command << " --all-modules" if params[:all_modules]

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class SwiftlintAction < Action
       def self.run(params)
-        if Helper.which('swiftlint').nil? && params[:executable].nil? && !Helper.test?
+        unless Helper.which('swiftlint') || params[:executable] || Helper.test?
           UI.user_error!("You have to install swiftlint using `brew install swiftlint` or specify the executable path with the `:executable` option.")
         end
 

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class SwiftlintAction < Action
       def self.run(params)
-        if `which swiftlint`.to_s.length == 0 && params[:executable].nil? && !Helper.test?
+        if Helper.which('swiftlint').nil? && params[:executable].nil? && !Helper.test?
           UI.user_error!("You have to install swiftlint using `brew install swiftlint` or specify the executable path with the `:executable` option.")
         end
 

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -74,7 +74,7 @@ module Fastlane
 
       def self.run(params)
         unless Helper.test?
-          UI.user_error!("xcodebuild not installed") if `which xcodebuild`.length == 0
+          UI.user_error!("xcodebuild not installed") if Helper.which('xcodebuild').nil?
         end
 
         # The args we will build with

--- a/fastlane/lib/fastlane/actions/xcodebuild.rb
+++ b/fastlane/lib/fastlane/actions/xcodebuild.rb
@@ -74,7 +74,7 @@ module Fastlane
 
       def self.run(params)
         unless Helper.test?
-          UI.user_error!("xcodebuild not installed") if Helper.which('xcodebuild').nil?
+          UI.user_error!("xcodebuild not installed") unless Helper.which('xcodebuild')
         end
 
         # The args we will build with

--- a/fastlane/lib/fastlane/actions/xctool.rb
+++ b/fastlane/lib/fastlane/actions/xctool.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         UI.important("Have you seen the new 'scan' tool to run tests? https://docs.fastlane.tools/actions/scan/")
         unless Helper.test?
-          UI.user_error!("xctool not installed, please install using `brew install xctool`") if Helper.which('xctool').nil?
+          UI.user_error!("xctool not installed, please install using `brew install xctool`") unless Helper.which('xctool')
         end
 
         params = [] if params.kind_of?(FastlaneCore::Configuration)

--- a/fastlane/lib/fastlane/actions/xctool.rb
+++ b/fastlane/lib/fastlane/actions/xctool.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         UI.important("Have you seen the new 'scan' tool to run tests? https://docs.fastlane.tools/actions/scan/")
         unless Helper.test?
-          UI.user_error!("xctool not installed, please install using `brew install xctool`") if `which xctool`.length == 0
+          UI.user_error!("xctool not installed, please install using `brew install xctool`") if Helper.which('xctool').nil?
         end
 
         params = [] if params.kind_of?(FastlaneCore::Configuration)

--- a/fastlane/lib/fastlane/helper/xcodebuild_formatter_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodebuild_formatter_helper.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Helper
     class XcodebuildFormatterHelper
       def self.xcbeautify_installed?
-        return `which xcbeautify`.include?("xcbeautify")
+        return !FastlaneCore::Helper.which('xcbeautify').nil?
       end
     end
   end

--- a/fastlane/lib/fastlane/helper/xcodebuild_formatter_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodebuild_formatter_helper.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Helper
     class XcodebuildFormatterHelper
       def self.xcbeautify_installed?
-        return !FastlaneCore::Helper.which('xcbeautify').nil?
+        return !!FastlaneCore::Helper.which('xcbeautify')
       end
     end
   end

--- a/fastlane/lib/fastlane/helper/xcodes_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodes_helper.rb
@@ -12,7 +12,7 @@ module Fastlane
       end
 
       def self.find_xcodes_binary_path
-        `which xcodes`.strip
+        FastlaneCore::Helper.which('xcodes').to_s
       end
 
       module Verify

--- a/fastlane_core/lib/fastlane_core/clipboard.rb
+++ b/fastlane_core/lib/fastlane_core/clipboard.rb
@@ -14,7 +14,7 @@ module FastlaneCore
     end
 
     def self.is_supported?
-      return !FastlaneCore::Helper.which('pbcopy').nil? && !FastlaneCore::Helper.which('pbpaste').nil?
+      return FastlaneCore::Helper.which('pbcopy') && FastlaneCore::Helper.which('pbpaste')
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/clipboard.rb
+++ b/fastlane_core/lib/fastlane_core/clipboard.rb
@@ -14,7 +14,7 @@ module FastlaneCore
     end
 
     def self.is_supported?
-      return `which pbcopy`.length > 0 && `which pbpaste`.length > 0
+      return !FastlaneCore::Helper.which('pbcopy').nil? && !FastlaneCore::Helper.which('pbpaste').nil?
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -3,6 +3,7 @@ require 'colored'
 require 'tty-spinner'
 require 'pathname'
 
+require_relative 'command_executor'
 require_relative 'fastlane_folder'
 require_relative 'ui/ui'
 require_relative 'env'

--- a/fastlane_core/lib/fastlane_core/helper.rb
+++ b/fastlane_core/lib/fastlane_core/helper.rb
@@ -184,7 +184,7 @@ module FastlaneCore
 
     # @return Swift version
     def self.swift_version
-      if system("which swift > /dev/null 2>&1")
+      if self.which('swift')
         output = `swift --version 2> /dev/null`
         return output.split("\n").first.match(/version ([0-9.]+)/).captures.first
       end
@@ -300,6 +300,18 @@ module FastlaneCore
 
     # helper methods
     #
+
+    # Cross-platform way of finding an executable in the $PATH.
+    # Returns the full path to the executable, or nil if not found.
+    # Unlike shelling out to `which`, this produces no output, making
+    # it suitable for CI environments.
+    #
+    #   Helper.which('ruby') #=> "/usr/bin/ruby"
+    #   Helper.which('not_real') #=> nil
+    #
+    def self.which(cmd)
+      FastlaneCore::CommandExecutor.which(cmd)
+    end
 
     # Runs a given command using backticks (`)
     # and prints them out using the UI.command method

--- a/fastlane_core/spec/helper_spec.rb
+++ b/fastlane_core/spec/helper_spec.rb
@@ -239,6 +239,18 @@ describe FastlaneCore do
       end
     end
 
+    describe "#which" do
+      it "delegates to FastlaneCore::CommandExecutor.which" do
+        expect(FastlaneCore::CommandExecutor).to receive(:which).with('ruby').and_return('/usr/bin/ruby')
+        expect(FastlaneCore::Helper.which('ruby')).to eq('/usr/bin/ruby')
+      end
+
+      it "returns nil when command is not found" do
+        expect(FastlaneCore::CommandExecutor).to receive(:which).with('not_a_real_command').and_return(nil)
+        expect(FastlaneCore::Helper.which('not_a_real_command')).to be_nil
+      end
+    end
+
     describe "#fastlane_enabled?" do
       it "returns false when FastlaneCore::FastlaneFolder.path is nil" do
         expect(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)

--- a/frameit/lib/frameit/dependency_checker.rb
+++ b/frameit/lib/frameit/dependency_checker.rb
@@ -9,7 +9,7 @@ module Frameit
     end
 
     def self.check_image_magick
-      unless `which convert`.include?("convert")
+      unless FastlaneCore::Helper.which('convert')
         UI.error('#############################################################')
         UI.error("# You have to install the ImageMagick to use FrameIt")
         UI.error("# Install it using 'brew update && brew install imagemagick'")

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
@@ -4,7 +4,7 @@ require_relative 'simulator_launcher_base'
 module Snapshot
   class CPUInspector
     def self.hwprefs_available?
-      !FastlaneCore::Helper.which('hwprefs').nil?
+      !!FastlaneCore::Helper.which('hwprefs')
     end
 
     def self.cpu_count

--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher.rb
@@ -4,7 +4,7 @@ require_relative 'simulator_launcher_base'
 module Snapshot
   class CPUInspector
     def self.hwprefs_available?
-      `which hwprefs` != ''
+      !FastlaneCore::Helper.which('hwprefs').nil?
     end
 
     def self.cpu_count


### PR DESCRIPTION
## Problem

<img width="1536" height="861" alt="image" src="https://github.com/user-attachments/assets/0fbcaceb-9bfd-410f-865e-e98794edecc0" />

Reviewing CI on Windows is impossible. Its full of spam.


## Solution

Introduce a new helper for `which` (system binary) in order to suppress output.