### PR TITLE
fix(match): remove single quotes around keychain path in utils_spec

### DIFF
--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -11,7 +11,7 @@ describe Fastlane do
         password = 'testpassword'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+        expected_command = "security import #{cert_name} -k #{keychain_path} -P #{password} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
@@ -39,7 +39,7 @@ describe Fastlane do
         format = 'pkcs12'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -f #{format} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+        expected_command = "security import #{cert_name} -k #{keychain_path} -P #{password} -f #{format} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
@@ -67,7 +67,7 @@ describe Fastlane do
         password = '\"test pa$$word\"'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_security_import_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+        expected_security_import_command = "security import #{cert_name.shellescape} -k #{keychain_path.shellescape} -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{password.shellescape} #{keychain_path.shellescape} 1> /dev/null"
@@ -95,7 +95,7 @@ describe Fastlane do
         password = 'testpassword'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign"
+        expected_command = "security import #{cert_name} -k #{keychain_path} -P #{password} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -10,7 +10,7 @@ module FastlaneCore
       password_part = " -P #{certificate_password.shellescape}"
       certificate_format_part = certificate_format.to_s.strip.empty? ? "" : " -f #{certificate_format.shellescape}"
 
-      command = "security import #{path.shellescape} -k '#{keychain_path.shellescape}'"
+      command = "security import #{path.shellescape} -k #{keychain_path.shellescape}"
       command << password_part
       command << certificate_format_part
       command << " -T /usr/bin/codesign" # to not be asked for permission when running a tool like `gym` (before Sierra)

--- a/match/spec/utils_spec.rb
+++ b/match/spec/utils_spec.rb
@@ -16,7 +16,7 @@ describe Match do
 
     describe 'import' do
       it 'finds a normal keychain name relative to ~/Library/Keychains' do
-        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+        expected_command = "security import item.path -k #{Dir.home}/Library/Keychains/login.keychain -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
@@ -36,7 +36,7 @@ describe Match do
       it 'treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path' do
         tmp_path = Dir.mktmpdir
         keychain = "#{tmp_path}/my/special.keychain"
-        expected_command = "security import item.path -k '#{keychain}' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+        expected_command = "security import item.path -k #{keychain} -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{''.shellescape} #{keychain} 1> /dev/null"
@@ -62,7 +62,7 @@ describe Match do
       end
 
       it "tries to find the macOS Sierra keychain too" do
-        expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain-db' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+        expected_command = "security import item.path -k #{Dir.home}/Library/Keychains/login.keychain-db -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{''.shellescape} #{Dir.home}/Library/Keychains/login.keychain-db 1> /dev/null"
@@ -81,7 +81,7 @@ describe Match do
 
       describe "keychain_password" do
         it 'prompts for keychain password when none given and not in keychain' do
-          expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+          expected_command = "security import item.path -k #{Dir.home}/Library/Keychains/login.keychain -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
           # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
           expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{'user_entered'.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"
@@ -105,7 +105,7 @@ describe Match do
         end
 
         it 'find keychain password in keychain when none given' do
-          expected_command = "security import item.path -k '#{Dir.home}/Library/Keychains/login.keychain' -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+          expected_command = "security import item.path -k #{Dir.home}/Library/Keychains/login.keychain -P #{''.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
           # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
           expected_partition_command = "security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{'from_keychain'.shellescape} #{Dir.home}/Library/Keychains/login.keychain 1> /dev/null"


### PR DESCRIPTION
## Fix

Companion to PR #30068 — that PR updated `keychain_importer.rb` and `import_certificate_spec.rb` but missed `match/spec/utils_spec.rb`, causing 5 test failures in CI.

### What changed

Remove single quotes wrapping keychain path in 5 test expectations in `match/spec/utils_spec.rb`, matching the source change in `keychain_importer.rb`.

### Tests fixed

- `finds a normal keychain name relative to ~/Library/Keychains`
- `treats a keychain name it cannot find in ~/Library/Keychains as the full keychain path`
- `tries to find the macOS Sierra keychain too`
- `keychain_password prompts for keychain password when none given and not in keychain`
- `keychain_password find keychain password in keychain when none given`

🤖 Generated with [Claude Code](https://claude.com/claude-code)