### PR TITLE
Stop the pilot transporter specs querying the real Keychain

### DIFF
--- a/pilot/spec/build_manager_spec.rb
+++ b/pilot/spec/build_manager_spec.rb
@@ -951,6 +951,14 @@ describe "Build Manager" do
   end
 
   describe "#transporter_for_selected_team" do
+    before do
+      # Building an ItunesTransporter looks up an application-specific password in the
+      # keychain before falling back to DELIVER_PASSWORD. Left unstubbed these examples
+      # query the real keychain, so which path they take depends on whoever runs them.
+      # nil is what that lookup returns on a machine with no matching entry.
+      allow(Security::InternetPassword).to receive(:find).and_return(nil)
+    end
+
     let(:fake_manager) { Pilot::BuildManager.new }
     let(:fake_team_api_key_json_path) do
       "./spaceship/spec/connect_api/fixtures/asc_key.json"


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green GitHub Action builds in the "All checks have passed" section of my PR.
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

`#transporter_for_selected_team` builds an `ItunesTransporter`, whose initializer calls `load_password_for_transporter`. That method looks up an application-specific password through `Security::InternetPassword.find` before falling back to `DELIVER_PASSWORD`, which `pilot/spec/spec_helper.rb` sets. Nothing stubs the lookup, so four examples perform a real macOS Keychain query, and which path they take depends on whether the machine running them happens to hold an entry for `deliver.appspecific.<user>`.

These are transporter selection tests. The keychain call is incidental to what they assert, and it makes them dependent on developer machine state.

### Description

Stub `Security::InternetPassword.find` to `nil` for that describe block. `nil` is what the lookup already returns on a machine with no matching entry, so the examples keep taking exactly the path they take today — the application-specific lookup finds nothing, and `DELIVER_PASSWORD` supplies the password — only deterministically and without touching the keychain.

### Testing Steps

Verified the stub is actually reached rather than decorative: with `and_raise` substituted for `and_return(nil)`, exactly four examples fail, at lines 1008, 1021, 1036 and 1052. The API key examples stay green, since they take the JWT path where `@user` is nil and `load_password_for_transporter` is never called, which is also why they legitimately assert a nil password.

With the stub as committed, on Ruby 4.0.5:

- `rspec pilot/spec/build_manager_spec.rb` — 53 examples, 0 failures
- full suite — 7847 examples, 6 failures, all six pre-existing and reproduced on `master` without this change (`project_spec.rb:453,458,478` and `plugin_generator_spec.rb:290,296,302`, local environment issues)
- `rubocop` on the changed file — no offenses
