### PR TITLE
[deliver] prevent duplicate image uploads

### DIFF
--- a/deliver/lib/deliver/upload_screenshots.rb
+++ b/deliver/lib/deliver/upload_screenshots.rb
@@ -171,13 +171,17 @@ module Deliver
     def wait_for_complete(iterator, timeout_seconds)
       start_time = Time.now
       loop do
+        # App Store Connect publishes a screenshot's `sourceFileChecksum` asynchronously,
+        # shortly after its state becomes COMPLETE. (#30094)
+        number_of_screenshots_missing_checksum = 0
         states = iterator.each_app_screenshot.map { |_, _, app_screenshot| app_screenshot }.each_with_object({}) do |app_screenshot, hash|
           state = app_screenshot.asset_delivery_state['state']
           hash[state] ||= 0
           hash[state] += 1
+          number_of_screenshots_missing_checksum += 1 if state == 'COMPLETE' && app_screenshot.source_file_checksum.nil?
         end
 
-        is_processing = states.fetch('UPLOAD_COMPLETE', 0) > 0
+        is_processing = states.fetch('UPLOAD_COMPLETE', 0) > 0 || number_of_screenshots_missing_checksum > 0
         return states unless is_processing
 
         if Time.now - start_time > timeout_seconds
@@ -185,7 +189,11 @@ module Deliver
           return states
         end
 
-        UI.verbose("There are still incomplete screenshots - #{states}")
+        if number_of_screenshots_missing_checksum > 0
+          UI.verbose("There are still incomplete screenshots - #{states}, missing checksum: #{number_of_screenshots_missing_checksum}")
+        else
+          UI.verbose("There are still incomplete screenshots - #{states}")
+        end
         sleep(5)
       end
     end
@@ -205,9 +213,9 @@ module Deliver
         UI.user_error!("Failed verification of all screenshots uploaded... #{incomplete_screenshot_count} incomplete screenshot(s) still exist")
       else
         UI.error("Failed to upload all screenshots... Tries remaining: #{tries}")
-        # Delete bad entries before retry
+        # Delete bad entries before retry (not complete OR missing checksum)
         iterator.each_app_screenshot do |_, _, app_screenshot|
-          app_screenshot.delete! unless app_screenshot.complete?
+          app_screenshot.delete! unless app_screenshot.complete? && !app_screenshot.source_file_checksum.nil?
         end
         upload_screenshots(localizations, screenshots_per_language, timeout_seconds, tries: tries)
       end

--- a/deliver/spec/upload_screenshots_spec.rb
+++ b/deliver/spec/upload_screenshots_spec.rb
@@ -266,7 +266,8 @@ describe Deliver::UploadScreenshots do
     context 'when all the screenshots are COMPLETE state' do
       it 'should finish without sleep' do
         app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot',
-                                asset_delivery_state: { 'state' => 'COMPLETE' })
+                                asset_delivery_state: { 'state' => 'COMPLETE' },
+                                source_file_checksum: 'checksum')
         app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
                                     screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55,
                                     app_screenshots: [app_screenshot])
@@ -297,6 +298,27 @@ describe Deliver::UploadScreenshots do
 
         expect_any_instance_of(Object).to receive(:sleep).with(kind_of(Numeric)).once
         expect(app_screenshot).to receive(:asset_delivery_state).and_return({ 'state' => 'UPLOAD_COMPLETE' }, { 'state' => 'COMPLETE' })
+        allow(app_screenshot).to receive(:source_file_checksum).and_return('checksum')
+        expect(subject.wait_for_complete(iterator, 3600)).to eq('COMPLETE' => 1)
+      end
+    end
+
+    context 'when all the screenshots are COMPLETE state but a checksum is not published yet' do
+      it 'should wait until the checksum is published' do
+        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot',
+                                asset_delivery_state: { 'state' => 'COMPLETE' })
+        app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
+                                    screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55,
+                                    app_screenshots: [app_screenshot])
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization',
+                              locale: 'en-US',
+                              get_app_screenshot_sets: [app_screenshot_set])
+        iterator = Deliver::AppScreenshotIterator.new([localization])
+
+        allow(Time).to receive(:now).and_return(0)
+
+        expect_any_instance_of(Object).to receive(:sleep).with(kind_of(Numeric)).once
+        expect(app_screenshot).to receive(:source_file_checksum).and_return(nil, 'checksum')
         expect(subject.wait_for_complete(iterator, 3600)).to eq('COMPLETE' => 1)
       end
     end
@@ -358,7 +380,7 @@ describe Deliver::UploadScreenshots do
 
     context 'when given number_of_screenshots doesn\'t match numbers in states in total' do
       it 'should retry upload_screenshots' do
-        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot', 'complete?' => true, 'error?' => false)
+        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot', 'complete?' => true, 'error?' => false, source_file_checksum: 'checksum')
         app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
                                     screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55,
                                     app_screenshots: [app_screenshot])
@@ -436,6 +458,35 @@ describe Deliver::UploadScreenshots do
         expect(subject).to receive(:upload_screenshots).with(any_args)
         expect(app_screenshot).to receive(:delete!)
         subject.retry_upload_screenshots_if_needed(iterator, states, 1, 1, 0, localizations, {})
+      end
+    end
+
+    context 'when a screenshot is in COMPLETE state without a published checksum' do
+      it 'should delete the screenshot before retrying' do
+        app_screenshot = double('Spaceship::ConnectAPI::AppScreenshot',
+                                'complete?' => true,
+                                'error?' => false,
+                                source_file_checksum: nil)
+        app_screenshot_set = double('Spaceship::ConnectAPI::AppScreenshotSet',
+                                    screenshot_display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55,
+                                    app_screenshots: [app_screenshot])
+        localization = double('Spaceship::ConnectAPI::AppStoreVersionLocalization',
+                              locale: 'en-US',
+                              get_app_screenshot_sets: [app_screenshot_set])
+        localizations = [localization]
+        iterator = Deliver::AppScreenshotIterator.new(localizations)
+        states = { 'COMPLETE' => 1 }
+
+        local_screenshot = double('Deliver::AppScreenshot',
+                                  path: '/path/to/screenshot',
+                                  language: 'en-US',
+                                  display_type: Spaceship::ConnectAPI::AppScreenshotSet::DisplayType::APP_IPHONE_55)
+        screenshots_per_language = { 'en-US' => [local_screenshot] }
+        allow(described_class).to receive(:calculate_checksum).with(local_screenshot.path).and_return('checksum')
+
+        expect(subject).to receive(:upload_screenshots).with(any_args)
+        expect(app_screenshot).to receive(:delete!)
+        subject.retry_upload_screenshots_if_needed(iterator, states, 1, 1, 0, localizations, screenshots_per_language)
       end
     end
   end


### PR DESCRIPTION
## Problem

Users in #30094 are reporting duplicate image uploads. This is occurring because Apple does not assign a checksum to the uploaded image immediately. This means our existing logic which leverages the hash fails and leads to duplicates until you get lucky enough that the upload returns the hash after the 1st check.

There are 2 workarounds in the wild - https://gist.github.com/dfed/f04aafd4c41943fb0b4154653cc126f5 & https://gist.github.com/robobit/8e68c330cfbd368352a5f165f6847ba2 which I peeked as my inspiration for a fix.

## Solution

We track a missing hash as well as a missing status of `COMPLETE`. We continue polling and then will delete any failures (no hash or right status) if we have to retry.

fixes: #30094 