### PR TITLE
[ci] test on Xcode 26.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,8 +212,8 @@ workflows:
           ruby_version: '3.4'
           ruby_opt: -W:deprecated
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 26.2.0, Ruby 3.4)'
-          xcode_version: '26.2.0'
+          name: 'Execute tests on macOS (Xcode 26.5.0, Ruby 3.4)'
+          xcode_version: '26.5.0'
           ruby_version: '3.4'
           ruby_opt: -W:deprecated
       - tests_ubuntu:


### PR DESCRIPTION
## Problem

Xcode 26.5 came out - we have no coverage for it.

## Solution

Add CI for latest, drop Xcode 26.2 for 26.5