### PR TITLE
Stop two specs depending on files an earlier run left behind

### DIFF
--- a/fastlane/spec/ruby_version_warning_spec.rb
+++ b/fastlane/spec/ruby_version_warning_spec.rb
@@ -5,6 +5,14 @@ describe Fastlane::CLIToolsDistributor do
     before(:each) do
       # Need to make sure we don't actually trigger at_exit during tests in a way that interferes
       allow(Fastlane::CLIToolsDistributor).to receive(:at_exit)
+
+      # take_off warns about bundler whenever Helper.bundler? is false, which is
+      # what a spec that drops BUNDLE_GEMFILE or BUNDLE_BIN_PATH leaves behind.
+      # It warns either way: "detected a Gemfile" when the working directory has
+      # one, "get started using a Gemfile" when it does not, so the working
+      # directory only picks the message. Every example below constrains all
+      # calls to UI.important, so either one fails them. See fastlane#30184.
+      allow(Fastlane::CLIToolsDistributor).to receive(:print_bundle_exec_warning)
     end
 
     it "displays a warning when Ruby version is older than SUGGESTED_MINIMUM_RUBY" do

--- a/internal/rakelib/isolated.rake
+++ b/internal/rakelib/isolated.rake
@@ -1,25 +1,31 @@
-# Runs the suite against a home directory the project controls, see fastlane#30184.
+# Runs the suite against a home and a temporary directory the project controls,
+# see fastlane#30184.
 #
-# The suite reads and writes the developer's real home. It leaves dozens of
-# entries there — `~/.fastlane`, `~/Library/Logs/{fastlane,gym,scan,snapshot}`,
+# The suite reads and writes both. It leaves dozens of entries in the home
+# directory — `~/.fastlane`, `~/Library/Logs/{fastlane,gym,scan,snapshot}`,
 # `~/Library/MobileDevice/Provisioning Profiles`, `~/.appstoreconnect` and more
-# — and it reads state left by earlier runs. That is how the itc_service_key
-# dependency survived for months: `Client#itc_service_key` caches to a file, the
-# examples depending on it passed on any machine that had ever run the suite,
-# and only a clean CI checkout ever failed.
+# — and it reads state left by earlier runs in either place.
 #
-# Pointing HOME at a temporary directory makes those dependencies fail here
+# Both matter, and the second is easy to forget. `Client#itc_service_key` caches
+# the App Store Connect key under the temporary directory, not the home one, so
+# examples depending on that cache pass on any machine that has run the suite
+# before and fail only on a clean checkout. Isolating HOME alone leaves that
+# whole class invisible, which it was until it broke CI.
+#
+# Pointing both at throwaway directories makes those dependencies fail here
 # rather than on someone else's machine.
 #
 #   rake test_isolated                 the whole suite
 #   rake test_isolated[spaceship/spec] a subset
-desc("Run the suite with HOME pointed at a throwaway directory")
+desc("Run the suite with HOME and TMPDIR pointed at throwaway directories")
 task(:test_isolated, [:pattern]) do |_task, args|
   require "tmpdir"
   require "fileutils"
 
   home = Dir.mktmpdir("fastlane-isolated-home")
-  env = { "HOME" => home }
+  # Made before TMPDIR is redirected, so both live somewhere real.
+  tmp = Dir.mktmpdir("fastlane-isolated-tmp")
+  env = { "HOME" => home, "TMPDIR" => tmp }
 
   # A keychain has to be seeded, because `security cms -D`, which fastlane uses
   # to decode provisioning profiles in verify_build, provisioning_profile.rb and
@@ -56,14 +62,22 @@ task(:test_isolated, [:pattern]) do |_task, args|
 
   # What the run left behind, which is the point of the exercise as much as the
   # pass or fail is.
-  written = Dir.glob(File.join(home, "**", "*"), File::FNM_DOTMATCH)
-               .select { |path| File.file?(path) }
-  puts("")
-  puts("The run wrote #{written.size} files into HOME:")
-  written.group_by { |path| File.dirname(path).delete_prefix(home) }
-         .sort_by { |directory, files| [-files.size, directory] }
-         .each { |directory, files| puts("  #{files.size.to_s.rjust(4)}  ~#{directory}") }
+  { "HOME" => home, "TMPDIR" => tmp }.each do |name, root|
+    written = Dir.glob(File.join(root, "**", "*"), File::FNM_DOTMATCH)
+                 .select { |path| File.file?(path) }
+    puts("")
+    puts("The run wrote #{written.size} files into #{name}:")
+    prefix = name == "HOME" ? "~" : ""
+    written.group_by { |path| File.dirname(path).delete_prefix(root) }
+           .sort_by { |directory, files| [-files.size, directory] }
+           .each do |directory, files|
+             # Files sitting at the root group under an empty string, and the
+             # ones that land there are usually the interesting ones.
+             label = directory.empty? ? files.map { |f| File.basename(f) }.sort.join(", ") : "#{prefix}#{directory}"
+             puts("  #{files.size.to_s.rjust(4)}  #{label}")
+           end
+  end
 
-  FileUtils.remove_entry(home)
-  abort("suite failed under an isolated HOME") unless ok
+  [home, tmp].each { |root| FileUtils.remove_entry(root) }
+  abort("suite failed under an isolated HOME and TMPDIR") unless ok
 end

--- a/internal/rakelib/isolated.rake
+++ b/internal/rakelib/isolated.rake
@@ -1,0 +1,69 @@
+# Runs the suite against a home directory the project controls, see fastlane#30184.
+#
+# The suite reads and writes the developer's real home. It leaves dozens of
+# entries there — `~/.fastlane`, `~/Library/Logs/{fastlane,gym,scan,snapshot}`,
+# `~/Library/MobileDevice/Provisioning Profiles`, `~/.appstoreconnect` and more
+# — and it reads state left by earlier runs. That is how the itc_service_key
+# dependency survived for months: `Client#itc_service_key` caches to a file, the
+# examples depending on it passed on any machine that had ever run the suite,
+# and only a clean CI checkout ever failed.
+#
+# Pointing HOME at a temporary directory makes those dependencies fail here
+# rather than on someone else's machine.
+#
+#   rake test_isolated                 the whole suite
+#   rake test_isolated[spaceship/spec] a subset
+desc("Run the suite with HOME pointed at a throwaway directory")
+task(:test_isolated, [:pattern]) do |_task, args|
+  require "tmpdir"
+  require "fileutils"
+
+  home = Dir.mktmpdir("fastlane-isolated-home")
+  env = { "HOME" => home }
+
+  # A keychain has to be seeded, because `security cms -D`, which fastlane uses
+  # to decode provisioning profiles in verify_build, provisioning_profile.rb and
+  # sigh's local_manage, imports the signing certificate to verify the signature
+  # and fails with "A default keychain could not be found" when there is none.
+  # The certificates it writes land in this throwaway keychain instead of the
+  # developer's login keychain, which is where they go today.
+  if RUBY_PLATFORM.include?("darwin")
+    FileUtils.mkdir_p(File.join(home, "Library", "Keychains"))
+    keychain = "login.keychain"
+    [
+      "security create-keychain -p '' #{keychain}",
+      "security default-keychain -s #{keychain}",
+      "security list-keychains -s #{keychain}",
+      "security unlock-keychain -p '' #{keychain}"
+    ].each { |command| system(env, command, out: File::NULL, err: File::NULL) }
+
+    # Check it took, and stop here if it did not. Running on without a keychain
+    # is worse than a failure: with a desktop session `security` puts up a modal
+    # asking for access and waits for someone to click it, so the suite hangs
+    # rather than reporting anything. Headless there is nobody to click it.
+    seeded = File.join(home, "Library", "Keychains", "#{keychain}-db")
+    unless File.exist?(seeded)
+      FileUtils.remove_entry(home)
+      abort("could not seed a keychain at #{seeded}, refusing to run: the suite would block on a keychain prompt")
+    end
+    puts("HOME is #{home}, keychain seeded")
+  else
+    puts("HOME is #{home}")
+  end
+
+  command = args[:pattern] ? "rspec #{args[:pattern]} --format progress" : "rake test_all"
+  ok = system(env, "bundle exec #{command}")
+
+  # What the run left behind, which is the point of the exercise as much as the
+  # pass or fail is.
+  written = Dir.glob(File.join(home, "**", "*"), File::FNM_DOTMATCH)
+               .select { |path| File.file?(path) }
+  puts("")
+  puts("The run wrote #{written.size} files into HOME:")
+  written.group_by { |path| File.dirname(path).delete_prefix(home) }
+         .sort_by { |directory, files| [-files.size, directory] }
+         .each { |directory, files| puts("  #{files.size.to_s.rjust(4)}  ~#{directory}") }
+
+  FileUtils.remove_entry(home)
+  abort("suite failed under an isolated HOME") unless ok
+end

--- a/spaceship/spec/tunes/iap_detail_spec.rb
+++ b/spaceship/spec/tunes/iap_detail_spec.rb
@@ -1,3 +1,4 @@
+require 'tempfile'
 describe Spaceship::Tunes::IAPDetail do
   before { TunesStubbing.itc_stub_iap }
   include_examples "common spaceship login"
@@ -97,12 +98,20 @@ describe Spaceship::Tunes::IAPDetail do
     end
 
     it "saved and changed screenshot" do
-      detailed.review_screenshot = "#{Dir.tmpdir}/fastlane_tests"
+      # Its own file. This used to point at "#{Dir.tmpdir}/fastlane_tests",
+      # which is where spec_helper redirects $stdout, so the example was relying
+      # on the harness's log file existing and being named that. Only the
+      # existence of the path is checked here: the upload and the content type
+      # are both stubbed below. See fastlane#30184.
+      screenshot = Tempfile.new(["review_screenshot", ".jpg"])
+      detailed.review_screenshot = screenshot.path
       expect(client.du_client).to receive(:upload_purchase_review_screenshot).and_return({ "token" => "tok", "height" => 100, "width" => 200, "md5" => "xxxx" })
       expect(client.du_client).to receive(:get_picture_type).and_return("MZPFT.SortedScreenShot")
       expect(Spaceship::Utilities).to receive(:content_type).and_return("image/jpg")
       expect(client).to receive(:update_iap!).with(app_id: '898536088', purchase_id: "1195137656", data: detailed.raw_data)
       detailed.save!
+    ensure
+      screenshot&.close!
     end
 
     it "saved with subscription pricing goal" do


### PR DESCRIPTION
Part of #30184. Chained on #30194 — review that one first, and the diff here will shrink to its own three commits once it merges.

### The problem

The specs in the earlier PRs in this chain depended on state held in the process: module level configuration, spaceship client singletons, `ENV`. This group is the other kind — specs depending on state that outlives the process entirely, in `/tmp` or in the developer's home directory.

Those are the ones that never fail where they are written. A file an earlier run created is there on any machine that has run the suite before, so the spec passes locally and in every re-run, and fails only on a clean checkout. The `itc_service_key` dependency fixed earlier in this chain survived for months exactly that way.

### What this does

**`iap_detail_spec` gets its own file.** The screenshot example set `review_screenshot` to `"#{Dir.tmpdir}/fastlane_tests"` — the path `spec_helper` redirects `$stdout` to. It was asserting against the harness's own log file, and passed only because the harness had created it. With `DEBUG` set, which skips the redirect, and that file removed, the example fails. Only the existence of the path is checked, since the upload and the content type are both stubbed, so a `Tempfile` does the job.

**`ruby_version_warning_spec` stops depending on the bundler environment.** `take_off` calls `print_bundle_exec_warning`, which warns whenever `Helper.bundler?` is false — the state a spec that drops `BUNDLE_GEMFILE` or `BUNDLE_BIN_PATH` leaves behind. It warns either way: "detected a Gemfile" when the working directory has one, "get started using a Gemfile" when it does not, so the working directory picks which message appears rather than whether one does. Every example in the group constrains all calls to `UI.important`, so either message fails them.

The `ENV` guard from #30194 already prevents this at source, so this is the spec standing on its own rather than being contained by a global hook — worth having, but not load-bearing. The commit says so.

**`rake test_isolated` runs the suite against a throwaway `HOME`.** It points `HOME` at a temporary directory, runs the suite, reports what was written into it, and removes it. That turns "this spec depends on a file in my home directory" from something you discover on someone else's clean machine into something that fails on yours.

On macOS it seeds a keychain first. `security cms -D`, which fastlane uses to decode provisioning profiles in `verify_build`, `provisioning_profile.rb` and sigh's `local_manage`, imports the signing certificate to verify the signature and fails with "A default keychain could not be found" when there is none. Seeding one also keeps those certificates out of the developer's login keychain, which is where they land today — that is #30186. If seeding does not take, the task stops rather than running on: with a desktop session `security` puts up a modal and waits for someone to click it, so the suite would hang rather than report.

### Checks

`rake test_isolated` on macOS: **7863 examples, 0 failures, 1 pending**, and the run wrote 27 files into the throwaway home:

```
  11  ~/.cache/rubocop_cache/<hash>/<hash>
  11  ~/.cache/rubocop_cache/<hash>/<hash>
   2  ~/Library/Keychains
   1  ~/.fastlane
   1  ~/Library/Developer/Xcode/UserData/Provisioning Profiles
   1  ~/Library/MobileDevice/Provisioning Profiles
```

The keychain is the one the task seeds. The rest is the suite still writing into the home directory it is given, which is #30187 and not addressed here — the point of the task is that the list is now visible and short enough to read.

The suite also passes normally on this branch: 7863 examples, 0 failures at seed 11378, with the guard from #30194 in enforce mode.

Both spec fixes were checked by reverting them: with the harness log removed, `iap_detail_spec` fails without its fix and passes with it; with the bundler variables dropped and the guard off, `ruby_version_warning_spec` fails without its fix and passes with it.
