### PR TITLE
[deliver] fix app previews always running during usage.

### DIFF
--- a/deliver/lib/deliver/detect_values.rb
+++ b/deliver/lib/deliver/detect_values.rb
@@ -58,13 +58,11 @@ module Deliver
     def find_folders(options)
       containing = Helper.fastlane_enabled? ? FastlaneCore::FastlaneFolder.path : '.'
       options[:screenshots_path] ||= File.join(containing, 'screenshots')
-      options[:app_previews_path] ||= File.join(containing, 'app-previews')
       options[:metadata_path] ||= File.join(containing, 'metadata')
     end
 
     def ensure_folders_created(options)
       FileUtils.mkdir_p(options[:screenshots_path])
-      FileUtils.mkdir_p(options[:app_previews_path])
       FileUtils.mkdir_p(options[:metadata_path])
     end
 

--- a/deliver/lib/deliver/sync_app_previews.rb
+++ b/deliver/lib/deliver/sync_app_previews.rb
@@ -14,13 +14,20 @@ module Deliver
       @app_previews_path = app_previews_path
       @frame_time_code = preview_frame_time_code
       @overwrite = overwrite_preview_videos
+
+      validate_path!
     end
 
     def sync_from_path
       UI.important("Uploading App Preview videos...")
-      validate_path!
 
-      localizations = editable_version.get_app_store_version_localizations
+      version = editable_version
+      if version.nil?
+        UI.important("Could not find an editable App Store version for platform #{@platform}. Skipping App Preview upload.")
+        return
+      end
+
+      localizations = version.get_app_store_version_localizations
       locale_by_code = localizations.each_with_object({}) { |l, h| h[l.locale] = l }
 
       video_previews_per_locale = discover_videos(@app_previews_path)

--- a/deliver/lib/deliver/sync_app_previews.rb
+++ b/deliver/lib/deliver/sync_app_previews.rb
@@ -14,20 +14,13 @@ module Deliver
       @app_previews_path = app_previews_path
       @frame_time_code = preview_frame_time_code
       @overwrite = overwrite_preview_videos
-
-      validate_path!
     end
 
     def sync_from_path
       UI.important("Uploading App Preview videos...")
+      validate_path!
 
-      version = editable_version
-      if version.nil?
-        UI.important("Could not find an editable App Store version for platform #{@platform}. Skipping App Preview upload.")
-        return
-      end
-
-      localizations = version.get_app_store_version_localizations
+      localizations = editable_version.get_app_store_version_localizations
       locale_by_code = localizations.each_with_object({}) { |l, h| h[l.locale] = l }
 
       video_previews_per_locale = discover_videos(@app_previews_path)

--- a/deliver/spec/detect_values_spec.rb
+++ b/deliver/spec/detect_values_spec.rb
@@ -11,40 +11,46 @@ describe Deliver::DetectValues do
         before do
           allow(FastlaneCore::Helper).to receive(:fastlane_enabled?).and_return(true)
           allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return('./fastlane')
-
-          value_detector.find_folders(options)
         end
 
         it 'sets up screenshots folder in fastlane folder' do
+          value_detector.find_folders(options)
           expect(options[:screenshots_path]).to eq('./fastlane/screenshots')
         end
 
         it 'sets up metadata folder in fastlane folder' do
+          value_detector.find_folders(options)
           expect(options[:metadata_path]).to eq('./fastlane/metadata')
         end
 
-        it 'sets up app previews folder in fastlane folder' do
-          expect(options[:app_previews_path]).to eq('./fastlane/app-previews')
+        it 'does not automatically set up app previews folder in fastlane folder even if it exists' do
+          FileUtils.mkdir_p('./fastlane/app-previews')
+          value_detector.find_folders(options)
+          expect(options[:app_previews_path]).to be_nil
+          FileUtils.rm_rf('./fastlane/app-previews')
         end
       end
 
       describe 'running without fastlane' do
         before do
           allow(FastlaneCore::Helper).to receive(:fastlane_enabled?).and_return(false)
-
-          value_detector.find_folders(options)
         end
 
         it 'sets up screenshots folder in current folder' do
+          value_detector.find_folders(options)
           expect(options[:screenshots_path]).to eq('./screenshots')
         end
 
         it 'sets up metadata folder in current folder' do
+          value_detector.find_folders(options)
           expect(options[:metadata_path]).to eq('./metadata')
         end
 
-        it 'sets up app previews folder in current folder' do
-          expect(options[:app_previews_path]).to eq('./app-previews')
+        it 'does not automatically set up app previews folder in current folder even if it exists' do
+          FileUtils.mkdir_p('./app-previews')
+          value_detector.find_folders(options)
+          expect(options[:app_previews_path]).to be_nil
+          FileUtils.rm_rf('./app-previews')
         end
       end
     end

--- a/deliver/spec/detect_values_spec.rb
+++ b/deliver/spec/detect_values_spec.rb
@@ -1,7 +1,14 @@
 require 'deliver/detect_values'
+require 'fileutils'
+require 'tmpdir'
 
 describe Deliver::DetectValues do
   let(:value_detector) { Deliver::DetectValues.new }
+  let(:tmpdir) { Dir.mktmpdir }
+
+  after do
+    FileUtils.remove_entry_secure(tmpdir)
+  end
 
   describe :find_folders do
     describe 'when folders are not specified in options' do
@@ -10,30 +17,36 @@ describe Deliver::DetectValues do
       describe 'running with fastlane' do
         before do
           allow(FastlaneCore::Helper).to receive(:fastlane_enabled?).and_return(true)
-          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return('./fastlane')
+          allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(File.join(tmpdir, 'fastlane'))
         end
 
         it 'sets up screenshots folder in fastlane folder' do
           value_detector.find_folders(options)
-          expect(options[:screenshots_path]).to eq('./fastlane/screenshots')
+          expect(options[:screenshots_path]).to eq(File.join(tmpdir, 'fastlane', 'screenshots'))
         end
 
         it 'sets up metadata folder in fastlane folder' do
           value_detector.find_folders(options)
-          expect(options[:metadata_path]).to eq('./fastlane/metadata')
+          expect(options[:metadata_path]).to eq(File.join(tmpdir, 'fastlane', 'metadata'))
         end
 
         it 'does not automatically set up app previews folder in fastlane folder even if it exists' do
-          FileUtils.mkdir_p('./fastlane/app-previews')
+          path = File.join(tmpdir, 'fastlane', 'app-previews')
+          FileUtils.mkdir_p(path)
           value_detector.find_folders(options)
           expect(options[:app_previews_path]).to be_nil
-          FileUtils.rm_rf('./fastlane/app-previews')
         end
       end
 
       describe 'running without fastlane' do
         before do
           allow(FastlaneCore::Helper).to receive(:fastlane_enabled?).and_return(false)
+          @old_cwd = Dir.pwd
+          Dir.chdir(tmpdir)
+        end
+
+        after do
+          Dir.chdir(@old_cwd)
         end
 
         it 'sets up screenshots folder in current folder' do
@@ -50,7 +63,6 @@ describe Deliver::DetectValues do
           FileUtils.mkdir_p('./app-previews')
           value_detector.find_folders(options)
           expect(options[:app_previews_path]).to be_nil
-          FileUtils.rm_rf('./app-previews')
         end
       end
     end


### PR DESCRIPTION
### Problem

App Previews is gated by the config parameter `app_previews_path`, which was silently populated like it was an output directory. So the logic always ran. Which would normally just "no-op" since no videos, but it first captures version number. If the IPA is purely internal and no public facing versions - it crashes.

### Solution
Gate App Previews only be the existence of the parameter. This make using App Previews "opt in".

fixes: #29983 