### PR TITLE
[match] prevent leaking keys if invalid usage

### DIFF
--- a/match/lib/match/storage/google_cloud_storage.rb
+++ b/match/lib/match/storage/google_cloud_storage.rb
@@ -82,7 +82,12 @@ module Match
         if self.google_cloud_keys_file.to_s.length > 0
           # Extract the Project ID from the `JSON` file
           # so the user doesn't have to provide it manually
-          keys_file_content = JSON.parse(File.read(self.google_cloud_keys_file))
+          begin
+            keys_file_content = JSON.parse(File.read(self.google_cloud_keys_file))
+          rescue JSON::ParserError
+            # Don't dump secret into logs in case a secret (p8) is passed. See fastlane/fastlane#21017
+            UI.user_error!("Provided keys file on path #{File.expand_path(self.google_cloud_keys_file)} is not a valid JSON file")
+          end
           if google_cloud_project_id.to_s.length > 0 && google_cloud_project_id != keys_file_content["project_id"]
             UI.important("The google_cloud_keys_file's project ID ('#{keys_file_content['project_id']}') doesn't match the google_cloud_project_id ('#{google_cloud_project_id}'). This may be the wrong keys file.")
           end

--- a/spaceship/lib/spaceship/connect_api/token.rb
+++ b/spaceship/lib/spaceship/connect_api/token.rb
@@ -36,7 +36,12 @@ module Spaceship
       end
 
       def self.from_json_file(filepath)
-        json = JSON.parse(File.read(filepath), { symbolize_names: true })
+        begin
+          json = JSON.parse(File.read(filepath), { symbolize_names: true })
+        rescue JSON::ParserError
+          # Don't dump secret into logs in case a secret (p8) is passed. See fastlane/fastlane#21017
+          raise "Invalid JSON in App Store Connect API key file '#{filepath}'. Expected a JSON file with at least the 'key_id' and 'key' fields."
+        end
 
         missing_keys = []
         missing_keys << 'key_id' unless json.key?(:key_id)

--- a/spaceship/spec/connect_api/token_spec.rb
+++ b/spaceship/spec/connect_api/token_spec.rb
@@ -52,14 +52,17 @@ describe Spaceship::ConnectAPI::Token do
       expect(token.in_house).to eq(true)
     end
 
-    it 'raises error with invalid JSON' do
+    it 'raises error with invalid JSON without leaking the file contents' do
       file = Tempfile.new('key.json')
-      file.write('abc123')
+      file.write('-----BEGIN PRIVATE KEY-----secret-key-value-----END PRIVATE KEY-----')
       file.close
 
       expect do
         Spaceship::ConnectAPI::Token.from_json_file(file.path)
-      end.to raise_error(JSON::ParserError, /unexpected character: 'abc123' at line 1 column 1/)
+      end.to raise_error do |error|
+        expect(error.message).to eq("Invalid JSON in App Store Connect API key file '#{file.path}'. Expected a JSON file with at least the 'key_id' and 'key' fields.")
+        expect(error.message).not_to include('secret-key-value')
+      end
     end
 
     it 'raises error with missing all keys' do


### PR DESCRIPTION
## Problem

If you mess up and switch up keys on match, swapping like the match key vs the asc key you can cause the JSON decoder to eat a p8 file and dump the full contents out.

```
unexpected token at '-----BEGIN PRIVATE KEY-----

[key value compromised]

-----END PRIVATE KEY-----'
```

## Solution

Lets wrap the 2 areas where we decode JSON and catch the ParserError so we can explain what we are looking for without dumping the raw secret into logs.


## Meta

The JSON gem actually changed how it exposes messages during a crash which you can see here: https://github.com/fastlane/fastlane/pull/30156, but it seems safer to not dump out parser errors when we can't control what might be passed to it.

---

fixes: #21017 