### PR TITLE
[frameit] Add iPhone 16 and iPhone 17 lineup device support

### DIFF
--- a/frameit/lib/frameit/device_types.rb
+++ b/frameit/lib/frameit/device_types.rb
@@ -89,6 +89,10 @@ module Frameit
     STARLIGHT ||= "Starlight"
     SIERRA ||= "Sierra"
     SORTA_SAGE ||= "Sorta Sage"
+    BLACK_TITANIUM ||= "Black Titanium"
+    DESERT_TITANIUM ||= "Desert Titanium"
+    NATURAL_TITANIUM ||= "Natural Titanium"
+    WHITE_TITANIUM ||= "White Titanium"
 
     def self.all_colors
       Color.constants.map { |c| Color.const_get(c).upcase.gsub(' ', '_') }
@@ -175,6 +179,13 @@ module Frameit
     IPHONE_14_PLUS ||= Device.new("iphone-14-plus", "Apple iPhone 14 Plus", 12, [[1284, 2778], [2778, 1284]], 458, Color::MIDNIGHT, Platform::IOS)
     IPHONE_14_PRO ||= Device.new("iphone-14-pro", "Apple iPhone 14 Pro", 12, [[1179, 2556], [2556, 1179]], 460, Color::BLACK, Platform::IOS)
     IPHONE_14_PRO_MAX ||= Device.new("iphone14-pro-max", "Apple iPhone 14 Pro Max", 12, [[1290, 2796], [2796, 1290]], 458, Color::BLACK, Platform::IOS)
+    IPHONE_16 ||= Device.new("iphone-16", "Apple iPhone 16", 13, [[1179, 2556], [2556, 1179]], 460, Color::BLACK, Platform::IOS)
+    IPHONE_16_PLUS ||= Device.new("iphone-16-plus", "Apple iPhone 16 Plus", 13, [[1290, 2796], [2796, 1290]], 460, Color::BLACK, Platform::IOS)
+    IPHONE_16_PRO ||= Device.new("iphone-16-pro", "Apple iPhone 16 Pro", 13, [[1206, 2622], [2622, 1206]], 460, Color::BLACK_TITANIUM, Platform::IOS)
+    IPHONE_16_PRO_MAX ||= Device.new("iphone16-pro-max", "Apple iPhone 16 Pro Max", 13, [[1320, 2868], [2868, 1320]], 460, Color::BLACK_TITANIUM, Platform::IOS)
+    IPHONE_17 ||= Device.new("iphone-17", "Apple iPhone 17", 14, [[1206, 2622], [2622, 1206]], 460, Color::BLACK, Platform::IOS)
+    IPHONE_17_PRO ||= Device.new("iphone-17-pro", "Apple iPhone 17 Pro", 14, [[1206, 2622], [2622, 1206]], 460, Color::SILVER, Platform::IOS)
+    IPHONE_17_PRO_MAX ||= Device.new("iphone17-pro-max", "Apple iPhone 17 Pro Max", 14, [[1320, 2868], [2868, 1320]], 460, Color::SILVER, Platform::IOS)
     IPAD_10_2 ||= Device.new("ipad-10-2", "Apple iPad 10.2", 1, [[1620, 2160], [2160, 1620]], 264, Color::SPACE_GRAY, Platform::IOS)
     IPAD_AIR_2 ||= Device.new("ipad-air-2", "Apple iPad Air 2", 1, [[1536, 2048], [2048, 1536]], 264, Color::SPACE_GRAY, Platform::IOS, DEVICE_SCREEN_IDS[DisplayType::APP_IPAD_97])
     IPAD_AIR_2019 ||= Device.new("ipad-air-2019", "Apple iPad Air (2019)", 2, [[1668, 2224], [2224, 1668]], 265, Color::SPACE_GRAY, Platform::IOS)


### PR DESCRIPTION
## Motivation

The `frameit-frames` repo added iPhone 16 and iPhone 17 device bezels in fastlane/frameit-frames#40, but the corresponding `Device` entries were never registered in `frameit/lib/frameit/device_types.rb`. As a result, frameit fails with `Unsupported screen size` on screenshots captured from any 2024–2025 iPhone, even though the frame PNGs are already downloaded into `~/.fastlane/frameit/latest/`.

Repro: capture any screenshot from an iPhone 17 Pro Max simulator (1320×2868) and run `fastlane frameit`. You'll see:
```
Unsupported screen size [1320, 2868] for path './01_Calculator_iphone-6-9.png'
```

## Changes

Adds `Device` entries for the iPhone 16 and iPhone 17 lineups, matching the frame assets already present in the community frames repo:

| Device | Resolution | Default color |
| --- | --- | --- |
| iPhone 16 | 1179×2556 | Black |
| iPhone 16 Plus | 1290×2796 | Black |
| iPhone 16 Pro | 1206×2622 | Black Titanium |
| iPhone 16 Pro Max | 1320×2868 | Black Titanium |
| iPhone 17 | 1206×2622 | Black |
| iPhone 17 Pro | 1206×2622 | Silver |
| iPhone 17 Pro Max | 1320×2868 | Silver |

Also adds four titanium color constants (`BLACK_TITANIUM`, `DESERT_TITANIUM`, `NATURAL_TITANIUM`, `WHITE_TITANIUM`) used as defaults for the Pro lineup. These match the frame filenames in frameit-frames#40.

## Deliberately out of scope

- **App Store Connect 6.9\" display type**: Apple introduced a new 6.9\" screenshot slot for the iPhone 16 Pro Max and iPhone 17 Pro Max, but the current `Spaceship::ConnectAPI::AppScreenshotSet::DisplayType` enum only goes up to `APP_IPHONE_67`. Adding the new slot touches spaceship + deliver and is better handled in a follow-up PR. The new devices in this PR omit the `DEVICE_SCREEN_IDS` mapping (same pattern as iPhone 14 and earlier modern devices), so priority/dimension-based detection still works for frameit's compositing path.

## Test plan

- [x] Verified `frameit/lib/frameit/device_types.rb` loads without errors
- [x] Confirmed `Devices::IPHONE_17_PRO_MAX.formatted_name == "Apple iPhone 17 Pro Max"` resolves cleanly
- [x] Ran `frameit` locally against iPhone 17 Pro Max (1320×2868) and iPhone 16 Pro (1206×2622) screenshots — compositing now succeeds