### PR TITLE
[ci] support releases with PRs that were deleted (or users)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -364,10 +364,10 @@ private_lane :github_changelog do |options|
 
     if item_infos.size == 0
       # In non-interactive mode (e.g. CI) we can't prompt, so skip the commit instead of crashing
-      if !UI.interactive? || UI.confirm("Error generating changelog. No commit found for #{sha}. Skip?")
+      if !UI.interactive? || UI.confirm("Error generating changelog. No pull request found for commit #{sha}. Skip?")
         next
       else
-        UI.user_error!("Cannot generate changelog. No commit found for #{sha}")
+        UI.user_error!("Cannot generate changelog. No pull request found for commit #{sha}")
       end
     elsif item_infos.size == 1 || !UI.interactive?
       message = item_infos[0][0]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -363,12 +363,13 @@ private_lane :github_changelog do |options|
     end
 
     if item_infos.size == 0
-      if UI.confirm("Error generating changelog. No commit found for #{sha}. Skip?")
+      # In non-interactive mode (e.g. CI) we can't prompt, so skip the commit instead of crashing
+      if !UI.interactive? || UI.confirm("Error generating changelog. No commit found for #{sha}. Skip?")
         next
       else
         UI.user_error!("Cannot generate changelog. No commit found for #{sha}")
       end
-    elsif item_infos.size == 1
+    elsif item_infos.size == 1 || !UI.interactive?
       message = item_infos[0][0]
       username = item_infos[0][1]
     else

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -362,14 +362,21 @@ private_lane :github_changelog do |options|
       [message, username]
     end
 
+    # We may find 0 PRs, 1 PR, n+ PRs and we may be interactive or not. Self recovery exists in non-interactive
+    # User selection is required in interactive
     if item_infos.size == 0
-      # In non-interactive mode (e.g. CI) we can't prompt, so skip the commit instead of crashing
-      if !UI.interactive? || UI.confirm("Error generating changelog. No pull request found for commit #{sha}. Skip?")
+      if !UI.interactive?
+        UI.important("No pull request found for commit #{sha}, falling back to the commit message for the changelog entry")
+      elsif UI.confirm("Error generating changelog. No pull request found for commit #{sha}. Skip?")
         next
       else
         UI.user_error!("Cannot generate changelog. No pull request found for commit #{sha}")
       end
-    elsif item_infos.size == 1 || !UI.interactive?
+    elsif item_infos.size == 1
+      message = item_infos[0][0]
+      username = item_infos[0][1]
+    elsif !UI.interactive?
+      UI.important("Multiple pull requests found for commit #{sha}: #{item_infos.map { |info| info[0] }.join(', ')} - using the first one")
       message = item_infos[0][0]
       username = item_infos[0][1]
     else
@@ -384,7 +391,7 @@ private_lane :github_changelog do |options|
       username = item_infos[index][1]
     end
 
-    "* #{message} via #{name} (@#{username})"
+    username ? "* #{message} via #{name} (@#{username})" : "* #{message} via #{name}"
   end.compact.join("\n")
 
   formatted


### PR DESCRIPTION
### Problem

```
[01:54:13]: ------------------------
[01:54:13]: --- Step: github_api ---
[01:54:13]: ------------------------
[01:54:14]: Error generating changelog. No commit found for 3e11dad529e24041b4769bf018bc2d4e3572ad3e. Skip?
```

Release tried to prompt user to confirm. In a non-interactive mode. Thus crashed. It crashed due to this commit: https://github.com/fastlane/fastlane/commit/3e11dad529e24041b4769bf018bc2d4e3572ad3e. The author is deleted and the PR, but the commit remains.

### Solution

Handle an automatic skip of missing changelog context for an item that is missing. Also rename the message since the commit is NOT missing, only the PR is.