### PR TITLE
Add Xcode 26 export method support to gym

### DIFF
--- a/gym/lib/gym/detect_values.rb
+++ b/gym/lib/gym/detect_values.rb
@@ -109,7 +109,7 @@ module Gym
       return if team_id.nil?
 
       case Gym.config[:export_method]
-      when "app-store"
+      when "app-store", "app-store-connect"
         prefix = "3rd Party Mac Developer Installer: "
       when "developer-id"
         prefix = "Developer ID Installer: "

--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -226,7 +226,7 @@ module Gym
       end
 
       def print_environment_information
-        if Gym.config[:export_method].to_s == "development"
+        if ["development", "debugging"].include?(Gym.config[:export_method].to_s)
           UI.message("")
           UI.error("Your `export_method` in gym is defined as `development`")
           UI.error("which might cause problems when signing your application")
@@ -250,6 +250,7 @@ module Gym
           # There is no 100% good way to detect the profile type based on the name
           available_export_types = {
             "app-store" => "app-store",
+            "app-store-connect" => "app-store-connect",
             "app store" => "app-store",
             "appstore" => "app-store",
             "enterprise" => "enterprise",
@@ -257,9 +258,11 @@ module Gym
             "in house" => "enterprise",
             "inhouse" => "enterprise",
             "ad-hoc" => "ad-hoc",
+            "release-testing" => "release-testing",
             "adhoc" => "ad-hoc",
             "ad hoc" => "ad-hoc",
-            "development" => "development"
+            "development" => "development",
+            "debugging" => "debugging"
           }
 
           selected_provisioning_profiles.each do |current_bundle_identifier, current_profile_name|

--- a/gym/lib/gym/generators/package_command_generator_xcode7.rb
+++ b/gym/lib/gym/generators/package_command_generator_xcode7.rb
@@ -190,7 +190,7 @@ module Gym
 
         # Overrides export options if needed
         hash[:method] = Gym.config[:export_method]
-        if Gym.config[:export_method] == 'app-store'
+        if ['app-store', 'app-store-connect'].include?(Gym.config[:export_method])
           hash[:uploadSymbols] = (Gym.config[:include_symbols] ? true : false) unless Gym.config[:include_symbols].nil?
           hash[:uploadBitcode] = (Gym.config[:include_bitcode] ? true : false) unless Gym.config[:include_bitcode].nil?
         end

--- a/gym/lib/gym/options.rb
+++ b/gym/lib/gym/options.rb
@@ -107,11 +107,11 @@ module Gym
         FastlaneCore::ConfigItem.new(key: :export_method,
                                      short_option: "-j",
                                      env_name: "GYM_EXPORT_METHOD",
-                                     description: "Method used to export the archive. Valid values are: app-store, validation, ad-hoc, package, enterprise, development, developer-id and mac-application",
+                                     description: "Method used to export the archive. Valid values are: app-store, app-store-connect, validation, ad-hoc, release-testing, package, enterprise, development, debugging, developer-id and mac-application. In Xcode 26+, app-store is replaced by app-store-connect, ad-hoc by release-testing, and development by debugging",
                                      type: String,
                                      optional: true,
                                      verify_block: proc do |value|
-                                       av = %w(app-store validation ad-hoc package enterprise development developer-id mac-application)
+                                       av = %w(app-store app-store-connect validation ad-hoc release-testing package enterprise development debugging developer-id mac-application)
                                        UI.user_error!("Unsupported export_method '#{value}', must be: #{av}") unless av.include?(value)
                                      end),
         FastlaneCore::ConfigItem.new(key: :export_options,

--- a/gym/lib/gym/runner.rb
+++ b/gym/lib/gym/runner.rb
@@ -372,7 +372,7 @@ module Gym
 
     # Create AppStoreInfo.plist using swinfo for iOS app-store exports
     def generate_appstore_info(ipa_path)
-      return unless Gym.config[:generate_appstore_info] && Gym.building_for_ios? && Gym.config[:export_method] == 'app-store'
+      return unless Gym.config[:generate_appstore_info] && Gym.building_for_ios? && ['app-store', 'app-store-connect'].include?(Gym.config[:export_method])
 
       swinfo_plist_path = File.join(File.expand_path(Gym.config[:output_directory]), "AppStoreInfo.plist")
       swinfo_path = File.join(FastlaneCore::Helper.xcode_path, "usr/bin/swinfo")


### PR DESCRIPTION
## Summary

Xcode 26 renamed/deprecated three `xcodebuild -exportArchive` export methods:

| Old (deprecated) | New (Xcode 26+) |
|---|---|
| `app-store` | `app-store-connect` |
| `ad-hoc` | `release-testing` |
| `development` | `debugging` |

The old names appear as deprecated in `xcodebuild -help` output but are **actively rejected** at export time:

```
exportArchive exportOptionsPlist error for key "method": expected one of {app-store-connect, release-testing, ...} but found app-store
```

From Xcode 26 `xcodebuild -help`:

```
Available keys for -exportOptionsPlist:

	method : String
		Describes how Xcode should export the archive. Available options: app-store-connect,
		release-testing, validation, package, enterprise, debugging, developer-id, and
		mac-application. The options app-store, ad-hoc, and development are deprecated
		aliases of app-store-connect, release-testing, and debugging respectively.
```

This PR adds the new export method names to gym while keeping backward compatibility with the old names for users on older Xcode versions.

### Changes

- **`gym/lib/gym/options.rb`** — Added `app-store-connect`, `release-testing`, and `debugging` to the `export_method` allowlist and updated the description
- **`gym/lib/gym/generators/package_command_generator_xcode7.rb`** — Updated `config_content` to treat `app-store-connect` the same as `app-store` for upload symbols/bitcode settings
- **`gym/lib/gym/detect_values.rb`** — Updated `detect_third_party_installer` to match `app-store-connect` alongside `app-store`
- **`gym/lib/gym/runner.rb`** — Updated `generate_appstore_info` to trigger for both `app-store` and `app-store-connect`
- **`gym/lib/gym/error_handler.rb`** — Updated environment mismatch detection to handle `debugging` alongside `development`, and added new method names to the export type mapping

## Test plan

- [ ] Verify `gym` accepts `app-store-connect`, `release-testing`, and `debugging` as valid `export_method` values
- [ ] Verify `gym` still accepts the old `app-store`, `ad-hoc`, and `development` values for backward compatibility
- [ ] Verify exporting with `app-store-connect` on Xcode 26 produces a valid IPA
- [ ] Verify the AppStoreInfo.plist generation triggers correctly with `app-store-connect`
- [ ] Verify third-party installer cert detection works with `app-store-connect`