### PR TITLE
[action][swiftlint] Fix path option for SwiftLint 0.48.0 and above

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -49,7 +49,6 @@ module Fastlane
 
       def self.optional_flags(params)
         command = ""
-        command << path_argument(params) if params[:path]
         command << supported_option_switch(params, :strict, "0.9.2", true)
         command << " --config #{params[:config_file].shellescape}" if params[:config_file]
         command << " --reporter #{params[:reporter]}" if params[:reporter]
@@ -58,6 +57,7 @@ module Fastlane
         command << supported_no_cache_option(params) if params[:no_cache]
         command << " --compiler-log-path #{params[:compiler_log_path].shellescape}" if params[:compiler_log_path]
         command << supported_option_switch(params, :progress, "0.49.1", true) if params[:progress]
+        command << path_argument(params) if params[:path]
         return command
       end
 

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -37,6 +37,8 @@ module Fastlane
           command << " --use-script-input-files"
         end
 
+        command << path_argument(params) if params[:path]
+
         command << " > #{params[:output_file].shellescape}" if params[:output_file]
 
         begin
@@ -57,7 +59,6 @@ module Fastlane
         command << supported_no_cache_option(params) if params[:no_cache]
         command << " --compiler-log-path #{params[:compiler_log_path].shellescape}" if params[:compiler_log_path]
         command << supported_option_switch(params, :progress, "0.49.1", true) if params[:progress]
-        command << path_argument(params) if params[:path]
         return command
       end
 

--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -49,7 +49,7 @@ module Fastlane
 
       def self.optional_flags(params)
         command = ""
-        command << " --path #{params[:path].shellescape}" if params[:path]
+        command << path_argument(params) if params[:path]
         command << supported_option_switch(params, :strict, "0.9.2", true)
         command << " --config #{params[:config_file].shellescape}" if params[:config_file]
         command << " --reporter #{params[:reporter]}" if params[:reporter]
@@ -59,6 +59,14 @@ module Fastlane
         command << " --compiler-log-path #{params[:compiler_log_path].shellescape}" if params[:compiler_log_path]
         command << supported_option_switch(params, :progress, "0.49.1", true) if params[:progress]
         return command
+      end
+
+      def self.path_argument(params)
+        escaped_path = params[:path].shellescape
+        version = swiftlint_version(executable: params[:executable])
+        return " --path #{escaped_path}" if version < Gem::Version.new('0.48.0')
+
+        " #{escaped_path}"
       end
 
       # Get current SwiftLint version

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -153,6 +153,21 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint --strict #{path}")
         end
 
+        it "appends the positional path after --use-script-input-files for swiftlint 0.48.0 and above" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.48.0'))
+          allow(File).to receive(:exist?).and_return(true)
+          path = "./spec/fixtures"
+          result = Fastlane::FastFile.new.parse("
+            lane :test do
+              swiftlint(
+                path: '#{path}',
+                files: ['AppDelegate.swift']
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("SCRIPT_INPUT_FILE_COUNT=1 SCRIPT_INPUT_FILE_0=AppDelegate.swift swiftlint lint --use-script-input-files #{path}")
+        end
+
         it "escapes spaces when passing path as a positional argument" do
           allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.48.0'))
           allow(File).to receive(:exist?).and_return(true)

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -139,6 +139,20 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint #{path}")
         end
 
+        it "passes path after option flags as a positional argument for swiftlint 0.48.0 and above" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.48.0'))
+          path = "./spec/fixtures"
+          result = Fastlane::FastFile.new.parse("
+            lane :test do
+              swiftlint(
+                path: '#{path}',
+                strict: true
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint --strict #{path}")
+        end
+
         it "escapes spaces when passing path as a positional argument" do
           allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.48.0'))
           allow(File).to receive(:exist?).and_return(true)

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -126,6 +126,33 @@ describe Fastlane do
           expect(result).to eq("swiftlint lint --path #{path}")
         end
 
+        it "passes path as a positional argument for swiftlint 0.48.0 and above" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.48.0'))
+          path = "./spec/fixtures"
+          result = Fastlane::FastFile.new.parse("
+            lane :test do
+              swiftlint(
+                path: '#{path}'
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint #{path}")
+        end
+
+        it "escapes spaces when passing path as a positional argument" do
+          allow(Fastlane::Actions::SwiftlintAction).to receive(:swiftlint_version).and_return(Gem::Version.new('0.48.0'))
+          allow(File).to receive(:exist?).and_return(true)
+          path = "./spec/my fixtures"
+          result = Fastlane::FastFile.new.parse("
+            lane :test do
+              swiftlint(
+                path: '#{path}'
+              )
+            end").runner.execute(:test)
+
+          expect(result).to eq("swiftlint lint #{path.shellescape}")
+        end
+
         it "adds invalid path option" do
           path = "./non/existent/path"
           expect do


### PR DESCRIPTION
🔑

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #22191
Resolves #22063
Closes #22124

SwiftLint deprecated the `--path` flag in [0.48.0](https://github.com/realm/SwiftLint/releases/tag/0.48.0) and newer releases reject it outright, so any lane using `swiftlint(path: ...)` fails with `Error: Unknown option '--path'`.

### Description

The `swiftlint` action always appended `--path <path>` to the command, regardless of the installed SwiftLint version. Since SwiftLint replaced `--path` with a positional path argument in 0.48.0, the emitted command became invalid on current SwiftLint installs.

The action now version-gates how the path is passed: it keeps `--path <path>` for SwiftLint below 0.48.0 and passes the path as a positional argument (`swiftlint lint <path>`) for 0.48.0 and above. Existing behavior for older versions is unchanged, and the path is still shell-escaped in both cases.

### Testing Steps

- `bundle exec rspec fastlane/spec/actions_specs/swiftlint_spec.rb`
- `bundle exec rubocop fastlane/lib/fastlane/actions/swiftlint.rb fastlane/spec/actions_specs/swiftlint_spec.rb`

New specs assert that for SwiftLint 0.48.0 and above the command is `swiftlint lint <path>` (no `--path`) and that spaces in the path are still escaped. The existing example pinning `--path` for older versions remains green.