### PR TITLE
[update_project_team] add support for sdk conditionals

### DIFF
--- a/fastlane/lib/fastlane/actions/update_project_team.rb
+++ b/fastlane/lib/fastlane/actions/update_project_team.rb
@@ -8,10 +8,8 @@ module Fastlane
         project_path = params[:path]
         selected_targets = params[:targets]
 
-        UI.user_error!("Could not find path to xcodeproj '#{project_path}'. Pass the path to your project (not workspace)!") unless File.exist?(project_path)
-
         # Load .xcodeproj
-        project = Xcodeproj::Project.open(project_path)
+        project = Fastlane::Helper::XcodeprojHelper.get_project!(project_path)
 
         # Fetch target
         targets = project.native_targets
@@ -25,10 +23,20 @@ module Fastlane
 
         # Set teamid in target
         targets.each do |target|
-          UI.message("Updating development team (#{params[:teamid]}) for target `#{target.name}` in the project '#{project_path}'")
-          # Update the build settings
           target.build_configurations.each do |configuration|
-            configuration.build_settings['DEVELOPMENT_TEAM'] = params[:teamid]
+            # Iterate over any keys that start with DEVELOPMENT_TEAM
+            # This will also set keys that have filtering like [sdk=iphoneos*]
+            keys = configuration.build_settings.keys.select { |key| key.to_s.start_with?("DEVELOPMENT_TEAM") }
+            keys.each do |key|
+              configuration.build_settings[key] = params[:teamid]
+              UI.message("Updated build setting '#{key}' to '#{params[:teamid]}' for configuration '#{configuration.name}'")
+            end
+
+            # Explicitly set the key with value if keys don't exist
+            unless keys.include?('DEVELOPMENT_TEAM')
+              configuration.build_settings['DEVELOPMENT_TEAM'] = params[:teamid]
+              UI.message("Added build setting 'DEVELOPMENT_TEAM' with value '#{params[:teamid]}' for configuration '#{configuration.name}'")
+            end
           end
 
           project.save
@@ -42,7 +50,7 @@ module Fastlane
       end
 
       def self.details
-        "This action updates the Developer Team ID of your Xcode project."
+        "This action updates (or adds) the Developer Team ID of your Xcode project."
       end
 
       def self.available_options
@@ -69,8 +77,8 @@ module Fastlane
         ]
       end
 
-      def self.author
-        "lgaches"
+      def self.authors
+        ["lgaches", "iBotPeaches"]
       end
 
       def self.is_supported?(platform)

--- a/fastlane/spec/actions_specs/update_project_team_spec.rb
+++ b/fastlane/spec/actions_specs/update_project_team_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe Fastlane do
+  describe Fastlane::Actions::UpdateProjectTeamAction do
+    describe "Update Project Team" do
+      let(:fixtures_path) { "./fastlane/spec/fixtures" }
+      let(:xcodeproj) { File.absolute_path(File.join(fixtures_path, 'xcodeproj', 'bundle.xcodeproj')) }
+
+      it "updates the development team ID for all targets and configurations" do
+        # We'll use a copy of the xcodeproj to avoid modifying the fixture
+        temp_xcodeproj = File.join(Dir.tmpdir, "bundle.xcodeproj")
+        FileUtils.cp_r(xcodeproj, temp_xcodeproj)
+
+        begin
+          Fastlane::Actions::UpdateProjectTeamAction.run(
+            path: temp_xcodeproj,
+            teamid: "NEWTEAM123"
+          )
+
+          project = Xcodeproj::Project.open(temp_xcodeproj)
+          project.native_targets.each do |target|
+            target.build_configurations.each do |config|
+              expect(config.build_settings['DEVELOPMENT_TEAM']).to eq("NEWTEAM123")
+            end
+          end
+        ensure
+          FileUtils.rm_rf(temp_xcodeproj)
+        end
+      end
+
+      it "updates conditional DEVELOPMENT_TEAM settings using a fixture" do
+        temp_xcodeproj = File.join(Dir.tmpdir, "sdk-qualifier.xcodeproj")
+        fixture_xcodeproj = File.join(fixtures_path, 'xcodeproj', 'sdk-qualifier.xcodeproj')
+        FileUtils.cp_r(fixture_xcodeproj, temp_xcodeproj)
+
+        begin
+          Fastlane::Actions::UpdateProjectTeamAction.run(
+            path: temp_xcodeproj,
+            teamid: 'NEWTEAM456'
+          )
+
+          project = Xcodeproj::Project.open(temp_xcodeproj)
+          project.native_targets.each do |target|
+            target.build_configurations.each do |config|
+              expect(config.build_settings['DEVELOPMENT_TEAM']).to eq('NEWTEAM456')
+              expect(config.build_settings['DEVELOPMENT_TEAM[sdk=iphoneos*]']).to eq('NEWTEAM456')
+            end
+          end
+        ensure
+          FileUtils.rm_rf(temp_xcodeproj)
+        end
+      end
+
+      it "works when only the base DEVELOPMENT_TEAM key exists" do
+        temp_xcodeproj = File.join(Dir.tmpdir, "bundle-no-sdk.xcodeproj")
+        FileUtils.cp_r(xcodeproj, temp_xcodeproj)
+
+        begin
+          # bundle.xcodeproj by default doesn't have DEVELOPMENT_TEAM,
+          # but the action should set it if it doesn't exist.
+          Fastlane::Actions::UpdateProjectTeamAction.run(
+            path: temp_xcodeproj,
+            teamid: 'NEWTEAM789'
+          )
+
+          project = Xcodeproj::Project.open(temp_xcodeproj)
+          project.native_targets.each do |target|
+            target.build_configurations.each do |config|
+              expect(config.build_settings['DEVELOPMENT_TEAM']).to eq('NEWTEAM789')
+              # Ensure no other DEVELOPMENT_TEAM keys were created
+              sdk_keys = config.build_settings.keys.select { |k| k.to_s.start_with?("DEVELOPMENT_TEAM") && k != "DEVELOPMENT_TEAM" }
+              expect(sdk_keys).to be_empty
+            end
+          end
+        ensure
+          FileUtils.rm_rf(temp_xcodeproj)
+        end
+      end
+    end
+  end
+end

--- a/fastlane/spec/fixtures/xcodeproj/sdk-qualifier.xcodeproj/project.pbxproj
+++ b/fastlane/spec/fixtures/xcodeproj/sdk-qualifier.xcodeproj/project.pbxproj
@@ -1,0 +1,255 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXFileReference section */
+		0EB04CE71BCD87E700FE17C5 /* bundle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = bundle.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0EB04CF81BCD87E700FE17C5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0EB04CE41BCD87E700FE17C5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0EB04CDE1BCD87E700FE17C5 = {
+			isa = PBXGroup;
+			children = (
+				0EB04CE91BCD87E700FE17C5 /* bundle */,
+				0EB04CE81BCD87E700FE17C5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0EB04CE81BCD87E700FE17C5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0EB04CE71BCD87E700FE17C5 /* bundle.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0EB04CE91BCD87E700FE17C5 /* bundle */ = {
+			isa = PBXGroup;
+			children = (
+				0EB04CF81BCD87E700FE17C5 /* Info.plist */,
+			);
+			path = bundle;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0EB04CE61BCD87E700FE17C5 /* bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0EB04CFB1BCD87E700FE17C5 /* Build configuration list for PBXNativeTarget "bundle" */;
+			buildPhases = (
+				0EB04CE31BCD87E700FE17C5 /* Sources */,
+				0EB04CE41BCD87E700FE17C5 /* Frameworks */,
+				0EB04CE51BCD87E700FE17C5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = bundle;
+			productName = bundle;
+			productReference = 0EB04CE71BCD87E700FE17C5 /* bundle.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0EB04CDF1BCD87E700FE17C5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0700;
+				ORGANIZATIONNAME = Fastlane;
+				TargetAttributes = {
+					0EB04CE61BCD87E700FE17C5 = {
+						CreatedOnToolsVersion = 7.0.1;
+					};
+				};
+			};
+			buildConfigurationList = 0EB04CE21BCD87E700FE17C5 /* Build configuration list for PBXProject "bundle" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0EB04CDE1BCD87E700FE17C5;
+			productRefGroup = 0EB04CE81BCD87E700FE17C5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0EB04CE61BCD87E700FE17C5 /* bundle */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0EB04CE51BCD87E700FE17C5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0EB04CE31BCD87E700FE17C5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0EB04CF91BCD87E700FE17C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0EB04CFA1BCD87E700FE17C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		0EB04CFC1BCD87E700FE17C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.bundle;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				DEVELOPMENT_TEAM = OLDTEAM;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = OLDTEAM_SDK;
+			};
+			name = Debug;
+		};
+		0EB04CFD1BCD87E700FE17C5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = tools.fastlane.bundle;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				DEVELOPMENT_TEAM = OLDTEAM;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = OLDTEAM_SDK;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0EB04CE21BCD87E700FE17C5 /* Build configuration list for PBXProject "bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0EB04CF91BCD87E700FE17C5 /* Debug */,
+				0EB04CFA1BCD87E700FE17C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0EB04CFB1BCD87E700FE17C5 /* Build configuration list for PBXNativeTarget "bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0EB04CFC1BCD87E700FE17C5 /* Debug */,
+				0EB04CFD1BCD87E700FE17C5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0EB04CDF1BCD87E700FE17C5 /* Project object */;
+}


### PR DESCRIPTION
## Problem

Our `.pbxproj` file has this.

```
DEVELOPMENT_TEAM = XX;
"DEVELOPMENT_TEAM[sdk=iphoneos*]" = XX;
```

The Xcode SDK conditional qualifiers to scope properties in addition to the regular property for `DEVELOPMENT_TEAM`. So we ran this 

```ruby
update_project_team(
 path: "xxx.xcodeproj",
 teamid: "YYY"
)
```

The `sdk=` did NOT change, but the `DEVELOPMENT_TEAM` one did.

## Context

We have 2 different ways in Codebase.

`gym` has a dedicate parameter for this.

```ruby
FastlaneCore::ConfigItem.new(
 key: :sdk,
 env_name: "FASTLANE_BUILD_SDK",
 optional: true,
 description: "Build target SDKs (iphoneos*, macosx*, iphonesimulator*)"
),
```

However, `update_code_signing_action` does it automatically for all.

```ruby
 # This will also set keys that have filtering like [sdk=iphoneos*]
 keys = configuration.build_settings.keys.select { |key| key.to_s.match(/#{name}.*/) }
 keys.each do |key|
  configuration.build_settings[key] = value
 end
```

## Solution

We follow the approach of an Action and automatically change all sdk conditionals for `update_project_team`. This sets up a pattern that top level major tools have flexibility, but actions just do them all.

We add some tests and rework the code to leverage some existing helpers to reduce userland code. We also update the messages emitted so they reflect what is actually changed, so those watching logs are not lost to why/what changed.