### PR TITLE
[metrics] move to GA4 and improve metrics

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,7 @@ require 'fileutils'
 fastlane_require 'xcodeproj'
 
 skip_docs # Do not create fastlane/README.txt
+opt_out_usage # Do not report analytics for runs of fastlane on the fastlane repo itself
 
 # Test and Validate
 

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_event_builder.rb
@@ -1,23 +1,49 @@
+require_relative '../helper'
+
 module FastlaneCore
   class AnalyticsEventBuilder
     attr_accessor :action_name
 
     # fastlane_client_language valid options are :ruby or :swift
-    def initialize(p_hash: nil, session_id: nil, action_name: nil, fastlane_client_language: :ruby)
+    def initialize(p_hash: nil, session_id: nil, action_name: nil, fastlane_client_language: :ruby, build_tool_version: nil)
       @p_hash = p_hash
       @session_id = session_id
       @action_name = action_name
       @fastlane_client_language = fastlane_client_language
+      @build_tool_version = build_tool_version
     end
 
     def new_event(action_stage)
       {
         client_id: @p_hash,
-        category: "fastlane Client Language - #{@fastlane_client_language}",
-        action: action_stage,
-        label: action_name,
-        value: nil
+        session_id: @session_id,
+        name: action_stage,
+        params: {
+          fastlane_client_language: @fastlane_client_language,
+          fastlane_version: Fastlane::VERSION,
+          install_method: install_method,
+          ruby_version: RUBY_VERSION,
+          operating_system: Helper.operating_system,
+          build_tool_version: @build_tool_version,
+          ci: Helper.ci?.to_s
+        }.reject { |_, value| value.nil? }
       }
+    end
+
+    private
+
+    def install_method
+      if Helper.bundler?
+        'bundler'
+      elsif Helper.contained_fastlane?
+        'standalone'
+      elsif Helper.homebrew?
+        'homebrew'
+      elsif Helper.mac_app?
+        'mac_app'
+      else
+        'gem'
+      end
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
@@ -34,21 +34,28 @@ module FastlaneCore
 
     def post_request(event)
       connection = Faraday.new(GA_URL) do |conn|
-        conn.request(:url_encoded)
         conn.adapter(Faraday.default_adapter)
       end
       connection.headers[:user_agent] = 'fastlane/' + Fastlane::VERSION
-      connection.post("/collect", {
-        v: "1",                                            # API Version
-        tid: @ga_tracking,                                 # Tracking ID / Property ID
-        cid: event[:client_id],                            # Client ID
-        t: "event",                                        # Event hit type
-        ec: event[:category],                              # Event category
-        ea: event[:action],                                # Event action
-        el: event[:label] || "na",                         # Event label
-        ev: event[:value] || "0",                          # Event value
-        aip: "1"                                           # IP anonymization
-      })
+
+      # GA4 protocol, event parameters are sent as `ep.<name>` query parameters
+      params = {
+        v: "2",                        # Protocol version (GA4)
+        tid: @ga_tracking,             # GA4 measurement ID
+        cid: event[:client_id],        # Client ID
+        sid: event[:session_id],       # Session ID
+        _ss: "1",                      # Session start
+        seg: "1",                      # Session engaged
+        _et: "100",                    # Engagement time in ms, required for events to count towards active users
+        en: event[:name].to_s          # Event name
+      }
+      (event[:params] || {}).each do |key, value|
+        params["ep.#{key}"] = value.to_s
+      end
+
+      connection.post("/g/collect") do |request|
+        request.params = params
+      end
     end
   end
 end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_ingester_client.rb
@@ -34,6 +34,10 @@ module FastlaneCore
 
     def post_request(event)
       connection = Faraday.new(GA_URL) do |conn|
+        # This request runs while fastlane is shutting down,
+        # so keep the timeouts short to not delay the user
+        conn.options.open_timeout = 5
+        conn.options.timeout = 5
         conn.adapter(Faraday.default_adapter)
       end
       connection.headers[:user_agent] = 'fastlane/' + Fastlane::VERSION
@@ -46,7 +50,8 @@ module FastlaneCore
         sid: event[:session_id],       # Session ID
         _ss: "1",                      # Session start
         seg: "1",                      # Session engaged
-        _et: "100",                    # Engagement time in ms, required for events to count towards active users
+        # Engagement time in ms, required for events to count towards active users
+        _et: (event[:engagement_time_msec] || 100).to_s,
         en: event[:name].to_s          # Event name
       }
       (event[:params] || {}).each do |key, value|

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -13,9 +13,11 @@ module FastlaneCore
     def initialize(analytics_ingester_client: AnalyticsIngesterClient.new(GA_TRACKING))
       # GA4 requires a numeric session ID for events to be attributed to a session
       @session_id = Time.now.to_i.to_s
+      @session_start_time = Time.now
       @client = analytics_ingester_client
       @threads = []
-      @launch_event_sent = false
+      @launch_event = nil
+      @launch_event_captured = false
     end
 
     def action_launched(launch_context: nil)
@@ -23,11 +25,11 @@ module FastlaneCore
         show_message
       end
 
-      if @launch_event_sent || launch_context.p_hash.nil?
+      if @launch_event_captured || launch_context.p_hash.nil?
         return
       end
 
-      @launch_event_sent = true
+      @launch_event_captured = true
       builder = AnalyticsEventBuilder.new(
         p_hash: launch_context.p_hash,
         session_id: session_id,
@@ -36,11 +38,9 @@ module FastlaneCore
         build_tool_version: launch_context.build_tool_version
       )
 
-      launch_event = builder.new_event(:launch)
-      post_thread = client.post_event(launch_event)
-      unless post_thread.nil?
-        @threads << post_thread
-      end
+      # The event is not posted until finalize_session, so that the
+      # run duration can be reported as GA4 engagement time
+      @launch_event = builder.new_event(:launch)
     end
 
     def action_completed(completion_context: nil)
@@ -65,6 +65,15 @@ module FastlaneCore
     end
 
     def finalize_session
+      unless @launch_event.nil?
+        @launch_event[:engagement_time_msec] = ((Time.now - @session_start_time) * 1000).round
+        post_thread = client.post_event(@launch_event)
+        unless post_thread.nil?
+          @threads << post_thread
+        end
+        @launch_event = nil
+      end
+
       @threads.map(&:join)
     end
   end

--- a/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
+++ b/fastlane_core/lib/fastlane_core/analytics/analytics_session.rb
@@ -4,15 +4,15 @@ require_relative 'analytics_event_builder'
 
 module FastlaneCore
   class AnalyticsSession
-    GA_TRACKING = "UA-121171860-1"
+    GA_TRACKING = "G-94HQ3VVP0X"
 
     private_constant :GA_TRACKING
     attr_accessor :session_id
     attr_accessor :client
 
     def initialize(analytics_ingester_client: AnalyticsIngesterClient.new(GA_TRACKING))
-      require 'securerandom'
-      @session_id = SecureRandom.uuid
+      # GA4 requires a numeric session ID for events to be attributed to a session
+      @session_id = Time.now.to_i.to_s
       @client = analytics_ingester_client
       @threads = []
       @launch_event_sent = false
@@ -32,7 +32,8 @@ module FastlaneCore
         p_hash: launch_context.p_hash,
         session_id: session_id,
         action_name: nil,
-        fastlane_client_language: launch_context.fastlane_client_language
+        fastlane_client_language: launch_context.fastlane_client_language,
+        build_tool_version: launch_context.build_tool_version
       )
 
       launch_event = builder.new_event(:launch)

--- a/fastlane_core/spec/analytics/analytics_event_builder_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_event_builder_spec.rb
@@ -1,0 +1,62 @@
+require 'fastlane_core/analytics/analytics_event_builder'
+
+describe FastlaneCore::AnalyticsEventBuilder do
+  let(:p_hash) { 'some_hash' }
+  let(:session_id) { '1750000000' }
+
+  let(:builder) do
+    FastlaneCore::AnalyticsEventBuilder.new(
+      p_hash: p_hash,
+      session_id: session_id,
+      action_name: nil,
+      fastlane_client_language: :ruby,
+      build_tool_version: 'Xcode 16.0'
+    )
+  end
+
+  describe "#new_event" do
+    before do
+      allow(FastlaneCore::Helper).to receive(:bundler?).and_return(false)
+      allow(FastlaneCore::Helper).to receive(:contained_fastlane?).and_return(false)
+      allow(FastlaneCore::Helper).to receive(:homebrew?).and_return(false)
+      allow(FastlaneCore::Helper).to receive(:mac_app?).and_return(false)
+      allow(FastlaneCore::Helper).to receive(:ci?).and_return(false)
+    end
+
+    it "creates a GA4 event with client_id, session_id, name and params" do
+      event = builder.new_event(:launch)
+
+      expect(event[:client_id]).to eq(p_hash)
+      expect(event[:session_id]).to eq(session_id)
+      expect(event[:name]).to eq(:launch)
+      expect(event[:params]).to eq({
+        fastlane_client_language: :ruby,
+        fastlane_version: Fastlane::VERSION,
+        install_method: 'gem',
+        ruby_version: RUBY_VERSION,
+        operating_system: FastlaneCore::Helper.operating_system,
+        build_tool_version: 'Xcode 16.0',
+        ci: 'false'
+      })
+    end
+
+    it "omits nil values from params" do
+      builder = FastlaneCore::AnalyticsEventBuilder.new(
+        p_hash: p_hash,
+        session_id: session_id,
+        fastlane_client_language: :ruby,
+        build_tool_version: nil
+      )
+
+      event = builder.new_event(:launch)
+      expect(event[:params]).not_to have_key(:build_tool_version)
+    end
+
+    it "reports the install method" do
+      allow(FastlaneCore::Helper).to receive(:bundler?).and_return(true)
+
+      event = builder.new_event(:launch)
+      expect(event[:params][:install_method]).to eq('bundler')
+    end
+  end
+end

--- a/fastlane_core/spec/analytics/analytics_ingester_client_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_ingester_client_spec.rb
@@ -1,0 +1,70 @@
+require 'fastlane_core/analytics/analytics_ingester_client'
+
+describe FastlaneCore::AnalyticsIngesterClient do
+  let(:client) { FastlaneCore::AnalyticsIngesterClient.new('G-XXXXXXXXXX') }
+
+  let(:event) do
+    {
+      client_id: 'some_hash',
+      session_id: '1750000000',
+      name: :launch,
+      params: {
+        fastlane_client_language: :ruby,
+        fastlane_version: '2.228.0',
+        install_method: 'gem',
+        ruby_version: '3.2.2',
+        operating_system: 'macOS',
+        build_tool_version: 'Xcode 16.0',
+        ci: 'false'
+      }
+    }
+  end
+
+  describe "#post_event" do
+    it "returns nil during tests and does not post" do
+      expect(client.post_event(event)).to be_nil
+    end
+
+    it "returns nil when the user opted out" do
+      allow(FastlaneCore::Helper).to receive(:test?).and_return(false)
+      FastlaneSpec::Env.with_env_values('FASTLANE_OPT_OUT_USAGE' => '1') do
+        expect(client.post_event(event)).to be_nil
+      end
+    end
+  end
+
+  describe "#post_request" do
+    it "posts the event to the GA4 /g/collect endpoint" do
+      stub = stub_request(:post, "https://www.google-analytics.com/g/collect")
+             .with(query: {
+               'v' => '2',
+               'tid' => 'G-XXXXXXXXXX',
+               'cid' => 'some_hash',
+               'sid' => '1750000000',
+               '_ss' => '1',
+               'seg' => '1',
+               '_et' => '100',
+               'en' => 'launch',
+               'ep.fastlane_client_language' => 'ruby',
+               'ep.fastlane_version' => '2.228.0',
+               'ep.install_method' => 'gem',
+               'ep.ruby_version' => '3.2.2',
+               'ep.operating_system' => 'macOS',
+               'ep.build_tool_version' => 'Xcode 16.0',
+               'ep.ci' => 'false'
+             },
+                   headers: { 'User-Agent' => 'fastlane/' + Fastlane::VERSION })
+
+      client.post_request(event)
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#send_request" do
+    it "retries failed requests" do
+      expect(client).to receive(:post_request).exactly(3).times.and_raise(Faraday::ConnectionFailed.new("error"))
+      client.send_request(event, retries: 2)
+    end
+  end
+end

--- a/fastlane_core/spec/analytics/analytics_ingester_client_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_ingester_client_spec.rb
@@ -8,6 +8,7 @@ describe FastlaneCore::AnalyticsIngesterClient do
       client_id: 'some_hash',
       session_id: '1750000000',
       name: :launch,
+      engagement_time_msec: 45_000,
       params: {
         fastlane_client_language: :ruby,
         fastlane_version: '2.228.0',
@@ -43,7 +44,7 @@ describe FastlaneCore::AnalyticsIngesterClient do
                'sid' => '1750000000',
                '_ss' => '1',
                'seg' => '1',
-               '_et' => '100',
+               '_et' => '45000',
                'en' => 'launch',
                'ep.fastlane_client_language' => 'ruby',
                'ep.fastlane_version' => '2.228.0',

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -1,0 +1,56 @@
+require 'fastlane_core/analytics/analytics_session'
+
+describe FastlaneCore::AnalyticsSession do
+  let(:ingester_client) { double("ingester_client") }
+  let(:session) { FastlaneCore::AnalyticsSession.new(analytics_ingester_client: ingester_client) }
+
+  before do
+    allow(session).to receive(:should_show_message?).and_return(false)
+  end
+
+  describe "#session_id" do
+    it "is numeric, as required by GA4" do
+      expect(session.session_id).to match(/^\d+$/)
+    end
+  end
+
+  describe "#action_launched" do
+    let(:launch_context) do
+      FastlaneCore::ActionLaunchContext.new(
+        action_name: 'gym',
+        p_hash: 'some_hash',
+        platform: :android,
+        fastlane_client_language: :ruby
+      )
+    end
+
+    it "posts a launch event with the environment params" do
+      expect(ingester_client).to receive(:post_event) do |event|
+        expect(event[:client_id]).to eq('some_hash')
+        expect(event[:session_id]).to eq(session.session_id)
+        expect(event[:name]).to eq(:launch)
+        expect(event[:params][:fastlane_client_language]).to eq(:ruby)
+        expect(event[:params][:build_tool_version]).to eq('android')
+        expect(event[:params][:ruby_version]).to eq(RUBY_VERSION)
+        expect(event[:params][:fastlane_version]).to eq(Fastlane::VERSION)
+        nil
+      end
+
+      session.action_launched(launch_context: launch_context)
+    end
+
+    it "only sends the launch event once per session" do
+      expect(ingester_client).to receive(:post_event).once.and_return(nil)
+
+      session.action_launched(launch_context: launch_context)
+      session.action_launched(launch_context: launch_context)
+    end
+
+    it "does not send an event when p_hash is nil" do
+      launch_context.p_hash = nil
+      expect(ingester_client).not_to receive(:post_event)
+
+      session.action_launched(launch_context: launch_context)
+    end
+  end
+end

--- a/fastlane_core/spec/analytics/analytics_session_spec.rb
+++ b/fastlane_core/spec/analytics/analytics_session_spec.rb
@@ -24,11 +24,19 @@ describe FastlaneCore::AnalyticsSession do
       )
     end
 
-    it "posts a launch event with the environment params" do
+    it "does not post the launch event before the session is finalized" do
+      expect(ingester_client).not_to receive(:post_event)
+
+      session.action_launched(launch_context: launch_context)
+    end
+
+    it "posts a launch event with the environment params and run duration on finalize" do
       expect(ingester_client).to receive(:post_event) do |event|
         expect(event[:client_id]).to eq('some_hash')
         expect(event[:session_id]).to eq(session.session_id)
         expect(event[:name]).to eq(:launch)
+        expect(event[:engagement_time_msec]).to be_kind_of(Integer)
+        expect(event[:engagement_time_msec]).to be >= 0
         expect(event[:params][:fastlane_client_language]).to eq(:ruby)
         expect(event[:params][:build_tool_version]).to eq('android')
         expect(event[:params][:ruby_version]).to eq(RUBY_VERSION)
@@ -37,6 +45,7 @@ describe FastlaneCore::AnalyticsSession do
       end
 
       session.action_launched(launch_context: launch_context)
+      session.finalize_session
     end
 
     it "only sends the launch event once per session" do
@@ -44,6 +53,8 @@ describe FastlaneCore::AnalyticsSession do
 
       session.action_launched(launch_context: launch_context)
       session.action_launched(launch_context: launch_context)
+      session.finalize_session
+      session.finalize_session
     end
 
     it "does not send an event when p_hash is nil" do
@@ -51,6 +62,13 @@ describe FastlaneCore::AnalyticsSession do
       expect(ingester_client).not_to receive(:post_event)
 
       session.action_launched(launch_context: launch_context)
+      session.finalize_session
+    end
+
+    it "does not send an event when no action was launched" do
+      expect(ingester_client).not_to receive(:post_event)
+
+      session.finalize_session
     end
   end
 end


### PR DESCRIPTION
## Problem

When _fastlane_ left Google - the Google accounts (Analytics) were deleted. So for the better part of 6~ years Analytics have been basically dead and going nowhere.

In 2026 with fastlane we have no idea what is used, what Ruby version is out there or really anything.

## Solution

A brand new Google Analytics account can ONLY use GA4, Universal Analytics is gone and not supported which is what fastlane abused (v1/collect). So we had to upgrade to v2 collect and learn the parameters.

Thankfully in era of AI - Fable made quick work of this and designed the parameters to work.

## The Payload
* `fastlane_client_language` - Swift, etc
* `fastlane_version` - The version
* `install_method` - Bundler, Homebrew, raw gem, etc
* `ruby_version` - The Ruby version in-use
* `operating_system` - The OS
* `build_tools_version` - Xcode version
* `ci` - Whether running in CI
* `client_id` - A derived hash of package name / bundle id - not reversible.

We teach Google Analytics about these properties to make custom dimensions.

<img width="1180" height="611" alt="Screenshot 2026-07-05 at 11 15 50 AM" src="https://github.com/user-attachments/assets/a6aedef0-0584-4042-a921-33f7505b35a8" />

fixes: #29852 

----

<img width="1103" height="560" alt="Screenshot 2026-07-05 at 1 01 08 PM" src="https://github.com/user-attachments/assets/d8dd75ed-ba73-4fa4-972f-c83db3c3ea72" />
<img width="1107" height="685" alt="Screenshot 2026-07-05 at 1 01 19 PM" src="https://github.com/user-attachments/assets/b05ad16d-739b-4a45-b298-56caca5c5d74" />
