### PR TITLE
[ci] run full workflows on master as they stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  queue: ${{ github.ref == 'refs/heads/master' && 'max' || 'single' }}
 
 permissions:
   contents: read

--- a/.github/workflows/module_test.yml
+++ b/.github/workflows/module_test.yml
@@ -9,6 +9,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  queue: ${{ github.ref == 'refs/heads/master' && 'max' || 'single' }}
 
 jobs:
   module_tests:

--- a/.github/workflows/module_test.yml
+++ b/.github/workflows/module_test.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   module_tests:


### PR DESCRIPTION
## Problem

If we merge too quick on `master`. Those `master` CI runs are cancelled - some stuff runs on `master` that we'd like to keep running.

## Solution

Only cancel in-progress on non-master.