### PR TITLE
[sigh] Fix duplicate prefix in application-identifier entitlement during resign

### DIFF
--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -866,13 +866,14 @@ function resign {
         OLD_BUNDLE_ID="$(PlistBuddy -c "Print :CFBundleIdentifier" "$TEMP_DIR/oldInfo.plist")"
         NEW_BUNDLE_ID="$(bundle_id_for_provision "$NEW_PROVISION")"
         log "Replacing old bundle ID '$OLD_BUNDLE_ID' with new bundle ID '$NEW_BUNDLE_ID' in patched entitlements"
-        # Note: ideally we'd match against the opening <string> tag too, but this isn't possible
-        # because $OLD_BUNDLE_ID and $NEW_BUNDLE_ID do not include the team ID prefix which is
-        # present in the entitlements file.
-        # e.g. <string>AB1GP98Q19.com.example.foo</string>
-        #         vs
-        #      com.example.foo
-        /usr/bin/sed -i .bak "s!${OLD_BUNDLE_ID}</string>!${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
+        # Anchor the replacement to OLD_TEAM_ID prefix or the opening <string> tag so that
+        # if NEW_BUNDLE_ID contains OLD_BUNDLE_ID as a suffix (e.g. enterprise.com.example.foo),
+        # the already-correct values (like <TEAM_ID>.enterprise.com.example.foo) do not have their
+        # suffix duplicated.
+        if [ -n "$OLD_TEAM_ID" ] && [ -n "$NEW_TEAM_ID" ]; then
+            /usr/bin/sed -i .bak "s!${OLD_TEAM_ID}\.${OLD_BUNDLE_ID}</string>!${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
+        fi
+        /usr/bin/sed -i .bak "s!<string>${OLD_BUNDLE_ID}</string>!<string>${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
 
         log "Resigning application using certificate: '$CERTIFICATE'"
         log "and patched entitlements:"

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -665,9 +665,18 @@ function resign {
         # Get the old and the new team ID
         # Old team ID is not part of app entitlements, have to get it from old embedded provisioning profile
         security cms -D -i "$TEMP_DIR/old-embedded.mobileprovision" > "$TEMP_DIR/old-embedded-profile.plist"
-        OLD_TEAM_ID=$(PlistBuddy -c "Print :TeamIdentifier:0" "$TEMP_DIR/old-embedded-profile.plist")
+        OLD_TEAM_ID=$(PlistBuddy -c "Print :TeamIdentifier:0" "$TEMP_DIR/old-embedded-profile.plist" 2>/dev/null)
+        if [ "$OLD_TEAM_ID" == "" ]; then
+            OLD_TEAM_ID="$OLD_APP_ID"
+        fi
         # New team ID is part of profile entitlements
-        NEW_TEAM_ID=$(PlistBuddy -c "Print com.apple.developer.team-identifier" "$PROFILE_ENTITLEMENTS" | grep -E '^[A-Z0-9]*' -o | tr -d '\n')
+        NEW_TEAM_ID=$(PlistBuddy -c "Print com.apple.developer.team-identifier" "$PROFILE_ENTITLEMENTS" 2>/dev/null | grep -E '^[A-Z0-9]*' -o | tr -d '\n')
+        if [ "$NEW_TEAM_ID" == "" ]; then
+            NEW_TEAM_ID="$TEAM_IDENTIFIER"
+        fi
+        if [ "$NEW_TEAM_ID" == "" ]; then
+            NEW_TEAM_ID="$NEW_APP_ID"
+        fi
 
         log "Patching profile entitlements with values from app entitlements"
         PATCHED_ENTITLEMENTS="$TEMP_DIR/patchedEntitlements"

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -670,7 +670,7 @@ function resign {
             OLD_TEAM_ID="$OLD_APP_ID"
         fi
         # New team ID is part of profile entitlements
-        NEW_TEAM_ID=$(PlistBuddy -c "Print com.apple.developer.team-identifier" "$PROFILE_ENTITLEMENTS" 2>/dev/null | grep -E '^[A-Z0-9]*' -o | tr -d '\n')
+        NEW_TEAM_ID=$(PlistBuddy -c "Print :com.apple.developer.team-identifier" "$PROFILE_ENTITLEMENTS" 2>/dev/null | grep -E '^[A-Z0-9]*' -o | tr -d '\n')
         if [ "$NEW_TEAM_ID" == "" ]; then
             NEW_TEAM_ID="$TEAM_IDENTIFIER"
         fi
@@ -880,7 +880,7 @@ function resign {
         # the already-correct values (like <TEAM_ID>.enterprise.com.example.foo) do not have their
         # suffix duplicated.
         if [ -n "$OLD_TEAM_ID" ] && [ -n "$NEW_TEAM_ID" ]; then
-            /usr/bin/sed -i .bak "s!${OLD_TEAM_ID}\.${OLD_BUNDLE_ID}</string>!${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
+            /usr/bin/sed -i .bak "s!<string>${OLD_TEAM_ID}\.${OLD_BUNDLE_ID}</string>!<string>${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
         fi
         /usr/bin/sed -i .bak "s!<string>${OLD_BUNDLE_ID}</string>!<string>${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
 

--- a/sigh/lib/assets/resign.sh
+++ b/sigh/lib/assets/resign.sh
@@ -875,14 +875,16 @@ function resign {
         OLD_BUNDLE_ID="$(PlistBuddy -c "Print :CFBundleIdentifier" "$TEMP_DIR/oldInfo.plist")"
         NEW_BUNDLE_ID="$(bundle_id_for_provision "$NEW_PROVISION")"
         log "Replacing old bundle ID '$OLD_BUNDLE_ID' with new bundle ID '$NEW_BUNDLE_ID' in patched entitlements"
-        # Anchor the replacement to OLD_TEAM_ID prefix or the opening <string> tag so that
-        # if NEW_BUNDLE_ID contains OLD_BUNDLE_ID as a suffix (e.g. enterprise.com.example.foo),
+        # Anchor the replacement to OLD_TEAM_ID prefix, app group prefix, or the opening <string> tag
+        # so that if NEW_BUNDLE_ID contains OLD_BUNDLE_ID as a suffix (e.g. enterprise.com.example.foo),
         # the already-correct values (like <TEAM_ID>.enterprise.com.example.foo) do not have their
         # suffix duplicated.
+        ESCAPED_OLD_BUNDLE_ID="${OLD_BUNDLE_ID//./\\.}"
         if [ -n "$OLD_TEAM_ID" ] && [ -n "$NEW_TEAM_ID" ]; then
-            /usr/bin/sed -i .bak "s!<string>${OLD_TEAM_ID}\.${OLD_BUNDLE_ID}</string>!<string>${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
+            /usr/bin/sed -i .bak "s!<string>${OLD_TEAM_ID}\.${ESCAPED_OLD_BUNDLE_ID}</string>!<string>${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
         fi
-        /usr/bin/sed -i .bak "s!<string>${OLD_BUNDLE_ID}</string>!<string>${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
+        /usr/bin/sed -i .bak "s!<string>group\.${ESCAPED_OLD_BUNDLE_ID}</string>!<string>group.${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
+        /usr/bin/sed -i .bak "s!<string>${ESCAPED_OLD_BUNDLE_ID}</string>!<string>${NEW_BUNDLE_ID}</string>!g" "$PATCHED_ENTITLEMENTS"
 
         log "Resigning application using certificate: '$CERTIFICATE'"
         log "and patched entitlements:"

--- a/sigh/spec/resign_sh_spec.rb
+++ b/sigh/spec/resign_sh_spec.rb
@@ -173,10 +173,12 @@ describe "resign.sh" do
           NEW_BUNDLE_ID="#{new_id}"
           OLD_TEAM_ID="#{old_team_id}"
           NEW_TEAM_ID="#{new_team_id}"
+          ESCAPED_OLD_BUNDLE_ID="${OLD_BUNDLE_ID//./\\\\.}"
           if [ -n "$OLD_TEAM_ID" ] && [ -n "$NEW_TEAM_ID" ]; then
-              /usr/bin/sed -i .bak "s!<string>${OLD_TEAM_ID}\\.${OLD_BUNDLE_ID}</string>!<string>${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
+              /usr/bin/sed -i .bak "s!<string>${OLD_TEAM_ID}\\.${ESCAPED_OLD_BUNDLE_ID}</string>!<string>${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
           fi
-          /usr/bin/sed -i .bak "s!<string>${OLD_BUNDLE_ID}</string>!<string>${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
+          /usr/bin/sed -i .bak "s!<string>group\\.${ESCAPED_OLD_BUNDLE_ID}</string>!<string>group.${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
+          /usr/bin/sed -i .bak "s!<string>${ESCAPED_OLD_BUNDLE_ID}</string>!<string>${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
           cat "#{file_path}"
         BASH
         stdout, _, status = run_bash(script)
@@ -194,10 +196,12 @@ describe "resign.sh" do
     it "replaces multiple occurrences" do
       input = <<~XML
         <string>TEAM.com.old.app</string>
+        <string>group.com.old.app</string>
         <string>com.old.app</string>
       XML
       result = run_sed_replacement(input, "com.old.app", "com.new.app", "TEAM", "TEAM")
       expect(result).to include("<string>TEAM.com.new.app</string>")
+      expect(result).to include("<string>group.com.new.app</string>")
       expect(result).to include("<string>com.new.app</string>")
     end
 
@@ -217,6 +221,12 @@ describe "resign.sh" do
       expect(result.strip).to eq("<string>TEAMIDPREF.com.new.app</string>")
     end
 
+    it "replaces app group entries" do
+      input = "<string>group.com.old.app</string>"
+      result = run_sed_replacement(input, "com.old.app", "com.new.app")
+      expect(result.strip).to eq("<string>group.com.new.app</string>")
+    end
+
     it "replaces un-prefixed bundle ID entries" do
       input = "<string>com.old.app</string>"
       result = run_sed_replacement(input, "com.old.app", "com.new.app")
@@ -233,6 +243,12 @@ describe "resign.sh" do
       expect(result).to include("<string>TEAM.com.new.app</string>")
     end
 
+    it "does not match unescaped dots in bundle ID regex" do
+      input = "<string>comXoldXapp</string>"
+      result = run_sed_replacement(input, "com.old.app", "com.new.app")
+      expect(result.strip).to eq("<string>comXoldXapp</string>")
+    end
+
     it "handles multi-component bundle IDs" do
       input = "<string>TEAM.com.example.my.app</string>"
       result = run_sed_replacement(input, "com.example.my.app", "com.newco.other.app", "TEAM", "TEAM")
@@ -243,11 +259,15 @@ describe "resign.sh" do
       input = <<~XML
         <string>NEWTEAM.enterprise.com.old.app</string>
         <string>OLDTEAM.com.old.app</string>
+        <string>group.enterprise.com.old.app</string>
+        <string>group.com.old.app</string>
         <string>com.old.app</string>
       XML
       result = run_sed_replacement(input, "com.old.app", "enterprise.com.old.app", "OLDTEAM", "NEWTEAM")
       expect(result).to include("<string>NEWTEAM.enterprise.com.old.app</string>")
       expect(result).not_to include("<string>NEWTEAM.enterprise.enterprise.com.old.app</string>")
+      expect(result).to include("<string>group.enterprise.com.old.app</string>")
+      expect(result).not_to include("<string>group.enterprise.enterprise.com.old.app</string>")
       expect(result).to include("<string>enterprise.com.old.app</string>")
     end
 
@@ -255,11 +275,15 @@ describe "resign.sh" do
       input = <<~XML
         <string>TEAMID.enterprise.com.old.app</string>
         <string>TEAMID.com.old.app</string>
+        <string>group.enterprise.com.old.app</string>
+        <string>group.com.old.app</string>
         <string>com.old.app</string>
       XML
       result = run_sed_replacement(input, "com.old.app", "enterprise.com.old.app", "TEAMID", "TEAMID")
       expect(result).to include("<string>TEAMID.enterprise.com.old.app</string>")
       expect(result).not_to include("<string>TEAMID.enterprise.enterprise.com.old.app</string>")
+      expect(result).to include("<string>group.enterprise.com.old.app</string>")
+      expect(result).not_to include("<string>group.enterprise.enterprise.com.old.app</string>")
       expect(result).to include("<string>enterprise.com.old.app</string>")
     end
   end

--- a/sigh/spec/resign_sh_spec.rb
+++ b/sigh/spec/resign_sh_spec.rb
@@ -174,7 +174,7 @@ describe "resign.sh" do
           OLD_TEAM_ID="#{old_team_id}"
           NEW_TEAM_ID="#{new_team_id}"
           if [ -n "$OLD_TEAM_ID" ] && [ -n "$NEW_TEAM_ID" ]; then
-              /usr/bin/sed -i .bak "s!${OLD_TEAM_ID}\\.${OLD_BUNDLE_ID}</string>!${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
+              /usr/bin/sed -i .bak "s!<string>${OLD_TEAM_ID}\\.${OLD_BUNDLE_ID}</string>!<string>${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
           fi
           /usr/bin/sed -i .bak "s!<string>${OLD_BUNDLE_ID}</string>!<string>${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
           cat "#{file_path}"

--- a/sigh/spec/resign_sh_spec.rb
+++ b/sigh/spec/resign_sh_spec.rb
@@ -164,14 +164,19 @@ describe "resign.sh" do
       skip("BSD sed required (macOS only)") unless RUBY_PLATFORM.include?("darwin")
     end
 
-    def run_sed_replacement(input_xml, old_id, new_id)
+    def run_sed_replacement(input_xml, old_id, new_id, old_team_id = "TEAM", new_team_id = "TEAM")
       Dir.mktmpdir do |dir|
         file_path = File.join(dir, "entitlements.plist")
         File.write(file_path, input_xml)
         script = <<~BASH
           OLD_BUNDLE_ID="#{old_id}"
           NEW_BUNDLE_ID="#{new_id}"
-          /usr/bin/sed -i .bak "s!${OLD_BUNDLE_ID}</string>!${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
+          OLD_TEAM_ID="#{old_team_id}"
+          NEW_TEAM_ID="#{new_team_id}"
+          if [ -n "$OLD_TEAM_ID" ] && [ -n "$NEW_TEAM_ID" ]; then
+              /usr/bin/sed -i .bak "s!${OLD_TEAM_ID}\\.${OLD_BUNDLE_ID}</string>!${NEW_TEAM_ID}.${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
+          fi
+          /usr/bin/sed -i .bak "s!<string>${OLD_BUNDLE_ID}</string>!<string>${NEW_BUNDLE_ID}</string>!g" "#{file_path}"
           cat "#{file_path}"
         BASH
         stdout, _, status = run_bash(script)
@@ -182,18 +187,18 @@ describe "resign.sh" do
 
     it "replaces bundle ID before </string> tag" do
       input = "<string>AB1GP98Q19.com.old.app</string>"
-      result = run_sed_replacement(input, "com.old.app", "com.new.app")
+      result = run_sed_replacement(input, "com.old.app", "com.new.app", "AB1GP98Q19", "AB1GP98Q19")
       expect(result.strip).to eq("<string>AB1GP98Q19.com.new.app</string>")
     end
 
     it "replaces multiple occurrences" do
       input = <<~XML
         <string>TEAM.com.old.app</string>
-        <string>group.com.old.app</string>
+        <string>com.old.app</string>
       XML
-      result = run_sed_replacement(input, "com.old.app", "com.new.app")
+      result = run_sed_replacement(input, "com.old.app", "com.new.app", "TEAM", "TEAM")
       expect(result).to include("<string>TEAM.com.new.app</string>")
-      expect(result).to include("<string>group.com.new.app</string>")
+      expect(result).to include("<string>com.new.app</string>")
     end
 
     it "only replaces before </string> tag, not </key>" do
@@ -201,21 +206,21 @@ describe "resign.sh" do
         <key>com.old.app</key>
         <string>TEAM.com.old.app</string>
       XML
-      result = run_sed_replacement(input, "com.old.app", "com.new.app")
+      result = run_sed_replacement(input, "com.old.app", "com.new.app", "TEAM", "TEAM")
       expect(result).to include("<key>com.old.app</key>")
       expect(result).to include("<string>TEAM.com.new.app</string>")
     end
 
     it "preserves team ID prefix" do
       input = "<string>TEAMIDPREF.com.old.app</string>"
-      result = run_sed_replacement(input, "com.old.app", "com.new.app")
+      result = run_sed_replacement(input, "com.old.app", "com.new.app", "TEAMIDPREF", "TEAMIDPREF")
       expect(result.strip).to eq("<string>TEAMIDPREF.com.new.app</string>")
     end
 
-    it "replaces app group entries" do
-      input = "<string>group.com.old.app</string>"
+    it "replaces un-prefixed bundle ID entries" do
+      input = "<string>com.old.app</string>"
       result = run_sed_replacement(input, "com.old.app", "com.new.app")
-      expect(result.strip).to eq("<string>group.com.new.app</string>")
+      expect(result.strip).to eq("<string>com.new.app</string>")
     end
 
     it "does not match partial IDs with extra suffix" do
@@ -223,15 +228,39 @@ describe "resign.sh" do
         <string>TEAM.com.old.app.extra</string>
         <string>TEAM.com.old.app</string>
       XML
-      result = run_sed_replacement(input, "com.old.app", "com.new.app")
+      result = run_sed_replacement(input, "com.old.app", "com.new.app", "TEAM", "TEAM")
       expect(result).to include("<string>TEAM.com.old.app.extra</string>")
       expect(result).to include("<string>TEAM.com.new.app</string>")
     end
 
     it "handles multi-component bundle IDs" do
       input = "<string>TEAM.com.example.my.app</string>"
-      result = run_sed_replacement(input, "com.example.my.app", "com.newco.other.app")
+      result = run_sed_replacement(input, "com.example.my.app", "com.newco.other.app", "TEAM", "TEAM")
       expect(result.strip).to eq("<string>TEAM.com.newco.other.app</string>")
+    end
+
+    it "does not duplicate prefix when new bundle ID has old bundle ID as suffix (issue #30167)" do
+      input = <<~XML
+        <string>NEWTEAM.enterprise.com.old.app</string>
+        <string>OLDTEAM.com.old.app</string>
+        <string>com.old.app</string>
+      XML
+      result = run_sed_replacement(input, "com.old.app", "enterprise.com.old.app", "OLDTEAM", "NEWTEAM")
+      expect(result).to include("<string>NEWTEAM.enterprise.com.old.app</string>")
+      expect(result).not_to include("<string>NEWTEAM.enterprise.enterprise.com.old.app</string>")
+      expect(result).to include("<string>enterprise.com.old.app</string>")
+    end
+
+    it "handles same-team resign with prefixed bundle ID (issue #30167)" do
+      input = <<~XML
+        <string>TEAMID.enterprise.com.old.app</string>
+        <string>TEAMID.com.old.app</string>
+        <string>com.old.app</string>
+      XML
+      result = run_sed_replacement(input, "com.old.app", "enterprise.com.old.app", "TEAMID", "TEAMID")
+      expect(result).to include("<string>TEAMID.enterprise.com.old.app</string>")
+      expect(result).not_to include("<string>TEAMID.enterprise.enterprise.com.old.app</string>")
+      expect(result).to include("<string>enterprise.com.old.app</string>")
     end
   end
 


### PR DESCRIPTION
### Motivation

Fixes #30167.

When using `resign` with `use_app_entitlements: true`, if the new bundle identifier is the old bundle identifier prefixed with an additional segment (e.g. old = `com.app.test`, new = `enterprise.com.app.test`), the unanchored `sed` replacement in `resign.sh` matched against the trailing substring of the already-correct `application-identifier` entitlement (`<TEAM_ID>.enterprise.com.app.test`), rewriting it into `<TEAM_ID>.enterprise.enterprise.com.app.test`.

### Modifications

In `sigh/lib/assets/resign.sh`:
- Anchored the replacement of `OLD_BUNDLE_ID` to the Team ID prefix (`\.</string>` -> `.</string>`) when team IDs are present.
- Anchored un-prefixed occurrences to the opening `<string>` tag (`<string></string>` -> `<string></string>`).

### Result

When resigning with `use_app_entitlements: true` where the new bundle ID prefixes the old bundle ID, the resulting entitlements preserve the correct `application-identifier` without duplicated prefixes.