### PR TITLE
Run the CI suite as several processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Run tests
         env:
           RUBYOPT: ${{ matrix.rubyopt }}
+          # Four measured best on both runner shapes. The task would otherwise
+          # take min(cores, 8), which is three on the macOS runners, and each
+          # worker spends much of its time waiting on an xcodebuild child rather
+          # than holding a core. See fastlane#30189.
+          WORKERS: '4'
         shell: bash
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,18 @@ jobs:
           git config --global user.name "github-actions[bot]"
           bundle exec fastlane execute_tests
 
+      # A worker's rspec output goes to its own log, not to stdout, so without
+      # this a failing job says which examples failed and never why.
+      - name: Keep the worker logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rspec-worker-logs-${{ matrix.os }}-ruby${{ matrix.ruby }}-xcode${{ matrix.xcode }}
+          path: |
+            rspec_worker_*.log
+            rspec_worker_*.units
+          if-no-files-found: warn
+
       - name: RSpec report
         if: always()
         uses: SonicGarden/rspec-report-action@v8

--- a/.github/workflows/parallel-tests.yml
+++ b/.github/workflows/parallel-tests.yml
@@ -1,15 +1,29 @@
-# Runs the spec suite as several independent rspec processes.
+# Keeps the per platform spec timings current, and runs the split in a random
+# order.
 #
-# Two purposes, and they are related. It is much faster than a single process,
-# 562s down to about 150s on a macOS runner. And a split is a harsher test of
-# spec isolation than any seed: a worker sees a subset no random order ever
-# produces, so a spec that depends on another file having run first fails here.
-# Combined with `--order random` it exercises both axes at once, which is how
-# the pty exit status defect (#30188) was found.
+# The speed argument for splitting the suite now lives in the CI workflow, which
+# runs `rake test_parallel` on every pull request. What is left here is the two
+# things that workflow does not do.
 #
-# While the isolation work from #30184 is still landing this will be red, and
-# that is the point: it is the monitor for that work.
-name: Parallel tests
+# Recording the timings. The split is balanced from measured per file durations,
+# and they have to come from the platform they balance: 61% of the example time
+# on macOS is in files that skip entirely on Linux, and balancing a Linux split
+# from macOS numbers left a worker idle 41% to 48% of the run. Each file records
+# where it was measured. They only shift when the shape of the suite changes, so
+# quarterly is enough, and a stale file costs a worse split rather than a wrong
+# result.
+#
+# Running the split in a random order. CI runs it in the defined order, so the
+# two axes of isolation are exercised separately there. A worker sees a subset
+# no seed produces, and a random order within that subset is the harsher test of
+# the two combined. That is how the `DisplayType` global and the pty exit status
+# defect (#30188) were found, neither of which had shown up in a random order
+# alone.
+#
+# The quarterly run is also what keeps this honest. A workflow nobody runs is a
+# workflow that has quietly stopped working, and the only other trigger is a
+# pull request touching the parallel machinery, which may be months apart.
+name: Spec timings and random order split
 
 on:
   pull_request:
@@ -19,14 +33,6 @@ on:
       - '.github/workflows/parallel-tests.yml'
   schedule:
     # 04:00 UTC on the first of January, April, July and October.
-    #
-    # Quarterly is a compromise. The timings only shift when the shape of the
-    # suite changes, so they do not need refreshing often, and a stale file
-    # costs a worse split rather than a wrong result. But a workflow nobody runs
-    # is a workflow that has quietly stopped working, and this one is only
-    # otherwise triggered by pull requests that touch the parallel machinery,
-    # which may be months apart. Running the whole thing four times a year keeps
-    # it honest without spending much.
     - cron: '0 4 1 1,4,7,10 *'
   workflow_dispatch:
     inputs:
@@ -37,7 +43,7 @@ on:
         options: ["no", "macos", "linux", "windows", "both"]
         default: "no"
       workers:
-        description: "Workers per runner. Four has measured best on the macOS and Linux runners."
+        description: "Workers per runner. Four has measured best on all three runners."
         required: false
         type: string
         default: "4"
@@ -96,8 +102,7 @@ jobs:
         shell: bash
         run: ulimit -n 65536
       # Without Xcode the requires_xcodebuild and requires_keychain specs skip,
-      # which is most of the example time on macOS. A different shape of suite,
-      # so worth splitting separately and balancing from its own timings.
+      # which is most of the example time on macOS: 558s there against 106s here.
       - name: Run the suite split across workers, in a random order
         shell: bash
         env:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -92,7 +92,9 @@ lane :execute_tests do
   # Run the tests
   build_fastlane_gem(version: version) unless File.file?("pkg/fastlane-#{version}.gem")
   Dir.chdir("..") do
-    sh("bundle", "exec", "rake", "test_all")
+    # Several processes rather than one. The suite is the same either way; a
+    # worker just gets a slice of it. See fastlane#30189.
+    sh("bundle", "exec", "rake", "test_parallel")
   end
 end
 


### PR DESCRIPTION
Addresses #30189. Chained on #30191, which adds the machinery this turns on. Draft until the isolation chain lands, because a split is a harsher test of isolation than any seed and this makes it the gate rather than a side workflow.

### What changes

Two files, twenty lines.

`bundle exec fastlane execute_tests` runs `rake test_parallel` instead of `rake test_all`, and the matrix passes `WORKERS: 4`. Nothing else about the matrix moves: same nine configurations, same Ruby and Xcode versions, same platforms.

Everything the split itself needs, including joining the workers' json into the one file the report action reads, lives in #30191 with the rest of the machinery. This pull request only points CI at it.

### Why four

Rather than the task's own `min(cores, 8)`, which is three on the macOS runners. Each worker spends much of its time waiting on an `xcodebuild` child rather than holding a core, so the useful worker count is above the core count. Four measured best on all three runner shapes, and six on macOS is slower than four.

### The failure report

A worker writes its rspec output to its own log rather than to stdout, so a failing job listed which examples failed and never why. The logs are uploaded on failure, as the split workflow already does. That gap cost a diagnosis on this very branch: a job failed on `import_spec` and there was nothing to read.

### What this leaves the other workflow doing

Once this lands, CI runs the split on every pull request, so the speed argument no longer belongs to `parallel-tests.yml`. What is left there is the two things CI does not do: keeping the per platform timings current, and running the split in a **random** order, since CI runs it in the defined one. Its documentation and name are updated here to say that, because this is the change that moves the responsibility.

### Measured

Same commit, the existing serial jobs against the split jobs, with the recorded timings in place:

| | serial | split, 4 workers | worker idle |
| --- | --- | --- | --- |
| macOS | 472-701s across the seven configurations | 236s | 6% |
| Linux | 174s | 58s | 21% |
| Windows | 403s | 146s | 5% |

### Verification

The merged report was checked on a clean run, where it carries all 7868 examples with the counts matching the four workers' own totals, and on a run with a deliberate failure in it, where the failure and its exception survive:

```
summary_line: 7869 examples, 1 failures, 1 pending
failed examples in json: 1
  forced failure ... (./fastlane/spec/zz_force_fail_spec.rb:2)
    has exception: true
```

`rake test_parallel` still exits non-zero when a worker fails, so a failing suite still fails the build. Checked by reading the exit status rather than the output, since a pipe had masked it the first time.
