### PR TITLE
[match] Fix match nuke deletion for provisioning profiles with wildcard filenames

### DIFF
--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -141,7 +141,7 @@ module Match
 
       def delete_files(files_to_delete: [], custom_message: nil)
         if files_to_delete.count > 0
-          commands = files_to_delete.map { |filename|  "git rm #{filename.shellescape}" }
+          commands = files_to_delete.map { |filename|  "git --literal-pathspecs rm -- #{filename.shellescape}" }
           git_push(commands: commands, commit_message: custom_message)
         end
       end

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -172,6 +172,29 @@ describe Match do
       end
     end
 
+    describe "#delete_files" do
+      it "uses literal pathspecs when removing files from git" do
+        storage = Match::Storage::GitStorage.new(
+          type: "development",
+          platform: "ios",
+          branch: git_branch
+        )
+
+        profile_with_wildcard = File.join(@path, "profiles", "development", "Development_com.example.WebDriverAgent.*.mobileprovision")
+        matched_profile = File.join(@path, "profiles", "development", "Development_com.example.WebDriverAgent.xctrunner.mobileprovision")
+
+        expected_commit_commands = [
+          "git --literal-pathspecs rm -- #{profile_with_wildcard.shellescape}",
+          "git --literal-pathspecs rm -- #{matched_profile.shellescape}",
+          "git commit -m " + '[fastlane] Updated development and platform ios'.shellescape,
+          "git push origin #{git_branch}"
+        ]
+        expect_command_execution(expected_commit_commands)
+
+        storage.delete_files(files_to_delete: [profile_with_wildcard, matched_profile])
+      end
+    end
+
     describe "#authentication" do
       describe "when using a private key file" do
         it "wraps the git command in ssh-agent shell" do


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #30002

`match nuke` can fail when deleting provisioning profiles from git-backed storage if a profile filename contains a literal wildcard character, such as `*`.

Although fastlane shell-escapes the filename before calling `git rm`, Git still interprets the argument as a pathspec. This can cause a wildcard profile filename to match neighboring profile files, so a later deletion command fails with `pathspec ... did not match any files`.

### Description

This updates `Match::Storage::GitStorage#delete_files` to remove files with:

```bash
git --literal-pathspecs rm -- <path>
```

Using Git's literal pathspec mode makes wildcard characters in provisioning profile filenames behave literally while preserving the existing shell escaping.

A regression spec was added for git-backed storage deletion with both a literal wildcard provisioning profile filename and a neighboring filename that would previously be matched by that wildcard.

### Testing Steps

Targeted tests:

```bash
rbenv exec bundle exec rspec match/spec/nuke_spec.rb match/spec/storage/git_storage_spec.rb
```

Result:

```text
13 examples, 0 failures
```

Style check:

```bash
RUBOCOP_CACHE_ROOT=/private/tmp/fastlane-rubocop-cache rbenv exec bundle exec rubocop -a
```

Result:

```text
1313 files inspected, no offenses detected
```

I also validated the behavior with a temporary local bare git remote containing wildcard and neighboring provisioning profile filenames. The patched deletion flow removed all files successfully, while reproducing the old `git rm <escaped path>` behavior failed on the second matched profile, matching the reported issue.
