### PR TITLE
[tests] Give each spec its own scratch directory instead of /tmp/fastlane

### DIFF
--- a/fastlane/spec/actions_specs/erb_spec.rb
+++ b/fastlane/spec/actions_specs/erb_spec.rb
@@ -2,7 +2,8 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "ERB template" do
       let(:template) { File.expand_path("./fastlane/spec/fixtures/templates/dummy_html_template.erb") }
-      let(:destination) { "/tmp/fastlane/template.html" }
+      # Not a fixed path under /tmp: parallel rspec processes share it. See fastlane#30184.
+      let(:destination) { File.join(Dir.mktmpdir("fl_spec_erb"), "template.html") }
 
       it "generate template without placeholders" do
         result = Fastlane::FastFile.new.parse("lane :test do
@@ -28,10 +29,6 @@ describe Fastlane do
       end
 
       context "save to file" do
-        before do
-          FileUtils.mkdir_p(File.dirname(destination))
-        end
-
         it "generate template and save to file" do
           result = Fastlane::FastFile.new.parse("lane :test do
             erb(
@@ -50,7 +47,7 @@ describe Fastlane do
         end
 
         after do
-          File.delete(destination)
+          FileUtils.remove_entry(File.dirname(destination))
         end
       end
     end

--- a/fastlane/spec/actions_specs/sonar_spec.rb
+++ b/fastlane/spec/actions_specs/sonar_spec.rb
@@ -1,17 +1,17 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Sonar Integration" do
-      let(:test_path) { "/tmp/fastlane/tests/fastlane" }
+      # Not a fixed path under /tmp: parallel rspec processes share it. See fastlane#30184.
+      let(:test_path) { Dir.mktmpdir("fl_spec_sonar") }
       let(:sonar_project_path) { "sonar-project.properties" }
 
       before do
         # Set up example sonar-project.properties file
-        FileUtils.mkdir_p(test_path)
         File.write(File.join(test_path, sonar_project_path), '')
       end
 
       after(:each) do
-        File.delete(File.join(test_path, sonar_project_path)) if File.exist?(File.join(test_path, sonar_project_path))
+        FileUtils.remove_entry(test_path)
       end
 
       it "Should not print sonar command" do

--- a/fastlane/spec/actions_specs/update_app_group_identifiers_spec.rb
+++ b/fastlane/spec/actions_specs/update_app_group_identifiers_spec.rb
@@ -1,13 +1,13 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Update Info Plist Integration" do
-      let(:test_path) { "/tmp/fastlane/tests/fastlane" }
+      # Not a fixed path under /tmp: parallel rspec processes share it. See fastlane#30184.
+      let(:test_path) { Dir.mktmpdir("fl_spec_update_app_group_identifiers") }
       let(:entitlements_path) { "com.test.entitlements" }
       let(:new_app_group) { 'group.com.enterprise.test' }
 
       before do
         # Set up example info.plist
-        FileUtils.mkdir_p(test_path)
         File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.application-groups</key><array><string>group.com.test</string></array></dict></plist>')
       end
 
@@ -60,8 +60,7 @@ describe Fastlane do
       end
 
       after do
-        # Clean up files
-        File.delete(File.join(test_path, entitlements_path))
+        FileUtils.remove_entry(test_path)
       end
     end
   end

--- a/fastlane/spec/actions_specs/update_app_identifier_spec.rb
+++ b/fastlane/spec/actions_specs/update_app_identifier_spec.rb
@@ -5,7 +5,8 @@ describe Fastlane do
   describe Fastlane::FastFile do
     describe "Update App Identifier Integration" do
       # Variables
-      let(:test_path) { "/tmp/fastlane/tests/fastlane" }
+      # Not a fixed path under /tmp: parallel rspec processes share it. See fastlane#30184.
+      let(:test_path) { Dir.mktmpdir("fl_spec_update_app_identifier") }
       let(:fixtures_path) { "./fastlane/spec/fixtures/xcodeproj" }
       let(:proj_file) { "bundle.xcodeproj" }
       let(:identifier_key) { 'PRODUCT_BUNDLE_IDENTIFIER' }
@@ -23,8 +24,6 @@ describe Fastlane do
       end
 
       before do
-        # Create test folder
-        FileUtils.mkdir_p(test_path)
         source = File.join(fixtures_path, proj_file)
         destination = File.join(test_path, proj_file)
 
@@ -58,7 +57,7 @@ describe Fastlane do
           stub_settings_2 = Hash['PRODUCT_BUNDLE_IDENTIFIER', 'com.something.entirely.else']
           stub_settings_2['INFOPLIST_FILE'] = "Other-Info.plist"
 
-          expect(Xcodeproj::Project).to receive(:open).with('/tmp/fastlane/tests/fastlane/bundle.xcodeproj').and_return(stub_project)
+          expect(Xcodeproj::Project).to receive(:open).with(xcodeproj).and_return(stub_project)
           expect(stub_project).to receive(:objects).and_return(stub_object)
           expect(stub_object).to receive(:select).and_return([stub_configuration_1, stub_configuration_2])
           expect(stub_configuration_1).to receive(:build_settings).twice.and_return(stub_settings_1)
@@ -88,7 +87,7 @@ describe Fastlane do
           stub_settings_2 = Hash['PRODUCT_BUNDLE_IDENTIFIER', 'com.something.entirely.else']
           stub_settings_2['INFOPLIST_FILE'] = "Other-Info.plist"
 
-          expect(Xcodeproj::Project).to receive(:open).with('/tmp/fastlane/tests/fastlane/bundle.xcodeproj').and_return(stub_project)
+          expect(Xcodeproj::Project).to receive(:open).with(xcodeproj).and_return(stub_project)
           expect(stub_project).to receive(:objects).and_return(stub_object)
           expect(stub_object).to receive(:select).and_return([stub_configuration_1, stub_configuration_2])
           expect(stub_configuration_1).to receive(:build_settings).twice.and_return(stub_settings_1)
@@ -118,7 +117,7 @@ describe Fastlane do
           stub_settings_2 = Hash['PRODUCT_BUNDLE_IDENTIFIER', 'com.something.entirely.else']
           stub_settings_2['INFOPLIST_FILE'] = "Other-Info.plist"
 
-          expect(Xcodeproj::Project).to receive(:open).with('/tmp/fastlane/tests/fastlane/bundle.xcodeproj').and_return(stub_project)
+          expect(Xcodeproj::Project).to receive(:open).with(xcodeproj).and_return(stub_project)
           expect(stub_project).to receive(:objects).and_return(stub_object)
           expect(stub_object).to receive(:select).and_return([stub_configuration_1, stub_configuration_2])
           expect(stub_configuration_1).to receive(:build_settings).twice.and_return(stub_settings_1)
@@ -148,7 +147,7 @@ describe Fastlane do
           stub_settings_2 = Hash['PRODUCT_BUNDLE_IDENTIFIER', 'com.something.entirely.else']
           stub_settings_2['INFOPLIST_FILE'] = "Other-Info.plist"
 
-          expect(Xcodeproj::Project).to receive(:open).with('/tmp/fastlane/tests/fastlane/bundle.xcodeproj').and_return(stub_project)
+          expect(Xcodeproj::Project).to receive(:open).with(xcodeproj).and_return(stub_project)
           expect(stub_project).to receive(:objects).and_return(stub_object)
           expect(stub_object).to receive(:select).and_return([stub_configuration_1, stub_configuration_2])
           expect(stub_configuration_1).to receive(:build_settings).twice.and_return(stub_settings_1)
@@ -174,7 +173,7 @@ describe Fastlane do
           stub_object = ['object']
           stub_settings = Hash['PRODUCT_BUNDLE_IDENTIFIER', 'com.something.else']
 
-          expect(Xcodeproj::Project).to receive(:open).with('/tmp/fastlane/tests/fastlane/bundle.xcodeproj').and_return(stub_project)
+          expect(Xcodeproj::Project).to receive(:open).with(xcodeproj).and_return(stub_project)
           expect(stub_project).to receive(:objects).and_return(stub_object)
           expect(stub_object).to receive(:select).and_return([stub_configuration])
           expect(stub_configuration).to receive(:build_settings).and_return(stub_settings)
@@ -196,7 +195,7 @@ describe Fastlane do
           stub_configuration = 'stub config'
           stub_object = ['object']
 
-          expect(Xcodeproj::Project).to receive(:open).with('/tmp/fastlane/tests/fastlane/bundle.xcodeproj').and_return(stub_project)
+          expect(Xcodeproj::Project).to receive(:open).with(xcodeproj).and_return(stub_project)
           expect(stub_project).to receive(:objects).and_return(stub_object)
           expect(stub_object).to receive(:select).and_return([])
 
@@ -214,8 +213,7 @@ describe Fastlane do
       end
 
       after do
-        # Clean up files
-        FileUtils.rm_r(test_path)
+        FileUtils.remove_entry(test_path)
       end
     end
   end

--- a/fastlane/spec/actions_specs/update_info_plist_spec.rb
+++ b/fastlane/spec/actions_specs/update_info_plist_spec.rb
@@ -1,7 +1,8 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Update Info Plist Integration" do
-      let(:test_path) { "/tmp/fastlane/tests/fastlane" }
+      # Not a fixed path under /tmp: parallel rspec processes share it. See fastlane#30184.
+      let(:test_path) { Dir.mktmpdir("fl_spec_update_info_plist") }
       let(:fixtures_path) { "./fastlane/spec/fixtures/xcodeproj" }
       let(:proj_file) { "bundle.xcodeproj" }
       let(:xcodeproj) { File.join(test_path, proj_file) }
@@ -27,7 +28,6 @@ describe Fastlane do
       describe "with existing xcodeproj file" do
         before do
           # Set up example info.plist
-          FileUtils.mkdir_p(test_path)
           source = File.join(fixtures_path, proj_file)
           destination = File.join(test_path, proj_file)
 
@@ -117,9 +117,7 @@ describe Fastlane do
         end
 
         after do
-          # Clean up files
-          File.delete(File.join(test_path, plist_path))
-          FileUtils.rm_rf(xcodeproj)
+          FileUtils.remove_entry(test_path)
         end
       end
     end

--- a/fastlane/spec/actions_specs/update_keychain_access_groups_spec.rb
+++ b/fastlane/spec/actions_specs/update_keychain_access_groups_spec.rb
@@ -1,13 +1,13 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Update Info Plist Integration" do
-      let(:test_path) { "/tmp/fastlane/tests/fastlane" }
+      # Not a fixed path under /tmp: parallel rspec processes share it. See fastlane#30184.
+      let(:test_path) { Dir.mktmpdir("fl_spec_update_keychain_access_groups") }
       let(:entitlements_path) { "com.test.entitlements" }
       let(:new_keychain_access_groups) { 'keychain.access.groups.test' }
 
       before do
         # Set up example info.plist
-        FileUtils.mkdir_p(test_path)
         File.write(File.join(test_path, entitlements_path), '<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>keychain-access-groups</key><array><string>keychain.access.groups.test</string></array></dict></plist>')
       end
 
@@ -59,8 +59,7 @@ describe Fastlane do
       end
 
       after do
-        # Clean up files
-        File.delete(File.join(test_path, entitlements_path))
+        FileUtils.remove_entry(test_path)
       end
     end
   end

--- a/fastlane/spec/actions_specs/update_plist_spec.rb
+++ b/fastlane/spec/actions_specs/update_plist_spec.rb
@@ -1,7 +1,8 @@
 describe Fastlane do
   describe Fastlane::FastFile do
     describe "Update Plist Integration" do
-      let(:test_path) { "/tmp/fastlane/tests/fastlane" }
+      # Not a fixed path under /tmp: parallel rspec processes share it. See fastlane#30184.
+      let(:test_path) { Dir.mktmpdir("fl_spec_update_plist") }
       let(:fixtures_path) { "./fastlane/spec/fixtures/xcodeproj" }
       let(:proj_file) { "bundle.xcodeproj" }
       let(:plist_path) { "Info.plist" }
@@ -10,7 +11,6 @@ describe Fastlane do
 
       before do
         # Set up example info.plist
-        FileUtils.mkdir_p(test_path)
         source = File.join(fixtures_path, proj_file)
         destination = File.join(test_path, proj_file)
 
@@ -50,8 +50,7 @@ describe Fastlane do
       end
 
       after do
-        # Clean up files
-        File.delete(File.join(test_path, plist_path))
+        FileUtils.remove_entry(test_path)
       end
     end
   end

--- a/fastlane/spec/private_public_fastfile_spec.rb
+++ b/fastlane/spec/private_public_fastfile_spec.rb
@@ -3,8 +3,6 @@ describe Fastlane do
     describe "Public/Private lanes" do
       let(:path) { './fastlane/spec/fixtures/fastfiles/FastfilePrivatePublic' }
       before do
-        FileUtils.rm_rf('/tmp/fastlane/')
-
         @ff = Fastlane::FastFile.new(path)
       end
 


### PR DESCRIPTION
Eight spec files used a fixed path under `/tmp` as a scratch directory: seven wrote their fixtures into `/tmp/fastlane/tests/fastlane`, and `erb_spec` wrote `/tmp/fastlane/template.html`. That path is machine-global, so every rspec process `rake test_parallel` starts shares one copy of it — and several of those specs delete it while others are still using it.

The sharpest case is `update_app_identifier_spec`, whose `after` hook removes the whole `tests/fastlane` tree once per example. Six other spec files write their fixtures into that same tree. A worker running the first deletes what another worker's `before` hook has just written, and that worker then fails on a file it created itself microseconds earlier.

## Reproducing it

Running just those two spec files against each other in two rspec processes — the same shape `rake test_parallel` uses — the victim failed 3 times in 15 runs on `master` and 0 times in 15 with this branch:

```
1) ... throws an error when the entitlements file does not exist
   Failure/Error: File.delete(File.join(test_path, entitlements_path))
   Errno::ENOENT:
```

The same race has been reaching CI as a different symptom: the action reporting `Could not find entitlements file` where the spec expected `cannot be parsed`, because the entitlements file disappeared between the `before` hook writing it and the action reading it.

## The change

Each spec now takes a `Dir.mktmpdir` of its own and removes it afterwards, so nothing is shared and no spec can reach another's fixtures. The explicit `mkdir_p` calls go away because `mktmpdir` already creates the directory, and the per-file cleanup collapses into one `remove_entry` of the whole tree — which also stops `update_plist_spec` leaking the `bundle.xcodeproj` copy it never deleted.

`private_public_fastfile_spec` also wiped `/tmp/fastlane` on every example, even though `FastfilePrivatePublic` writes nothing at all. That is pure collateral damage on other workers, so the line is removed rather than redirected.

## What this does not cover

`fast_file_spec` and the fixture Fastfiles share `/tmp/fastlane` itself rather than the `tests/fastlane` subtree. Those are coupled — the fixtures hardcode the path and are evaluated by the runner, so they need to learn it through the environment — and are left to a follow-up.

## Checks

- `bundle exec rake test_parallel` — 7874 examples, 0 failures
- `bundle exec rubocop` — 1337 files, no offenses

Part of #30184.
