### PR TITLE
Stop nine specs depending on what ran before them

### DIFF
--- a/deliver/spec/sync_screenshots_spec.rb
+++ b/deliver/spec/sync_screenshots_spec.rb
@@ -12,8 +12,8 @@ describe Deliver::SyncScreenshots do
     end
 
     let(:en_US) { mock_app_store_version_localization }
-    let(:app_screenshot_set_55) { mock_app_screenshot_set(display_type: DisplayType::APP_IPHONE_55) }
-    let(:app_screenshot_set_65) { mock_app_screenshot_set(display_type: DisplayType::APP_IPHONE_65) }
+    let(:app_screenshot_set_55) { mock_app_screenshot_set(display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_55) }
+    let(:app_screenshot_set_65) { mock_app_screenshot_set(display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_65) }
 
     context 'ASC has nothing and going to add screenshots' do
       let(:screenshots) do

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -2,7 +2,18 @@ require "xcodeproj"
 # 771D79501D9E69C900D840FA = demo
 # 77C503031DD3175E00AC8FF0 = today
 describe Fastlane do
-  describe "Automatic Code Signing" do
+  describe "Automatic Code Signing", order: :defined do
+    # These examples change the project they are given and then assert on it, and
+    # several of them assert on what an earlier one left behind, so the group is
+    # one scenario written as several examples. Two things follow. It has to run
+    # in the order it is written, hence order: :defined on the group. And it must
+    # not run against the checked in fixture, or a failed run leaves the
+    # repository dirty, so it gets one copy for the group. See fastlane#30184.
+    before :all do
+      @project_path = File.join(Dir.mktmpdir('fl_spec_automatic_code_signing'), 'automatic_code_signing.xcodeproj')
+      FileUtils.cp_r('./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', @project_path)
+    end
+
     before :each do
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
     end
@@ -11,11 +22,11 @@ describe Fastlane do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Automatic'")
       result = Fastlane::FastFile.new.parse("lane :test do
-        enable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'XXXX')
+        enable_automatic_code_signing(path: '#{@project_path}', team_id: 'XXXX')
       end").runner.execute(:test)
       expect(result).to eq(true)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Automatic")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Automatic")
@@ -38,11 +49,11 @@ describe Fastlane do
       expect(UI).to receive(:deprecated).with("Please use `update_code_signing_settings` action instead.")
       expect(UI).to receive(:important).with("Skipping demo not selected (today)")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', targets: ['today'])
+        disable_automatic_code_signing(path: '#{@project_path}', targets: ['today'])
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Automatic")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
@@ -58,11 +69,11 @@ describe Fastlane do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj')
+        disable_automatic_code_signing(path: '#{@project_path}')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
@@ -83,11 +94,11 @@ describe Fastlane do
       expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: demo")
       expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9')
+        disable_automatic_code_signing(path: '#{@project_path}', team_id: 'G3KGXDXQL9')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
@@ -105,7 +116,7 @@ describe Fastlane do
 
     it "sets code sign identity" do
       temp_dir = Dir.tmpdir
-      FileUtils.copy_entry('./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', temp_dir)
+      FileUtils.copy_entry(@project_path, temp_dir)
 
       # G3KGXDXQL9
       allow(UI).to receive(:success)
@@ -155,11 +166,11 @@ describe Fastlane do
       expect(UI).to receive(:important).with("Set Provisioning Profile name to: Mindera for target: demo")
       expect(UI).to receive(:important).with("Set Provisioning Profile name to: Mindera for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', profile_name: 'Mindera')
+        disable_automatic_code_signing(path: '#{@project_path}', team_id: 'G3KGXDXQL9', profile_name: 'Mindera')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
@@ -189,11 +200,11 @@ describe Fastlane do
       expect(UI).to receive(:important).with("Set Provisioning Profile UUID to: 1337 for target: demo")
       expect(UI).to receive(:important).with("Set Provisioning Profile UUID to: 1337 for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', profile_uuid: '1337')
+        disable_automatic_code_signing(path: '#{@project_path}', team_id: 'G3KGXDXQL9', profile_uuid: '1337')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
@@ -223,11 +234,11 @@ describe Fastlane do
       expect(UI).to receive(:important).with("Set Bundle identifier to: com.fastlane.mindera.cosigner for target: demo")
       expect(UI).to receive(:important).with("Set Bundle identifier to: com.fastlane.mindera.cosigner for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', bundle_identifier: 'com.fastlane.mindera.cosigner')
+        disable_automatic_code_signing(path: '#{@project_path}', team_id: 'G3KGXDXQL9', bundle_identifier: 'com.fastlane.mindera.cosigner')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
@@ -252,7 +263,7 @@ describe Fastlane do
       expect(UI).to receive(:deprecated).with("Please use `update_code_signing_settings` action instead.")
       expect(UI).to receive(:important).with("None of the specified targets has been modified")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', targets: ['not_found'])
+        disable_automatic_code_signing(path: '#{@project_path}', targets: ['not_found'])
       end").runner.execute(:test)
       expect(result).to eq(false)
     end

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -1,6 +1,14 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "import_from_git" do
+    # These examples are one scenario written as several examples: the `before :all`
+    # builds a git repository, and individual examples append commits, tags and
+    # branches to it that later ones then assert on. They therefore have to run in
+    # the order they are written, and a random order makes them assert against a
+    # repository at the wrong revision. Pinned rather than rewritten: making each
+    # example build its own repository would be order independent but would add a
+    # git init, several commits and several tags per example to a group that
+    # already takes eleven seconds. See fastlane#30184.
+    describe "import_from_git", order: :defined do
       it "raises an exception when no path is given" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/notification_spec.rb
+++ b/fastlane/spec/actions_specs/notification_spec.rb
@@ -1,3 +1,8 @@
+# The notification action requires this lazily, inside its run method, so
+# examples referencing the TerminalNotifier constant only find it when another
+# example has already run the action. See fastlane#30184.
+require 'terminal-notifier'
+
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "notification action" do

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 
 initialized = false
+bundled = false
 test_ui = nil
 generator = nil
 tmp_dir = nil
@@ -57,6 +58,7 @@ describe Fastlane::PluginGenerator do
       tmp_dir = nil
       oldwd = nil
       initialized = false
+      bundled = false
     end
 
     it "creates gem root directory" do
@@ -281,10 +283,17 @@ describe Fastlane::PluginGenerator do
     end
 
     describe "All tests and style validation of the new plugin are passing" do
-      before (:all) do
-        # let(:gem_name) is not available in before(:all), so pass the directory
-        # in explicitly once instead of making this a before(:each)
-        plugin_sh('bundle install', 'fastlane-plugin-tester_thing')
+      # before(:each) with a flag, not before(:all). RSpec runs an inner
+      # before(:all) ahead of an outer before(:each), so as a before(:all) this
+      # ran `bundle install` before the plugin above had been generated. It only
+      # ever worked because an earlier example in the file had generated it
+      # already, and running this group on its own failed with Errno::ENOENT for
+      # the plugin directory. See fastlane#30184.
+      before(:each) do
+        unless bundled
+          plugin_sh('bundle install')
+          bundled = true
+        end
       end
 
       it "rspec tests are passing" do

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -1,3 +1,10 @@
+# FastlanePty requires this lazily, inside spawn_with_pty, so examples below that
+# reference the PTY constant only find it when something has already run a pty
+# backed command in this process. Require it here so they do not depend on that.
+# Guarded because pty is not available on Windows, where those examples are
+# skipped anyway. See fastlane#30184.
+require 'pty' unless FastlaneCore::Helper.windows?
+
 describe FastlaneCore do
   describe FastlaneCore::CommandExecutor do
     describe "execute" do
@@ -7,7 +14,7 @@ describe FastlaneCore do
 
       it 'executes a simple command successfully' do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait)
+          expect(Process).to receive(:wait).and_call_original
         end
 
         result = FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => '1') do
@@ -37,7 +44,11 @@ describe FastlaneCore do
           # so we have to spawn a real process unless we want to mock methods
           # on nil.
           child_process_id = Process.spawn('echo foo', out: File::NULL)
-          expect(Process).to receive(:wait).with(child_process_id)
+          # and_call_original matters: Process.wait is what fills in $?, which
+          # FastlanePty reads for the exit status. Mocking it away leaves $? holding
+          # whatever the previous example left there, so these examples reported an
+          # earlier command's exit status when they did not run first.
+          expect(Process).to receive(:wait).with(child_process_id).and_call_original
 
           block.yield(fake_std_in, fake_std_out, child_process_id)
         end
@@ -69,7 +80,11 @@ describe FastlaneCore do
           # so we have to spawn a real process unless we want to mock methods
           # on nil.
           child_process_id = Process.spawn('echo foo', out: File::NULL)
-          expect(Process).to receive(:wait).with(child_process_id)
+          # and_call_original matters: Process.wait is what fills in $?, which
+          # FastlanePty reads for the exit status. Mocking it away leaves $? holding
+          # whatever the previous example left there, so these examples reported an
+          # earlier command's exit status when they did not run first.
+          expect(Process).to receive(:wait).with(child_process_id).and_call_original
 
           block.yield(fake_std_in, fake_std_out, child_process_id)
         end
@@ -88,7 +103,7 @@ Shopping list:
 
       it "does not print output to stdout when status != 0 and output was already printed" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait)
+          expect(Process).to receive(:wait).and_call_original
         end
 
         expect do
@@ -102,7 +117,7 @@ Shopping list:
 
       it "prints output to stdout only once when status != 0 and output was not already printed" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).exactly(3)
+          expect(Process).to receive(:wait).exactly(3).and_call_original
         end
 
         expect do
@@ -135,7 +150,7 @@ Shopping list:
 
       it "calls error block with output argument" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).twice
+          expect(Process).to receive(:wait).twice.and_call_original
         end
 
         error_block_input = nil
@@ -161,7 +176,7 @@ Shopping list:
 
       it "does not print output or exit status when failure output is suppressed" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait)
+          expect(Process).to receive(:wait).and_call_original
         end
 
         error_block_input = nil
@@ -267,7 +282,7 @@ Shopping list:
 
       it "still raises when failure output is suppressed without an error block" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait)
+          expect(Process).to receive(:wait).and_call_original
         end
 
         raised_error = nil

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -2,6 +2,14 @@ require 'open3'
 
 describe FastlaneCore do
   describe FastlaneCore::DeviceManager do
+    # runtime_build_os_versions memoises into a module level ivar, so an example
+    # that stubs the underlying command only sees its stub if nothing has already
+    # populated it. Clearing it per example rather than once per group, which is
+    # what the before(:all) below does for the simulator cache. See fastlane#30184.
+    before(:each) do
+      FastlaneCore::DeviceManager.instance_variable_set(:@runtime_build_os_versions, nil)
+    end
+
     before(:all) do
       @simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode7')
       @system_profiler_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSystem_profilerOutput')

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -74,39 +74,39 @@ describe Spaceship::Client do
 
     context 'when running non-interactive' do
       it 'raises an error' do
-        ENV["FASTLANE_IS_INTERACTIVE"] = "false"
-        expect(subject).to receive(:handle_two_factor)
-        stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
-        subject.handle_two_step_or_factor("response")
+        FastlaneSpec::Env.with_env_values('FASTLANE_IS_INTERACTIVE' => 'false', 'SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA' => nil) do
+          expect(subject).to receive(:handle_two_factor)
+          stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
+          subject.handle_two_step_or_factor("response")
+        end
       end
     end
 
     context 'when running non-interactive and force 2FA to be interactive only' do
       it 'raises an error' do
-        ENV["FASTLANE_IS_INTERACTIVE"] = "false"
-        ENV["SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA"] = "true"
-        expect { subject.handle_two_step_or_factor("response") }.to raise_error("2FA can only be performed in interactive mode")
-        ENV.delete('SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA')
+        FastlaneSpec::Env.with_env_values('FASTLANE_IS_INTERACTIVE' => 'false', 'SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA' => 'true') do
+          expect { subject.handle_two_step_or_factor("response") }.to raise_error("2FA can only be performed in interactive mode")
+        end
       end
     end
 
     context 'when running interactive' do
       it 'does not raise an error' do
-        ENV["FASTLANE_IS_INTERACTIVE"] = "true"
-        ENV["SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA"] = "true"
-        expect(subject).to receive(:handle_two_factor)
-        stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
-        subject.handle_two_step_or_factor("response")
+        FastlaneSpec::Env.with_env_values('FASTLANE_IS_INTERACTIVE' => 'true', 'SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA' => 'true') do
+          expect(subject).to receive(:handle_two_factor)
+          stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
+          subject.handle_two_step_or_factor("response")
+        end
       end
     end
 
     context 'when interactive mode is not set' do
       it 'does not raise an error' do
-        ENV["FASTLANE_IS_INTERACTIVE"] = nil
-        ENV["SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA"] = "false"
-        expect(subject).to receive(:handle_two_factor)
-        stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
-        subject.handle_two_step_or_factor("response")
+        FastlaneSpec::Env.with_env_values('FASTLANE_IS_INTERACTIVE' => nil, 'SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA' => 'false') do
+          expect(subject).to receive(:handle_two_factor)
+          stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
+          subject.handle_two_step_or_factor("response")
+        end
       end
     end
 

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -31,6 +31,14 @@ unless ENV["DEBUG"]
   $stdout = File.open(fastlane_tests_tmpdir, "w")
 end
 
+# FastlaneCore::Shell prints "Logging disabled while running tests" the first
+# time anything touches the logger, and memoises it, so whichever example gets
+# there first absorbs the banner. An example asserting on its own stdout then
+# fails or passes depending on what ran before it. Emit it here instead, while
+# stdout is the redirect above rather than an example's capture. See
+# fastlane#30184.
+FastlaneCore::UI.ui_object.log
+
 if FastlaneCore::Helper.mac?
   xcode_path = FastlaneCore::Helper.xcode_path
   unless xcode_path.include?("Contents/Developer")

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -81,8 +81,6 @@ describe Supply do
         @obb_dir = Dir.mktmpdir('supply')
         @apk_path = File.join(@obb_dir, 'my.apk')
 
-        # Makes Supply::Uploader.new.all_languages public for testing reasons
-        Supply::Uploader.send(:public, *Supply::Uploader.private_instance_methods)
       end
 
       def create_obb(name)
@@ -158,7 +156,7 @@ describe Supply do
           metadata_path: 'supply/spec/fixtures/metadata/android'
         }
 
-        only_directories = Supply::Uploader.new.all_languages
+        only_directories = Supply::Uploader.new.send(:all_languages)
         expect(only_directories).to eq(['en-US', 'fr-FR', 'ja-JP'])
       end
     end


### PR DESCRIPTION
Part of #30184. Based on #30192, because both touch `spec_helper.rb`; retarget to master once that lands.

Nine specs that depended on something another example had done. They do not share a cause, which is why they are one pull request rather than five: each is small and none generalises.

| Spec | Depended on |
| --- | --- |
| `import_from_git_spec` | its own earlier examples, as one scenario written as several |
| `command_executor_spec` | a stale `$?`, a one shot banner, and a lazily required constant |
| `uploader_spec` | an earlier example having made a private method public |
| `notification_spec` | lane context another example populated |
| `automatic_code_signing_spec` | a fixture project earlier examples had written to |
| `device_manager_spec`, `two_step_or_factor_client_spec` | values another example set |
| `sync_screenshots_spec` | a global constant three other spec files define |
| `plugin_generator_spec` | an earlier example having generated the plugin |

### Three worth reading

**`command_executor_spec`** mocked `Process.wait`, which is what fills in `$?`, while `FastlanePty` reads `$?` for its exit status. The examples therefore reported the *previous* example's status, which is how `Exit status: 42` appeared for commands that cannot fail. The mocks now let the wait happen. The underlying defect in `FastlanePty` is separate and still open as #30188; this only stops the spec depending on it.

**`sync_screenshots_spec`** used a bare `DisplayType` that nothing in it defines. Three other spec files assign `DisplayType = ...` inside a `describe` block, and a constant assigned in a block takes the block's lexical scope, so each defines a *global* `::DisplayType`. This file read whichever had loaded. It was found by splitting the suite across processes rather than by a seed: a worker ran it without the files that define the constant.

**`plugin_generator_spec`** had an inner `before(:all)` running `bundle install` before the plugin had been generated. RSpec runs an inner `before(:all)` ahead of an outer `before(:each)`, so it only ever worked because an earlier example in the file had generated it.

### Verification

All nine together at defined order and at seeds 1 and 2: 156 examples, 0 failures each. And each file **on its own**, which is where an intra-file dependency shows and where three of these would previously have failed: 0 failures in all nine.
