### PR TITLE
Fix flaky fastlane_pty_spec by applying the PTY flush workaround

### DIFF
--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -4,9 +4,15 @@ describe FastlaneCore do
       it 'executes a simple command successfully' do
         @all_lines = []
 
-        exit_status = FastlaneCore::FastlanePty.spawn('echo foo') do |command_stdout, command_stdin, pid|
-          command_stdout.each do |line|
-            @all_lines << line.chomp
+        # Without the workaround this reads back nothing every few thousand runs,
+        # which is #21792 again: a command that exits immediately can leave the
+        # pty with nothing to read. command_executor_spec covers the same path
+        # and sets this for the same reason.
+        exit_status = FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => '1') do
+          FastlaneCore::FastlanePty.spawn('echo foo') do |command_stdout, command_stdin, pid|
+            command_stdout.each do |line|
+              @all_lines << line.chomp
+            end
           end
         end
         expect(exit_status).to eq(0)


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green GitHub Action builds in the "All checks have passed" section of my PR.
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

`fastlane_core/spec/fastlane_pty_spec.rb` "executes a simple command successfully" fails
intermittently on CI:

```
1) FastlaneCore FastlaneCore::FastlanePty spawn executes a simple command successfully
   Failure/Error: expect(@all_lines).to eq(["foo"])
   expected: ["foo"]
        got: []
```

This is #21792 again. #21793 fixed that by adding `FASTLANE_EXEC_FLUSH_PTY_WORKAROUND` and applying it to `command_executor_spec.rb`, but this spec exercises the same real `PTY.spawn` + read path and was never given the workaround, so it is still exposed. It is the only remaining caller of that path without it.

The failure is not a lost write. Two measurements:

- Output already written is never dropped: sleeping in the parent so the child exits first still returns the data, 30/30 for every variant tried.
- A pty master with no slave open returns `EOFError` immediately, where a master with a slave open blocks and waits.

So a failing run is one where the first read lands in a window with no slave open and nothing buffered: `each` gets EOF at once and returns nothing, while the exit status is still 0 — exactly the observed symptom. What governs the exposure is how briefly the child holds the pty open, not how much it prints, which is why `echo foo` is close to a worst case and why real commands such as `xcodebuild` are not affected.

### Description

Wrap the spawn call in `FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => '1')`,
exactly as `command_executor_spec.rb:13` already does, and note why it is there.

### Testing Steps

Reproduced against `FastlaneCore::FastlanePty` itself, eight processes in parallel on macOS. It does not reproduce on an idle machine, which is why it only appears on loaded runners:

| | failures | runs |
| --- | --- | --- |
| idle, no workaround | 0 | 20,000 |
| under contention, no workaround | 1 | 32,000 |
| under contention, with workaround | 0 | 64,000 |

That rate matches the ~3 in 10,000 reported in #21792.
