### PR TITLE
[match] strip nbsp; from return of phone 2fa

### DIFF
--- a/spaceship/lib/spaceship/two_step_or_factor_client.rb
+++ b/spaceship/lib/spaceship/two_step_or_factor_client.rb
@@ -264,7 +264,8 @@ If it is, please open an issue at https://github.com/fastlane/fastlane/issues/ne
     end
 
     def match_phone_to_masked_phone(phone_number, masked_number)
-      characters_to_remove_from_phone_numbers = ' \-()"'
+      # Apple's response sometimes contains NBSP instead of a plain space.
+      characters_to_remove_from_phone_numbers = "  \\-()\""
 
       # start with e.g. +49 162 1234585 or +1-123-456-7866
       phone_number = phone_number.tr(characters_to_remove_from_phone_numbers, '')

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -35,7 +35,8 @@ describe Spaceship::Client do
         { "id" : 3, "numberWithDialCode" : "+1 (•••) •••-••66", "obfuscatedNumber" : "(•••) •••-••66", "pushMode" : "sms" },
         { "id" : 4, "numberWithDialCode" : "+39 ••• ••• ••71", "obfuscatedNumber" : "••• ••• ••71", "pushMode" : "sms" },
         { "id" : 5, "numberWithDialCode" : "+353 •• ••• ••43", "obfuscatedNumber" : "••• ••• •43", "pushMode" : "sms" },
-        { "id" : 6, "numberWithDialCode" : "+375 • ••• •••-••-59", "obfuscatedNumber" : "• ••• •••-••-59", "pushMode" : "sms" }
+        { "id" : 6, "numberWithDialCode" : "+375 • ••• •••-••-59", "obfuscatedNumber" : "• ••• •••-••-59", "pushMode" : "sms" },
+        { "id" : 7, "numberWithDialCode" : "+49\u00A0•••••••••11", "obfuscatedNumber" : "•••••••••11", "pushMode" : "sms" }
       ]
     '
   end
@@ -48,7 +49,8 @@ describe Spaceship::Client do
       "+1-123-456-7866" => 3,
       "+39 123 456 7871" => 4,
       "+353123456743" => 5,
-      "+375 00 000-00-59" => 6
+      "+375 00 000-00-59" => 6,
+      "+4900000000011" => 7
     }.each do |number_to_test, expected_phone_id|
       it "selects correct phone id #{expected_phone_id} for provided phone number #{number_to_test}" do
         phone_id = subject.phone_id_from_number(phone_numbers, number_to_test)


### PR DESCRIPTION
## Problem

Apple's return sometimes has a nbsp; in place of a plain space, so our regex fails.

## Solution

Its tough to see in GitHub review, but now we check for a space or nbsp. We could probably enhance this in future to a `gsub` with a more robust regex, but this will do for now.

fixes: #30001 
fixes (?): #21721