### PR TITLE
[ci] fix flaky test due to time shift

### DIFF
--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -1,9 +1,10 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    build_log_path = File.expand_path("#{FastlaneCore::Helper.buildlog_path}/fastlane/xcbuild/#{Time.now.strftime('%F')}/#{Process.pid}/xcodebuild.log")
+    let(:build_log_path) { File.expand_path("#{FastlaneCore::Helper.buildlog_path}/fastlane/xcbuild/#{Time.now.strftime('%F')}/#{Process.pid}/xcodebuild.log") }
 
     describe "Xcodebuild Integration" do
       before :each do
+        allow(Time).to receive(:now).and_return(Time.at(1_420_063_200))
         Fastlane::Actions.lane_context.delete(:IPA_OUTPUT_PATH)
         Fastlane::Actions.lane_context.delete(:XCODEBUILD_ARCHIVE)
       end


### PR DESCRIPTION
## Problem

I was working at night my time (8pm Eastern) - usually I work at 5-7am Eastern and I had a test failure that was so odd.

```
[00:03:04]: ▸ 1) Fastlane Fastlane::FastFile Xcodebuild Integration works with a destination list
xcodebuild -destination \"name=iPhone 5s,OS=8.1\" -destination \"name=iPhone 4,OS...nneradmin/Library/Logs/fastlane/xcbuild/2026-05-10/5952/xcodebuild.log' | xcpretty --color --simple"
[00:03:04]: ▸ got: "set -o pipefail && xcodebuild -destination \"name=iPhone 5s,OS=8.1\" -destination \"name=iPhone 4,OS...nneradmin/Library/Logs/fastlane/xcbuild/2026-05-11/5952/xcodebuild.log' | xcpretty --color --simple"
```

The issue was the day changed between the assertions and execution (I guess the time changing).

## Solution

1. We change a static reference into a let block so its resolved at runtime (not start time). This means even though we are mocking time - they will be closer together. Since test suite can take 1-10min

2. We mock Time