### PR TITLE
[ci] remove xcode 16.3 as CircleCI dropped it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,11 +182,6 @@ workflows:
   "Run Tests & Checks": # Name of the workflow, which ends up displayed on GitHub's PR Check
     jobs:
       - tests_macos:
-          name: 'Execute tests on macOS (Xcode 16.3.0, Ruby 3.1)'
-          xcode_version: '16.3.0'
-          ruby_version: '3.1'
-          ruby_opt: -W:deprecated
-      - tests_macos:
           name: 'Execute tests on macOS (Xcode 16.4.0, Ruby 3.1)'
           xcode_version: '16.4.0'
           ruby_version: '3.1'


### PR DESCRIPTION
## Problem

Builds are failing due to

```
Job was rejected because resource class m4pro.medium, image xcode:16.3.0 is not a valid resource class
```

https://circleci.com/changelog/deprecation-of-xcode-16-3-0-and-26-0-1/

## Solution

We already have testing for Ruby 3.1 on Xcode 16.4, so I just removed the Ruby 3.1 / Xcode 16.3 test.