### PR TITLE
[gem] move to faraday-retry 1.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-retry (1.0.4)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.3.0)


### PR DESCRIPTION
### Problem

```
faraday >= 1.9.0 depends on faraday-retry which:

Because faraday-retry >= 1.0.3, < 2.0.0 depends on Ruby >= 2.4, < 4
and faraday-retry < 1.0.3 depends on Ruby >= 2.6, < 4,
faraday-retry < 2.0.0 requires Ruby >= 2.4, < 4.
And because faraday >= 1.9.0, < 2.0.0.alpha.pre.1 depends on faraday-retry ~> 1.0,
faraday >= 1.9.0, < 2.0.0.alpha.pre.1 requires Ruby >= 2.4, < 4.
So, because Gemfile depends on faraday >= 1.10.5, < 2.A
and current Ruby version is = 4.0.1,
version solving has failed.
```

You can't use Ruby 4 with Faraday 1.

### Solution
Faraday Team [graciously](https://github.com/lostisland/faraday-retry/releases/tag/v1.0.4) helped out those in 1.x range again.

```
Fetching faraday-retry 1.0.4 (was 1.0.3)
Fetching rack 2.2.22
Installing faraday-retry 1.0.4 (was 1.0.3)
Installing rack 2.2.22
Bundle updated!
```

fixes #29874 