### PR TITLE
build: remove rubocop-require_tools

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
 require:
-  - rubocop/require_tools
   - rubocop-performance
   - ./rubocop/fork_usage.rb
   - ./rubocop/missing_keys_on_shared_area.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,21 +111,6 @@ Lint/UselessAssignment:
   Exclude:
     - '**/spec/**/*'
 
-# In specs requires are done automatically
-Require/MissingRequireStatement:
-  Exclude:
-    - '**/spec/**/*.rb'
-    - '**/spec_helper.rb'
-    - 'spaceship/lib/spaceship/babosa_fix.rb'
-    - 'fastlane_core/lib/fastlane_core/ui/disable_colors.rb'
-    - '**/Fastfile'
-    - '**/*.gemspec'
-    - 'rakelib/**/*'
-    - '**/*.rake'
-    - '**/Rakefile'
-    - 'fastlane/**/*' # TODO: remove
-    - 'supply/**/*' # TODO: remove
-
 # We could potentially enable the 2 below:
 Layout/FirstHashElementIndentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,6 @@ gem "rspec_junit_formatter", "~> 0.4.1"
 gem "rubocop", Fastlane::RUBOCOP_REQUIREMENT
 # A collection of RuboCop cops for performance optimizations.
 gem "rubocop-performance"
-# A RuboCop extension focused on enforcing tools.
-gem "rubocop-require_tools"
 # Used to mock servers.
 gem "sinatra", [">= 2.2.3", "< 3.0"]
 # A library for stubbing and setting expectations on HTTP requests.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,8 +315,6 @@ GEM
     rubocop-performance (1.10.2)
       rubocop (>= 0.90.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-require_tools (0.1.2)
-      rubocop (>= 0.49.1)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -417,7 +415,6 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4.1)
   rubocop (= 1.50.2)
   rubocop-performance
-  rubocop-require_tools
   sinatra (>= 2.2.3, < 3.0)
   webmock (~> 3.18)
   xcode-install (>= 2.6.7)

--- a/Rakefile
+++ b/Rakefile
@@ -108,7 +108,7 @@ task(:prepare_rubocop_config) do
   next unless File.exist?(rubocop_config)
 
   config = YAML.safe_load(File.read(rubocop_config), aliases: true)
-  config['require'] = %w[rubocop/require_tools rubocop-performance]
+  config['require'] = %w[rubocop-performance]
   config.delete('inherit_from')
   config.delete('CrossPlatform/ForkUsage')
   config.delete('Lint/IsStringUsage')

--- a/deliver/lib/deliver/app_screenshot.rb
+++ b/deliver/lib/deliver/app_screenshot.rb
@@ -220,9 +220,7 @@ module Deliver
     end
 
     def is_messages?
-      # rubocop:disable Require/MissingRequireStatement
       return DisplayType::ALL_IMESSAGE.include?(self.display_type)
-      # rubocop:enable Require/MissingRequireStatement
     end
 
     def self.calculate_display_type(path)
@@ -247,7 +245,6 @@ module Deliver
         is_2gen = path_lower.include?("app_ipad_pro_129") ||
                   (path_lower.include?("12.9") && path_lower.include?("2nd generation")) # e.g. iPad Pro (12.9-inch) (2nd generation)
 
-        # rubocop:disable Require/MissingRequireStatement
         if is_2gen
           return is_imessage ? DisplayType::IMESSAGE_APP_IPAD_PRO_129 : DisplayType::APP_IPAD_PRO_129
         else
@@ -256,7 +253,6 @@ module Deliver
       # Apple TV vs Vision Pro conflict
       when [3840, 2160]
         return path_lower.include?("vision") ? DisplayType::APP_APPLE_VISION_PRO : DisplayType::APP_APPLE_TV
-        # rubocop:enable Require/MissingRequireStatement
       else
         matching_display_type
       end

--- a/fastlane/lib/fastlane/plugins/template/Gemfile.erb
+++ b/fastlane/lib/fastlane/plugins/template/Gemfile.erb
@@ -16,8 +16,6 @@ gem 'rspec_junit_formatter'
 gem 'rubocop', '<%= Fastlane::RUBOCOP_REQUIREMENT %>'
 # A collection of RuboCop cops for performance optimizations.
 gem 'rubocop-performance'
-# A RuboCop extension focused on enforcing tools.
-gem 'rubocop-require_tools'
 # SimpleCov is a code coverage analysis tool for Ruby.
 gem 'simplecov'
 

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -112,7 +112,6 @@ describe Fastlane::PluginGenerator do
         "gem 'rspec_junit_formatter'",
         "gem 'rubocop', '#{Fastlane::RUBOCOP_REQUIREMENT}'",
         "gem 'rubocop-performance'",
-        "gem 'rubocop-require_tools'",
         "gem 'simplecov'",
         "gemspec"
       ].each do |line|

--- a/frameit/lib/frameit/screenshot.rb
+++ b/frameit/lib/frameit/screenshot.rb
@@ -48,7 +48,6 @@ module Frameit
     # Device name for a given screen size. Used to use the correct template
     def device_name
       @device.formatted_name
-      # rubocop:enable Require/MissingRequireStatement
     end
 
     def default_color

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -88,7 +88,6 @@ module Produce
     end
 
     # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Require/MissingRequireStatement
     def update(on, options)
       updated = valid_services_for(options).count
 

--- a/spaceship/lib/spaceship/globals.rb
+++ b/spaceship/lib/spaceship/globals.rb
@@ -8,7 +8,7 @@ module Spaceship
     # otherwise fallback to $verbose
     def self.verbose?
       if Object.const_defined?("FastlaneCore")
-        return FastlaneCore::Globals.verbose? # rubocop:disable Require/MissingRequireStatement
+        return FastlaneCore::Globals.verbose?
       end
       return $verbose
     end

--- a/spaceship/lib/spaceship/portal/ui/select_team.rb
+++ b/spaceship/lib/spaceship/portal/ui/select_team.rb
@@ -31,7 +31,6 @@ module Spaceship
       #     {...}
       #   ]
 
-      # rubocop:disable Require/MissingRequireStatement
       def self.ci?
         if Object.const_defined?("FastlaneCore") && FastlaneCore.const_defined?("Helper")
           return FastlaneCore::Helper.ci?
@@ -45,7 +44,6 @@ module Spaceship
         end
         return true
       end
-      # rubocop:enable Require/MissingRequireStatement
 
       def select_team(team_id: nil, team_name: nil)
         teams = client.teams


### PR DESCRIPTION
## Problem

Codebase is getting littered with

```
# rubocop:disable Require/MissingRequireStatement
```

I tried to fix, but this is a repo pushing 9 years without work. I don't think its worth our time to keep working on custom Rubocop extensions at the present state of fastlane maintainers. I submitted a bug regardless - https://github.com/milch/rubocop-require_tools/issues/3

## Solution

Remove rubocop-require_tools from templates, core and everywhere.