### PR TITLE
[match] Expand range of valid characters in app name

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -190,7 +190,7 @@ module Spaceship
 
     def valid_name_for(input)
       latinized = input.to_slug.transliterate
-      latinized = latinized.gsub(/[^0-9A-Za-z\d\s]/, '') # remove non-valid characters
+      latinized = latinized.gsub(/[^[:ascii:]]|[@&*"]/, '') # remove non-valid characters
       # Check if the input string was modified, since it might be empty now
       # (if it only contained non-latin symbols) or the duplicate of another app
       if latinized != input

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -130,6 +130,19 @@ describe Spaceship::Client do
       end
     end
 
+    describe '#valid_name_for' do
+      it 'does not modify input when it already contains only valid characters' do
+        input = 'Development App 123'
+        expect(subject.send(:valid_name_for, input)).to eq(input)
+      end
+
+      it 'sanitizes invalid characters and appends md5 hash when input changed' do
+        input = 'Development App λ@&*"'
+        expected = 'Development App  ' + Digest::MD5.hexdigest(input)
+        expect(subject.send(:valid_name_for, input)).to eq(expected)
+      end
+    end
+
     describe '#create_app' do
       it 'should make a request create an explicit app id' do
         response = subject.create_app!(:explicit, 'Production App', 'tools.fastlane.spaceship.some-explicit-app')
@@ -145,7 +158,7 @@ describe Spaceship::Client do
         expect(response['identifier']).to eq('tools.fastlane.spaceship.*')
       end
 
-      it 'should strip non ASCII characters' do
+      it 'does not modify input when it already contains only valid characters' do
         response = subject.create_app!(:explicit, 'pp Test 1ed9e25c93ac7142ff9df53e7f80e84c', 'tools.fastlane.spaceship.some-explicit-app')
         expect(response['isWildCard']).to eq(false)
         expect(response['name']).to eq('pp Test 1ed9e25c93ac7142ff9df53e7f80e84c')


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Fixes an issue where a hyphen was automatically removed from the app name with the warning:
`Your app name includes non-ASCII characters, which are not supported by the Apple Developer Portal`. 
Only the following ASCII characters are not allowed: `@, &, *, "`.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

Expands the range of characters allowed in the app name.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
