### PR TITLE
[spaceship] Fix appInfoLocalizations create/delete on the Tunes API

### DIFF
--- a/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
+++ b/spaceship/lib/spaceship/connect_api/tunes/tunes.rb
@@ -717,9 +717,9 @@ module Spaceship
               type: "appInfoLocalizations",
               attributes: attributes,
               relationships: {
-                appStoreVersion: {
+                appInfo: {
                   data: {
-                    type: "appStoreVersions",
+                    type: "appInfos",
                     id: app_info_id
                   }
                 }
@@ -740,6 +740,11 @@ module Spaceship
           }
 
           tunes_request_client.patch("#{Version::V1}/appInfoLocalizations/#{app_info_localization_id}", body)
+        end
+
+        def delete_app_info_localization(app_info_localization_id: nil)
+          params = tunes_request_client.build_params(filter: nil, includes: nil, limit: nil, sort: nil)
+          tunes_request_client.delete("#{Version::V1}/appInfoLocalizations/#{app_info_localization_id}", params)
         end
 
         #

--- a/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/connect_api/tunes/tunes_client_spec.rb
@@ -222,5 +222,49 @@ describe Spaceship::ConnectAPI::Tunes::Client do
         end
       end
     end
+
+    describe "appInfoLocalizations" do
+      context 'post_app_info_localization' do
+        let(:app_info_id) { "123456789" }
+        let(:attributes) { { locale: "en-US", name: "My App" } }
+        let(:path) { "v1/appInfoLocalizations" }
+        let(:body) do
+          {
+            data: {
+              type: "appInfoLocalizations",
+              attributes: attributes,
+              relationships: {
+                appInfo: {
+                  data: {
+                    type: "appInfos",
+                    id: app_info_id
+                  }
+                }
+              }
+            }
+          }
+        end
+
+        it 'uses the appInfo relationship' do
+          url = path
+          req_mock = test_request_body(url, body)
+
+          expect(client).to receive(:request).with(:post).and_yield(req_mock).and_return(req_mock)
+          client.post_app_info_localization(app_info_id: app_info_id, attributes: attributes)
+        end
+      end
+
+      context 'delete_app_info_localization' do
+        let(:app_info_localization_id) { "123456789" }
+        let(:path) { "v1/appInfoLocalizations/#{app_info_localization_id}" }
+
+        it 'succeeds' do
+          params = {}
+          req_mock = test_request_params(path, params)
+          expect(client).to receive(:request).with(:delete).and_yield(req_mock).and_return(req_mock)
+          client.delete_app_info_localization(app_info_localization_id: app_info_localization_id)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Two related bugs prevented managing App Info localizations for a locale that doesn't exist yet on an app:

- post_app_info_localization sent an `appStoreVersion` relationship, but appInfoLocalizations belong to an `appInfo`. Apple rejected the request ("'appStoreVersion' is not a relationship on the resource 'appInfoLocalizations'" / "You must provide a value for the relationship 'appInfo'"), so create_app_info_localization failed for new locales.
- delete_app_info_localization was never defined, yet AppInfoLocalization#delete! calls it — so every delete raised NoMethodError (surfaced as AppStoreLocalizationError).

Send the correct `appInfo` relationship and add the missing delete method (mirroring delete_app_info).

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

fixes: #29690
closes: #29691

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
