### PR TITLE
[supply] add google play endpoint for track meta

### DIFF
--- a/fastlane/lib/fastlane/actions/google_play_track_meta.rb
+++ b/fastlane/lib/fastlane/actions/google_play_track_meta.rb
@@ -1,0 +1,73 @@
+module Fastlane
+  module Actions
+    class GooglePlayTrackMetaAction < Action
+      OPTIONS = [
+        :package_name,
+        :track,
+        :key,
+        :issuer,
+        :json_key,
+        :json_key_data,
+        :root_url,
+        :timeout
+      ]
+
+      def self.run(params)
+        require 'supply'
+        require 'supply/options'
+        require 'supply/reader'
+
+        Supply.config = params
+
+        Supply::Reader.new.track_meta
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Retrieves track metadata for a Google Play track"
+      end
+
+      def self.details
+        "More information: [https://docs.fastlane.tools/actions/supply/](https://docs.fastlane.tools/actions/supply/)"
+      end
+
+      def self.available_options
+        require 'supply'
+        require 'supply/options'
+
+        Supply::Options.available_options.select do |option|
+          OPTIONS.include?(option.key)
+        end
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        "A Track object containing the track name and releases for the given Google Play track (see https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks)"
+      end
+
+      def self.authors
+        ["tshedor"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+
+      def self.example_code
+        [
+          'google_play_track_meta',
+          'google_play_track_meta(track: "beta")'
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/google_play_track_meta_spec.rb
+++ b/fastlane/spec/actions_specs/google_play_track_meta_spec.rb
@@ -1,0 +1,23 @@
+describe Fastlane do
+  describe Fastlane::Actions::GooglePlayTrackMetaAction do
+    let(:reader) { instance_double(Supply::Reader) }
+    let(:track) { AndroidPublisher::Track.new(track: "beta", releases: []) }
+    let(:json_key_path) { File.expand_path("./fastlane/spec/fixtures/google_play/google_play.json") }
+
+    it "configures Supply and returns track metadata from the reader" do
+      expect(Supply::Reader).to receive(:new).and_return(reader)
+      expect(reader).to receive(:track_meta).and_return(track)
+
+      result = described_class.run(
+        package_name: "com.example.app",
+        track: "beta",
+        json_key: json_key_path
+      )
+
+      expect(result).to be(track)
+      expect(Supply.config[:package_name]).to eq("com.example.app")
+      expect(Supply.config[:track]).to eq("beta")
+      expect(Supply.config[:json_key]).to eq(json_key_path)
+    end
+  end
+end

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -41,6 +41,7 @@ describe Fastlane do
           plugin_scores
           google_play_track_version_codes
           google_play_track_release_names
+          google_play_track_meta
           modify_services
           build_app
           build_android_app

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -488,6 +488,22 @@ module Supply
       end
     end
 
+    def get_track_meta(track)
+      ensure_active_edit!
+
+      begin
+        result = client.get_edit_track(
+          current_package_name,
+          current_edit.id,
+          track
+        )
+        return result
+      rescue Google::Apis::ClientError => e
+        return nil if e.status_code == 404 && track_empty_or_missing_message?(e)
+        raise
+      end
+    end
+
     # Get list of version codes for track
     def track_version_codes(track)
       ensure_active_edit!
@@ -654,6 +670,11 @@ module Supply
     end
 
     private
+
+    def track_empty_or_missing_message?(error)
+      combined = "#{error}#{error.body}"
+      combined.include?("trackEmpty") || combined.include?("Track not found")
+    end
 
     def ensure_active_edit!
       UI.user_error!("You need to have an active edit, make sure to call `begin_edit`") unless @current_edit

--- a/supply/lib/supply/reader.rb
+++ b/supply/lib/supply/reader.rb
@@ -16,6 +16,22 @@ module Supply
       version_codes
     end
 
+    def track_meta
+      track = Supply.config[:track]
+
+      client.begin_edit(package_name: Supply.config[:package_name])
+      meta = client.get_track_meta(track)
+      client.abort_current_edit
+
+      if meta.nil?
+        UI.important("No metadata found for track '#{track}'")
+      else
+        UI.success("Retrieved metadata for track '#{track}'")
+      end
+
+      meta
+    end
+
     def track_release_names
       track = Supply.config[:track]
 

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -123,5 +123,71 @@ describe Supply do
         expect(subject.class.method_defined?(:uploadbundle_internalappsharingartifact)).to eq(true)
       end
     end
+
+    describe "#get_track_meta" do
+      let(:service_account_file) { File.read(fixture_file("sample-service-account.json")) }
+
+      before do
+        stub_request(:post, "https://www.googleapis.com/oauth2/v4/token").
+          to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+        stub_request(:post, "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/pkg-meta/edits").
+          to_return(status: 200, body: '{"id":"edit-meta-1"}', headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it "returns a Track from the Android Publisher API" do
+        stub_request(:get, "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/pkg-meta/edits/edit-meta-1/tracks/production").
+          to_return(
+            status: 200,
+            body: '{"track":"production","releases":[{"name":"1.0.0","versionCodes":["42"],"status":"completed"}]}',
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        client = Supply::Client.new(service_account_json: StringIO.new(service_account_file), params: { timeout: 1 })
+        client.begin_edit(package_name: "pkg-meta")
+        result = client.get_track_meta("production")
+
+        expect(result).to be_a(AndroidPublisher::Track)
+        expect(result.track).to eq("production")
+        expect(result.releases.length).to eq(1)
+        expect(result.releases.first.version_codes).to eq(["42"])
+      end
+
+      it "returns nil when the track is empty (trackEmpty)" do
+        stub_request(:get, "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/pkg-meta/edits/edit-meta-1/tracks/internal").
+          to_return(
+            status: 404,
+            body: {
+              error: {
+                code: 404,
+                message: "track empty",
+                details: [{ "@type" => "type.googleapis.com/google.rpc.ErrorInfo", "reason" => "trackEmpty" }]
+              }
+            }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+
+        client = Supply::Client.new(service_account_json: StringIO.new(service_account_file), params: { timeout: 1 })
+        client.begin_edit(package_name: "pkg-meta")
+        expect(client.get_track_meta("internal")).to be_nil
+      end
+
+      it "returns nil when the track is not found" do
+        stub_request(:get, "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/pkg-meta/edits/edit-meta-1/tracks/unknown-track").
+          to_return(status: 404, body: '{"error":{"message":"Track not found"}}', headers: { 'Content-Type' => 'application/json' })
+
+        client = Supply::Client.new(service_account_json: StringIO.new(service_account_file), params: { timeout: 1 })
+        client.begin_edit(package_name: "pkg-meta")
+        expect(client.get_track_meta("unknown-track")).to be_nil
+      end
+
+      it "re-raises on other client errors" do
+        stub_request(:get, "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/pkg-meta/edits/edit-meta-1/tracks/production").
+          to_return(status: 403, body: '{"error":{"message":"forbidden"}}', headers: { 'Content-Type' => 'application/json' })
+
+        client = Supply::Client.new(service_account_json: StringIO.new(service_account_file), params: { timeout: 1 })
+        client.begin_edit(package_name: "pkg-meta")
+        expect { client.get_track_meta("production") }.to raise_error(Google::Apis::ClientError)
+      end
+    end
   end
 end

--- a/supply/spec/reader_spec.rb
+++ b/supply/spec/reader_spec.rb
@@ -1,0 +1,33 @@
+require 'supply'
+require 'supply/reader'
+
+describe Supply do
+  describe Supply::Reader do
+    describe "#track_meta" do
+      let(:reader) { described_class.new }
+      let(:client) { instance_double(Supply::Client) }
+      let(:track) { AndroidPublisher::Track.new(track: "production", releases: []) }
+
+      before do
+        allow(reader).to receive(:client).and_return(client)
+        Supply.config = { package_name: "com.example.app", track: "production" }
+      end
+
+      it "opens an edit, fetches track metadata, aborts the edit, and returns the track" do
+        expect(client).to receive(:begin_edit).with(package_name: "com.example.app").ordered
+        expect(client).to receive(:get_track_meta).with("production").and_return(track).ordered
+        expect(client).to receive(:abort_current_edit).ordered
+
+        expect(reader.track_meta).to be(track)
+      end
+
+      it "returns nil when the API reports an empty or missing track" do
+        expect(client).to receive(:begin_edit).with(package_name: "com.example.app")
+        expect(client).to receive(:get_track_meta).with("production").and_return(nil)
+        expect(client).to receive(:abort_current_edit)
+
+        expect(reader.track_meta).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Publishing is not permitted to Google Play if the track is in a "draft" state. This PR allows implementations to check the track's viability before uploading - or even building - an app.

### Description

Callers can access low-level track information by assigning the result of the action and navigating through it - `result.releases.any? { |r| r.status == 'draft' }`. The result maps 1:1 to [Google Play's documentation ](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks)

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->