### PR TITLE
[match/cert] add support for pass types (passbooks)

### DIFF
--- a/cert/lib/cert/options.rb
+++ b/cert/lib/cert/options.rb
@@ -21,9 +21,13 @@ module Cert
                                      optional: true,
                                      verify_block: proc do |value|
                                        value = value.to_s
-                                       types = %w(mac_installer_distribution developer_id_installer developer_id_application developer_id_kext)
+                                       types = %w(mac_installer_distribution developer_id_installer developer_id_application developer_id_kext pass_type_id)
                                        UI.user_error!("Unsupported types, must be: #{types}") unless types.include?(value)
                                      end),
+        FastlaneCore::ConfigItem.new(key: :identifier,
+                                     env_name: "CERT_IDENTIFIER",
+                                     description: "The identifier the certificate type is associated with, for certificate types that are bound to an identifier (e.g. the Pass Type ID identifier 'pass.com.example.mypass' when :type is 'pass_type_id'). The identifier needs to be registered on the Developer Portal before use",
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :force,
                                      env_name: "CERT_FORCE",
                                      description: "Create a certificate even if an existing certificate exists",

--- a/cert/lib/cert/runner.rb
+++ b/cert/lib/cert/runner.rb
@@ -45,6 +45,15 @@ module Cert
 
       FastlaneCore::PrintTable.print_values(config: Cert.config, hide_keys: [:output_path], title: "Summary for cert #{Fastlane::VERSION}")
 
+      if pass_type_certificate?
+        if Cert.config[:identifier].to_s.empty?
+          UI.user_error!("You need to provide an `identifier` (e.g. 'pass.com.example.mypass') when creating a Pass Type ID certificate")
+        end
+        unless Cert.config[:identifier].start_with?("pass.")
+          UI.user_error!("Pass Type ID identifiers need to start with 'pass.' (e.g. 'pass.com.example.mypass'), got: #{Cert.config[:identifier]}")
+        end
+      end
+
       login
 
       should_create = Cert.config[:force]
@@ -144,7 +153,15 @@ module Cert
       filter = {
         certificateType: certificate_types.join(",")
       }
-      return Spaceship::ConnectAPI::Certificate.all(filter: filter)
+      certificates = Spaceship::ConnectAPI::Certificate.all(filter: filter)
+
+      # A team can have pass certificates for multiple Pass Type IDs.
+      # The display name of a pass certificate is its Pass Type ID identifier (e.g. 'pass.com.example.mypass')
+      if pass_type_certificate? && Cert.config[:identifier]
+        certificates = certificates.select { |certificate| certificate.display_name == Cert.config[:identifier] }
+      end
+
+      return certificates
     end
 
     # The kind of certificate we're interested in (for creating)
@@ -165,6 +182,8 @@ module Cert
           ]
         when :developer_id_kext
           return [Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_KEXT]
+        when :pass_type_id
+          return [Spaceship::ConnectAPI::Certificate::CertificateType::PASS_TYPE_ID]
         when :developer_id_installer
           if !Spaceship::ConnectAPI.token.nil?
             raise "As of 2021-11-09, the App Store Connect API does not allow accessing DEVELOPER_ID_INSTALLER with the API Key. Please file an issue on GitHub if this has changed and needs to be updated"
@@ -197,6 +216,28 @@ module Cert
       return [cert_type]
     end
 
+    def pass_type_certificate?
+      return Cert.config[:type].to_s == "pass_type_id"
+    end
+
+    # Looks up the id of the Pass Type ID (e.g. 'pass.com.example.mypass') that
+    # a new pass certificate should be associated with
+    def pass_type_id
+      identifier = Cert.config[:identifier]
+
+      pass_type_ids = Spaceship::ConnectAPI::PassTypeId.all
+      pass_type = pass_type_ids.find { |p| p.identifier == identifier }
+      unless pass_type
+        UI.error("Couldn't find Pass Type ID '#{identifier}' on the Developer Portal")
+        UI.error("Register it first at https://developer.apple.com/account/resources/identifiers/list/passTypeId")
+        available = pass_type_ids.map(&:identifier)
+        UI.message("Available Pass Type IDs:\n- #{available.join("\n- ")}") unless available.empty?
+        UI.user_error!("Couldn't find Pass Type ID '#{identifier}' on the Developer Portal")
+      end
+
+      return pass_type.id
+    end
+
     def create_certificate
       # Create a new certificate signing request
       csr, pkey = Spaceship::ConnectAPI::Certificate.create_certificate_signing_request
@@ -205,7 +246,8 @@ module Cert
       begin
         certificate = Spaceship::ConnectAPI::Certificate.create(
           certificate_type: certificate_type,
-          csr_content: csr.to_pem
+          csr_content: csr.to_pem,
+          pass_type_id: pass_type_certificate? ? pass_type_id : nil
         )
       rescue => ex
         type_name = (Cert.config[:development] ? "Development" : "Distribution")

--- a/cert/spec/runner_spec.rb
+++ b/cert/spec/runner_spec.rb
@@ -151,5 +151,59 @@ describe Cert do
         end
       end
     end
+
+    describe "Pass Type ID certificates" do
+      before do
+        allow(Spaceship::ConnectAPI).to receive(:login).and_return(nil)
+        allow(Spaceship::ConnectAPI).to receive(:client).and_return("client")
+        allow(Spaceship::ConnectAPI.client).to receive(:in_house?).and_return(false)
+
+        options = { type: "pass_type_id", identifier: "pass.com.example.mypass" }
+        Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, options)
+      end
+
+      it "requests PASS_TYPE_ID certificates" do
+        expect(Cert::Runner.new.certificate_types).to eq([Spaceship::ConnectAPI::Certificate::CertificateType::PASS_TYPE_ID])
+      end
+
+      it "only considers certificates of the requested pass type identifier" do
+        matching_cert = double(display_name: "pass.com.example.mypass")
+        other_cert = double(display_name: "pass.com.example.otherpass")
+        allow(Spaceship::ConnectAPI::Certificate).to receive(:all).and_return([other_cert, matching_cert])
+
+        expect(Cert::Runner.new.certificates).to eq([matching_cert])
+      end
+
+      it "resolves the pass type id from the identifier" do
+        pass_type = double(identifier: "pass.com.example.mypass", id: "4B77K434AB")
+        allow(Spaceship::ConnectAPI::PassTypeId).to receive(:all).and_return([pass_type])
+
+        expect(Cert::Runner.new.pass_type_id).to eq("4B77K434AB")
+      end
+
+      it "shows an error when the pass type id is not registered on the portal" do
+        allow(Spaceship::ConnectAPI::PassTypeId).to receive(:all).and_return([])
+
+        expect do
+          Cert::Runner.new.pass_type_id
+        end.to raise_error("Couldn't find Pass Type ID 'pass.com.example.mypass' on the Developer Portal")
+      end
+
+      it "requires a identifier when running with type pass_type_id" do
+        Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, { type: "pass_type_id" })
+
+        expect do
+          Cert::Runner.new.run
+        end.to raise_error("You need to provide an `identifier` (e.g. 'pass.com.example.mypass') when creating a Pass Type ID certificate")
+      end
+
+      it "requires the identifier to start with 'pass.' when running with type pass_type_id" do
+        Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, { type: "pass_type_id", identifier: "com.example.app" })
+
+        expect do
+          Cert::Runner.new.run
+        end.to raise_error("Pass Type ID identifiers need to start with 'pass.' (e.g. 'pass.com.example.mypass'), got: com.example.app")
+      end
+    end
   end
 end

--- a/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
+++ b/fastlane/lib/fastlane/actions/docs/sync_code_signing.md
@@ -264,6 +264,22 @@ git_branch("master")
 
 _match_ will reuse certificates and will create separate provisioning profiles for each app.
 
+#### Pass Type ID (Wallet pass) certificates
+
+_match_ can also create and sync Pass Type ID certificates (historically known as Passbook certificates), which are used to sign Apple Wallet passes. Pass the Pass Type ID identifier (it always starts with `pass.`) as the `app_identifier`:
+
+```no-highlight
+fastlane match pass_type_id --app_identifier pass.com.example.mypass
+```
+
+or in your `Fastfile`:
+
+```ruby-skip-tests
+match(type: "pass_type_id", app_identifier: "pass.com.example.mypass")
+```
+
+The Pass Type ID needs to be [registered on the Apple Developer Portal](https://developer.apple.com/account/resources/identifiers/list/passTypeId) first. Since Pass Type ID certificates don't use provisioning profiles, only the certificate and its private key are created and synced. Note that only one Pass Type ID identifier can be synced per _match_ run - use separate storage (e.g. a separate git branch) for each Pass Type ID.
+
 #### Passphrase
 
 *Git Repo storage only*

--- a/match/lib/match/commands_generator.rb
+++ b/match/lib/match/commands_generator.rb
@@ -162,11 +162,11 @@ module Match
         c.syntax = "fastlane match nuke"
         c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal"
         c.action do |args, options|
-          FastlaneCore::UI.user_error!("Please run `fastlane match nuke [type], allowed values: development, distribution and enterprise. For the 'adhoc' type, please use 'distribution' instead.")
+          FastlaneCore::UI.user_error!("Please run `fastlane match nuke [type], allowed values: development, distribution, enterprise and pass_type_id. For the 'adhoc' type, please use 'distribution' instead.")
         end
       end
 
-      ["development", "distribution", "enterprise"].each do |type|
+      ["development", "distribution", "enterprise", "pass_type_id"].each do |type|
         command "nuke #{type}" do |c|
           c.syntax = "fastlane match nuke #{type}"
           c.description = "Delete all certificates and provisioning profiles from the Apple Dev Portal of the type #{type}"

--- a/match/lib/match/generator.rb
+++ b/match/lib/match/generator.rb
@@ -4,14 +4,14 @@ require_relative 'profile_includes'
 module Match
   # Generate missing resources
   class Generator
-    def self.generate_certificate(params, cert_type, working_directory, specific_cert_type: nil)
+    def self.generate_certificate(params, cert_type, working_directory, specific_cert_type: nil, identifier: nil)
       require 'cert/runner'
       require 'cert/options'
 
       output_path = File.join(working_directory, "certs", cert_type.to_s)
 
-      # Mapping match option to cert option for "Developer ID Application"
-      if cert_type.to_sym == :developer_id_application
+      # Mapping match option to cert option for "Developer ID Application" and "Pass Type ID"
+      if [:developer_id_application, :pass_type_id].include?(cert_type.to_sym)
         specific_cert_type = cert_type.to_s
       end
 
@@ -24,6 +24,7 @@ module Match
         platform: platform,
         development: params[:type] == "development",
         type: specific_cert_type,
+        identifier: identifier,
         generate_apple_certs: params[:generate_apple_certs],
         output_path: output_path,
         force: true, # we don't need a certificate without its private key, we only care about a new certificate

--- a/match/lib/match/importer.rb
+++ b/match/lib/match/importer.rb
@@ -58,6 +58,10 @@ module Match
         certificate_type = [
           Spaceship::ConnectAPI::Certificate::CertificateType::DEVELOPER_ID_INSTALLER
         ].join(',')
+      when :pass_type_id
+        certificate_type = [
+          Spaceship::ConnectAPI::Certificate::CertificateType::PASS_TYPE_ID
+        ].join(',')
       else
         UI.user_error!("Cert type '#{cert_type}' is not supported")
       end

--- a/match/lib/match/module.rb
+++ b/match/lib/match/module.rb
@@ -11,7 +11,7 @@ module Match
   DESCRIPTION = "Easily sync your certificates and profiles across your team"
 
   def self.environments
-    return %w(appstore adhoc development enterprise developer_id mac_installer_distribution developer_id_installer)
+    return %w(appstore adhoc development enterprise developer_id mac_installer_distribution developer_id_installer pass_type_id)
   end
 
   def self.storage_modes
@@ -27,6 +27,7 @@ module Match
     type = type.to_s.downcase
     return :mac_installer_distribution if type == "mac_installer_distribution"
     return :developer_id_installer if type == "developer_id_installer"
+    return :pass_type_id if type == "pass_type_id"
     return :developer_id_application if type == "developer_id"
     return :enterprise if type == "enterprise"
     return :development if type == "development"

--- a/match/lib/match/nuke.rb
+++ b/match/lib/match/nuke.rb
@@ -401,6 +401,10 @@ module Match
         return [
           Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION
         ]
+      when :pass_type_id
+        return [
+          Spaceship::ConnectAPI::Certificate::CertificateType::PASS_TYPE_ID
+        ]
       else
         raise "Unknown type '#{type}'"
       end

--- a/match/lib/match/portal_cache.rb
+++ b/match/lib/match/portal_cache.rb
@@ -8,14 +8,23 @@ module Match
         require_relative 'profile_includes'
         require 'sigh'
 
-        profile_type = Sigh.profile_type_for_distribution_type(
-          platform: params[:platform],
-          distribution_type: params[:type]
-        )
+        # Pass Type ID certificates don't use provisioning profiles,
+        # so there is no profile type to determine certificate types from
+        if params[:type] == "pass_type_id"
+          profile_type = nil
+          certificate_types = [Spaceship::ConnectAPI::Certificate::CertificateType::PASS_TYPE_ID]
+        else
+          profile_type = Sigh.profile_type_for_distribution_type(
+            platform: params[:platform],
+            distribution_type: params[:type]
+          )
+          certificate_types = nil
+        end
 
         cache = Portal::Cache.new(
           platform: params[:platform],
           profile_type: profile_type,
+          certificate_types: certificate_types,
           additional_cert_types: params[:additional_cert_types],
           bundle_id_identifiers: bundle_id_identifiers,
           needs_profiles_devices: ProfileIncludes.can_force_include_all_devices?(params: params, notify: true),
@@ -26,11 +35,12 @@ module Match
         return cache
       end
 
-      attr_reader :platform, :profile_type, :bundle_id_identifiers, :additional_cert_types, :needs_profiles_devices, :needs_profiles_certificate_content, :include_mac_in_profiles
+      attr_reader :platform, :profile_type, :certificate_types, :bundle_id_identifiers, :additional_cert_types, :needs_profiles_devices, :needs_profiles_certificate_content, :include_mac_in_profiles
 
-      def initialize(platform:, profile_type:, additional_cert_types:, bundle_id_identifiers:, needs_profiles_devices:, needs_profiles_certificate_content:, include_mac_in_profiles:)
+      def initialize(platform:, profile_type:, additional_cert_types:, bundle_id_identifiers:, needs_profiles_devices:, needs_profiles_certificate_content:, include_mac_in_profiles:, certificate_types: nil)
         @platform = platform
         @profile_type = profile_type
+        @certificate_types = certificate_types
 
         # Bundle Ids
         @bundle_id_identifiers = bundle_id_identifiers
@@ -77,7 +87,8 @@ module Match
         @certificates ||= Match::Portal::Fetcher.certificates(
           platform: @platform,
           profile_type: @profile_type,
-          additional_cert_types: @additional_cert_types
+          additional_cert_types: @additional_cert_types,
+          certificate_types: @certificate_types
         )
 
         return @certificates.dup

--- a/match/lib/match/portal_fetcher.rb
+++ b/match/lib/match/portal_fetcher.rb
@@ -24,9 +24,9 @@ module Match
         profiles
       end
 
-      def self.certificates(platform:, profile_type:, additional_cert_types:)
+      def self.certificates(platform:, profile_type:, additional_cert_types: nil, certificate_types: nil)
         require 'sigh'
-        certificate_types = Sigh.certificate_types_for_profile_and_platform(platform: platform, profile_type: profile_type)
+        certificate_types ||= Sigh.certificate_types_for_profile_and_platform(platform: platform, profile_type: profile_type)
 
         additional_cert_types ||= []
         additional_cert_types.map! do |cert_type|

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -38,6 +38,25 @@ module Match
 
       update_optional_values_depending_on_storage_type(params)
 
+      if params[:app_identifier].kind_of?(Array)
+        app_identifiers = params[:app_identifier]
+      else
+        app_identifiers = params[:app_identifier].to_s.split(/\s*,\s*/).uniq
+      end
+
+      # sometimes we get an array with arrays, this is a bug. To unblock people using match, I suggest we flatten
+      # then in the future address the root cause of https://github.com/fastlane/fastlane/issues/11324
+      app_identifiers = app_identifiers.flatten.uniq
+
+      # For the 'pass_type_id' type, `app_identifier` holds the Pass Type ID identifier (e.g. 'pass.com.example.mypass')
+      is_pass_type = params[:type] == "pass_type_id"
+      if is_pass_type
+        UI.user_error!("You need to provide the Pass Type ID identifier (e.g. 'pass.com.example.mypass') via the `app_identifier` option when using the 'pass_type_id' type") if app_identifiers.empty?
+        UI.user_error!("Only one Pass Type ID identifier can be synced per `match` run when using the 'pass_type_id' type, but got #{app_identifiers.count}: #{app_identifiers.join(', ')}") if app_identifiers.count > 1
+        invalid_identifiers = app_identifiers.reject { |app_identifier| app_identifier.start_with?("pass.") }
+        UI.user_error!("Pass Type ID identifiers need to start with 'pass.' (e.g. 'pass.com.example.mypass'), got: #{invalid_identifiers.join(', ')}") unless invalid_identifiers.empty?
+      end
+
       # Choose the right storage and encryption implementations
       storage_params = params
       storage_params[:username] = params[:readonly] ? nil : params[:username] # only pass username if not readonly
@@ -61,16 +80,6 @@ module Match
         end
       end
 
-      if params[:app_identifier].kind_of?(Array)
-        app_identifiers = params[:app_identifier]
-      else
-        app_identifiers = params[:app_identifier].to_s.split(/\s*,\s*/).uniq
-      end
-
-      # sometimes we get an array with arrays, this is a bug. To unblock people using match, I suggest we flatten
-      # then in the future address the root cause of https://github.com/fastlane/fastlane/issues/11324
-      app_identifiers = app_identifiers.flatten.uniq
-
       if spaceship
         # Cache bundle ids, certificates, profiles, and devices.
         self.cache = Portal::Cache.build(
@@ -78,14 +87,18 @@ module Match
           bundle_id_identifiers: app_identifiers
         )
 
-        # Verify the App ID (as we don't want 'match' to fail at a later point)
+        # Verify the App ID or Pass Type ID (as we don't want 'match' to fail at a later point)
         app_identifiers.each do |app_identifier|
-          spaceship.bundle_identifier_exists(username: params[:username], app_identifier: app_identifier, cached_bundle_ids: self.cache.bundle_ids)
+          if is_pass_type
+            spaceship.pass_type_id_exists(username: params[:username], pass_type_identifier: app_identifier)
+          else
+            spaceship.bundle_identifier_exists(username: params[:username], app_identifier: app_identifier, cached_bundle_ids: self.cache.bundle_ids)
+          end
         end
       end
 
       # Certificate
-      cert_id = fetch_certificate(params: params, renew_expired_certs: params[:renew_expired_certs])
+      cert_id = fetch_certificate(params: params, renew_expired_certs: params[:renew_expired_certs], identifier: is_pass_type ? app_identifiers.first : nil)
 
       # Mac Installer Distribution Certificate
       additional_cert_types = params[:additional_cert_types] || []
@@ -93,17 +106,21 @@ module Match
         fetch_certificate(params: params, renew_expired_certs: params[:renew_expired_certs], specific_cert_type: additional_cert_type)
       end
 
-      profile_type = Sigh.profile_type_for_distribution_type(
-        platform: params[:platform],
-        distribution_type: params[:type]
-      )
+      unless is_pass_type
+        profile_type = Sigh.profile_type_for_distribution_type(
+          platform: params[:platform],
+          distribution_type: params[:type]
+        )
+      end
 
       cert_ids << cert_id
       spaceship.certificates_exists(username: params[:username], certificate_ids: cert_ids, platform: params[:platform], profile_type: profile_type, cached_certificates: self.cache.certificates) if spaceship
 
       # Provisioning Profiles
 
-      unless params[:skip_provisioning_profiles]
+      if is_pass_type
+        UI.message("Pass Type ID certificates don't use provisioning profiles, skipping profile syncing")
+      elsif !params[:skip_provisioning_profiles]
         app_identifiers.each do |app_identifier|
           loop do
             break if fetch_provisioning_profile(params: params,
@@ -122,8 +139,11 @@ module Match
       end
 
       # Print a summary table for each app_identifier
-      app_identifiers.each do |app_identifier|
-        TablePrinter.print_summary(app_identifier: app_identifier, type: params[:type], platform: params[:platform])
+      # (for pass_type_id there is no provisioning profile to summarize, the certificate info was already printed)
+      unless is_pass_type
+        app_identifiers.each do |app_identifier|
+          TablePrinter.print_summary(app_identifier: app_identifier, type: params[:type], platform: params[:platform])
+        end
       end
 
       UI.success("All required keys, certificates and provisioning profiles are installed 🙌".green)
@@ -156,9 +176,9 @@ module Match
       end
     end
 
-    RENEWABLE_CERT_TYPES_VIA_API = [:mac_installer_distribution, :development, :distribution, :enterprise]
+    RENEWABLE_CERT_TYPES_VIA_API = [:mac_installer_distribution, :development, :distribution, :enterprise, :pass_type_id]
 
-    def fetch_certificate(params: nil, renew_expired_certs: false, specific_cert_type: nil)
+    def fetch_certificate(params: nil, renew_expired_certs: false, specific_cert_type: nil, identifier: nil)
       cert_type = Match.cert_type_sym(specific_cert_type || params[:type])
       certificate_id = specific_cert_type.nil? ? params[:certificate_id] : nil
 
@@ -203,7 +223,7 @@ module Match
       if !storage_has_certs
         UI.important("Couldn't find a valid code signing identity for #{cert_type}... creating one for you now")
         UI.crash!("No code signing identity found and cannot create a new one because you enabled `readonly`") if params[:readonly]
-        cert_path = Generator.generate_certificate(params, cert_type, prefixed_working_directory, specific_cert_type: specific_cert_type)
+        cert_path = Generator.generate_certificate(params, cert_type, prefixed_working_directory, specific_cert_type: specific_cert_type, identifier: identifier)
         private_key_path = cert_path.gsub(".cer", ".p12")
 
         self.files_to_commit << cert_path

--- a/match/lib/match/spaceship_ensure.rb
+++ b/match/lib/match/spaceship_ensure.rb
@@ -61,6 +61,20 @@ module Match
       UI.user_error!("Couldn't find bundle identifier '#{app_identifier}' for the user '#{username}'")
     end
 
+    def pass_type_id_exists(username: nil, pass_type_identifier: nil)
+      pass_type_ids = Spaceship::ConnectAPI::PassTypeId.all
+      found = pass_type_ids.any? { |pass_type_id| pass_type_id.identifier == pass_type_identifier }
+      return if found
+
+      UI.error("A Pass Type ID with identifier '#{pass_type_identifier}' needs to exist in order to create a Pass Type ID certificate for it")
+      UI.error("You can register one at https://developer.apple.com/account/resources/identifiers/list/passTypeId")
+      UI.error("================================================================")
+      available_pass_type_ids = pass_type_ids.collect { |p| "#{p.identifier} (#{p.name})" }
+      UI.message("Available Pass Type IDs:\n- #{available_pass_type_ids.join("\n- ")}") unless available_pass_type_ids.empty?
+      UI.error("Make sure to run `fastlane match` with the same user and team every time.")
+      UI.user_error!("Couldn't find Pass Type ID '#{pass_type_identifier}' for the user '#{username}'")
+    end
+
     def certificates_exists(username: nil, certificate_ids: [], platform:, profile_type:, cached_certificates:)
       certificates = cached_certificates
       certificates ||= Match::Portal::Fetcher.certificates(platform: platform, profile_type: profile_type)

--- a/match/spec/module_spec.rb
+++ b/match/spec/module_spec.rb
@@ -1,4 +1,16 @@
 describe Match do
+  context "#environments" do
+    it "contains pass_type_id" do
+      expect(Match.environments).to include("pass_type_id")
+    end
+  end
+
+  context "#cert_type_sym" do
+    it "maps pass_type_id to :pass_type_id" do
+      expect(Match.cert_type_sym("pass_type_id")).to eq(:pass_type_id)
+    end
+  end
+
   context "#profile_types" do
     it "profile types for appstore" do
       profiles = Match.profile_types("appstore")

--- a/match/spec/portal_cache_spec.rb
+++ b/match/spec/portal_cache_spec.rb
@@ -112,7 +112,7 @@ describe Match do
         # GIVEN
         sut = default_sut
 
-        allow(Match::Portal::Fetcher).to receive(:certificates).with(additional_cert_types: sut.additional_cert_types, platform: sut.platform, profile_type: sut.profile_type).and_return(['portal_certificate_1']).once
+        allow(Match::Portal::Fetcher).to receive(:certificates).with(additional_cert_types: sut.additional_cert_types, platform: sut.platform, profile_type: sut.profile_type, certificate_types: sut.certificate_types).and_return(['portal_certificate_1']).once
 
         # WHEN
         certificates = sut.certificates
@@ -127,12 +127,12 @@ describe Match do
         # GIVEN
         sut = default_sut
 
-        allow(Match::Portal::Fetcher).to receive(:certificates).with(additional_cert_types: sut.additional_cert_types, platform: sut.platform, profile_type: sut.profile_type).and_return(['portal_certificate_1']).once
+        allow(Match::Portal::Fetcher).to receive(:certificates).with(additional_cert_types: sut.additional_cert_types, platform: sut.platform, profile_type: sut.profile_type, certificate_types: sut.certificate_types).and_return(['portal_certificate_1']).once
 
         certificates = sut.certificates
         expect(certificates).to eq(['portal_certificate_1'])
 
-        allow(Match::Portal::Fetcher).to receive(:certificates).with(additional_cert_types: sut.additional_cert_types, platform: sut.platform, profile_type: sut.profile_type).and_return(['portal_certificate_2']).once
+        allow(Match::Portal::Fetcher).to receive(:certificates).with(additional_cert_types: sut.additional_cert_types, platform: sut.platform, profile_type: sut.profile_type, certificate_types: sut.certificate_types).and_return(['portal_certificate_2']).once
 
         # WHEN
         sut.reset_certificates

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -63,7 +63,7 @@ describe Match do
           expect(fake_storage).to receive(:clear_changes).and_return(nil)
           allow(fake_storage).to receive(:working_directory).and_return(repo_dir)
           allow(fake_storage).to receive(:prefixed_working_directory).and_return(repo_dir)
-          expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution, fake_storage.working_directory, specific_cert_type: nil).and_return(cert_path)
+          expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution, fake_storage.working_directory, specific_cert_type: nil, identifier: nil).and_return(cert_path)
           expect(Match::Generator).to receive(:generate_provisioning_profile).with(params: config,
                                                                                 prov_type: :appstore,
                                                                            certificate_id: "something",
@@ -289,7 +289,7 @@ describe Match do
 
           # Certificates
           # Ensure a new certificate is not generated.
-          expect(Match::Generator).not_to receive(:generate_certificate).with(match_config, :distribution, fake_storage.working_directory, specific_cert_type: nil)
+          expect(Match::Generator).not_to receive(:generate_certificate).with(match_config, :distribution, fake_storage.working_directory, specific_cert_type: nil, identifier: nil)
 
           # Profiles
           begin # Ensure profiles are installed, but not validated.
@@ -357,7 +357,7 @@ describe Match do
 
           # Certificate generator
           # Ensure a new certificate is generated.
-          expect(Match::Generator).to receive(:generate_certificate).with(match_config, :distribution, fake_storage.working_directory, specific_cert_type: nil).and_return(new_stored_valid_cert_path)
+          expect(Match::Generator).to receive(:generate_certificate).with(match_config, :distribution, fake_storage.working_directory, specific_cert_type: nil, identifier: nil).and_return(new_stored_valid_cert_path)
 
           # Spaceship ensure helper
           spaceship_ensure = create_fake_spaceship_ensure
@@ -488,7 +488,7 @@ describe Match do
           expect(fake_storage).to receive(:clear_changes).and_return(nil)
           allow(fake_storage).to receive(:working_directory).and_return(repo_dir)
           allow(fake_storage).to receive(:prefixed_working_directory).and_return(repo_dir)
-          expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution, fake_storage.working_directory, specific_cert_type: nil).and_return(cert_path)
+          expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution, fake_storage.working_directory, specific_cert_type: nil, identifier: nil).and_return(cert_path)
           expect(Match::Generator).to_not(receive(:generate_provisioning_profile))
           expect(FastlaneCore::ProvisioningProfile).to_not(receive(:install))
           expect(fake_storage).to receive(:save_changes!).with(
@@ -542,6 +542,79 @@ describe Match do
             Match::Runner.new.run(config)
           end.to raise_error("You defined the profile type 'enterprise', but your Apple account doesn't support In-House profiles")
         end
+      end
+    end
+
+    describe "pass_type_id type" do
+      before do
+        allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
+        allow(FastlaneCore::Helper).to receive(:xcode_at_least?).and_return(true)
+        stub_const('ENV', { "MATCH_PASSWORD" => '2"QAHg@v(Qp{=*n^' })
+      end
+
+      it "creates a pass type id certificate and skips provisioning profiles", requires_security: true do
+        git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+        values = {
+          app_identifier: "pass.com.example.mypass",
+          type: "pass_type_id",
+          git_url: git_url,
+          username: "flapple@something.com"
+        }
+
+        config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+        repo_dir = Dir.mktmpdir
+        cert_path = File.join(repo_dir, "something.cer")
+
+        create_fake_cache
+        fake_storage = create_fake_storage(match_config: config, repo_dir: repo_dir)
+
+        expect(Match::Generator).to receive(:generate_certificate).with(config, :pass_type_id, repo_dir, specific_cert_type: nil, identifier: "pass.com.example.mypass").and_return(cert_path)
+        expect(Match::Generator).not_to receive(:generate_provisioning_profile)
+
+        expect(fake_storage).to receive(:save_changes!).with(
+          files_to_commit: [
+            cert_path,
+            File.join(repo_dir, "something.p12")
+          ],
+          files_to_delete: []
+        )
+
+        spaceship = "spaceship"
+        allow(spaceship).to receive(:team_id).and_return("")
+        expect(Match::SpaceshipEnsure).to receive(:new).and_return(spaceship)
+        expect(spaceship).to receive(:pass_type_id_exists).with(username: "flapple@something.com", pass_type_identifier: "pass.com.example.mypass").and_return(true)
+        expect(spaceship).not_to receive(:bundle_identifier_exists)
+        expect(spaceship).to receive(:certificates_exists).and_return(true)
+
+        Match::Runner.new.run(config)
+      end
+
+      it "fails when multiple pass type identifiers are given" do
+        values = {
+          app_identifier: ["pass.com.example.a", "pass.com.example.b"],
+          type: "pass_type_id",
+          git_url: "https://github.com/fastlane/fastlane/tree/master/certificates",
+          username: "flapple@something.com"
+        }
+        config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+
+        expect do
+          Match::Runner.new.run(config)
+        end.to raise_error(/Only one Pass Type ID identifier can be synced/)
+      end
+
+      it "fails when the identifier does not start with 'pass.'" do
+        values = {
+          app_identifier: "com.example.app",
+          type: "pass_type_id",
+          git_url: "https://github.com/fastlane/fastlane/tree/master/certificates",
+          username: "flapple@something.com"
+        }
+        config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+
+        expect do
+          Match::Runner.new.run(config)
+        end.to raise_error(/Pass Type ID identifiers need to start with 'pass\.'/)
       end
     end
 

--- a/spaceship/lib/spaceship/connect_api.rb
+++ b/spaceship/lib/spaceship/connect_api.rb
@@ -13,6 +13,7 @@ require 'spaceship/connect_api/models/bundle_id'
 require 'spaceship/connect_api/models/capabilities'
 require 'spaceship/connect_api/models/certificate'
 require 'spaceship/connect_api/models/device'
+require 'spaceship/connect_api/models/pass_type_id'
 require 'spaceship/connect_api/models/profile'
 
 require 'spaceship/connect_api/models/user'

--- a/spaceship/lib/spaceship/connect_api/models/certificate.rb
+++ b/spaceship/lib/spaceship/connect_api/models/certificate.rb
@@ -42,6 +42,8 @@ module Spaceship
         DEVELOPER_ID_KEXT = "DEVELOPER_ID_KEXT"
         DEVELOPER_ID_APPLICATION = "DEVELOPER_ID_APPLICATION"
         DEVELOPER_ID_APPLICATION_G2 = "DEVELOPER_ID_APPLICATION_G2"
+        PASS_TYPE_ID = "PASS_TYPE_ID"
+        PASS_TYPE_ID_WITH_NFC = "PASS_TYPE_ID_WITH_NFC"
 
         # As of 2021-11-09, this is only available with Apple ID auth
         DEVELOPER_ID_INSTALLER = "DEVELOPER_ID_INSTALLER"
@@ -116,13 +118,26 @@ module Spaceship
         return certs
       end
 
-      def self.create(client: nil, certificate_type: nil, csr_content: nil)
+      # @param pass_type_id (String): The id of the passTypeIds resource, required when
+      #   creating a PASS_TYPE_ID or PASS_TYPE_ID_WITH_NFC certificate
+      def self.create(client: nil, certificate_type: nil, csr_content: nil, pass_type_id: nil)
         client ||= Spaceship::ConnectAPI
         attributes = {
           certificateType: certificate_type,
           csrContent: csr_content
         }
-        resp = client.post_certificate(attributes: attributes)
+        relationships = nil
+        if pass_type_id
+          relationships = {
+            passTypeId: {
+              data: {
+                type: "passTypeIds",
+                id: pass_type_id
+              }
+            }
+          }
+        end
+        resp = client.post_certificate(attributes: attributes, relationships: relationships)
         return resp.to_models.first
       end
 

--- a/spaceship/lib/spaceship/connect_api/models/pass_type_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/pass_type_id.rb
@@ -1,0 +1,40 @@
+require_relative '../model'
+
+module Spaceship
+  class ConnectAPI
+    class PassTypeId
+      include Spaceship::ConnectAPI::Model
+
+      attr_accessor :identifier
+      attr_accessor :name
+
+      attr_mapping({
+        "identifier" => "identifier",
+        "name" => "name"
+      })
+
+      def self.type
+        return "passTypeIds"
+      end
+
+      #
+      # API
+      #
+
+      # rubocop:disable Require/MissingRequireStatement
+      def self.all(client: nil, filter: {}, includes: nil, fields: nil, limit: Spaceship::ConnectAPI::MAX_OBJECTS_PER_PAGE_LIMIT, sort: nil)
+        client ||= Spaceship::ConnectAPI
+        resps = client.get_pass_type_ids(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort).all_pages
+        return resps.flat_map(&:to_models)
+      end
+      # rubocop:enable Require/MissingRequireStatement
+
+      def self.find(identifier, client: nil)
+        client ||= Spaceship::ConnectAPI
+        return all(client: client).find do |pass_type_id|
+          pass_type_id.identifier == identifier
+        end
+      end
+    end
+  end
+end

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -146,12 +146,15 @@ module Spaceship
           provisioning_request_client.get("#{Version::V1}/certificates/#{certificate_id}", params)
         end
 
-        def post_certificate(attributes: {})
+        def post_certificate(attributes: {}, relationships: nil)
+          data = {
+            attributes: attributes,
+            type: "certificates"
+          }
+          data[:relationships] = relationships if relationships
+
           body = {
-            data: {
-              attributes: attributes,
-              type: "certificates"
-            }
+            data: data
           }
 
           provisioning_request_client.post("#{Version::V1}/certificates", body)
@@ -161,6 +164,15 @@ module Spaceship
           raise "Certificate id is nil" if certificate_id.nil?
 
           provisioning_request_client.delete("#{Version::V1}/certificates/#{certificate_id}")
+        end
+
+        #
+        # passTypeIds
+        #
+
+        def get_pass_type_ids(filter: {}, includes: nil, fields: nil, limit: nil, sort: nil)
+          params = provisioning_request_client.build_params(filter: filter, includes: includes, fields: fields, limit: limit, sort: sort)
+          provisioning_request_client.get("#{Version::V1}/passTypeIds", params)
         end
 
         #

--- a/spaceship/spec/connect_api/fixtures/provisioning/pass_type_ids.json
+++ b/spaceship/spec/connect_api/fixtures/provisioning/pass_type_ids.json
@@ -1,0 +1,32 @@
+{
+    "data" : [ {
+      "type" : "passTypeIds",
+      "id" : "4B77K434AB",
+      "attributes" : {
+        "identifier" : "pass.com.joshholtz.FastlaneApp",
+        "name" : "Fastlane App Pass"
+      },
+      "links" : {
+        "self" : "https://developer.apple.com:443/services-account/v1/passTypeIds/4B77K434AB"
+      }
+    }, {
+      "type" : "passTypeIds",
+      "id" : "5C88L545BC",
+      "attributes" : {
+        "identifier" : "pass.com.joshholtz.circle.Example",
+        "name" : "Example Pass"
+      },
+      "links" : {
+        "self" : "https://developer.apple.com:443/services-account/v1/passTypeIds/5C88L545BC"
+      }
+    } ],
+    "links" : {
+      "self" : "https://developer.apple.com:443/services-account/v1/passTypeIds"
+    },
+    "meta" : {
+      "paging" : {
+        "total" : 2,
+        "limit" : 200
+      }
+    }
+}

--- a/spaceship/spec/connect_api/models/certificate_spec.rb
+++ b/spaceship/spec/connect_api/models/certificate_spec.rb
@@ -71,6 +71,46 @@ describe Spaceship::ConnectAPI::Certificate do
     end
   end
 
+  describe '#create' do
+    it 'creates a certificate without relationships by default' do
+      expect(Spaceship::ConnectAPI).to receive(:post_certificate).with(
+        attributes: {
+          certificateType: Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION,
+          csrContent: "csr content"
+        },
+        relationships: nil
+      ).and_return(double(to_models: []))
+
+      Spaceship::ConnectAPI::Certificate.create(
+        certificate_type: Spaceship::ConnectAPI::Certificate::CertificateType::IOS_DISTRIBUTION,
+        csr_content: "csr content"
+      )
+    end
+
+    it 'creates a Pass Type ID certificate with a passTypeId relationship' do
+      expect(Spaceship::ConnectAPI).to receive(:post_certificate).with(
+        attributes: {
+          certificateType: Spaceship::ConnectAPI::Certificate::CertificateType::PASS_TYPE_ID,
+          csrContent: "csr content"
+        },
+        relationships: {
+          passTypeId: {
+            data: {
+              type: "passTypeIds",
+              id: "4B77K434AB"
+            }
+          }
+        }
+      ).and_return(double(to_models: []))
+
+      Spaceship::ConnectAPI::Certificate.create(
+        certificate_type: Spaceship::ConnectAPI::Certificate::CertificateType::PASS_TYPE_ID,
+        csr_content: "csr content",
+        pass_type_id: "4B77K434AB"
+      )
+    end
+  end
+
   describe '#valid?' do
     let!(:certificate) do
       certificates_response = JSON.parse(File.read(File.join('spaceship', 'spec', 'connect_api', 'fixtures', 'provisioning', 'certificates.json')))

--- a/spaceship/spec/connect_api/models/pass_type_id_spec.rb
+++ b/spaceship/spec/connect_api/models/pass_type_id_spec.rb
@@ -1,0 +1,41 @@
+describe Spaceship::ConnectAPI::PassTypeId do
+  include_examples "common spaceship login"
+
+  describe '#client' do
+    it '#get_pass_type_ids' do
+      response = Spaceship::ConnectAPI.get_pass_type_ids
+      expect(response).to be_an_instance_of(Spaceship::ConnectAPI::Response)
+
+      expect(response.count).to eq(2)
+      response.each do |model|
+        expect(model).to be_an_instance_of(Spaceship::ConnectAPI::PassTypeId)
+      end
+
+      model = response.first
+      expect(model.id).to eq("4B77K434AB")
+      expect(model.identifier).to eq("pass.com.joshholtz.FastlaneApp")
+      expect(model.name).to eq("Fastlane App Pass")
+    end
+  end
+
+  describe '#all' do
+    it 'returns all pass type ids' do
+      pass_type_ids = Spaceship::ConnectAPI::PassTypeId.all
+      expect(pass_type_ids.count).to eq(2)
+      expect(pass_type_ids.map(&:identifier)).to eq(["pass.com.joshholtz.FastlaneApp", "pass.com.joshholtz.circle.Example"])
+    end
+  end
+
+  describe '#find' do
+    it 'finds a pass type id by its identifier' do
+      pass_type_id = Spaceship::ConnectAPI::PassTypeId.find("pass.com.joshholtz.circle.Example")
+      expect(pass_type_id).to be_an_instance_of(Spaceship::ConnectAPI::PassTypeId)
+      expect(pass_type_id.id).to eq("5C88L545BC")
+    end
+
+    it 'returns nil when the pass type id does not exist' do
+      pass_type_id = Spaceship::ConnectAPI::PassTypeId.find("pass.com.joshholtz.DoesNotExist")
+      expect(pass_type_id).to be_nil
+    end
+  end
+end

--- a/spaceship/spec/connect_api/provisioning/provisioning_stubbing.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_stubbing.rb
@@ -106,6 +106,11 @@ class ConnectAPIStubbing
         stub_request(:post, "https://developer.apple.com/services-account/v1/profiles").
           to_return(status: 200, body: read_fixture_file('profiles.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
       end
+
+      def stub_pass_type_ids
+        stub_request(:post, "https://developer.apple.com/services-account/v1/passTypeIds").
+          to_return(status: 200, body: read_fixture_file('pass_type_ids.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
+      end
     end
   end
 end

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -74,6 +74,7 @@ def before_each_spaceship
   ConnectAPIStubbing::Provisioning.stub_certificates
   ConnectAPIStubbing::Provisioning.stub_devices
   ConnectAPIStubbing::Provisioning.stub_profiles
+  ConnectAPIStubbing::Provisioning.stub_pass_type_ids
 
   ConnectAPIStubbing::TestFlight.stub_apps
   ConnectAPIStubbing::TestFlight.stub_beta_app_localizations


### PR DESCRIPTION
## Problem

fastlane can't automate Service based certs. It can partially via "pem", but that was based for push notifications and is a bit hardened to that structure. So folks that make Passes, Orders or Apple Pay can't automate them.

Its been requested a lot over the years: #6799, #2067, #15628.

## Solution

I debated a new tool like "pem", but I don't feel confident in myself to add a new top level tool to fastlane. Its been 10 years since one was added. So I started at the entrypoint and iterated until it worked :)

<img width="1045" height="67" alt="Screenshot 2026-07-22 at 5 23 58 PM" src="https://github.com/user-attachments/assets/ce302550-a608-47d8-8d75-7f3a739be1b4" />

I ended up modifying `cert` and `match` to make things work with passbooks. The biggest change is `cert` didn't have an `app_identifier` and you need to know that when creating a certificate for a Passbook. I don't love my changes, because I found areas that I needed to shove a parameter in such that I could do logic different between passbook and other certs.

Though I'm opening draft regardless.