### PR TITLE
[test] skip VisionOS test if sdk not installed

### DIFF
--- a/gym/spec/platform_detection_spec.rb
+++ b/gym/spec/platform_detection_spec.rb
@@ -33,6 +33,8 @@ describe Gym do
     options = { project: "./gym/examples/visionos/VisionExample.xcodeproj", sdk: "xros", skip_package_dependencies_resolution: true }
     Gym.config = FastlaneCore::Configuration.create(Gym::Options.available_options, options)
 
+    skip "visionOS SDK not available on this machine" unless Gym.project.supported_platforms.include?(:visionOS)
+
     expect(Gym.project.multiplatform?).to eq(false)
     expect(Gym.project.visionos?).to eq(true)
     expect(Gym.project.ios?).to eq(false)


### PR DESCRIPTION
## Problem

Your tests will fail if you don't have VisionOS installed. I didn't on my new computer.

## Solution

Skip the test if we resolve the supported platforms


fixes: #30006
fixes: #29709