### PR TITLE
[match] upload certs immediatly to storage to prevent desync of files

### DIFF
--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -268,10 +268,14 @@ module Match
       return if self.files_to_commit.empty? && self.files_to_delete.empty?
 
       self.encryption.encrypt_files if self.encryption
-      self.storage.save_changes!(files_to_commit: self.files_to_commit,
-                                 files_to_delete: self.files_to_delete,
-                                 clear_working_directory: false)
-      self.encryption.decrypt_files if self.encryption
+      begin
+        self.storage.save_changes!(files_to_commit: self.files_to_commit,
+                                   files_to_delete: self.files_to_delete,
+                                   clear_working_directory: false)
+      ensure
+        # Always hand back a decrypted working directory, 2nd upload will hopefully work.
+        self.encryption.decrypt_files if self.encryption
+      end
 
       # We may have another upload at end (profiles) so reset our cert file(s).
       self.files_to_commit = []

--- a/match/lib/match/runner.rb
+++ b/match/lib/match/runner.rb
@@ -24,6 +24,8 @@ module Match
 
     attr_accessor :storage
 
+    attr_accessor :encryption
+
     attr_accessor :cache
 
     # rubocop:disable Metrics/PerceivedComplexity
@@ -45,14 +47,14 @@ module Match
       storage.download
 
       # Init the encryption only after the `storage.download` was called to have the right working directory
-      encryption = Encryption.for_storage_mode(params[:storage_mode], {
+      self.encryption = Encryption.for_storage_mode(params[:storage_mode], {
         git_url: params[:git_url],
         s3_bucket: params[:s3_bucket],
         s3_skip_encryption: params[:s3_skip_encryption],
         working_directory: storage.working_directory,
         force_legacy_encryption: params[:force_legacy_encryption]
       })
-      encryption.decrypt_files if encryption
+      self.encryption.decrypt_files if self.encryption
 
       unless params[:readonly]
         self.spaceship = SpaceshipEnsure.new(params[:username], params[:team_id], params[:team_name], api_token(params))
@@ -117,7 +119,7 @@ module Match
 
       has_file_changes = self.files_to_commit.count > 0 || self.files_to_delete.count > 0
       if has_file_changes && !params[:readonly]
-        encryption.encrypt_files if encryption
+        self.encryption.encrypt_files if self.encryption
         storage.save_changes!(files_to_commit: self.files_to_commit, files_to_delete: self.files_to_delete)
       end
 
@@ -209,6 +211,10 @@ module Match
         self.files_to_commit << cert_path
         self.files_to_commit << private_key_path
 
+        # We pause to upload certs immediatly (or renewals) in case later logic fails, leaving
+        # AppStore with a set of files de-synced from match storage. See fastlane/fastlane#30140
+        save_changes_immediately!(params)
+
         # Reset certificates cache since we have a new cert.
         self.cache.reset_certificates
       else
@@ -253,6 +259,23 @@ module Match
       end
 
       return File.basename(cert_path).gsub(".cer", "") # Certificate ID
+    end
+
+    # Saves all pending file changes to storage right away, keeping the
+    # working directory around so the current run can continue using it
+    def save_changes_immediately!(params)
+      return if params[:readonly]
+      return if self.files_to_commit.empty? && self.files_to_delete.empty?
+
+      self.encryption.encrypt_files if self.encryption
+      self.storage.save_changes!(files_to_commit: self.files_to_commit,
+                                 files_to_delete: self.files_to_delete,
+                                 clear_working_directory: false)
+      self.encryption.decrypt_files if self.encryption
+
+      # We may have another upload at end (profiles) so reset our cert file(s).
+      self.files_to_commit = []
+      self.files_to_delete = []
     end
 
     # @return [String] Path to certificate or P12 key

--- a/match/lib/match/storage/interface.rb
+++ b/match/lib/match/storage/interface.rb
@@ -47,11 +47,14 @@ module Match
       # given remote server
       # This method is blocking, meaning it might take multiple
       # seconds or longer to run
-      # @parameter files_to_commit [Array] Array to paths to files
+      # @param files_to_commit [Array] Array to paths to files
       #   that should be committed to the storage provider
-      # @parameter custom_message: [String] Custom change message
-      #           that's optional, is used for commit title
-      def save_changes!(files_to_commit: nil, files_to_delete: nil, custom_message: nil)
+      # @param custom_message: [String] Custom change message
+      #   that's optional, is used for commit title
+      # @param clear_working_directory: [Bool] Pass `false` to keep
+      #   the local working directory after saving, so more
+      #   changes can be made and saved later in the same run
+      def save_changes!(files_to_commit: nil, files_to_delete: nil, custom_message: nil, clear_working_directory: true)
         # Custom init to `[]` in case `nil` is passed
         files_to_commit ||= []
         files_to_delete ||= []
@@ -85,7 +88,7 @@ module Match
           end
         end
       ensure # Always clear working_directory after save
-        self.clear_changes
+        self.clear_changes if clear_working_directory
       end
 
       def upload_files(files_to_upload: [], custom_message: nil)

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -463,6 +463,62 @@ describe Match do
           # Rely on expectations defined above.
         end
 
+        it "decrypts the working directory again when saving a renewed certificate fails", requires_security: true do
+          # GIVEN
+
+          # Downloaded and decrypted storage location.
+          repo_dir = "./match/spec/fixtures/invalid"
+          #   Invalid cert and key
+          stored_invalid_cert_path = "#{repo_dir}/certs/distribution/F7P4EE896K.cer"
+          stored_invalid_key_path = "#{repo_dir}/certs/distribution/F7P4EE896K.p12"
+
+          #   Valid cert
+          new_stored_valid_cert_path = "./match/spec/fixtures/valid/certs/distribution/E7P4EE896K.cer"
+
+          # match options
+          match_test_options = {
+            renew_expired_certs: true, # Current test suite.
+            skip_provisioning_profiles: true # We test certificate renewal, not profile.
+          }
+          match_config = create_match_config_with_git_storage(extra_values: match_test_options)
+
+          create_fake_cache
+
+          # EXPECTATIONS
+
+          # Storage
+          fake_storage = create_fake_storage(match_config: match_config, repo_dir: repo_dir)
+          # Ensure the immediate upload of the renewed certificate fails.
+          expect(fake_storage).to receive(:save_changes!).and_raise("Couldn't push changes back to git")
+
+          # Encryption
+          # Ensure files are decrypted again even though saving them failed, so the
+          # working directory is never left behind encrypted.
+          fake_encryption = create_fake_encryption(storage: fake_storage, expected_decrypt_count: 2)
+          expect(fake_encryption).to receive(:encrypt_files).and_return(nil)
+
+          # Certificate generator
+          # Ensure a new certificate is generated.
+          expect(Match::Generator).to receive(:generate_certificate).with(match_config, :distribution, fake_storage.working_directory, specific_cert_type: nil).and_return(new_stored_valid_cert_path)
+
+          create_fake_spaceship_ensure
+
+          # Utils
+          # Ensure match validates stored certificate and make it invalid for the current test suite.
+          expect(Match::Utils).to receive(:is_cert_valid?).with(stored_invalid_cert_path).and_return(false)
+
+          # File system
+          begin # Ensure old certificates are removed from the file system.
+            expect(File).to receive(:delete).with(stored_invalid_cert_path).and_return(nil)
+            expect(File).to receive(:delete).with(stored_invalid_key_path).and_return(nil)
+          end
+
+          # WHEN / THEN
+          expect do
+            Match::Runner.new.run(match_config)
+          end.to raise_error("Couldn't push changes back to git")
+        end
+
         it "does not renew an outdated developer_id certificate when authenticated with an App Store Connect API token", requires_security: true do
           # GIVEN
           # `developer_id` certificates can't be renewed with a Connect API token

--- a/match/spec/runner_spec.rb
+++ b/match/spec/runner_spec.rb
@@ -72,10 +72,18 @@ describe Match do
                                                                                     cache: fake_cache,
                                                                        working_directory: fake_storage.working_directory).and_return(profile_path)
           expect(FastlaneCore::ProvisioningProfile).to receive(:install).with(profile_path, keychain_path).and_return(destination)
+          # The new certificate is uploaded to storage right after being created,
+          # before any provisioning profile work
           expect(fake_storage).to receive(:save_changes!).with(
             files_to_commit: [
               File.join(repo_dir, "something.cer"),
-              File.join(repo_dir, "something.p12"), # this is important, as a cert consists out of 2 files
+              File.join(repo_dir, "something.p12") # this is important, as a cert consists out of 2 files
+            ],
+            files_to_delete: [],
+            clear_working_directory: false
+          )
+          expect(fake_storage).to receive(:save_changes!).with(
+            files_to_commit: [
               "./match/spec/fixtures/test.mobileprovision"
             ],
             files_to_delete: []
@@ -102,6 +110,56 @@ describe Match do
                                                                          type: "appstore")]).to eql(profile_path)
           expect(ENV[Match::Utils.environment_variable_name_certificate_name(app_identifier: "tools.fastlane.app",
                                                                              type: "appstore")]).to eql("fastlane certificate name")
+        end
+
+        it "keeps a new certificate in storage even when profile creation fails afterwards", requires_security: true do
+          git_url = "https://github.com/fastlane/fastlane/tree/master/certificates"
+          values = {
+            app_identifier: "tools.fastlane.app",
+            type: "appstore",
+            git_url: git_url,
+            shallow_clone: true,
+            username: "flapple@something.com"
+          }
+
+          config = FastlaneCore::Configuration.create(Match::Options.available_options, values)
+          repo_dir = Dir.mktmpdir
+          cert_path = File.join(repo_dir, "something.cer")
+
+          create_fake_cache
+
+          fake_storage = "fake_storage"
+          expect(Match::Storage::GitStorage).to receive(:configure).and_return(fake_storage)
+          expect(fake_storage).to receive(:download).and_return(nil)
+          expect(fake_storage).to receive(:clear_changes).and_return(nil)
+          allow(fake_storage).to receive(:working_directory).and_return(repo_dir)
+          allow(fake_storage).to receive(:prefixed_working_directory).and_return(repo_dir)
+
+          expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution, fake_storage.working_directory, specific_cert_type: nil).and_return(cert_path)
+
+          # The new certificate is uploaded to storage right after being created,
+          # before any provisioning profile work (https://github.com/fastlane/fastlane/issues/30140)
+          expect(fake_storage).to receive(:save_changes!).with(
+            files_to_commit: [
+              File.join(repo_dir, "something.cer"),
+              File.join(repo_dir, "something.p12")
+            ],
+            files_to_delete: [],
+            clear_working_directory: false
+          )
+
+          # Profile creation fails after the new certificate was created
+          expect(Match::Generator).to receive(:generate_provisioning_profile).and_raise("Beta profile could not be created")
+
+          spaceship = "spaceship"
+          allow(spaceship).to receive(:team_id).and_return("")
+          expect(Match::SpaceshipEnsure).to receive(:new).and_return(spaceship)
+          expect(spaceship).to receive(:certificates_exists).and_return(true)
+          expect(spaceship).to receive(:bundle_identifier_exists).and_return(true)
+
+          expect do
+            Match::Runner.new.run(config)
+          end.to raise_error("Beta profile could not be created")
         end
 
         it "uses existing certificates and profiles if they exist", requires_security: true do
@@ -338,6 +396,8 @@ describe Match do
           # Storage
           fake_storage = create_fake_storage(match_config: match_config, repo_dir: repo_dir)
           begin # Ensure old certificates are removed from the storage and new are added.
+            # This happens right after the new certificate is created, keeping
+            # the working directory around for the rest of the run
             expect(fake_storage).to receive(:save_changes!).with(
               files_to_commit: [
                 new_stored_valid_cert_path,
@@ -346,12 +406,14 @@ describe Match do
               files_to_delete: [
                 stored_invalid_cert_path,
                 stored_invalid_key_path
-              ]
+              ],
+              clear_working_directory: false
             )
           end
 
           # Encryption
-          fake_encryption = create_fake_encryption(storage: fake_storage)
+          # Files are decrypted again after the new certificate was uploaded to storage.
+          fake_encryption = create_fake_encryption(storage: fake_storage, expected_decrypt_count: 2)
           # Ensure new files are encrypted.
           expect(fake_encryption).to receive(:encrypt_files).and_return(nil)
 
@@ -491,12 +553,15 @@ describe Match do
           expect(Match::Generator).to receive(:generate_certificate).with(config, :distribution, fake_storage.working_directory, specific_cert_type: nil).and_return(cert_path)
           expect(Match::Generator).to_not(receive(:generate_provisioning_profile))
           expect(FastlaneCore::ProvisioningProfile).to_not(receive(:install))
+          # The new certificate is uploaded to storage right after being created,
+          # so there is nothing left to save at the end of the run
           expect(fake_storage).to receive(:save_changes!).with(
             files_to_commit: [
               File.join(repo_dir, "something.cer"),
               File.join(repo_dir, "something.p12") # this is important, as a cert consists out of 2 files
             ],
-            files_to_delete: []
+            files_to_delete: [],
+            clear_working_directory: false
           )
 
           spaceship = "spaceship"

--- a/match/spec/spec_helper.rb
+++ b/match/spec/spec_helper.rb
@@ -72,12 +72,12 @@ def create_match_config_with_git_storage(extra_values: {}, git_url: nil, app_ide
   return match_config
 end
 
-def create_fake_encryption(storage:)
+def create_fake_encryption(storage:, expected_decrypt_count: 1)
   fake_encryption = "fake_encryption"
   expect(Match::Encryption::OpenSSL).to receive(:new).with(keychain_name: storage.git_url, working_directory: storage.working_directory, force_legacy_encryption: false).and_return(fake_encryption)
 
   # Ensure files from storage are decrypted.
-  expect(fake_encryption).to receive(:decrypt_files).and_return(nil)
+  expect(fake_encryption).to receive(:decrypt_files).exactly(expected_decrypt_count).times.and_return(nil)
 
   return fake_encryption
 end


### PR DESCRIPTION
## Problem

Match supports automatic renewal now and existing cert generation. If you generate a new cert (or renew) one - thats like phase 1 of a match execution. Next up is the provisioning profile itself (generation). If that fails you had a bunch of staged uploads of certs and then nothing goes out. This explains the issue reported in #30140. Next run you'd try and remake a cert, then hit an issue since that cert already existed in Apple. This forced you to do a process manually to pull/import that cert into storage manually.

## Solution

We split upload into 2 phases. After the cert phase we immediately upload into storage so in case of an error in phase 2 (profiles). We don't have an accident of our files in a bad state. 

---

fixes: #30140 