### PR TITLE
[core] Stop hardcoding /tmp where a real path is needed

### DIFF
--- a/deliver/lib/deliver/runner.rb
+++ b/deliver/lib/deliver/runner.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 require 'precheck/options'
 require 'precheck/runner'
 require 'fastlane_core/configuration/configuration'
@@ -196,7 +197,7 @@ module Deliver
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           ipa_path: ipa_path,
-          package_path: "/tmp",
+          package_path: Dir.tmpdir,
           platform: platform
         )
         result = transporter.verify(package_path: package_path, asset_path: ipa_path, platform: platform)
@@ -204,7 +205,7 @@ module Deliver
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           pkg_path: pkg_path,
-          package_path: "/tmp",
+          package_path: Dir.tmpdir,
           platform: platform
         )
         result = transporter.verify(package_path: package_path, asset_path: pkg_path, platform: platform)
@@ -233,7 +234,7 @@ module Deliver
         package_path = FastlaneCore::IpaUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           ipa_path: ipa_path,
-          package_path: "/tmp",
+          package_path: Dir.tmpdir,
           platform: platform
         )
         result = transporter.upload(package_path: package_path, asset_path: ipa_path, platform: platform)
@@ -241,7 +242,7 @@ module Deliver
         package_path = FastlaneCore::PkgUploadPackageBuilder.new.generate(
           app_id: Deliver.cache[:app].id,
           pkg_path: pkg_path,
-          package_path: "/tmp",
+          package_path: Dir.tmpdir,
           platform: platform
         )
         result = transporter.upload(package_path: package_path, asset_path: pkg_path, platform: platform)

--- a/deliver/spec/runner_spec.rb
+++ b/deliver/spec/runner_spec.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 require 'deliver/runner'
 
 class MockSession
@@ -66,7 +67,7 @@ describe Deliver::Runner do
     describe 'with an IPA file for iOS' do
       it 'uploads the IPA for the iOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'ios')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'ios')
           .and_return('path')
         expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.ipa', platform: 'ios').and_return(true)
         runner.upload_binary
@@ -80,7 +81,7 @@ describe Deliver::Runner do
 
       it 'uploads the IPA for the tvOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'appletvos')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'appletvos')
           .and_return('path')
         expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.ipa', platform: 'appletvos').and_return(true)
         runner.upload_binary
@@ -94,7 +95,7 @@ describe Deliver::Runner do
 
       it 'uploads the IPA for the visionOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'xros')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'xros')
           .and_return('path')
         expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.ipa', platform: 'xros').and_return(true)
         runner.upload_binary
@@ -110,7 +111,7 @@ describe Deliver::Runner do
 
       it 'uploads the PKG for the macOS platform' do
         expect_any_instance_of(FastlaneCore::PkgUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: '/tmp', platform: 'osx')
+          .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: Dir.tmpdir, platform: 'osx')
           .and_return('path')
         expect(transporter).to receive(:upload).with(package_path: 'path', asset_path: 'ACME.pkg', platform: 'osx').and_return(true)
         runner.upload_binary
@@ -191,7 +192,7 @@ describe Deliver::Runner do
     describe 'with an IPA file for iOS' do
       it 'verifies the IPA for the iOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'ios')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'ios')
           .and_return('path')
         expect(transporter).to receive(:verify).with(asset_path: "ACME.ipa", package_path: 'path', platform: "ios").and_return(true)
         runner.verify_binary
@@ -205,7 +206,7 @@ describe Deliver::Runner do
 
       it 'verifies the IPA for the tvOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'appletvos')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'appletvos')
           .and_return('path')
         expect(transporter).to receive(:verify).with(asset_path: "ACME.ipa", package_path: 'path', platform: "appletvos").and_return(true)
         runner.verify_binary
@@ -219,7 +220,7 @@ describe Deliver::Runner do
 
       it 'verifies the IPA for the visionOS platform' do
         expect_any_instance_of(FastlaneCore::IpaUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: '/tmp', platform: 'xros')
+          .with(app_id: 'YI8C2AS', ipa_path: 'ACME.ipa', package_path: Dir.tmpdir, platform: 'xros')
           .and_return('path')
         expect(transporter).to receive(:verify).with(asset_path: "ACME.ipa", package_path: 'path', platform: "xros").and_return(true)
         runner.verify_binary
@@ -235,7 +236,7 @@ describe Deliver::Runner do
 
       it 'verifies the PKG for the macOS platform' do
         expect_any_instance_of(FastlaneCore::PkgUploadPackageBuilder).to receive(:generate)
-          .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: '/tmp', platform: 'osx')
+          .with(app_id: 'YI8C2AS', pkg_path: 'ACME.pkg', package_path: Dir.tmpdir, platform: 'osx')
           .and_return('path')
         expect(transporter).to receive(:verify).with(asset_path: "ACME.pkg", package_path: 'path', platform: "osx").and_return(true)
         runner.verify_binary

--- a/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
+++ b/fastlane/lib/fastlane/actions/build_and_upload_to_appetize.rb
@@ -1,8 +1,10 @@
+require 'tmpdir'
+
 module Fastlane
   module Actions
     class BuildAndUploadToAppetizeAction < Action
       def self.run(params)
-        tmp_path = "/tmp/fastlane_build"
+        tmp_path = File.join(Dir.tmpdir, "fastlane_build")
 
         xcodebuild_configs = params[:xcodebuild]
         xcodebuild_configs[:sdk] = "iphonesimulator"

--- a/fastlane/lib/fastlane/actions/lcov.rb
+++ b/fastlane/lib/fastlane/actions/lcov.rb
@@ -1,3 +1,5 @@
+require 'tmpdir'
+
 module Fastlane
   module Actions
     class LcovAction < Action
@@ -42,7 +44,7 @@ module Fastlane
       end
 
       def self.gen_cov(options)
-        tmp_cov_file = "/tmp/coverage.info"
+        tmp_cov_file = File.join(Dir.tmpdir, "coverage.info")
         output_dir = options[:output_dir]
         derived_data_path = derived_data_dir(options)
 

--- a/fastlane/lib/fastlane/actions/update_project_provisioning.rb
+++ b/fastlane/lib/fastlane/actions/update_project_provisioning.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+require 'tmpdir'
+
 module Fastlane
   module Actions
     module SharedValues
@@ -146,7 +148,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :certificate,
                                        env_name: "FL_PROJECT_PROVISIONING_CERTIFICATE_PATH",
                                        description: "Path to apple root certificate",
-                                       default_value: "/tmp/AppleIncRootCertificate.cer"),
+                                       default_value: File.join(Dir.tmpdir, "AppleIncRootCertificate.cer")),
           FastlaneCore::ConfigItem.new(key: :code_signing_identity,
                                        env_name: "FL_PROJECT_PROVISIONING_CODE_SIGN_IDENTITY",
                                        description: "Code sign identity for build configuration",

--- a/fastlane_core/lib/fastlane_core/itunes_transporter.rb
+++ b/fastlane_core/lib/fastlane_core/itunes_transporter.rb
@@ -35,7 +35,7 @@ module FastlaneCore
 
     private_constant :ERROR_REGEX, :WARNING_REGEX, :OUTPUT_REGEX, :RETURN_VALUE_REGEX, :SKIP_ERRORS
 
-    def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "", jwt = nil)
+    def build_download_command(username, password, apple_id, destination = Dir.tmpdir, provider_short_name = "", jwt = nil)
       not_implemented(__method__)
     end
 
@@ -43,11 +43,11 @@ module FastlaneCore
       not_implemented(__method__)
     end
 
-    def build_upload_command(username, password, source = "/tmp", options = {})
+    def build_upload_command(username, password, source = Dir.tmpdir, options = {})
       not_implemented(__method__)
     end
 
-    def build_verify_command(username, password, source = "/tmp", provider_short_name = "", **kwargs)
+    def build_verify_command(username, password, source = Dir.tmpdir, provider_short_name = "", **kwargs)
       not_implemented(__method__)
     end
 
@@ -319,7 +319,7 @@ module FastlaneCore
       end
     end
 
-    def build_upload_command(username, password, source = "/tmp", options = {})
+    def build_upload_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       provider_public_id = options.fetch(:provider_public_id, "")
       jwt = options[:jwt]
@@ -351,11 +351,11 @@ module FastlaneCore
       ].compact.join(' ')
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "", jwt = nil)
+    def build_download_command(username, password, apple_id, destination = Dir.tmpdir, provider_short_name = "", jwt = nil)
       raise "This feature has not been implemented yet with altool for Xcode 14"
     end
 
-    def build_verify_command(username, password, source = "/tmp", options = {})
+    def build_verify_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       provider_public_id = options.fetch(:provider_public_id, "")
       api_key = options[:api_key]
@@ -442,7 +442,7 @@ module FastlaneCore
       end
     end
 
-    def build_upload_command(username, password, source = "/tmp", options = {})
+    def build_upload_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       jwt = options[:jwt]
       api_key = options[:api_key]
@@ -458,7 +458,7 @@ module FastlaneCore
       ].compact.join(' ')
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "", jwt = nil)
+    def build_download_command(username, password, apple_id, destination = Dir.tmpdir, provider_short_name = "", jwt = nil)
       [
         '"' + Helper.transporter_path + '"',
         "-m lookupMetadata",
@@ -477,7 +477,7 @@ module FastlaneCore
       ].compact.join(' ')
     end
 
-    def build_verify_command(username, password, source = "/tmp", options = {})
+    def build_verify_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       jwt = options[:jwt]
       [
@@ -568,7 +568,7 @@ module FastlaneCore
       end
     end
 
-    def build_upload_command(username, password, source = "/tmp", options = {})
+    def build_upload_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       jwt = options[:jwt]
       api_key = options[:api_key]
@@ -607,7 +607,7 @@ module FastlaneCore
       end
     end
 
-    def build_verify_command(username, password, source = "/tmp", options = {})
+    def build_verify_command(username, password, source = Dir.tmpdir, options = {})
       provider_short_name = options.fetch(:provider_short_name, "")
       jwt = options[:jwt]
       credential_params = build_credential_params(username, password, jwt, nil, is_default_itms_on_xcode_11?)
@@ -641,7 +641,7 @@ module FastlaneCore
       end
     end
 
-    def build_download_command(username, password, apple_id, destination = "/tmp", provider_short_name = "", jwt = nil)
+    def build_download_command(username, password, apple_id, destination = Dir.tmpdir, provider_short_name = "", jwt = nil)
       credential_params = build_credential_params(username, password, jwt, nil, is_default_itms_on_xcode_11?)
       if is_default_itms_on_xcode_11?
         [
@@ -793,7 +793,9 @@ module FastlaneCore
     # @raise [Deliver::TransporterTransferError] when something went wrong
     #   when transferring
     def download(app_id, dir = nil)
-      dir ||= "/tmp"
+      # Dir.tmpdir, not a literal "/tmp": the transporter chdirs into this
+      # directory, and "/tmp" is not one on Windows. See fastlane#30184.
+      dir ||= Dir.tmpdir
 
       password_placeholder = @jwt.nil? ? 'YourPassword' : nil
       jwt_placeholder = @jwt.nil? ? nil : 'YourJWT'

--- a/spaceship/lib/spaceship/du/upload_file.rb
+++ b/spaceship/lib/spaceship/du/upload_file.rb
@@ -1,3 +1,4 @@
+require 'tmpdir'
 require 'fileutils'
 
 require_relative 'utilities'
@@ -30,10 +31,10 @@ module Spaceship
       end
 
       # As things like screenshots and app icon shouldn't contain the alpha channel
-      # This will copy the image into /tmp to remove the alpha channel there
-      # That's done to not edit the original image
+      # This will copy the image into the temporary directory to remove the
+      # alpha channel there. That's done to not edit the original image.
       def remove_alpha_channel(original)
-        path = "/tmp/#{Digest::MD5.hexdigest(original)}.png"
+        path = File.join(Dir.tmpdir, "#{Digest::MD5.hexdigest(original)}.png")
         FileUtils.copy(original, path)
         if mac? # sips is only available on macOS
           `sips -s format bmp '#{path}' &> /dev/null` # &> /dev/null since there is warning because of the extension


### PR DESCRIPTION
Reopens #30204, which was approved and merged but never reached master: its base branch had already been squashed into master, so the merge landed on a branch nothing merges from. The commits are unchanged, recreated on top of master.

All 21 of the literal `/tmp` uses below are still on master today, which is how the gap was found.

### The bug

`"/tmp"` is not a directory on every platform Ruby runs on. On Windows it resolves against the current drive, so `D:\tmp`, which does not exist on a clean machine. Writing to it raises `Errno::ENOENT` and chdir'ing into it fails outright.

#30197 fixed the two places in spaceship that this broke, because the split test suite found them. This is the rest of the codebase, found by grepping for it rather than by waiting for another failure.

### What changed

Everything that used `/tmp` as a real path now asks for `Dir.tmpdir`:

| | |
| --- | --- |
| `itunes_transporter` | thirteen default parameters, plus the download destination, which is the one that chdirs |
| `deliver/runner` | the parent directory the upload package is staged in, four callers |
| `spaceship/du/upload_file` | the copy made to strip the alpha channel from a screenshot |
| `lcov` | the intermediate coverage file |
| `build_and_upload_to_appetize` | its staging directory |
| `update_project_provisioning` | the default location the WWDR certificate is downloaded to |

On macOS this also moves them out of the shared `/tmp` into the per user directory, so a file written by one user no longer blocks another. On Linux `Dir.tmpdir` is `/tmp` unless `TMPDIR` says otherwise, so nothing changes.

### One user visible default

`update_project_provisioning`'s `certificate` option documented its default as `/tmp/AppleIncRootCertificate.cer`, and that default is now platform dependent. Anyone passing the option explicitly is unaffected. Anyone relying on the default gets a path that works on their platform, which on Windows it previously did not.

### What was deliberately left

Seven occurrences remain and all of them are correct:

- Example snippets in `scp`, `rsync`, `erb` and `spaceship_logs`. Illustrative, and in the first two the path is on the remote host rather than this machine
- Two `Helper.test?` fixtures in `hg_commit_version_bump`, which are fed to `Pathname` for string arithmetic and never touch the filesystem. The Windows suite exercises them and passes

### Verification

Full suite at seed 46869: 7866 examples, 0 failures. Rubocop clean on all seven files.

`deliver/spec/runner_spec.rb` asserted on the literal `/tmp` it was passing down, so those eight expectations move with it. That they pass on macOS, where `Dir.tmpdir` is under `/var/folders`, is the check that the caller and the expectation moved together rather than both being skipped.

