### PR TITLE
[docs] allow deletion of no longer existing docs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -458,18 +458,9 @@ lane :update_docs do |options|
     docs_path = generate_markdown_docs(target_path: ".")
     yml_path = File.expand_path("./mkdocs.yml")
     actions_md_path = File.expand_path(File.join(docs_path, "docs/generated/actions.md"))
-    action_docs = Dir[File.join(docs_path, "docs", "generated", "actions", "*")].collect do |current|
-      File.expand_path(current) # to make sure we commit the change
-    end
 
-    # Copy over the custom assets
-    custom_action_docs_path = "lib/fastlane/actions/docs/"
-    custom_assets = Dir[File.join(Fastlane::ROOT, custom_action_docs_path, "assets", "*")].collect do |current_asset_path|
-      current_output_path = File.join("docs/img/actions", File.basename(current_asset_path))
-      FileUtils.cp(current_asset_path, current_output_path)
-
-      File.expand_path(current_output_path) # to make sure we commit the change
-    end
+    action_docs_dir = File.join(docs_path, "docs/generated/actions")
+    custom_assets_dir = File.join(docs_path, "docs/img/actions")
 
     # We want to align fastlane/docs "fastlane" version with the latest released version.
     # This ensures documentation tests leverage the latest action parameters and code samples.
@@ -495,7 +486,7 @@ lane :update_docs do |options|
 
       Dir.chdir("fastlane") do # this is an assumption of fastlane, that we have to .. when shelling out
         # Commit the changes
-        changes_to_commit = [plugin_scores_cache_path, actions_md_path, "Gemfile.lock", plugins_path, yml_path] + action_docs + custom_assets
+        changes_to_commit = [plugin_scores_cache_path, actions_md_path, "Gemfile.lock", plugins_path, yml_path, action_docs_dir, custom_assets_dir]
         git_add(path: changes_to_commit)
         git_commit(path: changes_to_commit,
                 message: "Update docs for latest fastlane release #{version} (actions.md, available-plugins.md) 🚀")

--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -135,7 +135,10 @@ module Fastlane
       FileUtils.mkdir_p(target_path)
       docs_dir = File.join(target_path, "docs")
       generated_actions_dir = File.join("generated", "actions")
+      FileUtils.rm_rf(File.join(docs_dir, generated_actions_dir))
+
       FileUtils.mkdir_p(File.join(docs_dir, generated_actions_dir))
+      FileUtils.mkdir_p(File.join(docs_dir, "img", "actions"))
 
       # Generate actions.md
       template = File.join(Fastlane::ROOT, "lib/assets/Actions.md.erb")
@@ -144,7 +147,6 @@ module Fastlane
 
       # Generate actions sub pages (e.g. generated/actions/slather.md, generated/actions/scan.md)
       all_actions_ref_yml = []
-      FileUtils.mkdir_p(File.join(docs_dir, generated_actions_dir))
       ActionsList.all_actions do |action|
         @action = action # to provide a reference in the .html.erb template
         @action_filename = filename_for_action(action)


### PR DESCRIPTION
## Problem

We have https://github.com/fastlane/docs/issues/1317, which found that when an action/thing/plugin is deleted. Its never automatically removed from docs.


## Solution

Clean generated folder prior to re-generation. Thus remaining items are the ones not deleted. In testing this removed only 3 things 

 - docs/generated/actions/plugin_scores.md - not a real action, for internal use
 - docs/generated/actions/rspec.md - not real, internal code
 - docs/generated/actions/rubocop.md - not real, internal code

It seems the deletions are from accidentally globbing of too much. These correspond directly to the warnings you see during build. So this was fixed already, but never deleted retroactively.

```
[06:49:36]: Action 'Fastlane::Actions::RspecAction' doesn't contain category information... skipping
[06:49:36]: Action 'Fastlane::Actions::RubocopAction' doesn't contain category information... skipping
[06:49:36]: Action 'Fastlane::Actions::PluginScoresAction' not found in root fastlane project... skipping
[06:49:36]: Action 'Fastlane::Actions::RspecAction' not found in root fastlane project... skipping
[06:49:36]: Action 'Fastlane::Actions::RubocopAction' not found in root fastlane project... skipping
```

---

fixes: fastlane/docs#1317