### PR TITLE
[spaceship] Use the system temporary directory instead of a literal /tmp

### DIFF
--- a/fastlane/lib/fastlane/actions/spaceship_logs.rb
+++ b/fastlane/lib/fastlane/actions/spaceship_logs.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 module Fastlane
   module Actions
     class SpaceshipLogsAction < Action
@@ -8,8 +10,8 @@ module Fastlane
         copy_to_path = params[:copy_to_path]
         copy_to_clipboard = params[:copy_to_clipboard]
 
-        # Get log files
-        files = Dir.glob("/tmp/spaceship*.log").sort_by { |f| File.mtime(f) }.reverse
+        # Get log files, from wherever Spaceship::Client#logger writes them.
+        files = Dir.glob(File.join(Dir.tmpdir, "spaceship*.log")).sort_by { |f| File.mtime(f) }.reverse
 
         if files.size == 0
           UI.message("No Spaceship log files found")

--- a/fastlane/spec/actions_specs/spaceship_logs_spec.rb
+++ b/fastlane/spec/actions_specs/spaceship_logs_spec.rb
@@ -1,0 +1,28 @@
+require 'tmpdir'
+
+describe Fastlane do
+  describe Fastlane::Actions::SpaceshipLogsAction do
+    # This action reads the files Spaceship::Client#logger writes. The two used
+    # to agree on a literal "/tmp" and now agree on Dir.tmpdir, which is a thing
+    # they can only get wrong together. Moving one without the other leaves the
+    # action silently finding nothing. See fastlane#30184.
+    it "looks where spaceship writes its logs" do
+      path = File.join(Dir.tmpdir, "spaceship#{Time.now.to_i}_#{Process.pid}_spec.log")
+      File.write(path, "a log line")
+
+      begin
+        files = Fastlane::Actions::SpaceshipLogsAction.run(
+          latest: false,
+          print_contents: false,
+          print_paths: false,
+          copy_to_path: nil,
+          copy_to_clipboard: false
+        )
+
+        expect(files).to include(path)
+      ensure
+        File.delete(path) if File.exist?(path)
+      end
+    end
+  end
+end

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -1,7 +1,20 @@
+require 'tmpdir'
 require 'shellwords'
 require 'credentials_manager'
 
 describe FastlaneCore do
+  # Dir.tmpdir rather than a literal "/tmp". The transporter chdirs into the
+  # directory it is given, and "/tmp" is not one on Windows: it resolves against
+  # the current drive, so these examples failed with Errno::ENOENT unless
+  # something else had created it first. See fastlane#30184.
+  #
+  # Read once here rather than per call, because several examples below stub
+  # Dir.tmpdir and assert how often it is called. A local captured by
+  # define_method, not a constant: a constant assigned in a describe block takes
+  # the block's lexical scope and would be defined globally.
+  tmpdir_at_load = Dir.tmpdir
+  define_method(:tmp_dir) { tmpdir_at_load }
+
   let(:password) { "!> p@$s_-+=w'o%rd\"&#*<" }
   let(:email) { 'fabric.devtools@gmail.com' }
   let(:jwt) { '409jjl43j90ghjqoineio49024' }
@@ -15,12 +28,12 @@ describe FastlaneCore do
 
     def shell_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, username: email, input_pass: password, api_key: nil, is_mac: true, has_appstore_info: true)
       upload_part = if use_asset_path
-                      "-assetFile /tmp/#{random_uuid}.ipa"
+                      "-assetFile #{tmp_dir}/#{random_uuid}.ipa"
                     elsif !is_mac && has_appstore_info
                       # On non-macOS platforms, use -assetFile with -assetDescription for .itmsp directories
-                      "-assetFile /tmp/my.app.id.itmsp/my.app.id.ipa -assetDescription /tmp/my.app.id.itmsp/AppStoreInfo.plist"
+                      "-assetFile #{tmp_dir}/my.app.id.itmsp/my.app.id.ipa -assetDescription #{tmp_dir}/my.app.id.itmsp/AppStoreInfo.plist"
                     else
-                      "-f /tmp/my.app.id.itmsp"
+                      "-f #{tmp_dir}/my.app.id.itmsp"
                     end
 
       username = username if username != email
@@ -66,7 +79,7 @@ describe FastlaneCore do
         end
         escaped_password = "'" + escaped_password + "'"
       end
-      verify_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      verify_part = use_asset_path ? "-assetFile #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
       [
         '"' + FastlaneCore::Helper.transporter_path + '"',
         "-m verify",
@@ -95,7 +108,7 @@ describe FastlaneCore do
         ("-p #{escaped_password}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         "-apple_id my.app.id",
-        "-destination '/tmp'",
+        "-destination '#{tmp_dir}'",
         ("-itc_provider #{provider_short_name}" if provider_short_name)
       ].compact.join(' ')
     end
@@ -114,7 +127,7 @@ describe FastlaneCore do
     def altool_upload_command(api_key: nil, platform: "macos", provider_short_name: "", provider_public_id: "", use_asset_path: false)
       use_api_key = !api_key.nil?
       # altool never supports -assetFile, so even asset paths use -f
-      upload_part = use_asset_path ? "-f /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-f #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
       escaped_password = password.shellescape
 
       [
@@ -135,7 +148,7 @@ describe FastlaneCore do
     def altool_verify_command(api_key: nil, platform: "macos", provider_short_name: "", provider_public_id: "", use_asset_path: false)
       use_api_key = !api_key.nil?
       # altool never supports -assetFile, so even asset paths use -f
-      verify_part = use_asset_path ? "-f /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      verify_part = use_asset_path ? "-f #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
       escaped_password = password.shellescape
 
       [
@@ -168,7 +181,7 @@ describe FastlaneCore do
     end
 
     def java_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, classpath: true, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -209,7 +222,7 @@ describe FastlaneCore do
         "-m verify",
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
-        "-f /tmp/my.app.id.itmsp",
+        "-f #{tmp_dir}/my.app.id.itmsp",
         (transporter.to_s if transporter),
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
@@ -233,7 +246,7 @@ describe FastlaneCore do
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         '-apple_id my.app.id',
-        '-destination /tmp',
+        "-destination #{tmp_dir}",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
       ].compact.join(' ')
@@ -259,7 +272,7 @@ describe FastlaneCore do
     end
 
     def java_upload_command_9(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -296,7 +309,7 @@ describe FastlaneCore do
         "-m verify",
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
-        "-f /tmp/my.app.id.itmsp",
+        "-f #{tmp_dir}/my.app.id.itmsp",
         (transporter.to_s if transporter),
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
@@ -318,14 +331,14 @@ describe FastlaneCore do
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         '-apple_id my.app.id',
-        '-destination /tmp',
+        "-destination #{tmp_dir}",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
       ].compact.join(' ')
     end
 
     def xcrun_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
 
       [
         ("ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}" if jwt.nil?),
@@ -350,7 +363,7 @@ describe FastlaneCore do
         ("-u #{email.shellescape}" if jwt.nil?),
         ("-p @env:ITMS_TRANSPORTER_PASSWORD" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
-        "-f /tmp/my.app.id.itmsp",
+        "-f #{tmp_dir}/my.app.id.itmsp",
         '2>&1'
       ].compact.join(' ')
     end
@@ -364,7 +377,7 @@ describe FastlaneCore do
         ("-p @env:ITMS_TRANSPORTER_PASSWORD" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         '-apple_id my.app.id',
-        '-destination /tmp',
+        "-destination #{tmp_dir}",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
       ].compact.join(' ')
@@ -375,7 +388,7 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('7.3')
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
       end
 
       describe "by default" do
@@ -383,7 +396,7 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command)
             end
           end
 
@@ -392,7 +405,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(transporter: "-t DAV,Signiant"))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(transporter: "-t DAV,Signiant"))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -403,7 +416,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command)
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -412,14 +425,14 @@ describe FastlaneCore do
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command)
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command)
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command)
             end
           end
 
@@ -435,7 +448,7 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(jwt: jwt))
             end
           end
 
@@ -444,7 +457,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -455,7 +468,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(jwt: jwt))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -464,14 +477,14 @@ describe FastlaneCore do
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command(jwt: jwt))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command(jwt: jwt))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command(jwt: jwt))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command(jwt: jwt))
             end
           end
 
@@ -486,14 +499,14 @@ describe FastlaneCore do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(java_upload_command(jwt: jwt))
+                expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(java_upload_command(jwt: jwt))
               end
             end
 
             describe "verify command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.verify(package_path: '/tmp/my.app.id.itmsp')).to eq(java_verify_command(jwt: jwt))
+                expect(transporter.verify(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(java_verify_command(jwt: jwt))
               end
             end
           end
@@ -501,11 +514,11 @@ describe FastlaneCore do
           describe "with asset_path" do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
-                expect(Dir).to receive(:tmpdir).and_return("/tmp")
+                expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
                 expect(FileUtils).to receive(:cp)
 
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.upload(asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command(jwt: jwt, use_asset_path: true))
+                expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa")).to eq(java_upload_command(jwt: jwt, use_asset_path: true))
               end
             end
           end
@@ -513,11 +526,11 @@ describe FastlaneCore do
           describe "with package_path and asset_path" do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter with -assetFile' do
-                expect(Dir).to receive(:tmpdir).and_return("/tmp")
+                expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
                 expect(FileUtils).to receive(:cp)
 
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp', asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command(jwt: jwt, use_asset_path: true))
+                expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp", asset_path: "#{tmp_dir}/my_app.ipa")).to eq(java_upload_command(jwt: jwt, use_asset_path: true))
               end
             end
 
@@ -526,7 +539,7 @@ describe FastlaneCore do
                 stub_const('ENV', { 'ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD' => 'true' })
 
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp', asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command(jwt: jwt, use_asset_path: false))
+                expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp", asset_path: "#{tmp_dir}/my_app.ipa")).to eq(java_upload_command(jwt: jwt, use_asset_path: false))
               end
             end
           end
@@ -538,21 +551,21 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd1234')
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(provider_short_name: 'abcd1234'))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(provider_short_name: 'abcd1234'))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd1234')
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command(provider_short_name: 'abcd1234'))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command(provider_short_name: 'abcd1234'))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd1234')
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command('abcd1234'))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command('abcd1234'))
             end
           end
 
@@ -568,21 +581,21 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, 'abcd1234', jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(jwt: jwt))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, 'abcd1234', jwt)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command(jwt: jwt))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command(jwt: jwt))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, 'abcd1234', jwt)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command(jwt: jwt))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command(jwt: jwt))
             end
           end
         end
@@ -593,21 +606,21 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true, 'abcd1234')
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(provider_short_name: 'abcd1234'))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(provider_short_name: 'abcd1234'))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true, 'abcd1234')
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command(provider_short_name: 'abcd1234'))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command(provider_short_name: 'abcd1234'))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true, 'abcd1234')
-              expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command('abcd1234'))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command('abcd1234'))
             end
           end
 
@@ -623,21 +636,21 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(jwt: jwt))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command(jwt: jwt))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command(jwt: jwt))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command(jwt: jwt))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command(jwt: jwt))
             end
           end
 
@@ -645,14 +658,14 @@ describe FastlaneCore do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(shell_upload_command(jwt: jwt))
+                expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(shell_upload_command(jwt: jwt))
               end
             end
 
             describe "verify command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-                expect(transporter.verify(package_path: '/tmp/my.app.id.itmsp')).to eq(shell_verify_command(jwt: jwt))
+                expect(transporter.verify(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(shell_verify_command(jwt: jwt))
               end
             end
           end
@@ -660,11 +673,11 @@ describe FastlaneCore do
           describe "with asset_path" do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
-                expect(Dir).to receive(:tmpdir).and_return("/tmp")
+                expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
                 expect(FileUtils).to receive(:cp)
 
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-                expect(transporter.upload(asset_path: '/tmp/my_app.ipa')).to eq(shell_upload_command(jwt: jwt, use_asset_path: true))
+                expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa")).to eq(shell_upload_command(jwt: jwt, use_asset_path: true))
               end
             end
           end
@@ -676,7 +689,7 @@ describe FastlaneCore do
           it 'generates a call to the shell script' do
             FastlaneSpec::Env.with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
             end
           end
         end
@@ -685,7 +698,7 @@ describe FastlaneCore do
           it 'generates a call to the shell script' do
             FastlaneSpec::Env.with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command)
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command)
             end
           end
         end
@@ -694,7 +707,7 @@ describe FastlaneCore do
           it 'generates a call to the shell script' do
             FastlaneSpec::Env.with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command)
             end
           end
         end
@@ -713,31 +726,31 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
           end
         end
 
         describe "verify command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command)
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command)
           end
         end
 
         describe "verify command generation with .ipa source" do
           it "uses -assetFile for .ipa files" do
-            expect(Dir).to receive(:tmpdir).and_return("/tmp")
+            expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
             expect(FileUtils).to receive(:cp)
 
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-            expect(transporter.verify(asset_path: '/tmp/my_app.ipa')).to include("-assetFile")
+            expect(transporter.verify(asset_path: "#{tmp_dir}/my_app.ipa")).to include("-assetFile")
           end
         end
 
         describe "download command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command)
           end
         end
 
@@ -753,21 +766,21 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command)
           end
         end
 
         describe "verify command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command)
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command)
           end
         end
 
         describe "download command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command)
           end
         end
 
@@ -785,14 +798,14 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('6.4')
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
       end
 
       describe "with username and password" do
         describe "upload command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
           end
         end
 
@@ -801,7 +814,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(transporter: "-t DAV,Signiant"))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(transporter: "-t DAV,Signiant"))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -812,7 +825,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -821,14 +834,14 @@ describe FastlaneCore do
         describe "verify command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command)
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command)
           end
         end
 
         describe "download command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command)
           end
         end
 
@@ -844,7 +857,7 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(jwt: jwt))
           end
         end
 
@@ -853,7 +866,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -864,7 +877,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(jwt: jwt))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -873,14 +886,14 @@ describe FastlaneCore do
         describe "verify command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command(jwt: jwt))
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command(jwt: jwt))
           end
         end
 
         describe "download command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command(jwt: jwt))
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command(jwt: jwt))
           end
         end
 
@@ -898,14 +911,14 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('9.1')
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
       end
 
       describe "with username and password" do
         describe "upload command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9)
           end
         end
 
@@ -914,7 +927,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9(transporter: "-t DAV,Signiant"))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9(transporter: "-t DAV,Signiant"))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -925,7 +938,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9)
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -934,14 +947,14 @@ describe FastlaneCore do
         describe "verify command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command_9)
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command_9)
           end
         end
 
         describe "download command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command_9)
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command_9)
           end
         end
       end
@@ -950,7 +963,7 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9(jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9(jwt: jwt))
           end
         end
 
@@ -959,7 +972,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9(transporter: "-t DAV,Signiant", jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9(transporter: "-t DAV,Signiant", jwt: jwt))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -970,7 +983,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9(jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9(jwt: jwt))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -979,14 +992,14 @@ describe FastlaneCore do
         describe "verify command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command_9(jwt: jwt))
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command_9(jwt: jwt))
           end
         end
 
         describe "download command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command_9(jwt: jwt))
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command_9(jwt: jwt))
           end
         end
 
@@ -996,7 +1009,7 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(java_upload_command_9(jwt: jwt))
+              expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(java_upload_command_9(jwt: jwt))
             end
           end
         end
@@ -1006,11 +1019,11 @@ describe FastlaneCore do
 
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
-              expect(Dir).to receive(:tmpdir).and_return("/tmp")
+              expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
               expect(FileUtils).to receive(:cp)
 
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload(asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command_9(jwt: jwt, use_asset_path: true))
+              expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa")).to eq(java_upload_command_9(jwt: jwt, use_asset_path: true))
             end
           end
         end
@@ -1027,14 +1040,14 @@ describe FastlaneCore do
       describe "with username and password" do
         describe "with default itms_path" do
           before(:each) do
-            allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+            allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
             stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
           end
 
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command)
             end
           end
 
@@ -1043,7 +1056,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant"))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant"))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -1054,7 +1067,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command)
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -1063,41 +1076,41 @@ describe FastlaneCore do
           describe "verify command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(xcrun_verify_command)
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(xcrun_verify_command)
             end
           end
 
           describe "download command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(xcrun_download_command)
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(xcrun_download_command)
             end
           end
         end
 
         describe "with user defined itms_path" do
           before(:each) do
-            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/tmp' })
+            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => tmp_dir })
           end
 
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(classpath: false))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(classpath: false))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command(classpath: false))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command(classpath: false))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command(classpath: false))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command(classpath: false))
             end
           end
         end
@@ -1105,7 +1118,7 @@ describe FastlaneCore do
 
       describe "with JWT" do
         before(:each) do
-          allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+          allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
           stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
         end
 
@@ -1113,7 +1126,7 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command(jwt: jwt))
             end
           end
 
@@ -1122,7 +1135,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -1133,7 +1146,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command(jwt: jwt))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -1142,14 +1155,14 @@ describe FastlaneCore do
           describe "verify command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(xcrun_verify_command(jwt: jwt))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(xcrun_verify_command(jwt: jwt))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(xcrun_download_command(jwt: jwt))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(xcrun_download_command(jwt: jwt))
             end
           end
         end
@@ -1158,14 +1171,14 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(xcrun_upload_command(jwt: jwt))
+              expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(xcrun_upload_command(jwt: jwt))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.verify(package_path: '/tmp/my.app.id.itmsp')).to eq(xcrun_verify_command(jwt: jwt))
+              expect(transporter.verify(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(xcrun_verify_command(jwt: jwt))
             end
           end
         end
@@ -1173,11 +1186,11 @@ describe FastlaneCore do
         describe "with asset_path" do
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
-              expect(Dir).to receive(:tmpdir).and_return("/tmp")
+              expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
               expect(FileUtils).to receive(:cp)
 
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload(asset_path: '/tmp/my_app.ipa')).to eq(xcrun_upload_command(jwt: jwt, use_asset_path: true))
+              expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa")).to eq(xcrun_upload_command(jwt: jwt, use_asset_path: true))
             end
           end
         end
@@ -1200,13 +1213,13 @@ describe FastlaneCore do
           context "upload command generation" do
             it 'generates a call to altool' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd123', altool_compatible_command: true)
-              expect(transporter.upload('my.app.id', '/tmp', package_path: '/tmp/my.app.id.itmsp', platform: "osx")).to eq(altool_upload_command(provider_short_name: 'abcd123'))
+              expect(transporter.upload('my.app.id', tmp_dir, package_path: "#{tmp_dir}/my.app.id.itmsp", platform: "osx")).to eq(altool_upload_command(provider_short_name: 'abcd123'))
             end
 
             it 'generates a call to altool with provider_public_id' do
               provider_public_id = '00000000-0000-0000-0000-000000000000'
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, nil, altool_compatible_command: true, provider_public_id: provider_public_id)
-              expect(transporter.upload('my.app.id', '/tmp', package_path: '/tmp/my.app.id.itmsp', platform: "osx")).to eq(altool_upload_command(provider_short_name: nil, provider_public_id: provider_public_id))
+              expect(transporter.upload('my.app.id', tmp_dir, package_path: "#{tmp_dir}/my.app.id.itmsp", platform: "osx")).to eq(altool_upload_command(provider_short_name: nil, provider_public_id: provider_public_id))
             end
           end
 
@@ -1219,12 +1232,12 @@ describe FastlaneCore do
 
           context "upload command generation with .ipa source (asset file)" do
             it "still uses -f for .ipa files since altool does not support -assetFile" do
-              expect(Dir).to receive(:tmpdir).and_return("/tmp")
+              expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
               expect(FileUtils).to receive(:cp)
 
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, nil, nil,
                                                                 altool_compatible_command: true)
-              expect(transporter.upload(asset_path: '/tmp/my_app.ipa', platform: "osx")).to eq(
+              expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa", platform: "osx")).to eq(
                 altool_upload_command(use_asset_path: true, provider_short_name: "")
               )
             end
@@ -1232,12 +1245,12 @@ describe FastlaneCore do
 
           context "verify command generation with .ipa source (asset file)" do
             it "still uses -f for .ipa files since altool does not support -assetFile" do
-              expect(Dir).to receive(:tmpdir).and_return("/tmp")
+              expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
               expect(FileUtils).to receive(:cp)
 
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, nil, nil,
                                                                 altool_compatible_command: true)
-              expect(transporter.verify(asset_path: '/tmp/my_app.ipa', platform: "osx")).to eq(
+              expect(transporter.verify(asset_path: "#{tmp_dir}/my_app.ipa", platform: "osx")).to eq(
                 altool_verify_command(use_asset_path: true, provider_short_name: "")
               )
             end
@@ -1246,13 +1259,13 @@ describe FastlaneCore do
 
         context "with user defined itms_path" do
           before(:each) do
-            allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
-            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/tmp' })
+            allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
+            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => tmp_dir })
           end
           context "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter instead altool' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd123', altool_compatible_command: true)
-              expect(transporter.upload('my.app.id', '/tmp', platform: "osx")).to eq(java_upload_command(provider_short_name: 'abcd123', classpath: false))
+              expect(transporter.upload('my.app.id', tmp_dir, platform: "osx")).to eq(java_upload_command(provider_short_name: 'abcd123', classpath: false))
             end
           end
         end
@@ -1270,7 +1283,7 @@ describe FastlaneCore do
             it 'generates a call to altool' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd123', altool_compatible_command: true, api_key: api_key)
               expected = Regexp.new("API_PRIVATE_KEYS_DIR=#{Regexp.escape(Dir.tmpdir)}.*\s#{Regexp.escape(altool_upload_command(api_key: api_key, provider_short_name: 'abcd123'))}")
-              expect(transporter.upload('my.app.id', '/tmp', platform: "osx")).to match(expected)
+              expect(transporter.upload('my.app.id', tmp_dir, platform: "osx")).to match(expected)
             end
           end
 
@@ -1289,15 +1302,15 @@ describe FastlaneCore do
       shared_examples "non_macOS_setup" do
         before do
           allow(FastlaneCore::Helper).to receive(:is_mac?).and_return(false)
-          allow(File).to receive(:directory?).with('/tmp/my.app.id.itmsp').and_return(true)
-          allow(Dir).to receive(:glob).with('/tmp/my.app.id.itmsp/*.{ipa,pkg,dmg,zip}').and_return(['/tmp/my.app.id.itmsp/my.app.id.ipa'])
+          allow(File).to receive(:directory?).with("#{tmp_dir}/my.app.id.itmsp").and_return(true)
+          allow(Dir).to receive(:glob).with("#{tmp_dir}/my.app.id.itmsp/*.{ipa,pkg,dmg,zip}").and_return(["#{tmp_dir}/my.app.id.itmsp/my.app.id.ipa"])
           allow(FastlaneCore::UI).to receive(:verbose)
         end
       end
 
       before(:each) do
         ENV["FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT"] = "1"
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         allow(File).to receive(:exist?).with("C:/Program Files (x86)/itms").and_return(true) if FastlaneCore::Helper.windows?
       end
 
@@ -1309,30 +1322,30 @@ describe FastlaneCore do
 
           context "with AppStoreInfo.plist present" do
             before do
-              allow(File).to receive(:file?).with('/tmp/my.app.id.itmsp/AppStoreInfo.plist').and_return(true)
+              allow(File).to receive(:file?).with("#{tmp_dir}/my.app.id.itmsp/AppStoreInfo.plist").and_return(true)
             end
 
             it 'uses -assetFile and -assetDescription when uploading with package_path and JWT' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-              expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(shell_upload_command(jwt: jwt, is_mac: false, has_appstore_info: true))
+              expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(shell_upload_command(jwt: jwt, is_mac: false, has_appstore_info: true))
             end
 
             it 'uses -assetFile and -assetDescription when uploading with app_id and dir' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(is_mac: false, has_appstore_info: true))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(is_mac: false, has_appstore_info: true))
             end
           end
 
           context "without AppStoreInfo.plist" do
             before do
-              allow(File).to receive(:file?).with('/tmp/my.app.id.itmsp/AppStoreInfo.plist').and_return(false)
+              allow(File).to receive(:file?).with("#{tmp_dir}/my.app.id.itmsp/AppStoreInfo.plist").and_return(false)
               allow(FastlaneCore::UI).to receive(:error)
               allow(FastlaneCore::UI).to receive(:user_error!).and_raise(FastlaneCore::Interface::FastlaneError)
             end
 
             it 'raises an error about missing AppStoreInfo.plist' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-              expect { transporter.upload('my.app.id', '/tmp') }.to raise_error(FastlaneCore::Interface::FastlaneError)
+              expect { transporter.upload('my.app.id', tmp_dir) }.to raise_error(FastlaneCore::Interface::FastlaneError)
               expect(FastlaneCore::UI).to have_received(:error).with("AppStoreInfo.plist is required for uploading .ipa files on non-macOS platforms.")
             end
           end
@@ -1341,12 +1354,12 @@ describe FastlaneCore do
         context "on macOS platforms" do
           it 'generates a call to the shell script with user and password' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
           end
 
           it 'generates a call to the shell script with api key' do
             transporter = FastlaneCore::ItunesTransporter.new(api_key: api_key)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(username: nil, input_pass: nil, api_key: api_key))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(username: nil, input_pass: nil, api_key: api_key))
             expect(Dir.empty?(keys_parent_dir)).to be_truthy if Dir.exist?(keys_parent_dir)
           end
         end
@@ -1355,14 +1368,14 @@ describe FastlaneCore do
       describe "verify command generation" do
         it 'generates a call to the shell script' do
           transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-          expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command)
+          expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command)
         end
       end
 
       describe "download command generation" do
         it 'generates a call to the shell script' do
           transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-          expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+          expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command)
         end
       end
 
@@ -1371,7 +1384,7 @@ describe FastlaneCore do
 
     describe "with no special configuration" do
       before(:each) do
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         allow(File).to receive(:exist?).and_return(true) unless FastlaneCore::Helper.mac?
         ENV.delete("FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT")
       end
@@ -1388,7 +1401,7 @@ describe FastlaneCore do
           command = java_upload_command_9 if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(9)
           # If we are on Mac with Xcode >= 11, switch to xcrun command
           command = xcrun_upload_command if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(11)
-          expect(transporter.upload('my.app.id', '/tmp')).to eq(command)
+          expect(transporter.upload('my.app.id', tmp_dir)).to eq(command)
         end
       end
 
@@ -1404,7 +1417,7 @@ describe FastlaneCore do
           command = java_verify_command_9 if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(9)
           # If we are on Mac with Xcode >= 11, switch to xcrun command
           command = xcrun_verify_command if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(11)
-          expect(transporter.verify('my.app.id', '/tmp')).to eq(command)
+          expect(transporter.verify('my.app.id', tmp_dir)).to eq(command)
         end
       end
 
@@ -1420,7 +1433,7 @@ describe FastlaneCore do
           command = java_download_command_9 if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(9)
           # If we are on Mac with Xcode >= 11, switch to newer xcrun command
           command = xcrun_download_command if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(11)
-          expect(transporter.download('my.app.id', '/tmp')).to eq(command)
+          expect(transporter.download('my.app.id', tmp_dir)).to eq(command)
         end
       end
     end
@@ -1431,7 +1444,7 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
 
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
       end
 
@@ -1446,7 +1459,7 @@ describe FastlaneCore do
           # Call original implementation to undo above expect
           expect_any_instance_of(FastlaneCore::JavaTransporterExecutor).to receive(:execute).and_call_original
 
-          expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+          expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command)
         end
 
         it "with package_path" do
@@ -1459,7 +1472,7 @@ describe FastlaneCore do
           # Call original implementation to undo above expect
           expect_any_instance_of(FastlaneCore::JavaTransporterExecutor).to receive(:execute).and_call_original
 
-          expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(xcrun_upload_command)
+          expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(xcrun_upload_command)
         end
       end
     end
@@ -1470,7 +1483,7 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
 
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
       end
 
@@ -1485,7 +1498,7 @@ describe FastlaneCore do
           # Call original implementation to undo above expect
           expect_any_instance_of(FastlaneCore::JavaTransporterExecutor).to receive(:execute).and_call_original
 
-          expect(transporter.verify('my.app.id', '/tmp')).to eq(xcrun_verify_command)
+          expect(transporter.verify('my.app.id', tmp_dir)).to eq(xcrun_verify_command)
         end
 
         it "with package_path" do
@@ -1498,7 +1511,7 @@ describe FastlaneCore do
           # Call original implementation to undo above expect
           expect_any_instance_of(FastlaneCore::JavaTransporterExecutor).to receive(:execute).and_call_original
 
-          expect(transporter.verify(package_path: '/tmp/my.app.id.itmsp')).to eq(xcrun_verify_command)
+          expect(transporter.verify(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(xcrun_verify_command)
         end
       end
     end
@@ -1506,19 +1519,19 @@ describe FastlaneCore do
     describe "with simulated no-test environment" do
       before(:each) do
         allow(FastlaneCore::Helper).to receive(:test?).and_return(false)
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         @transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
       end
 
       describe "and faked command execution" do
         it 'handles successful execution with no errors' do
           expect(FastlaneCore::FastlanePty).to receive(:spawn).and_return(0)
-          expect(@transporter.upload('my.app.id', '/tmp')).to eq(true)
+          expect(@transporter.upload('my.app.id', tmp_dir)).to eq(true)
         end
 
         it 'handles exceptions' do
           expect(FastlaneCore::FastlanePty).to receive(:spawn).and_raise(StandardError, "It's all broken now.")
-          expect(@transporter.upload('my.app.id', '/tmp')).to eq(false)
+          expect(@transporter.upload('my.app.id', tmp_dir)).to eq(false)
         end
       end
     end
@@ -1526,7 +1539,7 @@ describe FastlaneCore do
   end
 
   describe FastlaneCore::AltoolTransporterExecutor do
-    let(:upload_cmd) { "xcrun altool --upload-app --apiKey #{api_key[:key_id]} --apiIssuer #{api_key[:issuer_id]} -t macos -f /tmp/my.app.id.itmsp -k 100000" }
+    let(:upload_cmd) { "xcrun altool --upload-app --apiKey #{api_key[:key_id]} --apiIssuer #{api_key[:issuer_id]} -t macos -f #{tmp_dir}/my.app.id.itmsp -k 100000" }
     let(:instance) { described_class.new }
     describe "#execute" do
       it "logs specific info about altool crash if exit code is -1" do

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -716,11 +716,15 @@ module Spaceship
       exit(has_valid_session)
     end
 
+    # <tmpdir>/spaceship_itc_service_key.txt
+    def itc_service_key_path
+      File.join(Dir.tmpdir, "spaceship_itc_service_key.txt")
+    end
+
     def itc_service_key
       return @service_key if @service_key
 
       # Check if we have a local cache of the key
-      itc_service_key_path = "/tmp/spaceship_itc_service_key.txt"
       return File.read(itc_service_key_path) if File.exist?(itc_service_key_path)
 
       # Fixes issue https://github.com/fastlane/fastlane/issues/13281

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -240,6 +240,11 @@ module Spaceship
 
     # The logger in which all requests are logged
     # <tmpdir>/spaceship[time]_[pid]_["threadid"].log by default
+    #
+    # Dir.tmpdir rather than a literal "/tmp", and it should stay that way:
+    # "/tmp" is not a directory on every platform Ruby runs on. On Windows it
+    # resolves against the current drive, so Logger.new raises Errno::ENOENT
+    # unless something else happens to have created it first.
     def logger
       unless @logger
         if ENV["VERBOSE"]
@@ -717,6 +722,14 @@ module Spaceship
     end
 
     # <tmpdir>/spaceship_itc_service_key.txt
+    #
+    # Dir.tmpdir rather than a literal "/tmp", for the same reason as #logger,
+    # and here the failure was worse than a missing file: itc_service_key
+    # rescues everything, so the write failing on Windows was reported as an
+    # App Store Connect outage. See #30198.
+    #
+    # On macOS this is also per user, so a cache written by one user no longer
+    # blocks another.
     def itc_service_key_path
       File.join(Dir.tmpdir, "spaceship_itc_service_key.txt")
     end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -37,7 +37,7 @@ module Spaceship
     attr_accessor :user_email
 
     # The logger in which all requests are logged
-    # /tmp/spaceship[time]_[pid].log by default
+    # <tmpdir>/spaceship[time]_[pid].log by default
     attr_accessor :logger
 
     attr_accessor :csrf_tokens
@@ -239,14 +239,14 @@ module Spaceship
     #####################################################
 
     # The logger in which all requests are logged
-    # /tmp/spaceship[time]_[pid]_["threadid"].log by default
+    # <tmpdir>/spaceship[time]_[pid]_["threadid"].log by default
     def logger
       unless @logger
         if ENV["VERBOSE"]
           @logger = Logger.new(STDOUT)
         else
           # Log to file by default
-          path = "/tmp/spaceship#{Time.now.to_i}_#{Process.pid}_#{Thread.current.object_id}.log"
+          path = File.join(Dir.tmpdir, "spaceship#{Time.now.to_i}_#{Process.pid}_#{Thread.current.object_id}.log")
           @logger = Logger.new(path)
         end
 

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -42,17 +42,14 @@ describe Spaceship::Client do
   end
 
   describe "#itc_service_key_path" do
-    # Was the literal "/tmp" too, and the write failure it caused on Windows
-    # came out of itc_service_key as an App Store Connect outage. See #30198.
+    # Guards against going back to a literal "/tmp"; the method says why.
     it "caches the key in the system temporary directory" do
       expect(TestClient.new.itc_service_key_path).to start_with(Dir.tmpdir)
     end
   end
 
   describe "#logger" do
-    # The path used to be the literal "/tmp", which is not a directory on every
-    # platform Ruby runs on. On Windows it resolves against the current drive,
-    # so Logger.new raised Errno::ENOENT unless something else had created it.
+    # Guards against going back to a literal "/tmp"; the method says why.
     it "writes to the system temporary directory" do
       client = TestClient.new
 

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -41,6 +41,14 @@ describe Spaceship::Client do
       then.to_return(status: status_ok, body: body)
   end
 
+  describe "#itc_service_key_path" do
+    # Was the literal "/tmp" too, and the write failure it caused on Windows
+    # came out of itc_service_key as an App Store Connect outage. See #30198.
+    it "caches the key in the system temporary directory" do
+      expect(TestClient.new.itc_service_key_path).to start_with(Dir.tmpdir)
+    end
+  end
+
   describe "#logger" do
     # The path used to be the literal "/tmp", which is not a directory on every
     # platform Ruby runs on. On Windows it resolves against the current drive,

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -41,6 +41,20 @@ describe Spaceship::Client do
       then.to_return(status: status_ok, body: body)
   end
 
+  describe "#logger" do
+    # The path used to be the literal "/tmp", which is not a directory on every
+    # platform Ruby runs on. On Windows it resolves against the current drive,
+    # so Logger.new raised Errno::ENOENT unless something else had created it.
+    it "writes to the system temporary directory" do
+      client = TestClient.new
+
+      FastlaneSpec::Env.with_env_values("VERBOSE" => nil) do
+        expect(client.logger.instance_variable_get(:@logdev).filename)
+          .to start_with(Dir.tmpdir)
+      end
+    end
+  end
+
   describe 'detect_most_common_errors_and_raise_exceptions' do
     # this test is strange, the `error` has a typo "InsufficentPermissions" and is not really relevant
     it "raises Spaceship::InsufficientPermissions for InsufficentPermissions" do


### PR DESCRIPTION
Chained on #30195 so that #30191's Windows split job can go green; the fix itself is independent of that chain and can be reviewed on its own. Retarget to master as the chain lands.

### The bug

`spaceship/lib/spaceship/client.rb` used the literal `/tmp` in two places: the request log and the App Store Connect key cache.

`Spaceship::Client#logger` built its path from it:

```ruby
path = "/tmp/spaceship#{Time.now.to_i}_#{Process.pid}_#{Thread.current.object_id}.log"
@logger = Logger.new(path)
```

`/tmp` is not a directory on every platform Ruby runs on. On Windows it resolves against the current drive — `D:\tmp` on a GitHub runner — which does not exist, so `Logger.new` raises `Errno::ENOENT`.

What makes it worse than a missing log file is where the error comes out. `itc_service_key` rescues everything:

```ruby
rescue => ex
  puts(ex.to_s)
  raise AppleTimeoutError.new, "Could not receive latest API key from App Store Connect, this might be a server issue."
```

So a local `ENOENT` is reported to the user as an App Store Connect outage, and the real message goes to `puts`. That masking is filed separately as #30198.

`itc_service_key` does the same for the key it caches, and there the failing call is the `File.write` inside the very method that owns that rescue.

### The fix

`Dir.tmpdir` in both places, which this file already uses for the cookie path. On macOS that also moves the key cache out of the shared `/tmp` into the per-user directory, so a file written by one user no longer blocks another.

The cache path moves into a method so a spec can assert where it points without stubbing the request.

### Why the suite never caught it

`fastlane/spec/fast_file_spec.rb` calls `FileUtils.mkdir_p('/tmp/fastlane/')`, which creates the directory as a side effect. In defined order that file runs long before any spaceship spec, so on Windows every spaceship spec has been relying on a spec in another tool having made a directory for it.

Splitting the suite across processes removes that guarantee: a worker gets the spaceship specs without `fast_file_spec.rb`, and 47 examples fail. That is how this was found, and it is the argument for #30191 in miniature.

### Verification

Two specs, one per path, asserting each points inside `Dir.tmpdir`. Both fail before the fix on macOS too, where `Dir.tmpdir` is under `/var/folders`, so they are real regression tests rather than ones that only mean something on Windows:

```
expected "/tmp/spaceship1789117080_73594_3104.log" to start with "/var/folders/.../T"
```

Each was checked by reverting its own line: red without, green with. `spaceship/spec/client_spec.rb`: 57 examples, 0 failures.

On the Windows split, the first fix removed every `/tmp/spaceship*.log` failure and uncovered the second path underneath it, which is what the follow-up commit addresses.
