### PR TITLE
[fastlane_core] Fix deprecated Transporter -f flag, use -assetFile fo…

### DIFF
--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -409,10 +409,6 @@ module FastlaneCore
 
     private
 
-    def file_upload_option(source)
-      "-f #{source.shellescape}"
-    end
-
     def platform_option(platform)
       "-t #{platform == 'osx' ? 'macos' : platform}"
     end
@@ -488,7 +484,7 @@ module FastlaneCore
         '"' + Helper.transporter_path + '"',
         '-m verify',
         build_credential_params(username, password, jwt),
-        "-f #{source.shellescape}",
+        file_upload_option(source),
         ("-WONoPause true" if Helper.windows?), # Windows only: process instantly returns instead of waiting for key press
         ("-itc_provider #{provider_short_name}" if jwt.nil? && !provider_short_name.to_s.empty?)
       ].compact.join(' ')

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -58,7 +58,7 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def shell_verify_command(provider_short_name: nil, transporter: nil, jwt: nil)
+    def shell_verify_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
       escaped_password = password.shellescape
       unless FastlaneCore::Helper.windows?
         escaped_password = escaped_password.gsub("\\'") do
@@ -66,13 +66,14 @@ describe FastlaneCore do
         end
         escaped_password = "'" + escaped_password + "'"
       end
+      verify_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
       [
         '"' + FastlaneCore::Helper.transporter_path + '"',
         "-m verify",
         ("-u #{email.shellescape}" if jwt.nil?),
         ("-p #{escaped_password}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
-        "-f /tmp/my.app.id.itmsp",
+        verify_part,
         (transporter.to_s if transporter),
         ("-WONoPause true" if FastlaneCore::Helper.windows?),
         ("-itc_provider #{provider_short_name}" if provider_short_name)
@@ -110,9 +111,9 @@ describe FastlaneCore do
       ].compact.join(' ')
     end
 
-    def altool_upload_command(api_key: nil, platform: "macos", provider_short_name: "", provider_public_id: "")
+    def altool_upload_command(api_key: nil, platform: "macos", provider_short_name: "", provider_public_id: "", use_asset_path: false)
       use_api_key = !api_key.nil?
-      upload_part = "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
       escaped_password = password.shellescape
 
       [
@@ -702,6 +703,16 @@ describe FastlaneCore do
           end
         end
 
+        describe "verify command generation with .ipa source" do
+          it "uses -assetFile for .ipa files" do
+            expect(Dir).to receive(:tmpdir).and_return("/tmp")
+            expect(FileUtils).to receive(:cp)
+
+            transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
+            expect(transporter.verify(asset_path: '/tmp/my_app.ipa')).to include("-assetFile")
+          end
+        end
+
         describe "download command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
@@ -1182,6 +1193,19 @@ describe FastlaneCore do
             it 'generates a call to altool' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd123', altool_compatible_command: true)
               expect(transporter.provider_ids).to eq(altool_provider_id_command)
+            end
+          end
+
+          context "upload command generation with .ipa source (asset file)" do
+            it "uses -assetFile instead of -f for .ipa files" do
+              expect(Dir).to receive(:tmpdir).and_return("/tmp")
+              expect(FileUtils).to receive(:cp)
+
+              transporter = FastlaneCore::ItunesTransporter.new(email, password, false, nil, nil,
+                                                                altool_compatible_command: true)
+              expect(transporter.upload(asset_path: '/tmp/my_app.ipa', platform: "osx")).to eq(
+                altool_upload_command(use_asset_path: true, provider_short_name: "")
+              )
             end
           end
         end


### PR DESCRIPTION
## Summary

Fixes the deprecated iTMSTransporter `-f` flag for `.ipa`/`.pkg` file uploads, replacing
it with `-assetFile` as required by Apple starting in 2026.

Fixes #29608

## Motivation

Apple's Transporter now warns on every upload:

> Deprecated Transporter usage. No action is required at this time. However, **starting in
> 2026**, you'll be required to use the `-assetFile` command instead of the `-f` command
> with your `.ipa` or `.pkg` files.

Fastlane already handles this in the base `TransporterExecutor#file_upload_option` helper:
it returns `-assetFile <path>` for `.ipa/.pkg/.dmg/.zip` files and `-f <path>` for
`.itmsp` directories. However, two executors bypassed this logic:

1. **`AltoolTransporterExecutor`** — had a private `file_upload_option` override that
   unconditionally returned `-f`, shadowing the correct base-class behavior.
2. **`ShellScriptTransporterExecutor#build_verify_command`** — hard-coded `-f` directly
   instead of calling `file_upload_option`.

## Changes

- **`AltoolTransporterExecutor`**: Removed the private `file_upload_option` override so
  the class inherits the correct base-class implementation.
- **`ShellScriptTransporterExecutor#build_verify_command`**: Replaced the hard-coded
  `-f #{source.shellescape}` with `file_upload_option(source)`.
- **Spec**: Updated `altool_upload_command` helper to support `use_asset_path`, and added
  tests covering `.ipa` → `-assetFile` for both altool and shell-script verify paths.

## Testing

```bash
bundle exec rspec fastlane_core/spec/itunes_transporter_spec.rb
bundle exec rubocop fastlane_core/lib/fastlane_core/itunes_transporter.rb
```

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

