### PR TITLE
[spaceship] Say what actually went wrong fetching the App Store Connect API key

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -737,24 +737,60 @@ module Spaceship
     def itc_service_key
       return @service_key if @service_key
 
-      # Check if we have a local cache of the key
-      return File.read(itc_service_key_path) if File.exist?(itc_service_key_path)
+      # Check if we have a local cache of the key. Reading it is best effort:
+      # an unreadable cache is a reason to fetch the key again, not to fail.
+      begin
+        return File.read(itc_service_key_path) if File.exist?(itc_service_key_path)
+      rescue SystemCallError => ex
+        logger.warn("Could not read the cached App Store Connect API key: #{ex.message}")
+      end
 
       # Fixes issue https://github.com/fastlane/fastlane/issues/13281
       # Even though we are using https://appstoreconnect.apple.com, the service key needs to still use a
       # hostname through itunesconnect.apple.com
-      response = request(:get, "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com")
-      @service_key = response.body["authServiceKey"].to_s
+      response = begin
+        request(:get, "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com")
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => ex
+        # The only case the old message was ever right about.
+        raise AppleTimeoutError.new, "Could not reach App Store Connect to fetch the API key: #{ex.message}"
+      end
 
-      raise "Service key is empty" if @service_key.length == 0
+      @service_key = extract_service_key(response)
 
-      # Cache the key locally
-      File.write(itc_service_key_path, @service_key)
+      # Cache the key locally. Best effort as well: having the key and failing
+      # to save it is not a reason to fail the login. See fastlane#30198.
+      begin
+        File.write(itc_service_key_path, @service_key)
+      rescue SystemCallError => ex
+        logger.warn("Could not cache the App Store Connect API key at #{itc_service_key_path}: #{ex.message}")
+      end
 
       return @service_key
-    rescue => ex
-      puts(ex.to_s)
-      raise AppleTimeoutError.new, "Could not receive latest API key from App Store Connect, this might be a server issue."
+    end
+
+    # The status matters, and used to be thrown away. A non 2xx response body is
+    # an HTML error page rather than JSON, and String#[] on it returns nil for
+    # the key being looked up, so the failure presented as an empty key no
+    # matter what had actually gone wrong. See fastlane#30199.
+    def extract_service_key(response)
+      status = response.status.to_i
+      body = response.body
+
+      unless (200..299).cover?(status)
+        detail = body.to_s.strip[0, 200]
+        message = "App Store Connect returned #{status} for the API key endpoint."
+        message += " #{detail}" unless detail.empty?
+
+        # 5xx and 429 are worth retrying, a 4xx is not, and with_retry decides
+        # that from the class rather than the message.
+        raise AppleTimeoutError.new, "#{message} This might be a temporary server error, check https://developer.apple.com/system-status/" if status >= 500
+        raise UnexpectedResponse.new, message
+      end
+
+      key = body.kind_of?(Hash) ? body["authServiceKey"].to_s : ""
+      raise UnexpectedResponse.new, "App Store Connect returned #{status} for the API key endpoint but no authServiceKey in the response." if key.empty?
+
+      key
     end
 
     #####################################################

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -41,6 +41,57 @@ describe Spaceship::Client do
       then.to_return(status: status_ok, body: body)
   end
 
+  describe "#itc_service_key" do
+    # Apple started returning 404 from the key endpoint, and every one of these
+    # surfaced as "Service key is empty" wrapped in a timeout. See #30199.
+    let(:key_url) { "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com" }
+    let(:client) { TestClient.new }
+
+    before do
+      allow(client).to receive(:itc_service_key_path).and_return(File.join(Dir.tmpdir, "spaceship_itc_service_key_spec_absent.txt"))
+    end
+
+    def response_double(status, body)
+      double("response", status: status, body: body)
+    end
+
+    it "reports the status when the endpoint is gone rather than an empty key" do
+      allow(client).to receive(:request).and_return(response_double(404, "<html><title>Error 404 Not Found</title></html>"))
+
+      expect { client.itc_service_key }
+        .to raise_error(Spaceship::UnexpectedResponse, /returned 404/)
+    end
+
+    it "does not report a permanent failure as something worth retrying" do
+      allow(client).to receive(:request).and_return(response_double(404, "<html>nope</html>"))
+
+      # AppleTimeoutError is in with_retry's list, so raising it for a 404 costs
+      # five attempts and three second sleeps before failing anyway.
+      expect { client.itc_service_key }.to_not(raise_error(Spaceship::AppleTimeoutError))
+    end
+
+    it "keeps a server error retryable" do
+      allow(client).to receive(:request).and_return(response_double(503, "<html>unavailable</html>"))
+
+      expect { client.itc_service_key }
+        .to raise_error(Spaceship::AppleTimeoutError, /returned 503/)
+    end
+
+    it "says the key was missing when the response was otherwise fine" do
+      allow(client).to receive(:request).and_return(response_double(200, {}))
+
+      expect { client.itc_service_key }
+        .to raise_error(Spaceship::UnexpectedResponse, /no authServiceKey/)
+    end
+
+    it "does not fail the login when the key cannot be cached" do
+      allow(client).to receive(:request).and_return(response_double(200, { "authServiceKey" => "e0abc" }))
+      allow(File).to receive(:write).and_raise(Errno::EACCES)
+
+      expect(client.itc_service_key).to eq("e0abc")
+    end
+  end
+
   describe "#itc_service_key_path" do
     # Guards against going back to a literal "/tmp"; the method says why.
     it "caches the key in the system temporary directory" do


### PR DESCRIPTION
Fixes #30198. Answers the third question in #30199, asked by the reporter and again by @znspace in that thread: that a failure fetching the key should not present as a timeout. #30206 sits on top of this and fixes the login itself. Chained on #30204; retarget to master as that lands.

### What #30199 ran into

Apple's key endpoint returns 404. I reproduced it independently:

```
appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com  ->  404
```

What the user was told instead:

```
Service key is empty
Could not receive latest API key from App Store Connect, this might be a server issue.
```

Neither sentence is true. It is not an empty key and it is not a timeout.

Two things conspired. `itc_service_key` wraps its whole body in `rescue => ex` and re-raises everything as `AppleTimeoutError`. And the 404 body is an HTML error page rather than JSON, so `response.body["authServiceKey"]` is `String#[]` looking for a substring, which returns `nil`. The status was thrown away before anyone could see it.

### What this changes

**The status is reported.** A failing response now says what it was, with a short excerpt of the body.

**The exception class matches whether retrying can help.** `with_retry` decides from the class, and `AppleTimeoutError` is in its list, so a permanent 404 cost five attempts and four three second sleeps before failing anyway. 5xx stays `AppleTimeoutError`. A 4xx becomes `UnexpectedResponse`, which is not retried.

**A 2xx without the key says so**, rather than borrowing the empty key message.

**The local cache is best effort both ways.** Having the key and failing to save it is not a reason to fail the login, and an unreadable cache is a reason to fetch again rather than to stop. Both log. That is #30198, which was filed when a Windows `File.write` failure came out as an App Store Connect outage.

**A genuine timeout still raises `AppleTimeoutError`**, which is the one case the old message described correctly.

### What this does not do

It does not make logins work again. This only changes what fastlane says when the key cannot be fetched. #30206 changes where the key is fetched from, which is the part that unblocks people.

The two are separate on purpose. Reporting a failure properly is worth having whatever the key source turns out to be, and it is what makes the next breakage on this path diagnosable rather than a second round of guessing at a timeout message.

### Verification

Five examples, each checked by running it against the old implementation first. All five fail there:

| | |
| --- | --- |
| reports the status when the endpoint is gone rather than an empty key | |
| does not report a permanent failure as something worth retrying | |
| keeps a server error retryable | |
| says the key was missing when the response was otherwise fine | |
| does not fail the login when the key cannot be cached | |

Full suite at seed 60587: 7871 examples, 0 failures.
