### PR TITLE
[gym] handle xcpretty errors cleaner & promote xcbeautify

### DIFF
--- a/gym/lib/gym/error_handler.rb
+++ b/gym/lib/gym/error_handler.rb
@@ -151,9 +151,19 @@ module Gym
         # `xcodebuild` doesn't properly mark lines as failure reason or important information
         # so we assume that the last few lines show the error message that's relevant
         # (at least that's what was correct during testing)
-        log_content = File.read(log_path).split("\n").last(5)
+        log_lines = File.read(log_path).split("\n")
+        log_content = log_lines.last(5)
         log_content.each do |row|
           UI.command_output(row)
+        end
+
+        # If we didn't find the error in the last 5 lines, let's search for it
+        # This is specifically for errors that might be buried by subsequent warnings
+        last_5_lines = log_content.join("\n")
+        unless last_5_lines.include?("error:")
+          UI.verbose("Error not found in last 5 lines, searching for it in the log...")
+          error_line = log_lines.reverse.find { |l| l.include?("error:") }
+          UI.command_output(error_line) if error_line
         end
 
         UI.message("")

--- a/gym/lib/gym/generators/build_command_generator.rb
+++ b/gym/lib/gym/generators/build_command_generator.rb
@@ -119,6 +119,8 @@ module Gym
       end
 
       def pipe_xcpretty
+        UI.important("Using xcpretty can result in missing some build errors and is slower than the preferred xcbeautify. See https://docs.fastlane.tools/best-practices/xcodebuild-formatters/ for more information.")
+
         pipe = []
 
         formatter = Gym.config[:xcpretty_formatter]

--- a/gym/spec/error_handler_spec.rb
+++ b/gym/spec/error_handler_spec.rb
@@ -55,6 +55,17 @@ Code signing is required for product type 'Application' in SDK 'iOS 11.0'
       Gym::ErrorHandler.handle_build_error(code_signing_output)
     end
 
+    it "prints the error even if it's not in the last 5 lines" do
+      buried_error_output = "error: buried here\n" + (1..10).map { |i| "warning #{i}" }.join("\n")
+      mock_gym_path(buried_error_output)
+
+      expect(UI).to receive(:command_output).with("error: buried here")
+      expect(UI).to receive(:command_output).at_least(5).times
+      expect(UI).to receive(:build_failure!)
+
+      Gym::ErrorHandler.handle_build_error(buried_error_output)
+    end
+
     it "prints mismatch between the export_method and the selected profiles only once" do
       mock_gym_path(@output)
       expect(UI).to receive(:build_failure!).with("Error building the application - see the log above", error_info: @output)

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -177,6 +177,8 @@ module Scan
     end
 
     def pipe_xcpretty
+      UI.important("Using xcpretty can result in missing some build errors and is slower than the preferred xcbeautify. See https://docs.fastlane.tools/best-practices/xcodebuild-formatters/ for more information.")
+
       formatter = []
       if (custom_formatter = Scan.config[:xcpretty_formatter] || Scan.config[:formatter])
         if custom_formatter.end_with?(".rb")


### PR DESCRIPTION
 ## Problem

Most users run `xcpretty`. They have no idea that you can "brew install" a better formatter. XCPretty at this point is pretty rough as it misses the newer Xcode error format, so errors are stuck in a log file and not emitted into the output.

Take this sample error ([xcpretty](https://github.com/fastlane/fastlane/pull/30097#issuecomment-4826367592)) and try and find the real error as to why the build failed. You can't. (well in this sample case you can, since error is on one of last 5 lines)

Now look at that same build with [xcbeautify](https://github.com/fastlane/fastlane/pull/30097#issuecomment-4826381970). The line is clear as a day with an emoji.

```
[10:19:20]: ▸ ❌ /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/ios/fastlaneSampleRn.xcodeproj: Signing for "fastlaneSampleRn" requires a development team. Select a development team in the Signing & Capabilities editor. (in target 'fastlaneSampleRn' from project 'fastlaneSampleRn')                                                                                                                                  
```

## Solution

1. Encourage people to use xcbeautify as they probably don't know. Spit out a message into logs drawing attention to the documentation for only xcpretty.
2. If still using xcpretty - grep for "error" and include those logs at the end. This will allow users that cannot access the log file on the runner, but still find the error and reason for the build failure


## Demo (xcpretty)

```
➜  ios git:(main) ✗ bundle exec fastlane beta          
[✔] 🚀 
[10:55:56]: It seems like you wanted to load some plugins, however they couldn't be loaded
[10:55:56]: Please follow the troubleshooting guide: https://docs.fastlane.tools/plugins/plugins-troubleshooting/
[10:55:56]: ------------------------------
[10:55:56]: --- Step: default_platform ---
[10:55:56]: ------------------------------
[10:55:56]: Driving the lane 'ios beta' 🚀
[10:55:56]: ------------------------------
[10:55:56]: --- Step: get_build_number ---
[10:55:56]: ------------------------------
[10:55:56]: $ cd /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/ios && agvtool what-version -terse
[10:55:56]: ▸ 1
[10:55:56]: --------------------------------------
[10:55:56]: --- Step: increment_version_number ---
[10:55:56]: --------------------------------------
[10:55:56]: $ cd /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/ios && agvtool new-marketing-version 1.19
[10:55:56]: ▸ Setting CFBundleShortVersionString of project fastlaneSampleRn to:
[10:55:56]: ▸ 1.19.
[10:55:56]: ▸ Updating CFBundleShortVersionString in Info.plist(s)...
[10:55:56]: ▸ Updated CFBundleShortVersionString in "fastlaneSampleRn.xcodeproj/../fastlaneSampleRn/Info.plist" to 1.19
[10:55:56]: -----------------------
[10:55:56]: --- Step: build_app ---
[10:55:56]: -----------------------
[10:55:56]: Resolving Swift Package Manager dependencies...
[10:55:56]: $ xcodebuild -resolvePackageDependencies -workspace ./fastlaneSampleRn.xcworkspace -scheme fastlaneSampleRn
[10:55:56]: ▸ Command line invocation:
[10:55:56]: ▸     /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -resolvePackageDependencies -workspace ./fastlaneSampleRn.xcworkspace -scheme fastlaneSampleRn
[10:55:56]: ▸ resolved source packages: 
[10:55:56]: $ xcodebuild -showBuildSettings -workspace ./fastlaneSampleRn.xcworkspace -scheme fastlaneSampleRn 2>&1

+-------------------------------------------------------------------------------------------------------+
|                                        Summary for gym 2.236.1                                        |
+--------------------------------------+----------------------------------------------------------------+
| workspace                            | ./fastlaneSampleRn.xcworkspace                                 |
| scheme                               | fastlaneSampleRn                                               |
| clean                                | false                                                          |
| output_directory                     | .                                                              |
| output_name                          | fastlaneSampleRn                                               |
| silent                               | false                                                          |
| skip_package_ipa                     | false                                                          |
| skip_package_pkg                     | false                                                          |
| build_path                           | /Users/ibotpeaches/Library/Developer/Xcode/Archives/2026-06-28 |
| result_bundle                        | false                                                          |
| buildlog_path                        | ~/Library/Logs/gym                                             |
| destination                          | generic/platform=iOS                                           |
| xcodebuild_formatter                 | xcpretty                                                       |
| build_timing_summary                 | false                                                          |
| skip_profile_detection               | false                                                          |
| xcodebuild_command                   | xcodebuild                                                     |
| skip_package_dependencies_resolution | false                                                          |
| disable_package_automatic_updates    | false                                                          |
| skip_package_repository_fetches      | false                                                          |
| use_system_scm                       | false                                                          |
| generate_appstore_info               | false                                                          |
| xcode_path                           | /Applications/Xcode.app                                        |
+--------------------------------------+----------------------------------------------------------------+

[10:55:57]: Using xcpretty can result in missing some build errors and is slower than the preferred xcbeautify. See https://docs.fastlane.tools/best-practices/xcodebuild-formatters/ for more information.
[10:55:57]: $ set -o pipefail && xcodebuild -workspace ./fastlaneSampleRn.xcworkspace -scheme fastlaneSampleRn -destination 'generic/platform=iOS' -archivePath /Users/ibotpeaches/Library/Developer/Xcode/Archives/2026-06-28/fastlaneSampleRn\ 2026-06-28\ 10.55.57.xcarchive archive | tee /Users/ibotpeaches/Library/Logs/gym/fastlaneSampleRn-fastlaneSampleRn.log | xcpretty                                            
[10:55:59]: ▸     Run script build phase 'Bundle React Native code and images' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'fastlaneSampleRn' from project 'fastlaneSampleRn')                      
[10:55:59]: ▸     Run script build phase '[CP-User] [Hermes] Replace Hermes for the right configuration, if needed' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'hermes-engine' from project 'Pods')
[10:55:59]: ▸ ** ARCHIVE FAILED **
[10:55:59]: ▸ The following build commands failed:
[10:55:59]: ▸   Archiving workspace fastlaneSampleRn with scheme fastlaneSampleRn
[10:55:59]: ▸ (1 failure)
[10:55:59]: Exit status: 65

+---------------------------------------+
|           Build environment           |
+-------------+-------------------------+
| xcode_path  | /Applications/Xcode.app |
| gym_version | 2.236.1                 |
| sdk         | iPhoneOS26.5.sdk        |
+-------------+-------------------------+

[10:55:59]: ▸ note: Run script build phase '[CP-User] [RNDeps] Replace React Native Dependencies for the right configuration, if needed' will be run during every build because the option to run the script phase "Based on dependency analysis" is unchecked. (in target 'ReactNativeDependencies' from project 'Pods')                                                                                                     
[10:55:59]: ▸ note: Run script build phase '[CP-User] [RNCore] Replace React Native Core for the right configuration, if needed' will be run during every build because the option to run the script phase "Based on dependency analysis" is unchecked. (in target 'React-Core-prebuilt' from project 'Pods')                                                                                                                 
[10:55:59]: ▸ /Volumes/Nexus/Projects/fastlane/fastlaneSampleRn/ios/fastlaneSampleRn.xcodeproj: error: Signing for "fastlaneSampleRn" requires a development team. Select a development team in the Signing & Capabilities editor. (in target 'fastlaneSampleRn' from project 'fastlaneSampleRn')                                                                                                                             
[10:55:59]: ▸ warning: Run script build phase 'Bundle React Native code and images' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'fastlaneSampleRn' from project 'fastlaneSampleRn')                 
[10:55:59]: ▸ warning: Run script build phase '[CP-User] [Hermes] Replace Hermes for the right configuration, if needed' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'hermes-engine' from project 'Pods')                                                                                                                                                                                                          
[10:55:59]: 
[10:55:59]: ⬆️  Check out the few lines of raw `xcodebuild` output above for potential hints on how to solve this error
[10:55:59]: 📋  For the complete and more detailed error log, check the full log at:
[10:55:59]: 📋  /Users/ibotpeaches/Library/Logs/gym/fastlaneSampleRn-fastlaneSampleRn.log
[10:55:59]: 
[10:55:59]: Looks like fastlane ran into a build/archive error with your project
[10:55:59]: It's hard to tell what's causing the error, so we wrote some guides on how
[10:55:59]: to troubleshoot build and signing issues: https://docs.fastlane.tools/codesigning/getting-started/
[10:55:59]: Before submitting an issue on GitHub, please follow the guide above and make
[10:55:59]: sure your project is set up correctly.
[10:55:59]: fastlane uses `xcodebuild` commands to generate your binary, you can see the
[10:55:59]: the full commands printed out in yellow in the above log.
[10:55:59]: Make sure to inspect the output above, as usually you'll find more error information there
[10:55:59]: 
+-----------------------------+
|        Lane Context         |
+------------------+----------+
| DEFAULT_PLATFORM | ios      |
| PLATFORM_NAME    | ios      |
| LANE_NAME        | ios beta |
| BUILD_NUMBER     | 1        |
| VERSION_NUMBER   | 1.19     |
+------------------+----------+
[10:55:59]: Called from Fastfile at line 24
[10:55:59]: ```
[10:55:59]:     22:         get_build_number
[10:55:59]:     23:         increment_version_number
[10:55:59]:  => 24:         build_app
[10:55:59]:     25:       end
[10:55:59]:     26:     end
[10:55:59]: ```
[10:55:59]: Error building the application - see the log above

+-----------------------------------------------+
|               fastlane summary                |
+------+--------------------------+-------------+
| Step | Action                   | Time (in s) |
+------+--------------------------+-------------+
| 1    | default_platform         | 0           |
| 2    | get_build_number         | 0           |
| 3    | increment_version_number | 0           |
| 💥   | build_app                | 3           |
+------+--------------------------+-------------+

[10:55:59]: fastlane finished with errors

[!] Error building the application - see the log above                                                                                                                                                         
➜  ios git:(main) ✗ 
```

* You can see the error has been extracted (requires a development team)
* You can see the callout for xcbeautify

