### PR TITLE
[screengrab] Fix screenshot copy count and path probe output

### DIFF
--- a/fastlane_core/lib/fastlane_core/command_executor.rb
+++ b/fastlane_core/lib/fastlane_core/command_executor.rb
@@ -29,9 +29,14 @@ module FastlaneCore
       # @param prefix [Array] An array containing a prefix + block which might get applied to the output
       # @param loading [String] A loading string that is shown before the first output
       # @param suppress_output [Boolean] Should we print the command's output?
+      # @param suppress_error_output [Boolean] Suppress replaying output and printing the exit status
+      #   when the command fails, unless verbose output is enabled.
       # @return [String] All the output as string
-      def execute(command: nil, print_all: false, print_command: true, error: nil, prefix: nil, loading: nil, suppress_output: false)
-        print_all = true if FastlaneCore::Globals.verbose?
+      def execute(command: nil, print_all: false, print_command: true, error: nil, prefix: nil, loading: nil,
+                  suppress_output: false, suppress_error_output: false)
+        verbose = FastlaneCore::Globals.verbose?
+        print_all = true if verbose
+        suppress_error_output = false if verbose
         prefix ||= {}
 
         output = []
@@ -67,7 +72,7 @@ module FastlaneCore
           # > invalid byte sequence in US-ASCII (ArgumentError)
           output << ex.to_s
           o = output.join("\n")
-          puts(o)
+          puts(o) unless suppress_error_output
           if error
             error.call(o, nil)
           else
@@ -79,9 +84,12 @@ module FastlaneCore
         if status != 0
           is_output_already_printed = print_all && !suppress_output
           o = output.join("\n")
-          puts(o) unless is_output_already_printed
 
-          UI.error("Exit status: #{status}")
+          unless suppress_error_output
+            puts(o) unless is_output_already_printed
+            UI.error("Exit status: #{status}")
+          end
+
           if error
             error.call(o, status)
           else

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -158,6 +158,138 @@ Shopping list:
         )
         expect(error_block_input).to eq(failing_command_error_input)
       end
+
+      it "does not print output or exit status when failure output is suppressed" do
+        unless FastlaneCore::Helper.windows?
+          expect(Process).to receive(:wait)
+        end
+
+        error_block_input = nil
+        error_block_status = nil
+
+        expect(FastlaneCore::UI).not_to receive(:error)
+
+        expect do
+          FastlaneCore::CommandExecutor.execute(
+            command: failing_command,
+            print_all: false,
+            print_command: false,
+            suppress_error_output: true,
+            error: proc do |error_output, status|
+              error_block_input = error_output
+              error_block_status = status
+            end
+          )
+        end.not_to output.to_stdout
+
+        expect(error_block_input).to eq(failing_command_error_input)
+        expect(error_block_status).to eq(42)
+      end
+
+      it "prints output and exit status when failure output is suppressed in verbose mode" do
+        expect(FastlaneCore::FastlanePty).to receive(:spawn) do |command, &block|
+          expect(command).to eq("failing command")
+
+          block.yield(["log\n"], nil, nil)
+          42
+        end
+
+        error_block_input = nil
+        error_block_status = nil
+
+        expect(FastlaneCore::UI).to receive(:command_output).with("log")
+        expect(FastlaneCore::UI).to receive(:error).with("Exit status: 42")
+
+        FastlaneSpec::Env.with_verbose(true) do
+          FastlaneCore::CommandExecutor.execute(
+            command: "failing command",
+            print_command: false,
+            suppress_error_output: true,
+            error: proc do |error_output, status|
+              error_block_input = error_output
+              error_block_status = status
+            end
+          )
+        end
+
+        expect(error_block_input).to eq("log")
+        expect(error_block_status).to eq(42)
+      end
+
+      it "does not print rescued command output when failure output is suppressed" do
+        command_error = StandardError.new("pty error")
+        allow(command_error).to receive(:exit_status).and_return(42)
+        expect(FastlaneCore::FastlanePty).to receive(:spawn).and_raise(command_error)
+
+        error_block_input = nil
+
+        expect do
+          FastlaneCore::CommandExecutor.execute(
+            command: "failing command",
+            print_command: false,
+            suppress_error_output: true,
+            error: proc do |error_output|
+              error_block_input = error_output
+            end
+          )
+        end.not_to output.to_stdout
+
+        expect(error_block_input).to eq("pty error")
+      end
+
+      it "prints rescued command output when failure output is suppressed in verbose mode" do
+        command_error = StandardError.new("pty error")
+        allow(command_error).to receive(:exit_status).and_return(42)
+        expect(FastlaneCore::FastlanePty).to receive(:spawn).and_raise(command_error)
+
+        error_block_input = nil
+        error_block_status = nil
+
+        expect(FastlaneCore::UI).to receive(:error).with("Exit status: 42")
+
+        expect do
+          FastlaneSpec::Env.with_verbose(true) do
+            FastlaneCore::CommandExecutor.execute(
+              command: "failing command",
+              print_command: false,
+              suppress_error_output: true,
+              error: proc do |error_output, status|
+                error_block_input = error_output
+                error_block_status = status
+              end
+            )
+          end
+        end.to output("pty error\n").to_stdout
+
+        expect(error_block_input).to eq("pty error")
+        expect(error_block_status).to eq(42)
+      end
+
+      it "still raises when failure output is suppressed without an error block" do
+        unless FastlaneCore::Helper.windows?
+          expect(Process).to receive(:wait)
+        end
+
+        raised_error = nil
+
+        expect(FastlaneCore::UI).not_to receive(:error)
+
+        expect do
+          begin
+            FastlaneCore::CommandExecutor.execute(
+              command: failing_command,
+              print_all: false,
+              print_command: false,
+              suppress_error_output: true
+            )
+          rescue => ex
+            raised_error = ex
+          end
+        end.not_to output.to_stdout
+
+        expect(raised_error).to be_a(FastlaneCore::Interface::FastlaneError)
+        expect(raised_error.to_s).to eq("Exit status: 42")
+      end
     end
 
     describe "which" do

--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -294,9 +294,6 @@ module Screengrab
 
     def pull_screenshots_from_device(locale, device_serial, device_type_dir_name)
       UI.message("Pulling captured screenshots for locale #{locale} from the device")
-      starting_screenshot_count = screenshot_file_names_in(@config[:output_directory], device_type_dir_name).length
-
-      UI.verbose("Starting screenshot count is: #{starting_screenshot_count}")
 
       device_screenshots_paths = [
         determine_external_screenshots_path(device_serial, @config[:app_package_name], [locale]),
@@ -306,7 +303,7 @@ module Screengrab
       # Make a temp directory into which to pull the screenshots before they are moved to their final location.
       # This makes directory cleanup easier, as the temp directory will be removed when the block completes.
 
-      Dir.mktmpdir do |tempdir|
+      copied_screenshot_count = Dir.mktmpdir do |tempdir|
         device_screenshots_paths.each do |(device_path, needs_run_as)|
           if_device_path_exists(@config[:app_package_name], device_serial, device_path, needs_run_as) do |path|
             UI.message(path)
@@ -337,19 +334,12 @@ module Screengrab
         move_pulled_screenshots(locale, tempdir, device_type_dir_name)
       end
 
-      ending_screenshot_count = screenshot_file_names_in(@config[:output_directory], device_type_dir_name).length
-
-      UI.verbose("Ending screenshot count is: #{ending_screenshot_count}")
-
-      # Because we can't guarantee the screenshot output directory will be empty when we pull, we determine
-      # success based on whether there are more screenshots there than when we started.
-      # This is only applicable though when `clear_previous_screenshots` is set to `true`.
-      if starting_screenshot_count == ending_screenshot_count && @config[:clear_previous_screenshots]
+      if copied_screenshot_count.zero? && @config[:clear_previous_screenshots]
         UI.error("Make sure you've used Screengrab.screenshot() in your tests and that your expected tests are being run.")
         UI.abort_with_message!("No screenshots were detected 📷❌")
       end
 
-      ending_screenshot_count - starting_screenshot_count
+      copied_screenshot_count
     end
 
     def move_pulled_screenshots(locale, pull_dir, device_type_dir_name)
@@ -359,8 +349,11 @@ module Screengrab
       #   [pull_dir]/screengrab/en-US/images/screenshots
       screenshots_dir_pattern = File.join(pull_dir, '**', "screenshots")
 
+      copied_screenshot_count = 0
+
       Dir.glob(screenshots_dir_pattern, File::FNM_CASEFOLD).each do |screenshots_dir|
         src_screenshots = Dir.glob(File.join(screenshots_dir, '*.png'), File::FNM_CASEFOLD)
+        next if src_screenshots.empty?
 
         # The :output_directory is the final location for the screenshots, so we begin by replacing
         # the temp directory portion of the path, with the output directory
@@ -380,8 +373,11 @@ module Screengrab
 
         FileUtils.mkdir_p(dest_dir)
         FileUtils.cp_r(src_screenshots, dest_dir)
+        copied_screenshot_count += src_screenshots.length
         UI.success("Screenshots copied to #{dest_dir}")
       end
+
+      copied_screenshot_count
     end
 
     # Some device commands fail if executed against a device path that does not exist, so this helper method
@@ -392,7 +388,8 @@ module Screengrab
 
       return if run_adb_command("-s #{device_serial.shellescape} shell#{run_as} ls #{device_path.shellescape.shellescape}",
                                 print_all: false,
-                                print_command: false).include?('No such file')
+                                print_command: false,
+                                suppress_error_output: true).include?('No such file')
 
       yield(device_path)
     rescue
@@ -408,7 +405,8 @@ module Screengrab
       packages.split("\n").map { |package| package.gsub("package:", "") }
     end
 
-    def run_adb_command(command, print_all: false, print_command: false, raise_errors: true)
+    def run_adb_command(command, print_all: false, print_command: false, raise_errors: true,
+                        suppress_error_output: false)
       adb_host = @config[:adb_host]
       host = adb_host.nil? ? '' : "-H #{adb_host.shellescape} "
       output = ''
@@ -417,6 +415,7 @@ module Screengrab
         cmdout = @executor.execute(command: @android_env.adb_path + " " + host + command,
                                   print_all: print_all,
                                   print_command: print_command,
+                                  suppress_error_output: suppress_error_output,
                                   error: raise_errors ? nil : proc { |out, status| errout = out }) || ''
         output = errout || cmdout
       rescue => ex

--- a/screengrab/spec/runner_spec.rb
+++ b/screengrab/spec/runner_spec.rb
@@ -236,6 +236,87 @@ describe Screengrab::Runner do
     end
   end
 
+  describe :if_device_path_exists do
+    let(:device_serial) { 'device_serial' }
+    let(:app_package_name) { 'tools.fastlane.dev' }
+    let(:device_path) { '/data/data/tools.fastlane.dev/app_screengrab/en-US/images/screenshots' }
+
+    before do
+      expect(mock_android_environment).to receive(:adb_path).and_return("adb")
+    end
+
+    it 'checks missing paths without printing expected adb failures' do
+      expect(mock_executor).to receive(:execute)
+        .with(hash_including(
+                command: "adb -s #{device_serial} shell run-as #{app_package_name} ls #{device_path}",
+                print_all: false,
+                print_command: false,
+                suppress_error_output: true
+              ))
+        .and_return("ls: #{device_path}: No such file or directory")
+
+      expect do |probe|
+        @runner.if_device_path_exists(app_package_name, device_serial, device_path, true, &probe)
+      end.not_to yield_control
+    end
+  end
+
+  describe :pull_screenshots_from_device do
+    let(:locale) { 'en-US' }
+    let(:device_serial) { 'device_serial' }
+    let(:device_type_dir_name) { 'phoneScreenshots' }
+
+    before do
+      config[:app_package_name] = 'tools.fastlane.dev'
+      config[:clear_previous_screenshots] = false
+      config[:output_directory] = Dir.mktmpdir
+
+      existing_screenshots_dir = File.join(config[:output_directory], locale, 'images', device_type_dir_name)
+      FileUtils.mkdir_p(existing_screenshots_dir)
+      FileUtils.touch(File.join(existing_screenshots_dir, 'screenshot.png'))
+
+      allow(@runner).to receive(:determine_external_screenshots_path).and_return([])
+      allow(@runner).to receive(:determine_internal_screenshots_paths).and_return([])
+      allow(@runner).to receive(:move_pulled_screenshots).and_return(1)
+    end
+
+    after do
+      FileUtils.remove_entry(config[:output_directory])
+    end
+
+    it 'returns the number of screenshots copied even when existing files are overwritten' do
+      expect(@runner.pull_screenshots_from_device(locale, device_serial, device_type_dir_name)).to eq(1)
+    end
+  end
+
+  describe :move_pulled_screenshots do
+    let(:locale) { 'en-US' }
+    let(:device_type_dir_name) { 'phoneScreenshots' }
+
+    before do
+      config[:output_directory] = Dir.mktmpdir
+    end
+
+    after do
+      FileUtils.remove_entry(config[:output_directory])
+    end
+
+    it 'returns the number of screenshots copied' do
+      Dir.mktmpdir do |pull_dir|
+        screenshots_dir = File.join(pull_dir, 'screenshots')
+        FileUtils.mkdir_p(screenshots_dir)
+        FileUtils.touch(File.join(screenshots_dir, 'first.png'))
+        FileUtils.touch(File.join(screenshots_dir, 'second.png'))
+
+        copied_count = @runner.move_pulled_screenshots(locale, pull_dir, device_type_dir_name)
+        destination_dir = File.join(config[:output_directory], locale, 'images', device_type_dir_name)
+
+        expect(copied_count).to eq(2)
+        expect(Dir.glob(File.join(destination_dir, '*.png')).length).to eq(2)
+      end
+    end
+  end
+
   describe :select_device do
     it 'connects to host if specified' do
       config[:adb_host] = "device_farm"


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #30037 

`screengrab` checks several possible on-device screenshot directories while cleaning old screenshots and pulling newly captured screenshots. Missing directories are expected during this search, because only one of the candidate paths may exist for a given Android version, storage location, or app configuration.

Those expected misses were still routed through the generic command executor as normal command failures. As a result, every missing candidate path printed both the `ls: ... No such file or directory` output and `Exit status: 1`, causing very noisy logs across all locales.

While investigating the report, I also found that the final screenshot summary could say `Captured 0 new screenshots!` even when screenshots were copied. That happened when screenshots overwrote existing files: the previous implementation calculated the count as the difference between the destination file count before and after pulling.

### Description

The investigation traced the noisy output to `Screengrab::Runner#if_device_path_exists`. That helper intentionally probes candidate screenshot paths using `adb shell ls`, and already treats missing paths as safe to ignore. The problem was that the command executor printed the failure output before the screengrab helper could ignore it.

This change adds an opt-in `suppress_error_output` parameter to `FastlaneCore::CommandExecutor.execute`. The command still returns output and status to the caller, and still raises when no error callback is supplied, but callers that expect a non-zero status can suppress replaying the command output and `Exit status` line.

`screengrab` now uses that option only for the expected missing-path probes. Other adb commands continue to use the existing behavior.

This also updates screenshot counting so `screengrab` counts the PNG files actually copied from the pulled screenshot directories. That makes the final summary accurate even when copied screenshots replace files that already existed in the output directory.

Unit coverage was added for:

- suppressing expected command failure output while preserving status handling
- preserving normal raise behavior when suppressed failures are not handled
- missing screengrab device paths not yielding or printing expected adb failures
- copied screenshot count being returned even when existing files are overwritten
- copied screenshot count from pulled screenshot directories

### Testing Steps

I reproduced the issue by following the path from the reported `adb shell ls` failures back to the screengrab directory probing helper. A missing path produced the same behavior shown in the issue: the missing-file message followed by `Exit status: 1`.

After the fix, the same missing-path probe still reports the non-zero status to the caller, but no longer prints the expected failure to the user.

I also reproduced the screenshot-count issue by simulating an existing output screenshot and a successful copy of a screenshot with the same destination count. Before the fix, the method reported `0`; after the fix, it reports the number of screenshots copied.