### PR TITLE
Define only the trainer fixture groups that apply to the current xcresulttool

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -689,7 +689,7 @@ Style/RedundantSort:
 Style/RedundantStringEscape:
   Enabled: false
 
-# Offense count: 192
+# Offense count: 210
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: implicit, explicit

--- a/trainer/lib/trainer/xcresult/helper.rb
+++ b/trainer/lib/trainer/xcresult/helper.rb
@@ -32,6 +32,29 @@ module Trainer
         node['children'].select { |child| node_types.include?(child['nodeType']) }
       end
 
+      # The version of the xcresulttool on the current PATH
+      #
+      # Not memoized: `xcrun` resolves through DEVELOPER_DIR, which the xcode_select,
+      # xcversion, xcodes and xcode_install actions change during a run, so the answer
+      # can differ between two calls in the same process.
+      #
+      # @return [Gem::Version, nil] The version, or nil when there is no xcrun to ask
+      def self.xcresulttool_version
+        # e.g. DEVELOPER_DIR=/Applications/Xcode_16_beta_3.app
+        # xcresulttool version 23021, format version 3.53 (current)
+        # xcresulttool version 24408, schema version: 0.1.0 (legacy commands format version: 3.56)
+        output = `xcrun xcresulttool version`
+        match = output.match(/xcresulttool version (?<version>[\d.]+)/)
+        raise "Could not read the xcresulttool version from #{output.strip.inspect}" if match.nil?
+
+        Gem::Version.new(match[:version])
+      rescue Errno::ENOENT
+        # No xcrun at all: not macOS, or no developer tools installed. Every other
+        # failure is left to surface, so a change in what xcresulttool reports is not
+        # silently read as "this version is not supported".
+        nil
+      end
+
       # Check if the current xcresulttool supports new commands introduced in Xcode 16+
       #
       # Since Xcode 16b3, xcresulttool has marked `get <object> --format json` as deprecated/legacy,
@@ -39,24 +62,15 @@ module Trainer
       #
       # @return [Boolean] Whether the xcresulttool supports Xcode 16+ commands
       def self.supports_xcresulttool_version_23?
-        # e.g. DEVELOPER_DIR=/Applications/Xcode_16_beta_3.app
-        # xcresulttool version 23021, format version 3.53 (current)
-        match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>[\d.]+)/)
-        version = match[:version]
+        version = xcresulttool_version
 
-        Gem::Version.new(version) >= Gem::Version.new(23_021)
-      rescue
-        false
+        !version.nil? && version >= Gem::Version.new(23_021)
       end
 
       def self.supports_xcresulttool_version_24?
-        # xcresulttool version 24408, schema version: 0.1.0 (legacy commands format version: 3.56)
-        match = `xcrun xcresulttool version`.match(/xcresulttool version (?<version>[\d.]+)/)
-        version = match[:version]
+        version = xcresulttool_version
 
-        Gem::Version.new(version) >= Gem::Version.new(24_408)
-      rescue
-        false
+        !version.nil? && version >= Gem::Version.new(24_408)
       end
     end
   end

--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -399,93 +399,96 @@ describe Trainer do
   end
 
   describe Trainer::XCResult::Parser do
-    it 'generates same data for legacy and new commands', requires_xcodebuild: true do
-      skip "Requires Xcode 16 or higher" unless Trainer::XCResult::Helper.supports_xcresulttool_version_23?
+    # Read once at load. Each fixture group below encodes the output of one
+    # xcresulttool version, so the groups that do not apply to this machine are
+    # left undefined rather than defined and skipped. Unlike the actions, the
+    # suite never switches Xcode mid-run, so reading this once is safe here.
+    xcresulttool_23 = Trainer::XCResult::Helper.supports_xcresulttool_version_23?
+    xcresulttool_24 = Trainer::XCResult::Helper.supports_xcresulttool_version_24?
 
-      xcresult_path = File.expand_path('../fixtures/Test.test_result.xcresult', __FILE__)
+    if xcresulttool_23
+      it 'generates same data for legacy and new commands', requires_xcodebuild: true do
+        xcresult_path = File.expand_path('../fixtures/Test.test_result.xcresult', __FILE__)
 
-      keys_to_compare = [
-        :number_of_tests,
-        :number_of_failures,
-        :number_of_tests_excluding_retries,
-        :number_of_failures_excluding_retries,
-        :number_of_retries,
-        :number_of_skipped
-      ]
+        keys_to_compare = [
+          :number_of_tests,
+          :number_of_failures,
+          :number_of_tests_excluding_retries,
+          :number_of_failures_excluding_retries,
+          :number_of_retries,
+          :number_of_skipped
+        ]
 
-      new_parser_data = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path).map do |hash|
-        hash.slice(*keys_to_compare)
-      end
+        new_parser_data = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path).map do |hash|
+          hash.slice(*keys_to_compare)
+        end
 
-      legacy_parser_data = Trainer::LegacyXCResult::Parser.parse_xcresult(path: xcresult_path).map do |hash|
-        hash.slice(*keys_to_compare)
-      end
+        legacy_parser_data = Trainer::LegacyXCResult::Parser.parse_xcresult(path: xcresult_path).map do |hash|
+          hash.slice(*keys_to_compare)
+        end
 
-      expect(legacy_parser_data).to eq(new_parser_data)
-    end
-
-    describe 'Xcode 16 (xcresulttool 23) xcresult bundle' do
-      let(:xcresult_path) { File.expand_path('../fixtures/Xcode16-Mixed-XCTest-SwiftTesting.xcresult', __FILE__) }
-      let(:json_fixture_path) { File.expand_path("../fixtures/Xcode16-Mixed-XCTest-SwiftTesting.json", __FILE__) }
-      let(:json_fixture) { JSON.parse(File.read(json_fixture_path)) }
-
-      it 'generates correct JUnit XML including retries', requires_xcodebuild: true do
-        skip "Requires xcresulttool version 23" unless Trainer::XCResult::Helper.supports_xcresulttool_version_23? && !Trainer::XCResult::Helper.supports_xcresulttool_version_24?
-
-        # Uncomment this if you want to bypass the xcresult_to_json call during testing
-        # allow(Trainer::XCResult::Parser).to receive(:xcresult_to_json).with(xcresult_path).and_return(json_fixture)
-
-        test_plan = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path)
-        junit_xml = test_plan.to_xml
-
-        expected_xml_path = File.expand_path('../fixtures/Xcode16-Mixed-XCTest-SwiftTesting-WithRetries.junit', __FILE__)
-        expected_xml = File.read(expected_xml_path)
-        expect(junit_xml.chomp).to eq(expected_xml.chomp)
-      end
-
-      it 'generates correct JUnit XML excluding retries', requires_xcodebuild: true do
-        skip "Requires xcresulttool version 23" unless Trainer::XCResult::Helper.supports_xcresulttool_version_23? && !Trainer::XCResult::Helper.supports_xcresulttool_version_24?
-
-        # Uncomment this if you want to bypass the xcresult_to_json call during testing
-        # allow(Trainer::XCResult::Parser).to receive(:xcresult_to_json).with(xcresult_path).and_return(json_fixture)
-
-        test_plan = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path, output_remove_retry_attempts: true)
-        junit_xml = test_plan.to_xml
-        expected_xml_path = File.expand_path('../fixtures/Xcode16-Mixed-XCTest-SwiftTesting-WithoutRetries.junit', __FILE__)
-        expected_xml = File.read(expected_xml_path)
-        expect(junit_xml.chomp).to eq(expected_xml.chomp)
+        expect(legacy_parser_data).to eq(new_parser_data)
       end
     end
 
-    describe 'Xcode 26 (xcresulttool 24) xcresult bundle' do
-      let(:xcresult_path) { File.expand_path('../fixtures/Xcode26-Mixed-XCTest-SwiftTesting.xcresult', __FILE__) }
-      let(:json_fixture_path) { File.expand_path("../fixtures/Xcode26-Mixed-XCTest-SwiftTesting.json", __FILE__) }
-      let(:json_fixture) { JSON.parse(File.read(json_fixture_path)) }
+    if xcresulttool_23 && !xcresulttool_24
+      describe 'Xcode 16 (xcresulttool 23) xcresult bundle' do
+        let(:xcresult_path) { File.expand_path('../fixtures/Xcode16-Mixed-XCTest-SwiftTesting.xcresult', __FILE__) }
+        let(:json_fixture_path) { File.expand_path("../fixtures/Xcode16-Mixed-XCTest-SwiftTesting.json", __FILE__) }
+        let(:json_fixture) { JSON.parse(File.read(json_fixture_path)) }
 
-      it 'generates correct JUnit XML including retries', requires_xcodebuild: true do
-        skip "Requires xcresulttool version 24" unless Trainer::XCResult::Helper.supports_xcresulttool_version_24?
+        it 'generates correct JUnit XML including retries', requires_xcodebuild: true do
+          # Uncomment this if you want to bypass the xcresult_to_json call during testing
+          # allow(Trainer::XCResult::Parser).to receive(:xcresult_to_json).with(xcresult_path).and_return(json_fixture)
 
-        # Uncomment this if you want to bypass the xcresult_to_json call during testing
-        # allow(Trainer::XCResult::Parser).to receive(:xcresult_to_json).with(xcresult_path).and_return(json_fixture)
-        test_plan = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path)
-        junit_xml = test_plan.to_xml
+          test_plan = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path)
+          junit_xml = test_plan.to_xml
 
-        expected_xml_path = File.expand_path('../fixtures/Xcode26-Mixed-XCTest-SwiftTesting-WithRetries.junit', __FILE__)
-        expected_xml = File.read(expected_xml_path)
-        expect(junit_xml.chomp).to eq(expected_xml.chomp)
+          expected_xml_path = File.expand_path('../fixtures/Xcode16-Mixed-XCTest-SwiftTesting-WithRetries.junit', __FILE__)
+          expected_xml = File.read(expected_xml_path)
+          expect(junit_xml.chomp).to eq(expected_xml.chomp)
+        end
+
+        it 'generates correct JUnit XML excluding retries', requires_xcodebuild: true do
+          # Uncomment this if you want to bypass the xcresult_to_json call during testing
+          # allow(Trainer::XCResult::Parser).to receive(:xcresult_to_json).with(xcresult_path).and_return(json_fixture)
+
+          test_plan = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path, output_remove_retry_attempts: true)
+          junit_xml = test_plan.to_xml
+          expected_xml_path = File.expand_path('../fixtures/Xcode16-Mixed-XCTest-SwiftTesting-WithoutRetries.junit', __FILE__)
+          expected_xml = File.read(expected_xml_path)
+          expect(junit_xml.chomp).to eq(expected_xml.chomp)
+        end
       end
+    end
 
-      it 'generates correct JUnit XML excluding retries', requires_xcodebuild: true do
-        skip "Requires xcresulttool version 24" unless Trainer::XCResult::Helper.supports_xcresulttool_version_24?
+    if xcresulttool_24
+      describe 'Xcode 26 (xcresulttool 24) xcresult bundle' do
+        let(:xcresult_path) { File.expand_path('../fixtures/Xcode26-Mixed-XCTest-SwiftTesting.xcresult', __FILE__) }
+        let(:json_fixture_path) { File.expand_path("../fixtures/Xcode26-Mixed-XCTest-SwiftTesting.json", __FILE__) }
+        let(:json_fixture) { JSON.parse(File.read(json_fixture_path)) }
 
-        # Uncomment this if you want to bypass the xcresult_to_json call during testing
-        # allow(Trainer::XCResult::Parser).to receive(:xcresult_to_json).with(xcresult_path).and_return(json_fixture)
+        it 'generates correct JUnit XML including retries', requires_xcodebuild: true do
+          # Uncomment this if you want to bypass the xcresult_to_json call during testing
+          # allow(Trainer::XCResult::Parser).to receive(:xcresult_to_json).with(xcresult_path).and_return(json_fixture)
+          test_plan = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path)
+          junit_xml = test_plan.to_xml
 
-        test_plan = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path, output_remove_retry_attempts: true)
-        junit_xml = test_plan.to_xml
-        expected_xml_path = File.expand_path('../fixtures/Xcode26-Mixed-XCTest-SwiftTesting-WithoutRetries.junit', __FILE__)
-        expected_xml = File.read(expected_xml_path)
-        expect(junit_xml.chomp).to eq(expected_xml.chomp)
+          expected_xml_path = File.expand_path('../fixtures/Xcode26-Mixed-XCTest-SwiftTesting-WithRetries.junit', __FILE__)
+          expected_xml = File.read(expected_xml_path)
+          expect(junit_xml.chomp).to eq(expected_xml.chomp)
+        end
+
+        it 'generates correct JUnit XML excluding retries', requires_xcodebuild: true do
+          # Uncomment this if you want to bypass the xcresult_to_json call during testing
+          # allow(Trainer::XCResult::Parser).to receive(:xcresult_to_json).with(xcresult_path).and_return(json_fixture)
+
+          test_plan = Trainer::XCResult::Parser.parse_xcresult(path: xcresult_path, output_remove_retry_attempts: true)
+          junit_xml = test_plan.to_xml
+          expected_xml_path = File.expand_path('../fixtures/Xcode26-Mixed-XCTest-SwiftTesting-WithoutRetries.junit', __FILE__)
+          expected_xml = File.read(expected_xml_path)
+          expect(junit_xml.chomp).to eq(expected_xml.chomp)
+        end
       end
     end
   end

--- a/trainer/spec/xcresult_helper_spec.rb
+++ b/trainer/spec/xcresult_helper_spec.rb
@@ -1,0 +1,89 @@
+describe Trainer do
+  describe Trainer::XCResult::Helper do
+    def stub_version_output(output)
+      allow(Trainer::XCResult::Helper).to receive(:`).with('xcrun xcresulttool version').and_return(output)
+    end
+
+    describe "#xcresulttool_version" do
+      it 'reads the version out of what xcresulttool reports' do
+        stub_version_output('xcresulttool version 23021, format version 3.53 (current)')
+        expect(Trainer::XCResult::Helper.xcresulttool_version).to eq(Gem::Version.new(23_021))
+      end
+
+      it 'reads the version from the newer banner shape' do
+        stub_version_output('xcresulttool version 24408, schema version: 0.1.0 (legacy commands format version: 3.56)')
+        expect(Trainer::XCResult::Helper.xcresulttool_version).to eq(Gem::Version.new(24_408))
+      end
+
+      it 'returns nil when there is no xcrun to ask' do
+        allow(Trainer::XCResult::Helper).to receive(:`).with('xcrun xcresulttool version').and_raise(Errno::ENOENT)
+        expect(Trainer::XCResult::Helper.xcresulttool_version).to be_nil
+      end
+
+      it 'raises when the output cannot be read, rather than reporting no support' do
+        stub_version_output("xcrun: error: unable to find utility \"xcresulttool\"\n")
+        expect do
+          Trainer::XCResult::Helper.xcresulttool_version
+        end.to raise_error(/Could not read the xcresulttool version from/)
+      end
+
+      it 'raises when the output is empty' do
+        stub_version_output('')
+        expect { Trainer::XCResult::Helper.xcresulttool_version }.to raise_error(/Could not read the xcresulttool version/)
+      end
+    end
+
+    describe "#supports_xcresulttool_version_23?" do
+      it 'is true from 23021 onwards' do
+        stub_version_output('xcresulttool version 23021, format version 3.53 (current)')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_23?).to be(true)
+      end
+
+      it 'is true for a newer major version' do
+        stub_version_output('xcresulttool version 24408, schema version: 0.1.0')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_23?).to be(true)
+      end
+
+      it 'is false for an older version' do
+        stub_version_output('xcresulttool version 22608, format version 3.49 (current)')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_23?).to be(false)
+      end
+
+      it 'is false when there is no xcrun to ask' do
+        allow(Trainer::XCResult::Helper).to receive(:`).with('xcrun xcresulttool version').and_raise(Errno::ENOENT)
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_23?).to be(false)
+      end
+
+      it 'raises when the version cannot be read, rather than reporting no support' do
+        stub_version_output("xcrun: error: unable to find utility \"xcresulttool\"\n")
+        expect do
+          Trainer::XCResult::Helper.supports_xcresulttool_version_23?
+        end.to raise_error(/Could not read the xcresulttool version/)
+      end
+    end
+
+    describe "#supports_xcresulttool_version_24?" do
+      it 'is true from 24408 onwards' do
+        stub_version_output('xcresulttool version 24408, schema version: 0.1.0')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_24?).to be(true)
+      end
+
+      it 'is false for version 23' do
+        stub_version_output('xcresulttool version 23021, format version 3.53 (current)')
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_24?).to be(false)
+      end
+
+      it 'is false when there is no xcrun to ask' do
+        allow(Trainer::XCResult::Helper).to receive(:`).with('xcrun xcresulttool version').and_raise(Errno::ENOENT)
+        expect(Trainer::XCResult::Helper.supports_xcresulttool_version_24?).to be(false)
+      end
+
+      it 'raises when the version cannot be read, rather than reporting no support' do
+        stub_version_output("xcrun: error: unable to find utility \"xcresulttool\"\n")
+        expect do
+          Trainer::XCResult::Helper.supports_xcresulttool_version_24?
+        end.to raise_error(/Could not read the xcresulttool version/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Depends on #30182, which this branch is stacked on. Review that one first; the diff here is only the last commit.

### Checklist

- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green GitHub Action builds in the "All checks have passed" section of my PR.
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.
- [x] I've added or updated relevant unit tests.

### Motivation and Context

`test_parser_spec.rb` carries two fixture groups, one per xcresulttool version, each asserting against JUnit XML captured from that version. Exactly one of them applies on any given machine, and they select themselves with a `skip` at the top of each example.

That has two costs. Every run reports the inapplicable pair as pending, which reads like something is wrong when it is entirely expected. And the condition is re-evaluated per example, twice, each evaluation shelling out to `xcrun`, so four examples spawn eight subprocesses to decide whether to run.

### Description

Read the version once at load into two locals and wrap each group in the condition, so groups that do not apply are never defined.

Reading it once is safe here in a way it would not be in the library. `xcrun` resolves through `DEVELOPER_DIR`, and the `xcode_select`, `xcversion`, `xcodes` and `xcode_install` actions all change it during a run, so the library must not cache. The suite never switches Xcode, so the spec can.

The diff looks larger than it is: the group bodies are unchanged apart from indentation and the removal of the four `skip` lines.

### Testing Steps

On a machine with xcresulttool 24, `rspec trainer/spec` goes from 40 examples with 2 pending to 38 with none, and `--format doc` shows only the Xcode 26 group defined, as expected.

Full suite: 7859 examples, 6 failures, 1 pending. The single remaining pending is `gym` on a visionOS SDK, unrelated. The six failures are pre-existing and reproduce on `master` without this change (`project_spec.rb:453,458,478` and `plugin_generator_spec.rb:290,296,302`, local environment issues).

`rubocop` on the changed file reports no offenses.

Checked the failure mode as well, by making the version unreadable: rspec reports `An error occurred while loading ./trainer/spec/test_parser_spec.rb` and names the output it could not parse, so a broken detector is loud rather than silently defining nothing. That behaviour comes from #30182.
