### PR TITLE
fix: use certificate id param on match

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -160,7 +160,7 @@ module Match
 
     def fetch_certificate(params: nil, renew_expired_certs: false, specific_cert_type: nil)
       cert_type = Match.cert_type_sym(specific_cert_type || params[:type])
-      certificate_id = params[:certificate_id]
+      certificate_id = specific_cert_type.nil? ? params[:certificate_id] : nil
 
       certs = Dir[File.join(prefixed_working_directory, "certs", cert_type.to_s, "*.cer")]
       keys = Dir[File.join(prefixed_working_directory, "certs", cert_type.to_s, "*.p12")]

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -255,7 +255,7 @@ module Match
 
     # @return [String] Path to certificate or P12 key
     def select_cert_or_key(paths:, certificate_id: nil)
-      return paths.last unless certificate_id
+      return paths.last if certificate_id.to_s.strip.empty?
 
       cert_id_path = paths.find { |path| File.basename(path, File.extname(path)) == certificate_id }
       return cert_id_path if cert_id_path

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -255,8 +255,12 @@ module Match
 
     # @return [String] Path to certificate or P12 key
     def select_cert_or_key(paths:, certificate_id: nil)
-      cert_id_path = certificate_id ? paths.find { |path| File.basename(path, File.extname(path)) == certificate_id } : nil
-      cert_id_path || paths.last
+      return paths.last unless certificate_id
+
+      cert_id_path = paths.find { |path| File.basename(path, File.extname(path)) == certificate_id }
+      return cert_id_path if cert_id_path
+
+      UI.user_error!("No certificate or key found for certificate_id '#{certificate_id}'")
     end
 
     # rubocop:disable Metrics/PerceivedComplexity

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -160,6 +160,7 @@ module Match
 
     def fetch_certificate(params: nil, renew_expired_certs: false, specific_cert_type: nil)
       cert_type = Match.cert_type_sym(specific_cert_type || params[:type])
+      certificate_id = params[:certificate_id]
 
       certs = Dir[File.join(prefixed_working_directory, "certs", cert_type.to_s, "*.cer")]
       keys = Dir[File.join(prefixed_working_directory, "certs", cert_type.to_s, "*.p12")]
@@ -174,7 +175,7 @@ module Match
 
       # Validate existing certificate first.
       if renew_expired_certs && is_cert_renewable && storage_has_certs && !params[:readonly]
-        cert_path = select_cert_or_key(paths: certs)
+        cert_path = select_cert_or_key(paths: certs, certificate_id: certificate_id)
 
         unless Utils.is_cert_valid?(cert_path)
           UI.important("Removing invalid certificate '#{File.basename(cert_path)}'")
@@ -209,7 +210,7 @@ module Match
         # Reset certificates cache since we have a new cert.
         self.cache.reset_certificates
       else
-        cert_path = select_cert_or_key(paths: certs)
+        cert_path = select_cert_or_key(paths: certs, certificate_id: certificate_id)
 
         # Check validity of certificate
         if Utils.is_cert_valid?(cert_path)
@@ -233,7 +234,7 @@ module Match
             # Import the private key
             # there seems to be no good way to check if it's already installed - so just install it
             # Key will only be added to the partition list if it isn't already installed
-            Utils.import(select_cert_or_key(paths: keys), params[:keychain_name], password: params[:keychain_password])
+            Utils.import(select_cert_or_key(paths: keys, certificate_id: certificate_id), params[:keychain_name], password: params[:keychain_password])
           end
         else
           UI.message("Skipping installation of certificate as it would not work on this operating system.")
@@ -241,7 +242,7 @@ module Match
 
         if params[:output_path]
           FileUtils.cp(cert_path, params[:output_path])
-          FileUtils.cp(select_cert_or_key(paths: keys), params[:output_path])
+          FileUtils.cp(select_cert_or_key(paths: keys, certificate_id: certificate_id), params[:output_path])
         end
 
         # Get and print info of certificate
@@ -253,8 +254,8 @@ module Match
     end
 
     # @return [String] Path to certificate or P12 key
-    def select_cert_or_key(paths:)
-      cert_id_path = ENV['MATCH_CERTIFICATE_ID'] ? paths.find { |path| path.include?(ENV['MATCH_CERTIFICATE_ID']) } : nil
+    def select_cert_or_key(paths:, certificate_id: nil)
+      cert_id_path = certificate_id ? paths.find { |path| File.basename(path, File.extname(path)) == certificate_id } : nil
       cert_id_path || paths.last
     end
 

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -398,13 +398,15 @@ describe Match do
       end
 
       it "does not substring-match certificate_id" do
-        result = runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "BBBB")
-        expect(result).to eq("/fake/certs/distribution/CCCC333333.cer")
+        expect do
+          runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "BBBB")
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, "No certificate or key found for certificate_id 'BBBB'")
       end
 
-      it "falls back to last path when certificate_id does not match any path" do
-        result = runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "NONEXISTENT")
-        expect(result).to eq("/fake/certs/distribution/CCCC333333.cer")
+      it "raises an error when certificate_id does not match any path" do
+        expect do
+          runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "NONEXISTENT")
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, "No certificate or key found for certificate_id 'NONEXISTENT'")
       end
 
       it "works with .p12 key paths" do
@@ -508,6 +510,40 @@ describe Match do
           ensure
             ENV.delete('MATCH_CERTIFICATE_ID')
           end
+        end
+      end
+
+      it "imports the matching .p12 key when certificate_id is set and on macOS" do
+        Dir.mktmpdir do |dir|
+          cert_dir = File.join(dir, "certs", "distribution")
+          FileUtils.mkdir_p(cert_dir)
+          File.write(File.join(cert_dir, "FIRST11111.cer"), "cert1")
+          File.write(File.join(cert_dir, "FIRST11111.p12"), "key1")
+          File.write(File.join(cert_dir, "SECOND2222.cer"), "cert2")
+          File.write(File.join(cert_dir, "SECOND2222.p12"), "key2")
+
+          allow(runner).to receive(:prefixed_working_directory).and_return(dir)
+          allow(Match::Utils).to receive(:is_cert_valid?).and_return(true)
+          allow(Match::Utils).to receive(:get_cert_info).and_return([["Common Name", "test"]])
+          allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+          allow(FastlaneCore::CertChecker).to receive(:installed?).and_return(false)
+
+          expected_cert_path = File.join(cert_dir, "FIRST11111.cer")
+          expected_key_path = File.join(cert_dir, "FIRST11111.p12")
+
+          expect(Match::Utils).to receive(:import).with(expected_cert_path, "login.keychain", password: nil).ordered
+          expect(Match::Utils).to receive(:import).with(expected_key_path, "login.keychain", password: nil).ordered
+
+          values = {
+            app_identifier: "com.test.app",
+            type: "appstore",
+            git_url: "https://example.com",
+            certificate_id: "FIRST11111"
+          }
+          config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+
+          cert_id = runner.send(:fetch_certificate, params: config)
+          expect(cert_id).to eq("FIRST11111")
         end
       end
     end

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -526,6 +526,7 @@ describe Match do
           allow(Match::Utils).to receive(:is_cert_valid?).and_return(true)
           allow(Match::Utils).to receive(:get_cert_info).and_return([["Common Name", "test"]])
           allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+          allow(FastlaneCore::Helper).to receive(:xcode_at_least?).and_return(false)
           allow(FastlaneCore::CertChecker).to receive(:installed?).and_return(false)
 
           expected_cert_path = File.join(cert_dir, "FIRST11111.cer")

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -557,6 +557,45 @@ describe Match do
           expect(cert_id).to eq("FIRST11111")
         end
       end
+
+      it "ignores certificate_id when fetching additional cert types" do
+        Dir.mktmpdir do |dir|
+          # Primary cert type directory with the target certificate
+          primary_dir = File.join(dir, "certs", "distribution")
+          FileUtils.mkdir_p(primary_dir)
+          File.write(File.join(primary_dir, "FIRST11111.cer"), "cert1")
+          File.write(File.join(primary_dir, "FIRST11111.p12"), "key1")
+
+          # Additional cert type directory with different certificates
+          additional_dir = File.join(dir, "certs", "mac_installer_distribution")
+          FileUtils.mkdir_p(additional_dir)
+          File.write(File.join(additional_dir, "INSTALLER1.cer"), "cert2")
+          File.write(File.join(additional_dir, "INSTALLER1.p12"), "key2")
+          File.write(File.join(additional_dir, "INSTALLER2.cer"), "cert3")
+          File.write(File.join(additional_dir, "INSTALLER2.p12"), "key3")
+
+          allow(runner).to receive(:prefixed_working_directory).and_return(dir)
+          allow(Match::Utils).to receive(:is_cert_valid?).and_return(true)
+          allow(Match::Utils).to receive(:get_cert_info).and_return([["Common Name", "test"]])
+          allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
+
+          values = {
+            app_identifier: "com.test.app",
+            type: "appstore",
+            git_url: "https://example.com",
+            certificate_id: "FIRST11111"
+          }
+          config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+
+          # Primary cert should use certificate_id
+          cert_id = runner.send(:fetch_certificate, params: config)
+          expect(cert_id).to eq("FIRST11111")
+
+          # Additional cert type should ignore certificate_id and pick the last cert
+          additional_cert_id = runner.send(:fetch_certificate, params: config, specific_cert_type: "mac_installer_distribution")
+          expect(additional_cert_id).to eq("INSTALLER2")
+        end
+      end
     end
   end
 end

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -392,6 +392,16 @@ describe Match do
         expect(result).to eq("/fake/certs/distribution/CCCC333333.cer")
       end
 
+      it "returns the last path when certificate_id is an empty string" do
+        result = runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "")
+        expect(result).to eq("/fake/certs/distribution/CCCC333333.cer")
+      end
+
+      it "returns the last path when certificate_id is whitespace-only" do
+        result = runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "  ")
+        expect(result).to eq("/fake/certs/distribution/CCCC333333.cer")
+      end
+
       it "selects the matching path when certificate_id matches exactly" do
         result = runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "BBBB222222")
         expect(result).to eq("/fake/certs/distribution/BBBB222222.cer")

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -365,5 +365,151 @@ describe Match do
         end
       end
     end
+
+    describe '#select_cert_or_key' do
+      let(:runner) { Match::Runner.new }
+      let(:cert_paths) do
+        [
+          "/fake/certs/distribution/AAAA111111.cer",
+          "/fake/certs/distribution/BBBB222222.cer",
+          "/fake/certs/distribution/CCCC333333.cer"
+        ]
+      end
+      let(:key_paths) do
+        [
+          "/fake/certs/distribution/AAAA111111.p12",
+          "/fake/certs/distribution/BBBB222222.p12"
+        ]
+      end
+
+      it "returns the last path when no certificate_id is provided" do
+        result = runner.send(:select_cert_or_key, paths: cert_paths)
+        expect(result).to eq("/fake/certs/distribution/CCCC333333.cer")
+      end
+
+      it "returns the last path when certificate_id is nil" do
+        result = runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: nil)
+        expect(result).to eq("/fake/certs/distribution/CCCC333333.cer")
+      end
+
+      it "selects the matching path when certificate_id matches exactly" do
+        result = runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "BBBB222222")
+        expect(result).to eq("/fake/certs/distribution/BBBB222222.cer")
+      end
+
+      it "does not substring-match certificate_id" do
+        result = runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "BBBB")
+        expect(result).to eq("/fake/certs/distribution/CCCC333333.cer")
+      end
+
+      it "falls back to last path when certificate_id does not match any path" do
+        result = runner.send(:select_cert_or_key, paths: cert_paths, certificate_id: "NONEXISTENT")
+        expect(result).to eq("/fake/certs/distribution/CCCC333333.cer")
+      end
+
+      it "works with .p12 key paths" do
+        result = runner.send(:select_cert_or_key, paths: key_paths, certificate_id: "AAAA111111")
+        expect(result).to eq("/fake/certs/distribution/AAAA111111.p12")
+      end
+    end
+
+    describe '#fetch_certificate certificate_id param resolution' do
+      let(:runner) { Match::Runner.new }
+
+      before do
+        allow(Spaceship::ConnectAPI).to receive(:token).and_return("fake_token")
+      end
+
+      it "uses certificate_id param to select the correct certificate" do
+        Dir.mktmpdir do |dir|
+          # Create two certs and keys
+          cert_dir = File.join(dir, "certs", "distribution")
+          FileUtils.mkdir_p(cert_dir)
+          File.write(File.join(cert_dir, "FIRST11111.cer"), "cert1")
+          File.write(File.join(cert_dir, "FIRST11111.p12"), "key1")
+          File.write(File.join(cert_dir, "SECOND2222.cer"), "cert2")
+          File.write(File.join(cert_dir, "SECOND2222.p12"), "key2")
+
+          allow(runner).to receive(:prefixed_working_directory).and_return(dir)
+          allow(Match::Utils).to receive(:is_cert_valid?).and_return(true)
+          allow(Match::Utils).to receive(:get_cert_info).and_return([["Common Name", "test"]])
+          allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
+
+          values = {
+            app_identifier: "com.test.app",
+            type: "appstore",
+            git_url: "https://example.com",
+            certificate_id: "FIRST11111"
+          }
+          config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+
+          cert_id = runner.send(:fetch_certificate, params: config)
+          expect(cert_id).to eq("FIRST11111")
+        end
+      end
+
+      it "uses MATCH_CERTIFICATE_ID env var for backward compatibility" do
+        Dir.mktmpdir do |dir|
+          cert_dir = File.join(dir, "certs", "distribution")
+          FileUtils.mkdir_p(cert_dir)
+          File.write(File.join(cert_dir, "FIRST11111.cer"), "cert1")
+          File.write(File.join(cert_dir, "FIRST11111.p12"), "key1")
+          File.write(File.join(cert_dir, "SECOND2222.cer"), "cert2")
+          File.write(File.join(cert_dir, "SECOND2222.p12"), "key2")
+
+          allow(runner).to receive(:prefixed_working_directory).and_return(dir)
+          allow(Match::Utils).to receive(:is_cert_valid?).and_return(true)
+          allow(Match::Utils).to receive(:get_cert_info).and_return([["Common Name", "test"]])
+          allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
+
+          ENV['MATCH_CERTIFICATE_ID'] = 'FIRST11111'
+          begin
+            values = {
+              app_identifier: "com.test.app",
+              type: "appstore",
+              git_url: "https://example.com"
+            }
+            config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+
+            cert_id = runner.send(:fetch_certificate, params: config)
+            expect(cert_id).to eq("FIRST11111")
+          ensure
+            ENV.delete('MATCH_CERTIFICATE_ID')
+          end
+        end
+      end
+
+      it "prefers explicit param over env var" do
+        Dir.mktmpdir do |dir|
+          cert_dir = File.join(dir, "certs", "distribution")
+          FileUtils.mkdir_p(cert_dir)
+          File.write(File.join(cert_dir, "FIRST11111.cer"), "cert1")
+          File.write(File.join(cert_dir, "FIRST11111.p12"), "key1")
+          File.write(File.join(cert_dir, "SECOND2222.cer"), "cert2")
+          File.write(File.join(cert_dir, "SECOND2222.p12"), "key2")
+
+          allow(runner).to receive(:prefixed_working_directory).and_return(dir)
+          allow(Match::Utils).to receive(:is_cert_valid?).and_return(true)
+          allow(Match::Utils).to receive(:get_cert_info).and_return([["Common Name", "test"]])
+          allow(FastlaneCore::Helper).to receive(:mac?).and_return(false)
+
+          ENV['MATCH_CERTIFICATE_ID'] = 'SECOND2222'
+          begin
+            values = {
+              app_identifier: "com.test.app",
+              type: "appstore",
+              git_url: "https://example.com",
+              certificate_id: "FIRST11111"
+            }
+            config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+
+            cert_id = runner.send(:fetch_certificate, params: config)
+            expect(cert_id).to eq("FIRST11111")
+          ensure
+            ENV.delete('MATCH_CERTIFICATE_ID')
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in
  the [ ] (don't: [x ], [ x], do: [x])
  -->

  ### Checklist

  - [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
  - [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
  - [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to
  GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
  - [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
  - [ ] I've updated the documentation if necessary.
  - [x] I've added or updated relevant unit tests.

  ### Motivation and Context

The `certificate_id` parameter in `match` has been non-functional since it was introduced in #21428 (Oct 2023). The parameter is defined as a `ConfigItem` with `env_name: "MATCH_CERTIFICATE_ID"`, but `select_cert_or_key` reads `ENV['MATCH_CERTIFICATE_ID']` directly instead of going through `params[:certificate_id]`.

FastlaneCore's `env_name` is a read-only fallback source. It reads values FROM environment variables but does not export parameter values TO environment variables. So:

  - `match(certificate_id: "ABC123")` in a Fastfile was silently ignored
  - Only `MATCH_CERTIFICATE_ID=ABC123` as a raw environment variable worked
  - `params[:certificate_id]` was never read anywhere in the match codebase

This made it impossible to use `certificate_id` as a standard parameter to select a specific certificate when multiple exist in storage, which could cause the wrong certificate ID to be passed downstream to `sigh` for provisioning profile generation.

  ### Description

`select_cert_or_key` in `match/lib/match/runner.rb` reads `ENV['MATCH_CERTIFICATE_ID']` directly instead of using `params[:certificate_id]`, which already handles both explicit param values and env var fallback through FastlaneCore's `Configuration#fetch` resolution order (explicit value > env var > config file > default).

  **What changed:**

  1. **`select_cert_or_key`** now takes a `certificate_id:` keyword argument instead of reading `ENV` directly. Matching was upgraded from substring (`path.include?`) to exact basename (`File.basename(path, File.extname(path)) == certificate_id`) to prevent accidental partial matches.

  2. **Fail-fast on mismatch.** When `certificate_id` is explicitly provided but doesn't match any certificate or key in storage, `select_cert_or_key` now raises `UI.user_error!` instead of silently falling back to the last available file. Blank or empty values (e.g. `MATCH_CERTIFICATE_ID=""`) are treated as "not provided" and fall back to default selection.

  3. **`fetch_certificate`** now does `certificate_id = params[:certificate_id]` to extract the value once via FastlaneCore's config resolution, which handles both explicit params and the `MATCH_CERTIFICATE_ID` env var.

  4. **Call sites.** All 4 calls to `select_cert_or_key` within `fetch_certificate` now pass the extracted `certificate_id`.

  **Backward compatibility:** `params[:certificate_id]` falls back to `ENV['MATCH_CERTIFICATE_ID']` via `ConfigItem#fetch_env_value`, so existing workflows using the environment variable continue to work.

  ### Testing Steps

  Added 12 tests in `match/spec/runner_spec.rb`:

  **Unit tests for `select_cert_or_key`:**
  ```bash
  bundle exec rspec match/spec/runner_spec.rb -e "select_cert_or_key"
  - Returns last path when no certificate_id provided
  - Returns last path when certificate_id is nil
  - Returns last path when certificate_id is an empty string
  - Returns last path when certificate_id is whitespace-only
  - Selects matching path on exact basename match
  - Raises error on substring match (e.g. "BBBB" does not match "BBBB222222.cer")
  - Raises error when certificate_id does not match any path
  - Works with .p12 key paths

  fetch_certificate param resolution tests:
  bundle exec rspec match/spec/runner_spec.rb -e "certificate_id param resolution"
  - certificate_id passed as a config param selects the correct certificate (proves the bug is fixed)
  - MATCH_CERTIFICATE_ID env var still works (backward compatibility)
  - Explicit param takes precedence over env var when both are set
  - Imports the matching .p12 key when certificate_id is set and on macOS