### PR TITLE
[robocop] suppress suggestions for new extensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.7
+  SuggestExtensions: false
   NewCops: enable
   Include:
     - '**/*.rb'


### PR DESCRIPTION
## Problem

Its annoying getting test output and having 4-15 lines about suggested extensions.

## Solution

Ignore the suggestions. Now output is clean :)

```
➜  fastlane git:(suggest-rubocop) bundle exec rubocop -a
Inspecting 1313 files
.................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

1313 files inspected, no offenses detected
```