### PR TITLE
Fix keychain import path escaping

### DIFF
--- a/fastlane/spec/actions_specs/import_certificate_spec.rb
+++ b/fastlane/spec/actions_specs/import_certificate_spec.rb
@@ -11,7 +11,7 @@ describe Fastlane do
         password = 'testpassword'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+        expected_command = "security import #{cert_name} -k #{keychain_path.shellescape} -P #{password} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
@@ -39,7 +39,7 @@ describe Fastlane do
         format = 'pkcs12'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -f #{format} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+        expected_command = "security import #{cert_name} -k #{keychain_path.shellescape} -P #{password} -f #{format} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
@@ -67,7 +67,7 @@ describe Fastlane do
         password = '\"test pa$$word\"'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_security_import_command = "security import #{cert_name.shellescape} -k '#{keychain_path.shellescape}' -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+        expected_security_import_command = "security import #{cert_name.shellescape} -k #{keychain_path.shellescape} -P #{password.shellescape} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         expected_set_key_partition_list_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{password.shellescape} #{keychain_path.shellescape} 1> /dev/null"
@@ -95,7 +95,7 @@ describe Fastlane do
         password = 'testpassword'
 
         keychain_path = File.expand_path(File.join('~', 'Library', 'Keychains', keychain))
-        expected_command = "security import #{cert_name} -k '#{keychain_path}' -P #{password} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign"
+        expected_command = "security import #{cert_name} -k #{keychain_path.shellescape} -P #{password} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign"
 
         # this command is also sent on macOS Sierra and we need to allow it or else the test will fail
         allowed_command = "security set-key-partition-list -S apple-tool:,apple: -s -k #{''.shellescape} #{keychain_path.shellescape} 1> /dev/null"
@@ -115,6 +115,19 @@ describe Fastlane do
             log_output: true
           })
         end").runner.execute(:test)
+      end
+
+      it "shellescapes keychain paths with spaces without wrapping them in quotes" do
+        cert_name = "test.cer"
+        keychain_path = "/Volumes/SSD 500/Users/test/Library/Keychains/test.keychain-db"
+        password = "testpassword"
+        expected_command = "security import #{cert_name} -k #{keychain_path.shellescape} -P #{password} -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild -T /usr/bin/productsign 1> /dev/null"
+
+        allow(File).to receive(:exist?).and_return(false)
+        expect(File).to receive(:exist?).with(cert_name).and_return(true)
+        expect(Open3).to receive(:popen3).with(expected_command)
+
+        FastlaneCore::KeychainImporter.import_file(cert_name, keychain_path, certificate_password: password)
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/keychain_importer.rb
+++ b/fastlane_core/lib/fastlane_core/keychain_importer.rb
@@ -10,7 +10,7 @@ module FastlaneCore
       password_part = " -P #{certificate_password.shellescape}"
       certificate_format_part = certificate_format.to_s.strip.empty? ? "" : " -f #{certificate_format.shellescape}"
 
-      command = "security import #{path.shellescape} -k '#{keychain_path.shellescape}'"
+      command = "security import #{path.shellescape} -k #{keychain_path.shellescape}"
       command << password_part
       command << certificate_format_part
       command << " -T /usr/bin/codesign" # to not be asked for permission when running a tool like `gym` (before Sierra)


### PR DESCRIPTION
## Summary

Fixes #29889.

This removes the extra manual quotes around the already `shellescape`d keychain path passed to `security import -k`. When the keychain path contains spaces, the previous command embedded escaped spaces inside quotes, so `security` looked for a path containing literal backslashes.

The import certificate specs now expect a single shell-escaped keychain argument, and include a regression case for a keychain path under a volume with a space in its name.

## Validation

- `mise exec ruby@3.4.7 -- bundle _2.5.23_ exec rspec fastlane/spec/actions_specs/import_certificate_spec.rb`
- `mise exec ruby@3.4.7 -- bundle _2.5.23_ exec rubocop fastlane_core/lib/fastlane_core/keychain_importer.rb fastlane/spec/actions_specs/import_certificate_spec.rb`
- `git diff --check`