### PR TITLE
[register_devices] Register devices normalization for UDIDs.

### DIFF
--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -53,9 +53,13 @@ module Fastlane
 
         UI.message("Fetching list of currently registered devices...")
         existing_devices = Spaceship::ConnectAPI::Device.all
-
+        
+        existing_udids = existing_devices.map(&:udid).map do |udid|
+         udid.tr("-", "").downcase
+        end
+        
         device_objs = new_devices.map do |device|
-          if existing_devices.map(&:udid).map(&:downcase).include?(device[0].downcase)
+          if existing_udids.include?(device[0].tr("-", "").downcase)
             UI.verbose("UDID #{device[0]} already exists - Skipping...")
             next
           end
@@ -73,9 +77,8 @@ module Fastlane
 
           try_create_device(name: device[1], platform: device_platform, udid: device[0])
         end
-
         UI.success("Successfully registered new devices.")
-        return device_objs
+        return device_objs.compact
       end
 
       def self.try_create_device(name: nil, platform: nil, udid: nil)

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -57,7 +57,7 @@ module Fastlane
         existing_udids = existing_devices.map(&:udid).map do |udid|
          udid.tr("-", "").downcase
         end
-        
+
         device_objs = new_devices.map do |device|
           if existing_udids.include?(device[0].tr("-", "").downcase)
             UI.verbose("UDID #{device[0]} already exists - Skipping...")
@@ -77,6 +77,7 @@ module Fastlane
 
           try_create_device(name: device[1], platform: device_platform, udid: device[0])
         end
+
         UI.success("Successfully registered new devices.")
         return device_objs.compact
       end

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -53,7 +53,7 @@ module Fastlane
 
         UI.message("Fetching list of currently registered devices...")
         existing_devices = Spaceship::ConnectAPI::Device.all
-        
+
         existing_udids = existing_devices.map(&:udid).map do |udid|
           udid.tr("-", "").downcase
         end

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -55,7 +55,7 @@ module Fastlane
         existing_devices = Spaceship::ConnectAPI::Device.all
         
         existing_udids = existing_devices.map(&:udid).map do |udid|
-         udid.tr("-", "").downcase
+          udid.tr("-", "").downcase
         end
 
         device_objs = new_devices.map do |device|

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -55,8 +55,13 @@ module Fastlane
         existing_devices = Spaceship::ConnectAPI::Device.all
 
         device_objs = new_devices.map do |device|
-          if existing_devices.map(&:udid).map(&:downcase).include?(device[0].downcase)
-            UI.verbose("UDID #{device[0]} already exists - Skipping...")
+          existing_device = existing_devices.find do |existing_device|
+            existing_device.udid.tr("-", "").downcase == device[0].tr("-", "").downcase
+          end
+
+          if existing_device
+            UI.verbose("UDID #{existing_device.udid} already exists - Skipping...")
+
             next
           end
 
@@ -74,8 +79,12 @@ module Fastlane
           try_create_device(name: device[1], platform: device_platform, udid: device[0])
         end
 
-        UI.success("Successfully registered new devices.")
-        return device_objs
+        if device_objs.compact.empty?
+          UI.success("No new devices to register")
+        else
+          UI.success("Successfully registered new devices.")
+        end
+        return device_objs.compact
       end
 
       def self.try_create_device(name: nil, platform: nil, udid: nil)

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -55,8 +55,8 @@ module Fastlane
         existing_devices = Spaceship::ConnectAPI::Device.all
 
         device_objs = new_devices.map do |device|
-          existing_device = existing_devices.find do |existing_device|
-            existing_device.udid.tr("-", "").downcase == device[0].tr("-", "").downcase
+          existing_device = existing_devices.find do |ed|
+            ed.udid.tr("-", "").casecmp(device[0].tr("-", "")).zero?
           end
 
           if existing_device

--- a/fastlane/lib/fastlane/actions/register_devices.rb
+++ b/fastlane/lib/fastlane/actions/register_devices.rb
@@ -55,8 +55,9 @@ module Fastlane
         existing_devices = Spaceship::ConnectAPI::Device.all
 
         device_objs = new_devices.map do |device|
+          normalized_udid = device[0].tr("-", "")
           existing_device = existing_devices.find do |ed|
-            ed.udid.tr("-", "").casecmp(device[0].tr("-", "")).zero?
+            ed.udid.tr("-", "").casecmp(normalized_udid).zero?
           end
 
           if existing_device

--- a/fastlane/spec/actions_specs/register_devices_spec.rb
+++ b/fastlane/spec/actions_specs/register_devices_spec.rb
@@ -112,17 +112,21 @@ describe Fastlane do
           platform: 'IOS'
         ).once
 
-        Fastlane::Actions::RegisterDevicesAction.run(
-          platform: 'ios',
-          devices_file: devices_list_with_hyphen,
-          username: 'test@test.com'
-        )
+        result1 = Fastlane::FastFile.new.parse("lane :test do
+            register_devices(
+              username: 'test@test.com',
+              devices_file: '#{devices_list_with_hyphen}',
+              platform: 'ios'
+            )
+          end").runner.execute(:test)
 
-        Fastlane::Actions::RegisterDevicesAction.run(
-          platform: 'ios',
-          devices_file: devices_list_normalized,
-          username: 'test@test.com'
-        )
+        result2 = Fastlane::FastFile.new.parse("lane :test do
+            register_devices(
+              username: 'test@test.com',
+              devices_file: '#{devices_list_normalized}',
+              platform: 'ios'
+            )
+          end").runner.execute(:test)
       end
 
       describe "displays error messages" do

--- a/fastlane/spec/actions_specs/register_devices_spec.rb
+++ b/fastlane/spec/actions_specs/register_devices_spec.rb
@@ -13,6 +13,12 @@ describe Fastlane do
       let(:devices_file_with_too_many_columns) do
         File.absolute_path('./fastlane/spec/fixtures/actions/register_devices/devices-list-with-too-many-columns.txt')
       end
+      let(:devices_list_with_hyphen) do
+        File.absolute_path('./fastlane/spec/fixtures/actions/register_devices/devices-list-with-hyphen.txt')
+      end
+      let(:devices_list_normalized) do
+        File.absolute_path('./fastlane/spec/fixtures/actions/register_devices/devices-list-normalized.txt')
+      end
 
       let(:existing_device) { double }
       let(:fake_devices) { [existing_device] }
@@ -36,18 +42,18 @@ describe Fastlane do
         expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
           name: 'NAME2',
           udid: 'B123456789012345678901234567890123456789',
-          platform: "IOS"
-        )
+          platform: 'IOS'
+        ).once
         expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
           name: 'NAME3',
           udid: 'A5B5CD50-14AB-5AF7-8B78-AB4751AB10A8',
-          platform: "MAC_OS"
-        )
+          platform: 'MAC_OS'
+        ).once
         expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
           name: 'NAME4',
           udid: 'A5B5CD50-14AB-5AF7-8B78-AB4751AB10A7',
-          platform: "MAC_OS"
-        )
+          platform: 'MAC_OS'
+        ).once
 
         result = Fastlane::FastFile.new.parse("lane :test do
             register_devices(
@@ -64,7 +70,7 @@ describe Fastlane do
           name: 'NAME2',
           udid: 'B123456789012345678901234567890123456789',
           platform: "IOS"
-        )
+        ).once
 
         result = Fastlane::FastFile.new.parse("lane :test do
             register_devices(
@@ -81,8 +87,8 @@ describe Fastlane do
         expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
           name: 'NAME2',
           udid: 'B123456789012345678901234567890123456789',
-          platform: "MAC_OS"
-        )
+          platform: 'MAC_OS'
+        ).once
 
         result = Fastlane::FastFile.new.parse("lane :test do
             register_devices(
@@ -91,6 +97,32 @@ describe Fastlane do
               platform: 'mac'
             )
           end").runner.execute(:test)
+      end
+
+      it "registers a device with a hyphenated UDID, then registers the same device without a hyphen" do
+        registered_device = double
+        allow(registered_device).to receive(:udid).and_return("A1234567-012345678901234")
+
+        expect(Spaceship::ConnectAPI::Device).to receive(:all)
+          .and_return(fake_devices, fake_devices + [registered_device])
+
+        expect(Fastlane::Actions::RegisterDevicesAction).to receive(:try_create_device).with(
+          name: 'NAME1',
+          udid: 'A1234567-012345678901234',
+          platform: 'IOS'
+        ).once
+
+        Fastlane::Actions::RegisterDevicesAction.run(
+          platform: 'ios',
+          devices_file: devices_list_with_hyphen,
+          username: 'test@test.com'
+        )
+
+        Fastlane::Actions::RegisterDevicesAction.run(
+          platform: 'ios',
+          devices_file: devices_list_normalized,
+          username: 'test@test.com'
+        )
       end
 
       describe "displays error messages" do

--- a/fastlane/spec/fixtures/actions/register_devices/devices-list-normalized.txt
+++ b/fastlane/spec/fixtures/actions/register_devices/devices-list-normalized.txt
@@ -1,0 +1,2 @@
+Device ID	Device Name	Device Platform
+A1234567012345678901234	NAME1	ios

--- a/fastlane/spec/fixtures/actions/register_devices/devices-list-with-hyphen.txt
+++ b/fastlane/spec/fixtures/actions/register_devices/devices-list-with-hyphen.txt
@@ -1,0 +1,2 @@
+Device ID	Device Name	Device Platform
+A1234567-012345678901234	NAME1	ios


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Check fails and tries to register existing device if you pass a UDID without a ~~colon~~ hyphen. This removes the ~~colon~~ hyphen from the UDID for the comparison part.

### Description

Remove ~~colon~~ hyphen from UDID in existing_devices and looped device for comparison.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
