### PR TITLE
[setup_ci] Add option to opt out of setting the default keychain

### DIFF
--- a/fastlane/lib/fastlane/actions/setup_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_ci.rb
@@ -41,7 +41,7 @@ module Fastlane
         UI.message("Creating temporary keychain: \"#{keychain_name}\".")
         Actions::CreateKeychainAction.run(
           name: keychain_name,
-          default_keychain: true,
+          default_keychain: params[:set_default_keychain],
           unlock: true,
           timeout: params[:timeout],
           lock_when_sleeps: true,
@@ -113,7 +113,12 @@ module Fastlane
                                        env_name: "FL_SETUP_CI_KEYCHAIN_NAME",
                                        description: "Set a custom keychain name",
                                        type: String,
-                                       default_value: "fastlane_tmp_keychain")
+                                       default_value: "fastlane_tmp_keychain"),
+          FastlaneCore::ConfigItem.new(key: :set_default_keychain,
+                                       env_name: "FL_SETUP_CI_SET_DEFAULT_KEYCHAIN",
+                                       description: "Set the temporary keychain as the system default",
+                                       type: Boolean,
+                                       default_value: true)
         ]
       end
 

--- a/fastlane/spec/actions_specs/setup_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_ci_spec.rb
@@ -83,6 +83,38 @@ describe Fastlane do
             described_class.run(force: true, keychain_name: "example_keychain_name")
           end
         end
+
+        describe "set_default_keychain option" do
+          before do
+            allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+          end
+
+          it "makes the temporary keychain the system default" do
+            expect(Fastlane::Actions::CreateKeychainAction).to receive(:run).with(hash_including(default_keychain: true))
+
+            Fastlane::FastFile.new.parse("lane :test do
+              setup_ci
+            end").runner.execute(:test)
+          end
+
+          it "keeps the existing default keychain when the option is false" do
+            expect(Fastlane::Actions::CreateKeychainAction).to receive(:run).with(hash_including(default_keychain: false))
+
+            Fastlane::FastFile.new.parse("lane :test do
+              setup_ci(set_default_keychain: false)
+            end").runner.execute(:test)
+          end
+
+          it "keeps the existing default keychain when disabled via ENV" do
+            stub_const("ENV", { "CI" => "anything", "FL_SETUP_CI_SET_DEFAULT_KEYCHAIN" => "false" })
+
+            expect(Fastlane::Actions::CreateKeychainAction).to receive(:run).with(hash_including(default_keychain: false))
+
+            Fastlane::FastFile.new.parse("lane :test do
+              setup_ci
+            end").runner.execute(:test)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### Motivation and Context

fixes #29893.

`setup_ci` passes `default_keychain: true` down to `create_keychain`, so the temporary keychain takes over as the system default. A hosted runner is thrown away after the build, so nobody notices. A self-hosted runner is somebody's real machine, and the keychain is still there, still the default, after the build ends.

### Description

Adds a `set_default_keychain` option to `setup_ci` (env `FL_SETUP_CI_SET_DEFAULT_KEYCHAIN`, default `true`) and passes it to `create_keychain` in place of the fixed `true`. The default keeps current behavior. `setup_jenkins` already has an option with the same name and default, so the naming follows that one.

On whether the signing tools need the keychain to be the default, I checked instead of assuming. With the same identity in the same keychain, `security find-identity -p codesigning` finds it either way, and `codesign` with no `--keychain` argument signs and verifies either way.

What the tools read is the search list, and `add_to_search_list: true` is passed either way. That covers `codesign` and `security`, not every tool, which is why the default stays on.

The keychain is still left behind when the build ends, so the cleanup question in the issue stays open.

### Testing Steps

- `bundle exec rake test_all`, 7778 examples. The 2 `PluginGenerator` failures also fail unchanged on `master` here.
- `bundle exec rubocop`, 1332 files, no offenses.
- `fastlane run setup_ci force:true keychain_name:tmp_kc set_default_keychain:false` leaves `security default-keychain` alone, and leaving the option out still switches it as before.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've added or updated relevant unit tests.
