### PR TITLE
build: move to Bundler 2.6.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,4 +452,4 @@ DEPENDENCIES
   yard (~> 0.9.42)
 
 BUNDLED WITH
-   2.5.23
+   2.6.9


### PR DESCRIPTION
## Problem

Bundler versions are old. We should track the highest version that supports the lowest Ruby version we support.

## Solution

In this case 2.6.9 is the last version to support Ruby 3.1 (our min)