### PR TITLE
[supply] fix crash if no release on track

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -111,7 +111,7 @@ module Supply
       return nil, nil if tracks.empty?
 
       track = tracks.first
-      releases = track.releases
+      releases = track.releases || []
 
       releases = releases.select { |r| statuses.include?(r.status) } unless statuses.nil? || statuses.empty?
       releases = releases.select { |r| (r.version_codes || []).map(&:to_s).include?(version_code.to_s) } if version_code

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -599,6 +599,16 @@ describe Supply do
           expect { subject.update_rollout }.to raise_error(/Unable to find the requested release on track/)
         end
       end
+
+      context 'when track releases is nil' do
+        before do
+          allow(track).to receive(:releases).and_return(nil)
+        end
+
+        it 'does not crash and raises an error about missing release' do
+          expect { subject.update_rollout }.to raise_error(/Unable to find the requested release on track/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

If you have no releases on a track - you get nill and then crash.

```
NoMethodError: [!] undefined method size' for nil:NilClass supply/lib/supply/uploader.rb:119:in fetch_track_and_release!'
```

## Solution

Fall back to an empty array + add a test to prevent regressions.

fixes: #21530 