### PR TITLE
harden: detected non-static command inside ` in...

### DIFF
--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -194,7 +194,7 @@ module Fastlane
         def append_git_data
           Dir.mktmpdir("fastlane-plugin") do |tmp|
             clone_folder = File.join(tmp, self.name)
-            `GIT_TERMINAL_PROMPT=0 git clone #{self.homepage.shellescape} #{clone_folder.shellescape}`
+            system({"GIT_TERMINAL_PROMPT" => "0"}, "git", "clone", self.homepage, clone_folder)
 
             break unless File.directory?(clone_folder)
 

--- a/fastlane/helper/plugin_scores_helper.rb
+++ b/fastlane/helper/plugin_scores_helper.rb
@@ -194,7 +194,7 @@ module Fastlane
         def append_git_data
           Dir.mktmpdir("fastlane-plugin") do |tmp|
             clone_folder = File.join(tmp, self.name)
-            system({"GIT_TERMINAL_PROMPT" => "0"}, "git", "clone", self.homepage, clone_folder)
+            system({ "GIT_TERMINAL_PROMPT" => "0" }, "git", "clone", self.homepage, clone_folder)
 
             break unless File.directory?(clone_folder)
 


### PR DESCRIPTION
## Summary
Harden input handling in `fastlane/helper/plugin_scores_helper.rb` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | ruby.lang.security.dangerous-subshell.dangerous-subshell |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `ruby.lang.security.dangerous-subshell.dangerous-subshell` |
| **File** | `fastlane/helper/plugin_scores_helper.rb:197` |
| **Assessment** | Defensive hardening |

**Description**: Detected non-static command inside `...`. If unverified user data can reach this call site, this is a code injection vulnerability. A malicious actor can inject a malicious script to execute arbitrary code.

## Changes
- `fastlane/helper/plugin_scores_helper.rb`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
