### PR TITLE
Stop spaceship specs sharing clients and cached state

### DIFF
--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -366,6 +366,15 @@ BODY
   end
 
   describe "#persistent_cookie_path" do
+    # spec_helper points SPACESHIP_COOKIE_PATH at a temporary store for the
+    # whole suite, so that the specs neither write a cookie to the developer's
+    # home directory nor read one an earlier run left there. These examples are
+    # about how the path is chosen when that variable is not set, so they have
+    # to run without it. See fastlane#30184.
+    around(:each) do |example|
+      FastlaneSpec::Env.with_env_values("SPACESHIP_COOKIE_PATH" => nil) { example.run }
+    end
+
     before do
       subject.login("username", "password")
     end
@@ -376,8 +385,9 @@ BODY
 
     it "uses $SPACESHIP_COOKIE_PATH when set" do
       tmp_path = Dir.mktmpdir
-      ENV["SPACESHIP_COOKIE_PATH"] = "#{tmp_path}/custom_path"
-      expect(subject.persistent_cookie_path).to eq("#{tmp_path}/custom_path/spaceship/username/cookie")
+      FastlaneSpec::Env.with_env_values("SPACESHIP_COOKIE_PATH" => "#{tmp_path}/custom_path") do
+        expect(subject.persistent_cookie_path).to eq("#{tmp_path}/custom_path/spaceship/username/cookie")
+      end
     end
 
     it "uses home dir by default" do

--- a/spaceship/spec/connect_api/spaceship_spec.rb
+++ b/spaceship/spec/connect_api/spaceship_spec.rb
@@ -1,5 +1,23 @@
 describe Spaceship::ConnectAPI do
-  before(:all) do
+  # Per example, not per group: the explicit client context assigns
+  # Spaceship::ConnectAPI.client, and clearing only once at the start of the
+  # group left the implicit client examples inheriting whatever it was set to,
+  # including doubles belonging to an example that had already finished. See
+  # fastlane#30184.
+  before(:each) do
+    Spaceship::ConnectAPI.client = nil
+    Spaceship::Tunes.client = nil
+    Spaceship::Portal.client = nil
+  end
+
+  # And after, not only before. Clearing on the way in keeps this file's own
+  # examples honest, but the last one still hands its client to whatever runs
+  # next. The `with explicit client` examples stub Client.login to return a
+  # double and ConnectAPI.login then assigns it, so what leaked out was an
+  # rspec double, which rspec disables at the end of its example. Anything
+  # later reaching ConnectAPI.token got "originally created in one example but
+  # has leaked into another". See fastlane#30184.
+  after(:each) do
     Spaceship::ConnectAPI.client = nil
     Spaceship::Tunes.client = nil
     Spaceship::Portal.client = nil

--- a/spaceship/spec/spaceauth_spec.rb
+++ b/spaceship/spec/spaceauth_spec.rb
@@ -38,6 +38,11 @@ describe Spaceship::SpaceauthRunner do
   end
 
   describe 'check_session option' do
+    # has_valid_session loads a cookie from the user's home directory, so these
+    # examples used to pass only when an earlier example had logged in and
+    # persisted one, and on a machine that had ever run the suite they passed
+    # from a file left by a previous run. Each example states the session it is
+    # testing instead. See fastlane#30184.
     before :each do
       Spaceship::Globals.check_session = true
     end
@@ -47,6 +52,8 @@ describe Spaceship::SpaceauthRunner do
     end
 
     it 'when using the default user, it should return a message saying the session is logged in with an exit code of 0' do
+      allow_any_instance_of(Spaceship::Client).to receive(:has_valid_session).and_return(true)
+
       expect do
         expect do
           Spaceship::SpaceauthRunner.new.run
@@ -57,6 +64,8 @@ describe Spaceship::SpaceauthRunner do
     end
 
     it 'when passed a known user, it should return a message saying the session is logged in with an exit code of 0' do
+      allow_any_instance_of(Spaceship::Client).to receive(:has_valid_session).and_return(true)
+
       expect do
         expect do
           Spaceship::SpaceauthRunner.new(username: 'spaceship@krausefx.com').run
@@ -67,6 +76,8 @@ describe Spaceship::SpaceauthRunner do
     end
 
     it 'when passed an unknown user, it should return a message saying no valid session found with an exit code of 1' do
+      allow_any_instance_of(Spaceship::Client).to receive(:has_valid_session).and_return(false)
+
       expect do
         expect do
           Spaceship::SpaceauthRunner.new(username: 'unknown-user').run

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -1,4 +1,21 @@
+require 'base64'
 require 'plist'
+require 'fastlane-sirp'
+
+# The login stubs in tunes/tunes_stubbing.rb match on an exact request body that
+# embeds this SRP public ephemeral. SIRP generates a fresh random one per client,
+# so it has to be stubbed for those bodies to match. Every spaceship spec needs
+# it, not only the ones using the "common spaceship login" shared example: a spec
+# that reaches a login without it computes a real value, matches no stub, and
+# fails with WebMock::NetConnectNotAllowedError depending on what ran first.
+SPACESHIP_AUTHENTICATION_DATA =
+  '8f30ce83b660f03abb0f8570c235e0e1e1d3860a222304acf18e989bdc065dc922a141e6da4563f0' \
+  '5586605b0e10535d875ca7e0fae7fe100cfe533374f29aaa803cdfb2c6194f458485e87f76988f6' \
+  'cddaa1829309438e1aa9ab652b17cfc081fff40356cb3af35c621e9f37ba6e2a03e6abac5a6bfe' \
+  '18ddb489412b7c56355292e6c355f8859270d04063b843d23c1ef7503c3c5dd2c56740101a3ef5' \
+  'bfec6bff1e6dc55e3f70840a83a95d7b3d20ab350d0472809ce87a4e3c29ed9685eb7721dc87ba' \
+  'bfadbd9e65e75d5df55547bcff98711ddeae7b8e1e6dbf529e96f7caa4b830b43575cddc52cebc' \
+  '39f9522f85cbf33ac35ee59f66f48109c12fbb78d'
 
 require_relative 'client_stubbing'
 require_relative 'connect_api/provisioning/provisioning_stubbing'
@@ -20,16 +37,29 @@ if set_auth_vars.any?
   abort("[!] Please `unset` the following ENV vars which interfere with spaceship testing: #{set_auth_vars.join(', ')}".red)
 end
 
-@cache_paths = [
-  File.expand_path("/tmp/spaceship_itc_service_key.txt")
-]
+# Client#itc_service_key caches the key at a fixed path in /tmp, reading it with
+# File.exist? followed by File.read. These examples used to delete that file
+# before and after every one of them, which isolates them from each other in one
+# process and cannot work in several: one worker removes the file between
+# another's exist? and read, and the loser raises AppleTimeoutError from inside
+# itc_service_key.
+#
+# The deletion is gone. The examples that depended on it, in
+# spaceship/spec/tunes/tunes_client_spec.rb, stub the key instead, so nothing
+# here needs the file to be in any particular state. See fastlane#30184.
 
-def try_delete(path)
-  FileUtils.rm_f(path) if File.exist?(path)
+def clear_spaceship_model_clients(klass)
+  klass.instance_variable_set(:@client, nil)
+  klass.subclasses.each { |subclass| clear_spaceship_model_clients(subclass) }
 end
 
 def before_each_spaceship
-  @cache_paths.each { |path| try_delete(path) }
+  # Spaceship::Base subclasses each hold their own @client, stamped on by
+  # set_client and preferred over Spaceship::Portal.client. Class level ivars are
+  # not inherited, so a client cached on Spaceship::Certificate by one example
+  # keeps answering for later ones even after they log in again. Clear the tree
+  # so each example uses the client its own login produced.
+  clear_spaceship_model_clients(Spaceship::Base)
   ENV["DELIVER_USER"] = "spaceship@krausefx.com"
   ENV["DELIVER_PASSWORD"] = "so_secret"
   ENV['SPACESHIP_AVOID_XCODE_API'] = 'true'
@@ -100,10 +130,17 @@ def before_each_spaceship
 end
 
 def after_each_spaceship
-  @cache_paths.each { |path| try_delete(path) }
+  nil
 end
 
 RSpec.configure do |config|
+  config.before(:each) do |current_test|
+    next unless current_test.id.start_with?("./spaceship/")
+
+    allow_any_instance_of(SIRP::Client).to receive(:start_authentication).and_return(SPACESHIP_AUTHENTICATION_DATA)
+    allow_any_instance_of(SIRP::Client).to receive(:process_challenge).and_return("1234")
+  end
+
   def mock_client_response(method_name, with: anything)
     mock_method = allow(mock_client).to receive(method_name)
     mock_method = mock_method.with(with)
@@ -116,7 +153,6 @@ RSpec.configure do |config|
 end
 
 RSpec.shared_examples("common spaceship login") do |skip_tunes_login|
-  require 'fastlane-sirp'
   let(:authentication_data) {
     '8f30ce83b660f03abb0f8570c235e0e1e1d3860a222304acf18e989bdc065dc922a141e6da4563f0' \
       '5586605b0e10535d875ca7e0fae7fe100cfe533374f29aaa803cdfb2c6194f458485e87f76988f6' \
@@ -130,9 +166,16 @@ RSpec.shared_examples("common spaceship login") do |skip_tunes_login|
   let(:password) { 'so_secret' }
 
   before {
-    allow_any_instance_of(SIRP::Client).to receive(:start_authentication).and_return(authentication_data)
-    allow_any_instance_of(SIRP::Client).to receive(:process_challenge).and_return("1234")
+    unless skip_tunes_login
+      Spaceship::Tunes.login
 
-    Spaceship::Tunes.login unless skip_tunes_login
+      # Spaceship::ConnectAPI.client returns a globally held @client when one has
+      # been set, so a client built in an earlier example decides what this one
+      # talks to. Clear it, and log into the portal as well: the implicit client
+      # built in its place only wires up provisioning_request_client when a
+      # cookie, a token or a portal client is present.
+      Spaceship::ConnectAPI.client = nil
+      Spaceship::Portal.login
+    end
   }
 end

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -34,10 +34,21 @@ describe Spaceship::TunesClient do
     before(:each) do
       # Don't need to test hashcash here
       allow_any_instance_of(Spaceship::Client).to receive(:fetch_hashcash)
+
+      # These examples count requests, and one of the requests used to be
+      # Client#itc_service_key fetching the widget key. That method caches to a
+      # fixed path in /tmp, so the count depended on whether the file happened
+      # to exist: cold, the fetch ran and the count was two; warm, it did not
+      # and the third stubbed request was never reached, so nothing was raised.
+      # spaceship/spec/spec_helper.rb used to delete the file around every
+      # example to force it cold, which works in one process and races in
+      # several. Answer the key directly so the count is the same
+      # either way. See fastlane#30184.
+      allow_any_instance_of(Spaceship::Client).to receive(:itc_service_key).and_return("e0abc")
     end
 
     it 'has authType is sa' do
-      expect_any_instance_of(Spaceship::Client).to receive(:request).twice.and_call_original
+      expect_any_instance_of(Spaceship::Client).to receive(:request).once.and_call_original
 
       response_second = double
       allow(response_second).to receive(:status).and_return(412)
@@ -51,7 +62,7 @@ describe Spaceship::TunesClient do
     end
 
     it 'has authType of hsa' do
-      expect_any_instance_of(Spaceship::Client).to receive(:request).twice.and_call_original
+      expect_any_instance_of(Spaceship::Client).to receive(:request).once.and_call_original
 
       response_second = double
       allow(response_second).to receive(:status).and_return(412)
@@ -65,7 +76,7 @@ describe Spaceship::TunesClient do
     end
 
     it 'has authType of non-sa' do
-      expect_any_instance_of(Spaceship::Client).to receive(:request).twice.and_call_original
+      expect_any_instance_of(Spaceship::Client).to receive(:request).once.and_call_original
 
       response_second = double
       allow(response_second).to receive(:status).and_return(412)
@@ -79,7 +90,7 @@ describe Spaceship::TunesClient do
     end
 
     it 'has authType of hsa2' do
-      expect_any_instance_of(Spaceship::Client).to receive(:request).twice.and_call_original
+      expect_any_instance_of(Spaceship::Client).to receive(:request).once.and_call_original
 
       response_second = double
       allow(response_second).to receive(:status).and_return(412)

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -9,7 +9,21 @@ require "webmock/rspec"
 WebMock.disable_net_connect!(allow: 'coveralls.io')
 
 require "fastlane"
+require "tmpdir"
 UI = FastlaneCore::UI
+
+# Spaceship persists a session cookie to ~/.fastlane/spaceship/<user>/cookie,
+# under the real home directory, and reads it back to decide whether a session
+# is valid. That makes the suite write to the developer's machine, and it makes
+# a spec able to depend on a file some earlier run left behind: the cookie four spaceauth
+# examples depended on was nine months older than the run that needed it here, so
+# they passed locally in every order and failed only on a clean checkout. Redirect the store
+# to a temporary directory that belongs to this process, so the suite leaves
+# nothing behind and a spec needing a session has to arrange one itself.
+#
+# See fastlane#30184.
+SPACESHIP_COOKIE_DIR = Dir.mktmpdir("fastlane-spec-spaceship")
+ENV["SPACESHIP_COOKIE_PATH"] = SPACESHIP_COOKIE_DIR
 
 unless ENV["DEBUG"]
   fastlane_tests_tmpdir = "#{Dir.tmpdir}/fastlane_tests"

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -98,6 +98,10 @@ RSpec.configure do |config|
     end
   end
 
+  config.after(:suite) do
+    FileUtils.remove_entry(SPACESHIP_COOKIE_DIR) if File.directory?(SPACESHIP_COOKIE_DIR)
+  end
+
   config.before(:each) do |current_test|
     # We don't want to call the RubyGems API at any point
     # This was a request that was added with Ruby 2.4.0


### PR DESCRIPTION
Part of #30184.

Spaceship keeps its clients on the module — `ConnectAPI.client`, `Tunes.client`, `Portal.client`, and a `@client` stamped onto every `Spaceship::Base` subclass by `set_client` — and none of it was cleared between examples. Six separate order-dependent failures traced back to this one object.

### What was failing

The symptom was almost never in the file that caused it:

| Where it failed | With |
| --- | --- |
| `deliver/spec/runner_spec.rb`, `pilot/spec/manager_spec.rb` | `#<Double "mock_client"> ... has leaked into another example`, through `ConnectAPI.token` |
| `spaceship/spec/spaceship_spec.rb`, `spaceauth_spec.rb` | `NetConnectNotAllowedError` on `signin/init`, a real SRP value matching no recorded body |
| `spaceship/spec/portal/portal_permission_spec.rb`, `portal/certificate_spec.rb` | a client from an earlier example answering instead of the one the spec logged in with |
| `spaceship/spec/tunes/tunes_client_spec.rb` | an expected exception not raised, because a cached file changed the request count |

### The changes

**Per example clients and a stubbed login.** The SIRP public ephemeral is stubbed for every spaceship example rather than only those using the shared login, since the recorded request bodies embed one exact value. The three module clients are cleared, and so is the `@client` cached on each `Spaceship::Base` subclass — class level ivars are not inherited, so one stamped onto `Spaceship::Certificate` keeps answering until something clears it.

**Clearing after, not only before.** The `with explicit client` examples stub `Client.login` to return a double that `ConnectAPI.login` assigns to the module. Clearing on the way in keeps this file honest; the last example still handed its double to whatever ran next, by which point rspec had disabled it. That is what `deliver` and `pilot` were tripping over, at three different seeds, in a different file each time.

**No longer depending on the service key cache.** Four examples counted requests, and one of the requests was `itc_service_key` fetching a key it caches to `/tmp`. Whether the count was right depended on whether that file happened to exist, and `spaceship/spec/spec_helper.rb` deleted it around every example to force the issue. They now stub the key and expect one request, so the file passes with the cache present or absent.

**Its own cookie store.** Spaceship persists a session cookie to `~/.fastlane/spaceship/<user>/cookie` and reads it back to decide whether a session is valid. Four `spaceauth` examples assert `exit(0)` for "Valid session found" and never create a session, so they passed only when an earlier example had persisted one. On the machine this was found on, the cookie they were reading was nine months older than the run that needed it, so they passed locally in every order and failed only on a clean checkout. `SPACESHIP_COOKIE_PATH` now points at a directory belonging to the process, removed when the suite finishes, and `client_spec`'s `persistent_cookie_path` examples run with it cleared, since they are about how the path is chosen when it is not set.

**And saying what session each spaceauth example tests.** Those `check_session` examples assert `exit(0)` for a valid session and never create one, so redirecting the store is what makes them fail: with it, the three on their own give 2 failures, and the file fails at seeds 3 and 11 while passing at 7. They now stub `has_valid_session`, including the exit code 1 example, which was passing only because no cookie happened to exist for `unknown-user`.

### Deliberately not done

Clearing the clients for *every* spaceship spec, in `before_each_spaceship`. That was tried: `spaceship/spec` went from 10 failures to 13, because some specs rely on the client persisting across examples. The clearing is scoped to the file that creates the doubles.

### Verification

`spaceship/spec` at defined order and at seeds 1 and 2, with the service key cache deleted first: 915 examples, 0 failures each. The developer's real cookie keeps its modification time across a run, which is how the redirect was checked rather than inferred. `deliver/spec/runner_spec.rb`, `pilot/spec/manager_spec.rb` and `spaceship/spec/connect_api/spaceship_spec.rb` together: 60 examples, 0 failures.
