### PR TITLE
[core] Stop hardcoding /tmp where a real path is needed

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 require 'precheck/options'
 require 'precheck/runner'
 require 'fastlane_core/configuration/configuration'
@@ -196,7 +197,7 @@ module Deliver
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           ipa_path: ipa_path,
-          package_path: "/tmp",
+          package_path: Dir.tmpdir,
           platform: platform
         )
         result = transporter.verify(package_path: package_path, asset_path: ipa_path, platform: platform)
@@ -204,7 +205,7 @@ module Deliver
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           pkg_path: pkg_path,
-          package_path: "/tmp",
+          package_path: Dir.tmpdir,
           platform: platform
         )
         result = transporter.verify(package_path: package_path, asset_path: pkg_path, platform: platform)
@@ -233,7 +234,7 @@ module Deliver
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           ipa_path: ipa_path,
-          package_path: "/tmp",
+          package_path: Dir.tmpdir,
           platform: platform
         )
         result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
@@ -241,7 +242,7 @@ module Deliver
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           pkg_path: pkg_path,
-          package_path: "/tmp",
+          package_path: Dir.tmpdir,
           platform: platform
         )
         result = transporter.upload(package_path: package_path, asset_path: pkg_path, platform: platform)

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 require 'deliver/runner'
 
 class MockSession
@@ -66,7 +67,7 @@ describe Deliver::Runner do
     describe 'with an IPA file for iOS' do
       it 'uploads the IPA for the iOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'ios')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'ios')
           .and_return('path')
         expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.ipa', platform: 'ios').and_return(true)
         runner.upload_binary
@@ -80,7 +81,7 @@ describe Deliver::Runner do
 
       it 'uploads the IPA for the tvOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'appletvos')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'appletvos')
           .and_return('path')
         expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.ipa', platform: 'appletvos').and_return(true)
         runner.upload_binary
@@ -94,7 +95,7 @@ describe Deliver::Runner do
 
       it 'uploads the IPA for the visionOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'xros')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'xros')
           .and_return('path')
         expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.ipa', platform: 'xros').and_return(true)
         runner.upload_binary
@@ -110,7 +111,7 @@ describe Deliver::Runner do
 
       it 'uploads the PKG for the macOS platform' do
         expect_any_instance_of(FastlaneCore::PkgUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: '/tmp', platform: 'osx')
+          .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: Dir.tmpdir, platform: 'osx')
           .and_return('path')
         expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.pkg', platform: 'osx').and_return(true)
         runner.upload_binary
@@ -191,7 +192,7 @@ describe Deliver::Runner do
     describe 'with an IPA file for iOS' do
       it 'verifies the IPA for the iOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'ios')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'ios')
           .and_return('path')
         expect(transporter).to receive(:verify).with(asset_path: "ACME.ipa", package_path: 'path', platform: "ios").and_return(true)
         runner.verify_binary
@@ -205,7 +206,7 @@ describe Deliver::Runner do
 
       it 'verifies the IPA for the tvOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'appletvos')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'appletvos')
           .and_return('path')
         expect(transporter).to receive(:verify).with(asset_path: "ACME.ipa", package_path: 'path', platform: "appletvos").and_return(true)
         runner.verify_binary
@@ -219,7 +220,7 @@ describe Deliver::Runner do
 
       it 'verifies the IPA for the visionOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'xros')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'xros')
           .and_return('path')
         expect(transporter).to receive(:verify).with(asset_path: "ACME.ipa", package_path: 'path', platform: "xros").and_return(true)
         runner.verify_binary
@@ -235,7 +236,7 @@ describe Deliver::Runner do
 
       it 'verifies the PKG for the macOS platform' do
         expect_any_instance_of(FastlaneCore::PkgUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: '/tmp', platform: 'osx')
+          .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: Dir.tmpdir, platform: 'osx')
           .and_return('path')
         expect(transporter).to receive(:verify).with(asset_path: "ACME.pkg", package_path: 'path', platform: "osx").and_return(true)
         runner.verify_binary

--- a/deliver/spec/sync_screenshots_spec.rb
+++ b/deliver/spec/sync_screenshots_spec.rb
@@ -12,8 +12,8 @@ describe Deliver::SyncScreenshots do
     end
 
     let(:en_US) { mock_app_store_version_localization }
-    let(:app_screenshot_set_55) { mock_app_screenshot_set(display_type: DisplayType::APP_IPHONE_55) }
-    let(:app_screenshot_set_65) { mock_app_screenshot_set(display_type: DisplayType::APP_IPHONE_65) }
+    let(:app_screenshot_set_55) { mock_app_screenshot_set(display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_55) }
+    let(:app_screenshot_set_65) { mock_app_screenshot_set(display_type: Deliver::AppScreenshot::DisplayType::APP_IPHONE_65) }
 
     context 'ASC has nothing and going to add screenshots' do
       let(:screenshots) do

--- a/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
+++ b/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
@@ -1,8 +1,9 @@
+require 'tmpdir'
 module Fastlane
   module Actions
     class BuildAndUploadToAppetizeAction < Action
       def self.run(params)
-        tmp_path = "/tmp/fastlane_build"
+        tmp_path = File.join(Dir.tmpdir, "fastlane_build")
 
         xcodebuild_configs = params[:xcodebuild]
         xcodebuild_configs[:sdk] = "iphonesimulator"

--- a/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
+++ b/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
@@ -1,4 +1,5 @@
 require 'tmpdir'
+
 module Fastlane
   module Actions
     class BuildAndUploadToAppetizeAction < Action

--- a/fastlane/lib/fastlane/actions/lcov.rb
+++ b/fastlane/lib/fastlane/actions/lcov.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 module Fastlane
   module Actions
     class LcovAction < Action
@@ -42,7 +43,7 @@ module Fastlane
       end
 
       def self.gen_cov(options)
-        tmp_cov_file = "/tmp/coverage.info"
+        tmp_cov_file = File.join(Dir.tmpdir, "coverage.info")
         output_dir = options[:output_dir]
         derived_data_path = derived_data_dir(options)
 

--- a/fastlane/lib/fastlane/actions/lcov.rb
+++ b/fastlane/lib/fastlane/actions/lcov.rb
@@ -1,4 +1,5 @@
 require 'tmpdir'
+
 module Fastlane
   module Actions
     class LcovAction < Action

--- a/fastlane/lib/fastlane/actions/spaceship_logs.rb
+++ b/fastlane/lib/fastlane/actions/spaceship_logs.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 module Fastlane
   module Actions
     class SpaceshipLogsAction < Action
@@ -8,8 +10,8 @@ module Fastlane
         copy_to_path = params[:copy_to_path]
         copy_to_clipboard = params[:copy_to_clipboard]
 
-        # Get log files
-        files = Dir.glob("/tmp/spaceship*.log").sort_by { |f| File.mtime(f) }.reverse
+        # Get log files, from wherever Spaceship::Client#logger writes them.
+        files = Dir.glob(File.join(Dir.tmpdir, "spaceship*.log")).sort_by { |f| File.mtime(f) }.reverse
 
         if files.size == 0
           UI.message("No Spaceship log files found")

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 # coding: utf-8
 
 module Fastlane
@@ -146,7 +147,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :certificate,
                                        env_name: "FL_PROJECT_PROVISIONING_CERTIFICATE_PATH",
                                        description: "Path to apple root certificate",
-                                       default_value: "/tmp/AppleIncRootCertificate.cer"),
+                                       default_value: File.join(Dir.tmpdir, "AppleIncRootCertificate.cer")),
           FastlaneCore::ConfigItem.new(key: :code_signing_identity,
                                        env_name: "FL_PROJECT_PROVISIONING_CODE_SIGN_IDENTITY",
                                        description: "Code sign identity for build configuration",

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -1,5 +1,6 @@
-require 'tmpdir'
 # coding: utf-8
+
+require 'tmpdir'
 
 module Fastlane
   module Actions

--- a/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
+++ b/fastlane/spec/actions_specs/automatic_code_signing_spec.rb
@@ -2,7 +2,18 @@ require "xcodeproj"
 # 771D79501D9E69C900D840FA = demo
 # 77C503031DD3175E00AC8FF0 = today
 describe Fastlane do
-  describe "Automatic Code Signing" do
+  describe "Automatic Code Signing", order: :defined do
+    # These examples change the project they are given and then assert on it, and
+    # several of them assert on what an earlier one left behind, so the group is
+    # one scenario written as several examples. Two things follow. It has to run
+    # in the order it is written, hence order: :defined on the group. And it must
+    # not run against the checked in fixture, or a failed run leaves the
+    # repository dirty, so it gets one copy for the group. See fastlane#30184.
+    before :all do
+      @project_path = File.join(Dir.mktmpdir('fl_spec_automatic_code_signing'), 'automatic_code_signing.xcodeproj')
+      FileUtils.cp_r('./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', @project_path)
+    end
+
     before :each do
       allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
     end
@@ -11,11 +22,11 @@ describe Fastlane do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Automatic'")
       result = Fastlane::FastFile.new.parse("lane :test do
-        enable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'XXXX')
+        enable_automatic_code_signing(path: '#{@project_path}', team_id: 'XXXX')
       end").runner.execute(:test)
       expect(result).to eq(true)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Automatic")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Automatic")
@@ -38,11 +49,11 @@ describe Fastlane do
       expect(UI).to receive(:deprecated).with("Please use `update_code_signing_settings` action instead.")
       expect(UI).to receive(:important).with("Skipping demo not selected (today)")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', targets: ['today'])
+        disable_automatic_code_signing(path: '#{@project_path}', targets: ['today'])
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Automatic")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
@@ -58,11 +69,11 @@ describe Fastlane do
       allow(UI).to receive(:success)
       expect(UI).to receive(:success).with("Successfully updated project settings to use Code Sign Style = 'Manual'")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj')
+        disable_automatic_code_signing(path: '#{@project_path}')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
       expect(root_attrs["77C503031DD3175E00AC8FF0"]["ProvisioningStyle"]).to eq("Manual")
@@ -83,11 +94,11 @@ describe Fastlane do
       expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: demo")
       expect(UI).to receive(:important).with("Set Team id to: G3KGXDXQL9 for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9')
+        disable_automatic_code_signing(path: '#{@project_path}', team_id: 'G3KGXDXQL9')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
@@ -105,7 +116,7 @@ describe Fastlane do
 
     it "sets code sign identity" do
       temp_dir = Dir.tmpdir
-      FileUtils.copy_entry('./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', temp_dir)
+      FileUtils.copy_entry(@project_path, temp_dir)
 
       # G3KGXDXQL9
       allow(UI).to receive(:success)
@@ -155,11 +166,11 @@ describe Fastlane do
       expect(UI).to receive(:important).with("Set Provisioning Profile name to: Mindera for target: demo")
       expect(UI).to receive(:important).with("Set Provisioning Profile name to: Mindera for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', profile_name: 'Mindera')
+        disable_automatic_code_signing(path: '#{@project_path}', team_id: 'G3KGXDXQL9', profile_name: 'Mindera')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
@@ -189,11 +200,11 @@ describe Fastlane do
       expect(UI).to receive(:important).with("Set Provisioning Profile UUID to: 1337 for target: demo")
       expect(UI).to receive(:important).with("Set Provisioning Profile UUID to: 1337 for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', profile_uuid: '1337')
+        disable_automatic_code_signing(path: '#{@project_path}', team_id: 'G3KGXDXQL9', profile_uuid: '1337')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
@@ -223,11 +234,11 @@ describe Fastlane do
       expect(UI).to receive(:important).with("Set Bundle identifier to: com.fastlane.mindera.cosigner for target: demo")
       expect(UI).to receive(:important).with("Set Bundle identifier to: com.fastlane.mindera.cosigner for target: today")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', team_id: 'G3KGXDXQL9', bundle_identifier: 'com.fastlane.mindera.cosigner')
+        disable_automatic_code_signing(path: '#{@project_path}', team_id: 'G3KGXDXQL9', bundle_identifier: 'com.fastlane.mindera.cosigner')
       end").runner.execute(:test)
       expect(result).to eq(false)
 
-      project = Xcodeproj::Project.open("./fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj")
+      project = Xcodeproj::Project.open(@project_path)
       root_attrs = project.root_object.attributes["TargetAttributes"]
 
       expect(root_attrs["771D79501D9E69C900D840FA"]["ProvisioningStyle"]).to eq("Manual")
@@ -252,7 +263,7 @@ describe Fastlane do
       expect(UI).to receive(:deprecated).with("Please use `update_code_signing_settings` action instead.")
       expect(UI).to receive(:important).with("None of the specified targets has been modified")
       result = Fastlane::FastFile.new.parse("lane :test do
-        disable_automatic_code_signing(path: './fastlane/spec/fixtures/xcodeproj/automatic_code_signing.xcodeproj', targets: ['not_found'])
+        disable_automatic_code_signing(path: '#{@project_path}', targets: ['not_found'])
       end").runner.execute(:test)
       expect(result).to eq(false)
     end

--- a/fastlane/spec/actions_specs/flock_spec.rb
+++ b/fastlane/spec/actions_specs/flock_spec.rb
@@ -12,8 +12,16 @@ describe Fastlane do
       end
 
       context 'options' do
+        # Scoped rather than assigned. These are the options' env_names, so a
+        # value left behind satisfies the option and the examples asserting that
+        # it is required stop raising. See fastlane#30184.
+        around do |example|
+          FastlaneSpec::Env.with_env_values('FL_FLOCK_BASE_URL' => 'https://example.com') do
+            example.run
+          end
+        end
+
         before do
-          ENV['FL_FLOCK_BASE_URL'] = 'https://example.com'
           stub_request(:any, /example\.com/)
         end
 
@@ -34,9 +42,9 @@ describe Fastlane do
         end
 
         it 'allows environment variables' do
-          ENV['FL_FLOCK_MESSAGE'] = 'xxx'
-          ENV['FL_FLOCK_TOKEN'] = 'xxx'
-          expect { run_flock }.to_not(raise_error)
+          FastlaneSpec::Env.with_env_values('FL_FLOCK_MESSAGE' => 'xxx', 'FL_FLOCK_TOKEN' => 'xxx') do
+            expect { run_flock }.to_not(raise_error)
+          end
         end
       end
 

--- a/fastlane/spec/actions_specs/import_from_git_spec.rb
+++ b/fastlane/spec/actions_specs/import_from_git_spec.rb
@@ -1,6 +1,14 @@
 describe Fastlane do
   describe Fastlane::FastFile do
-    describe "import_from_git" do
+    # These examples are one scenario written as several examples: the `before :all`
+    # builds a git repository, and individual examples append commits, tags and
+    # branches to it that later ones then assert on. They therefore have to run in
+    # the order they are written, and a random order makes them assert against a
+    # repository at the wrong revision. Pinned rather than rewritten: making each
+    # example build its own repository would be order independent but would add a
+    # git init, several commits and several tags per example to a group that
+    # already takes eleven seconds. See fastlane#30184.
+    describe "import_from_git", order: :defined do
       it "raises an exception when no path is given" do
         expect do
           Fastlane::FastFile.new.parse("lane :test do

--- a/fastlane/spec/actions_specs/notification_spec.rb
+++ b/fastlane/spec/actions_specs/notification_spec.rb
@@ -1,3 +1,8 @@
+# The notification action requires this lazily, inside its run method, so
+# examples referencing the TerminalNotifier constant only find it when another
+# example has already run the action. See fastlane#30184.
+require 'terminal-notifier'
+
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "notification action" do

--- a/fastlane/spec/actions_specs/spaceship_logs_spec.rb
+++ b/fastlane/spec/actions_specs/spaceship_logs_spec.rb
@@ -1,0 +1,28 @@
+require 'tmpdir'
+
+describe Fastlane do
+  describe Fastlane::Actions::SpaceshipLogsAction do
+    # This action reads the files Spaceship::Client#logger writes. The two used
+    # to agree on a literal "/tmp" and now agree on Dir.tmpdir, which is a thing
+    # they can only get wrong together. Moving one without the other leaves the
+    # action silently finding nothing. See fastlane#30184.
+    it "looks where spaceship writes its logs" do
+      path = File.join(Dir.tmpdir, "spaceship#{Time.now.to_i}_#{Process.pid}_spec.log")
+      File.write(path, "a log line")
+
+      begin
+        files = Fastlane::Actions::SpaceshipLogsAction.run(
+          latest: false,
+          print_contents: false,
+          print_paths: false,
+          copy_to_path: nil,
+          copy_to_clipboard: false
+        )
+
+        expect(files).to include(path)
+      ensure
+        File.delete(path) if File.exist?(path)
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/xcodebuild_spec.rb
+++ b/fastlane/spec/actions_specs/xcodebuild_spec.rb
@@ -679,34 +679,32 @@ describe Fastlane do
       end
 
       it "should save reports to BUILD_PATH + \"/report\" by default" do
-        ENV["XCODE_BUILD_PATH"] = "./build"
+        FastlaneSpec::Env.with_env_values('XCODE_BUILD_PATH' => "./build") do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            xctest(
+              destination: 'name=iPhone 5s,OS=8.1',
+              scheme: 'MyApp',
+              workspace: 'MyApp.xcworkspace',
+              report_formats: ['html'],
+              report_screenshots: true
+            )
+          end").runner.execute(:test)
 
-        result = Fastlane::FastFile.new.parse("lane :test do
-          xctest(
-            destination: 'name=iPhone 5s,OS=8.1',
-            scheme: 'MyApp',
-            workspace: 'MyApp.xcworkspace',
-            report_formats: ['html'],
-            report_screenshots: true
+          expect(result).to eq(
+            "set -o pipefail && " \
+            + "xcodebuild " \
+            + "-destination \"name=iPhone 5s,OS=8.1\" " \
+            + "-scheme \"MyApp\" " \
+            + "-workspace \"MyApp.xcworkspace\" " \
+            + "build " \
+            + "test " \
+            + "| tee '#{build_log_path}' | xcpretty --color " \
+            + "--report html " \
+            + "--screenshots " \
+            + "--output \"./build/report\" " \
+            + "--test"
           )
-        end").runner.execute(:test)
-
-        expect(result).to eq(
-          "set -o pipefail && " \
-          + "xcodebuild " \
-          + "-destination \"name=iPhone 5s,OS=8.1\" " \
-          + "-scheme \"MyApp\" " \
-          + "-workspace \"MyApp.xcworkspace\" " \
-          + "build " \
-          + "test " \
-          + "| tee '#{build_log_path}' | xcpretty --color " \
-          + "--report html " \
-          + "--screenshots " \
-          + "--output \"./build/report\" " \
-          + "--test"
-        )
-
-        ENV.delete("XCODE_BUILD_PATH")
+        end
       end
 
       it "should support multiple output formats" do
@@ -772,37 +770,37 @@ describe Fastlane do
       end
 
       it "should support omitting output when specifying multiple reports " do
-        ENV["XCODE_BUILD_PATH"] = "./build"
+        FastlaneSpec::Env.with_env_values('XCODE_BUILD_PATH' => "./build") do
+          result = Fastlane::FastFile.new.parse("lane :test do
+            xctest(
+              destination: 'name=iPhone 5s,OS=8.1',
+              scheme: 'MyApp',
+              workspace: 'MyApp.xcworkspace',
+              reports: [{
+                report: 'html',
+              },
+              {
+                report: 'junit',
+              }],
+            )
+          end").runner.execute(:test)
 
-        result = Fastlane::FastFile.new.parse("lane :test do
-          xctest(
-            destination: 'name=iPhone 5s,OS=8.1',
-            scheme: 'MyApp',
-            workspace: 'MyApp.xcworkspace',
-            reports: [{
-              report: 'html',
-            },
-            {
-              report: 'junit',
-            }],
+          expect(result).to eq(
+            "set -o pipefail && " \
+            + "xcodebuild " \
+            + "-destination \"name=iPhone 5s,OS=8.1\" " \
+            + "-scheme \"MyApp\" " \
+            + "-workspace \"MyApp.xcworkspace\" " \
+            + "build " \
+            + "test " \
+            + "| tee '#{build_log_path}' | xcpretty --color " \
+            + "--report html " \
+            + "--output \"./build/report/report.html\" " \
+            + "--report junit " \
+            + "--output \"./build/report/report.xml\" " \
+            + "--test"
           )
-        end").runner.execute(:test)
-
-        expect(result).to eq(
-          "set -o pipefail && " \
-          + "xcodebuild " \
-          + "-destination \"name=iPhone 5s,OS=8.1\" " \
-          + "-scheme \"MyApp\" " \
-          + "-workspace \"MyApp.xcworkspace\" " \
-          + "build " \
-          + "test " \
-          + "| tee '#{build_log_path}' | xcpretty --color " \
-          + "--report html " \
-          + "--output \"./build/report/report.html\" " \
-          + "--report junit " \
-          + "--output \"./build/report/report.xml\" " \
-          + "--test"
-        )
+        end
       end
 
       it "should detect and use the workspace, when a workspace is present" do

--- a/fastlane/spec/plugins_specs/plugin_generator_spec.rb
+++ b/fastlane/spec/plugins_specs/plugin_generator_spec.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 
 initialized = false
+bundled = false
 test_ui = nil
 generator = nil
 tmp_dir = nil
@@ -57,6 +58,7 @@ describe Fastlane::PluginGenerator do
       tmp_dir = nil
       oldwd = nil
       initialized = false
+      bundled = false
     end
 
     it "creates gem root directory" do
@@ -281,10 +283,17 @@ describe Fastlane::PluginGenerator do
     end
 
     describe "All tests and style validation of the new plugin are passing" do
-      before (:all) do
-        # let(:gem_name) is not available in before(:all), so pass the directory
-        # in explicitly once instead of making this a before(:each)
-        plugin_sh('bundle install', 'fastlane-plugin-tester_thing')
+      # before(:each) with a flag, not before(:all). RSpec runs an inner
+      # before(:all) ahead of an outer before(:each), so as a before(:all) this
+      # ran `bundle install` before the plugin above had been generated. It only
+      # ever worked because an earlier example in the file had generated it
+      # already, and running this group on its own failed with Errno::ENOENT for
+      # the plugin directory. See fastlane#30184.
+      before(:each) do
+        unless bundled
+          plugin_sh('bundle install')
+          bundled = true
+        end
       end
 
       it "rspec tests are passing" do

--- a/fastlane/spec/ruby_version_warning_spec.rb
+++ b/fastlane/spec/ruby_version_warning_spec.rb
@@ -5,6 +5,14 @@ describe Fastlane::CLIToolsDistributor do
     before(:each) do
       # Need to make sure we don't actually trigger at_exit during tests in a way that interferes
       allow(Fastlane::CLIToolsDistributor).to receive(:at_exit)
+
+      # take_off warns about bundler whenever Helper.bundler? is false, which is
+      # what a spec that drops BUNDLE_GEMFILE or BUNDLE_BIN_PATH leaves behind.
+      # It warns either way: "detected a Gemfile" when the working directory has
+      # one, "get started using a Gemfile" when it does not, so the working
+      # directory only picks the message. Every example below constrains all
+      # calls to UI.important, so either one fails them. See fastlane#30184.
+      allow(Fastlane::CLIToolsDistributor).to receive(:print_bundle_exec_warning)
     end
 
     it "displays a warning when Ruby version is older than SUGGESTED_MINIMUM_RUBY" do

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -35,7 +35,7 @@ module FastlaneCore
 
     private_constant :ERROR_REGEX, :WARNING_REGEX, :OUTPUT_REGEX, :RETURN_VALUE_REGEX, :SKIP_ERRORS
 
-    def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "", jwt = nil)
+    def build_download_command(username, password, apple_id, destination = Dir.tmpdir, provider_short_name = "", jwt = nil)
       not_implemented(__method__)
     end
 
@@ -43,11 +43,11 @@ module FastlaneCore
       not_implemented(__method__)
     end
 
-    def build_upload_command(username, password, source = "/tmp", options = {})
+    def build_upload_command(username, password, source = Dir.tmpdir, options = {})
       not_implemented(__method__)
     end
 
-    def build_verify_command(username, password, source = "/tmp", provider_short_name = "", **kwargs)
+    def build_verify_command(username, password, source = Dir.tmpdir, provider_short_name = "", **kwargs)
       not_implemented(__method__)
     end
 
@@ -319,7 +319,7 @@ module FastlaneCore
       end
     end
 
-    def build_upload_command(username, password, source = "/tmp", options = {})
+    def build_upload_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       provider_public_id = options.fetch(:provider_public_id, "")
       jwt = options[:jwt]
@@ -351,11 +351,11 @@ module FastlaneCore
       ].compact.join(' ')
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "", jwt = nil)
+    def build_download_command(username, password, apple_id, destination = Dir.tmpdir, provider_short_name = "", jwt = nil)
       raise "This feature has not been implemented yet with altool for Xcode 14"
     end
 
-    def build_verify_command(username, password, source = "/tmp", options = {})
+    def build_verify_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       provider_public_id = options.fetch(:provider_public_id, "")
       api_key = options[:api_key]
@@ -442,7 +442,7 @@ module FastlaneCore
       end
     end
 
-    def build_upload_command(username, password, source = "/tmp", options = {})
+    def build_upload_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       jwt = options[:jwt]
       api_key = options[:api_key]
@@ -458,7 +458,7 @@ module FastlaneCore
       ].compact.join(' ')
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "", jwt = nil)
+    def build_download_command(username, password, apple_id, destination = Dir.tmpdir, provider_short_name = "", jwt = nil)
       [
         '"' + Helper.transporter_path + '"',
         "-m lookupMetadata",
@@ -477,7 +477,7 @@ module FastlaneCore
       ].compact.join(' ')
     end
 
-    def build_verify_command(username, password, source = "/tmp", options = {})
+    def build_verify_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       jwt = options[:jwt]
       [
@@ -568,7 +568,7 @@ module FastlaneCore
       end
     end
 
-    def build_upload_command(username, password, source = "/tmp", options = {})
+    def build_upload_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       jwt = options[:jwt]
       api_key = options[:api_key]
@@ -607,7 +607,7 @@ module FastlaneCore
       end
     end
 
-    def build_verify_command(username, password, source = "/tmp", options = {})
+    def build_verify_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       jwt = options[:jwt]
       credential_params = build_credential_params(username, password, jwt, nil, is_default_itms_on_xcode_11?)
@@ -641,7 +641,7 @@ module FastlaneCore
       end
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "", jwt = nil)
+    def build_download_command(username, password, apple_id, destination = Dir.tmpdir, provider_short_name = "", jwt = nil)
       credential_params = build_credential_params(username, password, jwt, nil, is_default_itms_on_xcode_11?)
       if is_default_itms_on_xcode_11?
         [
@@ -793,7 +793,9 @@ module FastlaneCore
     # @raise [Deliver::TransporterTransferError] when something went wrong
     #   when transferring
     def download(app_id, dir = nil)
-      dir ||= "/tmp"
+      # Dir.tmpdir, not a literal "/tmp": the transporter chdirs into this
+      # directory, and "/tmp" is not one on Windows. See fastlane#30184.
+      dir ||= Dir.tmpdir
 
       password_placeholder = @jwt.nil? ? 'YourPassword' : nil
       jwt_placeholder = @jwt.nil? ? nil : 'YourJWT'

--- a/fastlane_core/spec/command_executor_spec.rb
+++ b/fastlane_core/spec/command_executor_spec.rb
@@ -1,3 +1,10 @@
+# FastlanePty requires this lazily, inside spawn_with_pty, so examples below that
+# reference the PTY constant only find it when something has already run a pty
+# backed command in this process. Require it here so they do not depend on that.
+# Guarded because pty is not available on Windows, where those examples are
+# skipped anyway. See fastlane#30184.
+require 'pty' unless FastlaneCore::Helper.windows?
+
 describe FastlaneCore do
   describe FastlaneCore::CommandExecutor do
     describe "execute" do
@@ -7,7 +14,7 @@ describe FastlaneCore do
 
       it 'executes a simple command successfully' do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait)
+          expect(Process).to receive(:wait).and_call_original
         end
 
         result = FastlaneSpec::Env.with_env_values('FASTLANE_EXEC_FLUSH_PTY_WORKAROUND' => '1') do
@@ -37,7 +44,11 @@ describe FastlaneCore do
           # so we have to spawn a real process unless we want to mock methods
           # on nil.
           child_process_id = Process.spawn('echo foo', out: File::NULL)
-          expect(Process).to receive(:wait).with(child_process_id)
+          # and_call_original matters: Process.wait is what fills in $?, which
+          # FastlanePty reads for the exit status. Mocking it away leaves $? holding
+          # whatever the previous example left there, so these examples reported an
+          # earlier command's exit status when they did not run first.
+          expect(Process).to receive(:wait).with(child_process_id).and_call_original
 
           block.yield(fake_std_in, fake_std_out, child_process_id)
         end
@@ -69,7 +80,11 @@ describe FastlaneCore do
           # so we have to spawn a real process unless we want to mock methods
           # on nil.
           child_process_id = Process.spawn('echo foo', out: File::NULL)
-          expect(Process).to receive(:wait).with(child_process_id)
+          # and_call_original matters: Process.wait is what fills in $?, which
+          # FastlanePty reads for the exit status. Mocking it away leaves $? holding
+          # whatever the previous example left there, so these examples reported an
+          # earlier command's exit status when they did not run first.
+          expect(Process).to receive(:wait).with(child_process_id).and_call_original
 
           block.yield(fake_std_in, fake_std_out, child_process_id)
         end
@@ -88,7 +103,7 @@ Shopping list:
 
       it "does not print output to stdout when status != 0 and output was already printed" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait)
+          expect(Process).to receive(:wait).and_call_original
         end
 
         expect do
@@ -102,7 +117,7 @@ Shopping list:
 
       it "prints output to stdout only once when status != 0 and output was not already printed" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).exactly(3)
+          expect(Process).to receive(:wait).exactly(3).and_call_original
         end
 
         expect do
@@ -135,7 +150,7 @@ Shopping list:
 
       it "calls error block with output argument" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait).twice
+          expect(Process).to receive(:wait).twice.and_call_original
         end
 
         error_block_input = nil
@@ -161,7 +176,7 @@ Shopping list:
 
       it "does not print output or exit status when failure output is suppressed" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait)
+          expect(Process).to receive(:wait).and_call_original
         end
 
         error_block_input = nil
@@ -267,7 +282,7 @@ Shopping list:
 
       it "still raises when failure output is suppressed without an error block" do
         unless FastlaneCore::Helper.windows?
-          expect(Process).to receive(:wait)
+          expect(Process).to receive(:wait).and_call_original
         end
 
         raised_error = nil

--- a/fastlane_core/spec/device_manager_spec.rb
+++ b/fastlane_core/spec/device_manager_spec.rb
@@ -2,6 +2,14 @@ require 'open3'
 
 describe FastlaneCore do
   describe FastlaneCore::DeviceManager do
+    # runtime_build_os_versions memoises into a module level ivar, so an example
+    # that stubs the underlying command only sees its stub if nothing has already
+    # populated it. Clearing it per example rather than once per group, which is
+    # what the before(:all) below does for the simulator cache. See fastlane#30184.
+    before(:each) do
+      FastlaneCore::DeviceManager.instance_variable_set(:@runtime_build_os_versions, nil)
+    end
+
     before(:all) do
       @simctl_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSimctlOutputXcode7')
       @system_profiler_output = File.read('./fastlane_core/spec/fixtures/DeviceManagerSystem_profilerOutput')

--- a/fastlane_core/spec/itunes_transporter_spec.rb
+++ b/fastlane_core/spec/itunes_transporter_spec.rb
@@ -1,7 +1,20 @@
+require 'tmpdir'
 require 'shellwords'
 require 'credentials_manager'
 
 describe FastlaneCore do
+  # Dir.tmpdir rather than a literal "/tmp". The transporter chdirs into the
+  # directory it is given, and "/tmp" is not one on Windows: it resolves against
+  # the current drive, so these examples failed with Errno::ENOENT unless
+  # something else had created it first. See fastlane#30184.
+  #
+  # Read once here rather than per call, because several examples below stub
+  # Dir.tmpdir and assert how often it is called. A local captured by
+  # define_method, not a constant: a constant assigned in a describe block takes
+  # the block's lexical scope and would be defined globally.
+  tmpdir_at_load = Dir.tmpdir
+  define_method(:tmp_dir) { tmpdir_at_load }
+
   let(:password) { "!> p@$s_-+=w'o%rd\"&#*<" }
   let(:email) { 'fabric.devtools@gmail.com' }
   let(:jwt) { '409jjl43j90ghjqoineio49024' }
@@ -15,12 +28,12 @@ describe FastlaneCore do
 
     def shell_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false, username: email, input_pass: password, api_key: nil, is_mac: true, has_appstore_info: true)
       upload_part = if use_asset_path
-                      "-assetFile /tmp/#{random_uuid}.ipa"
+                      "-assetFile #{tmp_dir}/#{random_uuid}.ipa"
                     elsif !is_mac && has_appstore_info
                       # On non-macOS platforms, use -assetFile with -assetDescription for .itmsp directories
-                      "-assetFile /tmp/my.app.id.itmsp/my.app.id.ipa -assetDescription /tmp/my.app.id.itmsp/AppStoreInfo.plist"
+                      "-assetFile #{tmp_dir}/my.app.id.itmsp/my.app.id.ipa -assetDescription #{tmp_dir}/my.app.id.itmsp/AppStoreInfo.plist"
                     else
-                      "-f /tmp/my.app.id.itmsp"
+                      "-f #{tmp_dir}/my.app.id.itmsp"
                     end
 
       username = username if username != email
@@ -66,7 +79,7 @@ describe FastlaneCore do
         end
         escaped_password = "'" + escaped_password + "'"
       end
-      verify_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      verify_part = use_asset_path ? "-assetFile #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
       [
         '"' + FastlaneCore::Helper.transporter_path + '"',
         "-m verify",
@@ -95,7 +108,7 @@ describe FastlaneCore do
         ("-p #{escaped_password}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         "-apple_id my.app.id",
-        "-destination '/tmp'",
+        "-destination '#{tmp_dir}'",
         ("-itc_provider #{provider_short_name}" if provider_short_name)
       ].compact.join(' ')
     end
@@ -114,7 +127,7 @@ describe FastlaneCore do
     def altool_upload_command(api_key: nil, platform: "macos", provider_short_name: "", provider_public_id: "", use_asset_path: false)
       use_api_key = !api_key.nil?
       # altool never supports -assetFile, so even asset paths use -f
-      upload_part = use_asset_path ? "-f /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-f #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
       escaped_password = password.shellescape
 
       [
@@ -135,7 +148,7 @@ describe FastlaneCore do
     def altool_verify_command(api_key: nil, platform: "macos", provider_short_name: "", provider_public_id: "", use_asset_path: false)
       use_api_key = !api_key.nil?
       # altool never supports -assetFile, so even asset paths use -f
-      verify_part = use_asset_path ? "-f /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      verify_part = use_asset_path ? "-f #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
       escaped_password = password.shellescape
 
       [
@@ -168,7 +181,7 @@ describe FastlaneCore do
     end
 
     def java_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, classpath: true, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -209,7 +222,7 @@ describe FastlaneCore do
         "-m verify",
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
-        "-f /tmp/my.app.id.itmsp",
+        "-f #{tmp_dir}/my.app.id.itmsp",
         (transporter.to_s if transporter),
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
@@ -233,7 +246,7 @@ describe FastlaneCore do
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         '-apple_id my.app.id',
-        '-destination /tmp',
+        "-destination #{tmp_dir}",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
       ].compact.join(' ')
@@ -259,7 +272,7 @@ describe FastlaneCore do
     end
 
     def java_upload_command_9(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
 
       [
         FastlaneCore::Helper.transporter_java_executable_path.shellescape,
@@ -296,7 +309,7 @@ describe FastlaneCore do
         "-m verify",
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
-        "-f /tmp/my.app.id.itmsp",
+        "-f #{tmp_dir}/my.app.id.itmsp",
         (transporter.to_s if transporter),
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
@@ -318,14 +331,14 @@ describe FastlaneCore do
         ("-u #{email.shellescape} -p #{password.shellescape}" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         '-apple_id my.app.id',
-        '-destination /tmp',
+        "-destination #{tmp_dir}",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
       ].compact.join(' ')
     end
 
     def xcrun_upload_command(provider_short_name: nil, transporter: nil, jwt: nil, use_asset_path: false)
-      upload_part = use_asset_path ? "-assetFile /tmp/#{random_uuid}.ipa" : "-f /tmp/my.app.id.itmsp"
+      upload_part = use_asset_path ? "-assetFile #{tmp_dir}/#{random_uuid}.ipa" : "-f #{tmp_dir}/my.app.id.itmsp"
 
       [
         ("ITMS_TRANSPORTER_PASSWORD=#{password.shellescape}" if jwt.nil?),
@@ -350,7 +363,7 @@ describe FastlaneCore do
         ("-u #{email.shellescape}" if jwt.nil?),
         ("-p @env:ITMS_TRANSPORTER_PASSWORD" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
-        "-f /tmp/my.app.id.itmsp",
+        "-f #{tmp_dir}/my.app.id.itmsp",
         '2>&1'
       ].compact.join(' ')
     end
@@ -364,7 +377,7 @@ describe FastlaneCore do
         ("-p @env:ITMS_TRANSPORTER_PASSWORD" if jwt.nil?),
         ("-jwt #{jwt}" unless jwt.nil?),
         '-apple_id my.app.id',
-        '-destination /tmp',
+        "-destination #{tmp_dir}",
         ("-itc_provider #{provider_short_name}" if provider_short_name),
         '2>&1'
       ].compact.join(' ')
@@ -375,7 +388,7 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('7.3')
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
       end
 
       describe "by default" do
@@ -383,7 +396,7 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command)
             end
           end
 
@@ -392,7 +405,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(transporter: "-t DAV,Signiant"))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(transporter: "-t DAV,Signiant"))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -403,7 +416,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command)
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -412,14 +425,14 @@ describe FastlaneCore do
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command)
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command)
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command)
             end
           end
 
@@ -435,7 +448,7 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(jwt: jwt))
             end
           end
 
@@ -444,7 +457,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -455,7 +468,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(jwt: jwt))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -464,14 +477,14 @@ describe FastlaneCore do
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command(jwt: jwt))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command(jwt: jwt))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command(jwt: jwt))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command(jwt: jwt))
             end
           end
 
@@ -486,14 +499,14 @@ describe FastlaneCore do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(java_upload_command(jwt: jwt))
+                expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(java_upload_command(jwt: jwt))
               end
             end
 
             describe "verify command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.verify(package_path: '/tmp/my.app.id.itmsp')).to eq(java_verify_command(jwt: jwt))
+                expect(transporter.verify(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(java_verify_command(jwt: jwt))
               end
             end
           end
@@ -501,11 +514,11 @@ describe FastlaneCore do
           describe "with asset_path" do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
-                expect(Dir).to receive(:tmpdir).and_return("/tmp")
+                expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
                 expect(FileUtils).to receive(:cp)
 
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.upload(asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command(jwt: jwt, use_asset_path: true))
+                expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa")).to eq(java_upload_command(jwt: jwt, use_asset_path: true))
               end
             end
           end
@@ -513,11 +526,11 @@ describe FastlaneCore do
           describe "with package_path and asset_path" do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter with -assetFile' do
-                expect(Dir).to receive(:tmpdir).and_return("/tmp")
+                expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
                 expect(FileUtils).to receive(:cp)
 
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp', asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command(jwt: jwt, use_asset_path: true))
+                expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp", asset_path: "#{tmp_dir}/my_app.ipa")).to eq(java_upload_command(jwt: jwt, use_asset_path: true))
               end
             end
 
@@ -526,7 +539,7 @@ describe FastlaneCore do
                 stub_const('ENV', { 'ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD' => 'true' })
 
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp', asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command(jwt: jwt, use_asset_path: false))
+                expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp", asset_path: "#{tmp_dir}/my_app.ipa")).to eq(java_upload_command(jwt: jwt, use_asset_path: false))
               end
             end
           end
@@ -538,21 +551,21 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd1234')
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(provider_short_name: 'abcd1234'))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(provider_short_name: 'abcd1234'))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd1234')
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command(provider_short_name: 'abcd1234'))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command(provider_short_name: 'abcd1234'))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd1234')
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command('abcd1234'))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command('abcd1234'))
             end
           end
 
@@ -568,21 +581,21 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, 'abcd1234', jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(jwt: jwt))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, 'abcd1234', jwt)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command(jwt: jwt))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command(jwt: jwt))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, 'abcd1234', jwt)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command(jwt: jwt))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command(jwt: jwt))
             end
           end
         end
@@ -593,21 +606,21 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true, 'abcd1234')
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(provider_short_name: 'abcd1234'))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(provider_short_name: 'abcd1234'))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true, 'abcd1234')
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command(provider_short_name: 'abcd1234'))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command(provider_short_name: 'abcd1234'))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true, 'abcd1234')
-              expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command('abcd1234'))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command('abcd1234'))
             end
           end
 
@@ -623,21 +636,21 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(jwt: jwt))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command(jwt: jwt))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command(jwt: jwt))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command(jwt: jwt))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command(jwt: jwt))
             end
           end
 
@@ -645,14 +658,14 @@ describe FastlaneCore do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-                expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(shell_upload_command(jwt: jwt))
+                expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(shell_upload_command(jwt: jwt))
               end
             end
 
             describe "verify command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-                expect(transporter.verify(package_path: '/tmp/my.app.id.itmsp')).to eq(shell_verify_command(jwt: jwt))
+                expect(transporter.verify(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(shell_verify_command(jwt: jwt))
               end
             end
           end
@@ -660,11 +673,11 @@ describe FastlaneCore do
           describe "with asset_path" do
             describe "upload command generation" do
               it 'generates a call to xcrun iTMSTransporter' do
-                expect(Dir).to receive(:tmpdir).and_return("/tmp")
+                expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
                 expect(FileUtils).to receive(:cp)
 
                 transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-                expect(transporter.upload(asset_path: '/tmp/my_app.ipa')).to eq(shell_upload_command(jwt: jwt, use_asset_path: true))
+                expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa")).to eq(shell_upload_command(jwt: jwt, use_asset_path: true))
               end
             end
           end
@@ -676,7 +689,7 @@ describe FastlaneCore do
           it 'generates a call to the shell script' do
             FastlaneSpec::Env.with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
             end
           end
         end
@@ -685,7 +698,7 @@ describe FastlaneCore do
           it 'generates a call to the shell script' do
             FastlaneSpec::Env.with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command)
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command)
             end
           end
         end
@@ -694,7 +707,7 @@ describe FastlaneCore do
           it 'generates a call to the shell script' do
             FastlaneSpec::Env.with_env_values('FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT' => 'true') do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command)
             end
           end
         end
@@ -713,31 +726,31 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
           end
         end
 
         describe "verify command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command)
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command)
           end
         end
 
         describe "verify command generation with .ipa source" do
           it "uses -assetFile for .ipa files" do
-            expect(Dir).to receive(:tmpdir).and_return("/tmp")
+            expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
             expect(FileUtils).to receive(:cp)
 
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-            expect(transporter.verify(asset_path: '/tmp/my_app.ipa')).to include("-assetFile")
+            expect(transporter.verify(asset_path: "#{tmp_dir}/my_app.ipa")).to include("-assetFile")
           end
         end
 
         describe "download command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command)
           end
         end
 
@@ -753,21 +766,21 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command)
           end
         end
 
         describe "verify command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command)
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command)
           end
         end
 
         describe "download command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command)
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command)
           end
         end
 
@@ -785,14 +798,14 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('6.4')
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
       end
 
       describe "with username and password" do
         describe "upload command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
           end
         end
 
@@ -801,7 +814,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(transporter: "-t DAV,Signiant"))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(transporter: "-t DAV,Signiant"))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -812,7 +825,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -821,14 +834,14 @@ describe FastlaneCore do
         describe "verify command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command)
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command)
           end
         end
 
         describe "download command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command)
           end
         end
 
@@ -844,7 +857,7 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(jwt: jwt))
           end
         end
 
@@ -853,7 +866,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -864,7 +877,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(jwt: jwt))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -873,14 +886,14 @@ describe FastlaneCore do
         describe "verify command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command(jwt: jwt))
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command(jwt: jwt))
           end
         end
 
         describe "download command generation" do
           it 'generates a call to the shell script' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command(jwt: jwt))
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command(jwt: jwt))
           end
         end
 
@@ -898,14 +911,14 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:xcode_version).and_return('9.1')
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
       end
 
       describe "with username and password" do
         describe "upload command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9)
           end
         end
 
@@ -914,7 +927,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9(transporter: "-t DAV,Signiant"))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9(transporter: "-t DAV,Signiant"))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -925,7 +938,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9)
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -934,14 +947,14 @@ describe FastlaneCore do
         describe "verify command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command_9)
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command_9)
           end
         end
 
         describe "download command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command_9)
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command_9)
           end
         end
       end
@@ -950,7 +963,7 @@ describe FastlaneCore do
         describe "upload command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9(jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9(jwt: jwt))
           end
         end
 
@@ -959,7 +972,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9(transporter: "-t DAV,Signiant", jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9(transporter: "-t DAV,Signiant", jwt: jwt))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -970,7 +983,7 @@ describe FastlaneCore do
 
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command_9(jwt: jwt))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command_9(jwt: jwt))
           end
 
           after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -979,14 +992,14 @@ describe FastlaneCore do
         describe "verify command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command_9(jwt: jwt))
+            expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command_9(jwt: jwt))
           end
         end
 
         describe "download command generation" do
           it 'generates a call to java directly' do
             transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-            expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command_9(jwt: jwt))
+            expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command_9(jwt: jwt))
           end
         end
 
@@ -996,7 +1009,7 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(java_upload_command_9(jwt: jwt))
+              expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(java_upload_command_9(jwt: jwt))
             end
           end
         end
@@ -1006,11 +1019,11 @@ describe FastlaneCore do
 
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
-              expect(Dir).to receive(:tmpdir).and_return("/tmp")
+              expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
               expect(FileUtils).to receive(:cp)
 
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload(asset_path: '/tmp/my_app.ipa')).to eq(java_upload_command_9(jwt: jwt, use_asset_path: true))
+              expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa")).to eq(java_upload_command_9(jwt: jwt, use_asset_path: true))
             end
           end
         end
@@ -1027,14 +1040,14 @@ describe FastlaneCore do
       describe "with username and password" do
         describe "with default itms_path" do
           before(:each) do
-            allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+            allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
             stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
           end
 
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command)
             end
           end
 
@@ -1043,7 +1056,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant"))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant"))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -1054,7 +1067,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command)
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -1063,41 +1076,41 @@ describe FastlaneCore do
           describe "verify command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(xcrun_verify_command)
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(xcrun_verify_command)
             end
           end
 
           describe "download command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(xcrun_download_command)
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(xcrun_download_command)
             end
           end
         end
 
         describe "with user defined itms_path" do
           before(:each) do
-            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/tmp' })
+            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => tmp_dir })
           end
 
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(java_upload_command(classpath: false))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(java_upload_command(classpath: false))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(java_verify_command(classpath: false))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(java_verify_command(classpath: false))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(java_download_command(classpath: false))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(java_download_command(classpath: false))
             end
           end
         end
@@ -1105,7 +1118,7 @@ describe FastlaneCore do
 
       describe "with JWT" do
         before(:each) do
-          allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+          allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
           stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
         end
 
@@ -1113,7 +1126,7 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command(jwt: jwt))
             end
           end
 
@@ -1122,7 +1135,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command(transporter: "-t DAV,Signiant", jwt: jwt))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -1133,7 +1146,7 @@ describe FastlaneCore do
 
             it 'generates a call to java directly' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command(jwt: jwt))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command(jwt: jwt))
             end
 
             after(:each) { ENV.delete("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS") }
@@ -1142,14 +1155,14 @@ describe FastlaneCore do
           describe "verify command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.verify('my.app.id', '/tmp')).to eq(xcrun_verify_command(jwt: jwt))
+              expect(transporter.verify('my.app.id', tmp_dir)).to eq(xcrun_verify_command(jwt: jwt))
             end
           end
 
           describe "download command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.download('my.app.id', '/tmp')).to eq(xcrun_download_command(jwt: jwt))
+              expect(transporter.download('my.app.id', tmp_dir)).to eq(xcrun_download_command(jwt: jwt))
             end
           end
         end
@@ -1158,14 +1171,14 @@ describe FastlaneCore do
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(xcrun_upload_command(jwt: jwt))
+              expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(xcrun_upload_command(jwt: jwt))
             end
           end
 
           describe "verify command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.verify(package_path: '/tmp/my.app.id.itmsp')).to eq(xcrun_verify_command(jwt: jwt))
+              expect(transporter.verify(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(xcrun_verify_command(jwt: jwt))
             end
           end
         end
@@ -1173,11 +1186,11 @@ describe FastlaneCore do
         describe "with asset_path" do
           describe "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter' do
-              expect(Dir).to receive(:tmpdir).and_return("/tmp")
+              expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
               expect(FileUtils).to receive(:cp)
 
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, false, nil, jwt)
-              expect(transporter.upload(asset_path: '/tmp/my_app.ipa')).to eq(xcrun_upload_command(jwt: jwt, use_asset_path: true))
+              expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa")).to eq(xcrun_upload_command(jwt: jwt, use_asset_path: true))
             end
           end
         end
@@ -1200,13 +1213,13 @@ describe FastlaneCore do
           context "upload command generation" do
             it 'generates a call to altool' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd123', altool_compatible_command: true)
-              expect(transporter.upload('my.app.id', '/tmp', package_path: '/tmp/my.app.id.itmsp', platform: "osx")).to eq(altool_upload_command(provider_short_name: 'abcd123'))
+              expect(transporter.upload('my.app.id', tmp_dir, package_path: "#{tmp_dir}/my.app.id.itmsp", platform: "osx")).to eq(altool_upload_command(provider_short_name: 'abcd123'))
             end
 
             it 'generates a call to altool with provider_public_id' do
               provider_public_id = '00000000-0000-0000-0000-000000000000'
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, nil, altool_compatible_command: true, provider_public_id: provider_public_id)
-              expect(transporter.upload('my.app.id', '/tmp', package_path: '/tmp/my.app.id.itmsp', platform: "osx")).to eq(altool_upload_command(provider_short_name: nil, provider_public_id: provider_public_id))
+              expect(transporter.upload('my.app.id', tmp_dir, package_path: "#{tmp_dir}/my.app.id.itmsp", platform: "osx")).to eq(altool_upload_command(provider_short_name: nil, provider_public_id: provider_public_id))
             end
           end
 
@@ -1219,12 +1232,12 @@ describe FastlaneCore do
 
           context "upload command generation with .ipa source (asset file)" do
             it "still uses -f for .ipa files since altool does not support -assetFile" do
-              expect(Dir).to receive(:tmpdir).and_return("/tmp")
+              expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
               expect(FileUtils).to receive(:cp)
 
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, nil, nil,
                                                                 altool_compatible_command: true)
-              expect(transporter.upload(asset_path: '/tmp/my_app.ipa', platform: "osx")).to eq(
+              expect(transporter.upload(asset_path: "#{tmp_dir}/my_app.ipa", platform: "osx")).to eq(
                 altool_upload_command(use_asset_path: true, provider_short_name: "")
               )
             end
@@ -1232,12 +1245,12 @@ describe FastlaneCore do
 
           context "verify command generation with .ipa source (asset file)" do
             it "still uses -f for .ipa files since altool does not support -assetFile" do
-              expect(Dir).to receive(:tmpdir).and_return("/tmp")
+              expect(Dir).to receive(:tmpdir).and_return(tmp_dir)
               expect(FileUtils).to receive(:cp)
 
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, nil, nil,
                                                                 altool_compatible_command: true)
-              expect(transporter.verify(asset_path: '/tmp/my_app.ipa', platform: "osx")).to eq(
+              expect(transporter.verify(asset_path: "#{tmp_dir}/my_app.ipa", platform: "osx")).to eq(
                 altool_verify_command(use_asset_path: true, provider_short_name: "")
               )
             end
@@ -1246,13 +1259,13 @@ describe FastlaneCore do
 
         context "with user defined itms_path" do
           before(:each) do
-            allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
-            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => '/tmp' })
+            allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
+            stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => tmp_dir })
           end
           context "upload command generation" do
             it 'generates a call to xcrun iTMSTransporter instead altool' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd123', altool_compatible_command: true)
-              expect(transporter.upload('my.app.id', '/tmp', platform: "osx")).to eq(java_upload_command(provider_short_name: 'abcd123', classpath: false))
+              expect(transporter.upload('my.app.id', tmp_dir, platform: "osx")).to eq(java_upload_command(provider_short_name: 'abcd123', classpath: false))
             end
           end
         end
@@ -1270,7 +1283,7 @@ describe FastlaneCore do
             it 'generates a call to altool' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, false, 'abcd123', altool_compatible_command: true, api_key: api_key)
               expected = Regexp.new("API_PRIVATE_KEYS_DIR=#{Regexp.escape(Dir.tmpdir)}.*\s#{Regexp.escape(altool_upload_command(api_key: api_key, provider_short_name: 'abcd123'))}")
-              expect(transporter.upload('my.app.id', '/tmp', platform: "osx")).to match(expected)
+              expect(transporter.upload('my.app.id', tmp_dir, platform: "osx")).to match(expected)
             end
           end
 
@@ -1289,15 +1302,15 @@ describe FastlaneCore do
       shared_examples "non_macOS_setup" do
         before do
           allow(FastlaneCore::Helper).to receive(:is_mac?).and_return(false)
-          allow(File).to receive(:directory?).with('/tmp/my.app.id.itmsp').and_return(true)
-          allow(Dir).to receive(:glob).with('/tmp/my.app.id.itmsp/*.{ipa,pkg,dmg,zip}').and_return(['/tmp/my.app.id.itmsp/my.app.id.ipa'])
+          allow(File).to receive(:directory?).with("#{tmp_dir}/my.app.id.itmsp").and_return(true)
+          allow(Dir).to receive(:glob).with("#{tmp_dir}/my.app.id.itmsp/*.{ipa,pkg,dmg,zip}").and_return(["#{tmp_dir}/my.app.id.itmsp/my.app.id.ipa"])
           allow(FastlaneCore::UI).to receive(:verbose)
         end
       end
 
       before(:each) do
         ENV["FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT"] = "1"
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         allow(File).to receive(:exist?).with("C:/Program Files (x86)/itms").and_return(true) if FastlaneCore::Helper.windows?
       end
 
@@ -1309,30 +1322,30 @@ describe FastlaneCore do
 
           context "with AppStoreInfo.plist present" do
             before do
-              allow(File).to receive(:file?).with('/tmp/my.app.id.itmsp/AppStoreInfo.plist').and_return(true)
+              allow(File).to receive(:file?).with("#{tmp_dir}/my.app.id.itmsp/AppStoreInfo.plist").and_return(true)
             end
 
             it 'uses -assetFile and -assetDescription when uploading with package_path and JWT' do
               transporter = FastlaneCore::ItunesTransporter.new(nil, nil, true, 'abcd1234', jwt)
-              expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(shell_upload_command(jwt: jwt, is_mac: false, has_appstore_info: true))
+              expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(shell_upload_command(jwt: jwt, is_mac: false, has_appstore_info: true))
             end
 
             it 'uses -assetFile and -assetDescription when uploading with app_id and dir' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-              expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(is_mac: false, has_appstore_info: true))
+              expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(is_mac: false, has_appstore_info: true))
             end
           end
 
           context "without AppStoreInfo.plist" do
             before do
-              allow(File).to receive(:file?).with('/tmp/my.app.id.itmsp/AppStoreInfo.plist').and_return(false)
+              allow(File).to receive(:file?).with("#{tmp_dir}/my.app.id.itmsp/AppStoreInfo.plist").and_return(false)
               allow(FastlaneCore::UI).to receive(:error)
               allow(FastlaneCore::UI).to receive(:user_error!).and_raise(FastlaneCore::Interface::FastlaneError)
             end
 
             it 'raises an error about missing AppStoreInfo.plist' do
               transporter = FastlaneCore::ItunesTransporter.new(email, password, true)
-              expect { transporter.upload('my.app.id', '/tmp') }.to raise_error(FastlaneCore::Interface::FastlaneError)
+              expect { transporter.upload('my.app.id', tmp_dir) }.to raise_error(FastlaneCore::Interface::FastlaneError)
               expect(FastlaneCore::UI).to have_received(:error).with("AppStoreInfo.plist is required for uploading .ipa files on non-macOS platforms.")
             end
           end
@@ -1341,12 +1354,12 @@ describe FastlaneCore do
         context "on macOS platforms" do
           it 'generates a call to the shell script with user and password' do
             transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command)
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command)
           end
 
           it 'generates a call to the shell script with api key' do
             transporter = FastlaneCore::ItunesTransporter.new(api_key: api_key)
-            expect(transporter.upload('my.app.id', '/tmp')).to eq(shell_upload_command(username: nil, input_pass: nil, api_key: api_key))
+            expect(transporter.upload('my.app.id', tmp_dir)).to eq(shell_upload_command(username: nil, input_pass: nil, api_key: api_key))
             expect(Dir.empty?(keys_parent_dir)).to be_truthy if Dir.exist?(keys_parent_dir)
           end
         end
@@ -1355,14 +1368,14 @@ describe FastlaneCore do
       describe "verify command generation" do
         it 'generates a call to the shell script' do
           transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-          expect(transporter.verify('my.app.id', '/tmp')).to eq(shell_verify_command)
+          expect(transporter.verify('my.app.id', tmp_dir)).to eq(shell_verify_command)
         end
       end
 
       describe "download command generation" do
         it 'generates a call to the shell script' do
           transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
-          expect(transporter.download('my.app.id', '/tmp')).to eq(shell_download_command)
+          expect(transporter.download('my.app.id', tmp_dir)).to eq(shell_download_command)
         end
       end
 
@@ -1371,7 +1384,7 @@ describe FastlaneCore do
 
     describe "with no special configuration" do
       before(:each) do
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         allow(File).to receive(:exist?).and_return(true) unless FastlaneCore::Helper.mac?
         ENV.delete("FASTLANE_ITUNES_TRANSPORTER_USE_SHELL_SCRIPT")
       end
@@ -1388,7 +1401,7 @@ describe FastlaneCore do
           command = java_upload_command_9 if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(9)
           # If we are on Mac with Xcode >= 11, switch to xcrun command
           command = xcrun_upload_command if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(11)
-          expect(transporter.upload('my.app.id', '/tmp')).to eq(command)
+          expect(transporter.upload('my.app.id', tmp_dir)).to eq(command)
         end
       end
 
@@ -1404,7 +1417,7 @@ describe FastlaneCore do
           command = java_verify_command_9 if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(9)
           # If we are on Mac with Xcode >= 11, switch to xcrun command
           command = xcrun_verify_command if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(11)
-          expect(transporter.verify('my.app.id', '/tmp')).to eq(command)
+          expect(transporter.verify('my.app.id', tmp_dir)).to eq(command)
         end
       end
 
@@ -1420,7 +1433,7 @@ describe FastlaneCore do
           command = java_download_command_9 if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(9)
           # If we are on Mac with Xcode >= 11, switch to newer xcrun command
           command = xcrun_download_command if FastlaneCore::Helper.is_mac? && FastlaneCore::Helper.xcode_at_least?(11)
-          expect(transporter.download('my.app.id', '/tmp')).to eq(command)
+          expect(transporter.download('my.app.id', tmp_dir)).to eq(command)
         end
       end
     end
@@ -1431,7 +1444,7 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
 
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
       end
 
@@ -1446,7 +1459,7 @@ describe FastlaneCore do
           # Call original implementation to undo above expect
           expect_any_instance_of(FastlaneCore::JavaTransporterExecutor).to receive(:execute).and_call_original
 
-          expect(transporter.upload('my.app.id', '/tmp')).to eq(xcrun_upload_command)
+          expect(transporter.upload('my.app.id', tmp_dir)).to eq(xcrun_upload_command)
         end
 
         it "with package_path" do
@@ -1459,7 +1472,7 @@ describe FastlaneCore do
           # Call original implementation to undo above expect
           expect_any_instance_of(FastlaneCore::JavaTransporterExecutor).to receive(:execute).and_call_original
 
-          expect(transporter.upload(package_path: '/tmp/my.app.id.itmsp')).to eq(xcrun_upload_command)
+          expect(transporter.upload(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(xcrun_upload_command)
         end
       end
     end
@@ -1470,7 +1483,7 @@ describe FastlaneCore do
         allow(FastlaneCore::Helper).to receive(:mac?).and_return(true)
         allow(FastlaneCore::Helper).to receive(:windows?).and_return(false)
 
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         stub_const('ENV', { 'FASTLANE_ITUNES_TRANSPORTER_PATH' => nil })
       end
 
@@ -1485,7 +1498,7 @@ describe FastlaneCore do
           # Call original implementation to undo above expect
           expect_any_instance_of(FastlaneCore::JavaTransporterExecutor).to receive(:execute).and_call_original
 
-          expect(transporter.verify('my.app.id', '/tmp')).to eq(xcrun_verify_command)
+          expect(transporter.verify('my.app.id', tmp_dir)).to eq(xcrun_verify_command)
         end
 
         it "with package_path" do
@@ -1498,7 +1511,7 @@ describe FastlaneCore do
           # Call original implementation to undo above expect
           expect_any_instance_of(FastlaneCore::JavaTransporterExecutor).to receive(:execute).and_call_original
 
-          expect(transporter.verify(package_path: '/tmp/my.app.id.itmsp')).to eq(xcrun_verify_command)
+          expect(transporter.verify(package_path: "#{tmp_dir}/my.app.id.itmsp")).to eq(xcrun_verify_command)
         end
       end
     end
@@ -1506,19 +1519,19 @@ describe FastlaneCore do
     describe "with simulated no-test environment" do
       before(:each) do
         allow(FastlaneCore::Helper).to receive(:test?).and_return(false)
-        allow(FastlaneCore::Helper).to receive(:itms_path).and_return('/tmp')
+        allow(FastlaneCore::Helper).to receive(:itms_path).and_return(tmp_dir)
         @transporter = FastlaneCore::ItunesTransporter.new(email, password, false)
       end
 
       describe "and faked command execution" do
         it 'handles successful execution with no errors' do
           expect(FastlaneCore::FastlanePty).to receive(:spawn).and_return(0)
-          expect(@transporter.upload('my.app.id', '/tmp')).to eq(true)
+          expect(@transporter.upload('my.app.id', tmp_dir)).to eq(true)
         end
 
         it 'handles exceptions' do
           expect(FastlaneCore::FastlanePty).to receive(:spawn).and_raise(StandardError, "It's all broken now.")
-          expect(@transporter.upload('my.app.id', '/tmp')).to eq(false)
+          expect(@transporter.upload('my.app.id', tmp_dir)).to eq(false)
         end
       end
     end
@@ -1526,7 +1539,7 @@ describe FastlaneCore do
   end
 
   describe FastlaneCore::AltoolTransporterExecutor do
-    let(:upload_cmd) { "xcrun altool --upload-app --apiKey #{api_key[:key_id]} --apiIssuer #{api_key[:issuer_id]} -t macos -f /tmp/my.app.id.itmsp -k 100000" }
+    let(:upload_cmd) { "xcrun altool --upload-app --apiKey #{api_key[:key_id]} --apiIssuer #{api_key[:issuer_id]} -t macos -f #{tmp_dir}/my.app.id.itmsp -k 100000" }
     let(:instance) { described_class.new }
     describe "#execute" do
       it "logs specific info about altool crash if exit code is -1" do

--- a/fastlane_core/spec/project_spec.rb
+++ b/fastlane_core/spec/project_spec.rb
@@ -398,45 +398,57 @@ describe FastlaneCore do
       end
     end
 
+    # Scoped rather than assigned. These examples used to set the variable
+    # directly, with a before hook resetting it only for examples inside this
+    # group, so the last value assigned leaked out and changed what later
+    # examples saw. See fastlane#30184.
     describe 'Project.xcode_build_settings_timeout' do
-      before do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = nil
-      end
       it "returns default value" do
-        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(3)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT' => nil) do
+          expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(3)
+        end
       end
       it "returns specified value" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '5'
-        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(5)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT' => '5') do
+          expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(5)
+        end
       end
       it "returns 0 if empty" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = ''
-        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(0)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT' => '') do
+          expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(0)
+        end
       end
       it "returns 0 if garbage" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = 'hiho'
-        expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(0)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT' => 'hiho') do
+          expect(FastlaneCore::Project.xcode_build_settings_timeout).to eq(0)
+        end
       end
     end
 
+    # Scoped rather than assigned. These examples used to set the variable
+    # directly, with a before hook resetting it only for examples inside this
+    # group, so the last value assigned leaked out and changed what later
+    # examples saw. See fastlane#30184.
     describe 'Project.xcode_build_settings_retries' do
-      before do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_RETRIES'] = nil
-      end
       it "returns default value" do
-        expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(3)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_RETRIES' => nil) do
+          expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(3)
+        end
       end
       it "returns specified value" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_RETRIES'] = '5'
-        expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(5)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_RETRIES' => '5') do
+          expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(5)
+        end
       end
       it "returns 0 if empty" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_RETRIES'] = ''
-        expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(0)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_RETRIES' => '') do
+          expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(0)
+        end
       end
       it "returns 0 if garbage" do
-        ENV['FASTLANE_XCODEBUILD_SETTINGS_RETRIES'] = 'hiho'
-        expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(0)
+        FastlaneSpec::Env.with_env_values('FASTLANE_XCODEBUILD_SETTINGS_RETRIES' => 'hiho') do
+          expect(FastlaneCore::Project.xcode_build_settings_retries).to eq(0)
+        end
       end
     end
 

--- a/fastlane_core/spec/update_checker_spec.rb
+++ b/fastlane_core/spec/update_checker_spec.rb
@@ -37,9 +37,16 @@ describe FastlaneCore do
     end
 
     describe "#update_command" do
-      before do
-        ENV.delete("BUNDLE_BIN_PATH")
-        ENV.delete("BUNDLE_GEMFILE")
+      # Scoped, not deleted. These two decide Helper.bundler?, and dropping them
+      # for the rest of the process makes every later example look as though it
+      # is not running under bundler. take_off then finds the Gemfile in the
+      # working directory and emits "fastlane detected a Gemfile", an extra call
+      # that was failing ruby_version_warning_spec's `.once` constraint on
+      # UI.important. See fastlane#30184.
+      around(:each) do |example|
+        FastlaneSpec::Env.with_env_values("BUNDLE_BIN_PATH" => nil, "BUNDLE_GEMFILE" => nil) do
+          example.run
+        end
       end
 
       it "works a custom gem name" do

--- a/internal/rakelib/isolated.rake
+++ b/internal/rakelib/isolated.rake
@@ -1,25 +1,31 @@
-# Runs the suite against a home directory the project controls, see fastlane#30184.
+# Runs the suite against a home and a temporary directory the project controls,
+# see fastlane#30184.
 #
-# The suite reads and writes the developer's real home. It leaves dozens of
-# entries there — `~/.fastlane`, `~/Library/Logs/{fastlane,gym,scan,snapshot}`,
+# The suite reads and writes both. It leaves dozens of entries in the home
+# directory — `~/.fastlane`, `~/Library/Logs/{fastlane,gym,scan,snapshot}`,
 # `~/Library/MobileDevice/Provisioning Profiles`, `~/.appstoreconnect` and more
-# — and it reads state left by earlier runs. That is how the itc_service_key
-# dependency survived for months: `Client#itc_service_key` caches to a file, the
-# examples depending on it passed on any machine that had ever run the suite,
-# and only a clean CI checkout ever failed.
+# — and it reads state left by earlier runs in either place.
 #
-# Pointing HOME at a temporary directory makes those dependencies fail here
+# Both matter, and the second is easy to forget. `Client#itc_service_key` caches
+# the App Store Connect key under the temporary directory, not the home one, so
+# examples depending on that cache pass on any machine that has run the suite
+# before and fail only on a clean checkout. Isolating HOME alone leaves that
+# whole class invisible, which it was until it broke CI.
+#
+# Pointing both at throwaway directories makes those dependencies fail here
 # rather than on someone else's machine.
 #
 #   rake test_isolated                 the whole suite
 #   rake test_isolated[spaceship/spec] a subset
-desc("Run the suite with HOME pointed at a throwaway directory")
+desc("Run the suite with HOME and TMPDIR pointed at throwaway directories")
 task(:test_isolated, [:pattern]) do |_task, args|
   require "tmpdir"
   require "fileutils"
 
   home = Dir.mktmpdir("fastlane-isolated-home")
-  env = { "HOME" => home }
+  # Made before TMPDIR is redirected, so both live somewhere real.
+  tmp = Dir.mktmpdir("fastlane-isolated-tmp")
+  env = { "HOME" => home, "TMPDIR" => tmp }
 
   # A keychain has to be seeded, because `security cms -D`, which fastlane uses
   # to decode provisioning profiles in verify_build, provisioning_profile.rb and
@@ -56,14 +62,22 @@ task(:test_isolated, [:pattern]) do |_task, args|
 
   # What the run left behind, which is the point of the exercise as much as the
   # pass or fail is.
-  written = Dir.glob(File.join(home, "**", "*"), File::FNM_DOTMATCH)
-               .select { |path| File.file?(path) }
-  puts("")
-  puts("The run wrote #{written.size} files into HOME:")
-  written.group_by { |path| File.dirname(path).delete_prefix(home) }
-         .sort_by { |directory, files| [-files.size, directory] }
-         .each { |directory, files| puts("  #{files.size.to_s.rjust(4)}  ~#{directory}") }
+  { "HOME" => home, "TMPDIR" => tmp }.each do |name, root|
+    written = Dir.glob(File.join(root, "**", "*"), File::FNM_DOTMATCH)
+                 .select { |path| File.file?(path) }
+    puts("")
+    puts("The run wrote #{written.size} files into #{name}:")
+    prefix = name == "HOME" ? "~" : ""
+    written.group_by { |path| File.dirname(path).delete_prefix(root) }
+           .sort_by { |directory, files| [-files.size, directory] }
+           .each do |directory, files|
+             # Files sitting at the root group under an empty string, and the
+             # ones that land there are usually the interesting ones.
+             label = directory.empty? ? files.map { |f| File.basename(f) }.sort.join(", ") : "#{prefix}#{directory}"
+             puts("  #{files.size.to_s.rjust(4)}  #{label}")
+           end
+  end
 
-  FileUtils.remove_entry(home)
-  abort("suite failed under an isolated HOME") unless ok
+  [home, tmp].each { |root| FileUtils.remove_entry(root) }
+  abort("suite failed under an isolated HOME and TMPDIR") unless ok
 end

--- a/internal/rakelib/isolated.rake
+++ b/internal/rakelib/isolated.rake
@@ -1,0 +1,69 @@
+# Runs the suite against a home directory the project controls, see fastlane#30184.
+#
+# The suite reads and writes the developer's real home. It leaves dozens of
+# entries there — `~/.fastlane`, `~/Library/Logs/{fastlane,gym,scan,snapshot}`,
+# `~/Library/MobileDevice/Provisioning Profiles`, `~/.appstoreconnect` and more
+# — and it reads state left by earlier runs. That is how the itc_service_key
+# dependency survived for months: `Client#itc_service_key` caches to a file, the
+# examples depending on it passed on any machine that had ever run the suite,
+# and only a clean CI checkout ever failed.
+#
+# Pointing HOME at a temporary directory makes those dependencies fail here
+# rather than on someone else's machine.
+#
+#   rake test_isolated                 the whole suite
+#   rake test_isolated[spaceship/spec] a subset
+desc("Run the suite with HOME pointed at a throwaway directory")
+task(:test_isolated, [:pattern]) do |_task, args|
+  require "tmpdir"
+  require "fileutils"
+
+  home = Dir.mktmpdir("fastlane-isolated-home")
+  env = { "HOME" => home }
+
+  # A keychain has to be seeded, because `security cms -D`, which fastlane uses
+  # to decode provisioning profiles in verify_build, provisioning_profile.rb and
+  # sigh's local_manage, imports the signing certificate to verify the signature
+  # and fails with "A default keychain could not be found" when there is none.
+  # The certificates it writes land in this throwaway keychain instead of the
+  # developer's login keychain, which is where they go today.
+  if RUBY_PLATFORM.include?("darwin")
+    FileUtils.mkdir_p(File.join(home, "Library", "Keychains"))
+    keychain = "login.keychain"
+    [
+      "security create-keychain -p '' #{keychain}",
+      "security default-keychain -s #{keychain}",
+      "security list-keychains -s #{keychain}",
+      "security unlock-keychain -p '' #{keychain}"
+    ].each { |command| system(env, command, out: File::NULL, err: File::NULL) }
+
+    # Check it took, and stop here if it did not. Running on without a keychain
+    # is worse than a failure: with a desktop session `security` puts up a modal
+    # asking for access and waits for someone to click it, so the suite hangs
+    # rather than reporting anything. Headless there is nobody to click it.
+    seeded = File.join(home, "Library", "Keychains", "#{keychain}-db")
+    unless File.exist?(seeded)
+      FileUtils.remove_entry(home)
+      abort("could not seed a keychain at #{seeded}, refusing to run: the suite would block on a keychain prompt")
+    end
+    puts("HOME is #{home}, keychain seeded")
+  else
+    puts("HOME is #{home}")
+  end
+
+  command = args[:pattern] ? "rspec #{args[:pattern]} --format progress" : "rake test_all"
+  ok = system(env, "bundle exec #{command}")
+
+  # What the run left behind, which is the point of the exercise as much as the
+  # pass or fail is.
+  written = Dir.glob(File.join(home, "**", "*"), File::FNM_DOTMATCH)
+               .select { |path| File.file?(path) }
+  puts("")
+  puts("The run wrote #{written.size} files into HOME:")
+  written.group_by { |path| File.dirname(path).delete_prefix(home) }
+         .sort_by { |directory, files| [-files.size, directory] }
+         .each { |directory, files| puts("  #{files.size.to_s.rjust(4)}  ~#{directory}") }
+
+  FileUtils.remove_entry(home)
+  abort("suite failed under an isolated HOME") unless ok
+end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -716,11 +716,15 @@ module Spaceship
       exit(has_valid_session)
     end
 
+    # <tmpdir>/spaceship_itc_service_key.txt
+    def itc_service_key_path
+      File.join(Dir.tmpdir, "spaceship_itc_service_key.txt")
+    end
+
     def itc_service_key
       return @service_key if @service_key
 
       # Check if we have a local cache of the key
-      itc_service_key_path = "/tmp/spaceship_itc_service_key.txt"
       return File.read(itc_service_key_path) if File.exist?(itc_service_key_path)
 
       # Fixes issue https://github.com/fastlane/fastlane/issues/13281

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -240,6 +240,11 @@ module Spaceship
 
     # The logger in which all requests are logged
     # <tmpdir>/spaceship[time]_[pid]_["threadid"].log by default
+    #
+    # Dir.tmpdir rather than a literal "/tmp", and it should stay that way:
+    # "/tmp" is not a directory on every platform Ruby runs on. On Windows it
+    # resolves against the current drive, so Logger.new raises Errno::ENOENT
+    # unless something else happens to have created it first.
     def logger
       unless @logger
         if ENV["VERBOSE"]
@@ -717,6 +722,14 @@ module Spaceship
     end
 
     # <tmpdir>/spaceship_itc_service_key.txt
+    #
+    # Dir.tmpdir rather than a literal "/tmp", for the same reason as #logger,
+    # and here the failure was worse than a missing file: itc_service_key
+    # rescues everything, so the write failing on Windows was reported as an
+    # App Store Connect outage. See #30198.
+    #
+    # On macOS this is also per user, so a cache written by one user no longer
+    # blocks another.
     def itc_service_key_path
       File.join(Dir.tmpdir, "spaceship_itc_service_key.txt")
     end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -37,7 +37,7 @@ module Spaceship
     attr_accessor :user_email
 
     # The logger in which all requests are logged
-    # /tmp/spaceship[time]_[pid].log by default
+    # <tmpdir>/spaceship[time]_[pid].log by default
     attr_accessor :logger
 
     attr_accessor :csrf_tokens
@@ -239,14 +239,14 @@ module Spaceship
     #####################################################
 
     # The logger in which all requests are logged
-    # /tmp/spaceship[time]_[pid]_["threadid"].log by default
+    # <tmpdir>/spaceship[time]_[pid]_["threadid"].log by default
     def logger
       unless @logger
         if ENV["VERBOSE"]
           @logger = Logger.new(STDOUT)
         else
           # Log to file by default
-          path = "/tmp/spaceship#{Time.now.to_i}_#{Process.pid}_#{Thread.current.object_id}.log"
+          path = File.join(Dir.tmpdir, "spaceship#{Time.now.to_i}_#{Process.pid}_#{Thread.current.object_id}.log")
           @logger = Logger.new(path)
         end
 

--- a/spaceship/lib/spaceship/du/upload_file.rb
+++ b/spaceship/lib/spaceship/du/upload_file.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 require 'fileutils'
 
 require_relative 'utilities'
@@ -30,10 +31,10 @@ module Spaceship
       end
 
       # As things like screenshots and app icon shouldn't contain the alpha channel
-      # This will copy the image into /tmp to remove the alpha channel there
-      # That's done to not edit the original image
+      # This will copy the image into the temporary directory to remove the
+      # alpha channel there. That's done to not edit the original image.
       def remove_alpha_channel(original)
-        path = "/tmp/#{Digest::MD5.hexdigest(original)}.png"
+        path = File.join(Dir.tmpdir, "#{Digest::MD5.hexdigest(original)}.png")
         FileUtils.copy(original, path)
         if mac? # sips is only available on macOS
           `sips -s format bmp '#{path}' &> /dev/null` # &> /dev/null since there is warning because of the extension

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -42,17 +42,14 @@ describe Spaceship::Client do
   end
 
   describe "#itc_service_key_path" do
-    # Was the literal "/tmp" too, and the write failure it caused on Windows
-    # came out of itc_service_key as an App Store Connect outage. See #30198.
+    # Guards against going back to a literal "/tmp"; the method says why.
     it "caches the key in the system temporary directory" do
       expect(TestClient.new.itc_service_key_path).to start_with(Dir.tmpdir)
     end
   end
 
   describe "#logger" do
-    # The path used to be the literal "/tmp", which is not a directory on every
-    # platform Ruby runs on. On Windows it resolves against the current drive,
-    # so Logger.new raised Errno::ENOENT unless something else had created it.
+    # Guards against going back to a literal "/tmp"; the method says why.
     it "writes to the system temporary directory" do
       client = TestClient.new
 

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -41,6 +41,14 @@ describe Spaceship::Client do
       then.to_return(status: status_ok, body: body)
   end
 
+  describe "#itc_service_key_path" do
+    # Was the literal "/tmp" too, and the write failure it caused on Windows
+    # came out of itc_service_key as an App Store Connect outage. See #30198.
+    it "caches the key in the system temporary directory" do
+      expect(TestClient.new.itc_service_key_path).to start_with(Dir.tmpdir)
+    end
+  end
+
   describe "#logger" do
     # The path used to be the literal "/tmp", which is not a directory on every
     # platform Ruby runs on. On Windows it resolves against the current drive,

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -366,6 +366,15 @@ BODY
   end
 
   describe "#persistent_cookie_path" do
+    # spec_helper points SPACESHIP_COOKIE_PATH at a temporary store for the
+    # whole suite, so that the specs neither write a cookie to the developer's
+    # home directory nor read one an earlier run left there. These examples are
+    # about how the path is chosen when that variable is not set, so they have
+    # to run without it. See fastlane#30184.
+    around(:each) do |example|
+      FastlaneSpec::Env.with_env_values("SPACESHIP_COOKIE_PATH" => nil) { example.run }
+    end
+
     before do
       subject.login("username", "password")
     end
@@ -376,8 +385,9 @@ BODY
 
     it "uses $SPACESHIP_COOKIE_PATH when set" do
       tmp_path = Dir.mktmpdir
-      ENV["SPACESHIP_COOKIE_PATH"] = "#{tmp_path}/custom_path"
-      expect(subject.persistent_cookie_path).to eq("#{tmp_path}/custom_path/spaceship/username/cookie")
+      FastlaneSpec::Env.with_env_values("SPACESHIP_COOKIE_PATH" => "#{tmp_path}/custom_path") do
+        expect(subject.persistent_cookie_path).to eq("#{tmp_path}/custom_path/spaceship/username/cookie")
+      end
     end
 
     it "uses home dir by default" do

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -41,6 +41,20 @@ describe Spaceship::Client do
       then.to_return(status: status_ok, body: body)
   end
 
+  describe "#logger" do
+    # The path used to be the literal "/tmp", which is not a directory on every
+    # platform Ruby runs on. On Windows it resolves against the current drive,
+    # so Logger.new raised Errno::ENOENT unless something else had created it.
+    it "writes to the system temporary directory" do
+      client = TestClient.new
+
+      FastlaneSpec::Env.with_env_values("VERBOSE" => nil) do
+        expect(client.logger.instance_variable_get(:@logdev).filename)
+          .to start_with(Dir.tmpdir)
+      end
+    end
+  end
+
   describe 'detect_most_common_errors_and_raise_exceptions' do
     # this test is strange, the `error` has a typo "InsufficentPermissions" and is not really relevant
     it "raises Spaceship::InsufficientPermissions for InsufficentPermissions" do

--- a/spaceship/spec/connect_api/spaceship_spec.rb
+++ b/spaceship/spec/connect_api/spaceship_spec.rb
@@ -1,5 +1,23 @@
 describe Spaceship::ConnectAPI do
-  before(:all) do
+  # Per example, not per group: the explicit client context assigns
+  # Spaceship::ConnectAPI.client, and clearing only once at the start of the
+  # group left the implicit client examples inheriting whatever it was set to,
+  # including doubles belonging to an example that had already finished. See
+  # fastlane#30184.
+  before(:each) do
+    Spaceship::ConnectAPI.client = nil
+    Spaceship::Tunes.client = nil
+    Spaceship::Portal.client = nil
+  end
+
+  # And after, not only before. Clearing on the way in keeps this file's own
+  # examples honest, but the last one still hands its client to whatever runs
+  # next. The `with explicit client` examples stub Client.login to return a
+  # double and ConnectAPI.login then assigns it, so what leaked out was an
+  # rspec double, which rspec disables at the end of its example. Anything
+  # later reaching ConnectAPI.token got "originally created in one example but
+  # has leaked into another". See fastlane#30184.
+  after(:each) do
     Spaceship::ConnectAPI.client = nil
     Spaceship::Tunes.client = nil
     Spaceship::Portal.client = nil

--- a/spaceship/spec/spaceauth_spec.rb
+++ b/spaceship/spec/spaceauth_spec.rb
@@ -38,6 +38,11 @@ describe Spaceship::SpaceauthRunner do
   end
 
   describe 'check_session option' do
+    # has_valid_session loads a cookie from the user's home directory, so these
+    # examples used to pass only when an earlier example had logged in and
+    # persisted one, and on a machine that had ever run the suite they passed
+    # from a file left by a previous run. Each example states the session it is
+    # testing instead. See fastlane#30184.
     before :each do
       Spaceship::Globals.check_session = true
     end
@@ -47,6 +52,8 @@ describe Spaceship::SpaceauthRunner do
     end
 
     it 'when using the default user, it should return a message saying the session is logged in with an exit code of 0' do
+      allow_any_instance_of(Spaceship::Client).to receive(:has_valid_session).and_return(true)
+
       expect do
         expect do
           Spaceship::SpaceauthRunner.new.run
@@ -57,6 +64,8 @@ describe Spaceship::SpaceauthRunner do
     end
 
     it 'when passed a known user, it should return a message saying the session is logged in with an exit code of 0' do
+      allow_any_instance_of(Spaceship::Client).to receive(:has_valid_session).and_return(true)
+
       expect do
         expect do
           Spaceship::SpaceauthRunner.new(username: 'spaceship@krausefx.com').run
@@ -67,6 +76,8 @@ describe Spaceship::SpaceauthRunner do
     end
 
     it 'when passed an unknown user, it should return a message saying no valid session found with an exit code of 1' do
+      allow_any_instance_of(Spaceship::Client).to receive(:has_valid_session).and_return(false)
+
       expect do
         expect do
           Spaceship::SpaceauthRunner.new(username: 'unknown-user').run

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -1,4 +1,21 @@
+require 'base64'
 require 'plist'
+require 'fastlane-sirp'
+
+# The login stubs in tunes/tunes_stubbing.rb match on an exact request body that
+# embeds this SRP public ephemeral. SIRP generates a fresh random one per client,
+# so it has to be stubbed for those bodies to match. Every spaceship spec needs
+# it, not only the ones using the "common spaceship login" shared example: a spec
+# that reaches a login without it computes a real value, matches no stub, and
+# fails with WebMock::NetConnectNotAllowedError depending on what ran first.
+SPACESHIP_AUTHENTICATION_DATA =
+  '8f30ce83b660f03abb0f8570c235e0e1e1d3860a222304acf18e989bdc065dc922a141e6da4563f0' \
+  '5586605b0e10535d875ca7e0fae7fe100cfe533374f29aaa803cdfb2c6194f458485e87f76988f6' \
+  'cddaa1829309438e1aa9ab652b17cfc081fff40356cb3af35c621e9f37ba6e2a03e6abac5a6bfe' \
+  '18ddb489412b7c56355292e6c355f8859270d04063b843d23c1ef7503c3c5dd2c56740101a3ef5' \
+  'bfec6bff1e6dc55e3f70840a83a95d7b3d20ab350d0472809ce87a4e3c29ed9685eb7721dc87ba' \
+  'bfadbd9e65e75d5df55547bcff98711ddeae7b8e1e6dbf529e96f7caa4b830b43575cddc52cebc' \
+  '39f9522f85cbf33ac35ee59f66f48109c12fbb78d'
 
 require_relative 'client_stubbing'
 require_relative 'connect_api/provisioning/provisioning_stubbing'
@@ -20,16 +37,29 @@ if set_auth_vars.any?
   abort("[!] Please `unset` the following ENV vars which interfere with spaceship testing: #{set_auth_vars.join(', ')}".red)
 end
 
-@cache_paths = [
-  File.expand_path("/tmp/spaceship_itc_service_key.txt")
-]
+# Client#itc_service_key caches the key at a fixed path in /tmp, reading it with
+# File.exist? followed by File.read. These examples used to delete that file
+# before and after every one of them, which isolates them from each other in one
+# process and cannot work in several: one worker removes the file between
+# another's exist? and read, and the loser raises AppleTimeoutError from inside
+# itc_service_key.
+#
+# The deletion is gone. The examples that depended on it, in
+# spaceship/spec/tunes/tunes_client_spec.rb, stub the key instead, so nothing
+# here needs the file to be in any particular state. See fastlane#30184.
 
-def try_delete(path)
-  FileUtils.rm_f(path) if File.exist?(path)
+def clear_spaceship_model_clients(klass)
+  klass.instance_variable_set(:@client, nil)
+  klass.subclasses.each { |subclass| clear_spaceship_model_clients(subclass) }
 end
 
 def before_each_spaceship
-  @cache_paths.each { |path| try_delete(path) }
+  # Spaceship::Base subclasses each hold their own @client, stamped on by
+  # set_client and preferred over Spaceship::Portal.client. Class level ivars are
+  # not inherited, so a client cached on Spaceship::Certificate by one example
+  # keeps answering for later ones even after they log in again. Clear the tree
+  # so each example uses the client its own login produced.
+  clear_spaceship_model_clients(Spaceship::Base)
   ENV["DELIVER_USER"] = "spaceship@krausefx.com"
   ENV["DELIVER_PASSWORD"] = "so_secret"
   ENV['SPACESHIP_AVOID_XCODE_API'] = 'true'
@@ -100,10 +130,17 @@ def before_each_spaceship
 end
 
 def after_each_spaceship
-  @cache_paths.each { |path| try_delete(path) }
+  nil
 end
 
 RSpec.configure do |config|
+  config.before(:each) do |current_test|
+    next unless current_test.id.start_with?("./spaceship/")
+
+    allow_any_instance_of(SIRP::Client).to receive(:start_authentication).and_return(SPACESHIP_AUTHENTICATION_DATA)
+    allow_any_instance_of(SIRP::Client).to receive(:process_challenge).and_return("1234")
+  end
+
   def mock_client_response(method_name, with: anything)
     mock_method = allow(mock_client).to receive(method_name)
     mock_method = mock_method.with(with)
@@ -116,7 +153,6 @@ RSpec.configure do |config|
 end
 
 RSpec.shared_examples("common spaceship login") do |skip_tunes_login|
-  require 'fastlane-sirp'
   let(:authentication_data) {
     '8f30ce83b660f03abb0f8570c235e0e1e1d3860a222304acf18e989bdc065dc922a141e6da4563f0' \
       '5586605b0e10535d875ca7e0fae7fe100cfe533374f29aaa803cdfb2c6194f458485e87f76988f6' \
@@ -130,9 +166,16 @@ RSpec.shared_examples("common spaceship login") do |skip_tunes_login|
   let(:password) { 'so_secret' }
 
   before {
-    allow_any_instance_of(SIRP::Client).to receive(:start_authentication).and_return(authentication_data)
-    allow_any_instance_of(SIRP::Client).to receive(:process_challenge).and_return("1234")
+    unless skip_tunes_login
+      Spaceship::Tunes.login
 
-    Spaceship::Tunes.login unless skip_tunes_login
+      # Spaceship::ConnectAPI.client returns a globally held @client when one has
+      # been set, so a client built in an earlier example decides what this one
+      # talks to. Clear it, and log into the portal as well: the implicit client
+      # built in its place only wires up provisioning_request_client when a
+      # cookie, a token or a portal client is present.
+      Spaceship::ConnectAPI.client = nil
+      Spaceship::Portal.login
+    end
   }
 end

--- a/spaceship/spec/tunes/iap_detail_spec.rb
+++ b/spaceship/spec/tunes/iap_detail_spec.rb
@@ -1,3 +1,4 @@
+require 'tempfile'
 describe Spaceship::Tunes::IAPDetail do
   before { TunesStubbing.itc_stub_iap }
   include_examples "common spaceship login"
@@ -97,12 +98,20 @@ describe Spaceship::Tunes::IAPDetail do
     end
 
     it "saved and changed screenshot" do
-      detailed.review_screenshot = "#{Dir.tmpdir}/fastlane_tests"
+      # Its own file. This used to point at "#{Dir.tmpdir}/fastlane_tests",
+      # which is where spec_helper redirects $stdout, so the example was relying
+      # on the harness's log file existing and being named that. Only the
+      # existence of the path is checked here: the upload and the content type
+      # are both stubbed below. See fastlane#30184.
+      screenshot = Tempfile.new(["review_screenshot", ".jpg"])
+      detailed.review_screenshot = screenshot.path
       expect(client.du_client).to receive(:upload_purchase_review_screenshot).and_return({ "token" => "tok", "height" => 100, "width" => 200, "md5" => "xxxx" })
       expect(client.du_client).to receive(:get_picture_type).and_return("MZPFT.SortedScreenShot")
       expect(Spaceship::Utilities).to receive(:content_type).and_return("image/jpg")
       expect(client).to receive(:update_iap!).with(app_id: '898536088', purchase_id: "1195137656", data: detailed.raw_data)
       detailed.save!
+    ensure
+      screenshot&.close!
     end
 
     it "saved with subscription pricing goal" do

--- a/spaceship/spec/tunes/tunes_client_spec.rb
+++ b/spaceship/spec/tunes/tunes_client_spec.rb
@@ -34,10 +34,21 @@ describe Spaceship::TunesClient do
     before(:each) do
       # Don't need to test hashcash here
       allow_any_instance_of(Spaceship::Client).to receive(:fetch_hashcash)
+
+      # These examples count requests, and one of the requests used to be
+      # Client#itc_service_key fetching the widget key. That method caches to a
+      # fixed path in /tmp, so the count depended on whether the file happened
+      # to exist: cold, the fetch ran and the count was two; warm, it did not
+      # and the third stubbed request was never reached, so nothing was raised.
+      # spaceship/spec/spec_helper.rb used to delete the file around every
+      # example to force it cold, which works in one process and races in
+      # several. Answer the key directly so the count is the same
+      # either way. See fastlane#30184.
+      allow_any_instance_of(Spaceship::Client).to receive(:itc_service_key).and_return("e0abc")
     end
 
     it 'has authType is sa' do
-      expect_any_instance_of(Spaceship::Client).to receive(:request).twice.and_call_original
+      expect_any_instance_of(Spaceship::Client).to receive(:request).once.and_call_original
 
       response_second = double
       allow(response_second).to receive(:status).and_return(412)
@@ -51,7 +62,7 @@ describe Spaceship::TunesClient do
     end
 
     it 'has authType of hsa' do
-      expect_any_instance_of(Spaceship::Client).to receive(:request).twice.and_call_original
+      expect_any_instance_of(Spaceship::Client).to receive(:request).once.and_call_original
 
       response_second = double
       allow(response_second).to receive(:status).and_return(412)
@@ -65,7 +76,7 @@ describe Spaceship::TunesClient do
     end
 
     it 'has authType of non-sa' do
-      expect_any_instance_of(Spaceship::Client).to receive(:request).twice.and_call_original
+      expect_any_instance_of(Spaceship::Client).to receive(:request).once.and_call_original
 
       response_second = double
       allow(response_second).to receive(:status).and_return(412)
@@ -79,7 +90,7 @@ describe Spaceship::TunesClient do
     end
 
     it 'has authType of hsa2' do
-      expect_any_instance_of(Spaceship::Client).to receive(:request).twice.and_call_original
+      expect_any_instance_of(Spaceship::Client).to receive(:request).once.and_call_original
 
       response_second = double
       allow(response_second).to receive(:status).and_return(412)

--- a/spaceship/spec/two_step_or_factor_client_spec.rb
+++ b/spaceship/spec/two_step_or_factor_client_spec.rb
@@ -74,39 +74,39 @@ describe Spaceship::Client do
 
     context 'when running non-interactive' do
       it 'raises an error' do
-        ENV["FASTLANE_IS_INTERACTIVE"] = "false"
-        expect(subject).to receive(:handle_two_factor)
-        stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
-        subject.handle_two_step_or_factor("response")
+        FastlaneSpec::Env.with_env_values('FASTLANE_IS_INTERACTIVE' => 'false', 'SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA' => nil) do
+          expect(subject).to receive(:handle_two_factor)
+          stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
+          subject.handle_two_step_or_factor("response")
+        end
       end
     end
 
     context 'when running non-interactive and force 2FA to be interactive only' do
       it 'raises an error' do
-        ENV["FASTLANE_IS_INTERACTIVE"] = "false"
-        ENV["SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA"] = "true"
-        expect { subject.handle_two_step_or_factor("response") }.to raise_error("2FA can only be performed in interactive mode")
-        ENV.delete('SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA')
+        FastlaneSpec::Env.with_env_values('FASTLANE_IS_INTERACTIVE' => 'false', 'SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA' => 'true') do
+          expect { subject.handle_two_step_or_factor("response") }.to raise_error("2FA can only be performed in interactive mode")
+        end
       end
     end
 
     context 'when running interactive' do
       it 'does not raise an error' do
-        ENV["FASTLANE_IS_INTERACTIVE"] = "true"
-        ENV["SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA"] = "true"
-        expect(subject).to receive(:handle_two_factor)
-        stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
-        subject.handle_two_step_or_factor("response")
+        FastlaneSpec::Env.with_env_values('FASTLANE_IS_INTERACTIVE' => 'true', 'SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA' => 'true') do
+          expect(subject).to receive(:handle_two_factor)
+          stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
+          subject.handle_two_step_or_factor("response")
+        end
       end
     end
 
     context 'when interactive mode is not set' do
       it 'does not raise an error' do
-        ENV["FASTLANE_IS_INTERACTIVE"] = nil
-        ENV["SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA"] = "false"
-        expect(subject).to receive(:handle_two_factor)
-        stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
-        subject.handle_two_step_or_factor("response")
+        FastlaneSpec::Env.with_env_values('FASTLANE_IS_INTERACTIVE' => nil, 'SPACESHIP_ONLY_ALLOW_INTERACTIVE_2FA' => 'false') do
+          expect(subject).to receive(:handle_two_factor)
+          stub_request(:get, "https://idmsa.apple.com/appleauth/auth").to_return(status: 200, body: '{"trustedPhoneNumbers": [{"1": ""}]}', headers: { 'Content-Type' => 'application/json' })
+          subject.handle_two_step_or_factor("response")
+        end
       end
     end
 

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -51,22 +51,34 @@ if FastlaneCore::Helper.mac?
   end
 end
 
+# A tool spec helper that writes to ENV at the top level rather than from a
+# before_each_* method would do it once, outside every example, where the guard
+# below can neither blame an example for it nor restore it. Nothing does that
+# today; this is here so that it cannot start silently. See fastlane#30184.
+env_guard_pristine = ENV.to_h
+
 (Fastlane::TOOLS + [:spaceship, :fastlane_core]).each do |tool|
   path = File.join(tool.to_s, "spec", "spec_helper.rb")
   require_relative path if File.exist?(path)
   require tool.to_s
 end
 
+env_guard_loaded = ENV.to_h
+ENV_GUARD_LOAD_TIME = ((env_guard_loaded.keys - env_guard_pristine.keys) |
+                       (env_guard_pristine.keys - env_guard_loaded.keys) |
+                       (env_guard_loaded.keys & env_guard_pristine.keys)
+                         .reject { |key| env_guard_loaded[key] == env_guard_pristine[key] }).sort.freeze
+
 my_main = self
 RSpec.configure do |config|
   # Singleton guard, see fastlane#30184.
   #
   # The fastlane tools keep their configuration on the module itself, so a value
-  # one example assigns is still there for every example after it. Four rows of
-  # internal/order_dependent_specs.md are the same defect: a group reading
-  # configuration it never set, green only while something earlier happened to
-  # leave one behind. Row W survived roughly twenty five random orders before a
-  # seed caught it, so waiting for seeds to find the rest is slow.
+  # one example assigns is still there for every example after it. Several groups
+  # were the same defect: reading configuration they never set, green only while
+  # something earlier happened to leave one behind. One of them survived roughly
+  # twenty five random orders before a seed caught it, so waiting for seeds to
+  # find the rest is slow.
   #
   # Clearing them after every example turns those from occasional failures into
   # permanent ones, which is the only way to enumerate them rather than wait.
@@ -108,6 +120,98 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     FileUtils.remove_entry(SPACESHIP_COOKIE_DIR) if File.directory?(SPACESHIP_COOKIE_DIR)
+  end
+
+  # Environment guard, see fastlane#30184.
+  #
+  # A test that leaves a variable behind changes what every later test in the
+  # process sees, and several of the ones involved carry credentials:
+  # DELIVER_PASSWORD, FASTLANE_PASSWORD and FASTLANE_SESSION have all been found
+  # leaking between examples. Tests should scope what they set with
+  # FastlaneSpec::Env.with_env_values rather than assigning to ENV directly.
+  #
+  # Modes, through FASTLANE_SPEC_ENV_GUARD:
+  #   enforce (default) restore ENV after each example, and report what escaped
+  #   report            leave ENV alone, report what escaped
+  #   off               do nothing
+  #
+  # Restoring is what makes the report worth reading. Without it each example is
+  # measured against whatever the previous one left behind, so an example setting
+  # a variable to the value already leaked there registers no change and is never
+  # named. Three specs set DELIVER_PASSWORD to "123": running those files in
+  # report mode names one example, enforce mode names all 64. The set of keys is
+  # the same either way, the attribution is not, and in report mode it depends
+  # entirely on the order the suite happened to run in.
+  #
+  # An example that is meant to leave something behind declares it:
+  #   it "sets the team id", env_output: %w[FASTLANE_TEAM_ID] do
+  #
+  # Two kinds of write are invisible here because both happen outside
+  # around(:each): top level writes in a tool spec helper, reported separately
+  # from ENV_GUARD_LOAD_TIME below, and writes in a before(:context) hook, which
+  # enter the baseline of every example in the group and outlive the group.
+  #
+  # FASTLANE_SPEC_ENV_GUARD_REPORT names a file to write the full inventory to.
+  # The console summary lists only the first few examples per variable, which is
+  # not enough to work from when a variable has a thousand of them.
+  #
+  # Only key names are ever reported. The values are the point of the exercise.
+  ENV_GUARD_MODE = (ENV["FASTLANE_SPEC_ENV_GUARD"] || "enforce").to_sym
+  ENV_GUARD_LEAKS = Hash.new { |hash, key| hash[key] = [] }
+  ENV_GUARD_REPORT_PATH = ENV["FASTLANE_SPEC_ENV_GUARD_REPORT"]
+
+  config.around(:each) do |example|
+    if ENV_GUARD_MODE == :off
+      example.run
+    else
+      before = ENV.to_h
+      begin
+        example.run
+      ensure
+        allowed = Array(example.metadata[:env_output]).map(&:to_s)
+        after = ENV.to_h
+        escaped = ((after.keys - before.keys) | (before.keys - after.keys) |
+                   (before.keys & after.keys).reject { |key| before[key] == after[key] }) - allowed
+        escaped.each { |key| ENV_GUARD_LEAKS[key] << example.id }
+        ENV.replace(before) if ENV_GUARD_MODE == :enforce
+      end
+    end
+  end
+
+  config.after(:suite) do
+    unless ENV_GUARD_LOAD_TIME.empty?
+      warn("")
+      warn("[env-guard] #{ENV_GUARD_LOAD_TIME.size} variables were set while the tool spec helpers loaded.")
+      warn("[env-guard] They are written outside any example, so no mode restores them and no example is blamed.")
+      warn("[env-guard] Move them into a hook to bring them under the guard: #{ENV_GUARD_LOAD_TIME.join(', ')}")
+    end
+
+    next if ENV_GUARD_LEAKS.empty?
+
+    ranked = ENV_GUARD_LEAKS.sort_by { |key, ids| [-ids.size, key] }
+
+    warn("")
+    warn("[env-guard] #{ENV_GUARD_LEAKS.size} environment variables escaped the example that changed them.")
+    warn("[env-guard] Scope them with FastlaneSpec::Env.with_env_values, or declare them with env_output:.")
+    warn("[env-guard] Reporting only, ENV was left as the examples made it.") if ENV_GUARD_MODE == :report
+    ranked.each do |key, ids|
+      warn("[env-guard]   #{key} (#{ids.size})")
+      ids.uniq.first(3).each { |id| warn("[env-guard]       #{id}") }
+      warn("[env-guard]       ...") if ids.uniq.size > 3
+    end
+
+    if ENV_GUARD_REPORT_PATH
+      File.open(ENV_GUARD_REPORT_PATH, "w") do |file|
+        file.puts("# fastlane#30184, environment guard, mode #{ENV_GUARD_MODE}")
+        file.puts("# set while the tool spec helpers loaded: #{ENV_GUARD_LOAD_TIME.join(', ')}") unless ENV_GUARD_LOAD_TIME.empty?
+        ranked.each do |key, ids|
+          file.puts("")
+          file.puts("#{key} (#{ids.uniq.size})")
+          ids.uniq.sort.each { |id| file.puts("  #{id}") }
+        end
+      end
+      warn("[env-guard] Full inventory written to #{ENV_GUARD_REPORT_PATH}")
+    end
   end
 
   config.before(:each) do |current_test|

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -9,7 +9,21 @@ require "webmock/rspec"
 WebMock.disable_net_connect!(allow: 'coveralls.io')
 
 require "fastlane"
+require "tmpdir"
 UI = FastlaneCore::UI
+
+# Spaceship persists a session cookie to ~/.fastlane/spaceship/<user>/cookie,
+# under the real home directory, and reads it back to decide whether a session
+# is valid. That makes the suite write to the developer's machine, and it makes
+# a spec able to depend on a file some earlier run left behind: the cookie four spaceauth
+# examples depended on was nine months older than the run that needed it here, so
+# they passed locally in every order and failed only on a clean checkout. Redirect the store
+# to a temporary directory that belongs to this process, so the suite leaves
+# nothing behind and a spec needing a session has to arrange one itself.
+#
+# See fastlane#30184.
+SPACESHIP_COOKIE_DIR = Dir.mktmpdir("fastlane-spec-spaceship")
+ENV["SPACESHIP_COOKIE_PATH"] = SPACESHIP_COOKIE_DIR
 
 unless ENV["DEBUG"]
   fastlane_tests_tmpdir = "#{Dir.tmpdir}/fastlane_tests"

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -31,6 +31,14 @@ unless ENV["DEBUG"]
   $stdout = File.open(fastlane_tests_tmpdir, "w")
 end
 
+# FastlaneCore::Shell prints "Logging disabled while running tests" the first
+# time anything touches the logger, and memoises it, so whichever example gets
+# there first absorbs the banner. An example asserting on its own stdout then
+# fails or passes depending on what ran before it. Emit it here instead, while
+# stdout is the redirect above rather than an example's capture. See
+# fastlane#30184.
+FastlaneCore::UI.ui_object.log
+
 if FastlaneCore::Helper.mac?
   xcode_path = FastlaneCore::Helper.xcode_path
   unless xcode_path.include?("Contents/Developer")

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -98,6 +98,10 @@ RSpec.configure do |config|
     end
   end
 
+  config.after(:suite) do
+    FileUtils.remove_entry(SPACESHIP_COOKIE_DIR) if File.directory?(SPACESHIP_COOKIE_DIR)
+  end
+
   config.before(:each) do |current_test|
     # We don't want to call the RubyGems API at any point
     # This was a request that was added with Ruby 2.4.0

--- a/supply/spec/uploader_spec.rb
+++ b/supply/spec/uploader_spec.rb
@@ -81,8 +81,6 @@ describe Supply do
         @obb_dir = Dir.mktmpdir('supply')
         @apk_path = File.join(@obb_dir, 'my.apk')
 
-        # Makes Supply::Uploader.new.all_languages public for testing reasons
-        Supply::Uploader.send(:public, *Supply::Uploader.private_instance_methods)
       end
 
       def create_obb(name)
@@ -158,7 +156,7 @@ describe Supply do
           metadata_path: 'supply/spec/fixtures/metadata/android'
         }
 
-        only_directories = Supply::Uploader.new.all_languages
+        only_directories = Supply::Uploader.new.send(:all_languages)
         expect(only_directories).to eq(['en-US', 'fr-FR', 'ja-JP'])
       end
     end


### PR DESCRIPTION
Part of #30184. Branches from #30197 rather than continuing the isolation stack, because it is the same subject and independent of everything else in it. Merge after #30197; retarget to master once that lands.

### The bug

`"/tmp"` is not a directory on every platform Ruby runs on. On Windows it resolves against the current drive, so `D:\tmp`, which does not exist on a clean machine. Writing to it raises `Errno::ENOENT` and chdir'ing into it fails outright.

#30197 fixed the two places in spaceship that this broke, because the split test suite found them. This is the rest of the codebase, found by grepping for it rather than by waiting for another failure.

### What changed

Everything that used `/tmp` as a real path now asks for `Dir.tmpdir`:

| | |
| --- | --- |
| `itunes_transporter` | thirteen default parameters, plus the download destination, which is the one that chdirs |
| `deliver/runner` | the parent directory the upload package is staged in, four callers |
| `spaceship/du/upload_file` | the copy made to strip the alpha channel from a screenshot |
| `lcov` | the intermediate coverage file |
| `build_and_upload_to_appetize` | its staging directory |
| `update_project_provisioning` | the default location the WWDR certificate is downloaded to |

On macOS this also moves them out of the shared `/tmp` into the per user directory, so a file written by one user no longer blocks another. On Linux `Dir.tmpdir` is `/tmp` unless `TMPDIR` says otherwise, so nothing changes.

### One user visible default

`update_project_provisioning`'s `certificate` option documented its default as `/tmp/AppleIncRootCertificate.cer`, and that default is now platform dependent. Anyone passing the option explicitly is unaffected. Anyone relying on the default gets a path that works on their platform, which on Windows it previously did not.

### What was deliberately left

Seven occurrences remain and all of them are correct:

- Example snippets in `scp`, `rsync`, `erb` and `spaceship_logs`. Illustrative, and in the first two the path is on the remote host rather than this machine
- Two `Helper.test?` fixtures in `hg_commit_version_bump`, which are fed to `Pathname` for string arithmetic and never touch the filesystem. The Windows suite exercises them and passes

### Verification

Full suite at seed 46869: 7866 examples, 0 failures. Rubocop clean on all seven files.

`deliver/spec/runner_spec.rb` asserted on the literal `/tmp` it was passing down, so those eight expectations move with it. That they pass on macOS, where `Dir.tmpdir` is under `/var/folders`, is the check that the caller and the expectation moved together rather than both being skipped.
