### PR TITLE
[core] chore: don't hold bounds on bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       babosa (>= 1.0.3, < 2.0.0)
       base64 (~> 0.2)
       benchmark (>= 0.1.0)
-      bundler (>= 2.4.0, < 5.0.0)
+      bundler (>= 2.4.0)
       colored (~> 1.2)
       commander (~> 4.6)
       csv (~> 3.3)

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -60,7 +60,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('artifactory', '~> 3.0') # Used to export to an artifactory server
   spec.add_dependency('aws-sdk-s3', '~> 1.197') # Used for S3 storage in fastlane match
   spec.add_dependency('babosa', '>= 1.0.3', '< 2.0.0') # library for creating human-friendly identifiers, aka "slugs"
-  spec.add_dependency('bundler', '>= 2.4.0', '< 5.0.0') # Used for fastlane plugins
+  spec.add_dependency('bundler', '>= 2.4.0') # Used for fastlane plugins
   spec.add_dependency('CFPropertyList', '>= 2.3', '< 5.0.0') # Needed to be able to read binary plist format
   spec.add_dependency('colored', '~> 1.2') # colored terminal output
   spec.add_dependency('commander', '~> 4.6') # CLI parser


### PR DESCRIPTION
## Problem

Tracking our own Bundler version (even though you need it to install fastlane in some instances) is odd. Odd because Dependabot gets in a loop trying to make constraints true.

```
Could not find compatible versions

Because every version of fastlane depends on bundler >= 2.4.0, < 5.0.0
  and every version of bundler depends on Ruby >= 3.2.0,
  every version of fastlane requires Ruby >= 3.2.0.
So, because Gemfile depends on fastlane >= 0
  and current Ruby version is = 3.0.7,
  version solving has failed.
```

## Solution

I don't think we can remove Bundler as a dep, but in meantime I'm testing removal of the upper bound to see if that helps.