### PR TITLE
[match] Remove command on failure to prevent secret exposure for git storage.

### DIFF
--- a/match/lib/match/storage/git_storage.rb
+++ b/match/lib/match/storage/git_storage.rb
@@ -117,13 +117,10 @@ module Match
                                             print_command: FastlaneCore::Globals.verbose?)
           end
         rescue
-          UI.error("Error cloning certificates repo, please make sure you have read access to the repository you want to use")
           if self.branch && self.clone_branch_directly
             UI.error("You passed '#{self.branch}' as branch in combination with the `clone_branch_directly` flag. Please remove `clone_branch_directly` flag on the first run for _match_ to create the branch.")
           end
-          UI.error("Run the following command manually to make sure you're properly authenticated:")
-          UI.command(command)
-          UI.user_error!("Error cloning certificates git repo, please make sure you have access to the repository - see instructions above")
+          UI.user_error!("Error cloning certificates repo, please make sure you have read access to the repository you want to use")
         end
 
         add_user_config(self.git_full_name, self.git_user_email)


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context
All private tokens must be masked when working with match. 

### Description
Removed the log because it exposes private data.

### Testing Steps
Install locally current version from last commit, run match command with git storage.

fixes: #30164
