### PR TITLE
[ci] unset GEM_HOST_API_KEY for GHA publish

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -292,7 +292,8 @@ lane :create_github_release do |options|
     download_github_release_gem(version: version)
   end
 
-  sh "gem push --key github --host https://rubygems.pkg.github.com/#{github_username} #{gem_path}" unless options[:skip_github_packages]
+  # Unset GEM_HOST_API_KEY as GitHub Action (rubygems/configure-rubygems-credentials) sets it.
+  sh "env -u GEM_HOST_API_KEY gem push --key github --host https://rubygems.pkg.github.com/#{github_username} #{gem_path}" unless options[:skip_github_packages]
 
   sh "gem push #{gem_path}" unless options[:skip_rubygems]
 end


### PR DESCRIPTION
## Problem

Deploys to GHA have been failing for a long time. It turns out that when we moved to Trusted Publishing, the action sets an env var (`GEM_HOST_API_KEY`) which takes precedence over the existing one we set.

## Solution

Unset that var so we can rely on our manually configured `.gem/credentials` for auth.