### PR TITLE
Stop specs depending on module level configuration another example left behind

### DIFF
--- a/cert/spec/runner_spec.rb
+++ b/cert/spec/runner_spec.rb
@@ -49,6 +49,11 @@ describe Cert do
         end
 
         it "correctly selects expired certificates" do
+          # Cert.config is module level and the example above assigns it from
+          # its own body, so this one passed only when that had run first. See
+          # fastlane#30184.
+          Cert.config = FastlaneCore::Configuration.create(Cert::Options.available_options, keychain_path: ".")
+
           expired_cert = stub_certificate("expired_cert", false)
           good_cert = stub_certificate
 

--- a/frameit/spec/spec_helper.rb
+++ b/frameit/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+def before_each_frameit
+  # Frameit.config is module level state, normally set by the commands generator.
+  # Screenshot#initialize reads it, so a spec that builds a Screenshot without
+  # setting it depends on an earlier example having left one behind, and fails
+  # with "undefined method '[]' for nil" when it runs first. Give every example
+  # an empty one to start from; specs that need a populated config still set
+  # their own, since example group hooks run after this one.
+  Frameit.config = {}
+end

--- a/scan/spec/detect_values_spec.rb
+++ b/scan/spec/detect_values_spec.rb
@@ -237,6 +237,19 @@ describe Scan do
     end
 
     describe "#detect_simulator" do
+      before do
+        # Both Scan.config and Scan.project are module level, and
+        # detect_values.rb:30 assigns Scan.project while detecting values, so a
+        # project built by an earlier example in this file outlives it. These
+        # examples are about simulator selection and do not care about the
+        # deployment target, but resolving one reads Scan.config and then shells
+        # out to xcodebuild against whatever project was left behind. Start from
+        # a known state. See fastlane#30184.
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options,
+                                                          { project: "./scan/examples/standard/app.xcodeproj" })
+        Scan.project = nil
+      end
+
       it 'returns simulators for requested devices', requires_xcodebuild: true do
         simctl_list_devices_output = double('xcrun simctl list devices', read: File.read("./scan/spec/fixtures/XcrunSimctlListDevicesOutput15"))
         allow(Open3).to receive(:popen3).with("xcrun simctl list devices").and_yield(nil, simctl_list_devices_output, nil, nil)

--- a/scan/spec/runner_spec.rb
+++ b/scan/spec/runner_spec.rb
@@ -177,6 +177,14 @@ describe Scan do
 
     describe "retry_execute" do
       before(:each) do
+        # Every other group in this file builds its own config. This one relied
+        # on whichever of them ran first leaving one behind, and Scan.config is
+        # module level, so it outlives the example that made it. See
+        # fastlane#30184.
+        Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, {
+          project: './scan/examples/standard/app.xcodeproj'
+        })
+
         @scan = Scan::Runner.new
       end
 

--- a/scan/spec/xcpretty_reporter_options_generator_spec.rb
+++ b/scan/spec/xcpretty_reporter_options_generator_spec.rb
@@ -1,9 +1,20 @@
 describe Scan do
   describe Scan::XCPrettyReporterOptionsGenerator, requires_xcodebuild: true do
+    # Scan.config is module level and the singleton guard in spec_helper clears
+    # it after every example, so the setup has to run per example rather than
+    # once. Build the configuration once all the same, and put it back by
+    # setting the ivars rather than assigning through Scan.config=, which runs
+    # DetectValues.set_additional_default_values and shells out to xcodebuild.
+    # Paying for that 26 times instead of once took this file from 5s to 48s.
+    # See fastlane#30184.
     before(:all) do
       options = { project: "./scan/examples/standard/app.xcodeproj" }
-      Scan.config = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
-      Scan.cache[:temp_junit_report] = nil
+      @configuration = FastlaneCore::Configuration.create(Scan::Options.available_options, options)
+    end
+
+    before(:each) do
+      Scan.instance_variable_set(:@config, @configuration)
+      Scan.instance_variable_set(:@cache, {})
     end
 
     describe "xcpretty reporter options generation" do

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -37,6 +37,53 @@ end
 
 my_main = self
 RSpec.configure do |config|
+  # Singleton guard, see fastlane#30184.
+  #
+  # The fastlane tools keep their configuration on the module itself, so a value
+  # one example assigns is still there for every example after it. Four rows of
+  # internal/order_dependent_specs.md are the same defect: a group reading
+  # configuration it never set, green only while something earlier happened to
+  # leave one behind. Row W survived roughly twenty five random orders before a
+  # seed caught it, so waiting for seeds to find the rest is slow.
+  #
+  # Clearing them after every example turns those from occasional failures into
+  # permanent ones, which is the only way to enumerate them rather than wait.
+  #
+  # The ivars are cleared rather than assigned through the writers: Scan, Gym
+  # and Snapshot define `config=` to run detection and reset their cache as a
+  # side effect, so assigning nil would run detection against a nil config.
+  #
+  # FASTLANE_SPEC_SINGLETON_GUARD=off restores the old behaviour.
+  SINGLETON_GUARD_MODE = (ENV["FASTLANE_SPEC_SINGLETON_GUARD"] || "reset").to_sym
+
+  # Read off the `class << self` blocks of each tool's module.rb, plus
+  # supply/lib/supply.rb, which keeps its accessor elsewhere.
+  SINGLETON_ACCESSORS = {
+    "Cert" => %i[config],
+    "Deliver" => %i[cache],
+    "Frameit" => %i[config],
+    "Gym" => %i[config project cache],
+    "PEM" => %i[config],
+    "Precheck" => %i[config],
+    "Produce" => %i[config],
+    "Scan" => %i[config project cache devices],
+    "Screengrab" => %i[config android_environment],
+    "Sigh" => %i[config],
+    "Snapshot" => %i[config project cache],
+    "Supply" => %i[config]
+  }.freeze
+
+  config.after(:each) do
+    next if SINGLETON_GUARD_MODE == :off
+
+    SINGLETON_ACCESSORS.each do |name, attributes|
+      next unless Object.const_defined?(name)
+
+      mod = Object.const_get(name)
+      attributes.each { |attribute| mod.instance_variable_set("@#{attribute}", nil) }
+    end
+  end
+
   config.before(:each) do |current_test|
     # We don't want to call the RubyGems API at any point
     # This was a request that was added with Ruby 2.4.0


### PR DESCRIPTION
Part of #30184.

Four groups of specs read module level configuration they never set, and passed only while an earlier example happened to leave a value behind. They are the same defect four times, so this closes the class rather than the four instances.

### The four

| Spec | Reads | Failed with |
| --- | --- | --- |
| `frameit/spec/editor_spec.rb` | `Frameit.config` | `undefined method '[]' for nil` at `screenshot.rb:45` |
| `scan/spec/runner_spec.rb`, retry_execute | `Scan.config` | `NoMethodError` on `Scan.config[:only_testing] =` |
| `cert/spec/runner_spec.rb`, expired certificates | `Cert.config` | `NoMethodError` on `Cert.config[:type]` |
| `scan/spec/detect_values_spec.rb`, detect_simulator | `Scan.config`, `Scan.project` | `xcodebuild` exit 64, against whatever project was left over |

Each reproduces on its own, and each is fixed by arranging its own state.

### The guard

Fixing them one at a time only catches what a seed exposes. The `detect_simulator` one survived roughly twenty five random orders before a seed found it, so `spec_helper.rb` now clears these after every example and a group that depends on one fails every time instead of occasionally.

The accessors come from each tool's `module.rb`, plus `supply/lib/supply.rb`, which keeps its accessor elsewhere and would have been missed by reading only `module.rb`.

The ivars are cleared rather than assigned through the writers: `Scan`, `Gym` and `Snapshot` define `config=` to run detection and reset their cache as a side effect, so assigning `nil` would run detection against a nil config.

### The fixes and the guard have to land together

The guard does not make the four fixes redundant, it makes them mandatory, and the dependency runs the opposite way to how it looks. Those groups used to pass by inheriting a configuration; the guard clears it, so without their own setup they find `nil`. Measured by restoring each spec file to its state before its fix and running it with the guard in place:

```
frameit config          58 examples, 5 failures
cert config             14 examples, 2 failures
scan retry_execute      15 examples, 2 failures
scan detect_simulator   33 examples, 2 failures
```

### Checking the guard does anything

With it in place the suite gains no failures at defined order, which says those four were the only instances rather than the only ones found so far. A guard that did nothing would produce the same number, so it was checked with a probe: one example assigns `Scan.config` and `Scan.project`, the next asserts both are nil. It passes with the guard on and fails with `FASTLANE_SPEC_SINGLETON_GUARD=off`.

### Deliberately not included

Spaceship's `ConnectAPI.client`, `Tunes.client` and `Portal.client` are the same shape and account for several more failures, but clearing them per example took `spaceship/spec` from 10 failures to 13, because some specs rely on the client persisting. They need individual work and are not in this change.

### One consequence worth reviewing

`xcpretty_reporter_options_generator_spec` set `Scan.config` in a `before(:all)`, which only serves the first example once the guard clears between them. It now builds the configuration once and puts it back by setting the ivars, rather than assigning through `Scan.config=` and paying for xcodebuild detection 26 times. That difference is 48s against 3s for the file.

### Verification

The affected files at defined order and at seeds 1 and 2: 146 examples, 0 failures each.
