### PR TITLE
[sigh, match] Pass keychain_path through Sigh::Manager to ProvisioningProfile

### DIFF
--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -115,7 +115,9 @@ module Match
       arguments = FastlaneCore::Configuration.create(Sigh::Options.available_options, values)
 
       Sigh.config = arguments
-      path = Sigh::Manager.start
+
+      keychain_path = FastlaneCore::Helper.keychain_path(params[:keychain_name]) if Helper.mac? && params[:keychain_name]
+      path = Sigh::Manager.start(keychain_path: keychain_path)
       return path
     end
 

--- a/match/spec/generator_spec.rb
+++ b/match/spec/generator_spec.rb
@@ -143,6 +143,57 @@ describe Match::Generator do
         }
         Match::Generator.generate_provisioning_profile(params: params, prov_type: :development, certificate_id: 'fake_cert_id', app_identifier: params[:app_identifier], force: false, working_directory: "workspace")
       end
+
+      context 'keychain_path passthrough' do
+        let(:params) {
+          {
+            app_identifier: 'app_identifier',
+            type: :development,
+            workspace: 'workspace',
+            username: 'username',
+            team_id: 'team_id',
+            platform: :ios,
+            template_name: 'template_name',
+            include_all_certificates: true,
+            keychain_name: 'login.keychain',
+          }
+        }
+
+        before do
+          allow(Sigh).to receive(:config=)
+        end
+
+        context 'on macOS' do
+          before do
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+          end
+
+          it 'passes keychain_path to Sigh::Manager.start' do
+            expect(FastlaneCore::Helper).to receive(:keychain_path).with("login.keychain").and_return("fake_keychain_path")
+            expect(Sigh::Manager).to receive(:start).with(keychain_path: "fake_keychain_path").and_return("fake_path")
+            Match::Generator.generate_provisioning_profile(params: params, prov_type: :development, certificate_id: 'fake_cert_id', app_identifier: params[:app_identifier], force: false, working_directory: "workspace")
+          end
+
+          it 'passes nil when keychain_name is not set' do
+            params_without_keychain = params.reject { |k, _| k == :keychain_name }
+            expect(FastlaneCore::Helper).not_to receive(:keychain_path)
+            expect(Sigh::Manager).to receive(:start).with(keychain_path: nil).and_return("fake_path")
+            Match::Generator.generate_provisioning_profile(params: params_without_keychain, prov_type: :development, certificate_id: 'fake_cert_id', app_identifier: params_without_keychain[:app_identifier], force: false, working_directory: "workspace")
+          end
+        end
+
+        context 'on non-macOS' do
+          before do
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
+          end
+
+          it 'does not resolve keychain_path' do
+            expect(FastlaneCore::Helper).not_to receive(:keychain_path)
+            expect(Sigh::Manager).to receive(:start).with(keychain_path: nil).and_return("fake_path")
+            Match::Generator.generate_provisioning_profile(params: params, prov_type: :development, certificate_id: 'fake_cert_id', app_identifier: params[:app_identifier], force: false, working_directory: "workspace")
+          end
+        end
+      end
     end
   end
 end

--- a/sigh/lib/sigh/manager.rb
+++ b/sigh/lib/sigh/manager.rb
@@ -4,7 +4,7 @@ require_relative 'runner'
 
 module Sigh
   class Manager
-    def self.start
+    def self.start(keychain_path: nil)
       path = Sigh::Runner.new.run
 
       return nil unless path
@@ -23,7 +23,7 @@ module Sigh
         # in case it already exists
       end
 
-      install_profile(output) unless Sigh.config[:skip_install]
+      install_profile(output, keychain_path) unless Sigh.config[:skip_install]
 
       puts(output.green)
 
@@ -35,13 +35,13 @@ module Sigh
       DownloadAll.new.download_all(download_xcode_profiles: download_xcode_profiles)
     end
 
-    def self.install_profile(profile)
-      uuid = FastlaneCore::ProvisioningProfile.uuid(profile)
-      name = FastlaneCore::ProvisioningProfile.name(profile)
+    def self.install_profile(profile, keychain_path = nil)
+      uuid = FastlaneCore::ProvisioningProfile.uuid(profile, keychain_path)
+      name = FastlaneCore::ProvisioningProfile.name(profile, keychain_path)
       ENV["SIGH_UDID"] = ENV["SIGH_UUID"] = uuid if uuid
       ENV["SIGH_NAME"] = name if name
 
-      FastlaneCore::ProvisioningProfile.install(profile)
+      FastlaneCore::ProvisioningProfile.install(profile, keychain_path)
     end
   end
 end

--- a/sigh/spec/manager_spec.rb
+++ b/sigh/spec/manager_spec.rb
@@ -55,5 +55,38 @@ describe Sigh do
 
       expect { Sigh::Manager.start }.to raise_error("The name 'com.krausefx.app AppStore' is already taken, and fail_on_name_taken is true")
     end
+
+    describe '.install_profile' do
+      after do
+        ENV.delete("SIGH_UDID")
+        ENV.delete("SIGH_UUID")
+        ENV.delete("SIGH_NAME")
+      end
+
+      it 'passes keychain_path to ProvisioningProfile methods' do
+        profile = "fake_profile.mobileprovision"
+        keychain_path = "/path/to/custom.keychain"
+
+        expect(FastlaneCore::ProvisioningProfile).to receive(:uuid).with(profile, keychain_path).and_return("fake-uuid")
+        expect(FastlaneCore::ProvisioningProfile).to receive(:name).with(profile, keychain_path).and_return("fake-name")
+        expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(profile, keychain_path)
+
+        Sigh::Manager.install_profile(profile, keychain_path)
+
+        expect(ENV["SIGH_UDID"]).to eq("fake-uuid")
+        expect(ENV["SIGH_UUID"]).to eq("fake-uuid")
+        expect(ENV["SIGH_NAME"]).to eq("fake-name")
+      end
+
+      it 'works without keychain_path' do
+        profile = "fake_profile.mobileprovision"
+
+        expect(FastlaneCore::ProvisioningProfile).to receive(:uuid).with(profile, nil).and_return("fake-uuid")
+        expect(FastlaneCore::ProvisioningProfile).to receive(:name).with(profile, nil).and_return("fake-name")
+        expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(profile, nil)
+
+        Sigh::Manager.install_profile(profile)
+      end
+    end
   end
 end


### PR DESCRIPTION
🔑                                                                                                                                        19:18:20 [9/340]

  ### Checklist

  - [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
  - [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
  - [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR
  - [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
  - [ ] I've updated the documentation if necessary.
  - [x] I've added or updated relevant unit tests.

  ### Motivation and Context

  When _match_ generates provisioning profiles via `Sigh::Manager`, the `keychain_path` resolved from `params[:keychain_name]` is never passed down to
  `FastlaneCore::ProvisioningProfile` methods. This causes provisioning profile installation to target the default keychain instead of the custom one
  specified in _match_ configuration.

  This is particularly problematic in CI environments where a temporary keychain is created for the build and certificates/profiles must be installed into
  that specific keychain.

  The certificate generation path (`generate_certificate`) already correctly passes `keychain_path` (line 35 of `generator.rb`), but the provisioning
  profile path does not — this PR fixes that inconsistency.

  ### Description

  - Added `keychain_path:` keyword argument to `Sigh::Manager.start`
  - Forward `keychain_path` from `Sigh::Manager.start` to `install_profile`
  - Pass `keychain_path` through to `FastlaneCore::ProvisioningProfile.uuid`, `.name`, and `.install`
  - Resolve `keychain_path` in `Match::Generator.generate_provisioning_profile` using `FastlaneCore::Helper.keychain_path`, guarded by `Helper.mac?` —
  consistent with the existing pattern in `generate_certificate`

  ### Testing Steps

```bash
  bundle exec rspec match/spec/generator_spec.rb sigh/spec/manager_spec.rb
```

All 15 tests pass (including 5 new ones). Full bundle exec rspec has pre-existing failures on master unrelated to this change.

 Added tests covering:
  - macOS: keychain_path is resolved and passed to Sigh::Manager.start
  - macOS without keychain_name: nil is passed
  - non-macOS: keychain_path is not resolved
  - Sigh::Manager.install_profile: forwards keychain_path to ProvisioningProfile methods
  - Sigh::Manager.install_profile: works without keychain_path (nil default)


fixes: #29179
fixes: #20559