### PR TITLE
[spaceship] fix provisioning profile repair when certificates include nil

### DIFF
--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -428,21 +428,42 @@ module Spaceship
         #
         # This is the minimum protection needed for people using spaceship directly
         unless certificate_valid?
+          available_certificates = nil
           if mac?
             if self.kind_of?(Development)
-              self.certificates = [Spaceship::Portal::Certificate::MacDevelopment.all.first]
+              cert = Spaceship::Portal::Certificate::MacDevelopment.all.first
+              if cert.nil?
+                available_certificates ||= Spaceship::Portal::Certificate.all(mac: true)
+                cert = available_certificates.find { |c| c.kind_of?(Spaceship::Portal::Certificate::AppleDevelopment) }
+              end
+              self.certificates = [cert].compact
             elsif self.kind_of?(Direct)
-              self.certificates = [Spaceship::Portal::Certificate::DeveloperIdApplication.all.first]
+              self.certificates = [Spaceship::Portal::Certificate::DeveloperIdApplication.all.first].compact
             else
-              self.certificates = [Spaceship::Portal::Certificate::MacAppDistribution.all.first]
+              cert = Spaceship::Portal::Certificate::MacAppDistribution.all.first
+              if cert.nil?
+                available_certificates ||= Spaceship::Portal::Certificate.all(mac: true)
+                cert = available_certificates.find { |c| c.kind_of?(Spaceship::Portal::Certificate::AppleDistribution) }
+              end
+              self.certificates = [cert].compact
             end
           else
             if self.kind_of?(Development)
-              self.certificates = [Spaceship::Portal::Certificate::Development.all.first]
+              cert = Spaceship::Portal::Certificate::Development.all.first
+              if cert.nil?
+                available_certificates ||= Spaceship::Portal::Certificate.all(mac: false)
+                cert = available_certificates.find { |c| c.kind_of?(Spaceship::Portal::Certificate::AppleDevelopment) }
+              end
+              self.certificates = [cert].compact
             elsif self.kind_of?(InHouse)
-              self.certificates = [Spaceship::Portal::Certificate::InHouse.all.first]
+              self.certificates = [Spaceship::Portal::Certificate::InHouse.all.first].compact
             else
-              self.certificates = [Spaceship::Portal::Certificate::Production.all.first]
+              cert = Spaceship::Portal::Certificate::Production.all.first
+              if cert.nil?
+                available_certificates ||= Spaceship::Portal::Certificate.all(mac: false)
+                cert = available_certificates.find { |c| c.kind_of?(Spaceship::Portal::Certificate::AppleDistribution) }
+              end
+              self.certificates = [cert].compact
             end
           end
         end
@@ -453,8 +474,8 @@ module Spaceship
             name,
             distribution_method,
             app.app_id,
-            certificates.map(&:id),
-            devices.map(&:id),
+            certificates.map(&:id).compact,
+            devices.map(&:id).compact,
             mac: mac?,
             sub_platform: tvos? ? 'tvOS' : nil,
             template_name: is_template_profile ? template.purpose_name : nil
@@ -473,11 +494,14 @@ module Spaceship
       # @return (Bool) is the certificate valid?
       def certificate_valid?
         return false if (certificates || []).count == 0
+
+        all_certificate_ids = Spaceship::Portal::Certificate.all(mac: mac?).collect(&:id)
         certificates.each do |c|
-          if Spaceship::Portal::Certificate.all(mac: mac?).collect(&:id).include?(c.id)
-            return true
-          end
+          next unless c&.id.to_s.length > 0
+
+          return true if all_certificate_ids.include?(c.id)
         end
+
         return false
       end
 
@@ -520,12 +544,24 @@ module Spaceship
       end
 
       def certificates
+        if @certificates
+          @certificates = @certificates.compact
+
+          # `@certificates` can be pre-populated from different sources (e.g. Xcode API/raw data).
+          # Ensure we only ever expose real Certificate model objects here.
+          if @certificates.any? { |c| !c.kind_of?(Spaceship::Portal::Certificate) }
+            @certificates = []
+          end
+        end
+
         if (@certificates || []).empty?
-          @certificates = (profile_details["certificates"] || []).collect do |cert|
+          @certificates = (profile_details["certificates"] || []).filter_map do |cert|
+            next unless cert
             Certificate.set_client(client).factory(cert)
           end
         end
 
+        @certificates.select! { |c| c&.id.to_s.length > 0 }
         @certificates
       end
 

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -427,46 +427,7 @@ module Spaceship
         # sigh handles more specific filtering and validation steps that make this logic OK
         #
         # This is the minimum protection needed for people using spaceship directly
-        unless certificate_valid?
-          available_certificates = nil
-          if mac?
-            if self.kind_of?(Development)
-              cert = Spaceship::Portal::Certificate::MacDevelopment.all.first
-              if cert.nil?
-                available_certificates ||= Spaceship::Portal::Certificate.all(mac: true)
-                cert = available_certificates.find { |c| c.kind_of?(Spaceship::Portal::Certificate::AppleDevelopment) }
-              end
-              self.certificates = [cert].compact
-            elsif self.kind_of?(Direct)
-              self.certificates = [Spaceship::Portal::Certificate::DeveloperIdApplication.all.first].compact
-            else
-              cert = Spaceship::Portal::Certificate::MacAppDistribution.all.first
-              if cert.nil?
-                available_certificates ||= Spaceship::Portal::Certificate.all(mac: true)
-                cert = available_certificates.find { |c| c.kind_of?(Spaceship::Portal::Certificate::AppleDistribution) }
-              end
-              self.certificates = [cert].compact
-            end
-          else
-            if self.kind_of?(Development)
-              cert = Spaceship::Portal::Certificate::Development.all.first
-              if cert.nil?
-                available_certificates ||= Spaceship::Portal::Certificate.all(mac: false)
-                cert = available_certificates.find { |c| c.kind_of?(Spaceship::Portal::Certificate::AppleDevelopment) }
-              end
-              self.certificates = [cert].compact
-            elsif self.kind_of?(InHouse)
-              self.certificates = [Spaceship::Portal::Certificate::InHouse.all.first].compact
-            else
-              cert = Spaceship::Portal::Certificate::Production.all.first
-              if cert.nil?
-                available_certificates ||= Spaceship::Portal::Certificate.all(mac: false)
-                cert = available_certificates.find { |c| c.kind_of?(Spaceship::Portal::Certificate::AppleDistribution) }
-              end
-              self.certificates = [cert].compact
-            end
-          end
-        end
+        ensure_valid_certificate_selection! unless certificate_valid?
 
         client.with_retry do
           client.repair_provisioning_profile!(
@@ -489,6 +450,45 @@ module Spaceship
 
         return profile
       end
+
+      def ensure_valid_certificate_selection!
+        self.certificates = suggested_certificates
+      end
+
+      def suggested_certificates
+        if mac?
+          return [Spaceship::Portal::Certificate::DeveloperIdApplication.all.first].compact if kind_of?(Direct)
+          if kind_of?(Development)
+            return [find_best_certificate(primary: Spaceship::Portal::Certificate::MacDevelopment,
+                                          fallback_kind: Spaceship::Portal::Certificate::AppleDevelopment,
+                                          mac: true)].compact
+          end
+
+          return [find_best_certificate(primary: Spaceship::Portal::Certificate::MacAppDistribution,
+                                        fallback_kind: Spaceship::Portal::Certificate::AppleDistribution,
+                                        mac: true)].compact
+        end
+
+        return [Spaceship::Portal::Certificate::InHouse.all.first].compact if kind_of?(InHouse)
+        if kind_of?(Development)
+          return [find_best_certificate(primary: Spaceship::Portal::Certificate::Development,
+                                        fallback_kind: Spaceship::Portal::Certificate::AppleDevelopment,
+                                        mac: false)].compact
+        end
+
+        [find_best_certificate(primary: Spaceship::Portal::Certificate::Production,
+                               fallback_kind: Spaceship::Portal::Certificate::AppleDistribution,
+                               mac: false)].compact
+      end
+
+      def find_best_certificate(primary:, fallback_kind:, mac:)
+        cert = primary.all.first
+        return cert if cert
+
+        Spaceship::Portal::Certificate.all(mac: mac).find { |c| c.kind_of?(fallback_kind) }
+      end
+
+      private :ensure_valid_certificate_selection!, :suggested_certificates, :find_best_certificate
 
       # Is the certificate of this profile available?
       # @return (Bool) is the certificate valid?

--- a/spaceship/lib/spaceship/portal/provisioning_profile.rb
+++ b/spaceship/lib/spaceship/portal/provisioning_profile.rb
@@ -452,7 +452,13 @@ module Spaceship
       end
 
       def ensure_valid_certificate_selection!
-        self.certificates = suggested_certificates
+        certs = suggested_certificates
+        if certs.nil? || certs.empty?
+          raise "No valid signing certificates were found to repair or regenerate this provisioning profile. " \
+                "Please create or import an appropriate signing certificate in your Apple Developer account " \
+                "and try again."
+        end
+        self.certificates = certs
       end
 
       def suggested_certificates
@@ -545,13 +551,9 @@ module Spaceship
 
       def certificates
         if @certificates
-          @certificates = @certificates.compact
-
           # `@certificates` can be pre-populated from different sources (e.g. Xcode API/raw data).
-          # Ensure we only ever expose real Certificate model objects here.
-          if @certificates.any? { |c| !c.kind_of?(Spaceship::Portal::Certificate) }
-            @certificates = []
-          end
+          # Filter to only real Certificate objects rather than clearing all on a single stray value.
+          @certificates = @certificates.compact.select { |c| c.kind_of?(Spaceship::Portal::Certificate) }
         end
 
         if (@certificates || []).empty?

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -290,6 +290,14 @@ describe Spaceship::ProvisioningProfile do
       profile.repair!
     end
 
+    it "raises when no valid signing certificates are available" do
+      allow(profile).to receive(:certificate_valid?).and_return(false)
+      allow(profile).to receive(:suggested_certificates).and_return([])
+      expect do
+        profile.repair!
+      end.to raise_error(/No valid signing certificates were found/)
+    end
+
     it "handles nil certificates in the certificate list" do
       original_details = profile.profile_details
       certificates_with_nil = original_details["certificates"].dup

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -1,4 +1,6 @@
 describe Spaceship::ProvisioningProfile do
+  # Skip tunes login and login with portal
+  include_examples "common spaceship login", true
   before { Spaceship.login }
   let(:client) { Spaceship::ProvisioningProfile.client }
   let(:cert_id) { "C8DL7464RQ" }
@@ -288,10 +290,23 @@ describe Spaceship::ProvisioningProfile do
       profile.repair!
     end
 
+    it "handles nil certificates in the certificate list" do
+      profile.certificates = [nil]
+      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil, template_name: nil).and_return({})
+      profile.repair!
+    end
+
     it "update the certificate if the current one is invalid" do
       expect(profile.certificates.first.id).to eq("3BH4JJSWM4")
       expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil, template_name: nil).and_return({})
       profile.repair! # repair will replace the old certificate with the new one
+    end
+
+    it "ignores nil entries when collecting certificate ids" do
+      valid_cert = Spaceship::Certificate.all.first
+      profile.certificates = [valid_cert, nil]
+      expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [valid_cert.id], [], mac: false, sub_platform: nil, template_name: nil).and_return({})
+      profile.repair!
     end
 
     it "repairs an existing profile with no devices" do

--- a/spaceship/spec/provisioning_profile_spec.rb
+++ b/spaceship/spec/provisioning_profile_spec.rb
@@ -291,7 +291,12 @@ describe Spaceship::ProvisioningProfile do
     end
 
     it "handles nil certificates in the certificate list" do
-      profile.certificates = [nil]
+      original_details = profile.profile_details
+      certificates_with_nil = original_details["certificates"].dup
+      certificates_with_nil << nil
+
+      allow(profile).to receive(:profile_details).and_return(original_details.merge("certificates" => certificates_with_nil))
+
       expect(client).to receive(:repair_provisioning_profile!).with('PP00000006', 'delete.me.please AppStore', 'store', '2UMR2S6P4L', [cert_id], [], mac: false, sub_platform: nil, template_name: nil).and_return({})
       profile.repair!
     end


### PR DESCRIPTION
## Problem
When a distribution certificate expires or is revoked all provisioning profiles become invalid. Running `sigh repair` crashes because the certificates are returned as `nil`, leading to the same error presented in #21295.

## Summary
- Prevent crash when provisioning profile certificates include `nil` (e.g. during `sigh repair`).
- Filter/compact certificate ids before making the repair/update request and ensure certificate lists contain valid certificate objects.

## Test plan
- `bundle exec rspec spaceship/spec/provisioning_profile_spec.rb`

Fixes #21295