### PR TITLE
[crashlytics] improve logging during error

### DIFF
--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -35,21 +35,35 @@ module Fastlane
           UI.message("Using #{max_worker_threads} threads for Crashlytics dSYM upload 🏎")
         end
 
+        upload_results = Queue.new
         worker = FastlaneCore::QueueWorker.new(max_worker_threads) do |dsym_path|
-          handle_dsym(params, dsym_path, max_worker_threads)
+          upload_results << handle_dsym(params, dsym_path)
         end
         worker.batch_enqueue(dsym_paths)
         worker.start
-        UI.success("Successfully uploaded dSYM files to Crashlytics 💯")
+
+        # Convert Queue to Array
+        results = []
+        results << upload_results.pop until upload_results.empty?
+
+        if results.all?
+          UI.success("Successfully uploaded dSYM files to Crashlytics 💯")
+        elsif results.any?
+          UI.success("Successfully uploaded some dSYM files to Crashlytics 💯")
+          UI.important("Some dSYM files failed to upload, see the errors above")
+        else
+          UI.user_error!("Service failed to upload any dSYM files to Crashlytics")
+        end
       end
 
       # @param current_path this is a path to either a dSYM or a zipped dSYM
       #   this might also be either nested or not, we're flexible
-      def self.handle_dsym(params, current_path, max_worker_threads)
+      def self.handle_dsym(params, current_path)
         if current_path.end_with?(".dSYM", ".zip")
-          upload_dsym(params, current_path)
+          return upload_dsym(params, current_path)
         else
           UI.error("Don't know how to handle '#{current_path}'")
+          return false
         end
       end
 
@@ -73,8 +87,10 @@ module Fastlane
           command_to_execute = command.join(" ")
           UI.verbose("upload_dsym using command: #{command_to_execute}")
           Actions.sh(command_to_execute, log: params[:debug])
+          return true
         rescue => ex
           UI.error(ex.to_s) # it fails, however we don't want to fail everything just for this
+          return false
         end
       end
 

--- a/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
+++ b/fastlane/lib/fastlane/actions/upload_symbols_to_crashlytics.rb
@@ -35,16 +35,11 @@ module Fastlane
           UI.message("Using #{max_worker_threads} threads for Crashlytics dSYM upload 🏎")
         end
 
-        upload_results = Queue.new
         worker = FastlaneCore::QueueWorker.new(max_worker_threads) do |dsym_path|
-          upload_results << handle_dsym(params, dsym_path)
+          handle_dsym(params, dsym_path)
         end
         worker.batch_enqueue(dsym_paths)
-        worker.start
-
-        # Convert Queue to Array
-        results = []
-        results << upload_results.pop until upload_results.empty?
+        results = worker.start
 
         if results.all?
           UI.success("Successfully uploaded dSYM files to Crashlytics 💯")

--- a/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
+++ b/fastlane/spec/actions_specs/upload_symbols_to_crashlytics_spec.rb
@@ -184,6 +184,46 @@ describe Fastlane do
             end").runner.execute(:test)
           end.to raise_error(FastlaneCore::Interface::FastlaneError)
         end
+
+        it "raises an error if all uploads fail" do
+          binary_path = './spec/fixtures/screenshots/screenshot1.png'
+          dsym_path = './spec/fixtures/dSYM/Themoji.dSYM'
+          app_id = '0:000000000000:ios:0f0000000ff0ff0'
+
+          expect(Fastlane::Actions).to receive(:sh).and_raise("some error")
+          expect(UI).to receive(:success).with("Driving the lane 'test' 🚀")
+          expect(UI).to receive(:error).with("some error")
+          expect(UI).to receive(:user_error!).with("Service failed to upload any dSYM files to Crashlytics")
+
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_symbols_to_crashlytics(
+              dsym_path: 'fastlane/#{dsym_path}',
+              app_id: '#{app_id}',
+              binary_path: 'fastlane/#{binary_path}')
+          end").runner.execute(:test)
+        end
+
+        it "displays a warning if only some uploads fail" do
+          binary_path = './spec/fixtures/screenshots/screenshot1.png'
+          dsym_1_path = './spec/fixtures/dSYM/Themoji.dSYM'
+          dsym_2_path = './spec/fixtures/dSYM/Themoji2.dSYM'
+          app_id = '0:000000000000:ios:0f0000000ff0ff0'
+
+          expect(Fastlane::Actions).to receive(:sh).and_return("")
+          expect(Fastlane::Actions).to receive(:sh).and_raise("some error")
+
+          expect(UI).to receive(:success).with("Driving the lane 'test' 🚀")
+          expect(UI).to receive(:success).with("Successfully uploaded some dSYM files to Crashlytics 💯")
+          expect(UI).to receive(:important).with("Some dSYM files failed to upload, see the errors above")
+          expect(UI).to receive(:error).with("some error")
+
+          Fastlane::FastFile.new.parse("lane :test do
+            upload_symbols_to_crashlytics(
+              dsym_paths: ['fastlane/#{dsym_1_path}', 'fastlane/#{dsym_2_path}'],
+              app_id: '#{app_id}',
+              binary_path: 'fastlane/#{binary_path}')
+          end").runner.execute(:test)
+        end
       end
     end
   end

--- a/fastlane_core/lib/fastlane_core/queue_worker.rb
+++ b/fastlane_core/lib/fastlane_core/queue_worker.rb
@@ -33,17 +33,23 @@ module FastlaneCore
       @queue.close
 
       threads = []
+      results = Queue.new
       @concurrency.times do
         threads << Thread.new do
           job = @queue.pop
           while job
-            @block.call(job)
+            results << @block.call(job)
             job = @queue.pop
           end
         end
       end
 
       threads.each(&:join)
+
+      # Convert Queue to Array
+      real_results = []
+      real_results << results.pop until results.empty?
+      real_results
     end
   end
 end

--- a/fastlane_core/spec/queue_worker_spec.rb
+++ b/fastlane_core/spec/queue_worker_spec.rb
@@ -49,5 +49,16 @@ describe FastlaneCore::QueueWorker do
 
       expect { subject.enqueue(2) }.to raise_error(ClosedQueueError)
     end
+
+    it 'should return an array of results from the block' do
+      subject = described_class.new(2) do |job|
+        job * 2
+      end
+
+      subject.batch_enqueue([1, 2, 3])
+      results = subject.start
+
+      expect(results).to contain_exactly(2, 4, 6)
+    end
   end
 end


### PR DESCRIPTION
## Problem

You can have some odd output.

```
[06:19:21]: Uploading 'REDACTED_PATH.app.dSYM.zip'...
[06:19:23]: Shell command exited with exit status  instead of 0.
[06:19:23]: Successfully uploaded dSYM files to Crashlytics 💯
```

## Solution

1. If ALL the uploads failed - fail it.
2. Track the individual status of each file and report status.


fixes: #22180