### PR TITLE
[precheck] Fix copyright year check to allow past years

### DIFF
--- a/precheck/lib/precheck/rules/copyright_date_rule.rb
+++ b/precheck/lib/precheck/rules/copyright_date_rule.rb
@@ -15,23 +15,29 @@ module Precheck
     end
 
     def self.description
-      "using a copyright date that is any different from this current year, or missing a date"
-    end
-
-    def pass_if_empty?
-      return false
+      "using a copyright year in the future, or missing a copyright year"
     end
 
     def supported_fields_symbol_set
       [:copyright].to_set
     end
 
-    def word_search_type
-      WORD_SEARCH_TYPES[:fail_on_exclusion]
+    def rule_block
+      return lambda { |text|
+        year = copyright_year(text)
+        if year.nil?
+          RuleReturn.new(validation_state: VALIDATION_STATES[:failed], failure_data: "missing copyright year")
+        elsif year > DateTime.now.year
+          RuleReturn.new(validation_state: VALIDATION_STATES[:failed], failure_data: "copyright year is in the future: #{year}")
+        else
+          RuleReturn.new(validation_state: VALIDATION_STATES[:passed])
+        end
+      }
     end
 
-    def lowercased_words_to_look_for
-      [DateTime.now.year.to_s]
+    def copyright_year(text)
+      match = text.to_s.match(/\b(?:19|20)\d{2}\b/)
+      match && match[0].to_i
     end
   end
 end

--- a/precheck/spec/rules/copyright_date_rule_spec.rb
+++ b/precheck/spec/rules/copyright_date_rule_spec.rb
@@ -6,10 +6,17 @@ module Precheck
       let(:rule) { CopyrightDateRule.new }
       let(:happy_item) { TextItemToCheck.new("Copyright taquitos, #{DateTime.now.year}", :copyright, "copyright") }
       let(:old_copyright_item) { TextItemToCheck.new("Copyright taquitos, 2016", :copyright, "copyright") }
+      let(:future_copyright_item) { TextItemToCheck.new("Copyright taquitos, #{DateTime.now.year + 1}", :copyright, "copyright") }
+      let(:missing_year_item) { TextItemToCheck.new("Copyright taquitos", :copyright, "copyright") }
       let(:empty_copyright_item) { TextItemToCheck.new(nil, :copyright, "copyright") }
 
       it "passes for current date" do
         result = rule.check_item(happy_item)
+        expect(result.status).to eq(VALIDATION_STATES[:passed])
+      end
+
+      it "passes for a past year" do
+        result = rule.check_item(old_copyright_item)
         expect(result.status).to eq(VALIDATION_STATES[:passed])
       end
 
@@ -19,8 +26,13 @@ module Precheck
         expect(result).to eq(nil)
       end
 
-      it "fails for old date" do
-        result = rule.check_item(old_copyright_item)
+      it "fails for a future year" do
+        result = rule.check_item(future_copyright_item)
+        expect(result.status).to eq(VALIDATION_STATES[:failed])
+      end
+
+      it "fails when no year is present" do
+        result = rule.check_item(missing_year_item)
         expect(result.status).to eq(VALIDATION_STATES[:failed])
       end
 


### PR DESCRIPTION
🔑

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #29600.

The _precheck_ `copyright_date` rule failed validation whenever the copyright field did not contain the **current** year. This rejects otherwise valid copyrights such as `2016 Acme Inc.`. App Store Connect's own guidance states the copyright should be _"preceded by the year the rights were obtained"_, which may be any past year, so the current-year requirement produces false-positive failures for legitimate values.

### Description

The rule previously used `fail_on_exclusion` against `DateTime.now.year`, so the copyright text had to contain the current year to pass. It now extracts the copyright year and passes as long as that year is present and not in the future, matching App Store Connect's documented expectation. A copyright with no year, or with a year set in the future, still fails.

### Testing Steps

- `bundle exec rspec precheck/spec/rules/copyright_date_rule_spec.rb`
- New examples cover: current year passes, a past year passes, a future year fails, a missing year fails, and an empty value fails.