### PR TITLE
[core] normalize FastlaneSwiftRunner.xcodeproj plist quoting

### DIFF
--- a/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
+++ b/fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj
@@ -46,7 +46,7 @@
 		C0459CAB27261886002CDFB9 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = "$SRCROOT/../..";
+			dstPath = $SRCROOT/../..;
 			dstSubfolderSpec = 0;
 			files = (
 				C0459CAC27261897002CDFB9 /* FastlaneRunner in CopyFiles */,


### PR DESCRIPTION
Normalizes a stray quoted `dstPath` string in `FastlaneSwiftRunner.xcodeproj` so it matches what current `xcodeproj` writes back on every save, pre-empting repeated one-line diff churn.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

While testing an unrelated `xcodeproj` version bump, I noticed that simply running the fastlane test suite (`bundle exec rspec`) rewrites the checked-in `fastlane/swift/FastlaneSwiftRunner/FastlaneSwiftRunner.xcodeproj/project.pbxproj` template on disk — one line changes from `dstPath = "$SRCROOT/../..";` to `dstPath = $SRCROOT/../..;`. I confirmed this happens identically on both `xcodeproj` 1.27.0 and 1.28.1, so it isn't caused by that bump; it's current `xcodeproj`'s ASCII-plist serializer normalizing a quoted string that doesn't actually need quotes (no spaces/parens/etc. in `$SRCROOT/../..`), whereas the file was last saved by an older tool that quoted it unconditionally.

This is purely a repo-hygiene fix: it doesn't change any test's outcome, but it stops every contributor's local test run (and every future CI run building this template) from silently reproducing the same one-line diff.

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

Single-line change: unquotes `dstPath` in the `PBXCopyFilesBuildPhase` section of `FastlaneSwiftRunner.xcodeproj/project.pbxproj` to match what `xcodeproj` itself writes when it resaves the file. No functional change — Xcode and `xcodeproj` parse `"$SRCROOT/../.."` and `$SRCROOT/../..` identically in the old-style ASCII plist grammar.

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->

- Loaded the edited project with `Xcodeproj::Project.open` and confirmed the `PBXCopyFilesBuildPhase`'s `dst_path` still resolves to `"$SRCROOT/../.."` (Ruby string, quotes are plist syntax not part of the value).
- Ran `bundle exec rspec` again after the change (7,782 examples) and confirmed `git status` is clean afterward — `project.pbxproj` is no longer modified by the test run.