### PR TITLE
[increment_version_number] update MARKETING_VERSION build setting

### DIFF
--- a/fastlane/lib/fastlane/actions/get_version_number.rb
+++ b/fastlane/lib/fastlane/actions/get_version_number.rb
@@ -5,6 +5,7 @@ module Fastlane
     end
 
     class GetVersionNumberAction < Action
+      require 'fastlane/helper/xcodeproj_helper'
       require 'shellwords'
 
       def self.run(params)
@@ -41,18 +42,7 @@ module Fastlane
       end
 
       def self.get_project!(xcodeproj_path_or_dir)
-        require 'xcodeproj'
-        if File.extname(xcodeproj_path_or_dir) == ".xcodeproj"
-          project_path = xcodeproj_path_or_dir
-        else
-          project_path = Dir.glob("#{xcodeproj_path_or_dir}/*.xcodeproj").first
-        end
-
-        if project_path && File.exist?(project_path)
-          return Xcodeproj::Project.open(project_path)
-        else
-          UI.user_error!("Unable to find Xcode project at #{project_path || xcodeproj_path_or_dir}")
-        end
+        Fastlane::Helper::XcodeprojHelper.get_project!(xcodeproj_path_or_dir)
       end
 
       def self.get_target!(project, target_name)

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -23,6 +23,8 @@ module Fastlane
           '&&'
         ].join(' ')
 
+        version_number_build_setting = nil
+
         begin
           current_version = Actions
                             .sh("#{command_prefix} agvtool what-marketing-version -terse1", log: FastlaneCore::Globals.verbose?)
@@ -31,7 +33,8 @@ module Fastlane
                             .strip
 
           if current_version =~ /\$\(([\w\-]+)\)/ || current_version =~ /\$\{([\w\-]+)\}/
-            UI.verbose("agvtool returned $(MARKETING_VERSION), resolving it...")
+            version_number_build_setting = $1
+            UI.verbose("agvtool returned $(#{version_number_build_setting}), resolving it...")
             current_version = GetVersionNumberAction.run(xcodeproj: params[:xcodeproj])
           end
         rescue
@@ -80,6 +83,12 @@ module Fastlane
           Actions.lane_context[SharedValues::VERSION_NUMBER] = command
         else
           Actions.sh(command)
+          version_number_build_setting ||= "MARKETING_VERSION"
+          update_project_version_build_setting(
+            params[:xcodeproj],
+            version_number_build_setting,
+            next_version_number.to_s.strip
+          )
           Actions.lane_context[SharedValues::VERSION_NUMBER] = next_version_number
         end
 
@@ -99,6 +108,22 @@ module Fastlane
 
       def self.version_token_error
         "Can't increment version"
+      end
+
+      def self.update_project_version_build_setting(xcodeproj_path_or_dir, build_setting, version_number)
+        project = GetVersionNumberAction.get_project!(xcodeproj_path_or_dir || '.')
+        changed = false
+
+        ([project] + project.targets).each do |item|
+          item.build_configurations.each do |config|
+            next unless config.build_settings.key?(build_setting)
+
+            config.build_settings[build_setting] = version_number
+            changed = true
+          end
+        end
+
+        project.save if changed
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -35,7 +35,7 @@ module Fastlane
 
           if current_version =~ /\$\(([\w\-]+)\)/ || current_version =~ /\$\{([\w\-]+)\}/
             version_number_build_setting = $1
-            UI.verbose("agvtool returned $(#{version_number_build_setting}), resolving it...")
+            UI.verbose("agvtool returned #{current_version}, resolving it...")
             current_version = GetVersionNumberAction.run(xcodeproj: params[:xcodeproj])
           end
         rescue
@@ -112,9 +112,21 @@ module Fastlane
       end
 
       def self.update_project_version_build_setting(xcodeproj_path_or_dir, build_setting, version_number)
-        project = Fastlane::Helper::XcodeprojHelper.get_project!(xcodeproj_path_or_dir || '.')
+        project_path_or_dir = xcodeproj_path_or_dir
+        if project_path_or_dir.nil?
+          xcodeproj_paths = Dir.glob("./*.xcodeproj")
+          return if xcodeproj_paths.empty?
+
+          if xcodeproj_paths.size > 1
+            return
+          end
+
+          project_path_or_dir = xcodeproj_paths.first
+        end
+
+        project = Fastlane::Helper::XcodeprojHelper.get_project!(project_path_or_dir)
         changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, build_setting, version_number)
-        project.save if changed
+        project.save if changed[:project]
       end
 
       def self.description

--- a/fastlane/lib/fastlane/actions/increment_version_number.rb
+++ b/fastlane/lib/fastlane/actions/increment_version_number.rb
@@ -5,6 +5,7 @@ module Fastlane
     end
 
     class IncrementVersionNumberAction < Action
+      require 'fastlane/helper/xcodeproj_helper'
       require 'shellwords'
 
       def self.is_supported?(platform)
@@ -111,18 +112,8 @@ module Fastlane
       end
 
       def self.update_project_version_build_setting(xcodeproj_path_or_dir, build_setting, version_number)
-        project = GetVersionNumberAction.get_project!(xcodeproj_path_or_dir || '.')
-        changed = false
-
-        ([project] + project.targets).each do |item|
-          item.build_configurations.each do |config|
-            next unless config.build_settings.key?(build_setting)
-
-            config.build_settings[build_setting] = version_number
-            changed = true
-          end
-        end
-
+        project = Fastlane::Helper::XcodeprojHelper.get_project!(xcodeproj_path_or_dir || '.')
+        changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, build_setting, version_number)
         project.save if changed
       end
 

--- a/fastlane/lib/fastlane/helper/xcodeproj_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodeproj_helper.rb
@@ -25,18 +25,142 @@ module Fastlane
       end
 
       def self.update_project_build_setting(project, build_setting, value)
-        changed = false
+        changed = { project: false, xcconfig: false }
 
         ([project] + project.targets).each do |item|
           item.build_configurations.each do |config|
-            next unless config.build_settings.key?(build_setting)
-
-            config.build_settings[build_setting] = value
-            changed = true
+            result = update_build_configuration_build_setting(config, build_setting, value)
+            changed[:project] ||= result[:project]
+            changed[:xcconfig] ||= result[:xcconfig]
           end
         end
 
         changed
+      end
+
+      def self.update_build_configuration_build_setting(config, build_setting, value)
+        changed = { project: false, xcconfig: false }
+        matching_keys = matching_build_setting_keys(config.build_settings, build_setting)
+
+        unless matching_keys.empty?
+          matching_keys.each do |key|
+            next if config.build_settings[key] == value
+
+            config.build_settings[key] = value
+            changed[:project] = true
+          end
+        end
+
+        changed[:xcconfig] = update_xcconfig_build_setting(config, build_setting, value)
+        changed
+      end
+
+      def self.update_xcconfig_build_setting(config, build_setting, value)
+        return false unless config.respond_to?(:base_configuration_reference)
+        return false unless config.base_configuration_reference
+
+        path = config.base_configuration_reference.real_path
+        update_xcconfig_build_setting_file(path, build_setting, value, {})
+      end
+
+      def self.update_xcconfig_build_setting_file(path, build_setting, value, visited)
+        path = path.to_s
+        expanded_path = File.expand_path(path)
+        return false if visited[expanded_path]
+
+        visited[expanded_path] = true
+        return false unless File.exist?(path)
+
+        content = File.read(path)
+        updated = false
+        in_block_comment = false
+
+        new_content = content.each_line.map do |line|
+          line_ending = line[/\r?\n\z/] || ""
+          line_without_ending = line.chomp
+          active_line, in_block_comment = uncomment_xcconfig_line(line_without_ending, in_block_comment)
+
+          # Match against the comment-stripped active_line so lines inside block comments
+          # are never modified. The trailing comment/suffix is preserved by slicing
+          # line_without_ending from the position just after the matched value.
+          if active_line =~ xcconfig_build_setting_regex(build_setting)
+            current_value = $4.rstrip
+            next line if current_value == value
+
+            trailing = line_without_ending[("#{$1}#{$2}#{$3}#{$4}").length..]
+            updated = true
+            "#{$1}#{$2}#{$3}#{value}#{trailing}#{line_ending}"
+          else
+            line
+          end
+        end.join
+
+        File.write(path, new_content) if updated
+
+        includes_updated = false
+        xcconfig_include_paths(content, path).each do |include_path|
+          include_updated = update_xcconfig_build_setting_file(include_path, build_setting, value, visited)
+          includes_updated ||= include_updated
+        end
+
+        updated || includes_updated
+      end
+
+      def self.xcconfig_include_paths(content, path)
+        in_block_comment = false
+
+        content.each_line.map do |line|
+          line_without_ending = line.chomp
+          active_line, in_block_comment = uncomment_xcconfig_line(line_without_ending, in_block_comment)
+          include = active_line.match(/^\s*#include\??\s*"(.+)"/)
+          next unless include
+
+          include_path = include[1]
+          include_path = "#{include_path}.xcconfig" if File.extname(include_path).empty?
+          File.expand_path(include_path, File.dirname(path))
+        end.compact
+      end
+
+      def self.uncomment_xcconfig_line(line, in_block_comment)
+        active_line = +""
+        index = 0
+
+        while index < line.length
+          if in_block_comment
+            block_comment_end = line.index("*/", index)
+            return [active_line, true] unless block_comment_end
+
+            index = block_comment_end + 2
+            in_block_comment = false
+          else
+            line_comment_start = line.index("//", index)
+            block_comment_start = line.index("/*", index)
+
+            if line_comment_start && (!block_comment_start || line_comment_start < block_comment_start)
+              active_line << line[index...line_comment_start]
+              return [active_line, false]
+            elsif block_comment_start
+              active_line << line[index...block_comment_start]
+              index = block_comment_start + 2
+              in_block_comment = true
+            else
+              active_line << line[index..-1]
+              return [active_line, false]
+            end
+          end
+        end
+
+        [active_line, in_block_comment]
+      end
+
+      def self.xcconfig_build_setting_regex(build_setting)
+        %r{^(\s*)(#{Regexp.escape(build_setting)}(?:\[[^\]]+\])*)(\s*=\s*)(.*?)(\s*(?://.*|/\*.*\*/)?$)}
+      end
+
+      def self.matching_build_setting_keys(build_settings, build_setting)
+        build_settings.keys.select do |key|
+          key.to_s == build_setting || key.to_s.start_with?("#{build_setting}[")
+        end
       end
     end
   end

--- a/fastlane/lib/fastlane/helper/xcodeproj_helper.rb
+++ b/fastlane/lib/fastlane/helper/xcodeproj_helper.rb
@@ -7,6 +7,37 @@ module Fastlane
         xcodeproj_paths = Dir[File.expand_path(File.join(dir, '**/*.xcodeproj'))]
         xcodeproj_paths.reject { |path| %r{/(#{DEPENDENCY_MANAGER_DIRS.join('|')})/.*.xcodeproj} =~ path }
       end
+
+      def self.get_project!(xcodeproj_path_or_dir)
+        require 'xcodeproj'
+
+        if File.extname(xcodeproj_path_or_dir) == ".xcodeproj"
+          project_path = xcodeproj_path_or_dir
+        else
+          project_path = Dir.glob("#{xcodeproj_path_or_dir}/*.xcodeproj").first
+        end
+
+        if project_path && File.exist?(project_path)
+          return Xcodeproj::Project.open(project_path)
+        else
+          UI.user_error!("Unable to find Xcode project at #{project_path || xcodeproj_path_or_dir}")
+        end
+      end
+
+      def self.update_project_build_setting(project, build_setting, value)
+        changed = false
+
+        ([project] + project.targets).each do |item|
+          item.build_configurations.each do |config|
+            next unless config.build_settings.key?(build_setting)
+
+            config.build_settings[build_setting] = value
+            changed = true
+          end
+        end
+
+        changed
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -177,6 +177,47 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("2.0.0")
       end
 
+      it "does not require an Xcode project when updating a custom version number" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return("1.2.3")
+
+        allow(Fastlane::Helper).to receive(:test?)
+          .and_return(false)
+
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool new-marketing-version 2.0.0/)
+          .once
+
+        expect(Fastlane::Helper::XcodeprojHelper).not_to receive(:get_project!)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            Fastlane::FastFile.new.parse("lane :test do
+              increment_version_number(version_number: '2.0.0')
+            end").runner.execute(:test)
+          end
+        end
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("2.0.0")
+      end
+
+      it "skips the update when multiple root projects exist and no project is provided" do
+        Dir.mktmpdir do |dir|
+          FileUtils.mkdir_p(File.join(dir, "App.xcodeproj"))
+          FileUtils.mkdir_p(File.join(dir, "Extension.xcodeproj"))
+
+          Dir.chdir(dir) do
+            expect(Fastlane::Helper::XcodeprojHelper).not_to receive(:get_project!)
+
+            expect do
+              Fastlane::Actions::IncrementVersionNumberAction.update_project_version_build_setting(nil, "MARKETING_VERSION", "2.0.0")
+            end.not_to raise_error
+          end
+        end
+      end
+
       it "resolves ${MARKETING_VERSION} using get_version_number action" do
         from_version = "${MARKETING_VERSION}"
         resolved_version = "1.2.3"
@@ -188,6 +229,8 @@ describe Fastlane do
         expect(Fastlane::Actions::GetVersionNumberAction).to receive(:run)
           .with(xcodeproj: nil)
           .and_return(resolved_version)
+        expect(UI).to receive(:verbose)
+          .with("agvtool returned ${MARKETING_VERSION}, resolving it...")
 
         Fastlane::FastFile.new.parse("lane :test do
           increment_version_number
@@ -232,6 +275,20 @@ describe Fastlane do
 
         expect(project_config.build_settings["CURRENT_PROJECT_VERSION"]).to eq("42")
         expect(target_config.build_settings["PRODUCT_BUNDLE_IDENTIFIER"]).to eq("tools.fastlane.example")
+      end
+
+      it "does not save the Xcode project when only an xcconfig changed" do
+        project = double("project")
+
+        expect(Fastlane::Helper::XcodeprojHelper).to receive(:get_project!)
+          .with("App.xcodeproj")
+          .and_return(project)
+        expect(Fastlane::Helper::XcodeprojHelper).to receive(:update_project_build_setting)
+          .with(project, "MARKETING_VERSION", "1.2.3")
+          .and_return(project: false, xcconfig: true)
+        expect(project).not_to receive(:save)
+
+        Fastlane::Actions::IncrementVersionNumberAction.update_project_version_build_setting("App.xcodeproj", "MARKETING_VERSION", "1.2.3")
       end
 
       it "returns the new version as return value" do

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -127,6 +127,56 @@ describe Fastlane do
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.2.4/)
       end
 
+      it "updates MARKETING_VERSION build settings after agvtool when the version is stored in the Xcode project" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return("$(MARKETING_VERSION)")
+
+        expect(Fastlane::Actions::GetVersionNumberAction).to receive(:run)
+          .with(xcodeproj: nil)
+          .and_return("1.2.3")
+
+        allow(Fastlane::Helper).to receive(:test?)
+          .and_return(false)
+
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool new-marketing-version 1.2.4/)
+          .once
+
+        expect(Fastlane::Actions::IncrementVersionNumberAction).to receive(:update_project_version_build_setting)
+          .with(nil, "MARKETING_VERSION", "1.2.4")
+
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_number
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("1.2.4")
+      end
+
+      it "updates MARKETING_VERSION build settings when a custom version number is provided" do
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool what-marketing-version/, any_args)
+          .once
+          .and_return("1.2.3")
+
+        allow(Fastlane::Helper).to receive(:test?)
+          .and_return(false)
+
+        expect(Fastlane::Actions).to receive(:sh)
+          .with(/agvtool new-marketing-version 2.0.0/)
+          .once
+
+        expect(Fastlane::Actions::IncrementVersionNumberAction).to receive(:update_project_version_build_setting)
+          .with(nil, "MARKETING_VERSION", "2.0.0")
+
+        Fastlane::FastFile.new.parse("lane :test do
+          increment_version_number(version_number: '2.0.0')
+        end").runner.execute(:test)
+
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("2.0.0")
+      end
+
       it "resolves ${MARKETING_VERSION} using get_version_number action" do
         from_version = "${MARKETING_VERSION}"
         resolved_version = "1.2.3"
@@ -144,6 +194,44 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to match(/cd .* && agvtool new-marketing-version 1.2.4/)
+      end
+
+      it "updates MARKETING_VERSION build settings when the version is stored in the Xcode project" do
+        build_configuration = Struct.new(:build_settings)
+        project_config = build_configuration.new({ "MARKETING_VERSION" => "1.0.0" })
+        target_config = build_configuration.new({ "MARKETING_VERSION" => "1.0.0" })
+        other_config = build_configuration.new({ "CURRENT_PROJECT_VERSION" => "42" })
+        target = double("target", build_configurations: [target_config, other_config])
+        project = double("project", build_configurations: [project_config], targets: [target])
+
+        expect(Fastlane::Actions::GetVersionNumberAction).to receive(:get_project!)
+          .with("App.xcodeproj")
+          .and_return(project)
+        expect(project).to receive(:save)
+
+        Fastlane::Actions::IncrementVersionNumberAction.update_project_version_build_setting("App.xcodeproj", "MARKETING_VERSION", "1.2.3")
+
+        expect(project_config.build_settings["MARKETING_VERSION"]).to eq("1.2.3")
+        expect(target_config.build_settings["MARKETING_VERSION"]).to eq("1.2.3")
+        expect(other_config.build_settings["CURRENT_PROJECT_VERSION"]).to eq("42")
+      end
+
+      it "does not save the Xcode project when MARKETING_VERSION is not set" do
+        build_configuration = Struct.new(:build_settings)
+        project_config = build_configuration.new({ "CURRENT_PROJECT_VERSION" => "42" })
+        target_config = build_configuration.new({ "PRODUCT_BUNDLE_IDENTIFIER" => "tools.fastlane.example" })
+        target = double("target", build_configurations: [target_config])
+        project = double("project", build_configurations: [project_config], targets: [target])
+
+        expect(Fastlane::Actions::GetVersionNumberAction).to receive(:get_project!)
+          .with("App.xcodeproj")
+          .and_return(project)
+        expect(project).not_to receive(:save)
+
+        Fastlane::Actions::IncrementVersionNumberAction.update_project_version_build_setting("App.xcodeproj", "MARKETING_VERSION", "1.2.3")
+
+        expect(project_config.build_settings["CURRENT_PROJECT_VERSION"]).to eq("42")
+        expect(target_config.build_settings["PRODUCT_BUNDLE_IDENTIFIER"]).to eq("tools.fastlane.example")
       end
 
       it "returns the new version as return value" do

--- a/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
+++ b/fastlane/spec/actions_specs/increment_version_number_action_spec.rb
@@ -204,7 +204,7 @@ describe Fastlane do
         target = double("target", build_configurations: [target_config, other_config])
         project = double("project", build_configurations: [project_config], targets: [target])
 
-        expect(Fastlane::Actions::GetVersionNumberAction).to receive(:get_project!)
+        expect(Fastlane::Helper::XcodeprojHelper).to receive(:get_project!)
           .with("App.xcodeproj")
           .and_return(project)
         expect(project).to receive(:save)
@@ -223,7 +223,7 @@ describe Fastlane do
         target = double("target", build_configurations: [target_config])
         project = double("project", build_configurations: [project_config], targets: [target])
 
-        expect(Fastlane::Actions::GetVersionNumberAction).to receive(:get_project!)
+        expect(Fastlane::Helper::XcodeprojHelper).to receive(:get_project!)
           .with("App.xcodeproj")
           .and_return(project)
         expect(project).not_to receive(:save)

--- a/fastlane/spec/helper/xcodeproj_helper_spec.rb
+++ b/fastlane/spec/helper/xcodeproj_helper_spec.rb
@@ -87,7 +87,7 @@ describe Fastlane::Actions do
 
         changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, "MARKETING_VERSION", "1.2.3")
 
-        expect(changed).to eq(true)
+        expect(changed).to eq(project: true, xcconfig: false)
         expect(project_config.build_settings["MARKETING_VERSION"]).to eq("1.2.3")
         expect(target_config.build_settings["MARKETING_VERSION"]).to eq("1.2.3")
         expect(other_config.build_settings["CURRENT_PROJECT_VERSION"]).to eq("42")
@@ -102,9 +102,199 @@ describe Fastlane::Actions do
 
         changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, "MARKETING_VERSION", "1.2.3")
 
-        expect(changed).to eq(false)
+        expect(changed).to eq(project: false, xcconfig: false)
         expect(project_config.build_settings["CURRENT_PROJECT_VERSION"]).to eq("42")
         expect(target_config.build_settings["PRODUCT_BUNDLE_IDENTIFIER"]).to eq("tools.fastlane.example")
+      end
+
+      it 'updates matching build settings in base xcconfig files' do
+        xcconfig_path = File.join(dir, "Version.xcconfig")
+        File.write(xcconfig_path, [
+          "// keep this comment",
+          "#include \"Base.xcconfig\"",
+          "MARKETING_VERSION = 1.2.3 // trailing comment",
+          "MARKETING_VERSION[sdk=iphoneos*] = 1.2.4",
+          "MARKETING_VERSION[sdk=iphoneos*][arch=arm64] = 1.2.4",
+          "MARKETING_VERSION[config=Release] = 1.2.5 /* release comment */",
+          "CURRENT_PROJECT_VERSION = 42"
+        ].join("\n") + "\n")
+        base_configuration_reference = double("base_configuration_reference", real_path: Pathname.new(xcconfig_path))
+        build_configuration = double("build_configuration", build_settings: {}, base_configuration_reference: base_configuration_reference)
+        target = double("target", build_configurations: [])
+        project = double("project", build_configurations: [build_configuration], targets: [target])
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, "MARKETING_VERSION", "5.6.7")
+
+        expect(changed).to eq(project: false, xcconfig: true)
+        expect(File.read(xcconfig_path)).to eq([
+          "// keep this comment",
+          "#include \"Base.xcconfig\"",
+          "MARKETING_VERSION = 5.6.7 // trailing comment",
+          "MARKETING_VERSION[sdk=iphoneos*] = 5.6.7",
+          "MARKETING_VERSION[sdk=iphoneos*][arch=arm64] = 5.6.7",
+          "MARKETING_VERSION[config=Release] = 5.6.7 /* release comment */",
+          "CURRENT_PROJECT_VERSION = 42"
+        ].join("\n") + "\n")
+      end
+
+      it 'does not update build settings inside xcconfig block comments' do
+        xcconfig_path = File.join(dir, "Version.xcconfig")
+        File.write(xcconfig_path, [
+          "/*",
+          "MARKETING_VERSION = 1.2.3",
+          "MARKETING_VERSION[sdk=iphoneos*] = 1.2.4",
+          "*/",
+          "MARKETING_VERSION = 2.3.4"
+        ].join("\n") + "\n")
+        base_configuration_reference = double("base_configuration_reference", real_path: Pathname.new(xcconfig_path))
+        build_configuration = double("build_configuration", build_settings: {}, base_configuration_reference: base_configuration_reference)
+        target = double("target", build_configurations: [])
+        project = double("project", build_configurations: [build_configuration], targets: [target])
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, "MARKETING_VERSION", "5.6.7")
+
+        expect(changed).to eq(project: false, xcconfig: true)
+        expect(File.read(xcconfig_path)).to eq([
+          "/*",
+          "MARKETING_VERSION = 1.2.3",
+          "MARKETING_VERSION[sdk=iphoneos*] = 1.2.4",
+          "*/",
+          "MARKETING_VERSION = 5.6.7"
+        ].join("\n") + "\n")
+      end
+
+      it 'updates matching build settings in included xcconfig files' do
+        included_xcconfig_path = File.join(dir, "Version.xcconfig")
+        File.write(included_xcconfig_path, [
+          "MARKETING_VERSION = 1.2.3"
+        ].join("\n") + "\n")
+        release_xcconfig_path = File.join(dir, "ReleaseVersion.xcconfig")
+        File.write(release_xcconfig_path, [
+          "MARKETING_VERSION[config=Release] = 1.2.4"
+        ].join("\n") + "\n")
+        xcconfig_path = File.join(dir, "Debug.xcconfig")
+        File.write(xcconfig_path, [
+          "#include \"Version\"",
+          "#include \"ReleaseVersion.xcconfig\"",
+          "CURRENT_PROJECT_VERSION = 42"
+        ].join("\n") + "\n")
+        base_configuration_reference = double("base_configuration_reference", real_path: Pathname.new(xcconfig_path))
+        build_configuration = double("build_configuration", build_settings: {}, base_configuration_reference: base_configuration_reference)
+        target = double("target", build_configurations: [])
+        project = double("project", build_configurations: [build_configuration], targets: [target])
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, "MARKETING_VERSION", "5.6.7")
+
+        expect(changed).to eq(project: false, xcconfig: true)
+        expect(File.read(xcconfig_path)).to eq([
+          "#include \"Version\"",
+          "#include \"ReleaseVersion.xcconfig\"",
+          "CURRENT_PROJECT_VERSION = 42"
+        ].join("\n") + "\n")
+        expect(File.read(included_xcconfig_path)).to eq([
+          "MARKETING_VERSION = 5.6.7"
+        ].join("\n") + "\n")
+        expect(File.read(release_xcconfig_path)).to eq([
+          "MARKETING_VERSION[config=Release] = 5.6.7"
+        ].join("\n") + "\n")
+      end
+
+      it 'does not follow xcconfig includes inside block comments' do
+        included_xcconfig_path = File.join(dir, "Version.xcconfig")
+        included_xcconfig_content = [
+          "MARKETING_VERSION = 1.2.3"
+        ].join("\n") + "\n"
+        File.write(included_xcconfig_path, included_xcconfig_content)
+        xcconfig_path = File.join(dir, "Debug.xcconfig")
+        File.write(xcconfig_path, [
+          "/*",
+          "#include \"Version\"",
+          "*/",
+          "CURRENT_PROJECT_VERSION = 42"
+        ].join("\n") + "\n")
+        base_configuration_reference = double("base_configuration_reference", real_path: Pathname.new(xcconfig_path))
+        build_configuration = double("build_configuration", build_settings: {}, base_configuration_reference: base_configuration_reference)
+        target = double("target", build_configurations: [])
+        project = double("project", build_configurations: [build_configuration], targets: [target])
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, "MARKETING_VERSION", "5.6.7")
+
+        expect(changed).to eq(project: false, xcconfig: false)
+        expect(File.read(included_xcconfig_path)).to eq(included_xcconfig_content)
+      end
+
+      it 'does not rewrite matching build settings when the value is already current' do
+        build_configuration = Struct.new(:build_settings)
+        project_config = build_configuration.new({ "MARKETING_VERSION" => "1.2.3" })
+        target = double("target", build_configurations: [])
+        project = double("project", build_configurations: [project_config], targets: [target])
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, "MARKETING_VERSION", "1.2.3")
+
+        expect(changed).to eq(project: false, xcconfig: false)
+      end
+    end
+
+    describe '.update_build_configuration_build_setting' do
+      it 'updates an inline build setting' do
+        build_configuration = double("build_configuration", build_settings: {
+          "MARKETING_VERSION" => "1.0.0",
+          "MARKETING_VERSION[sdk=iphoneos*]" => "1.0.1",
+          "MARKETING_VERSION[sdk=iphoneos*][arch=arm64]" => "1.0.2",
+          "CURRENT_PROJECT_VERSION" => "42"
+        })
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_build_configuration_build_setting(build_configuration, "MARKETING_VERSION", "1.2.3")
+
+        expect(changed).to eq(project: true, xcconfig: false)
+        expect(build_configuration.build_settings["MARKETING_VERSION"]).to eq("1.2.3")
+        expect(build_configuration.build_settings["MARKETING_VERSION[sdk=iphoneos*]"]).to eq("1.2.3")
+        expect(build_configuration.build_settings["MARKETING_VERSION[sdk=iphoneos*][arch=arm64]"]).to eq("1.2.3")
+        expect(build_configuration.build_settings["CURRENT_PROJECT_VERSION"]).to eq("42")
+      end
+
+      it 'updates inline and xcconfig build settings in the same configuration' do
+        xcconfig_path = File.join(dir, "Version.xcconfig")
+        File.write(xcconfig_path, [
+          "MARKETING_VERSION[sdk=iphoneos*] = 1.0.1",
+          "MARKETING_VERSION[sdk=iphoneos*][arch=arm64] = 1.0.2"
+        ].join("\n") + "\n")
+        base_configuration_reference = double("base_configuration_reference", real_path: Pathname.new(xcconfig_path))
+        build_configuration = double("build_configuration", build_settings: {
+          "MARKETING_VERSION" => "1.0.0"
+        }, base_configuration_reference: base_configuration_reference)
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_build_configuration_build_setting(build_configuration, "MARKETING_VERSION", "1.2.3")
+
+        expect(changed).to eq(project: true, xcconfig: true)
+        expect(build_configuration.build_settings["MARKETING_VERSION"]).to eq("1.2.3")
+        expect(File.read(xcconfig_path)).to eq([
+          "MARKETING_VERSION[sdk=iphoneos*] = 1.2.3",
+          "MARKETING_VERSION[sdk=iphoneos*][arch=arm64] = 1.2.3"
+        ].join("\n") + "\n")
+      end
+
+      it 'does not rewrite an xcconfig when the value is already current' do
+        xcconfig_path = File.join(dir, "Version.xcconfig")
+        content = [
+          "MARKETING_VERSION = 1.2.3 // trailing comment"
+        ].join("\n") + "\n"
+        File.write(xcconfig_path, content)
+        base_configuration_reference = double("base_configuration_reference", real_path: Pathname.new(xcconfig_path))
+        build_configuration = double("build_configuration", build_settings: {}, base_configuration_reference: base_configuration_reference)
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_build_configuration_build_setting(build_configuration, "MARKETING_VERSION", "1.2.3")
+
+        expect(changed).to eq(project: false, xcconfig: false)
+        expect(File.read(xcconfig_path)).to eq(content)
+      end
+
+      it 'returns unchanged when the build setting is not present inline or in an xcconfig' do
+        build_configuration = double("build_configuration", build_settings: {}, base_configuration_reference: nil)
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_build_configuration_build_setting(build_configuration, "MARKETING_VERSION", "1.2.3")
+
+        expect(changed).to eq(project: false, xcconfig: false)
       end
     end
 

--- a/fastlane/spec/helper/xcodeproj_helper_spec.rb
+++ b/fastlane/spec/helper/xcodeproj_helper_spec.rb
@@ -47,6 +47,67 @@ describe Fastlane::Actions do
       expect(paths).to contain_exactly(path, secondary_path)
     end
 
+    describe '.get_project!' do
+      it 'opens the given Xcode project' do
+        expect(Xcodeproj::Project).to receive(:open)
+          .with(File.join(dir, PATH))
+          .and_return(:project)
+
+        FileUtils.mkdir_p(File.join(dir, PATH))
+
+        expect(Fastlane::Helper::XcodeprojHelper.get_project!(File.join(dir, PATH))).to eq(:project)
+      end
+
+      it 'opens the first Xcode project in the given directory' do
+        path = File.join(dir, PATH)
+        FileUtils.mkdir_p(path)
+
+        expect(Xcodeproj::Project).to receive(:open)
+          .with(path)
+          .and_return(:project)
+
+        expect(Fastlane::Helper::XcodeprojHelper.get_project!(dir)).to eq(:project)
+      end
+
+      it 'raises when no Xcode project can be found' do
+        expect do
+          Fastlane::Helper::XcodeprojHelper.get_project!(dir)
+        end.to raise_error("Unable to find Xcode project at #{dir}")
+      end
+    end
+
+    describe '.update_project_build_setting' do
+      it 'updates matching build settings in the project and targets' do
+        build_configuration = Struct.new(:build_settings)
+        project_config = build_configuration.new({ "MARKETING_VERSION" => "1.0.0" })
+        target_config = build_configuration.new({ "MARKETING_VERSION" => "1.0.0" })
+        other_config = build_configuration.new({ "CURRENT_PROJECT_VERSION" => "42" })
+        target = double("target", build_configurations: [target_config, other_config])
+        project = double("project", build_configurations: [project_config], targets: [target])
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, "MARKETING_VERSION", "1.2.3")
+
+        expect(changed).to eq(true)
+        expect(project_config.build_settings["MARKETING_VERSION"]).to eq("1.2.3")
+        expect(target_config.build_settings["MARKETING_VERSION"]).to eq("1.2.3")
+        expect(other_config.build_settings["CURRENT_PROJECT_VERSION"]).to eq("42")
+      end
+
+      it 'returns false when no build setting matches' do
+        build_configuration = Struct.new(:build_settings)
+        project_config = build_configuration.new({ "CURRENT_PROJECT_VERSION" => "42" })
+        target_config = build_configuration.new({ "PRODUCT_BUNDLE_IDENTIFIER" => "tools.fastlane.example" })
+        target = double("target", build_configurations: [target_config])
+        project = double("project", build_configurations: [project_config], targets: [target])
+
+        changed = Fastlane::Helper::XcodeprojHelper.update_project_build_setting(project, "MARKETING_VERSION", "1.2.3")
+
+        expect(changed).to eq(false)
+        expect(project_config.build_settings["CURRENT_PROJECT_VERSION"]).to eq("42")
+        expect(target_config.build_settings["PRODUCT_BUNDLE_IDENTIFIER"]).to eq("tools.fastlane.example")
+      end
+    end
+
     after do
       FileUtils.rm_rf(dir)
     end


### PR DESCRIPTION
### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

PR #30011 fixed resolving `$(MARKETING_VERSION)` when reading the current version, but `agvtool new-marketing-version` can still leave the `MARKETING_VERSION` build setting unchanged in modern Xcode projects.

### Description

This syncs the new version back to the Xcode project's `MARKETING_VERSION` build setting after running `agvtool`.

The project is only saved when `MARKETING_VERSION` already exists.

### Testing Steps

```bash
bundle exec rspec fastlane/spec/actions_specs/increment_version_number_action_spec.rb
```

```text
28 examples, 0 failures
```

```bash
RUBOCOP_CACHE_ROOT=/private/tmp/rubocop_cache bundle exec rubocop fastlane/lib/fastlane/actions/increment_version_number.rb fastlane/spec/actions_specs/increment_version_number_action_spec.rb
```

```text
2 files inspected, no offenses detected
```
