### PR TITLE
[tests] Stop a spec mutating the plist fixture another spec reads

### DIFF
--- a/fastlane/spec/actions_specs/set_info_plist_value_spec.rb
+++ b/fastlane/spec/actions_specs/set_info_plist_value_spec.rb
@@ -1,10 +1,31 @@
+require 'tmpdir'
+
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "set_info_plist" do
-      let(:plist_path) { "./fastlane/spec/fixtures/plist/Info.plist" }
-      let(:test_path) { "/tmp/fastlane/tests/fastlane" }
+      # A copy, not the committed fixture. These examples mutate the plist and
+      # then put it back, which leaves a window where the file on disk holds
+      # NewValue<timestamp>. The checkout is shared by every worker when the
+      # suite is split, so get_info_plist_value_spec reading the same fixture on
+      # another worker saw that window and failed expecting com.krausefx.app.
+      #
+      # Working on a copy removes the restore step as well as the race: nothing
+      # else can observe this file, so nothing has to be put back.
+      let(:fixture_path) { "./fastlane/spec/fixtures/plist/Info.plist" }
+      let(:plist_dir) { Dir.mktmpdir("fl_spec_set_info_plist") }
+      let(:plist_path) { File.join(plist_dir, "Info.plist") }
+      let(:test_path) { Dir.mktmpdir("fl_spec_set_info_plist_out") }
       let(:output_path) { "Folder/output.plist" }
       let(:new_value) { "NewValue#{Time.now.to_i}" }
+
+      before(:each) do
+        FileUtils.cp(fixture_path, plist_path)
+      end
+
+      after(:each) do
+        FileUtils.remove_entry(plist_dir) if File.directory?(plist_dir)
+        FileUtils.remove_entry(test_path) if File.directory?(test_path)
+      end
 
       it "stores changes in the plist file" do
         allow(FastlaneCore::FastlaneFolder).to receive(:path).and_return(nil)
@@ -26,6 +47,8 @@ describe Fastlane do
 
         expect(value).to eq(new_value)
 
+        # Setting it back is still worth asserting: it is the round trip that
+        # proves the action writes what it is given rather than a fixed value.
         ret = Fastlane::FastFile.new.parse("lane :test do
           set_info_plist_value(path: '#{plist_path}', key: 'CFBundleIdentifier', value: '#{old_value}')
         end").runner.execute(:test)
@@ -53,8 +76,6 @@ describe Fastlane do
         end").runner.execute(:test)
 
         expect(value).to eq(new_value)
-
-        File.delete(File.join(test_path, output_path))
       end
     end
   end


### PR DESCRIPTION
Based on master. Same defect class as #30210, different resource — filed separately rather than folded into #30211, which is already approved.

### The failure

On Windows, in CI, on a pull request that touches none of this:

```
1) Fastlane Fastlane::FastFile get_info_plist fetches the value from the plist
   Failure/Error: expect(value).to eq("com.krausefx.app")

     expected: "com.krausefx.app"
          got: "NewValue1789211491"
```

`NewValue<timestamp>` is generated by `set_info_plist_value_spec.rb:7`. That spec saves, mutates, asserts and restores `./fastlane/spec/fixtures/plist/Info.plist` — a **tracked fixture**. `get_info_plist_value_spec.rb` reads the same file expecting the committed value.

Split across workers, one checkout is shared by all of them. The reader landed in the window between the writer's mutate and its restore.

### Why it is rare, and why running the two files together does not show it

The window is small. Running the writer and the reader against each other a dozen times finds nothing — I tried, and got zero failures both with and without this change, which means that experiment proves nothing either way.

Polling the fixture while the writer runs measures it directly:

| | polls that saw `NewValue` in the tracked fixture |
| --- | --- |
| without this change | **2** / 4000 |
| with it | **0** / 4000 |

About 0.05% of the writer's runtime. A dozen sequential runs will not hit that; thousands of examples across four workers over several minutes will.

### The change

The spec works on a copy in a temporary directory. That removes the restore step as well as the race — nothing else can observe the file, so nothing has to be put back. The output file moves to its own temporary directory too, instead of the shared `/tmp/fastlane/tests` tree.

The round trip assertion stays, because it is what proves the action writes the value it is given rather than a fixed one.

### The pattern

Third instance of one shape, all found this week, all pre-existing on master:

| Resource | Shared because | Status |
| --- | --- | --- |
| the system clipboard | one pasteboard per login session | #30210, fixed by #30211 |
| the login keychain | one keychain database per user | found, not yet filed |
| **a tracked fixture** | **one checkout per runner** | **this** |

Each is a spec doing save, mutate, assert, restore on a resource it does not own. `HOME` and `TMPDIR` redirection reaches none of them — the first two have no isolation lever at all, and this one lives inside the working copy, which is the one place such redirection deliberately does not touch.

### Verification

Both spec files pass. The fixture is left pristine after a run, confirmed with `git status`. Rubocop clean.
