### PR TITLE
[ci] correct codeql

### DIFF
--- a/.github/codeql/actions-config.yml
+++ b/.github/codeql/actions-config.yml
@@ -1,0 +1,2 @@
+queries:
+  - uses: security-and-quality

--- a/.github/codeql/javascript-config.yml
+++ b/.github/codeql/javascript-config.yml
@@ -1,0 +1,5 @@
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  - 'spaceship/spec/tunes/fixtures/login_cntrl.js'

--- a/.github/codeql/ruby-config.yml
+++ b/.github/codeql/ruby-config.yml
@@ -1,0 +1,2 @@
+queries:
+  - uses: security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - ruby
+          - javascript
+          - actions
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: .github/codeql/${{ matrix.language }}-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

We use an automatic enabled CodeQL, which means it just guesses. We have a C scanner despite only have 1 C file that was built to test race conditions. We have JS and Ruby and Actions and they don't pass since it pulls fixture files that are intentionally invalid, etc.

## Solution

Introduce configs to fix CodeQL failures in hopes to pull our security count down to 0.