### PR TITLE
[match] fail fast for SSH authentication prompts in non-interactive shell

### DIFF
--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -111,7 +111,7 @@ module Match
 
         begin
           # GIT_TERMINAL_PROMPT will fail the `git clone` command if user credentials are missing
-          Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+          Helper.with_env_values(git_env_values) do
             FastlaneCore::CommandExecutor.execute(command: command,
                                                 print_all: FastlaneCore::Globals.verbose?,
                                             print_command: FastlaneCore::Globals.verbose?)
@@ -252,7 +252,7 @@ module Match
         commands << git_push_command
 
         UI.message("Pushing changes to remote git repo...")
-        Helper.with_env_values('GIT_TERMINAL_PROMPT' => '0') do
+        Helper.with_env_values(git_env_values) do
           commands.each do |command|
             FastlaneCore::CommandExecutor.execute(command: command,
                                                 print_all: FastlaneCore::Globals.verbose?,
@@ -262,6 +262,18 @@ module Match
       rescue => ex
         UI.error("Couldn't commit or push changes back to git...")
         UI.error(ex)
+      end
+
+      def git_env_values
+        env_values = { 'GIT_TERMINAL_PROMPT' => '0' }
+        env_values['GIT_SSH_COMMAND'] = non_interactive_git_ssh_command if ENV['GIT_SSH_COMMAND']
+        env_values
+      end
+
+      def non_interactive_git_ssh_command
+        ssh_command = ENV['GIT_SSH_COMMAND']
+        return ssh_command if ssh_command.include?('BatchMode=yes')
+        "#{ssh_command} -o BatchMode=yes"
       end
     end
   end

--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -266,12 +266,16 @@ module Match
 
       def git_env_values
         env_values = { 'GIT_TERMINAL_PROMPT' => '0' }
-        env_values['GIT_SSH_COMMAND'] = non_interactive_git_ssh_command if ENV['GIT_SSH_COMMAND']
+        env_values['GIT_SSH_COMMAND'] = non_interactive_git_ssh_command
         env_values
       end
 
       def non_interactive_git_ssh_command
         ssh_command = ENV['GIT_SSH_COMMAND']
+
+        if ssh_command.nil? || ssh_command.empty?
+          return "ssh -o BatchMode=yes"
+        end
         return ssh_command if ssh_command.include?('BatchMode=yes')
         "#{ssh_command} -o BatchMode=yes"
       end

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -270,10 +270,10 @@ describe Match do
     end
 
     describe "#git_env_values" do
-      it "returns default env when GIT_SSH_COMMAND is unset" do
+      it "sets a default GIT_SSH_COMMAND with BatchMode=yes when GIT_SSH_COMMAND is unset" do
         allow(ENV).to receive(:[]).with('GIT_SSH_COMMAND').and_return(nil)
         storage = Match::Storage::GitStorage.new
-        expect(storage.send(:git_env_values)).to eq({ 'GIT_TERMINAL_PROMPT' => '0' })
+        expect(storage.send(:git_env_values)).to eq({ 'GIT_TERMINAL_PROMPT' => '0', 'GIT_SSH_COMMAND' => 'ssh -o BatchMode=yes' })
       end
 
       it "appends BatchMode=yes when GIT_SSH_COMMAND exists" do

--- a/match/spec/storage/git_storage_spec.rb
+++ b/match/spec/storage/git_storage_spec.rb
@@ -268,5 +268,25 @@ describe Match do
         end
       end
     end
+
+    describe "#git_env_values" do
+      it "returns default env when GIT_SSH_COMMAND is unset" do
+        allow(ENV).to receive(:[]).with('GIT_SSH_COMMAND').and_return(nil)
+        storage = Match::Storage::GitStorage.new
+        expect(storage.send(:git_env_values)).to eq({ 'GIT_TERMINAL_PROMPT' => '0' })
+      end
+
+      it "appends BatchMode=yes when GIT_SSH_COMMAND exists" do
+        allow(ENV).to receive(:[]).with('GIT_SSH_COMMAND').and_return('ssh -v')
+        storage = Match::Storage::GitStorage.new
+        expect(storage.send(:git_env_values)['GIT_SSH_COMMAND']).to eq('ssh -v -o BatchMode=yes')
+      end
+
+      it "does not duplicate if BatchMode already exists" do
+        allow(ENV).to receive(:[]).with('GIT_SSH_COMMAND').and_return('ssh -o BatchMode=yes')
+        storage = Match::Storage::GitStorage.new
+        expect(storage.send(:git_env_values)['GIT_SSH_COMMAND']).to eq('ssh -o BatchMode=yes')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR makes `match` fail fast instead of hanging when SSH authentication requires interactive input (for example, passphrase or password prompts in non-interactive CI environments).

`match` already sets `GIT_TERMINAL_PROMPT=0`, which prevents interactive Git/HTTPS credential prompts. However, SSH authentication prompts can still block indefinitely. This change enables non-interactive SSH behavior by default for `match` Git operations using `BatchMode=yes`.

## What changed

* Reuse the shared Git environment helper for `match` clone and push operations.
* Continue setting:

  * `GIT_TERMINAL_PROMPT=0`
* Add default SSH fail-fast behavior:

  * Configure `GIT_SSH_COMMAND` with `-o BatchMode=yes`.
* Preserve any existing user-provided `GIT_SSH_COMMAND` and append `-o BatchMode=yes` only if it is not already present.
* Add tests covering:

  * Default behavior when `GIT_SSH_COMMAND` is unset.
  * Appending `BatchMode=yes` to an existing `GIT_SSH_COMMAND`.
  * Avoiding duplicate `BatchMode=yes` options.

## Why

Without this change, `match` can appear to hang indefinitely while waiting for SSH authentication input that is unavailable in CI or other non-interactive environments. Enabling `BatchMode=yes` causes SSH to fail immediately with a clear authentication error instead of waiting for user input.

## Backward compatibility

* `BatchMode` is a long-standing and widely supported OpenSSH option.
* Existing `GIT_SSH_COMMAND` values are preserved.
* This change only affects interactive SSH authentication during `match` Git operations by converting hangs into fast failures.

## Related issue

Fixes: #26591


### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.
