### PR TITLE
[docs] keep docs assets moving along during update_docs

### DIFF
--- a/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
+++ b/fastlane/lib/fastlane/documentation/markdown_docs_generator.rb
@@ -188,7 +188,7 @@ module Fastlane
       File.write(mkdocs_yml_path, mkdocs_yml.to_yaml)
 
       # Copy over the assets from the `actions/docs/assets` directory
-      Dir[File.join(custom_action_docs_path, "assets", "*")].each do |current_asset_path|
+      Dir[File.join(Fastlane::ROOT, custom_action_docs_path, "assets", "*")].each do |current_asset_path|
         UI.message("Copying asset #{current_asset_path}")
         FileUtils.cp(current_asset_path, File.join(docs_dir, "img", "actions", File.basename(current_asset_path)))
       end


### PR DESCRIPTION
## Problem

After I did #30020 the next docs release failed for not having the new images. It turns out I was too greedy in my cleanup and broke the pathing of custom assets.

I never replicated this in testing as I was not testing with changes to doc assets. So it was missed in testing.

## Solution

Restore doc root for correct copy.

## Testing

1. Failed - https://github.com/fastlane/docs/pull/1334
2. Success - https://github.com/fastlane/docs/pull/1335