### PR TITLE
[increment_version_number] support MARKETING_VERSION resolving.

### DIFF
--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -29,6 +29,11 @@ module Fastlane
                             .split("\n")
                             .last
                             .strip
+
+          if current_version =~ /\$\(([\w\-]+)\)/ || current_version =~ /\$\{([\w\-]+)\}/
+            UI.verbose("agvtool returned $(MARKETING_VERSION), resolving it...")
+            current_version = GetVersionNumberAction.run(xcodeproj: params[:xcodeproj])
+          end
         rescue
           current_version = ''
         end

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -108,6 +108,44 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to end_with("&& agvtool new-marketing-version 1.77.3")
       end
 
+      it "resolves $(MARKETING_VERSION) using get_version_number action" do
+        from_version = "$(MARKETING_VERSION)"
+        resolved_version = "1.2.3"
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return(from_version)
+
+        expect(Fastlane::Actions::GetVersionNumberAction).to receive(:run)
+          .with(xcodeproj: nil)
+          .and_return(resolved_version)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_number
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.2.4/)
+      end
+
+      it "resolves ${MARKETING_VERSION} using get_version_number action" do
+        from_version = "${MARKETING_VERSION}"
+        resolved_version = "1.2.3"
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return(from_version)
+
+        expect(Fastlane::Actions::GetVersionNumberAction).to receive(:run)
+          .with(xcodeproj: nil)
+          .and_return(resolved_version)
+
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_number
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.2.4/)
+      end
+
       it "returns the new version as return value" do
         expect(Fastlane::Actions).to receive(:sh)
           .with(/agvtool what-marketing-version/, any_args)


### PR DESCRIPTION
## Problem

```
[07:04:32]: Called from Fastfile at line 22
[07:04:32]: ```
[07:04:32]:     20:       lane :bump do
[07:04:32]:     21:         skip_docs
[07:04:32]:  => 22:         increment_version_number
[07:04:32]:     23:       end
[07:04:32]:     24:     end
[07:04:32]: ```
[07:04:32]: Your current version ($(MARKETING_VERSION)) does not respect the format A or A.B or A.B.C
```

This is because plist is

```
	<key>CFBundleShortVersionString</key>
	<string>$(MARKETING_VERSION)</string>
```

## Solution

If we detect `MARKETING_VERSION` we call out to `GetVersionNumberAction` which reads the `.xcodeproj` in order to find it. Then we continue as-is to replace the value in the `info.plist`. Perfect for CI pipelines.

fixes: #20132 