### PR TITLE
Surface xcresulttool version detection failures instead of hiding them

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -689,7 +689,7 @@ Style/RedundantSort:
 Style/RedundantStringEscape:
   Enabled: false
 
-# Offense count: 192
+# Offense count: 210
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: implicit, explicit

--- a/trainer/lib/trainer/xcresult/helper.rb
+++ b/trainer/lib/trainer/xcresult/helper.rb
@@ -32,6 +32,29 @@ module Trainer
         node['children'].select { |child| node_types.include?(child['nodeType']) }
       end
 
+      # The version of the xcresulttool on the current PATH
+      #
+      # Not memoized: `xcrun` resolves through DEVELOPER_DIR, which the xcode_select,
+      # xcversion, xcodes and xcode_install actions change during a run, so the answer
+      # can differ between two calls in the same process.
+      #
+      # @return [Gem::Version, nil] The version, or nil when there is no xcrun to ask
+      def self.xcresulttool_version
+        # e.g. DEVELOPER_DIR=/Applications/Xcode_16_beta_3.app
+        # xcresulttool version 23021, format version 3.53 (current)
+        # xcresulttool version 24408, schema version: 0.1.0 (legacy commands format version: 3.56)
+        output = `xcrun xcresulttool version`
+        match = output.match(/xcresulttool version (?<version>[\d.]+)/)
+        raise "Could not read the xcresulttool version from #{output.strip.inspect}" if match.nil?
+
+        Gem::Version.new(match[:version])
+      rescue Errno::ENOENT
+        # No xcrun at all: not macOS, or no developer tools installed. Every other
+        # failure is left to surface, so a change in what xcresulttool reports is not
+        # silently read as "this version is not supported".
+        nil
+      end
+
       # Check if the current xcresulttool supports new commands introduced in Xcode 16+
       #
       # Since Xcode 16b3, xcresulttool has marked `get <object> --format json` as deprecated/legacy,
@@ -39,24 +62,15 @@ module Trainer
       #
       # @return [Boolean] Whether the xcresulttool supports Xcode 16+ commands
       def self.supports_xcresulttool_version_23?
-        # e.g. DEVELOPER_DIR=/Applications/Xcode_16_beta_3.app
-        # xcresulttool version 23021, format version 3.53 (current)
-        match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>[\d.]+)/)
-        version = match[:version]
+        version = xcresulttool_version
 
-        Gem::Version.new(version) >= Gem::Version.new(23_021)
-      rescue
-        false
+        !version.nil? && version >= Gem::Version.new(23_021)
       end
 
       def self.supports_xcresulttool_version_24?
-        # xcresulttool version 24408, schema version: 0.1.0 (legacy commands format version: 3.56)
-        match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>[\d.]+)/)
-        version = match[:version]
+        version = xcresulttool_version
 
-        Gem::Version.new(version) >= Gem::Version.new(24_408)
-      rescue
-        false
+        !version.nil? && version >= Gem::Version.new(24_408)
       end
     end
   end

--- a/trainer/spec/xcresult_helper_spec.rb
+++ b/trainer/spec/xcresult_helper_spec.rb
@@ -1,0 +1,89 @@
+describe Trainer do
+  describe Trainer::XCResult::Helper do
+    def stub_version_output(output)
+      allow(Trainer::XCResult::Helper).to receive(:`).with('xcrun xcresulttool version').and_return(output)
+    end
+
+    describe "#xcresulttool_version" do
+      it 'reads the version out of what xcresulttool reports' do
+        stub_version_output('xcresulttool version 23021, format version 3.53 (current)')
+        expect(Trainer::XCResult::Helper.xcresulttool_version).to eq(Gem::Version.new(23_021))
+      end
+
+      it 'reads the version from the newer banner shape' do
+        stub_version_output('xcresulttool version 24408, schema version: 0.1.0 (legacy commands format version: 3.56)')
+        expect(Trainer::XCResult::Helper.xcresulttool_version).to eq(Gem::Version.new(24_408))
+      end
+
+      it 'returns nil when there is no xcrun to ask' do
+        allow(Trainer::XCResult::Helper).to receive(:`).with('xcrun xcresulttool version').and_raise(Errno::ENOENT)
+        expect(Trainer::XCResult::Helper.xcresulttool_version).to be_nil
+      end
+
+      it 'raises when the output cannot be read, rather than reporting no support' do
+        stub_version_output("xcrun: error: unable to find utility \"xcresulttool\"\n")
+        expect do
+          Trainer::XCResult::Helper.xcresulttool_version
+        end.to raise_error(/Could not read the xcresulttool version from/)
+      end
+
+      it 'raises when the output is empty' do
+        stub_version_output('')
+        expect { Trainer::XCResult::Helper.xcresulttool_version }.to raise_error(/Could not read the xcresulttool version/)
+      end
+    end
+
+    describe "#supports_xcresulttool_version_23?" do
+      it 'is true from 23021 onwards' do
+        stub_version_output('xcresulttool version 23021, format version 3.53 (current)')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_23?).to be(true)
+      end
+
+      it 'is true for a newer major version' do
+        stub_version_output('xcresulttool version 24408, schema version: 0.1.0')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_23?).to be(true)
+      end
+
+      it 'is false for an older version' do
+        stub_version_output('xcresulttool version 22608, format version 3.49 (current)')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_23?).to be(false)
+      end
+
+      it 'is false when there is no xcrun to ask' do
+        allow(Trainer::XCResult::Helper).to receive(:`).with('xcrun xcresulttool version').and_raise(Errno::ENOENT)
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_23?).to be(false)
+      end
+
+      it 'raises when the version cannot be read, rather than reporting no support' do
+        stub_version_output("xcrun: error: unable to find utility \"xcresulttool\"\n")
+        expect do
+          Trainer::XCResult::Helper.supports_xcresulttool_version_23?
+        end.to raise_error(/Could not read the xcresulttool version/)
+      end
+    end
+
+    describe "#supports_xcresulttool_version_24?" do
+      it 'is true from 24408 onwards' do
+        stub_version_output('xcresulttool version 24408, schema version: 0.1.0')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_24?).to be(true)
+      end
+
+      it 'is false for version 23' do
+        stub_version_output('xcresulttool version 23021, format version 3.53 (current)')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_24?).to be(false)
+      end
+
+      it 'is false when there is no xcrun to ask' do
+        allow(Trainer::XCResult::Helper).to receive(:`).with('xcrun xcresulttool version').and_raise(Errno::ENOENT)
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_24?).to be(false)
+      end
+
+      it 'raises when the version cannot be read, rather than reporting no support' do
+        stub_version_output("xcrun: error: unable to find utility \"xcresulttool\"\n")
+        expect do
+          Trainer::XCResult::Helper.supports_xcresulttool_version_24?
+        end.to raise_error(/Could not read the xcresulttool version/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green GitHub Action builds in the "All checks have passed" section of my PR.
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

`Trainer::XCResult::Helper.supports_xcresulttool_version_23?` and `_24?` each shell out to `xcrun` and wrap the whole body in a bare `rescue false`. That single rescue covers two very different situations.

`Errno::ENOENT`, meaning there is no `xcrun` to ask, for which `false` is the right answer. And a `NoMethodError` from `match[:version]` when the output does not match the regexp at all, for which `false` is a guess. An `xcrun` that runs but errors because no Xcode is selected, or a future release that reports its version in a different shape, both come back as "this version is not supported".

Nothing surfaces when that happens. `test_parser.rb:104` quietly selects the legacy parser, `legacy_xcresult.rb:580` quietly stops passing `--legacy`, and the version gated specs in `test_parser_spec.rb` quietly stop running while still reporting as pending. The failure mode is silent degradation, which is the hardest kind to notice.

`Style/RescueStandardError` would have flagged the original, but it is disabled in `.rubocop_todo.yml:696` with an offense count of 192, parked there by the rubocop bump in #18564 in 2021.

### Description

Extract `xcresulttool_version`, which returns `nil` only for `Errno::ENOENT` and otherwise raises with the output it could not read, then define both predicates on top of it. That also removes the duplicated command and regexp, which is how the two methods came to have identical bodies differing only in a constant.

Deliberately not memoized. `xcrun` resolves through `DEVELOPER_DIR`, and the `xcode_select`, `xcversion`, `xcodes` and `xcode_install` actions all assign it during a run, so two calls in the same process can legitimately return different answers. There is a comment in the code to that effect so nobody adds a cache later.

The call keeps the exact `` `xcrun xcresulttool version` `` shape on `Helper`, because `test_parser_spec.rb:35` stubs that literal, so the existing trainer specs are untouched.

### Note for reviewers

This is a behaviour change in library code, not only in tests. A user whose `xcrun` runs but errors currently gets a silently degraded run through the legacy parser; afterwards they get an exception naming what could not be read. I believe that is the right trade, but it deserves a deliberate look rather than passing unnoticed alongside the refactor.

### Testing Steps

14 new examples in `trainer/spec/xcresult_helper_spec.rb`, covering both banner shapes, an older version, a missing `xcrun`, unreadable output and empty output.

Checked that they would actually have caught the old behaviour: with the helper reverted to `master`, 7 of the 14 fail. The two that matter most are the predicate cases, which assert that unreadable output now raises where the old code returned `false`.

On Ruby 4.0.5:

- `rspec trainer/spec` — 40 examples, 0 failures, 2 pending, the pending pair being the xcresulttool 23 fixtures which do not apply on a version 24 machine
- full suite — 7861 examples, 6 failures, all six pre-existing and reproduced on `master` without this change (`project_spec.rb:453,458,478` and `plugin_generator_spec.rb:290,296,302`, local environment issues)
- `rubocop` on both changed files — no offenses
