### PR TITLE
[match] Fix match_nuke certificate_id filtering

### DIFF
--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -168,6 +168,12 @@ module Match
     end
 
     def filter_by_cert
+      certificate_id = self.params[:certificate_id].to_s.strip
+      unless certificate_id.empty?
+        filter_by_certificate_ids([certificate_id], missing_error_message: "No certificate found for certificate_id '#{certificate_id}'")
+        return
+      end
+
       # Force will continue to revoke and delete all certificates and profiles
       return if self.params[:force] || !UI.interactive?
       return if self.certs.count < 2
@@ -198,44 +204,7 @@ module Match
           UI.user_error!("No certificates were selected based on option number(s) entered")
         end
 
-        # Do profile selection logic
-        cert_ids = self.certs.map(&:id)
-        self.profiles = self.profiles.select do |profile|
-          profile_cert_ids = profile.certificates.map(&:id)
-          (cert_ids & profile_cert_ids).any?
-        end
-
-        # Do file selection logic
-        self.files = self.files.select do |f|
-          found = false
-
-          ext = File.extname(f)
-          filename = File.basename(f, ".*")
-
-          # Attempt to find cert based on filename
-          if ext == ".cer" || ext == ".p12"
-            found ||= self.certs.any? do |cert|
-              filename == cert.id.to_s
-            end
-          end
-
-          # Attempt to find profile matched on UUIDs in profile
-          if ext == ".mobileprovision" || ext == ".provisionprofile"
-            storage_uuid = FastlaneCore::ProvisioningProfile.uuid(f)
-
-            found ||= self.profiles.any? do |profile|
-              tmp_file = Tempfile.new
-              tmp_file.write(Base64.decode64(profile.profile_content))
-              tmp_file.close
-
-              # Compare profile uuid in storage to profile uuid on developer portal
-              portal_uuid = FastlaneCore::ProvisioningProfile.uuid(tmp_file.path)
-              storage_uuid == portal_uuid
-            end
-          end
-
-          found
-        end
+        filter_profiles_and_files_by_selected_certificates
       end
     end
 
@@ -355,6 +324,57 @@ module Match
         UI.success("Successfully deleted file")
 
         file
+      end
+    end
+
+    def filter_by_certificate_ids(certificate_ids, missing_error_message: nil)
+      certificate_ids = certificate_ids.map { |id| id.to_s.strip }.reject(&:empty?)
+      self.certs = self.certs.select do |cert|
+        certificate_ids.include?(cert.id.to_s)
+      end
+
+      UI.user_error!(missing_error_message || "No certificates were selected") if self.certs.empty?
+
+      filter_profiles_and_files_by_selected_certificates
+    end
+
+    def filter_profiles_and_files_by_selected_certificates
+      # Do profile selection logic
+      cert_ids = self.certs.map { |cert| cert.id.to_s }
+      self.profiles = self.profiles.reject do |profile|
+        profile_cert_ids = profile.certificates.map { |cert| cert.id.to_s }
+        (cert_ids & profile_cert_ids).empty?
+      end
+
+      profile_uuids = self.profiles.map do |profile|
+        Tempfile.create("profile") do |tmp_file|
+          tmp_file.binmode
+          tmp_file.write(Base64.decode64(profile.profile_content))
+          tmp_file.flush
+
+          FastlaneCore::ProvisioningProfile.uuid(tmp_file.path)
+        end
+      end
+
+      # Do file selection logic
+      self.files = self.files.select do |f|
+        found = false
+
+        ext = File.extname(f)
+        filename = File.basename(f, ".*")
+
+        # Attempt to find cert based on filename
+        if ext == ".cer" || ext == ".p12"
+          found ||= cert_ids.include?(filename)
+        end
+
+        # Attempt to find profile matched on UUIDs in profile
+        if ext == ".mobileprovision" || ext == ".provisionprofile"
+          storage_uuid = FastlaneCore::ProvisioningProfile.uuid(f)
+          found ||= profile_uuids.include?(storage_uuid)
+        end
+
+        found
       end
     end
 

--- a/match/spec/nuke_spec.rb
+++ b/match/spec/nuke_spec.rb
@@ -1,5 +1,42 @@
 describe Match do
   describe Match::Nuke do
+    def nuke_with_certificates(certificate_id: "1111111111")
+      nuke = Match::Nuke.new
+      nuke.params = {
+        force: true,
+        certificate_id: certificate_id
+      }
+
+      selected_cert = double("selected_cert", id: "1111111111")
+      other_cert = double("other_cert", id: "2222222222")
+      selected_profile = double("selected_profile", certificates: [selected_cert], profile_content: Base64.encode64("selected profile"))
+      other_profile = double("other_profile", certificates: [other_cert], profile_content: Base64.encode64("other profile"))
+
+      nuke.certs = [selected_cert, other_cert]
+      nuke.profiles = [selected_profile, other_profile]
+      nuke.files = [
+        "/tmp/certs/distribution/1111111111.cer",
+        "/tmp/certs/distribution/2222222222.cer",
+        "/tmp/certs/distribution/1111111111.p12",
+        "/tmp/certs/distribution/2222222222.p12",
+        "/tmp/profiles/appstore/selected.mobileprovision",
+        "/tmp/profiles/appstore/other.mobileprovision"
+      ]
+
+      allow(FastlaneCore::ProvisioningProfile).to receive(:uuid) do |path|
+        case path
+        when /selected\.mobileprovision$/
+          "selected-profile-uuid"
+        when /other\.mobileprovision$/
+          "other-profile-uuid"
+        else
+          File.read(path) == "selected profile" ? "selected-profile-uuid" : "other-profile-uuid"
+        end
+      end
+
+      nuke
+    end
+
     before do
       allow(Spaceship::ConnectAPI).to receive(:login).and_return(nil)
       allow(Spaceship::ConnectAPI).to receive(:client).and_return("client")
@@ -57,6 +94,30 @@ describe Match do
       expect(fake_storage).to receive(:clear_changes)
 
       nuke.run(config, type: config[:type])
+    end
+
+    it "uses certificate_id to filter certificates, profiles, and files when force is enabled" do
+      nuke = nuke_with_certificates
+
+      nuke.filter_by_cert
+
+      expected_files = [
+        "/tmp/certs/distribution/1111111111.cer",
+        "/tmp/certs/distribution/1111111111.p12",
+        "/tmp/profiles/appstore/selected.mobileprovision"
+      ]
+
+      expect(nuke.certs.map(&:id)).to eq(["1111111111"])
+      expect(nuke.profiles.map { |profile| profile.certificates.first.id }).to eq(["1111111111"])
+      expect(nuke.files).to eq(expected_files)
+    end
+
+    it "raises an explicit error when certificate_id does not match a fetched certificate" do
+      nuke = nuke_with_certificates(certificate_id: "3333333333")
+
+      expect do
+        nuke.filter_by_cert
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, "No certificate found for certificate_id '3333333333'")
     end
   end
 end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
`match_nuke` exposes the `certificate_id` option, but the nuke flow did not use it when filtering certificates, provisioning profiles, or files.

As a result, running `match_nuke` with both `force: true` and a specific `certificate_id` could still list and revoke/delete every fetched certificate and matching provisioning profile, instead of only the selected certificate and profiles that depend on it.

Resolves #30015

### Description
This change makes `match_nuke` honor `certificate_id` before the existing `force` behavior short-circuits certificate filtering.

When `certificate_id` is provided, `match_nuke` now:
- filters the fetched certificates down to the requested certificate ID
- filters provisioning profiles to only profiles associated with that certificate
- filters repository files to only the selected certificate/key files and matching provisioning profile files
- raises an explicit error if the requested `certificate_id` does not match any fetched certificate

I also added unit coverage for the `force: true` case reported in the issue, plus coverage for the invalid `certificate_id` path.

No documentation update was needed because `certificate_id` was already documented for `match_nuke`; this fixes the implementation to match the documented behavior.

### Testing Steps

Added regression coverage that simulates the `match_nuke` environment from #30015:

- `force: true`
- `certificate_id: "1111111111"`
- two fetched certificates: `1111111111` and `2222222222`
- one provisioning profile tied to each certificate
- stored `.cer`, `.p12`, and `.mobileprovision` files for both certificates/profiles

The spec calls `filter_by_cert` and verifies that only the selected certificate, its key, and its dependent provisioning profile remain queued for deletion. It also verifies that an unmatched `certificate_id` raises an explicit error.

Ran the focused `match_nuke` specs covering this change:

```bash
env -u NO_COLOR bundle exec rspec match/spec/nuke_spec.rb
```

Result:

```text
3 examples, 0 failures
```

Ran RuboCop on the touched files:

```bash
env -u NO_COLOR RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop match/lib/match/nuke.rb match/spec/nuke_spec.rb
```

Result:

```text
2 files inspected, no offenses detected
```

Ran the full RuboCop suite:

```bash
RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop
```

Result:

```text
1313 files inspected, no offenses detected
```

Ran docs validation:

```bash
env -u NO_COLOR bundle exec fastlane validate_docs
```

Result: passed.
