### PR TITLE
[fastlane_core] Carry the pty exit status as a value rather than in $?

### DIFF
--- a/fastlane_core/lib/fastlane_core/fastlane_pty.rb
+++ b/fastlane_core/lib/fastlane_core/fastlane_pty.rb
@@ -30,6 +30,11 @@ module FastlaneCore
       require 'pty'
       # this forces the PTY flush - fixes #21792
       command = ENV['FASTLANE_EXEC_FLUSH_PTY_WORKAROUND'] ? "#{original_command};" : original_command
+      # The status is produced in the ensure below and read after the block. It
+      # travels in a local rather than in $?, which is a thread global: anything
+      # that runs a subprocess in between overwrites it, and nothing writes it at
+      # all when the wait does not happen. See fastlane#30188.
+      status = nil
       PTY.spawn(command) do |command_stdout, command_stdin, pid|
         begin
           yield(command_stdout, command_stdin, pid)
@@ -42,20 +47,28 @@ module FastlaneCore
           command_stdin.close
           command_stdout.close
           begin
-            Process.wait(pid)
-          rescue Errno::ECHILD, PTY::ChildExited
-            # The process might have exited.
+            _pid, status = Process.wait2(pid)
+          rescue PTY::ChildExited => e
+            # The pty saw the child go before we asked for it. The exception
+            # carries the status we were about to wait for.
+            status = e.status
+          rescue Errno::ECHILD
+            # Something else reaped it, so there is nothing left to ask for. $?
+            # may still hold it, and may just as easily hold someone else's.
           end
         end
       end
-      status = self.process_status
+      status ||= self.process_status
+      # Better a plain error than a NoMethodError raised from inside the handler
+      # that exists to report the failure, which is what nil used to produce.
+      raise StandardError, "Could not determine the exit status of the command" if status.nil?
       raise StandardError, "Process crashed" if status.signaled?
       status.exitstatus
     rescue StandardError => e
       # Wrapping any error in FastlanePtyError to allow callers to see and use
-      # $?.exitstatus that would usually get returned
-      status = self.process_status
-      raise FastlanePtyError.new(e, status.exitstatus || e.exit_status, status)
+      # the exit status that would usually get returned
+      status ||= self.process_status
+      raise FastlanePtyError.new(e, status&.exitstatus || e.exit_status, status)
     end
 
     def self.spawn_with_popen(command, &block)

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -12,6 +12,12 @@ describe FastlaneCore do
       let(:failing_command_output) { FastlaneCore::Helper.windows? ? "log \n" : "log\n" }
       let(:failing_command_error_input) { FastlaneCore::Helper.windows? ? "log " : "log" }
 
+      # A status object of the shape FastlanePty reads, for examples that stub
+      # PTY.spawn and so have no real child to reap.
+      let(:stubbed_status) do
+        instance_double(Process::Status, exitstatus: 0, signaled?: false)
+      end
+
       it 'executes a simple command successfully' do
         unless FastlaneCore::Helper.windows?
           expect(Process).to receive(:wait2).and_call_original
@@ -40,12 +46,11 @@ describe FastlaneCore do
         expect(PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('ls')
 
-          # FastlanePty reads the exit status from Process.wait2, so the
-          # example spawns a real process for it to reap.
-          child_process_id = Process.spawn('echo foo', out: File::NULL)
-          # and_call_original matters: wait2 is what produces the status
-          # FastlanePty returns, so mocking it away would leave nothing to read.
-          expect(Process).to receive(:wait2).with(child_process_id).and_call_original
+          # wait2 returns the status now, so the example hands one back rather
+          # than spawning a process for FastlanePty to reap. PTY.spawn is
+          # stubbed here, so there is no real child for the pid to refer to.
+          child_process_id = 4242
+          expect(Process).to receive(:wait2).with(child_process_id).and_return([child_process_id, stubbed_status])
 
           block.yield(fake_std_in, fake_std_out, child_process_id)
         end
@@ -73,12 +78,11 @@ describe FastlaneCore do
         expect(PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('echo foo')
 
-          # FastlanePty reads the exit status from Process.wait2, so the
-          # example spawns a real process for it to reap.
-          child_process_id = Process.spawn('echo foo', out: File::NULL)
-          # and_call_original matters: wait2 is what produces the status
-          # FastlanePty returns, so mocking it away would leave nothing to read.
-          expect(Process).to receive(:wait2).with(child_process_id).and_call_original
+          # wait2 returns the status now, so the example hands one back rather
+          # than spawning a process for FastlanePty to reap. PTY.spawn is
+          # stubbed here, so there is no real child for the pid to refer to.
+          child_process_id = 4242
+          expect(Process).to receive(:wait2).with(child_process_id).and_return([child_process_id, stubbed_status])
 
           block.yield(fake_std_in, fake_std_out, child_process_id)
         end

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -14,7 +14,7 @@ describe FastlaneCore do
 
       it 'executes a simple command successfully' do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).and_call_original
+          expect(Process).to receive(:wait2).and_call_original
         end
 
         result = FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => '1') do
@@ -36,19 +36,16 @@ describe FastlaneCore do
         expect(fake_std_in).to receive(:close)
         expect(fake_std_out).to receive(:close)
 
-        # Make a fake child process so we have a valid PID and $? is set correctly
+        # Make a fake child process so there is a valid PID to reap
         expect(PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('ls')
 
-          # PTY uses "$?" to get exitcode, which is filled in by Process.wait(),
-          # so we have to spawn a real process unless we want to mock methods
-          # on nil.
+          # FastlanePty reads the exit status from Process.wait2, so the
+          # example spawns a real process for it to reap.
           child_process_id = Process.spawn('echo foo', out: File::NULL)
-          # and_call_original matters: Process.wait is what fills in $?, which
-          # FastlanePty reads for the exit status. Mocking it away leaves $? holding
-          # whatever the previous example left there, so these examples reported an
-          # earlier command's exit status when they did not run first.
-          expect(Process).to receive(:wait).with(child_process_id).and_call_original
+          # and_call_original matters: wait2 is what produces the status
+          # FastlanePty returns, so mocking it away would leave nothing to read.
+          expect(Process).to receive(:wait2).with(child_process_id).and_call_original
 
           block.yield(fake_std_in, fake_std_out, child_process_id)
         end
@@ -76,15 +73,12 @@ describe FastlaneCore do
         expect(PTY).to receive(:spawn) do |command, &block|
           expect(command).to eq('echo foo')
 
-          # PTY uses "$?" to get exitcode, which is filled in by Process.wait(),
-          # so we have to spawn a real process unless we want to mock methods
-          # on nil.
+          # FastlanePty reads the exit status from Process.wait2, so the
+          # example spawns a real process for it to reap.
           child_process_id = Process.spawn('echo foo', out: File::NULL)
-          # and_call_original matters: Process.wait is what fills in $?, which
-          # FastlanePty reads for the exit status. Mocking it away leaves $? holding
-          # whatever the previous example left there, so these examples reported an
-          # earlier command's exit status when they did not run first.
-          expect(Process).to receive(:wait).with(child_process_id).and_call_original
+          # and_call_original matters: wait2 is what produces the status
+          # FastlanePty returns, so mocking it away would leave nothing to read.
+          expect(Process).to receive(:wait2).with(child_process_id).and_call_original
 
           block.yield(fake_std_in, fake_std_out, child_process_id)
         end
@@ -103,7 +97,7 @@ Shopping list:
 
       it "does not print output to stdout when status != 0 and output was already printed" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).and_call_original
+          expect(Process).to receive(:wait2).and_call_original
         end
 
         expect do
@@ -117,7 +111,7 @@ Shopping list:
 
       it "prints output to stdout only once when status != 0 and output was not already printed" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).exactly(3).and_call_original
+          expect(Process).to receive(:wait2).exactly(3).and_call_original
         end
 
         expect do
@@ -150,7 +144,7 @@ Shopping list:
 
       it "calls error block with output argument" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).twice.and_call_original
+          expect(Process).to receive(:wait2).twice.and_call_original
         end
 
         error_block_input = nil
@@ -176,7 +170,7 @@ Shopping list:
 
       it "does not print output or exit status when failure output is suppressed" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).and_call_original
+          expect(Process).to receive(:wait2).and_call_original
         end
 
         error_block_input = nil
@@ -282,7 +276,7 @@ Shopping list:
 
       it "still raises when failure output is suppressed without an error block" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).and_call_original
+          expect(Process).to receive(:wait2).and_call_original
         end
 
         raised_error = nil

--- a/fastlane_core/spec/fastlane_pty_spec.rb
+++ b/fastlane_core/spec/fastlane_pty_spec.rb
@@ -28,6 +28,41 @@ describe FastlaneCore do
         expect(@all_lines).to eq(["foo"])
       end
 
+      it 'returns the status of the command it ran rather than whatever $? holds', requires_pty: true do
+        # The status used to reach the end of spawn_with_pty through $?, read
+        # back via process_status, so anything that overwrote that global in
+        # between decided what the caller was told. Stub it to something the
+        # command did not produce: if the result still comes from there, this
+        # returns 99. See fastlane#30188.
+        wrong = double("ProcessStatus")
+        allow(wrong).to receive(:exitstatus).and_return(99)
+        allow(wrong).to receive(:signaled?).and_return(false)
+        allow(FastlaneCore::FastlanePty).to receive(:process_status).and_return(wrong)
+
+        exit_status = FastlaneCore::FastlanePty.spawn('exit 7') do |command_stdout, command_stdin, pid|
+          begin
+            command_stdout.read
+          rescue Errno::EIO
+            # Expected on Linux when the command exits while we are reading.
+          end
+        end
+
+        expect(exit_status).to eq(7)
+      end
+
+      it 'reports a clear error when no exit status can be determined', requires_pty: true do
+        # With nothing to reap and nothing in $?, the old code called
+        # exitstatus on nil from inside the handler that exists to report the
+        # failure, so the caller got a NoMethodError instead of the error.
+        allow(Process).to receive(:wait2).and_raise(Errno::ECHILD)
+        allow(FastlaneCore::FastlanePty).to receive(:process_status).and_return(nil)
+
+        expect {
+          FastlaneCore::FastlanePty.spawn('exit 0') do |command_stdout, command_stdin, pid|
+          end
+        }.to raise_error(FastlaneCore::FastlanePtyError, /Could not determine the exit status/)
+      end
+
       it 'doesn t return -1 if an exception was raised in the block in PTY.spawn' do
         status = double("ProcessStatus")
         allow(status).to receive(:exitstatus) { 0 }


### PR DESCRIPTION
Fixes #30188. Chained on #30200, which fixes two other instances of the same shape. Retarget to master as that chain lands.

### The defect

`FastlanePty.spawn_with_pty` produces the exit status inside the block passed to `PTY.spawn`, in an `ensure`, and reads it back after the block:

```ruby
ensure
  Process.wait(pid)        # sets $? as a side effect
end
...
status = self.process_status   # reads $?, well after the wait
```

Nothing carries the value across that boundary except `$?`, a thread global. Anything that runs a subprocess in between overwrites it, and nothing writes it at all when the wait does not happen — when the child was already reaped and `Errno::ECHILD` was swallowed, or when a caller stubbed the wait.

`Process.wait2` returns `[pid, status]`, so a local declared before the block holds it instead.

### The two cases the old code could not recover from

**`PTY::ChildExited`** carries the status on the exception itself. It is now read from there rather than discarded.

**`Errno::ECHILD`** means something else reaped the child. `$?` may legitimately hold the right answer — `spawn_with_pty` yields the pid, so a caller can wait on it — so that stays a fallback rather than the primary path. This is the one hole the change narrows rather than closes, and the fallback is a reasonable answer there rather than a guess.

### The nil case destroyed the original error

With nothing to read, `status` was nil. Line 52 called `signaled?` on it, the resulting `NoMethodError` was caught by the handler below, and that handler called `exitstatus` on the same nil — from inside the rescue, so nothing caught it. The caller got a `NoMethodError` in place of whatever had actually gone wrong. It now raises an error that says the status could not be determined.

### This does fix failing examples

The issue said it fixed none. Two regression tests now demonstrate it, each checked by reverting the fix first:

```
returns the status of the command it ran rather than whatever $? holds
  without the fix: expected: 7, got: 99

reports a clear error when no exit status can be determined
  without the fix: NoMethodError: undefined method 'exitstatus' for nil
```

The first stubs `process_status` to a value the command never produced. Before this change that stub decided the return value, which is the defect stated as a test rather than as prose.

### Two facts worth recording, both checked rather than assumed

`PTY.spawn`'s block form reaps the child itself, after the block returns. fastlane's own wait runs first, inside the block, so it normally wins and `PTY.spawn`'s wait takes the `ECHILD`. That rules out simply dropping fastlane's wait: `PTY.spawn`'s would then set `$?` and the status would be back in a global.

`PTY::ChildExited#status` exists, which is what makes the first case recoverable.

### The second commit

Two examples in `command_executor_spec.rb` stubbed `PTY.spawn` and then spawned a real `echo foo` purely so the wait had a child to reap and `$?` came out populated. With the status returned as a value they hand one back instead, and the real process goes away.

Only those two. The other six `and_call_original` mocks in that file run actual commands through the real pty, where the subprocess is the thing under test rather than scaffolding, and they are untouched.

### Verification

Full suite at seed 31884: 7868 examples, 0 failures, 1 pending. `command_executor_spec.rb` and `fastlane_pty_spec.rb` together in defined order and at seeds 2 and 8, and each on its own.
