### PR TITLE
[deliver] add support for social media rating keys

### DIFF
--- a/deliver/assets/example_rating_config.json
+++ b/deliver/assets/example_rating_config.json
@@ -9,6 +9,8 @@
   "profanityOrCrudeHumor": "NONE",
   "sexualContentGraphicAndNudity": "NONE",
   "sexualContentOrNudity": "NONE",
+  "socialMedia": false,
+  "socialMediaAgeRestricted": false,
   "violenceCartoonOrFantasy": "NONE",
   "violenceRealistic": "INFREQUENT_OR_MILD",
   "violenceRealisticProlongedGraphicOrSadistic": "FREQUENT_OR_INTENSE",

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -697,6 +697,8 @@ Key | Editable While Live | Directory | Filename
 - `profanityOrCrudeHumor`
 - `sexualContentGraphicAndNudity`
 - `sexualContentOrNudity`
+- `socialMedia`
+- `socialMediaAgeRestricted`
 - `violenceCartoonOrFantasy`
 - `violenceRealistic`
 - `violenceRealisticProlongedGraphicOrSadistic`

--- a/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
+++ b/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb
@@ -27,6 +27,8 @@ module Spaceship
       attr_accessor :loot_box
       attr_accessor :messaging_and_chat
       attr_accessor :parental_controls
+      attr_accessor :social_media
+      attr_accessor :social_media_age_restricted
       attr_accessor :unrestricted_web_access
       attr_accessor :user_generated_content
 
@@ -96,6 +98,8 @@ module Spaceship
         "profanityOrCrudeHumor" => "profanity_or_crude_humor",
         "sexualContentGraphicAndNudity" => "sexual_content_graphic_and_nudity",
         "sexualContentOrNudity" => "sexual_content_or_nudity",
+        "socialMedia" => "social_media",
+        "socialMediaAgeRestricted" => "social_media_age_restricted",
         "unrestrictedWebAccess" => "unrestricted_web_access",
         "userGeneratedContent" => "user_generated_content",
         "violenceCartoonOrFantasy" => "violence_cartoon_or_fantasy",
@@ -174,6 +178,8 @@ module Spaceship
           "lootBox",
           "messagingAndChat",
           "parentalControls",
+          "socialMedia",
+          "socialMediaAgeRestricted",
           "unrestrictedWebAccess",
           "userGeneratedContent"
         ]

--- a/spaceship/spec/connect_api/models/age_rating_declaration_spec.rb
+++ b/spaceship/spec/connect_api/models/age_rating_declaration_spec.rb
@@ -5,6 +5,8 @@ describe Spaceship::ConnectAPI::AgeRatingDeclaration do
       "REALISTIC_VIOLENCE" => 1,
       "HORROR" => 2,
       "UNRESTRICTED_WEB_ACCESS" => 1,
+      "socialMedia" => 1,
+      "socialMediaAgeRestricted" => 0,
       "profanityOrCrudeHumor" => "NONE"
     }
   end
@@ -62,6 +64,8 @@ describe Spaceship::ConnectAPI::AgeRatingDeclaration do
                            "violenceRealistic",
                            "horrorOrFearThemes",
                            "unrestrictedWebAccess",
+                           "socialMedia",
+                           "socialMediaAgeRestricted",
                            "profanityOrCrudeHumor"
                          ])
     end
@@ -77,6 +81,8 @@ describe Spaceship::ConnectAPI::AgeRatingDeclaration do
                              "INFREQUENT_OR_MILD",
                              "FREQUENT_OR_INTENSE",
                              true,
+                             true,
+                             false,
                              "NONE"
                            ])
     end


### PR DESCRIPTION
## Problem

<img width="1839" height="519" alt="Screenshot 2026-07-17 at 1 19 37 PM" src="https://github.com/user-attachments/assets/f714661b-4eae-4964-a660-95c1e6ed11c3" />

We don't support 2 new keys that were added - they aren't enforced till September 7, 2026 so explains why no one has really screamed yet. I first noticed it on submissions, but saw a thread as well here: #30123 

## Solution

Add the keys matching the API (added in 4.4.1 - https://developer.apple.com/documentation/appstoreconnectapi/app-store-connect-api-4-4-1-release-notes)