### PR TITLE
[spaceship] remove dots from names

### DIFF
--- a/spaceship/lib/spaceship/portal/portal_client.rb
+++ b/spaceship/lib/spaceship/portal/portal_client.rb
@@ -190,7 +190,7 @@ module Spaceship
 
     def valid_name_for(input)
       latinized = input.to_slug.transliterate
-      latinized = latinized.gsub(/[^[:ascii:]]|[@&*"]/, '') # remove non-valid characters
+      latinized = latinized.gsub(/[^[:ascii:]]|[\.@&*"]/, '') # remove non-valid characters
       # Check if the input string was modified, since it might be empty now
       # (if it only contained non-latin symbols) or the duplicate of another app
       if latinized != input

--- a/spaceship/spec/portal/portal_client_spec.rb
+++ b/spaceship/spec/portal/portal_client_spec.rb
@@ -137,7 +137,7 @@ describe Spaceship::Client do
       end
 
       it 'sanitizes invalid characters and appends md5 hash when input changed' do
-        input = 'Development App λ@&*"'
+        input = 'Development App. λ@&*"'
         expected = 'Development App  ' + Digest::MD5.hexdigest(input)
         expect(subject.send(:valid_name_for, input)).to eq(expected)
       end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Apple has very recently add a new validation requiring `.` be removed from names. Not sure if this is a temporary bug or a permanent adjustment since the helper text doesn't call out `.` as a special character, but it is easily reproducible across multiple Connect accounts.

<img width="899" height="334" alt="image" src="https://github.com/user-attachments/assets/71bca46b-414a-48e8-807c-7b9c08e07c3f" />

### Description

Removes the `.` from the name of a new app but returns the `.` in the app identifier.
