### PR TITLE
[pilot] Fix FrozenError when whats_new is a frozen string

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -326,7 +326,7 @@ module Pilot
 
     def self.strip_emoji(changelog)
       if changelog && changelog =~ emoji_regex
-        changelog.gsub!(emoji_regex, "")
+        changelog = changelog.gsub(emoji_regex, "")
         UI.important("Emoji symbols have been removed from the changelog, since they're not allowed by Apple.")
       end
       changelog
@@ -334,7 +334,7 @@ module Pilot
 
     def self.strip_less_than_sign(changelog)
       if changelog && changelog.include?("<")
-        changelog.delete!("<")
+        changelog = changelog.delete("<")
         UI.important("Less than signs (<) have been removed from the changelog, since they're not allowed by Apple.")
       end
       changelog

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -41,6 +41,16 @@ describe "Build Manager" do
       changelog = Pilot::BuildManager.sanitize_changelog(changelog)
       expect(changelog).to eq(File.read("./pilot/spec/fixtures/build_manager/changelog_long_truncated"))
     end
+    it "accepts a frozen changelog containing emoji" do
+      changelog = "I'm 🦇B🏧an🪴!".freeze
+      changelog = Pilot::BuildManager.sanitize_changelog(changelog)
+      expect(changelog).to eq("I'm Ban!")
+    end
+    it "accepts a frozen changelog containing less than signs" do
+      changelog = "I'm <script>man<<!".freeze
+      changelog = Pilot::BuildManager.sanitize_changelog(changelog)
+      expect(changelog).to eq("I'm script>man!")
+    end
   end
 
   describe ".has_changelog_or_whats_new?" do


### PR DESCRIPTION
### Motivation and Context

Resolves #29875

`Pilot::BuildManager.sanitize_changelog` raises `FrozenError` when `whats_new` is a frozen string. `strip_emoji` calls `gsub!` and `strip_less_than_sign` calls `delete!`, both of which modify `changelog` in place. A frozen value from `ENV` or any caller built under `# frozen_string_literal: true` triggers the crash before the build can upload to `TestFlight`.

### Description

Switched both helpers to `gsub` and `delete` and assigned the result back to `changelog`, so a frozen value is no longer modified. The guards and the `UI.important` notices are unchanged, and the one in-tree caller (`update_localized_build_review_for_lang`) already uses the return value, so the behavior is the same for any input that is not frozen.

### Testing Steps

Added two specs that pass a frozen changelog through `sanitize_changelog`, one containing emoji and one containing `<`. Each fails against the original code on the corresponding `FrozenError` and passes after the fix.

```bash
bundle exec rspec ./pilot/spec/build_manager_spec.rb
```

```text
49 examples, 0 failures
```

```bash
bundle exec rubocop ./pilot/lib/pilot/build_manager.rb ./pilot/spec/build_manager_spec.rb
```

```text
2 files inspected, no offenses detected
```
