### PR TITLE
[gems] move to json 2.21.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.5.1)
+    json (2.21.2)
     jwt (2.10.3)
       base64
     kramdown (2.5.2)

--- a/frameit/spec/fixtures/editor/Framefile.json
+++ b/frameit/spec/fixtures/editor/Framefile.json
@@ -17,7 +17,7 @@
     {
       "filter": "escaped-apostrophes",
       "title": {
-        "text": "Don\'t forget the apostrophes"
+        "text": "Don\\'t forget the apostrophes"
       }
     }
   ]

--- a/spaceship/spec/connect_api/token_spec.rb
+++ b/spaceship/spec/connect_api/token_spec.rb
@@ -59,7 +59,7 @@ describe Spaceship::ConnectAPI::Token do
 
       expect do
         Spaceship::ConnectAPI::Token.from_json_file(file.path)
-      end.to raise_error(JSON::ParserError, /unexpected token/)
+      end.to raise_error(JSON::ParserError, /unexpected character: 'abc123' at line 1 column 1/)
     end
 
     it 'raises error with missing all keys' do


### PR DESCRIPTION
Our constraints allow us to move past a version with a CVE. Fixes #30154