### PR TITLE
[fastlane_core] Create a unique package directory for non-macOS uploads

### DIFF
--- a/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
+++ b/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb
@@ -14,8 +14,12 @@ module FastlaneCore
 
     def generate(app_id: nil, ipa_path: nil, package_path: nil, platform: nil, app_identifier: nil, short_version: nil, bundle_version: nil)
       unless Helper.is_mac?
-        # .itmsp packages are not supported for ipa uploads starting Transporter 4.1, for non-macOS
-        self.package_path = package_path
+        # .itmsp packages are not supported for ipa uploads starting Transporter 4.1, for non-macOS.
+        # Use a unique subdirectory anyway: callers pass a shared parent (deliver passes "/tmp"),
+        # and ItunesTransporter#upload runs FileUtils.rm_rf on whatever this returns.
+        self.package_path = File.join(package_path, "#{app_id}-#{SecureRandom.uuid}")
+        FileUtils.mkdir_p(self.package_path)
+
         copy_ipa(ipa_path)
 
         # copy any AppStoreInfo.plist file that's next to the ipa file

--- a/fastlane_core/spec/ipa_upload_package_builder_spec.rb
+++ b/fastlane_core/spec/ipa_upload_package_builder_spec.rb
@@ -52,5 +52,94 @@ describe FastlaneCore do
         expect(unique_path_with_spaces.include?(' ')).to eq(false)
       end
     end
+
+    context '#generate' do
+      let(:app_id) { 'my.app.id' }
+
+      # `package_path` is a *parent* directory that the caller may share with unrelated files —
+      # `deliver` passes "/tmp". ItunesTransporter#upload does `FileUtils.rm_rf` on whatever
+      # `generate` returns, so returning the parent itself would delete it along with everything
+      # else in it, and would make the transporter's `Dir.glob` match foreign packages.
+      around do |example|
+        Dir.mktmpdir do |parent|
+          @parent = parent
+          example.run
+        end
+      end
+
+      def generate(source_ipa: path)
+        FastlaneCore::IpaUploadPackageBuilder.new.generate(
+          app_id: app_id,
+          ipa_path: source_ipa,
+          package_path: @parent,
+          platform: 'ios'
+        )
+      end
+
+      shared_examples 'a package contained in package_path' do
+        it 'does not return package_path itself' do
+          expect(generate).not_to eq(@parent)
+        end
+
+        it 'returns a new directory directly below package_path' do
+          result = generate
+
+          expect(File.dirname(result)).to eq(@parent)
+          expect(File.directory?(result)).to be(true)
+        end
+
+        it 'leaves package_path intact when the returned path is removed' do
+          sibling = File.join(@parent, 'unrelated.ipa')
+          File.write(sibling, 'not ours')
+
+          FileUtils.rm_rf(generate)
+
+          expect(File.directory?(@parent)).to be(true)
+          expect(File.exist?(sibling)).to be(true)
+        end
+
+        it 'uses a distinct directory for each invocation' do
+          expect(generate).not_to eq(generate)
+        end
+
+        it 'places exactly one package file inside the returned directory' do
+          result = generate
+
+          expect(Dir.glob(File.join(result, '*.ipa')).count).to eq(1)
+        end
+      end
+
+      context 'on macOS' do
+        before do
+          allow(FastlaneCore::Helper).to receive(:is_mac?).and_return(true)
+        end
+
+        it_behaves_like 'a package contained in package_path'
+
+        it 'builds an .itmsp package' do
+          expect(generate).to end_with('.itmsp')
+        end
+      end
+
+      context 'on non-macOS platforms' do
+        before do
+          allow(FastlaneCore::Helper).to receive(:is_mac?).and_return(false)
+        end
+
+        it_behaves_like 'a package contained in package_path'
+
+        it 'copies an adjacent AppStoreInfo.plist into the package' do
+          Dir.mktmpdir do |source|
+            source_ipa = File.join(source, 'MyApp.ipa')
+            FileUtils.cp(path, source_ipa)
+            File.write(File.join(source, 'AppStoreInfo.plist'), '<plist></plist>')
+
+            result = generate(source_ipa: source_ipa)
+
+            expect(File.file?(File.join(result, 'AppStoreInfo.plist'))).to be(true)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
🔑

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

Resolves #30141.

On non-macOS platforms, `IpaUploadPackageBuilder#generate` returns the `package_path` it was given verbatim rather than creating a directory underneath it:

https://github.com/fastlane/fastlane/blob/master/fastlane_core/lib/fastlane_core/ipa_upload_package_builder.rb#L16-L18

`ItunesTransporter#upload` and `#verify` then run `FileUtils.rm_rf` on that return value once the transfer finishes (itunes_transporter.rb#L888 and #L947). So the directory the caller passed in is deleted, together with anything else that happens to live in it.

_deliver_ passes a hardcoded `package_path: "/tmp"` — on both the upload and the verify path:

https://github.com/fastlane/fastlane/blob/master/deliver/lib/deliver/runner.rb#L233-L236
https://github.com/fastlane/fastlane/blob/master/deliver/lib/deliver/runner.rb#L196-L199

which means **a successful _deliver_ run on Linux deletes `/tmp`**.

The symptom this shows up as is misleading. The upload itself reports success, and the next thing to touch the filesystem is what breaks — commonly _precheck_, whose first API call makes _spaceship_ lazily create its hardcoded `/tmp/spaceship<ts>_<pid>_<tid>.log`. That raises `Errno::ENOENT`, `Deliver::Runner#precheck_app` catches it and reports it only through `UI.verbose`, so the user sees just:

```
fastlane precheck just tried to inspect your app's metadata for App Store guideline
violations and ran into a problem. We're not sure what the problem was, but precheck
failed to finish.
```

With `--verbose`:

```
#<Errno::ENOENT: No such file or directory @ rb_sysopen - /tmp/spaceship<...>.log>
  logger/log_device.rb:105:in `create_logfile'
  spaceship/lib/spaceship/client.rb:251:in `logger'
  spaceship/lib/spaceship/client.rb:1011:in `log_request'
  spaceship/lib/spaceship/connect_api/api_client.rb:107:in `get'
  spaceship/lib/spaceship/connect_api/models/app.rb:84:in `find'
  precheck/lib/precheck/runner.rb:198:in `ensure_app_exists!'
  deliver/lib/deliver/runner.rb:111:in `precheck_app'
```

There is a second consequence of the same aliasing: because the package directory is shared, `ItunesTransporter#file_upload_option` can select a binary that isn't the one being uploaded — it picks `Dir.glob(File.join(source, "*.{ipa,pkg,dmg,zip}")).first` and reads `AppStoreInfo.plist` from the same directory. A stale `.ipa` in `/tmp`, or two concurrent uploads on one machine, are enough.

Introduced in 2.230.0 by #29717, which added the `unless Helper.is_mac?` branch. Verified by gem bisect: 2.227.2 / 2.228.0 / 2.229.0 always build an `.itmsp` subdirectory; 2.230.0 onwards return `package_path` itself. Only reproduces off macOS.

### Description

`generate` now creates an `<app_id>-<uuid>` subdirectory under `package_path` on non-macOS too, mirroring what the macOS branch already does with `.itmsp`, and copies the ipa and any adjacent `AppStoreInfo.plist` into it. The returned path is therefore always a directory this method owns, which is what `rm_rf` on it assumes.

The non-macOS branch still produces a plain directory rather than an `.itmsp` package, so the Transporter 4.1 behaviour the original comment describes is preserved — only the location changes.

_pilot_ — the third and only other caller — was never affected: it passes a private `Dir.mktmpdir`, and deleting that is harmless. `PkgUploadPackageBuilder` is likewise fine; it unconditionally builds an `<app_id>-<uuid>.itmsp` subdirectory.

Changing _deliver_ to pass `Dir.mktmpdir` as well would be a smaller diff, but the builder's contract is "whatever I return gets `rm_rf`'d", so returning the caller's own argument is the actual defect — and fixing it here covers both of _deliver_'s call sites at once while leaving no trap for the next caller. Happy to switch to the _deliver_-side change if you'd prefer something more minimal.

Deliberately **not** in scope here, both noted in #30141:

- the hardcoded `/tmp` log path in `Spaceship::Client#logger` (a separate, older issue — see #15404), which is why this failure surfaces so opaquely rather than as an obvious filesystem error
- hardening `file_upload_option`'s glob

### Testing Steps

`#generate` had no spec at all before this, and `Helper.is_mac?` was never stubbed — the spec added in #29717 exercises `transporter.upload('my.app.id', '/tmp')`, the positional `app_id, dir` form, which produces a safe `/tmp/my.app.id.itmsp` subdirectory. That is not the call shape _deliver_ uses, which is how this went unnoticed.

The new spec covers both branches with a `Dir.mktmpdir` parent standing in for `/tmp`, asserting that the returned path is a fresh directory below `package_path`, that it differs per invocation, that removing it leaves `package_path` and an unrelated sibling file intact, and that it contains exactly one package file.

Against the previous behaviour, 4 of the new examples fail:

```
$ bundle exec rspec fastlane_core/spec/ipa_upload_package_builder_spec.rb -e '#generate'
12 examples, 4 failures
```

One of them reproduces the bug directly — `rm_rf` on the returned path destroys RSpec's own tmpdir, so `Dir.mktmpdir`'s cleanup then raises `Errno::ENOENT`.

With the fix:

```
$ bundle exec rspec fastlane_core/spec/ipa_upload_package_builder_spec.rb -e '#generate'
18 examples, 0 failures

$ bundle exec rspec fastlane_core/spec deliver/spec pilot/spec
1090 examples, 0 failures

$ bundle exec rubocop
no offenses
```
