### PR TITLE
[spaceship] Read the App Store Connect API key from where Apple keeps it now

### DIFF
--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -822,8 +822,12 @@ module Spaceship
 
       logger.debug("Read the App Store Connect API key from the sign out redirect")
       key
-    rescue StandardError => ex
-      # Anything at all: the fallback below is the point of this returning nil.
+    rescue Faraday::Error, URI::InvalidURIError => ex
+      # Only what this request can be expected to go wrong with. Rescuing
+      # everything here would put back the problem fastlane#30198 is about: a
+      # local failure, a missing log directory being the one that started it,
+      # would be swallowed and the caller would be handed whatever the fallback
+      # said instead of the real cause.
       logger.debug("Could not read the App Store Connect API key from the sign out redirect: #{ex.message}")
       nil
     end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -828,7 +828,12 @@ module Spaceship
       # local failure, a missing log directory being the one that started it,
       # would be swallowed and the caller would be handed whatever the fallback
       # said instead of the real cause.
-      logger.debug("Could not read the App Store Connect API key from the sign out redirect: #{ex.message}")
+      #
+      # Warn rather than debug. This is the source the key normally comes from,
+      # so failing here means the run is about to depend on an endpoint Apple has
+      # already removed once. If the fallback fails too, its message is all the
+      # caller sees, and this line is the half that says why.
+      logger.warn("Could not read the App Store Connect API key from the sign out redirect, falling back to the olympus endpoint: #{ex.message}")
       nil
     end
 

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -745,17 +745,7 @@ module Spaceship
         logger.warn("Could not read the cached App Store Connect API key: #{ex.message}")
       end
 
-      # Fixes issue https://github.com/fastlane/fastlane/issues/13281
-      # Even though we are using https://appstoreconnect.apple.com, the service key needs to still use a
-      # hostname through itunesconnect.apple.com
-      response = begin
-        request(:get, "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com")
-      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => ex
-        # The only case the old message was ever right about.
-        raise AppleTimeoutError.new, "Could not reach App Store Connect to fetch the API key: #{ex.message}"
-      end
-
-      @service_key = extract_service_key(response)
+      @service_key = fetch_service_key
 
       # Cache the key locally. Best effort as well: having the key and failing
       # to save it is not a reason to fail the login. See fastlane#30198.
@@ -766,6 +756,76 @@ module Spaceship
       end
 
       return @service_key
+    end
+
+    # Two sources, because the one this used to rely on is gone.
+    #
+    # App Store Connect's sign out route answers with a redirect that carries
+    # the key its own front end is using:
+    #
+    #   GET /logout -> 302 Location: .../appleauth/signout?widgetKey=<key>&...
+    #
+    # That is preferred over the olympus endpoint below, which Apple removed in
+    # September 2026 and which now answers 404. See fastlane#30199. The olympus
+    # call is kept as a fallback in case it comes back, since it is the source
+    # Apple documented rather than one scraped out of a redirect.
+    def fetch_service_key
+      key = fetch_service_key_from_signout
+      return key if key
+
+      # Fixes issue https://github.com/fastlane/fastlane/issues/13281
+      # Even though we are using https://appstoreconnect.apple.com, the service key needs to still use a
+      # hostname through itunesconnect.apple.com
+      response = begin
+        request(:get, "https://appstoreconnect.apple.com/olympus/v1/app/config?hostname=itunesconnect.apple.com")
+      rescue Faraday::TimeoutError, Faraday::ConnectionFailed => ex
+        # The only case the old message was ever right about.
+        raise AppleTimeoutError.new, "Could not reach App Store Connect to fetch the API key: #{ex.message}"
+      end
+
+      extract_service_key(response)
+    end
+
+    # Read the key out of the sign out redirect, or nil if it is not there.
+    #
+    # Two things about this request matter, and neither is decoration.
+    #
+    # It sends no cookies. The redirect it returns points at a signout with
+    # `asop=destroy-session`, so asking for it over the client's own connection,
+    # which carries the session jar, would end the session this method is being
+    # called in order to establish. A bare Faraday connection has neither a
+    # cookie jar nor redirect following, which is exactly what is wanted here.
+    #
+    # It does not follow the redirect. The key is in the Location header;
+    # following it is what performs the signout.
+    #
+    # Failure returns nil rather than raising, so the caller falls through to
+    # the other source rather than this becoming a new single point of failure.
+    # Deliberately not `self.class.client` or anything built from it. A bare
+    # Faraday connection has no cookie jar and no redirect following, which is
+    # the whole point; the spec asserts both rather than trusting this comment.
+    def signout_connection
+      Faraday.new(url: "https://appstoreconnect.apple.com")
+    end
+
+    def fetch_service_key_from_signout
+      response = signout_connection.head("/logout")
+
+      location = response.headers["location"].to_s
+      return nil if location.empty?
+
+      query = URI.parse(location).query
+      return nil if query.nil?
+
+      key = CGI.parse(query)["widgetKey"].first.to_s
+      return nil if key.empty?
+
+      logger.debug("Read the App Store Connect API key from the sign out redirect")
+      key
+    rescue StandardError => ex
+      # Anything at all: the fallback below is the point of this returning nil.
+      logger.debug("Could not read the App Store Connect API key from the sign out redirect: #{ex.message}")
+      nil
     end
 
     # The status matters, and used to be thrown away. A non 2xx response body is

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -87,6 +87,14 @@ describe Spaceship::Client do
       expect(client.itc_service_key).to eq("from-olympus")
     end
 
+    # fastlane#30198: a local failure on this path must not be swallowed and
+    # reported as whatever the fallback source had to say about itself.
+    it "does not swallow a local error as a reason to fall back" do
+      allow(client).to receive(:signout_connection).and_raise(Errno::ENOENT.new("/tmp/spaceship.log"))
+
+      expect { client.itc_service_key }.to raise_error(Errno::ENOENT)
+    end
+
     it "falls back when the sign out request fails outright" do
       allow(client).to receive(:signout_connection).and_raise(Faraday::ConnectionFailed.new("nope"))
       expect(client).to receive(:request).and_return(double("response", status: 200, body: { "authServiceKey" => "from-olympus" }))

--- a/spaceship/spec/client_spec.rb
+++ b/spaceship/spec/client_spec.rb
@@ -41,6 +41,60 @@ describe Spaceship::Client do
       then.to_return(status: status_ok, body: body)
   end
 
+  describe "the App Store Connect API key source" do
+    # Apple removed the olympus endpoint this used to come from. Its own front
+    # end now takes the key from the sign out redirect. See #30199.
+    let(:client) { TestClient.new }
+    let(:key) { "e0b80c3bf78523bfe80974d320935bfa30add02e1bff88ec2166c6bd5a706c42" }
+    let(:location) { "https://idmsa.apple.com/appleauth/signout?widgetKey=#{key}&asop=destroy-session&asoc=/&rv=3" }
+
+    before do
+      allow(client).to receive(:itc_service_key_path).and_return(File.join(Dir.tmpdir, "spaceship_key_absent_spec.txt"))
+      allow(File).to receive(:write)
+    end
+
+    def signout_returning(headers)
+      double("connection", head: double("response", headers: headers))
+    end
+
+    it "reads the key out of the sign out redirect" do
+      allow(client).to receive(:signout_connection).and_return(signout_returning("location" => location))
+
+      expect(client.itc_service_key).to eq(key)
+    end
+
+    # The redirect points at a signout with asop=destroy-session. Asking for it
+    # over the connection that carries the session cookies would end the very
+    # session this method is called to establish.
+    it "does not ask for it over the session carrying connection" do
+      allow(client).to receive(:signout_connection).and_return(signout_returning("location" => location))
+      expect(client).to_not(receive(:request))
+
+      client.itc_service_key
+    end
+
+    it "builds a connection with no cookie jar and no redirect following" do
+      handlers = client.send(:signout_connection).builder.handlers.map(&:name)
+
+      expect(handlers.join(" ")).to_not(match(/CookieJar/i))
+      expect(handlers.join(" ")).to_not(match(/FollowRedirects/i))
+    end
+
+    it "falls back to the olympus endpoint when the redirect carries no key" do
+      allow(client).to receive(:signout_connection).and_return(signout_returning({}))
+      expect(client).to receive(:request).and_return(double("response", status: 200, body: { "authServiceKey" => "from-olympus" }))
+
+      expect(client.itc_service_key).to eq("from-olympus")
+    end
+
+    it "falls back when the sign out request fails outright" do
+      allow(client).to receive(:signout_connection).and_raise(Faraday::ConnectionFailed.new("nope"))
+      expect(client).to receive(:request).and_return(double("response", status: 200, body: { "authServiceKey" => "from-olympus" }))
+
+      expect(client.itc_service_key).to eq("from-olympus")
+    end
+  end
+
   describe "#itc_service_key" do
     # Apple started returning 404 from the key endpoint, and every one of these
     # surfaced as "Service key is empty" wrapped in a timeout. See #30199.
@@ -49,6 +103,8 @@ describe Spaceship::Client do
 
     before do
       allow(client).to receive(:itc_service_key_path).and_return(File.join(Dir.tmpdir, "spaceship_itc_service_key_spec_absent.txt"))
+      # These are about the olympus endpoint, which is the fallback now.
+      allow(client).to receive(:fetch_service_key_from_signout).and_return(nil)
     end
 
     def response_double(status, body)

--- a/spaceship/spec/spec_helper.rb
+++ b/spaceship/spec/spec_helper.rb
@@ -139,6 +139,14 @@ RSpec.configure do |config|
 
     allow_any_instance_of(SIRP::Client).to receive(:start_authentication).and_return(SPACESHIP_AUTHENTICATION_DATA)
     allow_any_instance_of(SIRP::Client).to receive(:process_challenge).and_return("1234")
+
+    # The API key is read from the sign out redirect now, see fastlane#30199.
+    # Stubbed for every spaceship example rather than only the ones that log in:
+    # the key is fetched from whichever request first needs it, and the local
+    # cache means an unstubbed one passes on a machine that has run the suite
+    # before and fails on a clean checkout.
+    stub_request(:head, "https://appstoreconnect.apple.com/logout")
+      .to_return(status: 302, headers: { "Location" => "https://idmsa.apple.com/appleauth/signout?widgetKey=e0abc&asop=destroy-session&asoc=/&rv=3" })
   end
 
   def mock_client_response(method_name, with: anything)


### PR DESCRIPTION
Fixes #30199. Chained on #30205, which makes the failures on this path legible; retarget to master as that lands.

Credit to @znspace, who diagnosed this in #30199 well before this pull request existed: that the olympus endpoint returns 404, that the key had been rotated as well, that the old well known key gets through SIRP and 2FA only to be refused later with a 401, and that App Store Connect's front end now carries the key rather than fetching it. The route used here is a tidier source for the same value than the versioned javascript bundle they found it in.

### What broke

`GET /olympus/v1/app/config?hostname=itunesconnect.apple.com` now answers 404, so `itc_service_key` gets nothing and every Apple ID login fails. Reproduced independently:

```
olympus/v1/app/config?hostname=itunesconnect.apple.com   404   Jetty "Not Found", the route is gone
olympus/v2/app/config?hostname=itunesconnect.apple.com   401   the route exists but wants credentials
```

v2 is not a replacement. v1 served this without credentials precisely because its answer is what you need *in order to* authenticate.

### Where the key is now

App Store Connect's own front end no longer fetches this key, it carries it. The sign out route hands it out in a redirect, without credentials:

```
$ curl -i https://appstoreconnect.apple.com/logout
HTTP/2 302
location: https://idmsa.apple.com/appleauth/signout?widgetKey=e0b80c3b...706c42&asop=destroy-session&asoc=/&rv=3
```

That value is byte for byte the one in the front end bundle, so it is the key Apple is actually using, and Apple regenerates the redirect from the same configuration. A rotation is picked up without a fastlane release, which matters because they have already rotated once.

### The algorithm

1. **The local cache**, unchanged. Read is best effort as of #30205: an unreadable cache means fetch again, not fail.
2. **The sign out redirect.** `HEAD /logout`, pull `widgetKey` out of the `Location` header. Anything unexpected returns `nil` rather than raising.
3. **The olympus endpoint**, as a fallback in case it comes back. It is the source Apple documented, rather than one read out of a redirect, so it wins if it is ever serving again. Its failures are reported properly as of #30205.

Step 2 returning `nil` rather than raising is what keeps this from becoming a new single point of failure: if Apple changes the sign out route, the fallback is tried and the error comes from there.

### The part that is easy to get wrong

The redirect points at a signout with `asop=destroy-session`.

Asking for it over the client's own connection, which carries the session cookie jar, would end the session this method is being called in order to establish. And following the redirect is what performs the signout. So the request goes over a bare Faraday connection and does not follow.

A comment saying that would not survive the first person who reuses `Spaceship::Client`'s connection out of tidiness, so `signout_connection` is its own method and a spec asserts its middleware stack has neither a cookie jar nor redirect following. Putting both back makes that spec fail, which is how it was checked.

### Not undoing #30198 on the way past

The first version of the sign out fetch rescued `StandardError`, so that anything unexpected fell through to the other source. That is the pattern #30198 is about: a local failure, the missing log directory that started that issue being the obvious one, would be swallowed here and the caller handed whatever the fallback said about itself rather than the real cause.

It is narrowed to Faraday errors and an unparseable `Location`. Anything else is a bug or a local problem and propagates. A spec raises `Errno::ENOENT` from the request and expects it to come back out; putting `rescue StandardError` back makes that spec fail.

### Why not hardcode the key

It was considered. It does not fail closed.

@znspace tested exactly this: with a stale constant the key step passes, SIRP passes, 2FA passes, and the session is then refused with a 401 that points nowhere near the cause, after the user has already typed a verification code. A clear failure while fetching the key is a better outcome than a misleading one three steps later, and hardcoding puts every future rotation behind a fastlane release.

### Verification

`spaceship/spec`: 927 examples, 0 failures. Rubocop clean.

Against the live endpoint, through the new code path rather than a stub:

```
fetched from the live signout redirect: "e0b80c3bf78523bfe80974d320935bfa30add02e1bff88ec2166c6bd5a706c42"
64 hex chars? true
connection middleware: ["Faraday::Request::UrlEncoded"]
```

Five specs: reads the key; does not use the session carrying connection; the connection has neither middleware; falls back when the redirect carries no key; falls back when the request fails outright.

The four #30205 examples about the olympus endpoint now pin themselves to the fallback path. Without that they would have kept passing while testing nothing, since olympus is no longer what gets tried first.

### Worth confirming before this ships

Whether `/logout` answers the same from CI address ranges and outside the US, which I cannot test from one machine. And whether a second unauthenticated route carries the same key, so this is not betting on a single URL.
