### PR TITLE
Stop two specs depending on process wide state another example populated

### DIFF
--- a/fastlane/lib/fastlane/actions/swiftlint.rb
+++ b/fastlane/lib/fastlane/actions/swiftlint.rb
@@ -44,7 +44,10 @@ module Fastlane
         begin
           Actions.sh(command)
         rescue
-          handle_swiftlint_error(params[:ignore_exit_status], $?.exitstatus)
+          # $? is the status of the last subprocess this thread ran, not
+          # necessarily this one: nil when the command never launched, and stale
+          # when something else ran in between. Only report it when it is there.
+          handle_swiftlint_error(params[:ignore_exit_status], $?&.exitstatus)
           raise if params[:raise_if_swiftlint_error]
         end
       end
@@ -248,10 +251,10 @@ module Fastlane
         end
 
         UI.important("")
-        UI.important("SwiftLint finished with exit code #{exit_status}, #{failure_suffix}")
+        UI.important("SwiftLint finished with exit code #{exit_status || 'unknown'}, #{failure_suffix}")
         UI.important(secondary_message)
         UI.important("")
-        UI.user_error!("SwiftLint finished with errors (exit code: #{exit_status})") unless ignore_exit_status
+        UI.user_error!("SwiftLint finished with errors (exit code: #{exit_status || 'unknown'})") unless ignore_exit_status
       end
     end
   end

--- a/fastlane/spec/actions_specs/swiftlint_spec.rb
+++ b/fastlane/spec/actions_specs/swiftlint_spec.rb
@@ -211,6 +211,20 @@ describe Fastlane do
           end
         end
 
+        context "when no subprocess status is available" do
+          # $? is nil until something in this process has run a subprocess, so
+          # the action used to raise NoMethodError instead of reporting. Unix
+          # never shows it because spec_helper runs `which xar` as it loads;
+          # Windows takes the branch that skips that call, so a worker without
+          # any other shelling out hit it. See fastlane#30188.
+          it 'reports the exit code as unknown rather than raising' do
+            allow(FastlaneCore::UI).to receive(:important)
+            expect(FastlaneCore::UI).to receive(:important).with(/exit code unknown/)
+
+            Fastlane::Actions::SwiftlintAction.handle_swiftlint_error(true, nil)
+          end
+        end
+
         context "when enabled" do
           it 'should not raise if swiftlint completes with a non-zero exit status' do
             allow(FastlaneCore::UI).to receive(:important)

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -1,3 +1,12 @@
+# The examples below stub PTY, but fastlane_pty.rb only requires it from inside
+# spawn_with_pty, so the constant does not exist until something has run that
+# method. They passed only when an earlier example in this file had, and failed
+# with "uninitialized constant PTY" whenever they ran first.
+#
+# Not available on Windows, where the examples needing it are skipped by their
+# requires_pty tag. See fastlane#30184.
+require "pty" unless FastlaneCore::Helper.windows?
+
 describe FastlaneCore do
   describe FastlaneCore::FastlanePty do
     describe "spawn" do


### PR DESCRIPTION
Chained on #30197. These are the two failures that were still reddening #30191 at random, and both are the same shape: a value that lives in process wide state, read somewhere that never put it there.

Part of #30184, and related to #30188, which is the third instance of the same thing.

### `PTY` is required lazily, and two specs assume it is not

`fastlane_pty.rb` calls `require 'pty'` from inside `spawn_with_pty`, so the `PTY` constant does not exist until something has run that method. Two examples in `fastlane_pty_spec.rb` stub `PTY` before calling it:

```ruby
allow(PTY).to receive(:spawn).with("echo foo")
```

They passed only when an earlier example in the same file had run the real thing first. With `--order random` they sometimes run first, and then:

```
NameError: uninitialized constant PTY
```

Running just those two examples reproduces it on any platform:

```
bundle exec rspec fastlane_core/spec/fastlane_pty_spec.rb \
  -e "passes the command to Pty" -e "wraps the command with a workaround"
```

The fix is a `require` in the spec, skipped on Windows where those examples are already skipped by their `requires_pty` tag.

### SwiftLint crashes in its own error handler when nothing has run a subprocess

```ruby
begin
  Actions.sh(command)
rescue
  handle_swiftlint_error(params[:ignore_exit_status], $?.exitstatus)
```

`$?` is the status of the last subprocess *this thread* ran, not necessarily this one. It is stale when something else ran in between, and `nil` when nothing has run at all. In the nil case the action raises `NoMethodError` from inside the handler that exists to report the failure, so the real error is replaced by a crash.

Read it with `&.` and say `unknown` when there is nothing to report.

### Why this only ever failed on Windows

`spec_helper.rb` has:

```ruby
if FastlaneCore::Helper.windows? || !system('which xar')
```

On Unix that `system` call runs as the helper loads and populates `$?` for the rest of the process, so `$?` is never nil by the time any example runs. On Windows `windows?` is true and the `system` short circuits away, so `$?` stays nil until some spec shells out. Split the suite and a worker gets the swiftlint specs without one.

That is worth stating plainly: the suite has been unable to reach this branch on Unix because of an unrelated line in its own helper.

### Verification

Both checked by reverting the fix and confirming the test goes red first.

- `fastlane_pty_spec.rb`: the two examples alone fail with `uninitialized constant PTY` before, pass after; whole file green in defined order and at seeds 1 and 5
- `swiftlint_spec.rb`: a new example calls `handle_swiftlint_error(true, nil)` directly and asserts the message says `exit code unknown`. It fails before the fix. Testing it this way rather than through the action is deliberate, since `$?` cannot be made nil from inside a spec on Unix
