### PR TITLE
[core] Reduce duplication on output and noise during failure.

### DIFF
--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -66,11 +66,11 @@ module Fastlane
         # relevant platforms.
         if exit_status.exitstatus != 0
           message = if print_command
-                      "Exit status of command '#{shell_command}' was #{exit_status.exitstatus} instead of 0."
+                      "Exit status of command '#{shell_command}' was #{exit_status.exitstatus} instead of 0.\n"
                     else
-                      "Shell command exited with exit status #{exit_status.exitstatus} instead of 0."
+                      "Shell command exited with exit status #{exit_status.exitstatus} instead of 0.\n"
                     end
-          message += "\n#{result[-500..-1]}" if print_command_output && !$stdout.isatty
+          message += (result.length > 500 ? result[-500..-1] : result).to_s if print_command_output && !$stdout.isatty
 
           if error_callback || block_given?
             UI.error(message)

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -65,12 +65,16 @@ module Fastlane
         # with previous implementations of sh and... probably portable to all
         # relevant platforms.
         if exit_status.exitstatus != 0
+          # Due to some output and build systems having 30-80k lines of output.
+          # We will truncate what we will show to recap the failure.
+          truncated_msg = result.length > 500 ? result[-500..-1] : result
+
           message = if print_command
                       "Exit status of command '#{shell_command}' was #{exit_status.exitstatus} instead of 0.\n"
                     else
                       "Shell command exited with exit status #{exit_status.exitstatus} instead of 0.\n"
                     end
-          message += (result.length > 500 ? result[-500..-1] : result).to_s if print_command_output && !$stdout.isatty
+          message += (truncated_msg).to_s if print_command_output && !$stdout.isatty
 
           if error_callback || block_given?
             UI.error(message)

--- a/fastlane/lib/fastlane/helper/sh_helper.rb
+++ b/fastlane/lib/fastlane/helper/sh_helper.rb
@@ -70,7 +70,7 @@ module Fastlane
                     else
                       "Shell command exited with exit status #{exit_status.exitstatus} instead of 0."
                     end
-          message += "\n#{result[-500..-1]}" if print_command_output
+          message += "\n#{result[-500..-1]}" if print_command_output && !$stdout.isatty
 
           if error_callback || block_given?
             UI.error(message)

--- a/fastlane/lib/fastlane/lane_manager.rb
+++ b/fastlane/lib/fastlane/lane_manager.rb
@@ -55,7 +55,6 @@ module Fastlane
 
         print_lane_context
         print_error_line(ex)
-        UI.error(ex.to_s) if ex.kind_of?(StandardError) # we don't want to print things like 'system exit'
         e = ex
       end
 

--- a/fastlane/spec/helper/sh_helper_spec.rb
+++ b/fastlane/spec/helper/sh_helper_spec.rb
@@ -27,6 +27,24 @@ describe Fastlane::Actions do
 
           expect(UI).to have_received(:shell_error!).with("Exit status of command 'exit 1' was 1 instead of 0.\n")
         end
+
+        it "includes command output in error message when not a TTY" do
+          allow(FastlaneCore::UI).to receive(:shell_error!)
+          expect_command("exit 1", exitstatus: 1, output: "Error details")
+          allow($stdout).to receive(:isatty).and_return(false)
+          Fastlane::Actions.sh("exit 1")
+
+          expect(UI).to have_received(:shell_error!).with(match(/Error details/))
+        end
+
+        it "does not include command output in error message when it is a TTY" do
+          allow(FastlaneCore::UI).to receive(:shell_error!)
+          expect_command("exit 1", exitstatus: 1, output: "Error details")
+          allow($stdout).to receive(:isatty).and_return(true)
+          Fastlane::Actions.sh("exit 1")
+
+          expect(UI).to have_received(:shell_error!).with("Exit status of command 'exit 1' was 1 instead of 0.\n")
+        end
       end
     end
 

--- a/fastlane_core/lib/fastlane_core/ui/errors/fastlane_shell_error.rb
+++ b/fastlane_core/lib/fastlane_core/ui/errors/fastlane_shell_error.rb
@@ -3,6 +3,12 @@ require_relative 'fastlane_exception'
 module FastlaneCore
   class Interface
     class FastlaneShellError < FastlaneException
+      attr_reader :show_github_issues
+
+      def initialize(options = {})
+        @show_github_issues = options[:show_github_issues].nil? ? false : options[:show_github_issues]
+      end
+
       def prefix
         '[SHELL_ERROR]'
       end

--- a/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
+++ b/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb
@@ -167,7 +167,7 @@ module Commander
         end
       rescue FastlaneCore::Interface::FastlaneCommonException => e # these are exceptions that we don't count as crashes
         display_user_error!(e, e.to_s)
-      rescue FastlaneCore::Interface::FastlaneError => e # user_error!
+      rescue FastlaneCore::Interface::FastlaneError, FastlaneCore::Interface::FastlaneShellError => e # user_error! or shell_error!
         rescue_fastlane_error(e)
       rescue Errno::ENOENT => e
         rescue_file_error(e)

--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -77,4 +77,26 @@ describe Commander::Runner do
       end
     end
   end
+
+  describe '#rescue_fastlane_error' do
+    it 'calls show_github_issues if e.show_github_issues is true' do
+      runner = Commander::Runner.new
+      error = FastlaneCore::Interface::FastlaneShellError.new(show_github_issues: true)
+      allow(error).to receive(:message).and_return('error message')
+      expect(runner).to receive(:show_github_issues).with('error message')
+      expect(runner).to receive(:display_user_error!)
+
+      runner.rescue_fastlane_error(error)
+    end
+
+    it 'does not call show_github_issues if e.show_github_issues is false' do
+      runner = Commander::Runner.new
+      error = FastlaneCore::Interface::FastlaneShellError.new(show_github_issues: false)
+      allow(error).to receive(:message).and_return('error message')
+      expect(runner).to_not receive(:show_github_issues)
+      expect(runner).to receive(:display_user_error!)
+
+      runner.rescue_fastlane_error(error)
+    end
+  end
 end

--- a/fastlane_core/spec/fastlane_runner_spec.rb
+++ b/fastlane_core/spec/fastlane_runner_spec.rb
@@ -93,7 +93,7 @@ describe Commander::Runner do
       runner = Commander::Runner.new
       error = FastlaneCore::Interface::FastlaneShellError.new(show_github_issues: false)
       allow(error).to receive(:message).and_return('error message')
-      expect(runner).to_not receive(:show_github_issues)
+      expect(runner).to_not(receive(:show_github_issues))
       expect(runner).to receive(:display_user_error!)
 
       runner.rescue_fastlane_error(error)

--- a/fastlane_core/spec/fastlane_shell_error_spec.rb
+++ b/fastlane_core/spec/fastlane_shell_error_spec.rb
@@ -1,0 +1,21 @@
+describe FastlaneCore::Interface::FastlaneShellError do
+  it 'defaults to not showing github issues' do
+    error = FastlaneCore::Interface::FastlaneShellError.new
+    expect(error.show_github_issues).to be(false)
+  end
+
+  it 'respects the show_github_issues option when false' do
+    error = FastlaneCore::Interface::FastlaneShellError.new(show_github_issues: false)
+    expect(error.show_github_issues).to be(false)
+  end
+
+  it 'respects the show_github_issues option when true' do
+    error = FastlaneCore::Interface::FastlaneShellError.new(show_github_issues: true)
+    expect(error.show_github_issues).to be(true)
+  end
+
+  it 'has the correct prefix' do
+    error = FastlaneCore::Interface::FastlaneShellError.new
+    expect(error.prefix).to eq('[SHELL_ERROR]')
+  end
+end


### PR DESCRIPTION
## Problem

Doing any large scale build (React Native, Flutter and Unity) have enormous output. When they fail - it duplicates all that output in GitHub Actions. I'm talking 30-50k lines of stuff duplicated. Its so much text that when things fail on GitHub - it hurts the output and runner with so much text outputted at once.

It makes diagnosing issues a pain in the ass because of so much duplication. We sliced a bit of output off in #19545, but I think the story told in #11140 is my experience still as of today.

## Solution

If we have a working terminal not eating stdin/stdout - lets avoid duplicating the output. Any sane system (Gradle, xcodebuild and more) put the failure at the end of output naturally

Lets treat the ShellError as a known type of error. This means we do NOT spit out a stacktrace of internal Fastlane. Calling to an outbound tool (ie aapt) and that failing is not a stacktrace in fastlane. 


## Demo (new)
```
➜  android git:(main) ✗ FASTLANE_HIDE_GITHUB_ISSUES=false bundle exec fastlane beta

[✔] 🚀 
[06:40:53]: ------------------------------
[06:40:53]: --- Step: default_platform ---
[06:40:53]: ------------------------------
[06:40:53]: Driving the lane 'android beta' 🚀
[06:40:53]: -----------------------------------
[06:40:53]: --- Step: clean assembleRelease ---
[06:40:53]: -----------------------------------
[06:40:53]: $ /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/android/gradlew clean assembleRelease -p .
[06:40:53]: ▸ [Incubating] Problems report is available at: file:///Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/android/build/reports/problems/problems-report.html
[06:40:53]: ▸ FAILURE: Build failed with an exception.
[06:40:53]: ▸ * What went wrong:
[06:40:53]: ▸ Could not initialize class org.gradle.toolchains.foojay.DistributionsKt
[06:40:53]: ▸ > Exception java.lang.NoSuchFieldError: Class org.gradle.jvm.toolchain.JvmVendorSpec does not have member field 'org.gradle.jvm.toolchain.JvmVendorSpec IBM_SEMERU' [in thread "Daemon worker"]
[06:40:53]: ▸ * Try:
[06:40:53]: ▸ > Run with --stacktrace option to get the stack trace.
[06:40:53]: ▸ > Run with --info or --debug option to get more log output.
[06:40:53]: ▸ > Run with --scan to get full insights from a Build Scan (powered by Develocity).
[06:40:53]: ▸ > Get more help at https://help.gradle.org.
[06:40:53]: ▸ Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
[06:40:53]: ▸ You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
[06:40:53]: ▸ For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
[06:40:53]: ▸ BUILD FAILED in 402ms
+---------------------------------+
|          Lane Context           |
+------------------+--------------+
| DEFAULT_PLATFORM | android      |
| PLATFORM_NAME    | android      |
| LANE_NAME        | android beta |
+------------------+--------------+
[06:40:53]: Called from Fastfile at line 11
[06:40:53]: ```
[06:40:53]:      9:       desc "Submit a new Beta Build to Crashlytics Beta"
[06:40:53]:     10:       lane :beta do
[06:40:53]:  => 11:         gradle(task: "clean assembleRelease")
[06:40:53]:     12:         crashlytics
[06:40:53]:     13:       
[06:40:53]: ```

+--------------------------------------------+
|              fastlane summary              |
+------+-----------------------+-------------+
| Step | Action                | Time (in s) |
+------+-----------------------+-------------+
| 1    | default_platform      | 0           |
| 💥   | clean assembleRelease | 0           |
+------+-----------------------+-------------+

[06:40:53]: fastlane finished with errors

Looking for related GitHub issues on fastlane/fastlane...

➡️  Improve Beta Setup
    https://github.com/fastlane/fastlane/pull/1 [closed] 1 💬
    04 Feb 2017

🔗  You can ⌘ + double-click on links to open them directly in your browser.

[!] Exit status of command '/Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/android/gradlew clean assembleRelease -p .' was 1 instead of 0.    
```


## Demo (Old)

```
➜  android git:(main) ✗ FASTLANE_HIDE_GITHUB_ISSUES=false bundle exec fastlane beta

[✔] 🚀 
[07:56:00]: ------------------------------
[07:56:00]: --- Step: default_platform ---
[07:56:00]: ------------------------------
[07:56:00]: Driving the lane 'android beta' 🚀
[07:56:00]: -----------------------------------
[07:56:00]: --- Step: clean assembleRelease ---
[07:56:00]: -----------------------------------
[07:56:00]: $ /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/android/gradlew clean assembleRelease -p .
[07:56:01]: ▸ [Incubating] Problems report is available at: file:///Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/android/build/reports/problems/problems-report.html
[07:56:01]: ▸ FAILURE: Build failed with an exception.
[07:56:01]: ▸ * What went wrong:
[07:56:01]: ▸ Could not initialize class org.gradle.toolchains.foojay.DistributionsKt
[07:56:01]: ▸ > Exception java.lang.NoSuchFieldError: Class org.gradle.jvm.toolchain.JvmVendorSpec does not have member field 'org.gradle.jvm.toolchain.JvmVendorSpec IBM_SEMERU' [in thread "Daemon worker"]
[07:56:01]: ▸ * Try:
[07:56:01]: ▸ > Run with --stacktrace option to get the stack trace.
[07:56:01]: ▸ > Run with --info or --debug option to get more log output.
[07:56:01]: ▸ > Run with --scan to get full insights from a Build Scan (powered by Develocity).
[07:56:01]: ▸ > Get more help at https://help.gradle.org.
[07:56:01]: ▸ Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
[07:56:01]: ▸ You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
[07:56:01]: ▸ For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
[07:56:01]: ▸ BUILD FAILED in 389ms
+---------------------------------+
|          Lane Context           |
+------------------+--------------+
| DEFAULT_PLATFORM | android      |
| PLATFORM_NAME    | android      |
| LANE_NAME        | android beta |
+------------------+--------------+
[07:56:01]: Called from Fastfile at line 11
[07:56:01]: ```
[07:56:01]:      9:       desc "Submit a new Beta Build to Crashlytics Beta"
[07:56:01]:     10:       lane :beta do
[07:56:01]:  => 11:         gradle(task: "clean assembleRelease")
[07:56:01]:     12:         crashlytics
[07:56:01]:     13:       
[07:56:01]: ```
[07:56:01]: Exit status of command '/Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/android/gradlew clean assembleRelease -p .' was 1 instead of 0.
                                                                                                                                                                                                               
[Incubating] Problems report is available at: file:///Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/android/build/reports/problems/problems-report.html                                                     
                                                                                                                                                                                                               
FAILURE: Build failed with an exception.                                                                                                                                                                       
                                                                                                                                                                                                               
* What went wrong:                                                                                                                                                                                             
Could not initialize class org.gradle.toolchains.foojay.DistributionsKt                                                                                                                                        
> Exception java.lang.NoSuchFieldError: Class org.gradle.jvm.toolchain.JvmVendorSpec does not have member field 'org.gradle.jvm.toolchain.JvmVendorSpec IBM_SEMERU' [in thread "Daemon worker"]                
                                                                                                                                                                                                               
* Try:                                                                                                                                                                                                         
> Run with --stacktrace option to get the stack trace.                                                                                                                                                         
> Run with --info or --debug option to get more log output.                                                                                                                                                    
> Run with --scan to get full insights from a Build Scan (powered by Develocity).                                                                                                                              
> Get more help at https://help.gradle.org.                                                                                                                                                                    
                                                                                                                                                                                                               
Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.                                                                                                                     
                                                                                                                                                                                                               
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.                                                                      
                                                                                                                                                                                                               
For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.                                                   
                                                                                                                                                                                                               
BUILD FAILED in 389ms                                                                                                                                                                                          
                                                                                                                                                                                                               

+--------------------------------------------+
|              fastlane summary              |
+------+-----------------------+-------------+
| Step | Action                | Time (in s) |
+------+-----------------------+-------------+
| 1    | default_platform      | 0           |
| 💥   | clean assembleRelease | 0           |
+------+-----------------------+-------------+

[07:56:01]: fastlane finished with errors

Looking for related GitHub issues on fastlane/fastlane...

bundler: failed to load command: fastlane (/Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/vendor/bundle/ruby/3.4.0/bin/fastlane)
/Volumes/Nexus/Projects/fastlane/fastlane/fastlane_core/lib/fastlane_core/ui/interface.rb:153:in 'FastlaneCore::Interface#shell_error!': [!] Exit status of command '/Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/android/gradlew clean assembleRelease -p .' was 1 instead of 0. (FastlaneCore::Interface::FastlaneShellError)                                                                                          

[Incubating] Problems report is available at: file:///Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/android/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
Could not initialize class org.gradle.toolchains.foojay.DistributionsKt
> Exception java.lang.NoSuchFieldError: Class org.gradle.jvm.toolchain.JvmVendorSpec does not have member field 'org.gradle.jvm.toolchain.JvmVendorSpec IBM_SEMERU' [in thread "Daemon worker"]

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights from a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 389ms

        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in 'FastlaneCore::UI.method_missing'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/helper/sh_helper.rb:80:in 'Fastlane::Actions.sh_control_output'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/forwardable.rb:240:in 'Fastlane::Action.sh'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/helper/gradle_helper.rb:32:in 'FastlaneCore::Helper::GradleHelper#trigger'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/actions/gradle.rb:60:in 'Fastlane::Actions::GradleAction.run'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/runner.rb:263:in 'block (2 levels) in Fastlane::Runner#execute_action'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/actions/actions_helper.rb:69:in 'Fastlane::Actions.execute_action'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/runner.rb:255:in 'block in Fastlane::Runner#execute_action'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/runner.rb:229:in 'Dir.chdir'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/runner.rb:229:in 'Fastlane::Runner#execute_action'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/runner.rb:157:in 'Fastlane::Runner#trigger_action_by_name'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/fast_file.rb:159:in 'Fastlane::FastFile#method_missing'
        from Fastfile:11:in 'block (2 levels) in Fastlane::FastFile#parsing_binding'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/lane.rb:41:in 'Fastlane::Lane#call'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/runner.rb:49:in 'block in Fastlane::Runner#execute'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/runner.rb:45:in 'Dir.chdir'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/runner.rb:45:in 'Fastlane::Runner#execute'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/lane_manager.rb:46:in 'Fastlane::LaneManager.cruise_lane'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/command_line_handler.rb:34:in 'Fastlane::CommandLineHandler.handle'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/commands_generator.rb:110:in 'block (2 levels) in Fastlane::CommandsGenerator#run'
        from /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/vendor/bundle/ruby/3.4.0/gems/commander-4.6.0/lib/commander/command.rb:187:in 'Commander::Command#call'
        from /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/vendor/bundle/ruby/3.4.0/gems/commander-4.6.0/lib/commander/command.rb:157:in 'Commander::Command#run'
        from /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/vendor/bundle/ruby/3.4.0/gems/commander-4.6.0/lib/commander/runner.rb:444:in 'Commander::Runner#run_active_command'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in 'Commander::Runner#run!'
        from /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/vendor/bundle/ruby/3.4.0/gems/commander-4.6.0/lib/commander/delegates.rb:18:in 'Commander::Delegates#run!'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/commands_generator.rb:363:in 'Fastlane::CommandsGenerator#run'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/commands_generator.rb:43:in 'Fastlane::CommandsGenerator.start'
        from /Volumes/Nexus/Projects/fastlane/fastlane/fastlane/lib/fastlane/cli_tools_distributor.rb:132:in 'Fastlane::CLIToolsDistributor.take_off'
        from /Volumes/Nexus/Projects/fastlane/fastlane/bin/fastlane:23:in '<top (required)>'
        from /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/vendor/bundle/ruby/3.4.0/bin/fastlane:25:in 'Kernel#load'
        from /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/vendor/bundle/ruby/3.4.0/bin/fastlane:25:in '<top (required)>'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/cli/exec.rb:59:in 'Kernel.load'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/cli.rb:452:in 'Bundler::CLI#exec'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/cli.rb:29:in 'Bundler::CLI.start'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.6.9/exe/bundle:28:in 'block in <top (required)>'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/3.4.0/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-2.6.9/exe/bundle:20:in '<top (required)>'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/bin/bundle:25:in 'Kernel#load'
        from /Users/ibotpeaches/.rbenv/versions/3.4.7/bin/bundle:25:in '<main>'
```