### PR TITLE
[ci] move more workflows from CircleCI -> GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,45 +138,6 @@ jobs:
           command: bundle exec danger || echo "danger failed"
           when: always  # Run this even when tests fail
 
-  validate_fastlane_swift_generation:
-    resource_class: m4pro.medium
-    <<: *tests_macos_base
-    steps:
-      - *cache_restore_git
-      - checkout
-      - *cache_save_git
-      - macos/switch-ruby:
-          version: << parameters.ruby_version >>
-      - ruby/install-deps
-      - run: bundle exec fastlane generate_swift_api
-
-  validate_documentation:
-    parameters:
-      image:
-        type: string
-    docker:
-      - image: << parameters.image >>
-    steps:
-      - *cache_restore_git
-      - checkout
-      - *cache_save_git
-      - ruby/install-deps
-      - run: bundle exec fastlane validate_docs
-
-  lint_source_code:
-    parameters:
-      image:
-        type: string
-    docker:
-      - image: << parameters.image >>
-    steps:
-      - *cache_restore_git
-      - checkout
-      - *cache_save_git
-      - ruby/install-deps
-
-      - run: bundle exec fastlane lint_source
-
 workflows:
   version: 2
   "Run Tests & Checks": # Name of the workflow, which ends up displayed on GitHub's PR Check
@@ -217,13 +178,3 @@ workflows:
       - tests_ubuntu:
           name: 'Execute tests on Ubuntu (Ruby 3.2)'
           image: 'cimg/ruby:3.2.2-node'
-      - validate_fastlane_swift_generation:
-          name: 'Validate Fastlane.swift generation'
-          xcode_version: '16.4.0'
-          ruby_version: '3.2'
-      - validate_documentation:
-          name: 'Validate Documentation'
-          image: 'cimg/ruby:3.2'
-      - lint_source_code:
-          name: 'Lint source code'
-          image: 'cimg/ruby:3.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   TEST_REPORTS: ${{ github.workspace }}/test-reports
   CIRCLE_TEST_REPORTS: ${{ github.workspace }}/test-reports
@@ -87,3 +90,49 @@ jobs:
           name: ruby_warnings-${{ matrix.xcode }}-ruby-${{ matrix.ruby }}.txt
           path: ${{ env.TEST_REPORTS }}/ruby_warnings.txt
           if-no-files-found: ignore
+
+  validate_fastlane_swift_generation:
+    name: Validate Fastlane.swift generation
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.3'
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Generate Swift API
+        run: bundle exec fastlane generate_swift_api
+
+  validate_documentation:
+    name: Validate Documentation
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Validate docs
+        run: bundle exec fastlane validate_docs
+
+  lint_source_code:
+    name: Lint source code
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Lint
+        run: bundle exec fastlane lint_source


### PR DESCRIPTION
## Problem

We have split workflows (Used to have 3 with AppVeyor). Now down to 2 (GHA & CircleCI). CircleCI is getting annoying with Ruby versions in the official orbs not supporting latest (v4) and breaking older Rubies.

## Solution

GitHub Actions. This moves 3 tests over (Swift Generation, Documentation Validation and Lint Validation)