### PR TITLE
[supply] Fix version_codes_to_retain causing promote-only flow to use…

### DIFF
--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -19,9 +19,17 @@ module Supply
 
       track_to_update = Supply.config[:track]
 
+      # Determine whether we are in upload mode (new binaries were provided/uploaded)
+      # vs. promote-only mode (skip_upload_apk + skip_upload_aab both true).
+      # version_codes_to_retain must only influence the track update when we are
+      # actually uploading — appending retained codes before this check caused
+      # promote-only runs to take the upload path and deactivate the new bundle.
+      # See: https://github.com/fastlane/fastlane/issues/29984
+      uploading_new_binaries = !apk_version_codes.empty?
+
       apk_version_codes.concat(Supply.config[:version_codes_to_retain]) if Supply.config[:version_codes_to_retain]
 
-      if !apk_version_codes.empty?
+      if uploading_new_binaries
         # Only update tracks if we have version codes
         # update_track handle setting rollout if needed
         # Updating a track with empty version codes can completely clear out a track

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -19,11 +19,9 @@ module Supply
 
       track_to_update = Supply.config[:track]
 
-      # Determine whether we are in upload mode (new binaries were provided/uploaded)
-      # vs. promote-only mode (skip_upload_apk + skip_upload_aab both true).
-      # version_codes_to_retain must only influence the track update when we are
-      # actually uploading — appending retained codes before this check caused
-      # promote-only runs to take the upload path and deactivate the new bundle.
+      # Capture whether any new binaries were actually uploaded before appending
+      # version_codes_to_retain. The branch below uses this flag so that retained
+      # codes do not cause a promote-only run to take the upload path.
       # See: https://github.com/fastlane/fastlane/issues/29984
       uploading_new_binaries = !apk_version_codes.empty?
 

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -258,7 +258,7 @@ describe Supply do
       it_behaves_like 'run supply to upload metadata', version_codes: [3], with_explicit_changelogs: false
     end
 
-    describe 'perform_upload with version_codes_to_retain in promote-only mode' do
+    describe '#perform_upload with version_codes_to_retain in promote-only mode' do
       let(:client) { double('client') }
       let(:config) do
         {
@@ -312,7 +312,7 @@ describe Supply do
       end
     end
 
-    describe 'perform_upload with version_codes_to_retain when uploading new binaries' do
+    describe '#perform_upload with version_codes_to_retain when uploading new binaries' do
       let(:client) { double('client') }
       let(:config) do
         {

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -258,6 +258,106 @@ describe Supply do
       it_behaves_like 'run supply to upload metadata', version_codes: [3], with_explicit_changelogs: false
     end
 
+    describe 'perform_upload with version_codes_to_retain in promote-only mode' do
+      let(:client) { double('client') }
+      let(:config) do
+        {
+          package_name: 'com.example.app',
+          track: 'internal',
+          track_promote_to: 'production',
+          skip_upload_apk: true,
+          skip_upload_aab: true,
+          skip_upload_metadata: true,
+          skip_upload_images: true,
+          skip_upload_screenshots: true,
+          skip_upload_changelogs: true,
+          version_codes_to_retain: [1775721088],
+          version_code: 1776275968,
+          rollout: nil,
+          release_status: Supply::ReleaseStatus::COMPLETED,
+          track_promote_release_status: Supply::ReleaseStatus::COMPLETED,
+          validate_only: false,
+          metadata_path: nil
+        }
+      end
+
+      before do
+        Supply.config = config
+      end
+
+      it 'calls promote_track instead of update_track when skip_upload_apk and skip_upload_aab are true' do
+        uploader = Supply::Uploader.new
+        allow(uploader).to receive(:client).and_return(client)
+        allow(client).to receive(:begin_edit)
+        allow(client).to receive(:commit_current_edit!)
+
+        # THE CRITICAL ASSERTION: promote_track must be called, update_track must NOT
+        expect(uploader).to receive(:promote_track).once
+        expect(uploader).not_to receive(:update_track)
+
+        uploader.perform_upload
+      end
+
+      it 'does NOT call update_track with only version_codes_to_retain when no binaries uploaded' do
+        uploader = Supply::Uploader.new
+        allow(uploader).to receive(:client).and_return(client)
+        allow(client).to receive(:begin_edit)
+        allow(client).to receive(:commit_current_edit!)
+        allow(uploader).to receive(:promote_track)
+
+        # update_track must never be called in promote-only mode
+        expect(uploader).not_to receive(:update_track)
+
+        uploader.perform_upload
+      end
+    end
+
+    describe 'perform_upload with version_codes_to_retain when uploading new binaries' do
+      let(:client) { double('client') }
+      let(:config) do
+        {
+          package_name: 'com.example.app',
+          track: 'internal',
+          track_promote_to: nil,
+          skip_upload_apk: true,
+          skip_upload_aab: false,
+          aab: '/tmp/app.aab',
+          aab_paths: nil,
+          skip_upload_metadata: true,
+          skip_upload_images: true,
+          skip_upload_screenshots: true,
+          skip_upload_changelogs: true,
+          version_codes_to_retain: [1775721088],
+          version_code: 1776275968,
+          rollout: nil,
+          release_status: Supply::ReleaseStatus::COMPLETED,
+          track_promote_release_status: Supply::ReleaseStatus::COMPLETED,
+          validate_only: false,
+          metadata_path: nil
+        }
+      end
+
+      before do
+        Supply.config = config
+      end
+
+      it 'calls update_track with both new version code and retained codes when uploading' do
+        uploader = Supply::Uploader.new
+        allow(uploader).to receive(:client).and_return(client)
+        allow(client).to receive(:begin_edit)
+        allow(client).to receive(:commit_current_edit!)
+        # Simulate AAB upload returning a new version code
+        allow(uploader).to receive(:upload_bundles).and_return([1776275968])
+        allow(uploader).to receive(:upload_mapping)
+
+        # update_track must be called with BOTH the new version AND the retained code
+        expect(uploader).to receive(:update_track).with([1776275968, 1775721088])
+        expect(uploader).not_to receive(:promote_track)
+
+        uploader.perform_upload
+      end
+    end
+
     context 'when sync_image_upload is set' do
       let(:client) { double('client') }
       let(:language) { 'pt-BR' }

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -271,8 +271,8 @@ describe Supply do
           skip_upload_images: true,
           skip_upload_screenshots: true,
           skip_upload_changelogs: true,
-          version_codes_to_retain: [1775721088],
-          version_code: 1776275968,
+          version_codes_to_retain: [1_775_721_088],
+          version_code: 1_776_275_968,
           rollout: nil,
           release_status: Supply::ReleaseStatus::COMPLETED,
           track_promote_release_status: Supply::ReleaseStatus::COMPLETED,
@@ -327,8 +327,8 @@ describe Supply do
           skip_upload_images: true,
           skip_upload_screenshots: true,
           skip_upload_changelogs: true,
-          version_codes_to_retain: [1775721088],
-          version_code: 1776275968,
+          version_codes_to_retain: [1_775_721_088],
+          version_code: 1_776_275_968,
           rollout: nil,
           release_status: Supply::ReleaseStatus::COMPLETED,
           track_promote_release_status: Supply::ReleaseStatus::COMPLETED,
@@ -347,11 +347,11 @@ describe Supply do
         allow(client).to receive(:begin_edit)
         allow(client).to receive(:commit_current_edit!)
         # Simulate AAB upload returning a new version code
-        allow(uploader).to receive(:upload_bundles).and_return([1776275968])
+        allow(uploader).to receive(:upload_bundles).and_return([1_776_275_968])
         allow(uploader).to receive(:upload_mapping)
 
         # update_track must be called with BOTH the new version AND the retained code
-        expect(uploader).to receive(:update_track).with([1776275968, 1775721088])
+        expect(uploader).to receive(:update_track).with([1_776_275_968, 1_775_721_088])
         expect(uploader).not_to receive(:promote_track)
 
         uploader.perform_upload


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2>
<p>When <code>skip_upload_apk: true</code> and <code>skip_upload_aab: true</code> are both set alongside <code>version_codes_to_retain</code>, fastlane incorrectly takes the upload path instead of calling <code>promote_track</code>. This causes the retained version code to be submitted as the new release, deactivating the bundle that was supposed to go live.</p>
<p>Fixes #29984</p>
<h2>Root Cause</h2>
<p>In <code>perform_upload</code> (<code>supply/lib/supply/uploader.rb</code>), <code>apk_version_codes</code> is used both as the container for newly uploaded binary version codes and as the condition to decide between the upload path and the promote path.</p>
<p><code>version_codes_to_retain</code> was appended to <code>apk_version_codes</code> <strong>before</strong> that branch check:</p>
<pre><code class="language-ruby">apk_version_codes.concat(Supply.config[:version_codes_to_retain]) if Supply.config[:version_codes_to_retain]

if !apk_version_codes.empty?
  update_track(apk_version_codes)   # upload path — runs incorrectly in promote-only mode
else
  promote_track                     # correct path — never reached
end
</code></pre>
<p>So in promote-only mode, <code>apk_version_codes</code> appeared non-empty due to the retained codes, and <code>update_track</code> was called with the retained version code as if it were a new upload.</p>
<h2>Fix</h2>
<p>Capture whether new binaries were actually uploaded (<code>uploading_new_binaries</code>) before appending <code>version_codes_to_retain</code>, and use that boolean for the branch decision:</p>
<pre><code class="language-ruby">uploading_new_binaries = !apk_version_codes.empty?

apk_version_codes.concat(Supply.config[:version_codes_to_retain]) if Supply.config[:version_codes_to_retain]

if uploading_new_binaries
  update_track(apk_version_codes)
else
  promote_track
end
</code></pre>
<p>The retained codes are still appended to <code>apk_version_codes</code> after the check so that changelog and metadata updates for retained versions continue to work correctly.</p>
<h2>Behaviour</h2>

Scenario | Before | After
-- | -- | --
skip_upload_apk: true + skip_upload_aab: true + version_codes_to_retain | ❌ Calls update_track with retained code — wrong version promoted | ✅ Calls promote_track correctly
Upload AAB/APK + version_codes_to_retain | ✅ Calls update_track with new + retained codes | ✅ Unchanged
Promote only, no version_codes_to_retain | ✅ Calls promote_track | ✅ Unchanged


<h2>Testing</h2>
<ul>
<li>Added spec: promote-only mode with <code>version_codes_to_retain</code> → <code>promote_track</code> called, <code>update_track</code> never called</li>
<li>Added spec: upload mode with <code>version_codes_to_retain</code> → <code>update_track</code> called with both new and retained version codes</li>
</ul>
</body>
</html>

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

