### PR TITLE
[spaceship] Fix getting App Preview Sets with new endpoint

### DIFF
--- a/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb
@@ -62,9 +62,9 @@ module Spaceship
       # API
       #
 
-      def self.all(client: nil, filter: {}, includes: nil, limit: nil, sort: nil)
+      def self.all(client: nil, app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
-        resp = client.get_app_preview_sets(filter: filter, includes: includes, limit: limit, sort: sort)
+        resp = client.get_app_preview_sets(app_store_version_localization_id: app_store_version_localization_id, filter: filter, includes: includes, limit: limit, sort: sort)
         return resp.to_models
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
+++ b/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb
@@ -78,8 +78,7 @@ module Spaceship
       def get_app_preview_sets(client: nil, filter: {}, includes: "appPreviews", limit: nil, sort: nil)
         client ||= Spaceship::ConnectAPI
         filter ||= {}
-        filter["appStoreVersionLocalization"] = id
-        return Spaceship::ConnectAPI::AppPreviewSet.all(client: client, filter: filter, includes: includes, limit: limit, sort: sort)
+        return Spaceship::ConnectAPI::AppPreviewSet.all(client: client, app_store_version_localization_id: id, filter: filter, includes: includes, limit: limit, sort: sort)
       rescue => error
         raise Spaceship::AppStoreAppPreviewError.new(@locale, error)
       end

--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -367,9 +367,9 @@ module Spaceship
         # appPreviewSets
         #
 
-        def get_app_preview_sets(filter: {}, includes: nil, limit: nil, sort: nil)
+        def get_app_preview_sets(app_store_version_localization_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)
           params = tunes_request_client.build_params(filter: filter, includes: includes, limit: limit, sort: sort)
-          tunes_request_client.get("#{Version::V1}/appPreviewSets", params)
+          tunes_request_client.get("#{Version::V1}/appStoreVersionLocalizations/#{app_store_version_localization_id}/appPreviewSets", params)
         end
 
         def get_app_preview_set(app_preview_set_id: nil, filter: {}, includes: nil, limit: nil, sort: nil)


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

Fix the following error while getting AppPreviewSets (with the new sync feature introduced in #29831):
```
./fastlane/spaceship/lib/spaceship/connect_api/api_client.rb:252:in `handle_error': The given operation is not allowed - The resource 'appPreviewSets' does not allow 'GET_COLLECTION'. Allowed operations are: CREATE, DELETE, GET_INSTANCE (Spaceship::AccessForbiddenError)
     from ./fastlane/spaceship/lib/spaceship/client.rb:1053:in `block in send_request'
     from ./fastlane/spaceship/lib/spaceship/client.rb:808:in `with_retry'
     from ./fastlane/spaceship/lib/spaceship/client.rb:1049:in `send_request'
     from ./fastlane/spaceship/lib/spaceship/client.rb:893:in `request'
     from ./fastlane/spaceship/lib/spaceship/connect_api/api_client.rb:107:in `block in get'
     from ./fastlane/spaceship/lib/spaceship/connect_api/api_client.rb:167:in `with_asc_retry'
     from ./fastlane/spaceship/lib/spaceship/connect_api/api_client.rb:106:in `get'
     from ./fastlane/spaceship/lib/spaceship/connect_api/tunes/tunes.rb:373:in `get_app_preview_sets'
     from ./.rbenv/versions/3.3.0/lib/ruby/3.3.0/forwardable.rb:240:in `get_app_preview_sets'
     from ./fastlane/spaceship/lib/spaceship/connect_api/models/app_preview_set.rb:67:in `all'
     from ./fastlane/spaceship/lib/spaceship/connect_api/models/app_store_version_localization.rb:82:in `get_app_preview_sets'
     from ./fastlane/deliver/lib/deliver/sync_app_previews.rb:87:in `process_locale_videos'
```

### Description

Getting the app previews the old way doesn't work anymore and there's no documentation available on ASC for the old API (which was `/v1/appPreviewSets`).

The solution is to use the currently documented `/v1/appStoreVersionLocalizations/{id}/appPreviewSets` [API endpoint](https://developer.apple.com/documentation/appstoreconnectapi/get-v1-appstoreversionlocalizations-_id_-apppreviewsets).

`get_app_preview_sets` from `tunes.rb` was updated with the new endpoint + add an extra `app_store_version_localization_id` param, which makes it aligned with its counterpart `get_app_screenshot_sets`.

### Testing Steps

See #29831 for testing.
