### PR TITLE
[ci] fix: add 'multi_json' as direct dep due to upstream googleapis bug.

### DIFF
--- a/.github/workflows/module_test.yml
+++ b/.github/workflows/module_test.yml
@@ -40,6 +40,10 @@ jobs:
         shell: bash
         run: gem install --no-document --env-shebang "${{ steps.build.outputs.gem_file }}"
 
+      - name: Dump installed gems
+        shell: bash
+        run: gem list
+
       - name: Run module tests against built gem
         shell: bash
         run: ./.github/scripts/run_module_tests.sh

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ PATH
       jwt (>= 2.10.3, < 4)
       logger (>= 1.6, < 2.0)
       mini_magick (>= 4.9.4, < 5.0.0)
+      multi_json (~> 1.12)
       multipart-post (>= 2.0.0, < 3.0.0)
       mutex_m (~> 0.3)
       naturally (~> 2.2)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -82,6 +82,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('json', '< 3.0.0') # Because sometimes it's just not installed
   spec.add_dependency('jwt', '>= 2.10.3', '< 4') # Used for generating authentication tokens for App Store Connect API
   spec.add_dependency('mini_magick', '>= 4.9.4', '< 5.0.0') # To open, edit and export PSD files
+  spec.add_dependency('multi_json', '~> 1.12') # Needed for upstream Google bug: googleapis/google-api-ruby-client/issues/26611
   spec.add_dependency('multipart-post', '>= 2.0.0', '< 3.0.0') # Needed for uploading builds to appetize
   spec.add_dependency('naturally', '~> 2.2') # Used to sort strings with numbers in a human-friendly way
   spec.add_dependency('optparse', '>= 0.1.1', '< 1.0.0') # Used to parse options with Commander


### PR DESCRIPTION
## Problem

All builds are failing on Ruby 3.3+ module tests, due to https://github.com/googleapis/google-api-ruby-client/issues/26611

## Solution

Make `multi_json` a direct dependency as Google is not.