### PR TITLE
[ci] move release workflows to Ruby 3.4

### DIFF
--- a/.github/workflows/release_step_1_create_version_bump.yml
+++ b/.github/workflows/release_step_1_create_version_bump.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2
+        ruby-version: 3.4
 
     - name: Install fastlane
       run: bundle install

--- a/.github/workflows/release_step_2_create_github_release.yml
+++ b/.github/workflows/release_step_2_create_github_release.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.2'
+        ruby-version: '3.4'
 
     - name: Install fastlane
       run: bundle install


### PR DESCRIPTION
A bit odd our workflows are using a version of Ruby we do not suggest. So lets move to Ruby 3.4