### PR TITLE
chore: ruby 3.2 is eol, 3.3 is suggested

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -4,5 +4,5 @@ module Fastlane
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '1.50.2'.freeze
-  SUGGESTED_MINIMUM_RUBY = '3.2.0'.freeze
+  SUGGESTED_MINIMUM_RUBY = '3.3.0'.freeze
 end


### PR DESCRIPTION
# Problem
_fastlane_ lags behind on Ruby versions. 3.2 is now EOL. Lets encourage people to get to 3.3+

# Solution
Move to 3.3 as suggested min - https://endoflife.date/ruby