### PR TITLE
[core] detect installed Developer ID intermediate certificates by their common name

### DIFF
--- a/fastlane_core/lib/fastlane_core/cert_checker.rb
+++ b/fastlane_core/lib/fastlane_core/cert_checker.rb
@@ -43,6 +43,15 @@ WWDRCA_CERTIFICATES = [
   }
 ]
 
+# Common names of the certificates in `WWDRCA_CERTIFICATES`. The WWDR
+# certificates (G2-G6) and the Developer ID certificates (DEV-ID-G1,
+# DEV-ID-G2) use different common names, so each of them has to be queried
+# separately when looking up the installed certificates
+WWDRCA_CERTIFICATE_NAMES = [
+  'Apple Worldwide Developer Relations',
+  'Developer ID Certification Authority'
+]
+
 module FastlaneCore
   # This class checks if a specific certificate is installed on the current mac
   class CertChecker
@@ -123,18 +132,21 @@ module FastlaneCore
     end
 
     def self.installed_wwdr_certificates(keychain: nil)
-      certificate_name = "Apple Worldwide Developer Relations"
       keychain ||= wwdr_keychain # backwards compatibility
 
-      # Find all installed WWDRCA certificates
+      # Find all installed WWDRCA certificates. A single `security
+      # find-certificate` call can only match one common name, so query the
+      # keychain once per common name used by the certificates
       installed_certs = []
-      Helper.backticks("security find-certificate -a -c '#{certificate_name}' -p #{keychain.shellescape}", print: false)
-            .lines
-            .each do |line|
-        if line.start_with?('-----BEGIN CERTIFICATE-----')
-          installed_certs << line
-        else
-          installed_certs.last << line
+      WWDRCA_CERTIFICATE_NAMES.each do |certificate_name|
+        Helper.backticks("security find-certificate -a -c '#{certificate_name}' -p #{keychain.shellescape}", print: false)
+              .lines
+              .each do |line|
+          if line.start_with?('-----BEGIN CERTIFICATE-----')
+            installed_certs << line
+          else
+            installed_certs.last << line
+          end
         end
       end
 
@@ -145,6 +157,7 @@ module FastlaneCore
           WWDRCA_CERTIFICATES.find { |c| c[:sha256].casecmp?(sha256) }&.fetch(:alias)
         end
         .compact
+        .uniq
     end
 
     def self.install_missing_wwdr_certificates(in_keychain: nil)

--- a/fastlane_core/spec/cert_checker_spec.rb
+++ b/fastlane_core/spec/cert_checker_spec.rb
@@ -59,6 +59,18 @@ describe FastlaneCore do
 
         expect(FastlaneCore::CertChecker.installed_wwdr_certificates).to eq([])
       end
+
+      it "should find Developer ID certificates by their own common name" do
+        expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return('login.keychain')
+
+        expect(FastlaneCore::Helper).to receive(:backticks).with(/security find-certificate -a -c 'Apple Worldwide Developer Relations'/, { print: false }).and_return("")
+        expect(FastlaneCore::Helper).to receive(:backticks).with(/security find-certificate -a -c 'Developer ID Certification Authority'/, { print: false }).and_return("-----BEGIN CERTIFICATE-----\nDEV-ID-G2\n-----END CERTIFICATE-----\n")
+
+        allow(Digest::SHA256).to receive(:hexdigest).with(cert.to_der).and_return('f16cd3c54c7f83cea4bf1a3e6a0819c8aaa8e4a1528fd144715f350643d2df3a')
+        allow(OpenSSL::X509::Certificate).to receive(:new).and_return(cert)
+
+        expect(FastlaneCore::CertChecker.installed_wwdr_certificates).to eq(['DEV-ID-G2'])
+      end
     end
 
     describe '#install_missing_wwdr_certificates' do
@@ -116,7 +128,7 @@ describe FastlaneCore do
 
       it 'should shell escape keychain names when checking for installation' do
         expect(FastlaneCore::CertChecker).to receive(:wwdr_keychain).and_return(keychain_name)
-        expect(FastlaneCore::Helper).to receive(:backticks).with(name_regex, { print: false }).and_return("")
+        expect(FastlaneCore::Helper).to receive(:backticks).with(name_regex, { print: false }).twice.and_return("")
 
         FastlaneCore::CertChecker.installed_wwdr_certificates
       end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Since #20902, `WWDRCA_CERTIFICATES` also contains the two Developer ID intermediate certificates (`DEV-ID-G1`, `DEV-ID-G2`). However, `CertChecker.installed_wwdr_certificates` still looks up installed certificates with `security find-certificate -c 'Apple Worldwide Developer Relations'`, and the Developer ID intermediates use a different common name (`Developer ID Certification Authority`), so they can never be detected as installed.

As a result:

- Every run of `match` (or anything else going through `CertChecker.installed_identities`) re-downloads `DeveloperIDCA.cer` and `DeveloperIDG2CA.cer` from apple.com, even when they are already present in the keychain.
- On CI machines without network access to apple.com, `match` aborts with `Could not install WWDR certificate` on every run (including `readonly: true`), even though all intermediates are already installed. This also adds unnecessary flakiness of the kind reported in #20960, since the download step now runs on every invocation instead of only when something is actually missing.

### Description

- Added `WWDRCA_CERTIFICATE_NAMES` with the common names used by the certificates in `WWDRCA_CERTIFICATES`.
- `installed_wwdr_certificates` now queries the keychain once per common name and aggregates the results (a single `security find-certificate -c` call can only match one name).
- The resulting aliases are deduplicated with `uniq`, since the same certificate can be present in the keychain more than once.
- The install/download path is unchanged: genuinely missing certificates are still downloaded exactly as before.
- Tests: added a spec verifying that Developer ID intermediates are detected via their own common name; updated the shell-escaping spec to expect one keychain query per common name.

### Testing Steps

```
bundle exec rspec fastlane_core/spec/cert_checker_spec.rb   # 11 examples, 0 failures
bundle exec rspec fastlane_core/spec                                         # 720 examples, 0 failures
bundle exec rubocop fastlane_core/lib/fastlane_core/cert_checker.rb fastlane_core/spec/cert_checker_spec.rb   # no offenses
```

Manual verification on a Mac with all 7 intermediates installed in the login keychain:

- Before this change, `FastlaneCore::CertChecker.install_missing_wwdr_certificates` re-downloaded the two Developer ID certificates on every call and aborted with `Could not install WWDR certificate` when apple.com was unreachable.
- With this change, it returns 0 and performs no network calls (verified with `curl` blocked via a `PATH` shim). With an empty test keychain, all 7 certificates are still detected as missing and installed as before.

fixes: #20902