### PR TITLE
Report the environment variables that escape the example that set them

### DIFF
--- a/fastlane/spec/actions_specs/flock_spec.rb
+++ b/fastlane/spec/actions_specs/flock_spec.rb
@@ -12,8 +12,16 @@ describe Fastlane do
       end
 
       context 'options' do
+        # Scoped rather than assigned. These are the options' env_names, so a
+        # value left behind satisfies the option and the examples asserting that
+        # it is required stop raising. See fastlane#30184.
+        around do |example|
+          FastlaneSpec::Env.with_env_values('FL_FLOCK_BASE_URL' => 'https://example.com') do
+            example.run
+          end
+        end
+
         before do
-          ENV['FL_FLOCK_BASE_URL'] = 'https://example.com'
           stub_request(:any, /example\.com/)
         end
 
@@ -34,9 +42,9 @@ describe Fastlane do
         end
 
         it 'allows environment variables' do
-          ENV['FL_FLOCK_MESSAGE'] = 'xxx'
-          ENV['FL_FLOCK_TOKEN'] = 'xxx'
-          expect { run_flock }.to_not(raise_error)
+          FastlaneSpec::Env.with_env_values('FL_FLOCK_MESSAGE' => 'xxx', 'FL_FLOCK_TOKEN' => 'xxx') do
+            expect { run_flock }.to_not(raise_error)
+          end
         end
       end
 

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -679,34 +679,32 @@ describe Fastlane do
       end
 
       it "should save reports to BUILD_PATH + \"/report\" by default" do
-        ENV["XCODE_BUILD_PATH"] = "./build"
+        FastlaneSpec::Env.with_env_values('XCODE_BUILD_PATH' => "./build") do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            xctest(
+              destination: 'name=iPhone 5s,OS=8.1',
+              scheme: 'MyApp',
+              workspace: 'MyApp.xcworkspace',
+              report_formats: ['html'],
+              report_screenshots: true
+            )
+          end").runner.execute(:test)
 
-        result = Fastlane::FastFile.new.parse("lane :test do
-          xctest(
-            destination: 'name=iPhone 5s,OS=8.1',
-            scheme: 'MyApp',
-            workspace: 'MyApp.xcworkspace',
-            report_formats: ['html'],
-            report_screenshots: true
+          expect(result).to eq(
+            "set -o pipefail && " \
+            + "xcodebuild " \
+            + "-destination \"name=iPhone 5s,OS=8.1\" " \
+            + "-scheme \"MyApp\" " \
+            + "-workspace \"MyApp.xcworkspace\" " \
+            + "build " \
+            + "test " \
+            + "| tee '#{build_log_path}' | xcpretty --color " \
+            + "--report html " \
+            + "--screenshots " \
+            + "--output \"./build/report\" " \
+            + "--test"
           )
-        end").runner.execute(:test)
-
-        expect(result).to eq(
-          "set -o pipefail && " \
-          + "xcodebuild " \
-          + "-destination \"name=iPhone 5s,OS=8.1\" " \
-          + "-scheme \"MyApp\" " \
-          + "-workspace \"MyApp.xcworkspace\" " \
-          + "build " \
-          + "test " \
-          + "| tee '#{build_log_path}' | xcpretty --color " \
-          + "--report html " \
-          + "--screenshots " \
-          + "--output \"./build/report\" " \
-          + "--test"
-        )
-
-        ENV.delete("XCODE_BUILD_PATH")
+        end
       end
 
       it "should support multiple output formats" do
@@ -772,37 +770,37 @@ describe Fastlane do
       end
 
       it "should support omitting output when specifying multiple reports " do
-        ENV["XCODE_BUILD_PATH"] = "./build"
+        FastlaneSpec::Env.with_env_values('XCODE_BUILD_PATH' => "./build") do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            xctest(
+              destination: 'name=iPhone 5s,OS=8.1',
+              scheme: 'MyApp',
+              workspace: 'MyApp.xcworkspace',
+              reports: [{
+                report: 'html',
+              },
+              {
+                report: 'junit',
+              }],
+            )
+          end").runner.execute(:test)
 
-        result = Fastlane::FastFile.new.parse("lane :test do
-          xctest(
-            destination: 'name=iPhone 5s,OS=8.1',
-            scheme: 'MyApp',
-            workspace: 'MyApp.xcworkspace',
-            reports: [{
-              report: 'html',
-            },
-            {
-              report: 'junit',
-            }],
+          expect(result).to eq(
+            "set -o pipefail && " \
+            + "xcodebuild " \
+            + "-destination \"name=iPhone 5s,OS=8.1\" " \
+            + "-scheme \"MyApp\" " \
+            + "-workspace \"MyApp.xcworkspace\" " \
+            + "build " \
+            + "test " \
+            + "| tee '#{build_log_path}' | xcpretty --color " \
+            + "--report html " \
+            + "--output \"./build/report/report.html\" " \
+            + "--report junit " \
+            + "--output \"./build/report/report.xml\" " \
+            + "--test"
           )
-        end").runner.execute(:test)
-
-        expect(result).to eq(
-          "set -o pipefail && " \
-          + "xcodebuild " \
-          + "-destination \"name=iPhone 5s,OS=8.1\" " \
-          + "-scheme \"MyApp\" " \
-          + "-workspace \"MyApp.xcworkspace\" " \
-          + "build " \
-          + "test " \
-          + "| tee '#{build_log_path}' | xcpretty --color " \
-          + "--report html " \
-          + "--output \"./build/report/report.html\" " \
-          + "--report junit " \
-          + "--output \"./build/report/report.xml\" " \
-          + "--test"
-        )
+        end
       end
 
       it "should detect and use the workspace, when a workspace is present" do

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -398,45 +398,57 @@ describe FastlaneCore do
       end
     end
 
+    # Scoped rather than assigned. These examples used to set the variable
+    # directly, with a before hook resetting it only for examples inside this
+    # group, so the last value assigned leaked out and changed what later
+    # examples saw. See fastlane#30184.
     describe 'Project.xcode_build_settings_timeout' do
-      before do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = nil
-      end
       it "returns default value" do
-        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(3)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT' => nil) do
+          expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(3)
+        end
       end
       it "returns specified value" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '5'
-        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(5)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT' => '5') do
+          expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(5)
+        end
       end
       it "returns 0 if empty" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = ''
-        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(0)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT' => '') do
+          expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(0)
+        end
       end
       it "returns 0 if garbage" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = 'hiho'
-        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(0)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT' => 'hiho') do
+          expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(0)
+        end
       end
     end
 
+    # Scoped rather than assigned. These examples used to set the variable
+    # directly, with a before hook resetting it only for examples inside this
+    # group, so the last value assigned leaked out and changed what later
+    # examples saw. See fastlane#30184.
     describe 'Project.xcode_build_settings_retries' do
-      before do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_RETRIES'] = nil
-      end
       it "returns default value" do
-        expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(3)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_RETRIES' => nil) do
+          expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(3)
+        end
       end
       it "returns specified value" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_RETRIES'] = '5'
-        expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(5)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_RETRIES' => '5') do
+          expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(5)
+        end
       end
       it "returns 0 if empty" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_RETRIES'] = ''
-        expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(0)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_RETRIES' => '') do
+          expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(0)
+        end
       end
       it "returns 0 if garbage" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_RETRIES'] = 'hiho'
-        expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(0)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_RETRIES' => 'hiho') do
+          expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(0)
+        end
       end
     end
 

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -37,9 +37,16 @@ describe FastlaneCore do
     end
 
     describe "#update_command" do
-      before do
-        ENV.delete("BUNDLE_BIN_PATH")
-        ENV.delete("BUNDLE_GEMFILE")
+      # Scoped, not deleted. These two decide Helper.bundler?, and dropping them
+      # for the rest of the process makes every later example look as though it
+      # is not running under bundler. take_off then finds the Gemfile in the
+      # working directory and emits "fastlane detected a Gemfile", an extra call
+      # that was failing ruby_version_warning_spec's `.once` constraint on
+      # UI.important. See fastlane#30184.
+      around(:each) do |example|
+        FastlaneSpec::Env.with_env_values("BUNDLE_BIN_PATH" => nil, "BUNDLE_GEMFILE" => nil) do
+          example.run
+        end
       end
 
       it "works a custom gem name" do

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -51,22 +51,34 @@ if FastlaneCore::Helper.mac?
   end
 end
 
+# A tool spec helper that writes to ENV at the top level rather than from a
+# before_each_* method would do it once, outside every example, where the guard
+# below can neither blame an example for it nor restore it. Nothing does that
+# today; this is here so that it cannot start silently. See fastlane#30184.
+env_guard_pristine = ENV.to_h
+
 (Fastlane::TOOLS + [:spaceship, :fastlane_core]).each do |tool|
   path = File.join(tool.to_s, "spec", "spec_helper.rb")
   require_relative path if File.exist?(path)
   require tool.to_s
 end
 
+env_guard_loaded = ENV.to_h
+ENV_GUARD_LOAD_TIME = ((env_guard_loaded.keys - env_guard_pristine.keys) |
+                       (env_guard_pristine.keys - env_guard_loaded.keys) |
+                       (env_guard_loaded.keys & env_guard_pristine.keys)
+                         .reject { |key| env_guard_loaded[key] == env_guard_pristine[key] }).sort.freeze
+
 my_main = self
 RSpec.configure do |config|
   # Singleton guard, see fastlane#30184.
   #
   # The fastlane tools keep their configuration on the module itself, so a value
-  # one example assigns is still there for every example after it. Four rows of
-  # internal/order_dependent_specs.md are the same defect: a group reading
-  # configuration it never set, green only while something earlier happened to
-  # leave one behind. Row W survived roughly twenty five random orders before a
-  # seed caught it, so waiting for seeds to find the rest is slow.
+  # one example assigns is still there for every example after it. Several groups
+  # were the same defect: reading configuration they never set, green only while
+  # something earlier happened to leave one behind. One of them survived roughly
+  # twenty five random orders before a seed caught it, so waiting for seeds to
+  # find the rest is slow.
   #
   # Clearing them after every example turns those from occasional failures into
   # permanent ones, which is the only way to enumerate them rather than wait.
@@ -108,6 +120,98 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     FileUtils.remove_entry(SPACESHIP_COOKIE_DIR) if File.directory?(SPACESHIP_COOKIE_DIR)
+  end
+
+  # Environment guard, see fastlane#30184.
+  #
+  # A test that leaves a variable behind changes what every later test in the
+  # process sees, and several of the ones involved carry credentials:
+  # DELIVER_PASSWORD, FASTLANE_PASSWORD and FASTLANE_SESSION have all been found
+  # leaking between examples. Tests should scope what they set with
+  # FastlaneSpec::Env.with_env_values rather than assigning to ENV directly.
+  #
+  # Modes, through FASTLANE_SPEC_ENV_GUARD:
+  #   enforce (default) restore ENV after each example, and report what escaped
+  #   report            leave ENV alone, report what escaped
+  #   off               do nothing
+  #
+  # Restoring is what makes the report worth reading. Without it each example is
+  # measured against whatever the previous one left behind, so an example setting
+  # a variable to the value already leaked there registers no change and is never
+  # named. Three specs set DELIVER_PASSWORD to "123": running those files in
+  # report mode names one example, enforce mode names all 64. The set of keys is
+  # the same either way, the attribution is not, and in report mode it depends
+  # entirely on the order the suite happened to run in.
+  #
+  # An example that is meant to leave something behind declares it:
+  #   it "sets the team id", env_output: %w[FASTLANE_TEAM_ID] do
+  #
+  # Two kinds of write are invisible here because both happen outside
+  # around(:each): top level writes in a tool spec helper, reported separately
+  # from ENV_GUARD_LOAD_TIME below, and writes in a before(:context) hook, which
+  # enter the baseline of every example in the group and outlive the group.
+  #
+  # FASTLANE_SPEC_ENV_GUARD_REPORT names a file to write the full inventory to.
+  # The console summary lists only the first few examples per variable, which is
+  # not enough to work from when a variable has a thousand of them.
+  #
+  # Only key names are ever reported. The values are the point of the exercise.
+  ENV_GUARD_MODE = (ENV["FASTLANE_SPEC_ENV_GUARD"] || "enforce").to_sym
+  ENV_GUARD_LEAKS = Hash.new { |hash, key| hash[key] = [] }
+  ENV_GUARD_REPORT_PATH = ENV["FASTLANE_SPEC_ENV_GUARD_REPORT"]
+
+  config.around(:each) do |example|
+    if ENV_GUARD_MODE == :off
+      example.run
+    else
+      before = ENV.to_h
+      begin
+        example.run
+      ensure
+        allowed = Array(example.metadata[:env_output]).map(&:to_s)
+        after = ENV.to_h
+        escaped = ((after.keys - before.keys) | (before.keys - after.keys) |
+                   (before.keys & after.keys).reject { |key| before[key] == after[key] }) - allowed
+        escaped.each { |key| ENV_GUARD_LEAKS[key] << example.id }
+        ENV.replace(before) if ENV_GUARD_MODE == :enforce
+      end
+    end
+  end
+
+  config.after(:suite) do
+    unless ENV_GUARD_LOAD_TIME.empty?
+      warn("")
+      warn("[env-guard] #{ENV_GUARD_LOAD_TIME.size} variables were set while the tool spec helpers loaded.")
+      warn("[env-guard] They are written outside any example, so no mode restores them and no example is blamed.")
+      warn("[env-guard] Move them into a hook to bring them under the guard: #{ENV_GUARD_LOAD_TIME.join(', ')}")
+    end
+
+    next if ENV_GUARD_LEAKS.empty?
+
+    ranked = ENV_GUARD_LEAKS.sort_by { |key, ids| [-ids.size, key] }
+
+    warn("")
+    warn("[env-guard] #{ENV_GUARD_LEAKS.size} environment variables escaped the example that changed them.")
+    warn("[env-guard] Scope them with FastlaneSpec::Env.with_env_values, or declare them with env_output:.")
+    warn("[env-guard] Reporting only, ENV was left as the examples made it.") if ENV_GUARD_MODE == :report
+    ranked.each do |key, ids|
+      warn("[env-guard]   #{key} (#{ids.size})")
+      ids.uniq.first(3).each { |id| warn("[env-guard]       #{id}") }
+      warn("[env-guard]       ...") if ids.uniq.size > 3
+    end
+
+    if ENV_GUARD_REPORT_PATH
+      File.open(ENV_GUARD_REPORT_PATH, "w") do |file|
+        file.puts("# fastlane#30184, environment guard, mode #{ENV_GUARD_MODE}")
+        file.puts("# set while the tool spec helpers loaded: #{ENV_GUARD_LOAD_TIME.join(', ')}") unless ENV_GUARD_LOAD_TIME.empty?
+        ranked.each do |key, ids|
+          file.puts("")
+          file.puts("#{key} (#{ids.uniq.size})")
+          ids.uniq.sort.each { |id| file.puts("  #{id}") }
+        end
+      end
+      warn("[env-guard] Full inventory written to #{ENV_GUARD_REPORT_PATH}")
+    end
   end
 
   config.before(:each) do |current_test|


### PR DESCRIPTION
Part of #30184. Chained on #30193, which this branch is based on — review that one first, and the diff here will shrink to its own two commits once it merges.

### The problem

A spec that assigns to `ENV` and does not put it back changes what every later example in the process sees. Whether that matters depends on which examples run after it, so the failures it causes move with the seed and are expensive to chase one at a time.

Some of the variables involved carry credentials. On a full run of this branch, 1336 examples set `DELIVER_PASSWORD` and `DELIVER_USER` without putting them back — they come from per-example hooks in the match and cert spec helpers. Without something restoring `ENV`, the first of those to run leaves a password in the environment of every example that follows it, whatever that example was testing.

### What this does

**Scopes the variables four specs were assigning.** `project_spec` reset `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT` and `_RETRIES` in a `before` hook covering only its own group, so the last value assigned escaped it. `flock_spec` assigned the options' `env_names`, which satisfy the options — once a value is left behind, the examples asserting those options are required stop raising. `xcodebuild_spec` deleted `XCODE_BUILD_PATH` after its assertion, which is skipped whenever the assertion fails. `update_checker_spec` deleted `BUNDLE_BIN_PATH` and `BUNDLE_GEMFILE` for the rest of the process, making every later example look as though it were not running under bundler. All four now use `FastlaneSpec::Env.with_env_values`, which restores what was there whether the example passes or not.

**Adds a guard that reports the rest.** `spec_helper.rb` snapshots `ENV` around each example and names what changed. It reports rather than fails, so it does not block anything today, and it finds leaks without depending on the order the suite ran in — the thing that makes these bugs cheap to enumerate rather than slow to stumble into.

Restoring is what makes the report worth reading. Without it each example is measured against whatever the previous one left behind, so an example setting a variable to the value already leaked there registers no change and is never named. Running the same seed both ways shows it: the two modes name the same 33 keys, but enforce attributes `DELIVER_PASSWORD` to the 1336 examples that actually set it while report attributes it to 24.

Restoring also matters in its own right. At that seed, report mode — which is what the suite does today, with nothing putting `ENV` back — fails three examples that enforce mode passes. Two are in `credentials_manager`, where `AccountManager` falls back to the legacy `DELIVER_PASSWORD` and picks up a value another spec left behind:

```
expected: "Yeah! Pass!"
     got: "DELIVERPASS"
```

An example that is meant to leave something behind says so:

```ruby
it "sets the team id", env_output: %w[FASTLANE_TEAM_ID] do
```

`FASTLANE_SPEC_ENV_GUARD` selects `enforce` (the default), `report` or `off`. `FASTLANE_SPEC_ENV_GUARD_REPORT` names a file to write the full inventory to, since the console summary lists only the first few examples per variable. Only key names are ever reported — the values are the point of the exercise.

### What it does not cover

A write at the top level of a tool spec helper happens once, outside every example, where no mode can restore it and no example can be blamed for it. Nothing does that today, and the load-time check is there so that it cannot start silently.

A write in a `before(:context)` hook enters the baseline of every example in the group and outlives the group, so the per-example comparison cannot see it either.

### Still reported

With the four fixes in, a full run still names 33 variables — including the `DELIVER_*` pair above, which comes from the match and cert spec helpers and is left for a follow-up. The four fixed here are the ones whose leaks had already been traced to specific order-dependent failures; the point of the guard is that the rest can now be listed rather than discovered one seed at a time. Not all 33 are spec bugs — `FASTLANE_LANE_NAME` is set by the lane runner itself, so it is the product's behaviour showing through, and enforce mode contains it either way.
