### PR TITLE
[scan] Forward force_legacy_xcresulttool to trainer

### DIFF
--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -273,6 +273,11 @@ module Scan
                                      description: "Remove retry attempts from test results table and the JUnit report (if not using xcpretty)",
                                      type: Boolean,
                                      default_value: false),
+        FastlaneCore::ConfigItem.new(key: :force_legacy_xcresulttool,
+                                     env_names: ["SCAN_FORCE_LEGACY_XCRESULTTOOL", "TRAINER_FORCE_LEGACY_XCRESULTTOOL"],
+                                     description: "Force the use of the '--legacy' flag for xcresulttool instead of using the new commands",
+                                     type: Boolean,
+                                     default_value: false),
 
         # xcpretty
         FastlaneCore::ConfigItem.new(key: :disable_xcpretty,

--- a/scan/lib/scan/runner.rb
+++ b/scan/lib/scan/runner.rb
@@ -216,6 +216,7 @@ module Scan
       params = {
         path: result_bundle_path,
         output_remove_retry_attempts: Scan.config[:output_remove_retry_attempts],
+        force_legacy_xcresulttool: Scan.config[:force_legacy_xcresulttool],
         silent: !FastlaneCore::Globals.verbose?
       }
 

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -66,6 +66,22 @@ describe Scan do
         end
       end
 
+      describe "with scan option :force_legacy_xcresulttool set to true" do
+        it "forwards force_legacy_xcresulttool to trainer", requires_xcodebuild: true do
+          Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+            output_directory: '/tmp/scan_results',
+            project: './scan/examples/standard/app.xcodeproj',
+            force_legacy_xcresulttool: true
+          })
+
+          # This is a needed side effect from running TestCommandGenerator which is not done in this test
+          Scan.cache[:result_bundle_path] = '/tmp/scan_results/test.xcresults'
+
+          expect(Trainer::TestParser).to receive(:auto_convert).with(hash_including(force_legacy_xcresulttool: true)).and_return({})
+          @scan.handle_results(0)
+        end
+      end
+
       describe "Test Failure" do
         it "raises a FastlaneTestFailure instead of a crash or UserError", requires_xcodebuild: true do
           expect do


### PR DESCRIPTION
### Motivation and Context

Resolves #29614.

`scan` runs its test results through `Trainer::TestParser.auto_convert`, but it never forwarded the `force_legacy_xcresulttool` option that trainer added in #29463. Setting it (or `TRAINER_FORCE_LEGACY_XCRESULTTOOL`) had no effect when running tests through `scan`, and the issue confirms it was left out by mistake.

### Description

Adds a `force_legacy_xcresulttool` option to `scan` (env `SCAN_FORCE_LEGACY_XCRESULTTOOL`, default `false`) and passes it through to trainer in the `params` hash, next to the existing `output_remove_retry_attempts`.

### Testing Steps

- `bundle exec rspec scan/spec/runner_spec.rb`
- `bundle exec rubocop scan/lib/scan/options.rb scan/lib/scan/runner.rb scan/spec/runner_spec.rb`

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR
- [x] I've read the Contribution Guidelines
- [x] I've added or updated relevant unit tests.
