### PR TITLE
[produce] Support App Store Connect API key for create/enable_services/disable_services

### DIFF
--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -86,6 +86,8 @@ module Produce
     end
 
     def create_new_app
+      return create_new_app_via_connect_api if using_connect_api?
+
       ENV["CREATED_NEW_APP_ID"] = Time.now.to_i.to_s
       if app_exists?
         UI.success("[DevCenter] App '#{Produce.config[:app_identifier]}' already exists, nothing to do on the Dev Center")
@@ -114,6 +116,41 @@ module Produce
 
         UI.success("Finished creating new app '#{app_name}' on the Dev Center")
       end
+
+      return true
+    end
+
+    # App Store Connect API path — used when an API key is configured instead of
+    # a session-based Apple ID login. Only covers app creation itself; inline
+    # capability flags passed to `produce create` aren't mapped here yet (see
+    # `using_connect_api?` call site) — use `produce enable_services` afterward
+    # instead, which fully supports the API key for all capabilities.
+    def create_new_app_via_connect_api
+      config_enabled_services = Produce.config[:enable_services] || Produce.config[:enabled_features]
+      if config_enabled_services && !config_enabled_services.empty?
+        UI.user_error!("Enabling capabilities inline during `produce create` isn't supported yet when using an API key. Run `produce create` without capability flags, then use `produce enable_services` to enable them (fully supported with an API key).")
+      end
+
+      ENV["CREATED_NEW_APP_ID"] = Time.now.to_i.to_s
+
+      existing = Spaceship::ConnectAPI::BundleId.find(app_identifier)
+      if existing
+        UI.success("[DevCenter] App '#{Produce.config[:app_identifier]}' already exists, nothing to do on the Dev Center")
+        ENV["CREATED_NEW_APP_ID"] = nil
+        return true
+      end
+
+      app_name = Produce.config[:app_name]
+      UI.message("Creating new app '#{app_name}' on the Apple Dev Center")
+
+      connect_api_platform = Spaceship::ConnectAPI::BundleIdPlatform.map(platform)
+      bundle_id = Spaceship::ConnectAPI::BundleId.create(name: app_name, platform: connect_api_platform, identifier: app_identifier)
+
+      UI.crash!("Something went wrong when creating the new app - it's not listed in the apps list") unless bundle_id
+
+      UI.message("Created app #{bundle_id.id}")
+      ENV["CREATED_NEW_APP_ID"] = Time.now.to_i.to_s
+      UI.success("Finished creating new app '#{app_name}' on the Dev Center")
 
       return true
     end
@@ -174,9 +211,31 @@ module Produce
       Spaceship.app.find(app_identifier, mac: platform == "osx") != nil
     end
 
+    def using_connect_api?
+      !connect_api_token.nil?
+    end
+
+    def connect_api_token
+      Spaceship::ConnectAPI::Token.from(hash: Produce.config[:api_key], filepath: Produce.config[:api_key_path])
+    end
+
     def login
-      Spaceship.login(Produce.config[:username], nil)
-      Spaceship.select_team
+      if using_connect_api?
+        UI.message("Authenticating with App Store Connect API Key")
+
+        # Not using `Spaceship::ConnectAPI.token = connect_api_token` (which
+        # only sets `token:`) because some ConnectAPI provisioning calls (e.g.
+        # patch_bundle_id_capability) resolve `teamId` via the *separate*
+        # Provisioning::Client's own `team_id` getter — not the top-level
+        # ConnectAPI client. Left uncached, that getter falls back to a live,
+        # session-based lookup with no session to use. Passing
+        # `current_team_id:` here threads it down into that Provisioning::Client
+        # at construction time so the lookup never fires.
+        Spaceship::ConnectAPI.client = Spaceship::ConnectAPI::Client.new(token: connect_api_token, current_team_id: Produce.config[:team_id])
+      else
+        Spaceship.login(Produce.config[:username], nil)
+        Spaceship.select_team
+      end
     end
   end
 end

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -1,5 +1,7 @@
+require 'ostruct'
 require 'spaceship'
 require_relative 'module'
+require_relative 'service'
 
 module Produce
   class DeveloperCenter
@@ -123,9 +125,6 @@ module Produce
     # App Store Connect API key path — used instead of Spaceship.login.
     def create_new_app_via_connect_api
       config_enabled_services = Produce.config[:enable_services] || Produce.config[:enabled_features]
-      if config_enabled_services && !config_enabled_services.empty?
-        UI.user_error!("Enabling capabilities inline during `produce create` isn't supported yet when using an API key. Run `produce create` without capability flags, then use `produce enable_services` to enable them (fully supported with an API key).")
-      end
 
       existing = Spaceship::ConnectAPI::BundleId.find(app_identifier)
       if existing
@@ -142,7 +141,7 @@ module Produce
       UI.crash!("Something went wrong when creating the new app - it's not listed in the apps list") unless bundle_id
 
       UI.message("Created app #{bundle_id.id}")
-      ENV["CREATED_NEW_APP_ID"] = Time.now.to_i.to_s
+      enable_inline_services(config_enabled_services) if config_enabled_services && !config_enabled_services.empty?
       UI.success("Finished creating new app '#{app_name}' on the Dev Center")
 
       return true
@@ -190,6 +189,17 @@ module Produce
     end
 
     private
+
+    # Delegates to Service#update instead of duplicating its ~40-capability mapping.
+    # Skips any capability explicitly marked "off" — meaningless on a brand-new app.
+    def enable_inline_services(config_enabled_services)
+      to_enable = config_enabled_services.reject { |_, v| v == SERVICE_OFF }
+      return if to_enable.empty?
+
+      options = OpenStruct.new(to_enable)
+      options.define_singleton_method(:__hash__) { to_enable }
+      Produce::Service.new.update(true, options)
+    end
 
     def platform
       # This was added to support creation of multiple platforms

--- a/produce/lib/produce/developer_center.rb
+++ b/produce/lib/produce/developer_center.rb
@@ -120,23 +120,16 @@ module Produce
       return true
     end
 
-    # App Store Connect API path — used when an API key is configured instead of
-    # a session-based Apple ID login. Only covers app creation itself; inline
-    # capability flags passed to `produce create` aren't mapped here yet (see
-    # `using_connect_api?` call site) — use `produce enable_services` afterward
-    # instead, which fully supports the API key for all capabilities.
+    # App Store Connect API key path — used instead of Spaceship.login.
     def create_new_app_via_connect_api
       config_enabled_services = Produce.config[:enable_services] || Produce.config[:enabled_features]
       if config_enabled_services && !config_enabled_services.empty?
         UI.user_error!("Enabling capabilities inline during `produce create` isn't supported yet when using an API key. Run `produce create` without capability flags, then use `produce enable_services` to enable them (fully supported with an API key).")
       end
 
-      ENV["CREATED_NEW_APP_ID"] = Time.now.to_i.to_s
-
       existing = Spaceship::ConnectAPI::BundleId.find(app_identifier)
       if existing
         UI.success("[DevCenter] App '#{Produce.config[:app_identifier]}' already exists, nothing to do on the Dev Center")
-        ENV["CREATED_NEW_APP_ID"] = nil
         return true
       end
 
@@ -223,14 +216,8 @@ module Produce
       if using_connect_api?
         UI.message("Authenticating with App Store Connect API Key")
 
-        # Not using `Spaceship::ConnectAPI.token = connect_api_token` (which
-        # only sets `token:`) because some ConnectAPI provisioning calls (e.g.
-        # patch_bundle_id_capability) resolve `teamId` via the *separate*
-        # Provisioning::Client's own `team_id` getter — not the top-level
-        # ConnectAPI client. Left uncached, that getter falls back to a live,
-        # session-based lookup with no session to use. Passing
-        # `current_team_id:` here threads it down into that Provisioning::Client
-        # at construction time so the lookup never fires.
+        # `current_team_id:` avoids a live, session-based team_id lookup elsewhere in
+        # ConnectAPI's provisioning client, which has no session to use here.
         Spaceship::ConnectAPI.client = Spaceship::ConnectAPI::Client.new(token: connect_api_token, current_team_id: Produce.config[:team_id])
       else
         Spaceship.login(Produce.config[:username], nil)

--- a/produce/lib/produce/options.rb
+++ b/produce/lib/produce/options.rb
@@ -17,6 +17,23 @@ module Produce
                                      code_gen_sensitive: true,
                                      default_value: user,
                                      default_value_dynamic: true),
+
+        # App Store Connect API
+        FastlaneCore::ConfigItem.new(key: :api_key_path,
+                                     env_names: ["PRODUCE_API_KEY_PATH", "APP_STORE_CONNECT_API_KEY_PATH"],
+                                     description: "Path to your App Store Connect API Key JSON file (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)",
+                                     optional: true,
+                                     conflicting_options: [:api_key],
+                                     verify_block: proc do |value|
+                                       UI.user_error!("Couldn't find API key JSON file at path '#{value}'") unless File.exist?(value)
+                                     end),
+        FastlaneCore::ConfigItem.new(key: :api_key,
+                                     env_names: ["PRODUCE_API_KEY", "APP_STORE_CONNECT_API_KEY"],
+                                     description: "Your App Store Connect API Key information (https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-hash-option)",
+                                     type: Hash,
+                                     optional: true,
+                                     sensitive: true,
+                                     conflicting_options: [:api_key_path]),
         FastlaneCore::ConfigItem.new(key: :app_identifier,
                                      env_name: "PRODUCE_APP_IDENTIFIER",
                                      short_option: "-a",

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -425,15 +425,8 @@ module Produce
       if api_token
         UI.message("Authenticating with App Store Connect API Key")
 
-        # Not using `Spaceship::ConnectAPI.token = api_token` (which only sets
-        # `token:`) because `patch_bundle_id_capability` (used by
-        # `update_capability` below) always includes `teamId`, resolved via
-        # the *separate* Provisioning::Client's own `team_id` getter — not the
-        # top-level ConnectAPI client. Left uncached, that getter falls back to
-        # a live, session-based lookup with no session to use, crashing on
-        # Apple's non-JSON "Unauthenticated" response. Passing `current_team_id:`
-        # here threads it down into that Provisioning::Client at construction
-        # time so the lookup never fires.
+        # `current_team_id:` avoids a live, session-based team_id lookup elsewhere in
+        # ConnectAPI's provisioning client, which has no session to use here.
         Spaceship::ConnectAPI.client = Spaceship::ConnectAPI::Client.new(token: api_token, current_team_id: Produce.config[:team_id])
       else
         UI.message("Starting login with user '#{Produce.config[:username]}'")

--- a/produce/lib/produce/service.rb
+++ b/produce/lib/produce/service.rb
@@ -420,10 +420,28 @@ module Produce
 
     def bundle_id
       return @bundle_id if @bundle_id
-      UI.message("Starting login with user '#{Produce.config[:username]}'")
-      Spaceship.login(Produce.config[:username], nil)
-      Spaceship.select_team
-      UI.message("Successfully logged in")
+
+      api_token = Spaceship::ConnectAPI::Token.from(hash: Produce.config[:api_key], filepath: Produce.config[:api_key_path])
+      if api_token
+        UI.message("Authenticating with App Store Connect API Key")
+
+        # Not using `Spaceship::ConnectAPI.token = api_token` (which only sets
+        # `token:`) because `patch_bundle_id_capability` (used by
+        # `update_capability` below) always includes `teamId`, resolved via
+        # the *separate* Provisioning::Client's own `team_id` getter — not the
+        # top-level ConnectAPI client. Left uncached, that getter falls back to
+        # a live, session-based lookup with no session to use, crashing on
+        # Apple's non-JSON "Unauthenticated" response. Passing `current_team_id:`
+        # here threads it down into that Provisioning::Client at construction
+        # time so the lookup never fires.
+        Spaceship::ConnectAPI.client = Spaceship::ConnectAPI::Client.new(token: api_token, current_team_id: Produce.config[:team_id])
+      else
+        UI.message("Starting login with user '#{Produce.config[:username]}'")
+        Spaceship.login(Produce.config[:username], nil)
+        Spaceship.select_team
+        UI.message("Successfully logged in")
+      end
+
       @bundle_id ||= Spaceship::ConnectAPI::BundleId.find(Produce.config[:app_identifier].to_s)
     end
   end

--- a/produce/spec/developer_center_spec.rb
+++ b/produce/spec/developer_center_spec.rb
@@ -57,6 +57,7 @@ describe Produce::DeveloperCenter do
         platform: "IOS",
         identifier: "com.example.app"
       ).and_return(created_app)
+      expect(Produce::Service).not_to receive(:new)
 
       instance = Produce::DeveloperCenter.new
       instance.send(:login)
@@ -65,14 +66,47 @@ describe Produce::DeveloperCenter do
       expect(result).to eq(true)
     end
 
-    it "raises a clear error instead of silently ignoring inline capability flags" do
-      config_with(api_key: api_key, enable_services: { push_notification: "on" })
+    it "enables inline capabilities via the API instead of erroring, skipping ones marked off" do
+      config_with(api_key: api_key, enable_services: { push_notification: "on", app_group: "off" })
       allow(Spaceship::ConnectAPI::BundleId).to receive(:find).and_return(nil)
+      created_app = double("created_bundle_id", id: "ABC123")
+      allow(Spaceship::ConnectAPI::BundleId).to receive(:create).and_return(created_app)
+
+      fake_service = instance_double(Produce::Service)
+      expect(Produce::Service).to receive(:new).and_return(fake_service)
+      expect(fake_service).to receive(:update) do |on, options|
+        expect(on).to eq(true)
+        expect(options.push_notification).to eq("on")
+        expect(options.app_group).to be_nil
+      end
 
       instance = Produce::DeveloperCenter.new
       instance.send(:login)
+      result = instance.create_new_app
 
-      expect { instance.create_new_app }.to raise_error(FastlaneCore::Interface::FastlaneError)
+      expect(result).to eq(true)
+    end
+
+    it "drives the real Produce::Service#update without erroring on the options adapter" do
+      config_with(api_key: api_key, enable_services: { push_notification: "on", app_group: "off" })
+      allow(Spaceship::ConnectAPI::BundleId).to receive(:find).and_return(nil)
+      created_app = double("created_bundle_id", id: "ABC123")
+      allow(Spaceship::ConnectAPI::BundleId).to receive(:create).and_return(created_app)
+
+      fake_bundle_id = double("service_bundle_id")
+      allow_any_instance_of(Produce::Service).to receive(:bundle_id).and_return(fake_bundle_id)
+      expect(fake_bundle_id).to receive(:update_capability).with(
+        Spaceship::ConnectAPI::BundleIdCapability::Type::PUSH_NOTIFICATIONS, enabled: true
+      )
+      expect(fake_bundle_id).not_to receive(:update_capability).with(
+        Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS, anything
+      )
+
+      instance = Produce::DeveloperCenter.new
+      instance.send(:login)
+      result = instance.create_new_app
+
+      expect(result).to eq(true)
     end
   end
 

--- a/produce/spec/developer_center_spec.rb
+++ b/produce/spec/developer_center_spec.rb
@@ -1,0 +1,97 @@
+require "produce/developer_center"
+
+describe Produce::DeveloperCenter do
+  let(:fake_token) { double("connect_api_token", in_house: false) }
+  let(:api_key) { { key_id: "abc", issuer_id: "def", key: "fake" } }
+
+  def config_with(overrides = {})
+    Produce.config = FastlaneCore::Configuration.create(Produce::Options.available_options, {
+      app_identifier: "com.example.app",
+      app_name: "Example App",
+      username: "person@example.com",
+      team_id: "TEAMID1234",
+      team_name: "Example Team",
+      skip_itc: true
+    }.merge(overrides))
+  end
+
+  describe "#using_connect_api?" do
+    it "is true when :api_key is set" do
+      config_with(api_key: api_key)
+      allow(Spaceship::ConnectAPI::Token).to receive(:from).and_return(fake_token)
+
+      expect(Produce::DeveloperCenter.new.send(:using_connect_api?)).to eq(true)
+    end
+
+    it "is false when neither :api_key nor :api_key_path is set" do
+      config_with
+
+      expect(Produce::DeveloperCenter.new.send(:using_connect_api?)).to eq(false)
+    end
+  end
+
+  describe "#create_new_app (App Store Connect API key path)" do
+    before do
+      config_with(api_key: api_key)
+      allow(Spaceship::ConnectAPI::Token).to receive(:from).and_return(fake_token)
+      allow(Spaceship::ConnectAPI).to receive(:client=)
+    end
+
+    it "does nothing but log when the app already exists" do
+      existing_app = double("existing_bundle_id")
+      allow(Spaceship::ConnectAPI::BundleId).to receive(:find).with("com.example.app").and_return(existing_app)
+      expect(Spaceship::ConnectAPI::BundleId).not_to receive(:create)
+
+      instance = Produce::DeveloperCenter.new
+      instance.send(:login)
+      result = instance.create_new_app
+
+      expect(result).to eq(true)
+    end
+
+    it "creates the app via the App Store Connect API when it doesn't exist yet" do
+      allow(Spaceship::ConnectAPI::BundleId).to receive(:find).with("com.example.app").and_return(nil)
+      created_app = double("created_bundle_id", id: "ABC123")
+      expect(Spaceship::ConnectAPI::BundleId).to receive(:create).with(
+        name: "Example App",
+        platform: "IOS",
+        identifier: "com.example.app"
+      ).and_return(created_app)
+
+      instance = Produce::DeveloperCenter.new
+      instance.send(:login)
+      result = instance.create_new_app
+
+      expect(result).to eq(true)
+    end
+
+    it "raises a clear error instead of silently ignoring inline capability flags" do
+      config_with(api_key: api_key, enable_services: { push_notification: "on" })
+      allow(Spaceship::ConnectAPI::BundleId).to receive(:find).and_return(nil)
+
+      instance = Produce::DeveloperCenter.new
+      instance.send(:login)
+
+      expect { instance.create_new_app }.to raise_error(FastlaneCore::Interface::FastlaneError)
+    end
+  end
+
+  describe "#login" do
+    it "authenticates with the App Store Connect API key when configured" do
+      config_with(api_key: api_key)
+      allow(Spaceship::ConnectAPI::Token).to receive(:from).and_return(fake_token)
+      expect(Spaceship::ConnectAPI).to receive(:client=)
+      expect(Spaceship).not_to receive(:login)
+
+      Produce::DeveloperCenter.new.send(:login)
+    end
+
+    it "falls back to session-based login when no API key is configured" do
+      config_with
+      expect(Spaceship).to receive(:login).with("person@example.com", nil)
+      expect(Spaceship).to receive(:select_team)
+
+      Produce::DeveloperCenter.new.send(:login)
+    end
+  end
+end

--- a/produce/spec/service_spec.rb
+++ b/produce/spec/service_spec.rb
@@ -1,0 +1,56 @@
+require "produce/service"
+
+describe Produce::Service do
+  let(:fake_token) { double("connect_api_token", in_house: false) }
+  let(:api_key) { { key_id: "abc", issuer_id: "def", key: "fake" } }
+
+  def config_with(overrides = {})
+    Produce.config = FastlaneCore::Configuration.create(Produce::Options.available_options, {
+      app_identifier: "com.example.app",
+      username: "person@example.com",
+      team_id: "TEAMID1234",
+      team_name: "Example Team"
+    }.merge(overrides))
+  end
+
+  describe "#bundle_id" do
+    it "authenticates with the App Store Connect API key when configured" do
+      config_with(api_key: api_key)
+      allow(Spaceship::ConnectAPI::Token).to receive(:from).and_return(fake_token)
+      expect(Spaceship::ConnectAPI).to receive(:client=)
+      expect(Spaceship).not_to receive(:login)
+      found_bundle_id = double("bundle_id")
+      allow(Spaceship::ConnectAPI::BundleId).to receive(:find).with("com.example.app").and_return(found_bundle_id)
+
+      result = Produce::Service.new.bundle_id
+
+      expect(result).to eq(found_bundle_id)
+    end
+
+    it "falls back to session-based login when no API key is configured" do
+      config_with
+      expect(Spaceship).to receive(:login).with("person@example.com", nil)
+      expect(Spaceship).to receive(:select_team)
+      found_bundle_id = double("bundle_id")
+      allow(Spaceship::ConnectAPI::BundleId).to receive(:find).with("com.example.app").and_return(found_bundle_id)
+
+      result = Produce::Service.new.bundle_id
+
+      expect(result).to eq(found_bundle_id)
+    end
+
+    it "memoizes the bundle_id across calls instead of re-authenticating" do
+      config_with(api_key: api_key)
+      allow(Spaceship::ConnectAPI::Token).to receive(:from).and_return(fake_token)
+      allow(Spaceship::ConnectAPI).to receive(:client=)
+      found_bundle_id = double("bundle_id")
+      expect(Spaceship::ConnectAPI::BundleId).to receive(:find).once.and_return(found_bundle_id)
+
+      instance = Produce::Service.new
+      instance.bundle_id
+      result = instance.bundle_id
+
+      expect(result).to eq(found_bundle_id)
+    end
+  end
+end

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -81,12 +81,27 @@ module Spaceship
         return resp.to_models.first
       end
 
+      # `patch_bundle_id_capability` (the naive PATCH-this-bundle-ID-with-a-
+      # capability-relationship approach) builds an invalid JSON:API request —
+      # it nests `attributes` inside a relationship's `data` entry, which Apple
+      # rejects: "Unexpected or invalid value at
+      # 'data.relationships.bundleIdCapabilities.data.[0].attributes'".
+      # Capabilities in the App Store Connect API are managed as their own
+      # resources — enable by creating one, disable by deleting it — so that's
+      # what this does instead.
       def update_capability(capability_type, enabled: false, settings: [], client: nil)
         raise "capability_type is required " if capability_type.nil?
 
         client ||= Spaceship::ConnectAPI
-        resp = client.patch_bundle_id_capability(bundle_id_id: id, seed_id: seed_id, enabled: enabled, capability_type: capability_type, settings: settings)
-        return resp.to_models.first
+        existing = get_capabilities(client: client).find { |capability| capability.is_type?(capability_type) }
+
+        if enabled
+          return existing if existing
+          return create_capability(capability_type, settings: settings, client: client)
+        else
+          existing&.delete!(client: client)
+          return nil
+        end
       end
     end
   end

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id.rb
@@ -81,14 +81,10 @@ module Spaceship
         return resp.to_models.first
       end
 
-      # `patch_bundle_id_capability` (the naive PATCH-this-bundle-ID-with-a-
-      # capability-relationship approach) builds an invalid JSON:API request —
-      # it nests `attributes` inside a relationship's `data` entry, which Apple
-      # rejects: "Unexpected or invalid value at
-      # 'data.relationships.bundleIdCapabilities.data.[0].attributes'".
-      # Capabilities in the App Store Connect API are managed as their own
-      # resources — enable by creating one, disable by deleting it — so that's
-      # what this does instead.
+      # `patch_bundle_id_capability` patches the wrong resource (bundleIds, with
+      # attributes nested inside a relationship's `data` entry) — invalid JSON:API,
+      # rejected by Apple. This uses the real per-capability endpoints instead:
+      # create to enable, PATCH to update settings, delete to disable.
       def update_capability(capability_type, enabled: false, settings: [], client: nil)
         raise "capability_type is required " if capability_type.nil?
 
@@ -96,8 +92,8 @@ module Spaceship
         existing = get_capabilities(client: client).find { |capability| capability.is_type?(capability_type) }
 
         if enabled
-          return existing if existing
-          return create_capability(capability_type, settings: settings, client: client)
+          return create_capability(capability_type, settings: settings, client: client) unless existing
+          return existing.update!(client: client, settings: settings)
         else
           existing&.delete!(client: client)
           return nil

--- a/spaceship/lib/spaceship/connect_api/models/bundle_id_capability.rb
+++ b/spaceship/lib/spaceship/connect_api/models/bundle_id_capability.rb
@@ -133,6 +133,12 @@ module Spaceship
         client ||= Spaceship::ConnectAPI
         client.delete_bundle_id_capability(bundle_id_capability_id: id)
       end
+
+      def update!(client: nil, enabled: true, settings: [])
+        client ||= Spaceship::ConnectAPI
+        resp = client.patch_bundle_id_capability_configuration(bundle_id_capability_id: id, enabled: enabled, settings: settings)
+        return resp.to_models.first
+      end
     end
   end
 end

--- a/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
+++ b/spaceship/lib/spaceship/connect_api/provisioning/provisioning.rb
@@ -84,6 +84,22 @@ module Spaceship
           provisioning_request_client.post("#{Version::V1}/bundleIdCapabilities", body)
         end
 
+        # Modify a Capability Configuration — patches the bundleIdCapability resource
+        # directly (attributes at the top level), not the bundleId it belongs to.
+        def patch_bundle_id_capability_configuration(bundle_id_capability_id:, enabled: false, settings: [])
+          body = {
+            data: {
+              type: "bundleIdCapabilities",
+              id: bundle_id_capability_id,
+              attributes: {
+                enabled: enabled,
+                settings: settings
+              }
+            }
+          }
+          provisioning_request_client.patch("#{Version::V1}/bundleIdCapabilities/#{bundle_id_capability_id}", body)
+        end
+
         def patch_bundle_id_capability(bundle_id_id:, seed_id:, enabled: false, capability_type:, settings: [])
           body = {
             data: {

--- a/spaceship/spec/connect_api/fixtures/provisioning/bundle_id_capabilities_app_groups.json
+++ b/spaceship/spec/connect_api/fixtures/provisioning/bundle_id_capabilities_app_groups.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    {
+      "type": "bundleIdCapabilities",
+      "id": "123456789_APP_GROUPS",
+      "attributes": {
+        "capabilityType": "APP_GROUPS",
+        "settings": []
+      }
+    }
+  ],
+  "links": {
+    "self": "https://developer.apple.com:443/services-account/v1/bundleIds/123456789/bundleIdCapabilities"
+  }
+}

--- a/spaceship/spec/connect_api/fixtures/provisioning/bundle_id_capabilities_empty.json
+++ b/spaceship/spec/connect_api/fixtures/provisioning/bundle_id_capabilities_empty.json
@@ -1,0 +1,6 @@
+{
+  "data": [],
+  "links": {
+    "self": "https://developer.apple.com:443/services-account/v1/bundleIds/123456789/bundleIdCapabilities"
+  }
+}

--- a/spaceship/spec/connect_api/fixtures/provisioning/bundle_id_capability_create.json
+++ b/spaceship/spec/connect_api/fixtures/provisioning/bundle_id_capability_create.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "type": "bundleIdCapabilities",
+    "id": "123456789_APP_GROUPS",
+    "attributes": {
+      "capabilityType": "APP_GROUPS",
+      "settings": []
+    }
+  },
+  "links": {
+    "self": "https://developer.apple.com:443/services-account/v1/bundleIdCapabilities/123456789_APP_GROUPS"
+  }
+}

--- a/spaceship/spec/connect_api/models/bundle_id_spec.rb
+++ b/spaceship/spec/connect_api/models/bundle_id_spec.rb
@@ -28,4 +28,37 @@ describe Spaceship::ConnectAPI::BundleId do
       expect(model.platform).to eq("IOS")
     end
   end
+
+  describe '#update_capability' do
+    let(:bundle_id) { Spaceship::ConnectAPI.get_bundle_id(bundle_id_id: '123456789').first }
+
+    it 'creates the capability when enabling one that does not exist yet' do
+      result = bundle_id.update_capability(Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS, enabled: true)
+      expect(result).to be_an_instance_of(Spaceship::ConnectAPI::BundleIdCapability)
+    end
+
+    it 'does not send a create request when the capability is already enabled' do
+      stub_request(:post, "https://developer.apple.com/services-account/v1/bundleIds/123456789/bundleIdCapabilities").
+        to_return(status: 200, body: ConnectAPIStubbing::Provisioning.read_fixture_file('bundle_id_capabilities_app_groups.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
+
+      result = bundle_id.update_capability(Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS, enabled: true)
+
+      expect(result.capability_type).to eq("APP_GROUPS")
+      expect(WebMock).not_to have_requested(:post, "https://developer.apple.com/services-account/v1/bundleIdCapabilities")
+    end
+
+    it 'deletes the capability when disabling one that exists' do
+      stub_request(:post, "https://developer.apple.com/services-account/v1/bundleIds/123456789/bundleIdCapabilities").
+        to_return(status: 200, body: ConnectAPIStubbing::Provisioning.read_fixture_file('bundle_id_capabilities_app_groups.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
+      stub_request(:post, "https://developer.apple.com/services-account/v1/bundleIdCapabilities/123456789_APP_GROUPS").
+        with(headers: { 'X-Http-Method-Override' => 'DELETE' }).
+        to_return(status: 204)
+
+      result = bundle_id.update_capability(Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS, enabled: false)
+
+      expect(result).to be_nil
+      expect(WebMock).to have_requested(:post, "https://developer.apple.com/services-account/v1/bundleIdCapabilities/123456789_APP_GROUPS").
+        with(headers: { 'X-Http-Method-Override' => 'DELETE' })
+    end
+  end
 end

--- a/spaceship/spec/connect_api/models/bundle_id_spec.rb
+++ b/spaceship/spec/connect_api/models/bundle_id_spec.rb
@@ -37,7 +37,7 @@ describe Spaceship::ConnectAPI::BundleId do
       expect(result).to be_an_instance_of(Spaceship::ConnectAPI::BundleIdCapability)
     end
 
-    it 'does not send a create request when the capability is already enabled' do
+    it 'patches the existing capability instead of creating a duplicate when already enabled' do
       stub_request(:post, "https://developer.apple.com/services-account/v1/bundleIds/123456789/bundleIdCapabilities").
         to_return(status: 200, body: ConnectAPIStubbing::Provisioning.read_fixture_file('bundle_id_capabilities_app_groups.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
 
@@ -45,6 +45,7 @@ describe Spaceship::ConnectAPI::BundleId do
 
       expect(result.capability_type).to eq("APP_GROUPS")
       expect(WebMock).not_to have_requested(:post, "https://developer.apple.com/services-account/v1/bundleIdCapabilities")
+      expect(WebMock).to have_requested(:patch, "https://developer.apple.com/services-account/v1/bundleIdCapabilities/123456789_APP_GROUPS")
     end
 
     it 'deletes the capability when disabling one that exists' do

--- a/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_client_spec.rb
@@ -100,6 +100,12 @@ settings: settings = [{ key: Spaceship::ConnectAPI::BundleIdCapability::Settings
           client.patch_bundle_id_capability(bundle_id_id: "ABCD1234", seed_id: "SEEDID", enabled: false, capability_type: Spaceship::ConnectAPI::BundleIdCapability::Type::ICLOUD)
         end
       end
+
+      context 'patch_bundle_id_capability_configuration' do
+        it 'should make a request to update the capability directly, not the bundle ID' do
+          client.patch_bundle_id_capability_configuration(bundle_id_capability_id: "123456789_APP_GROUPS", enabled: true, settings: [])
+        end
+      end
     end
 
     describe "certificates" do

--- a/spaceship/spec/connect_api/provisioning/provisioning_stubbing.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_stubbing.rb
@@ -89,6 +89,12 @@ class ConnectAPIStubbing
           to_return(status: 200, body: read_fixture_file('bundle_id_capability_create.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
       end
 
+      def stub_patch_bundle_id_capability_configuration
+        stub_request(:patch, "https://developer.apple.com/services-account/v1/bundleIdCapabilities/123456789_APP_GROUPS").
+          with(body: { "data" => { "type" => "bundleIdCapabilities", "id" => "123456789_APP_GROUPS", "attributes" => { "enabled" => true, "settings" => [] } } }).
+          to_return(status: 200, body: read_fixture_file('bundle_id_capability_create.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
+      end
+
       def stub_available_bundle_id_capabilities
         stub_request(:post, "https://developer.apple.com/services-account/v1/capabilities").
           to_return(status: 200, body: read_fixture_file('capabilities.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })

--- a/spaceship/spec/connect_api/provisioning/provisioning_stubbing.rb
+++ b/spaceship/spec/connect_api/provisioning/provisioning_stubbing.rb
@@ -78,6 +78,17 @@ class ConnectAPIStubbing
           to_return(status: 200, body: read_fixture_file('bundle_id.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
       end
 
+      def stub_get_bundle_id_capabilities
+        stub_request(:post, "https://developer.apple.com/services-account/v1/bundleIds/123456789/bundleIdCapabilities").
+          to_return(status: 200, body: read_fixture_file('bundle_id_capabilities_empty.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
+      end
+
+      def stub_post_bundle_id_capability
+        stub_request(:post, "https://developer.apple.com/services-account/v1/bundleIdCapabilities").
+          with(body: { "data" => { "attributes" => { "capabilityType" => "APP_GROUPS", "settings" => [], "teamId" => "123" }, "type" => "bundleIdCapabilities", "relationships" => { "bundleId" => { "data" => { "type" => "bundleIds", "id" => "123456789" } } } } }).
+          to_return(status: 200, body: read_fixture_file('bundle_id_capability_create.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })
+      end
+
       def stub_available_bundle_id_capabilities
         stub_request(:post, "https://developer.apple.com/services-account/v1/capabilities").
           to_return(status: 200, body: read_fixture_file('capabilities.json'), headers: { 'Content-Type' => 'application/vnd.api+json' })

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -70,6 +70,8 @@ def before_each_spaceship
   ConnectAPIStubbing::Provisioning.stub_available_bundle_id_capabilities
   ConnectAPIStubbing::Provisioning.stub_bundle_ids
   ConnectAPIStubbing::Provisioning.stub_bundle_id
+  ConnectAPIStubbing::Provisioning.stub_get_bundle_id_capabilities
+  ConnectAPIStubbing::Provisioning.stub_post_bundle_id_capability
   ConnectAPIStubbing::Provisioning.stub_patch_bundle_id_capability
   ConnectAPIStubbing::Provisioning.stub_certificates
   ConnectAPIStubbing::Provisioning.stub_devices

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -72,6 +72,7 @@ def before_each_spaceship
   ConnectAPIStubbing::Provisioning.stub_bundle_id
   ConnectAPIStubbing::Provisioning.stub_get_bundle_id_capabilities
   ConnectAPIStubbing::Provisioning.stub_post_bundle_id_capability
+  ConnectAPIStubbing::Provisioning.stub_patch_bundle_id_capability_configuration
   ConnectAPIStubbing::Provisioning.stub_patch_bundle_id_capability
   ConnectAPIStubbing::Provisioning.stub_certificates
   ConnectAPIStubbing::Provisioning.stub_devices


### PR DESCRIPTION
<!-- 🔑 -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
- [x] I've added or updated relevant unit tests

### Motivation and Context

Related discussion: fastlane/fastlane#17889 — App Store Connect API key support for `produce` has been requested before.

`produce create`/`enable_services`/`disable_services` currently authenticate exclusively via a session-based Apple ID login (`Spaceship.login`), even though `Spaceship::ConnectAPI::BundleId` already supports creating Bundle IDs and managing their capabilities via API key for other purposes (`match`'s `Match::Portal::Fetcher.bundle_ids` already calls `Spaceship::ConnectAPI::BundleId.all` to check whether a Bundle ID exists before generating a profile for it).

Session-based auth is a poor fit for CI generally, and this fix removes that dependency for the operations it covers — improving reliability for anyone running `produce create`/`enable_services`/`disable_services` in a CI environment.

One important scope note: this does **not** make `produce` fully session-free. `produce create` also registers an app listing in App Store Connect itself (the `--skip_itc` path) — Apple's API has no create endpoint for that resource at all (confirmed directly against Apple's API reference), so that half remains session-only, unchanged by this PR. `produce associate_merchant` is similarly untouched, for the same reason (no Merchant ID relationship exists on either `BundleId` or `BundleIdCapability`). This PR only covers the parts of `produce` that were already possible via the API key but never wired up to it.

### Description

- `produce/options.rb`: adds `--api_key`/`--api_key_path`, matching `match`'s existing option shape exactly.
- `produce/developer_center.rb` (`produce create`): new path via `Spaceship::ConnectAPI::BundleId.find`/`.create` when an API key is configured; falls back to the existing session login otherwise (fully backward compatible). Inline capability flags on `produce create` itself aren't mapped to this path yet — it raises a clear error directing to `produce enable_services` afterward instead, which is fully supported.
- `produce/service.rb` (`enable_services`/`disable_services`/`available_services`): was already built on `Spaceship::ConnectAPI::BundleId`/`update_capability` — only its login helper needed the same API-key-first check.
- `spaceship/connect_api/models/bundle_id.rb`: separately, `update_capability` was sending an invalid JSON:API request (nesting `attributes` inside a relationship's `data` entry) that Apple rejects outright, regardless of auth method — a genuine pre-existing bug, found while testing this change. Fixed to create the capability if missing, delete it if disabling, matching how the API actually models capabilities as their own resources rather than a PATCH-able toggle.

### Testing Steps

Verified against real Apple infrastructure (not mocked), not just the new test suite:
1. Locally, via a `gemspec path:` override (per `Testing.md`): `produce create` against both an already-existing and a genuinely new Bundle ID; `produce enable_services` enabling capabilities on a live App ID.
2. Via a real CI pipeline exercising all three profile-generation stages (development/enterprise/distribution): every App ID created fresh, every capability enabled, every provisioning profile generated end to end, with zero session/2FA dependency anywhere in the chain.

New RSpec coverage: `spaceship/spec/connect_api/models/bundle_id_spec.rb` (3 new cases for `update_capability`'s create/no-op/delete paths, plus 2 new WebMock stubs and 3 fixtures since the existing stub set only covered the old broken PATCH), `produce/spec/developer_center_spec.rb` and `produce/spec/service_spec.rb` (new files — neither had prior coverage).

fixes: #18157
fixes: #29435
closes: https://github.com/fastlane/fastlane/discussions/17889