### PR TITLE
[core] move to xcodeproj 1.28.1 (from 1.27.0)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,12 +359,14 @@ GEM
     xcode-install (2.6.8)
       claide (>= 0.9.1, < 1.1.0)
       fastlane (>= 2.1.0, < 3.0.0)
-    xcodeproj (1.27.0)
+    xcodeproj (1.28.1)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
+      base64
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.4.0)
+      nkf
       rexml (>= 3.3.6, < 4.0)
     xcov (1.9.0)
       abbrev


### PR DESCRIPTION
xcodeproj 1.28.0 adds objectVersion 100 for Xcode 26.3 project format compatibility. The fastlane gemspec already allows xcodeproj < 2.0.0, so this only needed a Gemfile.lock update.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

`xcodeproj` 1.27.0 doesn't understand the project format written by Xcode 26.3+, which breaks fastlane actions that open and parse `.xcodeproj` files (e.g. `update_project_team`, `get_version_number`, `increment_build_number`, `gym`, `scan`) against projects saved with that Xcode version.

`xcodeproj` 1.28.0 adds `objectVersion` 100 for Xcode 26.3 project format compatibility, and 1.28.1 fixes a Ruby 3.4 crash (missing `kconv`/`base64` requires). The `fastlane.gemspec` dependency constraint (`>= 1.13.0, < 2.0.0`) already permits `1.28.1` — this PR is a `Gemfile.lock` update to actually resolve to it.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Bumps the locked `xcodeproj` version from `1.27.0` to `1.28.1` via `bundle update xcodeproj`. No gemspec change was needed.

I compared the `xcodeproj` gem source between 1.27.0 and 1.28.1 directly (`diff -rq` on the installed gems) to check for breaking changes: the only files that differ are `constants.rb` (new `LAST_KNOWN_*_SDK` and `LAST_KNOWN_OBJECT_VERSION` constants) and `file_system_synchronized_exception_set.rb` (one new, additive `asset_tags_by_relative_path` attribute). No public API was removed or renamed. fastlane's own code doesn't reference `objectVersion` anywhere, so no source changes were required beyond the lockfile.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

- Installed with Ruby 3.3.0 + Bundler 2.5.23 and ran `bundle exec rspec --pattern 'spec/**/*_spec.rb,*/spec/**/*_spec.rb'` across the whole monorepo: 7,782 examples, 78 failures.
- Re-ran the same 78 failing spec files in isolation against `xcodeproj 1.27.0` (pre-change): identical 78 failures. These are pre-existing environment issues on the test host (no real Xcode/simctl, stale App Store Connect pricing-tier fixtures, etc.), unrelated to this dependency bump — no new failures were introduced by the upgrade.
- Confirmed `bundle install` / `bundle update xcodeproj` resolves cleanly with no other dependency shifts — the diff is limited to the `xcodeproj` stanza in `Gemfile.lock` (plus its two newly-explicit stdlib deps, `base64` and `nkf`).