### PR TITLE
[supply] Support authorized_user and Application Default Credentials for Google authentication

### DIFF
--- a/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
+++ b/fastlane/lib/fastlane/actions/create_app_on_managed_play_store.rb
@@ -57,7 +57,7 @@ module Fastlane
                                        short_option: "-j",
                                        conflicting_options: [:json_key_data],
                                        optional: true, # optional until it is possible specify either json_key OR json_key_data are required
-                                       description: "The path to a file containing service account JSON, used to authenticate with Google",
+                                       description: "The path to a Google credentials JSON file (Application Default, Workload Identity, or Service Account), used to authenticate with Google",
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
                                        default_value_dynamic: true,
@@ -70,7 +70,7 @@ module Fastlane
                                        short_option: "-c",
                                        conflicting_options: [:json_key],
                                        optional: true,
-                                       description: "The raw service account JSON data used to authenticate with Google",
+                                       description: "The raw content of a Google credentials JSON file (Application Default, Workload Identity, or Service Account) used to authenticate with Google",
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
                                        default_value_dynamic: true,

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -78,7 +78,7 @@ module Fastlane
                                        short_option: "-j",
                                        conflicting_options: [:json_key_data],
                                        optional: true, # optional until it is possible specify either json_key OR json_key_data are required
-                                       description: "The path to a Google credentials JSON file (Application Default, Workload Identity, or Service Account) used to authenticate with Google",
+                                       description: "The path to a file containing service account JSON, used to authenticate with Google",
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
                                        default_value_dynamic: true,
@@ -91,7 +91,7 @@ module Fastlane
                                        short_option: "-c",
                                        conflicting_options: [:json_key],
                                        optional: true,
-                                       description: "The raw content of a Google credentials JSON file (Application Default, Workload Identity, or Service Account) used to authenticate with Google",
+                                       description: "The raw service account JSON data used to authenticate with Google",
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
                                        default_value_dynamic: true,

--- a/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
+++ b/fastlane/lib/fastlane/actions/get_managed_play_store_publishing_rights.rb
@@ -78,7 +78,7 @@ module Fastlane
                                        short_option: "-j",
                                        conflicting_options: [:json_key_data],
                                        optional: true, # optional until it is possible specify either json_key OR json_key_data are required
-                                       description: "The path to a file containing service account JSON, used to authenticate with Google",
+                                       description: "The path to a Google credentials JSON file (Application Default, Workload Identity, or Service Account) used to authenticate with Google",
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
                                        default_value_dynamic: true,
@@ -91,7 +91,7 @@ module Fastlane
                                        short_option: "-c",
                                        conflicting_options: [:json_key],
                                        optional: true,
-                                       description: "The raw service account JSON data used to authenticate with Google",
+                                       description: "The raw content of a Google credentials JSON file (Application Default, Workload Identity, or Service Account) used to authenticate with Google",
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
                                        default_value_dynamic: true,

--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -21,7 +21,7 @@ module Fastlane
       end
 
       def self.description
-        "Validate a Google credentials JSON file used to authenticate with the Google Play Store"
+        "Validate Google credentials JSON for the Google Play Store"
       end
 
       def self.authors

--- a/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
+++ b/fastlane/lib/fastlane/actions/validate_play_store_json_key.rb
@@ -21,7 +21,7 @@ module Fastlane
       end
 
       def self.description
-        "Validate that the Google Play Store `json_key` works"
+        "Validate a Google credentials JSON file used to authenticate with the Google Play Store"
       end
 
       def self.authors
@@ -29,7 +29,7 @@ module Fastlane
       end
 
       def self.details
-        "Use this action to test and validate your private key json key file used to connect and authenticate with the Google Play API"
+        "Use this action to test and validate your Google credentials JSON file (of type authorized_user, external_account, service_account) used to connect and authenticate with the Google Play API"
       end
 
       def self.example_code
@@ -47,7 +47,7 @@ module Fastlane
                                        short_option: "-j",
                                        conflicting_options: [:json_key_data],
                                        optional: true,
-                                       description: "The path to a file containing service account JSON, used to authenticate with Google",
+                                       description: "The path to a Google credentials JSON file (Application Default, Workload Identity, or Service Account), used to authenticate with Google",
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
                                        default_value_dynamic: true,
@@ -60,7 +60,7 @@ module Fastlane
                                        short_option: "-c",
                                        conflicting_options: [:json_key],
                                        optional: true,
-                                       description: "The raw service account JSON data used to authenticate with Google",
+                                       description: "The raw content of a Google credentials JSON file (Application Default, Workload Identity, or Service Account), used to authenticate with Google",
                                        code_gen_sensitive: true,
                                        default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
                                        default_value_dynamic: true,

--- a/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
+++ b/fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb
@@ -7,6 +7,7 @@ describe Fastlane do
 
       describe "without :json_key or :json_key_data" do
         it "without :json_key or :json_key_data - could not find file" do
+          allow(Google::Auth).to receive(:get_application_default).and_raise(RuntimeError, "Your credentials were not found.")
           expect(UI).to receive(:interactive?).and_return(true)
           expect(UI).to receive(:important).with("To not be asked about this value, you can specify it using 'json_key'")
           expect(UI).to receive(:input).with(anything).and_return("not_a_file")
@@ -18,12 +19,13 @@ describe Fastlane do
         end
 
         it "without :json_key or :json_key_data - crashes in a not an interactive place" do
+          allow(Google::Auth).to receive(:get_application_default).and_raise(RuntimeError, "Your credentials were not found.")
           expect(UI).to receive(:interactive?).and_return(false)
           expect do
             Fastlane::FastFile.new.parse("lane :test do
               create_app_on_managed_play_store()
             end").runner.execute(:test)
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not load Google authentication. Make sure it has been added as an environment variable in 'json_key' or 'json_key_data'")
+          end.to raise_error(FastlaneCore::Interface::FastlaneError, /Could not load Google credentials.*GOOGLE_APPLICATION_CREDENTIALS/m)
         end
       end
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -57,6 +57,8 @@ module Supply
 
       # use correct credential class based on type
       case google_credentials['type']
+      when "authorized_user"
+        auth_client = Google::Auth::UserRefreshCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
       when "external_account"
         auth_client = Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
       when "service_account"

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -121,6 +121,11 @@ module Supply
 
       if error
         message = error["error"] && error["error"]["message"]
+        details = error["error"] && error["error"]["details"]
+        if details&.any? { |d| d["reason"] == "ACCESS_TOKEN_SCOPE_INSUFFICIENT" }
+          UI.important("Your credentials are missing the required scope. If using Application Default Credentials, re-run:")
+          UI.important("  gcloud auth application-default login --scopes=openid,email,https://www.googleapis.com/auth/androidpublisher")
+        end
       else
         message = e.body
       end

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -16,55 +16,68 @@ module Supply
     def self.make_from_config(params: nil)
       params ||= Supply.config
       service_account_data = self.service_account_authentication(params: params)
-      return self.new(service_account_json: service_account_data, params: params)
+
+      if service_account_data
+        return self.new(service_account_json: service_account_data, params: params)
+      end
+
+      # No explicit credentials — try Application Default Credentials discovery
+      # (GOOGLE_APPLICATION_CREDENTIALS env var, ~/.config/gcloud/application_default_credentials.json, or GCE metadata)
+      UI.verbose("No json_key provided, attempting Application Default Credentials...")
+      begin
+        auth_client = Google::Auth.get_application_default(self::SCOPE)
+        return self.new(auth_client: auth_client, params: params)
+      rescue RuntimeError => e
+        UI.verbose("Application Default Credentials not available: #{e.message}")
+      end
+
+      if UI.interactive?
+        UI.important("To not be asked about this value, you can specify it using 'json_key'")
+        json_key_path = UI.input("The service account json file used to authenticate with Google: ")
+        json_key_path = File.expand_path(json_key_path)
+        UI.user_error!("Could not find service account json file at path '#{json_key_path}'") unless File.exist?(json_key_path)
+        params[:json_key] = json_key_path
+        return self.new(service_account_json: File.open(json_key_path), params: params)
+      else
+        UI.user_error!("Could not load Google credentials. Provide 'json_key'/'json_key_data', set GOOGLE_APPLICATION_CREDENTIALS, or run: gcloud auth application-default login --scopes=openid,email,https://www.googleapis.com/auth/androidpublisher")
+      end
     end
 
     # Supply authentication file
+    # Returns an IO object for the credentials file, or nil if no explicit credentials were provided.
     def self.service_account_authentication(params: nil)
-      unless params[:json_key] || params[:json_key_data]
-        if UI.interactive?
-          UI.important("To not be asked about this value, you can specify it using 'json_key'")
-          json_key_path = UI.input("The service account json file used to authenticate with Google: ")
-          json_key_path = File.expand_path(json_key_path)
-
-          UI.user_error!("Could not find service account json file at path '#{json_key_path}'") unless File.exist?(json_key_path)
-          params[:json_key] = json_key_path
-        else
-          UI.user_error!("Could not load Google authentication. Make sure it has been added as an environment variable in 'json_key' or 'json_key_data'")
-        end
-      end
-
       if params[:json_key]
-        service_account_json = File.open(File.expand_path(params[:json_key]))
+        File.open(File.expand_path(params[:json_key]))
       elsif params[:json_key_data]
-        service_account_json = StringIO.new(params[:json_key_data])
+        StringIO.new(params[:json_key_data])
       end
-
-      service_account_json
     end
 
     # Initializes the service and its auth_client using the specified information
     # @param service_account_json: The raw service account Json data
-    def initialize(service_account_json: nil, params: nil)
-      # decode the json and check its type
-      begin
-        json_content = service_account_json.read
-        google_credentials = JSON.parse(json_content)
-        service_account_json.rewind
-      rescue JSON::ParserError
-        UI.user_error!("Invalid Google Credentials file provided - unable to parse json.")
-      end
+    # @param auth_client: A pre-built auth client (e.g. from Application Default Credentials discovery)
+    def initialize(service_account_json: nil, auth_client: nil, params: nil)
+      if auth_client.nil?
+        # decode the json and check its type
+        begin
+          json_content = service_account_json.read
+          google_credentials = JSON.parse(json_content)
+          service_account_json.rewind
+        rescue JSON::ParserError
+          UI.user_error!("Invalid Google Credentials file provided - unable to parse json.")
+        end
 
-      # use correct credential class based on type
-      case google_credentials['type']
-      when "authorized_user"
-        auth_client = Google::Auth::UserRefreshCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
-      when "external_account"
-        auth_client = Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
-      when "service_account"
-        auth_client = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
-      else
-        UI.user_error!("Invalid Google Credentials file provided - no credential type found.")
+        # use correct credential class based on type
+        case google_credentials['type']
+        when "authorized_user"
+          auth_client = Google::Auth::UserRefreshCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
+        when "external_account"
+          auth_client = Google::Auth::ExternalAccount::Credentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
+        when "service_account"
+          auth_client = Google::Auth::ServiceAccountCredentials.make_creds(json_key_io: service_account_json, scope: self.class::SCOPE)
+        else
+          UI.user_error!("Invalid Google Credentials file provided - no credential type found.")
+        end
       end
 
       UI.verbose("Fetching a new access token from Google...")
@@ -150,7 +163,7 @@ module Supply
         service_account_json = StringIO.new(JSON.dump(cred_json))
         service_account_json
       else
-        UI.user_error!("No authentication parameters were specified. These must be provided in order to authenticate with Google")
+        nil
       end
     end
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -152,7 +152,7 @@ module Supply
     def self.service_account_authentication(params: nil)
       if params[:json_key] || params[:json_key_data]
         super(params: params)
-      elsif params[:key] && params[:issuer]
+      elsif params.respond_to?(:all_keys) && params.all_keys.include?(:key) && params[:key] && params[:issuer]
         require 'google/api_client/auth/key_utils'
         UI.important("This type of authentication is deprecated. Please consider using JSON authentication instead")
         key = Google::APIClient::KeyUtils.load_from_pkcs12(File.expand_path(params[:key]), 'notasecret')

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -162,8 +162,6 @@ module Supply
         }
         service_account_json = StringIO.new(JSON.dump(cred_json))
         service_account_json
-      else
-        nil
       end
     end
 

--- a/supply/lib/supply/options.rb
+++ b/supply/lib/supply/options.rb
@@ -94,7 +94,7 @@ module Supply
                                      short_option: "-j",
                                      conflicting_options: [:issuer, :key, :json_key_data],
                                      optional: true, # this shouldn't be optional but is until --key and --issuer are completely removed
-                                     description: "The path to a file containing service account JSON, used to authenticate with Google",
+                                     description: "The path to a Google credentials JSON file (Application Default, Workload Identity, or Service Account), used to authenticate with Google",
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_file),
                                      default_value_dynamic: true,
@@ -107,7 +107,7 @@ module Supply
                                      short_option: "-c",
                                      conflicting_options: [:issuer, :key, :json_key],
                                      optional: true,
-                                     description: "The raw service account JSON data used to authenticate with Google",
+                                     description: "The raw content of a Google credentials JSON file (Application Default, Workload Identity, or Service Account), used to authenticate with Google",
                                      code_gen_sensitive: true,
                                      default_value: CredentialsManager::AppfileConfig.try_fetch_value(:json_key_data_raw),
                                      default_value_dynamic: true,

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -2,6 +2,7 @@ describe Supply do
   describe Supply::Client do
     let(:service_account_file) { File.read(fixture_file("sample-service-account.json")) }
     let(:external_account_file) { File.read(fixture_file("sample-external-account.json")) }
+    let(:authorized_user_file) { File.read(fixture_file("sample-authorized-user.json")) }
     before do
       stub_request(:post, "https://www.googleapis.com/oauth2/v4/token").
         to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
@@ -30,6 +31,21 @@ describe Supply do
           to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
 
         file_path = fixture_file("sample-external-account.json")
+        Supply::Client.make_from_config(params: { json_key: file_path, timeout: 1 })
+      end
+
+      it "with authorized_user credentials" do
+        stub_request(:post, "https://oauth2.googleapis.com/token").
+          to_return(status: 200, body: '{"access_token": "fake-access-token", "token_type": "Bearer", "expires_in": 3600}', headers: { 'Content-Type' => 'application/json' })
+
+        Supply::Client.new(service_account_json: StringIO.new(authorized_user_file), params: { timeout: 1 })
+      end
+
+      it "with authorized_user credentials from file" do
+        stub_request(:post, "https://oauth2.googleapis.com/token").
+          to_return(status: 200, body: '{"access_token": "fake-access-token", "token_type": "Bearer", "expires_in": 3600}', headers: { 'Content-Type' => 'application/json' })
+
+        file_path = fixture_file("sample-authorized-user.json")
         Supply::Client.make_from_config(params: { json_key: file_path, timeout: 1 })
       end
     end

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -48,6 +48,23 @@ describe Supply do
         file_path = fixture_file("sample-authorized-user.json")
         Supply::Client.make_from_config(params: { json_key: file_path, timeout: 1 })
       end
+
+      it "with Application Default Credentials when no json_key is provided" do
+        mock_auth_client = double("auth_client")
+        allow(Google::Auth).to receive(:get_application_default).with(Supply::Client::SCOPE).and_return(mock_auth_client)
+        allow(mock_auth_client).to receive(:fetch_access_token!)
+
+        Supply::Client.make_from_config(params: { timeout: 1 })
+      end
+
+      it "raises an informative error when no credentials are found" do
+        allow(Google::Auth).to receive(:get_application_default).and_raise(RuntimeError, "Your credentials were not found.")
+        allow(UI).to receive(:interactive?).and_return(false)
+
+        expect {
+          Supply::Client.make_from_config(params: { timeout: 1 })
+        }.to raise_error(FastlaneCore::Interface::FastlaneError, /json_key.*GOOGLE_APPLICATION_CREDENTIALS.*gcloud/m)
+      end
     end
 
     describe "displays error messages from the API" do

--- a/supply/spec/fixtures/sample-authorized-user.json
+++ b/supply/spec/fixtures/sample-authorized-user.json
@@ -1,0 +1,6 @@
+{
+  "type": "authorized_user",
+  "client_id": "000000000000-fake.apps.googleusercontent.com",
+  "client_secret": "fake-client-secret",
+  "refresh_token": "1//fake-refresh-token"
+}


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Original requests: #19869, #20022
Previous attempts: #20034, #27949, #29492
Partial implementation this builds on: #29796
Proposal this implements: #29970

`supply` supported `service_account` and `external_account` JSON via `json_key`/`json_key_data` (#29796), but not `authorized_user` credentials or authentication without an explicit key file. This PR implements the two flows proposed in #29970: adding `authorized_user` support and an ADC fallback when no `json_key` is provided.

### Description

**Flow 1 — `authorized_user` support via `json_key`**
Adds support for user credential files produced by `gcloud auth application-default login`. Previously this threw an error and they can now be passed directly via `--json_key` or `--json_key_data`.

**Flow 2 — ADC fallback when no `json_key` provided**
When no credentials are explicitly provided, the client now attempts to discover credentials through [Google's Application Default Credentials chain](https://docs.cloud.google.com/docs/authentication/application-default-credentials) before falling back to interactive prompting. If the chain is exhausted, an actionable error message is shown.

The ADC fallback applies to both `Supply::Client` and `PlaycustomappClient` as it lives in their shared base class.

`json_key` and `json_key_data` option descriptions updated across `supply/options.rb`, `create_app_on_managed_play_store.rb`, `get_managed_play_store_publishing_rights.rb`, and `validate_play_store_json_key.rb` to reflect the broader credential support.

### Testing Steps

```bash
bundle exec rspec supply/spec/client_spec.rb fastlane/spec/actions_specs/create_app_on_managed_play_store_spec.rb fastlane/spec/actions_specs/get_managed_play_store_publishing_rights_spec.rb --format documentation
→ 22 examples, 0 failures

bundle exec rspec
→ 7587 examples, 3 failures # all pre-existing in `plugin_generator_spec`, reproduced on `master` without this change.
```