### PR TITLE
[core] Upgraded jwt gem dependency range to include v3 series

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
       highline (~> 2.0)
       http-cookie (~> 1.0.5)
       json (< 3.0.0)
-      jwt (>= 2.1.0, < 3)
+      jwt (>= 2.1.0, < 4)
       logger (>= 1.6, < 2.0)
       mini_magick (>= 4.9.4, < 5.0.0)
       multipart-post (>= 2.0.0, < 3.0.0)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -80,7 +80,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('highline', '~> 2.0') # user inputs (e.g. passwords)
   spec.add_dependency('http-cookie', '~> 1.0.5') # Must be 1.0.5+ for Ruby 3 compatibility: https://github.com/sparklemotion/http-cookie/commit/d12449a983d3dd660c5fe1f2b135c35e83755cc3
   spec.add_dependency('json', '< 3.0.0') # Because sometimes it's just not installed
-  spec.add_dependency('jwt', '>= 2.1.0', '< 3') # Used for generating authentication tokens for App Store Connect API
+  spec.add_dependency('jwt', '>= 2.1.0', '< 4') # Used for generating authentication tokens for App Store Connect API
   spec.add_dependency('mini_magick', '>= 4.9.4', '< 5.0.0') # To open, edit and export PSD files
   spec.add_dependency('multipart-post', '>= 2.0.0', '< 3.0.0') # Needed for uploading builds to appetize
   spec.add_dependency('naturally', '~> 2.2') # Used to sort strings with numbers in a human-friendly way


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests. (existing unit tests already covered `JWT` usage)

### Motivation and Context

The `ruby-jwt` gem v2.x has a vulnerability ([GHSA-c32j-vqhx-rx3x](https://github.com/advisories/GHSA-c32j-vqhx-rx3x) / [CVE-2026-45363](https://www.cve.org/CVERecord?id=CVE-2026-45363)) where `nil` or empty-string HMAC keys are silently accepted during signature verification. An attacker can forge tokens that pass validation when application code accidentally supplies an empty key (e.g. via `ENV['SECRET'] || ''`, Redis misses, or ORM defaults).

This is fixed in jwt v3.2.0, which rejects nil/empty HMAC keys outright. However, fastlane's current constraint (`< 3`) prevents downstream consumers from resolving to the patched version.

### Description

Widen the `jwt` gem dependency from `>= 2.1.0, < 3` to `>= 2.1.0, < 4.0` to allow resolution of jwt v3.x.

**Changes:**
- `fastlane.gemspec`: `jwt` constraint widened from `< 3` to `< 4.0`
- `Gemfile.lock`: updated to reflect the new constraint

**Compatibility:**
fastlane uses `JWT.encode` with ES256 (asymmetric key) for App Store Connect API tokens — not HMAC. The v3.x API for `JWT.encode`/`JWT.decode` remains backward-compatible for this use case. Full test suite passes (7637 examples, 0 JWT-related failures).

**Note:** The lockfile still resolves to jwt 2.7.1 because `googleauth` and `signet` also constrain `jwt < 3.0`. Once those upstream gems release compatible versions, downstream consumers of fastlane will be able to resolve to jwt v3.x. This PR removes fastlane as a blocker in that dependency chain.

### Testing Steps

```bash
# Verified JWT token generation and decoding:
bundle exec rspec spaceship/spec/connect_api/token_spec.rb
# 18 examples, 0 failures
```

fixes: #30041
