### PR TITLE
[tests] Stop two spec files racing for the system clipboard

### DIFF
--- a/fastlane/spec/actions_specs/clipboard_spec.rb
+++ b/fastlane/spec/actions_specs/clipboard_spec.rb
@@ -5,11 +5,16 @@ describe Fastlane do
         it "properly stores the value in the clipboard" do
           str = "Some value: #{Time.now.to_i}"
 
-          value = Fastlane::FastFile.new.parse("lane :test do
+          # Asserted against the helper rather than the real pasteboard. There
+          # is one pasteboard per machine, shared by every process, so writing
+          # to it here overwrote what spaceship's spaceauth specs had saved on
+          # another worker. What this example is about is the action passing its
+          # value through, not pbcopy itself. See fastlane#30210.
+          expect(FastlaneCore::Clipboard).to receive(:copy).with(content: str)
+
+          Fastlane::FastFile.new.parse("lane :test do
             clipboard(value: '#{str}')
           end").runner.execute(:test)
-
-          expect(`pbpaste`).to eq(str)
         end
       end
 

--- a/fastlane_core/spec/clipboard_spec.rb
+++ b/fastlane_core/spec/clipboard_spec.rb
@@ -1,3 +1,20 @@
+# The only test in the suite that uses the real clipboard, and it should stay
+# that way. There is one pasteboard per logged-in session, shared by every
+# process on the machine, so two specs touching it on different workers race for
+# it: that is fastlane#30210. Everywhere else the clipboard is mocked, which is
+# what lets the suite run split across processes.
+#
+# This one is kept unmocked because it is the test of the pbcopy and pbpaste
+# boundary itself, and mocking it would leave nothing verifying that boundary
+# works at all. Keeping exactly one means there is nothing for it to race with.
+#
+# It does modify the user's environment while it runs. It saves the pasteboard
+# and puts it back, but anything copied during that window is lost, which is the
+# price of covering the real thing.
+#
+# If you need to assert that something reached the clipboard, mock
+# FastlaneCore::Clipboard and assert against that rather than adding a second
+# spec here.
 describe FastlaneCore do
   describe FastlaneCore::Clipboard do
     describe '#copy and paste' do

--- a/spaceship/spec/spaceauth_spec.rb
+++ b/spaceship/spec/spaceauth_spec.rb
@@ -17,13 +17,14 @@ describe Spaceship::SpaceauthRunner do
 
   describe 'copy_to_clipboard option', if: FastlaneCore::Clipboard.is_supported? do
     before :each do
-      # Save clipboard
-      @clipboard = FastlaneCore::Clipboard.paste
-    end
-
-    after :each do
-      # Restore clipboard
-      FastlaneCore::Clipboard.copy(content: @clipboard)
+      # Stubbed rather than driving the real pasteboard. There is one per
+      # machine, shared by every process, so two workers running this and
+      # fastlane's clipboard specs at the same time overwrite each other's.
+      # What these examples care about is whether the runner copied anything,
+      # not what is actually on the pasteboard. See fastlane#30210.
+      @clipboard = ""
+      allow(FastlaneCore::Clipboard).to receive(:paste) { @clipboard }
+      allow(FastlaneCore::Clipboard).to receive(:copy) { |args| @clipboard = args[:content] }
     end
 
     it 'when true, it should copy the session to clipboard' do


### PR DESCRIPTION
Fixes #30210. Based on master, independent of everything else in flight.

### The failure

```
1) Spaceship::SpaceauthRunner copy_to_clipboard option when false, it should not copy the session to clipboard
   Failure/Error: expect(FastlaneCore::Clipboard.paste).to eq(@clipboard)

     expected: ""
          got: "Some value: 1789198149"
```

`"Some value: <timestamp>"` comes from `fastlane/spec/actions_specs/clipboard_spec.rb`, in a different gem, on a different worker. The spaceauth example saved an empty pasteboard in its `before` hook, and by the time it asserted, the other worker had written over it.

Three files drove the real pasteboard, each doing save, write, assert, restore. Split across processes, any two overlapping in time fight for a resource there is only one of per machine.

### Why it needs a different fix from everything else in #30184

Every other isolation problem in that work had a lever. `ENV` and the working directory are per process. `HOME` and `TMPDIR` can be pointed somewhere else. **The pasteboard has none.** There is one per logged-in session, shared by every process, and no harness can make a second.

It also cannot be fixed by ordering, because it is a genuine race rather than a dependency on what ran first. No seed produces it and no seed avoids it.

### What changed

Only one of the three files is actually about the pasteboard. The other two were using it as a convenient observable:

| File | Before | After |
| --- | --- | --- |
| `spaceship/spec/spaceauth_spec.rb` | saved and restored the real pasteboard around every example | stubs the helper, keeps an in-memory value. It cares whether the runner copied the session |
| `fastlane/spec/actions_specs/clipboard_spec.rb` | wrote through the action, read back with a literal `` `pbpaste` `` | expects the helper to receive `copy` with the value. It cares that the action passes its value through |
| `fastlane_core/spec/clipboard_spec.rb` | drives `pbcopy` and `pbpaste` | unchanged. This is the thing it exists to test |

Once the other two stop touching it, `fastlane_core`'s spec is the only file using the pasteboard, so there is nothing left to race with.

### One real test, kept deliberately

The point is not to mock the clipboard everywhere. It is to keep **exactly one** test exercising it for real, so the `pbcopy` and `pbpaste` boundary is still covered, and to mock it everywhere else so the suite can run split.

`fastlane_core/spec/clipboard_spec.rb` is the right one to keep: it round trips through both commands, saves and restores the pasteboard, asserts the restore worked, and covers the unsupported platform in its other example. It also sits in the gem that owns the code it tests, where the two mocked ones were reaching across gem boundaries at a shared OS resource to observe something they could see locally.

That file now carries a comment saying it is the only unmocked one and why, so the property does not quietly regress the next time someone wants to assert that something reached the clipboard. The answer there is to mock the helper, not to add a second real test.

**It does still modify the user's environment.** It saves the pasteboard and puts it back, but anything copied during that window is lost. Three files doing this made that likely; one narrows it considerably but does not close it. Closing it entirely would mean mocking the last real test, leaving nothing to verify the boundary at all, which seems the worse trade — but it is a real cost rather than a free fix.

### Verification

All three files pass individually. The whole suite split across four workers, which is the configuration the failure needs, is green:

```
worker 0  exit 0   69.3s  1529 examples, 0 failures, 1 pending
worker 1  exit 0   55.7s  3835 examples, 0 failures
worker 2  exit 0   89.4s  1325 examples, 0 failures
worker 3  exit 0   76.6s  1180 examples, 0 failures
```

A green run is weaker evidence than usual here, since the race is intermittent by nature — the stronger argument is that only one file can now touch the resource at all. Rubocop clean.

Pre-existing rather than introduced by anything in flight: the split landed in #30202 and this was already latent behind it.
