### PR TITLE
[scan] Handle array destination in xcodebuild_destination_parameter

### DIFF
--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -396,7 +396,7 @@ module FastlaneCore
       if xcode_at_least_13 && options[:destination]
         begin
           destination = options[:destination]
-          destination = destination.first if destination.is_a?(Array)
+          destination = destination.first if destination.kind_of?(Array)
           destination_parameter = " " + "-destination #{destination.shellescape}"
         rescue => ex
           # xcodebuild command can continue without destination parameter, so

--- a/fastlane_core/lib/fastlane_core/project.rb
+++ b/fastlane_core/lib/fastlane_core/project.rb
@@ -395,7 +395,9 @@ module FastlaneCore
       xcode_at_least_13 = FastlaneCore::Helper.xcode_at_least?("13")
       if xcode_at_least_13 && options[:destination]
         begin
-          destination_parameter = " " + "-destination #{options[:destination].shellescape}"
+          destination = options[:destination]
+          destination = destination.first if destination.is_a?(Array)
+          destination_parameter = " " + "-destination #{destination.shellescape}"
         rescue => ex
           # xcodebuild command can continue without destination parameter, so
           # we really don't care about this exception if something goes wrong with shellescape

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 describe FastlaneCore do
   describe FastlaneCore::Project do
     describe 'project and workspace detection' do
@@ -665,7 +667,8 @@ describe FastlaneCore do
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
               destination: ["platform=iOS Simulator,id=ABC123", "platform=iOS Simulator,id=DEF456"]
             })
-            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination platform\\=iOS\\ Simulator,id\\=ABC123 2>&1"
+            destination = Shellwords.escape("platform=iOS Simulator,id=ABC123")
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination #{destination} 2>&1"
             expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
           end
 
@@ -674,7 +677,8 @@ describe FastlaneCore do
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
               destination: ["platform=iOS Simulator,id=ABC123", "platform=iOS Simulator,id=DEF456"]
               })
-            command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination platform\\=iOS\\ Simulator,id\\=ABC123"
+            destination = Shellwords.escape("platform=iOS Simulator,id=ABC123")
+            command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination #{destination}"
             expect(project.build_xcodebuild_resolvepackagedependencies_command).to eq(command)
           end
         end

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -667,7 +667,7 @@ describe FastlaneCore do
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
               destination: ["platform=iOS Simulator,id=ABC123", "platform=iOS Simulator,id=DEF456"]
             })
-            destination = Shellwords.escape("platform=iOS Simulator,id=ABC123")
+            destination = "platform=iOS Simulator,id=ABC123".shellescape
             command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination #{destination} 2>&1"
             expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
           end
@@ -677,7 +677,7 @@ describe FastlaneCore do
               project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
               destination: ["platform=iOS Simulator,id=ABC123", "platform=iOS Simulator,id=DEF456"]
               })
-            destination = Shellwords.escape("platform=iOS Simulator,id=ABC123")
+            destination = "platform=iOS Simulator,id=ABC123".shellescape
             command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination #{destination}"
             expect(project.build_xcodebuild_resolvepackagedependencies_command).to eq(command)
           end

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -659,6 +659,26 @@ describe FastlaneCore do
           end
         end
 
+        context "when destination parameter is provided as an array" do
+          it 'generates an xcodebuild -showBuildSettings command that uses the first destination', requires_xcode: true do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+              destination: ["platform=iOS Simulator,id=ABC123", "platform=iOS Simulator,id=DEF456"]
+            })
+            command = "xcodebuild -showBuildSettings -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination platform\\=iOS\\ Simulator,id\\=ABC123 2>&1"
+            expect(project.build_xcodebuild_showbuildsettings_command).to eq(command)
+          end
+
+          it 'generates an xcodebuild -resolvePackageDependencies command that uses the first destination' do
+            project = FastlaneCore::Project.new({
+              project: "./fastlane_core/spec/fixtures/projects/Example.xcodeproj",
+              destination: ["platform=iOS Simulator,id=ABC123", "platform=iOS Simulator,id=DEF456"]
+              })
+            command = "xcodebuild -resolvePackageDependencies -project ./fastlane_core/spec/fixtures/projects/Example.xcodeproj -destination platform\\=iOS\\ Simulator,id\\=ABC123"
+            expect(project.build_xcodebuild_resolvepackagedependencies_command).to eq(command)
+          end
+        end
+
         context "when destination parameter is not provided in options" do
           it 'generates an xcodebuild -showBuildSettings command that does not include destination', requires_xcode: true do
             project = FastlaneCore::Project.new({


### PR DESCRIPTION
## Motivation

When `scan` detects devices automatically (via `:device` and `:deployment_target_version` instead of `:destination`), it sets `Scan.config[:destination]` as an **array** of strings in `detect_values.rb`:

```ruby
Scan.config[:destination] = Scan.devices.map { |d| "platform=#{d.os_type} Simulator,id=#{d.udid}" }
```

However, `xcodebuild_destination_parameter` in `project.rb` calls `.shellescape` on the value, which raises `NoMethodError` because `shellescape` is a `String` method and not available on `Array`.

This causes a noisy warning in the build log:
> Failed to set destination parameter for xcodebuild command: undefined method `shellescape` for ["platform=iOS Simulator,id=..."]:Array

The destination parameter is then silently dropped from the `xcodebuild -showBuildSettings` and `xcodebuild -resolvePackageDependencies` commands.

## Fix

Extract the first element when `options[:destination]` is an `Array` before calling `shellescape`. For `showBuildSettings` and `resolvePackageDependencies`, a single destination is sufficient — the purpose is to suppress the Xcode 13+ warning about missing destination.

## Testing

Added two test cases for array destination in `project_spec.rb` covering both `build_xcodebuild_showbuildsettings_command` and `build_xcodebuild_resolvepackagedependencies_command`.

Closes #29873