### PR TITLE
[sigh] add: introduce ability to control codesign page_size

### DIFF
--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -114,7 +114,13 @@ module Fastlane
                                        env_name: "FL_RESIGN_PAGESIZE",
                                        description: "Page size in bytes passed to `/usr/bin/codesign --pagesize` (must be a power of two)",
                                        type: Integer,
-                                       optional: true)
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                        next if value.nil?
+                                        unless value.is_a?(Integer) && value.positive? && (value & (value - 1)).zero?
+                                          UI.user_error!("'pagesize' must be a positive power of two. Provided value: #{value}")
+                                        end
+                                      end)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -6,7 +6,7 @@ module Fastlane
         require 'sigh'
 
         # try to resign the ipa
-        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name], params[:short_version], params[:bundle_version], params[:bundle_id], params[:use_app_entitlements], params[:keychain_path])
+        if Sigh::Resign.resign(params[:ipa], params[:signing_identity], params[:provisioning_profile], params[:entitlements], params[:version], params[:display_name], params[:short_version], params[:bundle_version], params[:bundle_id], params[:use_app_entitlements], params[:keychain_path], params[:pagesize])
           UI.success('Successfully re-signed .ipa 🔏.')
         else
           UI.user_error!("Failed to re-sign .ipa")
@@ -109,6 +109,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :keychain_path,
                                        env_name: "FL_RESIGN_KEYCHAIN_PATH",
                                        description: "Provide a path to a keychain file that should be used by `/usr/bin/codesign`",
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :pagesize,
+                                       env_name: "FL_RESIGN_PAGESIZE",
+                                       description: "Page size in bytes passed to `/usr/bin/codesign --pagesize` (must be a power of two)",
+                                       type: Integer,
                                        optional: true)
         ]
       end

--- a/fastlane/lib/fastlane/actions/resign.rb
+++ b/fastlane/lib/fastlane/actions/resign.rb
@@ -116,11 +116,11 @@ module Fastlane
                                        type: Integer,
                                        optional: true,
                                        verify_block: proc do |value|
-                                        next if value.nil?
-                                        unless value.is_a?(Integer) && value.positive? && (value & (value - 1)).zero?
-                                          UI.user_error!("'pagesize' must be a positive power of two. Provided value: #{value}")
-                                        end
-                                      end)
+                                         next if value.nil?
+                                         unless value.kind_of?(Integer) && value.positive? && (value & (value - 1)).zero?
+                                           UI.user_error!("'pagesize' must be a positive power of two. Provided value: #{value}")
+                                         end
+                                       end)
         ]
       end
 

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -562,6 +562,8 @@ function resign {
         do
             if [[ "$assetpack" == *.assetpack ]]; then
                 rm -rf "$assetpack"/_CodeSignature
+                # Must not quote PAGESIZE_FLAG because it needs to be unwrapped and passed to codesign with spaces
+                # shellcheck disable=SC2086
                 /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" "$assetpack"
                 checkStatus
             else
@@ -582,7 +584,7 @@ function resign {
         do
             if [[ "$framework" == *.framework || "$framework" == *.dylib ]]; then
                 log "Resigning '$framework'"
-                # Must not quote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
+                # Must not quote KEYCHAIN_FLAG, PAGESIZE_FLAG because they need to be unwrapped and passed to codesign with spaces
                 # shellcheck disable=SC2086
                 /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$framework"
                 checkStatus
@@ -638,6 +640,8 @@ function resign {
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
             cp -f "$ENTITLEMENTS" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
+        # Must not quote PAGESIZE_FLAG because it needs to be unwrapped and passed to codesign with spaces
+        # shellcheck disable=SC2086
         /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$ENTITLEMENTS" "$APP_PATH"
         checkStatus
     elif  [[ -n "${USE_APP_ENTITLEMENTS}" ]]; then
@@ -883,6 +887,8 @@ function resign {
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
             cp -f "$PATCHED_ENTITLEMENTS" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
+        # Must not quote PAGESIZE_FLAG because it needs to be unwrapped and passed to codesign with spaces
+        # shellcheck disable=SC2086
         /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$PATCHED_ENTITLEMENTS" "$APP_PATH"
         checkStatus
     else
@@ -895,7 +901,7 @@ function resign {
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
             cp -- "$TEMP_DIR/newEntitlements" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
-        # Must not quote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
+        # Must not quote KEYCHAIN_FLAG, PAGESIZE_FLAG because they need to be unwrapped and passed to codesign with spaces
         # shellcheck disable=SC2086
         /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
         checkStatus

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -254,9 +254,9 @@ if [ -n "$KEYCHAIN_PATH" ]; then
     KEYCHAIN_FLAG="--keychain $KEYCHAIN_PATH"
 fi
 
-PAGESIZE_FLAG=
+PAGESIZE_ARGS=()
 if [ -n "$PAGESIZE" ]; then
-    PAGESIZE_FLAG="--pagesize $PAGESIZE"
+    PAGESIZE_ARGS=(--pagesize "$PAGESIZE")
 fi
 
 # Log the options
@@ -562,9 +562,7 @@ function resign {
         do
             if [[ "$assetpack" == *.assetpack ]]; then
                 rm -rf "$assetpack"/_CodeSignature
-                # Must not quote PAGESIZE_FLAG because it needs to be unwrapped and passed to codesign with spaces
-                # shellcheck disable=SC2086
-                /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" "$assetpack"
+                /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" "$assetpack"
                 checkStatus
             else
                 log "Ignoring non-assetpack: $assetpack"
@@ -584,9 +582,9 @@ function resign {
         do
             if [[ "$framework" == *.framework || "$framework" == *.dylib ]]; then
                 log "Resigning '$framework'"
-                # Must not quote KEYCHAIN_FLAG, PAGESIZE_FLAG because they need to be unwrapped and passed to codesign with spaces
+                # Must not quote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
                 # shellcheck disable=SC2086
-                /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$framework"
+                /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$framework"
                 checkStatus
             else
                 log "Ignoring non-framework: $framework"
@@ -640,9 +638,7 @@ function resign {
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
             cp -f "$ENTITLEMENTS" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
-        # Must not quote PAGESIZE_FLAG because it needs to be unwrapped and passed to codesign with spaces
-        # shellcheck disable=SC2086
-        /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$ENTITLEMENTS" "$APP_PATH"
+        /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$ENTITLEMENTS" "$APP_PATH"
         checkStatus
     elif  [[ -n "${USE_APP_ENTITLEMENTS}" ]]; then
         # Extract entitlements from provisioning profile and from the app binary
@@ -887,9 +883,7 @@ function resign {
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
             cp -f "$PATCHED_ENTITLEMENTS" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
-        # Must not quote PAGESIZE_FLAG because it needs to be unwrapped and passed to codesign with spaces
-        # shellcheck disable=SC2086
-        /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$PATCHED_ENTITLEMENTS" "$APP_PATH"
+        /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$PATCHED_ENTITLEMENTS" "$APP_PATH"
         checkStatus
     else
         log "Extracting entitlements from provisioning profile"
@@ -901,9 +895,9 @@ function resign {
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
             cp -- "$TEMP_DIR/newEntitlements" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
-        # Must not quote KEYCHAIN_FLAG, PAGESIZE_FLAG because they need to be unwrapped and passed to codesign with spaces
+        # Must not quote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
         # shellcheck disable=SC2086
-        /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
+        /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
         checkStatus
     fi
 

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -152,6 +152,7 @@ usage() {
     echo -e "\t    --use-app-entitlements\t\tExtract app bundle codesigning entitlements and combine with entitlements from new provisioning profile." >&2
     echo -e "\t\t\t\t\t\t\tCan't use together with '-e, --entitlements' option." >&2
     echo -e "\t--keychain-path path\t\t\tSpecify the path to a keychain that /usr/bin/codesign should use." >&2
+    echo -e "\t--pagesize size\t\t\t\tSpecify the page size (in bytes) for codesign. Must be a power of two." >&2
     echo -e "\t-v, --verbose\t\t\t\tVerbose output." >&2
     echo -e "\t-h, --help\t\t\t\tDisplay help message." >&2
     exit 2
@@ -171,6 +172,7 @@ VERSION_NUMBER=""
 SHORT_VERSION=
 BUNDLE_VERSION=
 KEYCHAIN_PATH=
+PAGESIZE=
 RAW_PROVISIONS=()
 PROVISIONS_BY_ID=()
 DEFAULT_PROVISION=""
@@ -227,6 +229,10 @@ while [ "$1" != "" ]; do
             shift
             KEYCHAIN_PATH="$1"
             ;;
+        --pagesize )
+            shift
+            PAGESIZE="$1"
+            ;;
         -v | --verbose )
             VERBOSE="--verbose"
             ;;
@@ -248,6 +254,11 @@ if [ -n "$KEYCHAIN_PATH" ]; then
     KEYCHAIN_FLAG="--keychain $KEYCHAIN_PATH"
 fi
 
+PAGESIZE_FLAG=
+if [ -n "$PAGESIZE" ]; then
+    PAGESIZE_FLAG="--pagesize $PAGESIZE"
+fi
+
 # Log the options
 for provision in "${RAW_PROVISIONS[@]}"; do
     if [[ "$provision" =~ .+=.+ ]]; then
@@ -267,6 +278,7 @@ log "Certificate: '$CERTIFICATE'"
 [[ -n "${SHORT_VERSION}" ]] && log "Specified short version to use: '$SHORT_VERSION'"
 [[ -n "${BUNDLE_VERSION}" ]] && log "Specified bundle version to use: '$BUNDLE_VERSION'"
 [[ -n "${KEYCHAIN_FLAG}" ]] && log "Specified keychain to use: '$KEYCHAIN_PATH'"
+[[ -n "${PAGESIZE}" ]] && log "Specified page size: '$PAGESIZE'"
 [[ -n "${NEW_FILE}" ]] && log "Output file name: '$NEW_FILE'"
 [[ -n "${USE_APP_ENTITLEMENTS}" ]] && log "Extract app entitlements: YES"
 
@@ -550,7 +562,7 @@ function resign {
         do
             if [[ "$assetpack" == *.assetpack ]]; then
                 rm -rf "$assetpack"/_CodeSignature
-                /usr/bin/codesign ${VERBOSE} --generate-entitlement-der "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" "$assetpack"
+                /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" "$assetpack"
                 checkStatus
             else
                 log "Ignoring non-assetpack: $assetpack"
@@ -572,7 +584,7 @@ function resign {
                 log "Resigning '$framework'"
                 # Must not quote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
                 # shellcheck disable=SC2086
-                /usr/bin/codesign ${VERBOSE} --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$framework"
+                /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$framework"
                 checkStatus
             else
                 log "Ignoring non-framework: $framework"
@@ -626,7 +638,7 @@ function resign {
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
             cp -f "$ENTITLEMENTS" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
-        /usr/bin/codesign ${VERBOSE} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$ENTITLEMENTS" "$APP_PATH"
+        /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$ENTITLEMENTS" "$APP_PATH"
         checkStatus
     elif  [[ -n "${USE_APP_ENTITLEMENTS}" ]]; then
         # Extract entitlements from provisioning profile and from the app binary
@@ -871,7 +883,7 @@ function resign {
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
             cp -f "$PATCHED_ENTITLEMENTS" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
-        /usr/bin/codesign ${VERBOSE} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$PATCHED_ENTITLEMENTS" "$APP_PATH"
+        /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der -f -s "$CERTIFICATE" --entitlements "$PATCHED_ENTITLEMENTS" "$APP_PATH"
         checkStatus
     else
         log "Extracting entitlements from provisioning profile"
@@ -885,7 +897,7 @@ function resign {
         fi
         # Must not quote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
         # shellcheck disable=SC2086
-        /usr/bin/codesign ${VERBOSE} --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
+        /usr/bin/codesign ${VERBOSE} ${PAGESIZE_FLAG} --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
         checkStatus
     fi
 

--- a/sigh/lib/sigh/commands_generator.rb
+++ b/sigh/lib/sigh/commands_generator.rb
@@ -114,6 +114,7 @@ module Sigh
         c.option('--use_app_entitlements', 'Extract app bundle codesigning entitlements and combine with entitlements from new provisioning profile.')
         c.option('-g', '--new_bundle_id STRING', String, 'New application bundle ID (CFBundleIdentifier)')
         c.option('--keychain_path STRING', String, 'Path to the keychain that /usr/bin/codesign should use')
+        c.option('--page_size STRING', String, 'Page size in bytes for codesign --pagesize (power of two)')
 
         c.action do |args, options|
           Sigh::Resign.new.run(options, args)

--- a/sigh/lib/sigh/resign.rb
+++ b/sigh/lib/sigh/resign.rb
@@ -8,18 +8,18 @@ module Sigh
   class Resign
     def run(options, args)
       # get the command line inputs and parse those into the vars we need...
-      ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path = get_inputs(options, args)
+      ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path, page_size = get_inputs(options, args)
       # ... then invoke our programmatic interface with these vars
-      unless resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
+      unless resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path, page_size)
         UI.user_error!("Failed to re-sign .ipa")
       end
     end
 
-    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
-      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
+    def self.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path, pagesize = nil)
+      self.new.resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path, pagesize)
     end
 
-    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path)
+    def resign(ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path, pagesize = nil)
       resign_path = find_resign_path
 
       if keychain_path
@@ -53,6 +53,7 @@ module Sigh
       bundle_id = "-b '#{new_bundle_id}'" if new_bundle_id
       use_app_entitlements_flag = "--use-app-entitlements" if use_app_entitlements
       specific_keychain = "--keychain-path #{keychain_path.shellescape}" if keychain_path
+      pagesize_option = "--pagesize #{pagesize}" if pagesize
 
       command = [
         resign_path.shellescape,
@@ -68,6 +69,7 @@ module Sigh
         verbose,
         bundle_id,
         specific_keychain,
+        pagesize_option,
         ipa.shellescape # Output path must always be last argument
       ].join(' ')
 
@@ -97,12 +99,13 @@ module Sigh
       new_bundle_id = options.new_bundle_id || nil
       use_app_entitlements = options.use_app_entitlements || nil
       keychain_path = options.keychain_path || nil
+      page_size = options.page_size || nil
 
       if options.provisioning_name
         UI.important("The provisioning_name (-n) option is not applicable to resign. You should use provisioning_profile (-p) instead")
       end
 
-      return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path
+      return ipa, signing_identity, provisioning_profiles, entitlements, version, display_name, short_version, bundle_version, new_bundle_id, use_app_entitlements, keychain_path, page_size
     end
 
     def find_resign_path

--- a/sigh/spec/commands_generator_spec.rb
+++ b/sigh/spec/commands_generator_spec.rb
@@ -37,6 +37,17 @@ describe Sigh::CommandsGenerator do
 
       Sigh::CommandsGenerator.start
     end
+
+    it "accepts page_size option" do
+      stub_commander_runner_args(['resign', '--page_size', '16384'])
+
+      options = Commander::Command::Options.new
+      options.page_size = '16384'
+
+      expect_resign_run(options)
+
+      Sigh::CommandsGenerator.start
+    end
   end
 
   describe "renew option handling" do


### PR DESCRIPTION
### Motivation and Context

We've noticed, that size of our ipa, created with `gym`, started to vary from time to time. We've found that all the difference was in the `LC_CODE_SIGNATURE` command under the `_LINKEDIT` segment of binary. The main reason of that change was the different number of hash slots due to different value of page size: **4096** for `SEQUOIA` and **16384** for `TAHOE`.  So the size of the final binary was dependent on the machine, it was produced on.

Apple’s codesign supports a `--pagesize` argument. We (and probably some other teams need resigning to use the same page size as the original build (e.g. after repackaging). Today` fastlane/sigh’s resign.sh `never passes --pagesize, so a re-signed IPA can diverge from the initially signed binary.

Firstly we've tried to use `OTHER_CODE_SIGN_FLAGS=--pagesize 16384` to have universal size across the building machines, but it didn't work out:  during generation of ipa there are actually two singings:
1) The singing of binary inside `.xcarchive`
1) The re-signing of binary during `xcodebuild export ...` phase

For the first case the provided setting worked out: the inspected via 
```bash
codesign -d -vvvv App 2>&1 | grep "Page size" | awk -F= '{print $2}'
```
gave expected output of **16384**.

The second case didn't have correct page size, as `xcodebuild export ...` doesn't look at `OTHER_CODE_SIGN_FLAGS` (that was pased via  gym's `export_xcargs`): setting invalid value (not the power of two), doesn't break signing process. I've also managed to get xcodebuild logs via

```bash
log stream --style compact --predicate 'process == "xcodebuild" OR process == "codesign"' --level trace
```

They have no occurrences of `--pagesize`:

```text
2026-03-24 13:43:27.236 Df xcodebuild[93993:a08c53] [IDEDistributionPipeline:verbose] invoking codesign: <NSConcreteTask: 0x8a1b21bd0; launchPath='/usr/bin/codesign', arguments='(
    "-f",
    "-s",
    8C38C4A2CB0388A3DB6BAEFE438F20E044EE6CB2,
    "--entitlements",
    "/var/folders/w_/5t00sclx2vlcm4_fvly7wvh00000gn/T/XcodeDistPipeline.~~~T3Dcdf/entitlements~~~c2srXx",
    "--preserve-metadata=identifier,flags,runtime,launch-constraints,library-constraints",
    "--generate-entitlement-der",
    "--strip-disallowed-xattrs",
    "-vvv",
    "/var/folders/w_/5t00sclx2vlcm4_fvly7wvh00000gn/T/XcodeDistPipeline.~~~T3Dcdf/Root/Payload/App.app/Frameworks/FLEXWrapper.framework"
)'>
```

I didn't find out any information on why the default page size changed on `TAHOE` (created a topic on apple forum - https://developer.apple.com/forums/thread/820311), so the only solution was to introduce page size option to resign and resign ipa after the export. 

### Description

Add optional `page_size` for sigh resign:
* `sigh/lib/assets/resign.sh` - parse` --pagesize`, set `PAGESIZE_FLAG`, pass it on every signing **codesign**
* `sigh/lib/sigh/resign.rb` - forward page_size from CLI/options to the script
* `fastlane/lib/fastlane/actions/resign.rb` - `:pagesize` / `FL_RESIGN_PAGESIZE`

### Testing Steps

I've tested  locally (`TAHOE`) and on ci (`SEQUOIA` and `TAHOE`) following scenarios:

* From the repo root (after bundle install):
```bash
bundle exec rspec sigh/spec/commands_generator_spec.rb sigh/spec/resign_spec.rb sigh/spec/resign_sh_spec.rb
```
* With a real IPA, identity, and profile:
```bash
bundle exec fastlane sigh resign path/to/App.ipa -i "iPhone Distribution: …" -p path/to/profile.mobileprovision --page_size 16384
```
* Fastfile:
```bash
resign(ipa: "…", signing_identity: "…", provisioning_profile: "…", pagesize: 16_384)
```
