### PR TITLE
[snapshot] Open the requested simulator for non-headless runs

### DIFF
--- a/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
+++ b/snapshot/lib/snapshot/simulator_launchers/simulator_launcher_base.rb
@@ -81,7 +81,10 @@ module Snapshot
 
       unless launcher_config.headless
         simulator_path = File.join(Helper.xcode_path, 'Applications', 'Simulator.app')
-        Helper.backticks("open -a #{simulator_path} -g", print: FastlaneCore::Globals.verbose?)
+        device_udid = TestCommandGenerator.device_udid(device_types.first)
+        command = "open -a #{simulator_path} -g"
+        command += " --args -CurrentDeviceUDID #{device_udid}" if device_udid
+        Helper.backticks(command, print: FastlaneCore::Globals.verbose?)
       end
     end
 

--- a/snapshot/spec/simulator_launcher_base_spec.rb
+++ b/snapshot/spec/simulator_launcher_base_spec.rb
@@ -3,6 +3,64 @@ describe Snapshot do
     let(:device_udid) { "123456789" }
     let(:paths) { ['./logo.png'] }
 
+    describe '#prepare_simulators_for_launch' do
+      let(:launcher_config) do
+        instance_double(
+          Snapshot::SimulatorLauncherConfiguration,
+          headless: headless,
+          erase_simulator: false,
+          localize_simulator: false,
+          dark_mode: nil,
+          reinstall_app: false,
+          disable_slide_to_type: false
+        )
+      end
+      let(:headless) { false }
+      let(:launcher) { Snapshot::SimulatorLauncherBase.new(launcher_configuration: launcher_config) }
+      let(:simulator_path) { "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app" }
+
+      before do
+        allow(Snapshot).to receive(:kill_simulator)
+        allow(Fastlane::Helper).to receive(:backticks)
+          .with("xcrun simctl shutdown booted", print: FastlaneCore::Globals.verbose?)
+          .and_return("")
+        allow(Snapshot::Fixes::SimulatorZoomFix).to receive(:patch)
+        allow(Snapshot::Fixes::HardwareKeyboardFix).to receive(:patch)
+        allow(Snapshot::Fixes::SharedPasteboardFix).to receive(:patch)
+        allow(Fastlane::Helper).to receive(:xcode_path).and_return("/Applications/Xcode.app/Contents/Developer")
+      end
+
+      it "opens the first requested simulator" do
+        allow(Snapshot::TestCommandGenerator).to receive(:device_udid).with("iPhone 16 Pro").and_return(device_udid)
+
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("open -a #{simulator_path} -g --args -CurrentDeviceUDID #{device_udid}", print: FastlaneCore::Globals.verbose?)
+          .and_return("")
+
+        launcher.prepare_simulators_for_launch(["iPhone 16 Pro", "iPad Pro 13-inch (M4)"])
+      end
+
+      it "preserves the generic Simulator launch when the device cannot be resolved" do
+        allow(Snapshot::TestCommandGenerator).to receive(:device_udid).with("Mac").and_return(nil)
+
+        expect(Fastlane::Helper).to receive(:backticks)
+          .with("open -a #{simulator_path} -g", print: FastlaneCore::Globals.verbose?)
+          .and_return("")
+
+        launcher.prepare_simulators_for_launch(["Mac"])
+      end
+
+      it "does not resolve or open a simulator when running headlessly" do
+        allow(launcher_config).to receive(:headless).and_return(true)
+
+        expect(Snapshot::TestCommandGenerator).not_to receive(:device_udid)
+        expect(Fastlane::Helper).not_to receive(:backticks)
+          .with(match(/^open /), print: FastlaneCore::Globals.verbose?)
+
+        launcher.prepare_simulators_for_launch(["iPhone 16 Pro"])
+      end
+    end
+
     describe '#add_media' do
       it "should call simctl addmedia", requires_xcode: true do
         allow(Snapshot::TestCommandGenerator).to receive(:device_udid).and_return(device_udid)


### PR DESCRIPTION
🔑

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green GitHub Actions checks in the "All checks have passed" section of my PR
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

> Note: #30108 migrated the repository CI from CircleCI to GitHub Actions; the pull-request template still refers to CircleCI.

### Motivation and Context

When _snapshot_ runs with `headless(false)`, it currently opens Simulator without specifying a device UDID. Simulator therefore displays and boots the last-used device while the project builds, even when a different device was requested.

When testing begins, Xcode switches to the requested destination. This causes an unnecessary simulator boot, a visible device switch, and additional delay during screenshot runs.

I searched the existing issues and pull requests for this behavior. The closest related items are:

- #12682 introduced the request for non-headless Simulator support;
- #12493 concerns Simulator visibility during _snapshot_;
- #30054 makes the later `xcodebuild` destination use a simulator UDID, but does not change the earlier visible Simulator pre-launch addressed here.

### Description

This change resolves the UDID of the first requested simulator and supplies it to Simulator using `-CurrentDeviceUDID` when starting a non-headless _snapshot_ run.

For concurrent simulator batches, the first requested destination is displayed while all configured destinations continue to run concurrently.

Existing behavior is preserved when:

- the simulator UDID cannot be resolved, in which case Simulator is opened without a device argument;
- _snapshot_ is running headlessly, in which case Simulator is not opened.

The change is confined to Snapshot's simulator launcher. It does not modify _scan_, which has its own simulator pre-launch path, or the shared FastlaneCore simulator behavior.

Unit tests cover:

- selecting the first requested simulator;
- retaining the generic Simulator launch when no UDID resolves;
- avoiding device resolution and Simulator launch in headless mode.

### Testing Steps

Focused regression specs:

```sh
bundle exec rspec snapshot/spec/simulator_launcher_base_spec.rb
```

Result: 7 examples, 0 failures.

Full code-style validation:

```sh
bundle exec rubocop -a
```

Result: 1,332 files inspected, no offenses detected and no files modified.

Snapshot suite comparison:

- PR branch: 103 examples, 22 failures
- Parent commit: 100 examples, 22 failures
- The failure lists are identical, demonstrating that the three added regression tests pass without introducing additional Snapshot failures.

The full root `bundle exec rspec` suite was also attempted. It is not green in my local macOS/Xcode environment because of unrelated environment-sensitive integration and legacy tests involving areas such as clipboard access, `xcresulttool`, signing fixtures, _scan_, Spaceship, and Trainer. The focused regression suite and differential Snapshot-suite results are reported above.

Manual verification:

1. Leave a simulator other than the requested device selected as the last-used Simulator.
2. Configure _snapshot_ with `headless(false)` and request a different device.
3. Run _snapshot_.
4. Confirm that Simulator displays the requested device immediately instead of first booting the last-used device.