### PR TITLE
[pilot] Match groups by either name or id

### DIFF
--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -459,7 +459,7 @@ module Pilot
       if options[:groups]
         app = uploaded_build.app
         beta_groups = app.get_beta_groups.select do |group|
-          options[:groups].include?(group.name)
+          options[:groups].include?(group.name) || options[:groups].include?(group.id)
         end
 
         unless beta_groups.empty?

--- a/pilot/lib/pilot/build_manager.rb
+++ b/pilot/lib/pilot/build_manager.rb
@@ -459,7 +459,7 @@ module Pilot
       if options[:groups]
         app = uploaded_build.app
         beta_groups = app.get_beta_groups.select do |group|
-          options[:groups].include?(group.name) || options[:groups].include?(group.id)
+          group.matches_identifiers?(options[:groups])
         end
 
         unless beta_groups.empty?

--- a/pilot/lib/pilot/options.rb
+++ b/pilot/lib/pilot/options.rb
@@ -267,7 +267,7 @@ module Pilot
         FastlaneCore::ConfigItem.new(key: :groups,
                                      short_option: "-g",
                                      env_name: "PILOT_GROUPS",
-                                     description: "Associate tester to one group or more by group name / group id. E.g. `-g \"Team 1\",\"Team 2\"` This is required when `distribute_external` option is set to true or when we want to add a tester to one or more external testing groups ",
+                                     description: "Associate tester to one group or more by group name / group id. E.g. `-g \"Team 1\",\"a06cf5b5-95a9-4beb-88c6-f22bd6b3f7a2\"` This is required when `distribute_external` option is set to true or when we want to add a tester to one or more external testing groups ",
                                      optional: true,
                                      type: Array,
                                      verify_block: proc do |value|

--- a/pilot/lib/pilot/tester_manager.rb
+++ b/pilot/lib/pilot/tester_manager.rb
@@ -13,7 +13,7 @@ module Pilot
       UI.user_error!("You must provide 1 or more groups (with the `:groups` option)") unless groups_param
 
       app.get_beta_groups.select do |group|
-        next unless groups_param.include?(group.name)
+        next unless group.matches_identifiers?(groups_param)
         user = {
           email: config[:email],
           firstName: config[:first_name],
@@ -54,7 +54,7 @@ module Pilot
           UI.success("Successfully removed tester #{tester.email} from app: #{app.name}")
         else
           groups = tester.beta_groups.select do |group|
-            config[:groups].include?(group.name)
+            group.matches_identifiers?(config[:groups])
           end
           tester.delete_from_beta_groups(beta_groups: groups)
 

--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -252,7 +252,7 @@ describe "Build Manager" do
           apple_id: 'mock_apple_id',
           app_identifier: 'mock_app_id',
           distribute_external: true,
-          groups: ["Blue Man Group"],
+          groups: ["Blue Man Group", "654"],
           skip_submission: false,
           demo_account_required: true,
           notify_external_testers: true,
@@ -413,9 +413,9 @@ describe "Build Manager" do
         # 2. client.add_beta_groups_to_build is called inside of build.add_beta_groups
         expect(Spaceship::ConnectAPI).to receive(:add_beta_groups_to_build).with({
           build_id: ready_to_submit_mock_build.id,
-          beta_group_ids: [beta_groups[0].id]
+          beta_group_ids: [beta_groups[0].id, beta_groups[1].id]
         }).and_return(Spaceship::ConnectAPI::Response.new)
-        expect(ready_to_submit_mock_build).to receive(:add_beta_groups).with(beta_groups: [beta_groups[0]]).and_wrap_original do |m, *args|
+        expect(ready_to_submit_mock_build).to receive(:add_beta_groups).with(beta_groups: [beta_groups[0], beta_groups[1]]).and_wrap_original do |m, *args|
           options = args.first
           m.call(**options)
         end

--- a/pilot/spec/tester_manager_spec.rb
+++ b/pilot/spec/tester_manager_spec.rb
@@ -10,6 +10,12 @@ describe Pilot::TesterManager do
       })
     end
 
+    let(:second_tester_group) do
+      Spaceship::ConnectAPI::BetaGroup.new("2", {
+        name: "Second Group"
+      })
+    end
+
     let(:app_context_testers) do
       [
         Spaceship::ConnectAPI::BetaTester.new("1", {
@@ -37,7 +43,8 @@ describe Pilot::TesterManager do
       Spaceship::ConnectAPI::BetaTester.new("1", {
         firstName: 'fake',
         lastName: 'tester',
-        email: 'fabric-devtools@gmail.com+fake@gmail.com'
+        email: 'fabric-devtools@gmail.com+fake@gmail.com',
+        betaGroups: [custom_tester_group, second_tester_group]
       })
     end
 
@@ -65,7 +72,7 @@ describe Pilot::TesterManager do
         email: fake_tester.email,
         first_name: fake_tester.first_name,
         last_name: fake_tester.last_name,
-        groups: ["Test Group"]
+        groups: ["Test Group", second_tester_group.id]
       })
     end
 
@@ -104,15 +111,15 @@ describe Pilot::TesterManager do
       end
     end
 
-    describe "when asked to invite a new tester to a specific existing custom group" do
-      it "creates a new tester and adds it to the default group" do
+    describe "when asked to invite a new tester to specific existing custom groups" do
+      it "creates a new tester and adds it to the default groups" do
         allow(tester_manager).to receive(:find_app_tester).and_return(fake_tester)
-        allow(fake_app).to receive(:get_beta_groups).and_return([custom_tester_group])
+        allow(fake_app).to receive(:get_beta_groups).and_return([custom_tester_group, second_tester_group])
 
         expect(custom_tester_group).to receive(:post_bulk_beta_tester_assignments)
+        expect(second_tester_group).to receive(:post_bulk_beta_tester_assignments)
 
-        groups = [custom_tester_group]
-        group_names = groups.map(&:name).join(';')
+        group_names = [custom_tester_group.name, second_tester_group.id].join(';')
         expect(FastlaneCore::UI).to receive(:success).with("Successfully added tester #{fake_tester.email} to app #{fake_app_name} in group(s) #{group_names}")
 
         tester_manager.add_tester(default_add_tester_options_with_group)

--- a/spaceship/lib/spaceship/connect_api/models/beta_group.rb
+++ b/spaceship/lib/spaceship/connect_api/models/beta_group.rb
@@ -32,6 +32,11 @@ module Spaceship
         return "betaGroups"
       end
 
+      # Whether this group is referenced by any of the given identifiers (its name or id)
+      def matches_identifiers?(identifiers)
+        identifiers.include?(name) || identifiers.include?(id)
+      end
+
       #
       # API
       #

--- a/spaceship/spec/connect_api/models/beta_group_spec.rb
+++ b/spaceship/spec/connect_api/models/beta_group_spec.rb
@@ -37,4 +37,24 @@ describe Spaceship::ConnectAPI::BetaGroup do
       model.delete!
     end
   end
+
+  describe '#matches_identifiers?' do
+    let(:group) do
+      Spaceship::ConnectAPI::BetaGroup.new("987", {
+        name: "Blue Man Group"
+      })
+    end
+
+    it 'matches by name' do
+      expect(group.matches_identifiers?(["Blue Man Group"])).to eq(true)
+    end
+
+    it 'matches by id' do
+      expect(group.matches_identifiers?(["987"])).to eq(true)
+    end
+
+    it 'does not match unrelated identifiers' do
+      expect(group.matches_identifiers?(["Green Eggs and Ham", "654"])).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

Match TestFlight `groups` in Pilot not only by `name`, but also by `id`.

[Pilot documentation](https://docs.fastlane.tools/actions/pilot/) suggests that external tester `groups` could be matched by either group name or group id. In practice this doesn't happen. Group identifiers are "stable" and therefore better to use in Fastlane configuration files. Group names, on the other side, could be changed anytime and break existing automations (e.g.: a nightly "distribute to external testers" CI job).

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

The change is trivial:
```diff
- options[:groups].include?(group.name)
+ options[:groups].include?(group.name) || options[:groups].include?(group.id)
```
I also updated existing unit tests (added a second group by `id`) and documentation (changed `Team 2` to a random UUID)

### Testing Steps

Run pilot to re-distribute existing build to an External Testers group which don't have this build yet
```ruby
  pilot(
    api_key: CHANGE_API_KEY, # use `app_store_connect_api_key` to obtain it
    app_platform: "ios",
    distribute_only: true,
    distribute_external: true,
    notify_external_testers: true,
    groups: ["CHANGE_GROUP_ID"], # take from a TestFlight url https://appstoreconnect.apple.com/teams/TEAM_ID/apps/APP_ID/testflight/groups/GROUP_ID
    app_version: CHANGE_VERSION,
    build_number: CHANGE_BUILD_NUMBER,
  )
```
Check "Builds" tab contents of that External Testers group – selected build should be there.