### PR TITLE
[action] Add update_app_age_rating action for standalone age rating updates

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,1 +1,2 @@
 * [deliver] fix app previews always running during usage. (#29989) via Connor Tumbleson (@iBotPeaches)
+* [deliver] Add `update_app_age_rating` action for standalone App Store age rating updates - [@PratikPatil131](https://github.com/PratikPatil131)

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,2 +1,1 @@
 * [deliver] fix app previews always running during usage. (#29989) via Connor Tumbleson (@iBotPeaches)
-* [deliver] Add `update_app_age_rating` action for standalone App Store age rating updates - [@PratikPatil131](https://github.com/PratikPatil131)

--- a/fastlane/lib/fastlane/actions/update_app_age_rating.rb
+++ b/fastlane/lib/fastlane/actions/update_app_age_rating.rb
@@ -80,6 +80,9 @@ module Fastlane
         require 'spaceship'
         require 'json'
 
+        # Honour an API key that was set by app_store_connect_api_key earlier in the lane
+        params[:api_key] ||= Actions.lane_context[SharedValues::APP_STORE_CONNECT_API_KEY]
+
         # Authenticate: API key takes priority, falls back to Apple ID session
         token = Spaceship::ConnectAPI::Token.from(
           hash: params[:api_key],
@@ -193,11 +196,12 @@ module Fastlane
       private_class_method :parse_config
 
       def self.build_attributes(config_json)
-        config_json.each_with_object({}) do |(key, value), attrs|
-          new_key   = Spaceship::ConnectAPI::AgeRatingDeclaration.map_key_from_itc(key)
+        attributes = config_json.each_with_object({}) do |(key, value), attrs|
+          new_key = Spaceship::ConnectAPI::AgeRatingDeclaration.map_key_from_itc(key)
           new_value = Spaceship::ConnectAPI::AgeRatingDeclaration.map_value_from_itc(new_key, value)
           attrs[new_key] = new_value
         end
+        Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecation_if_possible(attributes)
       end
       private_class_method :build_attributes
     end

--- a/fastlane/lib/fastlane/actions/update_app_age_rating.rb
+++ b/fastlane/lib/fastlane/actions/update_app_age_rating.rb
@@ -1,0 +1,203 @@
+module Fastlane
+  module Actions
+    class UpdateAppAgeRatingAction < Action
+      def self.description
+        "Update your app's age rating on App Store Connect"
+      end
+
+      def self.details
+        "Updates only the age rating of your app on App Store Connect without touching " \
+          "any other metadata, screenshots, or binaries. Useful for CI pipelines that need " \
+          "to update age ratings independently of an app release. Supports both API key " \
+          "and Apple ID authentication."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :api_key_path,
+            env_name: "APP_STORE_CONNECT_API_KEY_PATH",
+            description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/)",
+            optional: true,
+            conflicting_options: %i[api_key],
+            type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :api_key,
+            env_name: "APP_STORE_CONNECT_API_KEY",
+            description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/)",
+            optional: true,
+            conflicting_options: %i[api_key_path],
+            sensitive: true,
+            type: Hash
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :app_identifier,
+            env_name: "DELIVER_APP_IDENTIFIER",
+            description: "The bundle identifier of your app",
+            optional: false,
+            type: String,
+            code_gen_sensitive: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :username,
+            env_name: "DELIVER_USER",
+            description: "Your Apple ID username",
+            optional: true,
+            type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :age_rating_config_path,
+            env_name: "DELIVER_AGE_RATING_CONFIG_PATH",
+            description: "Path to the JSON file containing the age rating configuration",
+            optional: false,
+            type: String,
+            verify_block: proc do |value|
+              UI.user_error!("Age rating configuration file not found at: '#{value}'") unless File.exist?(value)
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :team_id,
+            env_name: "FASTLANE_TEAM_ID",
+            description: "The ID of your App Store Connect team if you're in multiple teams",
+            optional: true,
+            type: String,
+            code_gen_sensitive: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :team_name,
+            env_name: "FASTLANE_TEAM_NAME",
+            description: "The name of your App Store Connect team if you're in multiple teams",
+            optional: true,
+            type: String
+          )
+        ]
+      end
+
+      def self.run(params)
+        require 'spaceship'
+        require 'json'
+
+        # Authenticate: API key takes priority, falls back to Apple ID session
+        token = Spaceship::ConnectAPI::Token.from(
+          hash: params[:api_key],
+          filepath: params[:api_key_path]
+        )
+
+        if token
+          UI.message("Creating authorization token for App Store Connect API")
+          Spaceship::ConnectAPI.token = token
+        else
+          UI.message("Login to App Store Connect (#{params[:username]})")
+          Spaceship::ConnectAPI.login(
+            params[:username],
+            nil,
+            use_portal: false,
+            use_tunes: true,
+            team_id: params[:team_id],
+            team_name: params[:team_name]
+          )
+        end
+
+        # Find the app by bundle identifier
+        app = Spaceship::ConnectAPI::App.find(params[:app_identifier])
+        UI.user_error!("Could not find app with identifier '#{params[:app_identifier]}'") unless app
+
+        # Fetch the editable app info
+        app_info = app.fetch_edit_app_info
+        unless app_info
+          UI.user_error!(
+            "Could not fetch editable app info for '#{params[:app_identifier]}'. " \
+            "Ensure the app is in an editable state in App Store Connect."
+          )
+        end
+
+        # Parse age rating config and map ITC keys to ASC keys
+        config_json = parse_config(params[:age_rating_config_path])
+        attributes  = build_attributes(config_json)
+
+        # Fetch and update the age rating declaration
+        age_rating = app_info.fetch_age_rating_declaration
+        UI.user_error!("Could not fetch age rating declaration for '#{params[:app_identifier]}'") unless age_rating
+
+        UI.message("Updating age rating for '#{params[:app_identifier]}'...")
+        age_rating.update(attributes: attributes)
+        UI.success("Successfully updated age rating for '#{params[:app_identifier]}'")
+
+        true
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.example_code
+        [
+          '# Using App Store Connect API key (recommended for CI)
+          update_app_age_rating(
+            api_key_path: "fastlane/api_key.json",
+            app_identifier: "com.example.app",
+            age_rating_config_path: "fastlane/metadata/age_rating.json"
+          )',
+          '# Using Apple ID
+          update_app_age_rating(
+            username: "user@example.com",
+            app_identifier: "com.example.app",
+            age_rating_config_path: "fastlane/metadata/age_rating.json",
+            team_id: "ABC123456"
+          )',
+          '# Using the api_key hash returned by app_store_connect_api_key action
+          api_key = app_store_connect_api_key(
+            key_id: "D383SF739",
+            issuer_id: "6053b7fe-68a8-4acb-89be-165aa6465141",
+            key_filepath: "./AuthKey_D383SF739.p8"
+          )
+          update_app_age_rating(
+            api_key: api_key,
+            app_identifier: "com.example.app",
+            age_rating_config_path: "fastlane/metadata/age_rating.json"
+          )'
+        ]
+      end
+
+      def self.category
+        :app_store_connect
+      end
+
+      def self.authors
+        ["PratikPatil131"]
+      end
+
+      def self.return_value
+        "Returns true if the age rating was successfully updated"
+      end
+
+      def self.is_supported?(platform) # rubocop:disable Naming/PredicateName
+        # fastlane's Action interface mandates the method name `is_supported?`
+        %i[ios mac tvos].include?(platform)
+      end
+
+      #####################################################
+      # @!group Private helpers
+      #####################################################
+
+      def self.parse_config(config_path)
+        JSON.parse(File.read(config_path))
+      rescue JSON::ParserError => ex
+        UI.user_error!("Invalid JSON in age rating configuration file '#{config_path}': #{ex.message}")
+      rescue StandardError => ex
+        UI.user_error!("Could not read age rating configuration file '#{config_path}': #{ex.message}")
+      end
+      private_class_method :parse_config
+
+      def self.build_attributes(config_json)
+        config_json.each_with_object({}) do |(key, value), attrs|
+          new_key   = Spaceship::ConnectAPI::AgeRatingDeclaration.map_key_from_itc(key)
+          new_value = Spaceship::ConnectAPI::AgeRatingDeclaration.map_value_from_itc(new_key, value)
+          attrs[new_key] = new_value
+        end
+      end
+      private_class_method :build_attributes
+    end
+  end
+end

--- a/fastlane/lib/fastlane/actions/update_app_age_rating.rb
+++ b/fastlane/lib/fastlane/actions/update_app_age_rating.rb
@@ -201,7 +201,8 @@ module Fastlane
           new_value = Spaceship::ConnectAPI::AgeRatingDeclaration.map_value_from_itc(new_key, value)
           attrs[new_key] = new_value
         end
-        Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecation_if_possible(attributes)
+        attributes, = Spaceship::ConnectAPI::AgeRatingDeclaration.map_deprecation_if_possible(attributes)
+        attributes
       end
       private_class_method :build_attributes
     end

--- a/fastlane/lib/fastlane/actions/update_app_age_rating.rb
+++ b/fastlane/lib/fastlane/actions/update_app_age_rating.rb
@@ -16,15 +16,17 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(
             key: :api_key_path,
-            env_name: "APP_STORE_CONNECT_API_KEY_PATH",
+            env_names: ["DELIVER_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
             description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/)",
             optional: true,
             conflicting_options: %i[api_key],
-            type: String
+            verify_block: proc do |value|
+              UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+            end
           ),
           FastlaneCore::ConfigItem.new(
             key: :api_key,
-            env_name: "APP_STORE_CONNECT_API_KEY",
+            env_names: ["DELIVER_API_KEY", "APP_STORE_CONNECT_API_KEY"],
             description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/)",
             optional: true,
             conflicting_options: %i[api_key_path],

--- a/fastlane/spec/update_app_age_rating_spec.rb
+++ b/fastlane/spec/update_app_age_rating_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'deliver'
+require_relative '../lib/fastlane/actions/update_app_age_rating'
+
+describe Fastlane::Actions::UpdateAppAgeRatingAction do
+  let(:app_id)      { 'com.example.app' }
+  let(:config_path) { '/tmp/age_rating.json' }
+  let(:app)         { double('Spaceship::ConnectAPI::App') }
+  let(:app_info)    { double('Spaceship::ConnectAPI::AppInfo') }
+  let(:age_rating)  { double('Spaceship::ConnectAPI::AgeRatingDeclaration') }
+  let(:valid_json)  { '{"VIOLENCE":"FREQUENT"}' }
+  let(:mapped_key)  { 'violence_cartoon_fantasy' }
+  let(:mapped_val)  { 2 }
+
+  # Shared setup: establishes the full happy-path stub set.
+  # Individual contexts override only the piece they are exercising.
+  before do
+    allow(Spaceship::ConnectAPI::Token).to receive(:from).and_return(nil)
+    allow(Spaceship::ConnectAPI).to receive(:login)
+    allow(Spaceship::ConnectAPI).to receive(:token=)
+
+    allow(Spaceship::ConnectAPI::App).to receive(:find).with(app_id).and_return(app)
+    allow(app).to receive(:fetch_edit_app_info).and_return(app_info)
+    allow(app_info).to receive(:fetch_age_rating_declaration).and_return(age_rating)
+    allow(age_rating).to receive(:update)
+
+    allow(File).to receive(:exist?).with(config_path).and_return(true)
+    allow(File).to receive(:read).with(config_path).and_return(valid_json)
+
+    allow(Spaceship::ConnectAPI::AgeRatingDeclaration)
+      .to receive(:map_key_from_itc).with('VIOLENCE').and_return(mapped_key)
+    allow(Spaceship::ConnectAPI::AgeRatingDeclaration)
+      .to receive(:map_value_from_itc).with(mapped_key, 'FREQUENT').and_return(mapped_val)
+  end
+
+  # Convenience: avoids repeating the full params hash in every example
+  def run(overrides = {})
+    described_class.run({
+      app_identifier: app_id,
+      age_rating_config_path: config_path,
+      username: 'user@example.com'
+    }.merge(overrides))
+  end
+
+  # ---------------------------------------------------------------------------
+  describe 'authentication' do
+    context 'when an api_key hash is provided' do
+      let(:api_key) { { key_id: 'KEY', issuer_id: 'ISSUER', key: 'CONTENT' } }
+      let(:token)   { double('Spaceship::ConnectAPI::Token') }
+
+      before do
+        allow(Spaceship::ConnectAPI::Token).to receive(:from)
+          .with(hash: api_key, filepath: nil).and_return(token)
+      end
+
+      it 'sets the Spaceship token and skips Apple ID login' do
+        expect(Spaceship::ConnectAPI).to receive(:token=).with(token)
+        expect(Spaceship::ConnectAPI).not_to receive(:login)
+        run(api_key: api_key)
+      end
+    end
+
+    context 'when an api_key_path is provided' do
+      let(:token) { double('Spaceship::ConnectAPI::Token') }
+
+      before do
+        allow(Spaceship::ConnectAPI::Token).to receive(:from)
+          .with(hash: nil, filepath: '/tmp/api_key.json').and_return(token)
+      end
+
+      it 'sets the Spaceship token and skips Apple ID login' do
+        expect(Spaceship::ConnectAPI).to receive(:token=).with(token)
+        expect(Spaceship::ConnectAPI).not_to receive(:login)
+        run(api_key_path: '/tmp/api_key.json')
+      end
+    end
+
+    context 'when no API key is provided' do
+      before do
+        allow(Spaceship::ConnectAPI::Token).to receive(:from)
+          .with(hash: nil, filepath: nil).and_return(nil)
+      end
+
+      it 'falls back to Apple ID username/password login' do
+        expect(Spaceship::ConnectAPI).to receive(:login).with(
+          'user@example.com',
+          nil,
+          use_portal: false,
+          use_tunes: true,
+          team_id: nil,
+          team_name: nil
+        )
+        run
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '#run' do
+    context 'when all inputs are valid' do
+      it 'finds the app by bundle identifier' do
+        expect(Spaceship::ConnectAPI::App).to receive(:find).with(app_id).and_return(app)
+        run
+      end
+
+      it 'fetches the editable app info' do
+        expect(app).to receive(:fetch_edit_app_info).and_return(app_info)
+        run
+      end
+
+      it 'fetches the age rating declaration' do
+        expect(app_info).to receive(:fetch_age_rating_declaration).and_return(age_rating)
+        run
+      end
+
+      it 'updates the declaration with correctly mapped attributes' do
+        expect(age_rating).to receive(:update).with(
+          attributes: { mapped_key => mapped_val }
+        )
+        run
+      end
+
+      it 'returns true' do
+        expect(run).to be(true)
+      end
+    end
+
+    context 'when the app cannot be found' do
+      before { allow(Spaceship::ConnectAPI::App).to receive(:find).and_return(nil) }
+
+      it 'raises a user-facing error' do
+        expect { run }.to raise_error(
+          FastlaneCore::Interface::FastlaneError,
+          /Could not find app with identifier/
+        )
+      end
+    end
+
+    context 'when app info cannot be fetched' do
+      before { allow(app).to receive(:fetch_edit_app_info).and_return(nil) }
+
+      it 'raises a user-facing error' do
+        expect { run }.to raise_error(
+          FastlaneCore::Interface::FastlaneError,
+          /Could not fetch editable app info/
+        )
+      end
+    end
+
+    context 'when the config file contains invalid JSON' do
+      before { allow(File).to receive(:read).with(config_path).and_return('{ invalid') }
+
+      it 'raises a user-facing error' do
+        expect { run }.to raise_error(
+          FastlaneCore::Interface::FastlaneError,
+          /Invalid JSON in age rating configuration file/
+        )
+      end
+    end
+
+    context 'when the age rating declaration cannot be fetched' do
+      before { allow(app_info).to receive(:fetch_age_rating_declaration).and_return(nil) }
+
+      it 'raises a user-facing error' do
+        expect { run }.to raise_error(
+          FastlaneCore::Interface::FastlaneError,
+          /Could not fetch age rating declaration/
+        )
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '.available_options' do
+    subject(:options) { described_class.available_options }
+
+    it 'returns an array of FastlaneCore::ConfigItem objects' do
+      expect(options).to all(be_a(FastlaneCore::ConfigItem))
+    end
+
+    it 'marks :app_identifier and :age_rating_config_path as required' do
+      required_keys = options.reject(&:optional).map(&:key)
+      expect(required_keys).to include(:app_identifier, :age_rating_config_path)
+    end
+
+    it 'marks auth and team options as optional' do
+      optional_keys = options.select(&:optional).map(&:key)
+      expect(optional_keys).to include(:api_key, :api_key_path, :username, :team_id, :team_name)
+    end
+
+    it 'marks :api_key and :api_key_path as conflicting options with each other' do
+      api_key_item = options.find { |o| o.key == :api_key }
+      expect(api_key_item.conflicting_options).to include(:api_key_path)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '.is_supported?' do
+    it 'returns true for :ios'      do expect(described_class.is_supported?(:ios)).to   be(true)  end
+    it 'returns true for :mac'      do expect(described_class.is_supported?(:mac)).to   be(true)  end
+    it 'returns true for :tvos'     do expect(described_class.is_supported?(:tvos)).to  be(true)  end
+    it 'returns false for :android' do expect(described_class.is_supported?(:android)).to be(false) end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '.description' do
+    it 'returns a non-empty string' do
+      expect(described_class.description).not_to be_empty
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '.authors' do
+    it 'includes the contributor handle' do
+      expect(described_class.authors).to include('PratikPatil131')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new `update_app_age_rating` action for standalone App Store Connect age rating updates.

This follows the discussion in #30017, where maintainer @iBotPeaches suggested introducing a dedicated action (similar to `match_nuke`) instead of extending the existing `skip_metadata` behavior.

## Motivation

Age ratings are app-level metadata and can be updated independently from screenshots, descriptions, or binary uploads.

Currently, automating an age rating update through fastlane requires invoking the broader `deliver` metadata flow, even when only the age rating declaration needs to change.

This action provides a lightweight and explicit workflow for that use case.

## Changes

* Added `update_app_age_rating` action
* Added RSpec coverage for success and failure paths


## Implementation Details

The action:

1. Authenticates using either:

   * App Store Connect API key
   * Apple ID session fallback
2. Finds the app via bundle identifier
3. Fetches editable `AppInfo`
4. Parses the supplied JSON configuration
5. Reuses existing `AgeRatingDeclaration` mapping helpers already used by `deliver`
6. Updates the age rating declaration via Spaceship

No new Spaceship API surface was introduced.

## Example

```ruby
update_app_age_rating(
  api_key_path: "fastlane/api_key.json",
  app_identifier: "com.example.app",
  age_rating_config_path: "fastlane/metadata/age_rating.json"
)
```

## Testing

```bash
bundle exec rspec fastlane/spec/update_app_age_rating_spec.rb

bundle exec rubocop fastlane/lib/fastlane/actions/update_app_age_rating.rb

bundle exec rubocop fastlane/spec/update_app_age_rating_spec.rb
```

---

## Checklist

* [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
* [x] I've followed the fastlane code style and run `bundle exec rubocop -a`
* [x] I see green `ci/circleci` builds passing
* [x] I've read the Contribution Guidelines
* [x] I've added/updated relevant unit tests
* [ ] I've updated the CHANGELOG
