### PR TITLE
[sigh] fix: prevent empty string as input to codesign on KEYCHAIN_FLAG

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -562,7 +562,7 @@ function resign {
         do
             if [[ "$assetpack" == *.assetpack ]]; then
                 rm -rf "$assetpack"/_CodeSignature
-                /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" "$assetpack"
+                /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$assetpack"
                 checkStatus
             else
                 log "Ignoring non-assetpack: $assetpack"

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -249,9 +249,9 @@ while [ "$1" != "" ]; do
     shift
 done
 
-KEYCHAIN_FLAG=
+KEYCHAIN_ARGS=()
 if [ -n "$KEYCHAIN_PATH" ]; then
-    KEYCHAIN_FLAG="--keychain $KEYCHAIN_PATH"
+    KEYCHAIN_ARGS=(--keychain "$KEYCHAIN_PATH")
 fi
 
 PAGESIZE_ARGS=()
@@ -277,7 +277,7 @@ log "Certificate: '$CERTIFICATE'"
 [[ -n "${VERSION_NUMBER}" ]] && log "Specified version number to use: '$VERSION_NUMBER'"
 [[ -n "${SHORT_VERSION}" ]] && log "Specified short version to use: '$SHORT_VERSION'"
 [[ -n "${BUNDLE_VERSION}" ]] && log "Specified bundle version to use: '$BUNDLE_VERSION'"
-[[ -n "${KEYCHAIN_FLAG}" ]] && log "Specified keychain to use: '$KEYCHAIN_PATH'"
+[[ ${#KEYCHAIN_ARGS[@]} -gt 0 ]] && log "Specified keychain to use: '$KEYCHAIN_PATH'"
 [[ -n "${PAGESIZE}" ]] && log "Specified page size: '$PAGESIZE'"
 [[ -n "${NEW_FILE}" ]] && log "Output file name: '$NEW_FILE'"
 [[ -n "${USE_APP_ENTITLEMENTS}" ]] && log "Extract app entitlements: YES"
@@ -562,7 +562,7 @@ function resign {
         do
             if [[ "$assetpack" == *.assetpack ]]; then
                 rm -rf "$assetpack"/_CodeSignature
-                /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$assetpack"
+                /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der "${KEYCHAIN_ARGS[@]}" -f -s "$CERTIFICATE" "$assetpack"
                 checkStatus
             else
                 log "Ignoring non-assetpack: $assetpack"
@@ -582,9 +582,7 @@ function resign {
         do
             if [[ "$framework" == *.framework || "$framework" == *.dylib ]]; then
                 log "Resigning '$framework'"
-                # Must not quote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
-                # shellcheck disable=SC2086
-                /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$framework"
+                /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der "${KEYCHAIN_ARGS[@]}" -f -s "$CERTIFICATE" "$framework"
                 checkStatus
             else
                 log "Ignoring non-framework: $framework"
@@ -895,9 +893,7 @@ function resign {
             log "Creating an archived-expanded-entitlements.xcent file for Xcode 9 builds or earlier"
             cp -- "$TEMP_DIR/newEntitlements" "$APP_PATH/archived-expanded-entitlements.xcent"
         fi
-        # Must not quote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces
-        # shellcheck disable=SC2086
-        /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
+        /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der "${KEYCHAIN_ARGS[@]}" -f -s "$CERTIFICATE" --entitlements "$TEMP_DIR/newEntitlements" "$APP_PATH"
         checkStatus
     fi
 


### PR DESCRIPTION
使用 fastlane sigh resign 对一个包含 OnDemandResources 目录（其中带有 .assetpack 资源包）的 .ipa 进行重签名时，签名过程会中止并报错：                      
                                               
  No such file or directory                                                                                                                                  
  Encountered an error, aborting!        
  [!] Failed to re-sign .ipa                                                                                                                                 
                                                                                                                                                             
  该问题只在未传 --keychain-path 参数（即 KEYCHAIN_FLAG 为空）时出现。                                                                                       
                                                                                                                                                             
  根因分析                                                                                                                                                   
                                      
  在 sigh/lib/assets/resign.sh 中，用于签名 .assetpack 的 codesign 调用对 ${KEYCHAIN_FLAG} 加了双引号：                                                      
                                               
  https://github.com/fastlane/fastlane/blob/master/sigh/lib/assets/resign.sh#L565                                                                            
                                         
  /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der "${KEYCHAIN_FLAG}" -f -s "$CERTIFICATE" "$assetpack"                         
                                                                                                                                                             
  当用户没有传 --keychain-path 时，KEYCHAIN_FLAG 是空字符串。由于被双引号包裹，bash 会把它展开成一个字面量空参数 '' 传给 codesign，于是 codesign             
  把这个空字符串当作要签的文件路径来处理，从而抛出 No such file or directory 错误。                                                                          
                                                                                                                                                             
  同一脚本里另外两处 codesign 调用（约第 587 行的 frameworks 签名、约第 900 行的主 app 签名）做法是正确的——${KEYCHAIN_FLAG} 不加引号，并附有明确注释：       
                                               
  # Must not quote KEYCHAIN_FLAG because it needs to be unwrapped and passed to codesign with spaces                                                         
  # shellcheck disable=SC2086                                                                                                                                
  /usr/bin/codesign ${VERBOSE} "${PAGESIZE_ARGS[@]}" --generate-entitlement-der ${KEYCHAIN_FLAG} -f -s "$CERTIFICATE" "$framework"                           
                                                                                                                                                             
  所以第 565 行看起来是一处回归 / 与文件其余部分不一致的写法。

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
