### PR TITLE
[trainer] Fix output_remove_retry_attempts not stripping failures for skipped-on-retry tests (modern xcresult parser)

### DIFF
--- a/trainer/lib/trainer/xcresult/test_case.rb
+++ b/trainer/lib/trainer/xcresult/test_case.rb
@@ -115,11 +115,30 @@ module Trainer
         @retries&.count || 0
       end
 
-      def total_tests_count
+      # Result of the final attempt (last repetition), or the overall result when there are no retries.
+      # When retry attempts are removed, counts should reflect this final outcome rather than the
+      # aggregate `@result`, which xcresulttool reports as `Failed` even if the test was skipped on retry.
+      def final_result
+        @retries && !@retries.empty? ? @retries.last.result : @result
+      end
+
+      def final_failed?
+        final_result == 'Failed'
+      end
+
+      def final_skipped?
+        final_result == 'Skipped'
+      end
+
+      def total_tests_count(output_remove_retry_attempts: false)
+        return 1 if output_remove_retry_attempts
+
         retries_count > 0 ? retries_count : 1
       end
 
-      def total_failures_count
+      def total_failures_count(output_remove_retry_attempts: false)
+        return final_failed? ? 1 : 0 if output_remove_retry_attempts
+
         if retries_count > 0
           @retries.count(&:failed?)
         elsif failed?

--- a/trainer/lib/trainer/xcresult/test_plan.rb
+++ b/trainer/lib/trainer/xcresult/test_plan.rb
@@ -40,7 +40,7 @@ module Trainer
       # Allows iteration over test suites. Used by TestParser to collect test results
       include Enumerable
       def each(&block)
-        test_suites.map(&:to_hash).each(&block)
+        test_suites.map { |suite| suite.to_hash(output_remove_retry_attempts: output_remove_retry_attempts) }.each(&block)
       end
 
       # Generates a JUnit-compatible XML representation of the test plan
@@ -49,8 +49,8 @@ module Trainer
         # Create the root testsuites element with calculated summary attributes
         testsuites = Helper.create_xml_element('testsuites',
           tests: test_suites.sum(&:test_cases_count).to_s,
-          failures: test_suites.sum(&:failures_count).to_s,
-          skipped: test_suites.sum(&:skipped_count).to_s,
+          failures: test_suites.sum { |suite| suite.failures_count(output_remove_retry_attempts: output_remove_retry_attempts) }.to_s,
+          skipped: test_suites.sum { |suite| suite.skipped_count(output_remove_retry_attempts: output_remove_retry_attempts) }.to_s,
           time: test_suites.sum(&:duration).to_s)
 
         # Create <properties> node for configuration and device, to be applied to each suite node

--- a/trainer/lib/trainer/xcresult/test_suite.rb
+++ b/trainer/lib/trainer/xcresult/test_suite.rb
@@ -58,38 +58,47 @@ module Trainer
         @test_cases_count ||= @test_cases.count + @sub_suites.sum(&:test_cases_count)
       end
 
-      def failures_count
-        @failures_count ||= @test_cases.count(&:failed?) + @sub_suites.sum(&:failures_count)
+      # When output_remove_retry_attempts is true, counts reflect each test case's final attempt
+      # only (matching the trimmed JUnit output), so a test that failed then was skipped on retry
+      # is no longer counted as a failure.
+      def failures_count(output_remove_retry_attempts: false)
+        predicate = output_remove_retry_attempts ? :final_failed? : :failed?
+        @test_cases.count(&predicate) +
+          @sub_suites.sum { |suite| suite.failures_count(output_remove_retry_attempts: output_remove_retry_attempts) }
       end
 
-      def skipped_count
-        @skipped_count ||= @test_cases.count(&:skipped?) + @sub_suites.sum(&:skipped_count)
+      def skipped_count(output_remove_retry_attempts: false)
+        predicate = output_remove_retry_attempts ? :final_skipped? : :skipped?
+        @test_cases.count(&predicate) +
+          @sub_suites.sum { |suite| suite.skipped_count(output_remove_retry_attempts: output_remove_retry_attempts) }
       end
 
-      def total_tests_count
-        @test_cases.sum(&:total_tests_count) +
-          @sub_suites.sum(&:total_tests_count)
+      def total_tests_count(output_remove_retry_attempts: false)
+        @test_cases.sum { |test_case| test_case.total_tests_count(output_remove_retry_attempts: output_remove_retry_attempts) } +
+          @sub_suites.sum { |suite| suite.total_tests_count(output_remove_retry_attempts: output_remove_retry_attempts) }
       end
 
-      def total_failures_count
-        @test_cases.sum(&:total_failures_count) +
-          @sub_suites.sum(&:total_failures_count)
+      def total_failures_count(output_remove_retry_attempts: false)
+        @test_cases.sum { |test_case| test_case.total_failures_count(output_remove_retry_attempts: output_remove_retry_attempts) } +
+          @sub_suites.sum { |suite| suite.total_failures_count(output_remove_retry_attempts: output_remove_retry_attempts) }
       end
 
-      def total_retries_count
+      def total_retries_count(output_remove_retry_attempts: false)
+        return 0 if output_remove_retry_attempts
+
         @test_cases.sum(&:retries_count) +
           @sub_suites.sum(&:total_retries_count)
       end
 
       # Hash representation used by TestParser to collect test results
-      def to_hash
+      def to_hash(output_remove_retry_attempts: false)
         {
-          number_of_tests: total_tests_count,
-          number_of_failures: total_failures_count,
+          number_of_tests: total_tests_count(output_remove_retry_attempts: output_remove_retry_attempts),
+          number_of_failures: total_failures_count(output_remove_retry_attempts: output_remove_retry_attempts),
           number_of_tests_excluding_retries: test_cases_count,
-          number_of_failures_excluding_retries: failures_count,
-          number_of_retries: total_retries_count,
-          number_of_skipped: skipped_count
+          number_of_failures_excluding_retries: failures_count(output_remove_retry_attempts: output_remove_retry_attempts),
+          number_of_retries: total_retries_count(output_remove_retry_attempts: output_remove_retry_attempts),
+          number_of_skipped: skipped_count(output_remove_retry_attempts: output_remove_retry_attempts)
         }
       end
 
@@ -100,8 +109,8 @@ module Trainer
           name: @name,
           time: duration.to_s,
           tests: test_cases_count.to_s,
-          failures: failures_count.to_s,
-          skipped: skipped_count.to_s)
+          failures: failures_count(output_remove_retry_attempts: output_remove_retry_attempts).to_s,
+          skipped: skipped_count(output_remove_retry_attempts: output_remove_retry_attempts).to_s)
 
         # Add test cases
         @test_cases.each do |test_case|

--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -346,6 +346,58 @@ describe Trainer do
     end
   end
 
+  describe Trainer::XCResult::TestSuite do
+    # Mirrors the LegacyXCResult regression above for the Xcode 16+ xcresult parser:
+    # a test that fails on the first attempt and is skipped on retry must not be
+    # counted as a failure once retry attempts are removed.
+    describe '#to_hash with output_remove_retry_attempts' do
+      let(:test_case) do
+        Trainer::XCResult::TestCase.new(
+          name: "testFlaky()",
+          identifier: "MyTests/testFlaky()",
+          duration: 0.6,
+          result: "Failed",
+          classname: "MyTests",
+          retries: [
+            Trainer::XCResult::Repetition.new(name: "Repetition 1", duration: 0.5, result: "Failed", failure_messages: ["XCTAssertTrue failed"]),
+            Trainer::XCResult::Repetition.new(name: "Retry 2", duration: 0.1, result: "Skipped", failure_messages: ["flaky test"])
+          ]
+        )
+      end
+
+      let(:test_suite) do
+        Trainer::XCResult::TestSuite.new(
+          name: "MyTests",
+          identifier: "MyTests",
+          type: "Unit test bundle",
+          result: "Failed",
+          test_cases: [test_case]
+        )
+      end
+
+      it 'reports counts reflecting only the final skipped attempt when retries are removed' do
+        hash = test_suite.to_hash(output_remove_retry_attempts: true)
+        expect(hash[:number_of_tests]).to eq(1)
+        expect(hash[:number_of_failures]).to eq(0)
+        expect(hash[:number_of_skipped]).to eq(1)
+        expect(hash[:number_of_failures_excluding_retries]).to eq(0)
+        expect(hash[:number_of_retries]).to eq(0)
+      end
+
+      it 'still counts the failure when retries are not removed' do
+        hash = test_suite.to_hash
+        expect(hash[:number_of_failures_excluding_retries]).to eq(1)
+        expect(hash[:number_of_retries]).to eq(2)
+      end
+
+      it 'reports zero failures in the JUnit testsuite attributes when retries are removed' do
+        xml = test_suite.to_xml(output_remove_retry_attempts: true)
+        expect(xml.attribute('failures').value).to eq('0')
+        expect(xml.attribute('skipped').value).to eq('1')
+      end
+    end
+  end
+
   describe Trainer::XCResult::Parser do
     it 'generates same data for legacy and new commands', requires_xcodebuild: true do
       skip "Requires Xcode 16 or higher" unless Trainer::XCResult::Helper.supports_xcresulttool_version_23?


### PR DESCRIPTION
### Motivation and Context

Follow-up to #29887. That PR taught `output_remove_retry_attempts` to drop a failure when a test is **skipped on retry**, but only fixed the **legacy** xcresult path. The **modern** (Xcode 16+) parser (`trainer/lib/trainer/xcresult/`) was only half-fixed:

- `TestSuite#to_xml` trimmed the `<testcase>` XML nodes to the final attempt (`runs.last(1)`), so the skipped node renders and xcodebuild logs **"Test Execute Succeeded."**
- But the **counts** (`failures_count` / `to_hash`) were still derived from each test case's *aggregate* `result`, which `xcresulttool` reports as `Failed` even when the final attempt was skipped — and were never made retry-aware.

Result: the JUnit reported the test as `<skipped>` while the suite still carried `failures='1'` (with no `<failure>` element — internally inconsistent), so `number_of_failures_excluding_retries` stayed at `1`, `TestParser#tests_successful?` returned `false`, and **scan reported a failure to CI despite the test run succeeding.**

### Description

Thread `output_remove_retry_attempts` through the modern parser's count methods so that — **only when the flag is set** — counts reflect each test case's final attempt:

- `test_case.rb` — add `final_result` / `final_failed?` / `final_skipped?`; `total_tests_count` / `total_failures_count` accept the flag.
- `test_suite.rb` — `failures_count` / `skipped_count` / `total_*` / `to_hash` / `to_xml` accept the flag (failures use `final_failed?`, skips use `final_skipped?` when removing retries).
- `test_plan.rb` — `each` (feeds CI pass/fail) and the root `to_xml` summary pass the flag through.

Behaviour with the flag **off** is unchanged. This matches the legacy regression test's contract under the flag (`failures=0, skipped=1, retries=0`).

### Testing

- Added a modern-path regression spec (`Trainer::XCResult::TestSuite`) mirroring the existing legacy one — fails before, passes after.
- Full `trainer/spec/test_parser_spec.rb`: **21 examples, 0 failures** (existing Xcode 26 JUnit fixture tests still pass — no regression; neither checked-in fixture contained a final-result ≠ aggregate case, which is why the bug went uncaught).
- Verified against a real `.xcresult` from a fail-then-skip-on-retry CI run: with the flag → `tests_successful? = true`; with the flag off → unchanged (`false`).
- Rubocop: clean.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)