### PR TITLE
[supply] Add chromebookScreenshots to supported screenshot types

### DIFF
--- a/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_play_store.md
@@ -145,6 +145,7 @@ You can also supply screenshots by creating directories within the `images` dire
 - `tenInchScreenshots/` (10-inch tablets)
 - `tvScreenshots/`
 - `wearScreenshots/`
+- `chromebookScreenshots/`
 
 You may name images anything you like, but screenshots will appear in the Play Store in alphanumerical filename order.
 Note that these will replace the current images and screenshots on the play store listing, not add to them.

--- a/supply/lib/supply.rb
+++ b/supply/lib/supply.rb
@@ -19,7 +19,7 @@ module Supply
 
   AVAILABLE_METADATA_FIELDS = %w(title short_description full_description video)
   IMAGES_TYPES = %w(featureGraphic icon tvBanner) # https://developers.google.com/android-publisher/api-ref/rest/v3/AppImageType
-  SCREENSHOT_TYPES = %w(phoneScreenshots sevenInchScreenshots tenInchScreenshots tvScreenshots wearScreenshots)
+  SCREENSHOT_TYPES = %w(phoneScreenshots sevenInchScreenshots tenInchScreenshots tvScreenshots wearScreenshots chromebookScreenshots)
 
   IMAGES_FOLDER_NAME = "images"
   IMAGE_FILE_EXTENSIONS = "{png,jpg,jpeg}"

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -710,5 +710,11 @@ describe Supply do
         end
       end
     end
+
+    describe 'Supply::SCREENSHOT_TYPES' do
+      it 'includes chromebookScreenshots' do
+        expect(Supply::SCREENSHOT_TYPES).to include('chromebookScreenshots')
+      end
+    end
   end
 end

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -716,5 +716,33 @@ describe Supply do
         expect(Supply::SCREENSHOT_TYPES).to include('chromebookScreenshots')
       end
     end
+
+    context 'when sync_image_upload is not set' do
+      let(:client) { double('client') }
+      let(:language) { 'en-US' }
+      let(:config) { { metadata_path: 'spec_metadata', sync_image_upload: false } }
+
+      before do
+        Supply.config = config
+        allow(Supply::Client).to receive(:make_from_config).and_return(client)
+      end
+
+      it 'clears and uploads chromebook screenshots when present locally' do
+        chromebook_path = 'spec_metadata/en-US/images/chromebookScreenshots/1.png'
+        allow(Dir).to receive(:glob) do |pattern, *|
+          if pattern.include?('chromebookScreenshots')
+            [chromebook_path]
+          else
+            []
+          end
+        end
+
+        expect(client).to receive(:clear_screenshots).with(image_type: 'chromebookScreenshots', language: language)
+        expect(client).to receive(:upload_image).with(image_path: File.expand_path(chromebook_path), image_type: 'chromebookScreenshots', language: language)
+
+        uploader = Supply::Uploader.new
+        uploader.upload_screenshots(language)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description
Fixes #29948.

Google Play Store supports `chromebookScreenshots` in the Google Play Developer Publishing API (`AppImageType` v3), but `Supply::SCREENSHOT_TYPES` previously omitted it from the list of recognized screenshot directories (`%w(phoneScreenshots sevenInchScreenshots tenInchScreenshots tvScreenshots wearScreenshots)`).

As a result:
- `fastlane supply` skipped uploading screenshots placed under `metadata/android/<locale>/images/chromebookScreenshots/`.
- `fastlane supply init` did not create or download Chromebook screenshot directories from the Play Console.

This PR adds `chromebookScreenshots` to `Supply::SCREENSHOT_TYPES`, enabling `supply` to download and upload Chromebook screenshots seamlessly alongside phone, tablet, TV, and Wear OS screenshots.

### Testing Steps
- Added an RSpec test in `supply/spec/uploader_spec.rb` verifying `Supply::SCREENSHOT_TYPES` includes `'chromebookScreenshots'`.
- Ran full test suite with `bundle exec rspec supply/spec/` (61 examples, 0 failures).
- Verified code formatting with `rubocop supply/lib/supply.rb supply/spec/uploader_spec.rb` (no offenses).
